### PR TITLE
fix(changelog): strip squash PR suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,11 @@
 
 - Add explicit favicon metadata
 
-- Restore Nightward-style homepage flow (#9)
+- Restore Nightward-style homepage flow
 
 - Use Gittensor screenshot in homepage hero
+
+- Strip squash PR suffixes
 
 
 

--- a/cliff.mcp.toml
+++ b/cliff.mcp.toml
@@ -24,6 +24,10 @@ split_commits = false
 tag_pattern = "^mcp-v[0-9].*"
 sort_commits = "oldest"
 
+commit_preprocessors = [
+  { pattern = " \\(#[0-9]+\\)$", replace = "" },
+]
+
 commit_parsers = [
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Fixes" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,6 +24,10 @@ split_commits = false
 tag_pattern = "^v[0-9].*"
 sort_commits = "oldest"
 
+commit_preprocessors = [
+  { pattern = " \\(#[0-9]+\\)$", replace = "" },
+]
+
 commit_parsers = [
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Fixes" },


### PR DESCRIPTION
## Summary
- strips GitHub squash-merge PR suffixes from generated changelog entries
- refreshes the root changelog after the homepage/release workflow merge

## What changed
- adds a git-cliff commit preprocessor to both root and MCP changelog configs
- removes generated `(#123)` suffix drift from changelog comparisons

## Why
GitHub squash merges append the PR number to the commit subject. Without preprocessing, every squash merge that touches changelogs can make `changelog:check` fail on `main` even when the PR passed before merge.

## Validation
- `npm run test:ci`
