### PR TITLE
fix(docs): use Gittensor screenshot in homepage hero

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ on:
       - "mcp-v*.*.*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -66,3 +66,26 @@ jobs:
 
       - name: Publish with npm trusted publishing
         run: npx -y npm@11.15.0 publish --workspace @jsonbored/gittensory-mcp --access public --provenance
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#mcp-v}"
+          NOTES_FILE="$(mktemp)"
+          cat > "$NOTES_FILE" <<EOF
+          Published [@jsonbored/gittensory-mcp v${VERSION}](https://www.npmjs.com/package/@jsonbored/gittensory-mcp/v/${VERSION}) to npm with provenance.
+
+          Install:
+
+          \`\`\`sh
+          npm install -g @jsonbored/gittensory-mcp@${VERSION}
+          \`\`\`
+          EOF
+          if gh release view "$REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$REF_NAME" --repo "$GITHUB_REPOSITORY" --title "@jsonbored/gittensory-mcp v${VERSION}" --notes-file "$NOTES_FILE"
+          else
+            gh release create "$REF_NAME" --repo "$GITHUB_REPOSITORY" --title "@jsonbored/gittensory-mcp v${VERSION}" --notes-file "$NOTES_FILE" --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,5 +57,7 @@
 
 - Restore Nightward-style homepage flow (#9)
 
+- Use Gittensor screenshot in homepage hero
+
 
 

--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+
+### Fixes
+
+- Use Gittensor screenshot in homepage hero
+
+
 ## mcp-v0.1.4 - 2026-05-26
 
 

--- a/site/.vitepress/theme/custom.css
+++ b/site/.vitepress/theme/custom.css
@@ -256,28 +256,29 @@ body {
 }
 
 .VPHomeHero {
-  padding-top: 76px !important;
-  padding-bottom: 36px !important;
+  padding-top: 124px !important;
+  padding-bottom: 42px !important;
 }
 
 .VPHomeHero .container {
   max-width: 1120px;
+  gap: 52px;
 }
 
 .VPHomeHero .main {
-  max-width: 740px;
+  max-width: 600px;
 }
 
 .VPHomeHero .name {
-  font-size: clamp(44px, 7vw, 78px);
+  font-size: clamp(42px, 5.4vw, 68px);
   line-height: 0.95;
 }
 
 .VPHomeHero .text {
-  max-width: 760px;
+  max-width: 640px;
   color: var(--gt-text);
-  font-size: clamp(32px, 4vw, 54px);
-  line-height: 1.08;
+  font-size: clamp(28px, 3.25vw, 44px);
+  line-height: 1.12;
 }
 
 .VPHomeHero .tagline {
@@ -287,9 +288,29 @@ body {
   line-height: 1.65;
 }
 
+.VPHomeHero .image {
+  flex: 1 1 460px;
+  min-width: 0;
+}
+
+.VPHomeHero .image-container {
+  transform: none;
+}
+
+.VPHomeHero .image-bg {
+  opacity: 0.54;
+}
+
 .VPHome .image-src {
-  width: 220px;
-  height: 220px;
+  width: min(45vw, 560px);
+  max-width: 100%;
+  height: auto;
+  border: 1px solid rgba(126, 231, 135, 0.28);
+  border-radius: 8px;
+  background: #050608;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 24px 70px rgba(0, 0, 0, 0.48);
 }
 
 .VPButton {
@@ -477,76 +498,21 @@ body {
   white-space: nowrap;
 }
 
-.gtn-context-media {
-  display: grid;
-  grid-template-columns: minmax(240px, 0.56fr) minmax(340px, 1fr);
-  align-items: center;
-  gap: 28px;
-  margin: 34px 0 42px;
-}
-
-.gtn-context-media__copy h2 {
-  margin: 6px 0 10px;
-  border: 0;
-  padding: 0;
-  color: var(--gt-text);
-  font-size: 26px;
-  line-height: 1.2;
-  text-transform: none;
-}
-
-.gtn-context-media__copy p {
-  margin: 0;
-  color: var(--gt-muted);
-}
-
-.gtn-context-media__links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 18px !important;
-}
-
-.gtn-context-media__links a {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--gt-line);
-  border-radius: 999px;
-  padding: 7px 12px;
-  color: var(--gt-text);
-  font-size: 13px;
-  font-weight: 800;
-  text-decoration: none;
-}
-
-.gtn-context-media__links a:hover {
-  border-color: rgba(126, 231, 135, 0.44);
-  color: var(--gt-green);
-}
-
-.gtn-context-media__frame {
-  display: block;
-  overflow: hidden;
-  border: 1px solid rgba(126, 231, 135, 0.24);
-  border-radius: 8px;
-  background: #05080b;
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
-}
-
-.gtn-context-media__frame img {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
 @media (max-width: 960px) {
-  .gtn-install-strip,
-  .gtn-context-media {
-    grid-template-columns: 1fr;
+  .VPHomeHero {
+    padding-top: 96px !important;
   }
 
-  .gtn-context-media {
-    gap: 18px;
+  .VPHomeHero .container {
+    gap: 32px;
+  }
+
+  .VPHome .image-src {
+    width: min(82vw, 560px);
+  }
+
+  .gtn-install-strip {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -583,7 +549,7 @@ body {
   }
 
   .VPHomeHero {
-    padding-top: 56px !important;
+    padding-top: 82px !important;
   }
 
   .VPHomeHero .name {
@@ -602,8 +568,7 @@ body {
   }
 
   .VPHome .image-src {
-    width: 168px;
-    height: 168px;
+    width: min(88vw, 420px);
   }
 
   .gtn-install-strip {
@@ -611,7 +576,4 @@ body {
     padding: 18px;
   }
 
-  .gtn-context-media {
-    grid-template-columns: 1fr;
-  }
 }

--- a/site/index.md
+++ b/site/index.md
@@ -6,8 +6,8 @@ hero:
   text: Know the Gittensor lane before you submit.
   tagline: MCP branch analysis and GitHub App context for score blockers, queue pressure, lane fit, and maintainer review load. Not a Gittensor frontend.
   image:
-    src: /logo.svg
-    alt: Gittensory logo
+    src: /images/gittensor-home-signal.webp
+    alt: Gittensor homepage showing live miner, reward, and repository activity.
   actions:
     - theme: brand
       text: Install MCP
@@ -55,36 +55,16 @@ Prefer a full setup first? Start with [install](/guide/install), run `gittensory
 
 ## Where It Fits
 
-| Audience | What Gittensory adds |
+| Audience | Gittensory adds |
 | --- | --- |
 | Gittensor miners | Scoreability blockers, lane fit, queue pressure, local diff quality, and cleanup-first guidance. |
-| Maintainers | Confirmed-miner context, sticky public-safe comments, configured labels, and private reviewability packets. |
+| Maintainers | Confirmed-miner comments, configured labels, and private reviewability packets. |
 | Coding agents | Structured MCP tools for repo context, current branch preflight, next actions, and PR packet drafting. |
 | Repo owners | Config quality, label readiness, maintainer-lane handling, and contribution intake health. |
 
-<section class="gtn-context-media" aria-labelledby="gtn-context-title">
-  <div class="gtn-context-media__copy">
-    <p class="gtn-eyebrow">Gittensor context</p>
-    <h2 id="gtn-context-title">Built around the live contribution market, not another dashboard.</h2>
-    <p>
-      Gittensory reads the Gittensor and GitHub signals that affect contribution quality:
-      registered repo lanes, miner history, open PR pressure, linked issue context, and maintainer friction.
-    </p>
-    <p class="gtn-context-media__links">
-      <a href="https://gittensor.io/" target="_blank" rel="noreferrer">Open Gittensor</a>
-      <a href="/guide/miners">Miner workflow</a>
-      <a href="/guide/maintainers">Maintainer workflow</a>
-    </p>
-  </div>
-  <a class="gtn-context-media__frame" href="https://gittensor.io/" target="_blank" rel="noreferrer" aria-label="Open Gittensor">
-    <img
-      src="/images/gittensor-home-signal.webp"
-      alt="Gittensor homepage showing live miner, reward, and repository activity."
-      width="1180"
-      height="660"
-    />
-  </a>
-</section>
+## Gittensor Context
+
+Gittensory reads the signals that affect contribution quality: registered repo lanes, official miner context, open PR pressure, linked issue expectations, local validation evidence, and maintainer friction. It turns those into MCP/API guidance and sanitized GitHub App output.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- moves the real Gittensor screenshot into the homepage hero and removes the generic logo-art hero image
- adds more top spacing and tightens the homepage hero type scale
- updates the MCP publish workflow so future package tags create/update a GitHub Release after npm trusted publishing

## What changed
- uses `/images/gittensor-home-signal.webp` as the VitePress homepage hero image
- removes the duplicated lower screenshot block and simplifies the lower context copy
- adjusts desktop/mobile hero spacing, image sizing, and headline scale
- grants the publish workflow `contents: write` so it can create GitHub Releases for `mcp-v*` tags
- adds an idempotent release creation/edit step after the npm publish step
- refreshes root and MCP changelogs

## Why
The previous page still had the screenshot buried near the bottom, used unrelated logo art in the hero, and sat too close to the navbar. The package release also had a tag but no GitHub Release, so the repo sidebar did not show a release version.

## Validation
- `npm run test:ci`

## Notes
- `@jsonbored/gittensory-mcp@0.1.4` already has npm provenance attestation.
- GitHub Packages sidebar remains empty unless we intentionally publish a duplicate package to GitHub Packages; npm registry packages do not show there.
