### PR TITLE
fix(ci): isolate GitHub write token to release job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,8 +6,7 @@ on:
       - "mcp-v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: npm-publish-${{ github.ref_name }}
@@ -16,12 +15,16 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -67,6 +70,13 @@ jobs:
       - name: Publish with npm trusted publishing
         run: npx -y npm@11.15.0 publish --workspace @jsonbored/gittensory-mcp --access public --provenance
 
+  github-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Motivation
- Remediate a workflow-level elevation where `contents: write` left a write-scoped `github.token` available during dependency/tooling steps in `.github/workflows/npm-publish.yml`.
- Prevent the default `actions/checkout` behavior from persisting potentially dangerous write credentials into local git config before untrusted package/tooling execution.
- Ensure GitHub release creation (which requires write) is executed in a minimal, isolated job after validation and publishing complete.

### Description
- Changed the workflow-level permission in `.github/workflows/npm-publish.yml` from `contents: write` to `contents: read`.
- Scoped the `publish` job with `permissions: contents: read` and `id-token: write` so tooling steps run with read-only repo access.
- Added `persist-credentials: false` to the `actions/checkout` step to avoid writing the token into git config before `npm ci`/tests/build steps.
- Moved the GitHub release creation into a new `github-release` job that runs `needs: publish` and is the only job granted `contents: write` and which uses `GH_TOKEN: ${{ github.token }}`.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check failures and succeeded.
- Validated YAML syntactic correctness with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-publish.yml")'` which succeeded.
- Attempted `npm run actionlint` but it was blocked by network/DNS resolution in the environment (`github-actionlint: getaddrinfo EAI_AGAIN github.com`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1955917924832cab05cd9dc091ddd9)