### PR TITLE
docs(changelog): refresh homepage fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 
 - Add explicit favicon metadata
 
-- Restore Nightward-style homepage flow
+- Restore Nightward-style homepage flow (#9)
 
 
 


### PR DESCRIPTION
## Summary
- refreshes the root changelog after the homepage fix was squash-merged

## What changed
- updates the homepage fix changelog entry to include the merged PR reference

## Why
The changelog check is generated from the merged commit metadata. After squash merge, the committed changelog needed the PR number added by git-cliff.

## Validation
- `npm run changelog:check`
