### PR TITLE
fix(changelog): label mcp release workflow changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,5 +61,7 @@
 
 - Strip squash PR suffixes
 
+- Label mcp release workflow changes
+
 
 

--- a/cliff.mcp.toml
+++ b/cliff.mcp.toml
@@ -26,6 +26,7 @@ sort_commits = "oldest"
 
 commit_preprocessors = [
   { pattern = " \\(#[0-9]+\\)$", replace = "" },
+  { pattern = "^fix\\(docs\\): use Gittensor screenshot in homepage hero$", replace = "fix(release): create GitHub releases for MCP tag publishes" },
 ]
 
 commit_parsers = [

--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### Fixes
 
-- Use Gittensor screenshot in homepage hero
+- Create GitHub releases for MCP tag publishes
+
+- Label mcp release workflow changes
 
 
 ## mcp-v0.1.4 - 2026-05-26


### PR DESCRIPTION
## Summary
- labels the mixed homepage/release workflow commit correctly in the MCP changelog

## What changed
- adds an MCP changelog preprocessor for the prior mixed commit
- updates `packages/gittensory-mcp/CHANGELOG.md` to describe the release workflow impact instead of the docs visual change

## Why
The MCP changelog should track npm/package/release behavior. The prior commit touched the publish workflow and docs, but its title was docs-focused, which made the MCP changelog misleading.

## Validation
- `npm run test:ci`
