### PR TITLE
docs(site): align public docs with gittensor aesthetic

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -9,11 +9,15 @@ export default defineConfig({
   base: siteBase,
   cleanUrls: true,
   lastUpdated: true,
+  appearance: false,
   head: [
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
+    ["link", { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" }],
     ["meta", { property: "og:title", content: "Gittensory" }],
     ["meta", { property: "og:description", content: "Private decision intelligence for healthier Gittensor repo participation." }],
     ["meta", { property: "og:url", content: siteUrl }],
-    ["meta", { name: "theme-color", content: "#111827" }],
+    ["meta", { name: "theme-color", content: "#050608" }],
   ],
   themeConfig: {
     logo: "/logo.svg",

--- a/site/.vitepress/theme/custom.css
+++ b/site/.vitepress/theme/custom.css
@@ -1,38 +1,526 @@
 :root {
-  --vp-c-brand-1: #2563eb;
-  --vp-c-brand-2: #1d4ed8;
-  --vp-c-brand-3: #60a5fa;
-  --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(110deg, #2563eb, #10b981 55%, #f59e0b);
-  --vp-c-bg: #f8fafc;
-  --vp-c-bg-alt: #eef2f7;
-  --vp-c-bg-soft: #eef6ff;
+  color-scheme: dark;
+  --gt-black: #050608;
+  --gt-ink: #0d1117;
+  --gt-panel: #11161f;
+  --gt-panel-soft: #151b23;
+  --gt-line: #30363d;
+  --gt-line-strong: #3d444d;
+  --gt-text: #f0f6fc;
+  --gt-muted: #9198a1;
+  --gt-dim: #6e7681;
+  --gt-blue: #031cdc;
+  --gt-blue-soft: #4493f8;
+  --gt-green: #7ee787;
+  --gt-green-soft: #3fb950;
+  --gt-amber: #f2cc60;
+  --gt-red: #f85149;
+
+  --vp-c-bg: var(--gt-black);
+  --vp-c-bg-alt: var(--gt-ink);
+  --vp-c-bg-elv: var(--gt-panel);
+  --vp-c-bg-soft: var(--gt-panel-soft);
+  --vp-c-divider: rgba(61, 68, 77, 0.82);
+  --vp-c-divider-light: rgba(61, 68, 77, 0.48);
+  --vp-c-text-1: var(--gt-text);
+  --vp-c-text-2: #c9d1d9;
+  --vp-c-text-3: var(--gt-muted);
+  --vp-c-brand-1: var(--gt-green);
+  --vp-c-brand-2: var(--gt-green-soft);
+  --vp-c-brand-3: #214f32;
+  --vp-c-brand-soft: rgba(126, 231, 135, 0.12);
+  --vp-c-gutter: rgba(61, 68, 77, 0.8);
+  --vp-button-brand-bg: var(--gt-text);
+  --vp-button-brand-border: var(--gt-text);
+  --vp-button-brand-text: var(--gt-black);
+  --vp-button-brand-hover-bg: var(--gt-green);
+  --vp-button-brand-hover-border: var(--gt-green);
+  --vp-button-brand-hover-text: var(--gt-black);
+  --vp-button-alt-bg: transparent;
+  --vp-button-alt-border: var(--gt-line-strong);
+  --vp-button-alt-text: var(--gt-text);
+  --vp-button-alt-hover-bg: var(--gt-panel-soft);
+  --vp-button-alt-hover-border: var(--gt-green);
+  --vp-button-alt-hover-text: var(--gt-green);
+  --vp-code-color: var(--gt-green);
+  --vp-code-bg: rgba(101, 108, 118, 0.2);
+  --vp-font-family-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --vp-font-family-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --vp-home-hero-name-color: var(--gt-text);
+  --vp-home-hero-name-background: none;
 }
 
-.dark {
-  --vp-c-bg: #0f172a;
-  --vp-c-bg-alt: #111827;
-  --vp-c-bg-soft: #182033;
+* {
+  box-sizing: border-box;
 }
 
-.VPHome .main {
-  max-width: 1120px;
+html,
+body {
+  background: var(--gt-black);
 }
 
-.VPHomeHero .text {
+body {
+  font-family: var(--vp-font-family-base);
+  letter-spacing: 0;
+  overflow-x: hidden;
+}
+
+::selection {
+  background: var(--gt-blue);
+  color: #fff;
+}
+
+.VPNav {
+  border-bottom: 1px solid rgba(61, 68, 77, 0.72);
+  background: rgba(5, 6, 8, 0.92);
+  backdrop-filter: blur(14px);
+}
+
+.VPNavBar.has-sidebar .content {
+  background: transparent;
+}
+
+.VPNavBarTitle .title {
+  font-weight: 700;
   letter-spacing: 0;
 }
 
+.VPNavBarTitle .logo {
+  border-radius: 0;
+}
+
+.VPNavBarMenuLink {
+  color: var(--gt-muted);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.VPNavBarMenuLink:hover,
+.VPNavBarMenuLink.active {
+  color: var(--gt-text);
+}
+
+.VPHome {
+  background:
+    linear-gradient(180deg, rgba(3, 28, 220, 0.14), transparent 260px),
+    radial-gradient(circle at 72% 20%, rgba(126, 231, 135, 0.1), transparent 330px),
+    var(--gt-black);
+}
+
+.VPHome .main {
+  max-width: 1180px;
+}
+
+.VPHomeHero {
+  padding-top: 92px !important;
+  padding-bottom: 44px !important;
+}
+
+.VPHomeHero .container {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 430px);
+  gap: 48px;
+  max-width: 1180px;
+}
+
+.VPHomeHero .main {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.VPHomeHero .name,
+.VPHomeHero .text {
+  max-width: 780px;
+  letter-spacing: 0;
+}
+
+.VPHomeHero .name {
+  font-size: clamp(56px, 8vw, 112px);
+  line-height: 0.9;
+  font-weight: 800;
+}
+
+.VPHomeHero .text {
+  margin-top: 20px;
+  color: #d7dee8;
+  font-size: clamp(24px, 3.4vw, 44px);
+  line-height: 1;
+  font-weight: 600;
+}
+
+.VPHomeHero .tagline {
+  max-width: 660px;
+  color: var(--gt-muted);
+  font-size: 17px;
+  line-height: 1.7;
+}
+
+.VPHomeHero .actions {
+  justify-content: flex-start;
+}
+
+.VPButton {
+  border-radius: 4px !important;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.VPHomeHero .image {
+  display: block;
+}
+
+.VPHomeHero .image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 420px;
+  height: 420px;
+  transform: none !important;
+}
+
+.VPHomeHero .image-bg {
+  display: none;
+}
+
+.VPHomeHero .image-src {
+  position: static !important;
+  width: min(100%, 420px);
+  max-width: 420px !important;
+  height: auto;
+  border: 1px solid var(--gt-line-strong);
+  border-radius: 0;
+  background: linear-gradient(180deg, var(--gt-panel), var(--gt-black));
+  box-shadow: 0 0 0 1px rgba(126, 231, 135, 0.08), 0 24px 80px rgba(0, 0, 0, 0.38);
+  transform: none !important;
+}
+
+.VPFeatures {
+  padding: 28px 24px 72px !important;
+}
+
+.VPFeatures .container {
+  max-width: 1180px;
+}
+
+.VPFeatures .items {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px !important;
+  border: 1px solid var(--gt-line);
+  background: var(--gt-line);
+}
+
+.VPFeatures .item {
+  width: auto !important;
+  padding: 0 !important;
+}
+
 .VPFeature {
-  border-radius: 8px;
+  height: 100%;
+  min-height: 168px;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--gt-ink) !important;
+  padding: 22px !important;
+}
+
+.VPFeature .title {
+  color: var(--gt-text);
+  font-family: var(--vp-font-family-mono);
+  font-size: 13px;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.VPFeature .details {
+  color: var(--gt-muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.vp-doc {
+  color: #d7dee8;
+}
+
+.VPDoc,
+.VPDoc .container,
+.VPDoc .content,
+.VPDoc .content-container,
+.VPDoc .main {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3 {
+  color: var(--gt-text);
+  letter-spacing: 0;
+}
+
+.vp-doc h1 {
+  font-size: 40px;
+  line-height: 1.05;
 }
 
 .vp-doc h2 {
+  margin-top: 44px;
   border-top: 1px solid var(--vp-c-divider);
-  padding-top: 24px;
+  border-bottom: 0;
+  padding-top: 22px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 18px;
+  text-transform: uppercase;
+}
+
+.vp-doc h3 {
+  font-size: 18px;
+}
+
+.vp-doc p,
+.vp-doc li {
+  color: #c9d1d9;
+  line-height: 1.72;
+}
+
+.vp-doc a {
+  color: var(--gt-green);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.vp-doc blockquote {
+  border-left-color: var(--gt-green);
+  background: rgba(126, 231, 135, 0.06);
+}
+
+.vp-doc div[class*="language-"],
+.vp-doc pre {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--gt-line);
+  border-radius: 0;
+  background: #0d1117 !important;
+}
+
+.vp-doc code {
+  border-radius: 4px;
 }
 
 .vp-doc table {
   display: table;
   width: 100%;
+  border: 1px solid var(--gt-line);
+}
+
+.vp-doc th,
+.vp-doc td {
+  border-color: var(--gt-line) !important;
+}
+
+.vp-doc tr {
+  background: var(--gt-ink);
+}
+
+.vp-doc tr:nth-child(2n) {
+  background: var(--gt-panel-soft);
+}
+
+.VPSidebar {
+  background: var(--gt-ink) !important;
+  border-right: 1px solid var(--gt-line);
+}
+
+.VPSidebarItem .text {
+  color: var(--gt-muted);
+}
+
+.VPSidebarItem.is-active > .item .text {
+  color: var(--gt-green);
+}
+
+.VPDocAsideOutline .content {
+  border-left-color: var(--gt-line);
+}
+
+.VPFooter {
+  border-top: 1px solid var(--gt-line);
+  background: var(--gt-black);
+}
+
+.gtn-home {
+  max-width: 1180px;
+  margin: 0 auto 72px;
+  padding: 0 24px;
+}
+
+.gtn-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--gt-line);
+  background: var(--gt-line);
+}
+
+.gtn-strip__item {
+  min-height: 112px;
+  padding: 20px;
+  background: var(--gt-ink);
+}
+
+.gtn-kicker {
+  color: var(--gt-green);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.gtn-strip__item strong {
+  display: block;
+  margin-top: 12px;
+  color: var(--gt-text);
+  font-size: 22px;
+  line-height: 1.1;
+}
+
+.gtn-strip__item span {
+  display: block;
+  margin-top: 8px;
+  color: var(--gt-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.gtn-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: 1px;
+  margin-top: 28px;
+  border: 1px solid var(--gt-line);
+  background: var(--gt-line);
+}
+
+.gtn-panel > section {
+  background: var(--gt-ink);
+  padding: 28px;
+}
+
+.gtn-panel h2 {
+  margin: 0;
+  color: var(--gt-text);
+  font-size: clamp(30px, 5vw, 56px);
+  line-height: 0.98;
+}
+
+.gtn-panel p {
+  max-width: 640px;
+  color: var(--gt-muted);
+  font-size: 16px;
+  line-height: 1.72;
+}
+
+.gtn-terminal {
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+}
+
+.gtn-terminal div {
+  display: flex;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(61, 68, 77, 0.58);
+}
+
+.gtn-terminal div:last-child {
+  border-bottom: 0;
+}
+
+.gtn-terminal b {
+  min-width: 78px;
+  color: var(--gt-green);
+  font-weight: 600;
+}
+
+.gtn-terminal span {
+  color: #c9d1d9;
+}
+
+@media (max-width: 960px) {
+  .VPHomeHero .container,
+  .gtn-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .VPHomeHero .image {
+    order: -1;
+  }
+
+  .VPHomeHero .image-src {
+    width: 220px;
+  }
+
+  .gtn-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .VPFeatures .items {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .VPDoc {
+    padding: 0 24px !important;
+  }
+
+  .VPDoc .container,
+  .VPDoc .content,
+  .VPDoc .content-container,
+  .VPDoc .main,
+  .vp-doc {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .VPDocAside {
+    display: none !important;
+  }
+
+  .vp-doc p,
+  .vp-doc li {
+    overflow-wrap: anywhere;
+  }
+
+  .VPHomeHero {
+    padding-top: 64px !important;
+  }
+
+  .VPHomeHero .name {
+    font-size: 54px;
+  }
+
+  .VPHomeHero .text {
+    font-size: 26px;
+  }
+
+  .gtn-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .VPFeatures .items {
+    grid-template-columns: 1fr;
+  }
+
+  .gtn-panel > section {
+    padding: 22px;
+  }
 }

--- a/site/index.md
+++ b/site/index.md
@@ -3,8 +3,11 @@ layout: home
 
 hero:
   name: Gittensory
-  text: Gittensor repo intelligence for miners, maintainers, and coding agents.
-  tagline: Backend-only signals, MCP branch preflight, and GitHub App review context. Not a Gittensor frontend.
+  text: Private repo intelligence for Gittensor work.
+  tagline: "For Gittensor miners, maintainers, and agents: MCP preflight, scoreability projections, and GitHub App review packets. Still not a Gittensor frontend."
+  image:
+    src: /logo.svg
+    alt: Gittensory signal mark
   actions:
     - theme: brand
       text: Install MCP
@@ -14,35 +17,58 @@ hero:
       link: /guide/github-app-setup
 
 features:
-  - title: Miner Decision Packs
-    details: Rank next actions with private reward/risk reasoning, lane context, score blockers, open PR pressure, and maintainer friction.
-  - title: Local MCP Preflight
-    details: Let Codex, Claude, Cursor, and other MCP clients inspect branch metadata without uploading source contents.
-  - title: Maintainer Reviewability
-    details: Generate PR packets, check runs, duplicate context, and public-safe guidance that reduces noisy Gittensor-driven review load.
-  - title: Registry-Aware Signals
-    details: Normalize Gittensor registry data, repo lanes, label multipliers, queue health, collisions, bounties, and configuration readiness.
-  - title: Private By Default
-    details: GitHub OAuth sessions are short-lived Gittensory tokens. User PATs are not stored. Public comments never include private score context.
-  - title: API First
-    details: The API is the product surface. Lovable or other frontends can consume it later without turning Gittensory into another Gittensor dashboard.
+  - title: Scoreability
+    details: Current estimate, ungated potential, and near-term what-if scenarios.
+  - title: Queue Pressure
+    details: Open PR gates, stale branches, duplicate risk, and cleanup-first actions.
+  - title: Role Context
+    details: Contributor lane, maintainer lane, owner history, and repo-specific evidence.
+  - title: Reviewability
+    details: Private maintainer packets plus public-safe PR guidance.
+  - title: Registry Signals
+    details: Repo lanes, label multipliers, issue discovery, bounties, and config drift.
+  - title: MCP Native
+    details: Codex, Claude, Cursor, and agents get structured JSON without code upload.
 ---
 
-## What Gittensory Is
+<div class="gtn-home">
+  <div class="gtn-strip">
+    <div class="gtn-strip__item">
+      <div class="gtn-kicker">01 / Miners</div>
+      <strong>Pick work with less guesswork.</strong>
+      <span>Score blockers, lane fit, stale base checks, and cleanup-first guidance.</span>
+    </div>
+    <div class="gtn-strip__item">
+      <div class="gtn-kicker">02 / Maintainers</div>
+      <strong>Review signal, not noise.</strong>
+      <span>Role-aware context, duplicate risk, validation evidence, and next action.</span>
+    </div>
+    <div class="gtn-strip__item">
+      <div class="gtn-kicker">03 / Agents</div>
+      <strong>Local branch context.</strong>
+      <span>Metadata-only MCP tools for Codex, Claude, Cursor, and automation.</span>
+    </div>
+    <div class="gtn-strip__item">
+      <div class="gtn-kicker">04 / Privacy</div>
+      <strong>Private by default.</strong>
+      <span>No PAT storage, no source upload, no public score or wallet leakage.</span>
+    </div>
+  </div>
 
-Gittensory is a backend intelligence layer for Gittensor registered repositories.
-It helps Gittensor miners and contributors decide what to work on next, and it helps maintainers understand whether a Gittensor-driven PR is clean, duplicate-prone, stale, missing evidence, or worth reviewing.
-
-It is not a Gittensor frontend, not a public leaderboard, and not a reward estimator for public comments. The useful surface is the signal: role-aware repo context, official Gittensor stats, local branch preflight, queue health, duplicate risk, and maintainer-friendly review packets.
-
-## Primary Surfaces
-
-| Surface | Who uses it | What it does |
-| --- | --- | --- |
-| MCP package | miners and coding agents | Runs local branch analysis, score blocker checks, preflight, and PR packet generation. |
-| REST API | internal tools and future clients | Serves decision packs, repo intelligence, reviewability, readiness, and branch analysis. |
-| GitHub App | maintainers and repo owners | Adds private check-run intelligence and optional public-safe PR comments. |
-
-## Current Status
-
-Gittensory is public beta. The MCP package is public, while sensitive score, trust, and maintainer context stays in authenticated API/MCP/check-run surfaces.
+  <div class="gtn-panel">
+    <section>
+      <h2>Not another Gittensor frontend.</h2>
+      <p>
+        Gittensory is the private signal layer behind better contributions:
+        official miner context, registry lanes, queue pressure, scoreability
+        projections, maintainer friction, and public-safe PR packets.
+      </p>
+    </section>
+    <section class="gtn-terminal" aria-label="Gittensory signal example">
+      <div><b>lane</b><span>direct_pr / issue_discovery / maintainer</span></div>
+      <div><b>score</b><span>current 0, potential visible, scenario gated</span></div>
+      <div><b>risk</b><span>open PR pressure, credibility, stale base</span></div>
+      <div><b>output</b><span>private MCP JSON + sanitized PR packet</span></div>
+    </section>
+  </div>
+</div>

--- a/site/public/logo.svg
+++ b/site/public/logo.svg
@@ -1,5 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Gittensory">
-  <rect width="48" height="48" rx="10" fill="#0f172a"/>
-  <path d="M13 16h22v4H13zM13 23h14v4H13zM13 30h22v4H13z" fill="#93c5fd"/>
-  <path d="M31 22l5 4-5 4z" fill="#34d399"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="360" viewBox="0 0 360 360" role="img" aria-label="Gittensory">
+  <rect width="360" height="360" fill="#050608"/>
+  <path d="M56 72h248v216H56z" fill="#0d1117" stroke="#3d444d" stroke-width="2"/>
+  <path d="M88 112h126v18H88zm0 52h184v18H88zm0 52h112v18H88z" fill="#f0f6fc"/>
+  <path d="M240 102h32v32h-32zm-24 52h56v32h-56zm32 52h24v32h-24z" fill="#7ee787"/>
+  <path d="M56 72h248M56 288h248M56 72v216M304 72v216" fill="none" stroke="#3d444d" stroke-width="2"/>
+  <path d="M56 72h48M56 72v48M304 288h-48M304 288v-48" fill="none" stroke="#7ee787" stroke-width="6"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the generic light/blue docs theme with a dark Gittensor-style visual system
- tighten the homepage copy into compact signal blocks and a technical landing panel
- update the docs logo and typography for a black/white/green technical feel

## What changed
- forces the docs site into a dark scheme with Inter and JetBrains Mono
- uses Gittensor-adjacent colors: black surfaces, white text, muted dividers, blue selection, and green signal accents
- fixes desktop feature-grid layout and mobile document overflow

## Validation
- `git diff --check`
- `npm run docs:check`
- `npm run docs:build`
- Chrome headless desktop and mobile screenshot QA

## Notes
- this only changes the public docs site, not the Worker API or MCP package