### PR TITLE
feat(scoring): detect approved and mergeable pending PR scenarios

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -100,6 +100,7 @@ import {
 } from "../signals/engine";
 import { attachDataQuality, buildCoreSignalFidelity, buildFreshnessSloReport, buildRepoDataQuality, buildSignalFidelity } from "../signals/data-quality";
 import { buildPullRequestReviewability } from "../signals/reward-risk";
+import { loadContributorRepoOpenPrSignalRecords } from "../scoring/pending-pr-scenarios";
 import { buildLocalBranchAnalysis } from "../signals/local-branch";
 import { buildRepoSettingsPreview } from "../signals/settings-preview";
 import type { ContributorEvidenceRecord, JobMessage, JsonValue, RepoSyncSegmentRecord } from "../types";
@@ -752,6 +753,12 @@ export function createApp() {
       listRecentMergedPullRequests(c.env, parsed.data.repoFullName),
       getOrCreateScoringModelSnapshot(c.env),
     ]);
+    const openPrSignals = await loadContributorRepoOpenPrSignalRecords(
+      c.env,
+      parsed.data.repoFullName,
+      parsed.data.login,
+      pullRequests,
+    );
     const fit = buildContributorFit(context.profile, context.repositories, [], [], context.syncStates, context.repoStats);
     const scoringProfile = buildContributorScoringProfile({ login: parsed.data.login, fit, scoringSnapshot: snapshot });
     const analysis = buildLocalBranchAnalysis({
@@ -759,6 +766,7 @@ export function createApp() {
       repo,
       issues,
       pullRequests,
+      ...openPrSignals,
       recentMergedPullRequests,
       profile: context.profile,
       outcomeHistory: context.outcomeHistory,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -51,6 +51,7 @@ import {
   buildRegistryChangeReport,
   buildRoleContext,
 } from "../signals/engine";
+import { loadContributorRepoOpenPrSignalRecords } from "../scoring/pending-pr-scenarios";
 import { buildLocalBranchAnalysis } from "../signals/local-branch";
 import { buildRepoDataQuality } from "../signals/data-quality";
 
@@ -748,6 +749,7 @@ export class GittensoryMcp {
       listRecentMergedPullRequests(this.env, input.repoFullName),
       getOrCreateScoringModelSnapshot(this.env),
     ]);
+    const openPrSignals = await loadContributorRepoOpenPrSignalRecords(this.env, input.repoFullName, input.login, pullRequests);
     const fit = buildContributorFit(context.profile, context.repositories, [], [], context.syncStates, context.repoStats);
     const scoringProfile = buildContributorScoringProfile({ login: input.login, fit, scoringSnapshot: snapshot });
     return {
@@ -756,6 +758,7 @@ export class GittensoryMcp {
         repo,
         issues,
         pullRequests,
+        ...openPrSignals,
         recentMergedPullRequests,
         profile: context.profile,
         outcomeHistory: context.outcomeHistory,

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -830,7 +830,7 @@ const ScoreGateDeltaSchema = z.object({
 
 const ScoreScenarioPreviewSchema = z.object({
   name: z.enum(["current", "cleanGates", "afterPendingMerges", "linkedIssueFixed", "bestReasonableCase"]),
-  source: z.enum(["current_data", "user_supplied", "gittensory_projection"]),
+  source: z.enum(["current_data", "user_supplied", "gittensory_projection", "github_observed"]),
   assumptions: z.array(z.string()),
   scoreEstimate: ScoreEstimateSchema,
   gates: ScoreGatesSchema,
@@ -1274,6 +1274,25 @@ export const LocalBranchAnalysisSchema = z
       publicSafeWarnings: z.array(z.string()),
     }),
     nextActions: z.array(RewardRiskActionSchema),
+    detectedPendingScenario: z
+      .object({
+        source: z.enum(["github_observed", "user_supplied"]),
+        pendingMergedPrCount: z.number().int().min(0),
+        pendingClosedPrCount: z.number().int().min(0),
+        approvedPrCount: z.number().int().min(0),
+        expectedOpenPrCountAfterMerge: z.number().int().min(0).optional(),
+        scenarioNotes: z.array(z.string()),
+        classified: z.array(
+          z.object({
+            repoFullName: z.string(),
+            number: z.number().int(),
+            title: z.string(),
+            classification: z.enum(["merge_ready", "stale_likely_close", "draft", "blocked", "maintainer_lane", "open_other"]),
+            reasons: z.array(z.string()),
+          }),
+        ),
+      })
+      .optional(),
     summary: z.string(),
   })
   .openapi("LocalBranchAnalysis");

--- a/src/scoring/pending-pr-scenarios.ts
+++ b/src/scoring/pending-pr-scenarios.ts
@@ -1,0 +1,238 @@
+import { listCheckSummaries, listPullRequestReviews } from "../db/repositories";
+import { isMaintainerAssociation } from "../github/commands";
+import type { CheckSummaryRecord, PullRequestRecord, PullRequestReviewRecord } from "../types";
+import type { RoleContext } from "../signals/engine";
+import type { ScorePreviewInput } from "./preview";
+
+export type OpenPrPendingClass =
+  | "merge_ready"
+  | "stale_likely_close"
+  | "draft"
+  | "blocked"
+  | "maintainer_lane"
+  | "open_other";
+
+export type ClassifiedOpenPullRequest = {
+  repoFullName: string;
+  number: number;
+  title: string;
+  classification: OpenPrPendingClass;
+  reasons: string[];
+};
+
+export type PendingPrScenarioDetection = {
+  source: "github_observed" | "user_supplied";
+  pendingMergedPrCount: number;
+  pendingClosedPrCount: number;
+  approvedPrCount: number;
+  expectedOpenPrCountAfterMerge?: number | undefined;
+  scenarioNotes: string[];
+  classified: ClassifiedOpenPullRequest[];
+};
+
+export type ContributorRepoOpenPrSignals = {
+  reviewsByPullNumber: Map<number, PullRequestReviewRecord[]>;
+  checksByPullNumber: Map<number, CheckSummaryRecord[]>;
+};
+
+const STALE_DAYS = 14;
+
+export async function loadContributorRepoOpenPrSignalRecords(
+  env: Env,
+  repoFullName: string,
+  login: string,
+  pullRequests: PullRequestRecord[],
+): Promise<{ pullRequestReviews: PullRequestReviewRecord[]; pullRequestChecks: CheckSummaryRecord[] }> {
+  const open = pullRequests.filter(
+    (pr) => pr.repoFullName === repoFullName && pr.state === "open" && sameLogin(pr.authorLogin, login),
+  );
+  const signals = await loadContributorRepoOpenPrSignals(env, repoFullName, open);
+  return {
+    pullRequestReviews: [...signals.reviewsByPullNumber.values()].flat(),
+    pullRequestChecks: [...signals.checksByPullNumber.values()].flat(),
+  };
+}
+
+export async function loadContributorRepoOpenPrSignals(
+  env: Env,
+  repoFullName: string,
+  pullRequests: PullRequestRecord[],
+): Promise<ContributorRepoOpenPrSignals> {
+  const open = pullRequests.filter((pr) => pr.repoFullName === repoFullName && pr.state === "open");
+  const reviewsByPullNumber = new Map<number, PullRequestReviewRecord[]>();
+  const checksByPullNumber = new Map<number, CheckSummaryRecord[]>();
+  await Promise.all(
+    open.map(async (pr) => {
+      const [reviews, checks] = await Promise.all([
+        listPullRequestReviews(env, repoFullName, pr.number),
+        listCheckSummaries(env, repoFullName, pr.number),
+      ]);
+      reviewsByPullNumber.set(pr.number, reviews);
+      checksByPullNumber.set(pr.number, checks);
+    }),
+  );
+  return { reviewsByPullNumber, checksByPullNumber };
+}
+
+export function detectPendingPrScenario(args: {
+  login: string;
+  repoFullName: string;
+  pullRequests: PullRequestRecord[];
+  roleContext: RoleContext;
+  openPrCount?: number | undefined;
+  reviewsByPullNumber?: Map<number, PullRequestReviewRecord[]> | undefined;
+  checksByPullNumber?: Map<number, CheckSummaryRecord[]> | undefined;
+  excludePullNumbers?: number[] | undefined;
+  userSupplied?: Pick<
+    ScorePreviewInput,
+    "pendingMergedPrCount" | "pendingClosedPrCount" | "approvedPrCount" | "expectedOpenPrCountAfterMerge" | "projectedCredibility" | "scenarioNotes"
+  > | undefined;
+}): PendingPrScenarioDetection | null {
+  const user = args.userSupplied;
+  const hasUserCounts =
+    user?.pendingMergedPrCount !== undefined ||
+    user?.pendingClosedPrCount !== undefined ||
+    user?.approvedPrCount !== undefined ||
+    user?.expectedOpenPrCountAfterMerge !== undefined;
+  if (hasUserCounts) {
+    return {
+      source: "user_supplied",
+      pendingMergedPrCount: nonNegative(user?.pendingMergedPrCount),
+      pendingClosedPrCount: nonNegative(user?.pendingClosedPrCount),
+      approvedPrCount: nonNegative(user?.approvedPrCount),
+      ...(user?.expectedOpenPrCountAfterMerge !== undefined ? { expectedOpenPrCountAfterMerge: nonNegative(user.expectedOpenPrCountAfterMerge) } : {}),
+      scenarioNotes: user?.scenarioNotes ?? [],
+      classified: [],
+    };
+  }
+
+  const excluded = new Set(args.excludePullNumbers ?? []);
+  const contributorOpen = args.pullRequests.filter(
+    (pr) =>
+      pr.repoFullName === args.repoFullName &&
+      pr.state === "open" &&
+      sameLogin(pr.authorLogin, args.login) &&
+      !excluded.has(pr.number),
+  );
+  if (contributorOpen.length === 0) return null;
+
+  const classified = contributorOpen.map((pr) =>
+    classifyOpenPullRequest({
+      pr,
+      roleContext: args.roleContext,
+      reviews: args.reviewsByPullNumber?.get(pr.number) ?? [],
+      checks: args.checksByPullNumber?.get(pr.number) ?? [],
+    }),
+  );
+
+  const mergeReady = classified.filter((entry) => entry.classification === "merge_ready");
+  const staleLikelyClose = classified.filter((entry) => entry.classification === "stale_likely_close");
+  const pendingMergedPrCount = mergeReady.length;
+  const pendingClosedPrCount = staleLikelyClose.length;
+  if (pendingMergedPrCount === 0 && pendingClosedPrCount === 0) return null;
+
+  const currentOpen = args.openPrCount ?? contributorOpen.length;
+  const expectedOpenPrCountAfterMerge = Math.max(0, currentOpen - pendingMergedPrCount - pendingClosedPrCount);
+  const scenarioNotes = [
+    "GitHub-observed open PR state from cached reviews, checks, and activity timestamps (estimate only).",
+    ...(pendingMergedPrCount > 0
+      ? [`${pendingMergedPrCount} open PR(s) look merge-ready (approved, no changes requested, no failing checks, not draft/stale).`]
+      : []),
+    ...(pendingClosedPrCount > 0 ? [`${pendingClosedPrCount} open PR(s) look stale and may be closed instead of merged.`] : []),
+    ...classified
+      .filter((entry) => entry.classification === "draft" || entry.classification === "blocked" || entry.classification === "maintainer_lane")
+      .map((entry) => `PR #${entry.number} treated as ${entry.classification.replace(/_/g, " ")} for this projection.`),
+  ];
+
+  return {
+    source: "github_observed",
+    pendingMergedPrCount,
+    pendingClosedPrCount,
+    approvedPrCount: 0,
+    expectedOpenPrCountAfterMerge,
+    scenarioNotes,
+    classified,
+  };
+}
+
+export function classifyOpenPullRequest(args: {
+  pr: PullRequestRecord;
+  roleContext: RoleContext;
+  reviews: PullRequestReviewRecord[];
+  checks: CheckSummaryRecord[];
+}): ClassifiedOpenPullRequest {
+  const reasons: string[] = [];
+  if (args.roleContext.maintainerLane) {
+    reasons.push("Maintainer-lane context for this repo; not counted as outside-contributor pending reward work.");
+    return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "maintainer_lane", reasons };
+  }
+  if (isMaintainerAssociation(args.pr.authorAssociation)) {
+    reasons.push("Author association indicates maintainer-authored work.");
+    return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "maintainer_lane", reasons };
+  }
+  if (isDraftPullRequest(args.pr)) {
+    reasons.push("Draft PRs are not treated as likely to land.");
+    return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "draft", reasons };
+  }
+
+  const approvalCount = args.reviews.filter((review) => review.state.toUpperCase() === "APPROVED").length;
+  const changeRequestCount = args.reviews.filter((review) => review.state.toUpperCase() === "CHANGES_REQUESTED").length;
+  const checkFailureCount = args.checks.filter(
+    (check) => check.conclusion === "failure" || check.conclusion === "timed_out" || check.conclusion === "cancelled",
+  ).length;
+  const ageDays = daysSince(args.pr.updatedAt ?? args.pr.createdAt);
+
+  if (changeRequestCount > 0) reasons.push(`${changeRequestCount} changes-requested review(s).`);
+  if (checkFailureCount > 0) reasons.push(`${checkFailureCount} failing or cancelled check(s).`);
+  if (approvalCount === 0) reasons.push("No approved review in cache.");
+
+  if (changeRequestCount > 0 || checkFailureCount > 0 || approvalCount === 0) {
+    return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "blocked", reasons };
+  }
+
+  if (ageDays >= STALE_DAYS) {
+    reasons.push(`No meaningful update in at least ${STALE_DAYS} days; may be closed instead of merged.`);
+    return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "stale_likely_close", reasons };
+  }
+
+  reasons.push("Approved with passing checks and recent activity; treated as likely to merge (estimate).");
+  return { repoFullName: args.pr.repoFullName, number: args.pr.number, title: args.pr.title, classification: "merge_ready", reasons };
+}
+
+export function applyPendingPrDetectionToScoreInput(
+  input: ScorePreviewInput,
+  detection: PendingPrScenarioDetection | null,
+): ScorePreviewInput {
+  if (!detection || detection.source === "user_supplied") return input;
+  return {
+    ...input,
+    pendingMergedPrCount: detection.pendingMergedPrCount,
+    pendingClosedPrCount: detection.pendingClosedPrCount,
+    approvedPrCount: detection.approvedPrCount,
+    expectedOpenPrCountAfterMerge: detection.expectedOpenPrCountAfterMerge,
+    scenarioNotes: [...(input.scenarioNotes ?? []), ...detection.scenarioNotes],
+    pendingScenarioObserved: true,
+  };
+}
+
+function isDraftPullRequest(pr: PullRequestRecord): boolean {
+  const title = pr.title.trim();
+  if (/^\[?\s*draft\s*\]?/i.test(title) || /^draft:/i.test(title)) return true;
+  return pr.labels.some((label) => label.toLowerCase() === "draft" || label.toLowerCase() === "wip");
+}
+
+function sameLogin(value: string | null | undefined, login: string): boolean {
+  return Boolean(value && value.toLowerCase() === login.toLowerCase());
+}
+
+function daysSince(value: string | null | undefined): number {
+  if (!value) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, (Date.now() - parsed) / 86_400_000);
+}
+
+function nonNegative(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}

--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -25,6 +25,7 @@ export type ScorePreviewInput = {
   expectedOpenPrCountAfterMerge?: number | undefined;
   projectedCredibility?: number | undefined;
   scenarioNotes?: string[] | undefined;
+  pendingScenarioObserved?: boolean | undefined;
 };
 
 export type ScoreGateBlocker = {
@@ -49,7 +50,7 @@ export type ScoreGateDelta = {
 
 export type ScoreScenarioPreview = {
   name: "current" | "cleanGates" | "afterPendingMerges" | "linkedIssueFixed" | "bestReasonableCase";
-  source: "current_data" | "user_supplied" | "gittensory_projection";
+  source: "current_data" | "user_supplied" | "gittensory_projection" | "github_observed";
   assumptions: string[];
   scoreEstimate: ScorePreviewResult["scoreEstimate"];
   gates: ScorePreviewResult["gates"];
@@ -303,12 +304,18 @@ function buildScenarioPreviews(
     ], repo),
     scenario(
       "afterPendingMerges",
-      pendingCount > 0 || input.expectedOpenPrCountAfterMerge !== undefined || input.projectedCredibility !== undefined ? "user_supplied" : "gittensory_projection",
+      pendingCount > 0 || input.expectedOpenPrCountAfterMerge !== undefined || input.projectedCredibility !== undefined
+        ? input.pendingScenarioObserved
+          ? "github_observed"
+          : "user_supplied"
+        : "gittensory_projection",
       afterPendingInput,
       computeScoreCore(afterPendingInput, repo, snapshot, contributorEvidence),
       [
         pendingCount > 0
-          ? `${pendingCount} supplied pending approved/merged/closed PR(s) are treated as no longer open for this scenario.`
+          ? input.pendingScenarioObserved
+            ? `${pendingCount} cached open PR(s) classified as likely merge/close are treated as no longer open for this estimate.`
+            : `${pendingCount} supplied pending approved/merged/closed PR(s) are treated as no longer open for this scenario.`
           : "No pending merge/close count was supplied; this scenario preserves current open PR pressure.",
         ...(input.projectedCredibility !== undefined
           ? [`Projected credibility is user-supplied as ${roundScore(projectedCredibility)}.`]

--- a/src/services/agent-orchestrator.ts
+++ b/src/services/agent-orchestrator.ts
@@ -23,6 +23,7 @@ import { getOrCreateScoringModelSnapshot } from "../scoring/model";
 import { loadContributorDecisionPackForServing, repoDecisionFromPack, type ContributorDecisionPack, type DecisionAction, type RepoDecision } from "./decision-pack";
 import { summarizeAgentBundleWithAi } from "./ai-summaries";
 import { buildContributorFit, buildContributorOutcomeHistory, buildContributorProfile, buildContributorScoringProfile } from "../signals/engine";
+import { loadContributorRepoOpenPrSignalRecords } from "../scoring/pending-pr-scenarios";
 import { buildLocalBranchAnalysis, type LocalBranchAnalysis, type LocalBranchAnalysisInput } from "../signals/local-branch";
 import type {
   AgentActionRecord,
@@ -300,11 +301,13 @@ async function analyzeLocalBranch(env: Env, input: LocalBranchAnalysisInput): Pr
   const outcomeHistory = buildContributorOutcomeHistory({ login: input.login, profile, repositories, pullRequests: contributorPullRequests, issues: contributorIssues, repoStats });
   const fit = buildContributorFit(profile, repositories, [], [], syncStates, repoStats);
   const scoringProfile = buildContributorScoringProfile({ login: input.login, fit, scoringSnapshot });
+  const openPrSignals = await loadContributorRepoOpenPrSignalRecords(env, input.repoFullName, input.login, pullRequests);
   return buildLocalBranchAnalysis({
     input,
     repo,
     issues,
     pullRequests,
+    ...openPrSignals,
     recentMergedPullRequests,
     profile,
     outcomeHistory,

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1,6 +1,19 @@
 import type { ScorePreviewInput, ScorePreviewResult } from "../scoring/preview";
 import { buildScorePreview } from "../scoring/preview";
-import type { IssueRecord, PullRequestRecord, RecentMergedPullRequestRecord, RepositoryRecord, ScoringModelSnapshotRecord } from "../types";
+import {
+  applyPendingPrDetectionToScoreInput,
+  detectPendingPrScenario,
+  type PendingPrScenarioDetection,
+} from "../scoring/pending-pr-scenarios";
+import type {
+  CheckSummaryRecord,
+  IssueRecord,
+  PullRequestRecord,
+  PullRequestReviewRecord,
+  RecentMergedPullRequestRecord,
+  RepositoryRecord,
+  ScoringModelSnapshotRecord,
+} from "../types";
 import { nowIso } from "../utils/json";
 import {
   buildLaneAdvice,
@@ -98,6 +111,7 @@ export type LocalBranchAnalysis = {
     gateDeltas: ScorePreviewResult["gateDeltas"];
     blockedBy: ScorePreviewResult["blockedBy"];
   };
+  detectedPendingScenario?: PendingPrScenarioDetection | undefined;
   rewardRisk: RepoRewardRisk;
   scoreBlockers: string[];
   branchQualityBlockers: string[];
@@ -140,6 +154,8 @@ export function buildLocalBranchAnalysis(args: {
   repo: RepositoryRecord | null;
   issues: IssueRecord[];
   pullRequests: PullRequestRecord[];
+  pullRequestReviews?: PullRequestReviewRecord[] | undefined;
+  pullRequestChecks?: CheckSummaryRecord[] | undefined;
   recentMergedPullRequests?: RecentMergedPullRequestRecord[] | undefined;
   profile: ContributorProfile;
   outcomeHistory: ContributorOutcomeHistory;
@@ -180,16 +196,32 @@ export function buildLocalBranchAnalysis(args: {
   });
   const lane = buildLaneAdvice(args.repo, args.input.repoFullName);
   const repoOutcome = args.outcomeHistory.repoOutcomes.find((outcome) => sameRepo(outcome.repoFullName, args.input.repoFullName));
-  const scoreInput = buildLocalScoreInput({
-    input: args.input,
-    changedFiles,
-    changedLineCount,
-    testFiles,
-    linkedIssueCount: preflight.linkedIssues.length,
-    roleContext,
-    outcomeHistory: args.outcomeHistory,
-    repoOutcome,
-  });
+  const reviewsByPullNumber = indexReviewsByPullNumber(args.pullRequestReviews ?? [], args.input.repoFullName);
+  const checksByPullNumber = indexChecksByPullNumber(args.pullRequestChecks ?? [], args.input.repoFullName);
+  const detectedPendingScenario =
+    detectPendingPrScenario({
+      login: args.input.login,
+      repoFullName: args.input.repoFullName,
+      pullRequests: args.pullRequests,
+      roleContext,
+      openPrCount: repoOutcome?.openPullRequests ?? args.outcomeHistory.totals.openPullRequests,
+      reviewsByPullNumber,
+      checksByPullNumber,
+      userSupplied: args.input,
+    }) ?? undefined;
+  const scoreInput = applyPendingPrDetectionToScoreInput(
+    buildLocalScoreInput({
+      input: args.input,
+      changedFiles,
+      changedLineCount,
+      testFiles,
+      linkedIssueCount: preflight.linkedIssues.length,
+      roleContext,
+      outcomeHistory: args.outcomeHistory,
+      repoOutcome,
+    }),
+    detectedPendingScenario ?? null,
+  );
   const scorePreview = buildScorePreview({
     input: scoreInput,
     repo: args.repo,
@@ -260,6 +292,7 @@ export function buildLocalBranchAnalysis(args: {
     preflight,
     scorePreview,
     scenarioScorePreview,
+    ...(detectedPendingScenario ? { detectedPendingScenario } : {}),
     rewardRisk,
     scoreBlockers: [...new Set(scoreBlockers)],
     branchQualityBlockers,
@@ -625,6 +658,28 @@ function isCodeFile(file: string): boolean {
 
 function sameRepo(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
+}
+
+function indexReviewsByPullNumber(records: PullRequestReviewRecord[], repoFullName: string): Map<number, PullRequestReviewRecord[]> {
+  const map = new Map<number, PullRequestReviewRecord[]>();
+  for (const record of records) {
+    if (record.repoFullName !== repoFullName) continue;
+    const current = map.get(record.pullNumber) ?? [];
+    current.push(record);
+    map.set(record.pullNumber, current);
+  }
+  return map;
+}
+
+function indexChecksByPullNumber(records: CheckSummaryRecord[], repoFullName: string): Map<number, CheckSummaryRecord[]> {
+  const map = new Map<number, CheckSummaryRecord[]>();
+  for (const record of records) {
+    if (record.repoFullName !== repoFullName || record.pullNumber === undefined || record.pullNumber === null) continue;
+    const current = map.get(record.pullNumber) ?? [];
+    current.push(record);
+    map.set(record.pullNumber, current);
+  }
+  return map;
 }
 
 function nonNegative(value: number | undefined): number {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -114,6 +114,72 @@ describe("local branch analysis", () => {
     expect(analysis.nextActions[0]?.whyThisHelps.join(" ")).toMatch(/waiting for pending PRs/i);
   });
 
+  it("auto-detects merge-ready open PRs from cached reviews when pending counts are omitted", () => {
+    const pressuredHistory: ContributorOutcomeHistory = {
+      ...outcomeHistory,
+      totals: { ...outcomeHistory.totals, openPullRequests: 3, credibility: 1 },
+      repoOutcomes: [
+        {
+          ...outcomeHistory.repoOutcomes[0]!,
+          openPullRequests: 3,
+          credibility: 1,
+        },
+      ],
+    };
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        branchName: "fix-queue",
+        changedFiles: [{ path: "src/cache.ts", additions: 20, deletions: 2, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 48, totalTokenScore: 70, sourceLines: 40 },
+      },
+      repo,
+      issues: [],
+      pullRequests: [
+        {
+          repoFullName: repo.fullName,
+          number: 201,
+          title: "Approved queue fix",
+          state: "open",
+          authorLogin: "oktofeesh1",
+          labels: [],
+          linkedIssues: [7],
+          createdAt: "2026-05-25T00:00:00.000Z",
+          updatedAt: "2026-05-27T00:00:00.000Z",
+        },
+        {
+          repoFullName: repo.fullName,
+          number: 202,
+          title: "Draft experiment",
+          state: "open",
+          authorLogin: "oktofeesh1",
+          labels: ["draft"],
+          linkedIssues: [],
+          createdAt: "2026-05-25T00:00:00.000Z",
+          updatedAt: "2026-05-27T00:00:00.000Z",
+        },
+      ],
+      pullRequestReviews: [
+        { id: "r-201", repoFullName: repo.fullName, pullNumber: 201, state: "APPROVED", payload: {} },
+      ],
+      pullRequestChecks: [],
+      profile,
+      outcomeHistory: pressuredHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.detectedPendingScenario).toMatchObject({
+      source: "github_observed",
+      pendingMergedPrCount: 1,
+      pendingClosedPrCount: 0,
+    });
+    expect(analysis.detectedPendingScenario?.classified.find((entry) => entry.number === 202)?.classification).toBe("draft");
+    expect(analysis.scenarioScorePreview.afterPendingMerges?.source).toBe("github_observed");
+    expect(analysis.scenarioScorePreview.afterPendingMerges?.effectiveEstimatedScore).toBeGreaterThan(0);
+  });
+
   it("classifies stale base state and treats passed validation as test evidence", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {

--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePublicComment } from "../../src/github/commands";
+import {
+  classifyOpenPullRequest,
+  detectPendingPrScenario,
+} from "../../src/scoring/pending-pr-scenarios";
+import { buildScorePreview } from "../../src/scoring/preview";
+import type { PullRequestRecord, PullRequestReviewRecord, ScoringModelSnapshotRecord } from "../../src/types";
+import type { RoleContext } from "../../src/signals/engine";
+
+const outsideContributorRole: RoleContext = {
+  login: "miner-a",
+  repoFullName: "entrius/allways-ui",
+  generatedAt: "2026-05-28T00:00:00.000Z",
+  role: "outside_contributor",
+  maintainerLane: false,
+  normalContributorEvidenceAllowed: true,
+  source: "cache",
+  association: "NONE",
+  reasons: [],
+  guidance: "contributor",
+};
+
+const maintainerRole: RoleContext = {
+  ...outsideContributorRole,
+  login: "repo-owner",
+  role: "owner",
+  maintainerLane: true,
+  normalContributorEvidenceAllowed: false,
+  source: "repo_owner_match",
+  guidance: "maintainer",
+};
+
+function pr(overrides: Partial<PullRequestRecord> & Pick<PullRequestRecord, "number">): PullRequestRecord {
+  return {
+    repoFullName: "entrius/allways-ui",
+    title: `PR #${overrides.number}`,
+    state: "open",
+    authorLogin: "miner-a",
+    labels: [],
+    linkedIssues: [1],
+    createdAt: "2026-05-20T00:00:00.000Z",
+    updatedAt: "2026-05-27T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function approvedReview(pullNumber: number): PullRequestReviewRecord {
+  return {
+    id: `review-${pullNumber}`,
+    repoFullName: "entrius/allways-ui",
+    pullNumber,
+    state: "APPROVED",
+    payload: {},
+  };
+}
+
+describe("pending PR scenario detection", () => {
+  it("treats approved-but-unmerged PRs as merge-ready pending work", () => {
+    const detection = detectPendingPrScenario({
+      login: "miner-a",
+      repoFullName: "entrius/allways-ui",
+      pullRequests: [pr({ number: 11 }), pr({ number: 12, title: "blocked work" })],
+      roleContext: outsideContributorRole,
+      openPrCount: 3,
+      reviewsByPullNumber: new Map([
+        [11, [approvedReview(11)]],
+        [12, [{ ...approvedReview(12), state: "CHANGES_REQUESTED" }]],
+      ]),
+      checksByPullNumber: new Map([
+        [11, []],
+        [12, []],
+      ]),
+    });
+    expect(detection).toMatchObject({
+      source: "github_observed",
+      pendingMergedPrCount: 1,
+      pendingClosedPrCount: 0,
+      expectedOpenPrCountAfterMerge: 2,
+    });
+    expect(detection?.classified.find((entry) => entry.number === 12)?.classification).toBe("blocked");
+  });
+
+  it("does not treat draft, stale, or maintainer-lane PRs as likely-to-land", () => {
+    const staleDate = new Date(Date.now() - 20 * 86_400_000).toISOString();
+    const classified = [
+      classifyOpenPullRequest({
+        pr: pr({ number: 1, title: "Draft: experiment", labels: ["draft"] }),
+        roleContext: outsideContributorRole,
+        reviews: [approvedReview(1)],
+        checks: [],
+      }),
+      classifyOpenPullRequest({
+        pr: pr({ number: 2, updatedAt: staleDate, createdAt: staleDate }),
+        roleContext: outsideContributorRole,
+        reviews: [approvedReview(2)],
+        checks: [],
+      }),
+      classifyOpenPullRequest({
+        pr: pr({ number: 3, authorAssociation: "MEMBER" }),
+        roleContext: outsideContributorRole,
+        reviews: [approvedReview(3)],
+        checks: [],
+      }),
+      classifyOpenPullRequest({
+        pr: pr({ number: 4 }),
+        roleContext: maintainerRole,
+        reviews: [approvedReview(4)],
+        checks: [],
+      }),
+    ];
+    expect(classified.map((entry) => entry.classification)).toEqual(["draft", "stale_likely_close", "maintainer_lane", "maintainer_lane"]);
+  });
+
+  it("labels user-supplied assumptions separately from GitHub-observed state", () => {
+    const user = detectPendingPrScenario({
+      login: "miner-a",
+      repoFullName: "entrius/allways-ui",
+      pullRequests: [pr({ number: 9 })],
+      roleContext: outsideContributorRole,
+      userSupplied: { pendingMergedPrCount: 2, scenarioNotes: ["manual assumption"] },
+    });
+    expect(user?.source).toBe("user_supplied");
+
+    const observed = detectPendingPrScenario({
+      login: "miner-a",
+      repoFullName: "entrius/allways-ui",
+      pullRequests: [pr({ number: 10 })],
+      roleContext: outsideContributorRole,
+      reviewsByPullNumber: new Map([[10, [approvedReview(10)]]]),
+      checksByPullNumber: new Map([[10, []]]),
+    });
+    expect(observed?.source).toBe("github_observed");
+    expect(observed?.scenarioNotes[0]).toMatch(/GitHub-observed/i);
+  });
+
+  it("keeps effective score distinct from underlying potential in observed after-pending scenario", () => {
+    const snapshot: ScoringModelSnapshotRecord = {
+      id: "score-model-fixture",
+      sourceKind: "test",
+      sourceUrl: "fixture://constants.py",
+      fetchedAt: "2026-05-23T00:00:00.000Z",
+      activeModel: "current_density_model",
+      constants: {
+        OSS_EMISSION_SHARE: 0.9,
+        MERGED_PR_BASE_SCORE: 25,
+        MIN_TOKEN_SCORE_FOR_BASE_SCORE: 5,
+        MAX_CODE_DENSITY_MULTIPLIER: 1.15,
+        MAX_CONTRIBUTION_BONUS: 25,
+        CONTRIBUTION_SCORE_FOR_FULL_BONUS: 1500,
+        STANDARD_ISSUE_MULTIPLIER: 1.33,
+        MAINTAINER_ISSUE_MULTIPLIER: 1.66,
+        MIN_CREDIBILITY: 0.8,
+        REVIEW_PENALTY_RATE: 0.15,
+        EXCESSIVE_PR_PENALTY_BASE_THRESHOLD: 2,
+        OPEN_PR_THRESHOLD_TOKEN_SCORE: 300,
+        MAX_OPEN_PR_THRESHOLD: 30,
+        OPEN_PR_COLLATERAL_PERCENT: 0.2,
+        SRC_TOK_SATURATION_SCALE: 58,
+      },
+      programmingLanguages: {},
+      registrySnapshotId: "registry-fixture",
+      warnings: [],
+      payload: {},
+    };
+    const preview = buildScorePreview({
+      repo: {
+        fullName: "entrius/allways-ui",
+        owner: "entrius",
+        name: "allways-ui",
+        isInstalled: false,
+        isRegistered: true,
+        isPrivate: false,
+        registryConfig: { repo: "entrius/allways-ui", emissionShare: 0.02, issueDiscoveryShare: 0.25, labelMultipliers: {}, maintainerCut: 0, raw: {} },
+      },
+      snapshot,
+      input: {
+        repoFullName: "entrius/allways-ui",
+        sourceTokenScore: 60,
+        totalTokenScore: 90,
+        sourceLines: 50,
+        openPrCount: 3,
+        credibility: 1,
+        pendingMergedPrCount: 1,
+        pendingScenarioObserved: true,
+      },
+    });
+    const afterPending = preview.scenarioPreviews.find((scenario) => scenario.name === "afterPendingMerges");
+    expect(preview.effectiveEstimatedScore).toBe(0);
+    expect(preview.underlyingPotentialScore).toBeGreaterThan(0);
+    expect(afterPending?.source).toBe("github_observed");
+    expect(afterPending?.effectiveEstimatedScore).toBeGreaterThan(0);
+  });
+
+  it("sanitizes public comment text that mentions score, reward, wallet, or hotkey language", () => {
+    const dirty =
+      "Estimated score 42, reward estimate, wallet abc, hotkey xyz, payout farming, reviewability ranking, raw trust score.";
+    expect(sanitizePublicComment(dirty)).not.toMatch(/estimated score|reward estimate|wallet|hotkey|payout|farming|reviewability|raw trust score/i);
+    expect(sanitizePublicComment(dirty)).toContain("private context");
+  });
+});


### PR DESCRIPTION
## Summary

Miners can now get realistic `afterPendingMerges` score previews from cached GitHub PR state instead of only manual pending counts.

- Classifies open PRs as merge-ready, stale (likely close), draft, blocked, or maintainer-lane
- Loads cached reviews/checks for contributor open PRs in local branch analysis (API, MCP, agent)
- Labels scenarios as `github_observed` vs `user_supplied` vs projection
- Draft/stale/blocked/maintainer PRs are excluded from likely-to-land pending merge pressure

Fixes #17

## Test plan
- [x] `npm test -- --run test/unit/pending-pr-scenarios.test.ts test/unit/local-branch.test.ts test/unit/github-commands.test.ts` (22/22)
- [x] `npm run typecheck`

Made with [Cursor](https://cursor.com)