### PR TITLE
chore(release): prepare public gittensory launch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -53,4 +53,4 @@ jobs:
           "$TMP/node_modules/.bin/gittensory-mcp" --help >/dev/null
 
       - name: Publish with npm trusted publishing
-        run: npx -y npm@11.15.0 publish --workspace @jsonbored/gittensory-mcp --access restricted
+        run: npx -y npm@11.15.0 publish --workspace @jsonbored/gittensory-mcp --access public

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build docs
         env:
-          GITTENSORY_SITE_URL: https://jsonbored.github.io/gittensory/
-          GITTENSORY_SITE_BASE: /gittensory/
+          GITTENSORY_SITE_URL: https://gittensory.aethereal.dev/
+          GITTENSORY_SITE_BASE: /
         run: npm run docs:build
 
       - name: Upload Pages artifact

--- a/README.md
+++ b/README.md
@@ -20,29 +20,28 @@ Gittensory is not a Gittensor frontend, not a public leaderboard, and not an aut
 - Worker API: Cloudflare Workers + Hono + D1 + Queues.
 - MCP package: `@jsonbored/gittensory-mcp`, a local stdio wrapper for coding agents.
 - GitHub App: check runs and optional sanitized sticky PR comments.
-- Docs site: VitePress under `site/`, deployable by GitHub Pages when the repo is public.
+- Docs site: VitePress under `site/`, deployed at `https://gittensory.aethereal.dev/`.
 
 ## MCP Install
 
-Private beta:
+Public npm:
 
 ```sh
-npm install
-npm link --workspace @jsonbored/gittensory-mcp
+npm install -g @jsonbored/gittensory-mcp
 gittensory-mcp login
 gittensory-mcp doctor
 gittensory-mcp --stdio
 ```
 
-Public npm path, once intentionally launched:
+Local checkout:
 
 ```sh
-npx @jsonbored/gittensory-mcp login
-npm install -g @jsonbored/gittensory-mcp
+npm install
+npm link --workspace @jsonbored/gittensory-mcp
 gittensory-mcp --stdio
 ```
 
-The package is restricted until launch. Public release requires changing npm access to `public`, bumping the MCP package version, and publishing through the tag-gated release workflow.
+Future MCP package releases are published from protected `mcp-vX.Y.Z` tags through the trusted-publishing workflow.
 
 ## MCP Client Config
 
@@ -94,7 +93,7 @@ wrangler secret put INTERNAL_JOB_TOKEN
 
 ## Canonical API
 
-Private beta endpoints use `Authorization: Bearer <GITTENSORY_API_TOKEN>` or a Gittensory OAuth session where supported.
+Protected endpoints use `Authorization: Bearer <GITTENSORY_API_TOKEN>` or a Gittensory OAuth session where supported.
 
 - `GET /health`
 - `GET /openapi.json`
@@ -153,7 +152,7 @@ npm run docs:build
 npm run docs:preview
 ```
 
-The Pages workflow builds the docs on `main`, but deploys only when the repository variable `GITTENSORY_DOCS_DEPLOY` is set to `true`.
+The Pages workflow builds the docs on `main` for `https://gittensory.aethereal.dev/`, but deploys only when the repository variable `GITTENSORY_DOCS_DEPLOY` is set to `true`.
 
 ## Validation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7566,7 +7566,7 @@
     },
     "packages/gittensory-mcp": {
       "name": "@jsonbored/gittensory-mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -2,27 +2,26 @@
 
 Local stdio MCP wrapper for Gittensory contributor intelligence.
 
-It inspects local git metadata and calls the private Gittensory API for branch preflight, score blockers, reward/risk reasoning, contributor decision packs, and public-safe PR packets. It does not upload source contents in v1.
+It inspects local git metadata and calls the Gittensory API for branch preflight, score blockers, reward/risk reasoning, contributor decision packs, and public-safe PR packets. It does not upload source contents in v1.
 
 ## Status
 
-The package is restricted during private beta. Public npm install will be enabled only after the launch gate passes.
+The package is public beta. Gittensory still keeps sensitive score, trust, and maintainer context out of public PR comments.
 
 ## Install
 
-Private beta from the repo:
+Public npm:
+
+```sh
+npm install -g @jsonbored/gittensory-mcp
+gittensory-mcp login
+```
+
+From a local checkout:
 
 ```sh
 npm install
 npm link --workspace @jsonbored/gittensory-mcp
-gittensory-mcp login
-```
-
-Public npm path once launched:
-
-```sh
-npx @jsonbored/gittensory-mcp login
-npm install -g @jsonbored/gittensory-mcp
 ```
 
 ## Commands

--- a/packages/gittensory-mcp/package.json
+++ b/packages/gittensory-mcp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@jsonbored/gittensory-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "AGPL-3.0-only",
   "type": "module",
-  "description": "Local stdio MCP wrapper for private Gittensory contributor intelligence.",
+  "description": "Local stdio MCP wrapper for Gittensory contributor intelligence.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JSONbored/gittensory.git",
@@ -22,7 +22,7 @@
     "preflight"
   ],
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "bin": {
     "gittensory-mcp": "bin/gittensory-mcp.js"

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitepress";
 
-const siteUrl = process.env.GITTENSORY_SITE_URL ?? "https://jsonbored.github.io/gittensory/";
-const siteBase = process.env.GITTENSORY_SITE_BASE ?? "/gittensory/";
+const siteUrl = process.env.GITTENSORY_SITE_URL ?? "https://gittensory.aethereal.dev/";
+const siteBase = process.env.GITTENSORY_SITE_BASE ?? "/";
 
 export default defineConfig({
   title: "Gittensory",

--- a/site/guide/github-app-setup.md
+++ b/site/guide/github-app-setup.md
@@ -4,7 +4,7 @@ The GitHub App is the maintainer/install surface. GitHub OAuth is the MCP user-a
 
 ## Basic Fields
 
-Use these values for private beta:
+Use these values:
 
 | Field | Value |
 | --- | --- |
@@ -74,4 +74,4 @@ Before Marketplace submission, add:
 - clear setup flow
 - valid webhook and install diagnostics
 
-Do not submit while Gittensory is private beta or invite-only.
+Do not submit until the privacy, support, terms, install diagnostics, and public setup flow are complete.

--- a/site/guide/install.md
+++ b/site/guide/install.md
@@ -1,10 +1,23 @@
 # Install
 
-Gittensory has two install paths: private beta from the repository, and public npm once the package is intentionally launched.
+Gittensory has two install paths: public npm for normal use, and local checkout for development.
 
-## Private Beta
+## Public npm
 
-Use this while `JSONbored/gittensory` is still private.
+Use this for Codex, Claude Desktop, Cursor, or any other stdio MCP client:
+
+```sh
+npm install -g @jsonbored/gittensory-mcp
+gittensory-mcp login
+gittensory-mcp status
+gittensory-mcp --stdio
+```
+
+The login command uses GitHub Device Flow and stores a short-lived Gittensory session token in your local config directory.
+
+## Local checkout
+
+Use this when developing Gittensory itself:
 
 ```sh
 git clone https://github.com/JSONbored/gittensory.git
@@ -12,29 +25,8 @@ cd gittensory
 npm install
 npm link --workspace @jsonbored/gittensory-mcp
 gittensory-mcp login
-gittensory-mcp status
-```
-
-After login, start the MCP server with:
-
-```sh
 gittensory-mcp --stdio
 ```
-
-The login command uses GitHub Device Flow and stores a short-lived Gittensory session token in your local config directory.
-
-## Public npm
-
-This path is prepared but stays disabled until public launch.
-
-```sh
-npx @jsonbored/gittensory-mcp login
-npm install -g @jsonbored/gittensory-mcp
-gittensory-mcp status
-gittensory-mcp --stdio
-```
-
-The package should remain restricted until the launch gate passes. Public launch means changing npm publish access to `public`, bumping the MCP package version, and publishing from the release workflow.
 
 ## Verify The Install
 

--- a/site/index.md
+++ b/site/index.md
@@ -30,7 +30,7 @@ features:
 
 ## What Gittensory Is
 
-Gittensory is a private backend intelligence layer for Gittensor registered repositories.
+Gittensory is a backend intelligence layer for Gittensor registered repositories.
 It helps Gittensor miners and contributors decide what to work on next, and it helps maintainers understand whether a Gittensor-driven PR is clean, duplicate-prone, stale, missing evidence, or worth reviewing.
 
 It is not a Gittensor frontend, not a public leaderboard, and not a reward estimator for public comments. The useful surface is the signal: role-aware repo context, official Gittensor stats, local branch preflight, queue health, duplicate risk, and maintainer-friendly review packets.
@@ -45,4 +45,4 @@ It is not a Gittensor frontend, not a public leaderboard, and not a reward estim
 
 ## Current Status
 
-Gittensory is still private beta. The MCP package remains restricted until the public launch gate passes, but the install flow is already shaped for a simple public npm path.
+Gittensory is public beta. The MCP package is public, while sensitive score, trust, and maintainer context stays in authenticated API/MCP/check-run surfaces.

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+gittensory.aethereal.dev

--- a/site/reference/api.md
+++ b/site/reference/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-The REST API is private beta and bearer-token protected except for `/health`, GitHub webhook delivery, and public auth start/poll endpoints.
+The REST API is bearer-token protected except for `/health`, GitHub webhook delivery, and public auth start/poll endpoints.
 
 Use the live OpenAPI document when authenticated:
 
@@ -46,4 +46,4 @@ curl "$GITTENSORY_API_URL/openapi.json" \
 
 ## MCP Endpoint
 
-`POST /mcp` exposes remote private-beta MCP over Streamable HTTP style requests. The local npm wrapper is still the preferred MCP user surface.
+`POST /mcp` exposes remote MCP over Streamable HTTP style requests. The local npm wrapper is still the preferred MCP user surface.

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## `gittensory-mcp: command not found`
 
-For private beta:
+If the command is not installed globally:
 
 ```sh
 npm link --workspace @jsonbored/gittensory-mcp


### PR DESCRIPTION
## Summary
- prepare the repository docs and MCP package metadata for public launch
- switch the MCP package publish config and release workflow to public npm access
- point the docs site at gittensory.aethereal.dev with a Pages CNAME

## What changed
- updated README and docs install flows for public npm usage
- bumped @jsonbored/gittensory-mcp to 0.1.2 and set npm access to public
- updated GitHub Pages build config for the custom docs domain
- removed stale private-beta and restricted-package language from public docs

## Why
- the repo and MCP package need public-safe metadata before visibility and npm access are changed
- docs should match the intended public domain and install flow before launch

## Validation
- git diff --check
- gitleaks detect --source . --redact --no-banner
- tracked-file sensitive-pattern scan
- actionlint .github/workflows/*.yml
- npm run docs:check
- npm run docs:build
- npm run test:mcp-pack
- npm pack --workspace @jsonbored/gittensory-mcp --dry-run --json
- npm run test:ci

## Notes
- root package remains private for npm workspace safety
- only @jsonbored/gittensory-mcp is publishable
- CI may be blocked by account billing, but the full local gate passed before launch