### PR TITLE
fix(docs): add explicit favicon metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,9 @@
 
 
 
+### Fixes
+
+- Add explicit favicon metadata
+
+
+

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -31,6 +31,7 @@ export default defineConfig({
   lastUpdated: true,
   appearance: false,
   head: [
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/logo.svg" }],
     ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
     ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
     ["link", { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" }],


### PR DESCRIPTION
## Summary
- add explicit SVG favicon metadata to the VitePress docs head
- update the root changelog for the docs polish fix

## What changed
- links `/logo.svg` as the docs favicon
- keeps GitHub Pages as the only docs deployment path

## Why
- browser smoke found a `/favicon.ico` 404 after the version-widget deployment

## Validation
- `npm run docs:build`
- `npm run docs:smoke`
- `npm run test:ci`
