### PR TITLE
fix: restrict session access to private advisory data

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { z } from "zod";
 import { createSessionFromGitHubToken, pollGitHubDeviceFlow, startGitHubDeviceFlow } from "../auth/github-oauth";
 import { enforceRateLimit, routeClassForPath } from "../auth/rate-limit";
-import { authenticateInternalToken, authenticatePrivateToken, authenticateSessionToken, extractBearerToken, revokeSession } from "../auth/security";
+import { authenticateInternalToken, authenticatePrivateToken, authenticateSessionToken, extractBearerToken, revokeSession, type AuthIdentity } from "../auth/security";
 import { normalizeGittBountySnapshot } from "../bounties/ingest";
 import {
   countOpenIssues,
@@ -622,6 +622,8 @@ export function createApp() {
   });
 
   app.get("/v1/repos/:owner/:repo/pulls/:number/maintainer-packet", async (c) => {
+    const unauthorized = await requireStaticProtectedApiToken(c);
+    if (unauthorized) return unauthorized;
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
     const number = Number(c.req.param("number"));
     if (!Number.isFinite(number)) return c.json({ error: "invalid_pull_number" }, 400);
@@ -692,6 +694,8 @@ export function createApp() {
 
   app.get("/v1/contributors/:login/decision-pack", async (c) => {
     const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
     const serving = await loadContributorDecisionPackForServing(c.env, login);
     if (serving.kind === "ready") return c.json(serving.pack);
     return c.json(serving.refresh, 202);
@@ -699,6 +703,8 @@ export function createApp() {
 
   app.get("/v1/contributors/:login/repos/:owner/:repo/decision", async (c) => {
     const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
     const serving = await loadContributorDecisionPackForServing(c.env, login);
     if (serving.kind === "needs_refresh") {
@@ -1310,6 +1316,30 @@ function contributorEvidenceFromProfile(profile: {
       credibilityAssumption: profile.evidence.credibilityAssumption,
     },
   };
+}
+
+type ProtectedRouteContext = {
+  env: Env;
+  req: { header: (name: string) => string | undefined | null };
+  json: (object: { error: string }, status?: number) => Response;
+};
+
+async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {
+  return authenticatePrivateToken(c.env, extractBearerToken(c.req.header("authorization")));
+}
+
+async function requireStaticProtectedApiToken(c: ProtectedRouteContext): Promise<Response | null> {
+  const identity = await authenticateRequestIdentity(c);
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
+  if (identity.kind === "session") return c.json({ error: "static_token_required" }, 403);
+  return null;
+}
+
+async function requireContributorAccess(c: ProtectedRouteContext, login: string): Promise<Response | null> {
+  const identity = await authenticateRequestIdentity(c);
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
+  if (identity.kind === "session" && identity.actor.toLowerCase() !== login.toLowerCase()) return c.json({ error: "forbidden_contributor" }, 403);
+  return null;
 }
 
 function requiresApiToken(path: string): boolean {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,7 @@ import { createMcpHandler } from "agents/mcp";
 import type { Context } from "hono";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { authenticatePrivateToken, extractBearerToken } from "../auth/security";
+import { authenticatePrivateToken, extractBearerToken, type AuthIdentity } from "../auth/security";
 import {
   countOpenIssues,
   countOpenPullRequests,
@@ -220,14 +220,18 @@ const variantsShape = {
 
 export async function handleMcpRequest(c: AppContext): Promise<Response> {
   if (c.req.method === "OPTIONS") return new Response(null, { status: 204 });
-  if (!(await isAuthorizedMcpRequest(c))) return c.json({ error: "unauthorized" }, 401);
+  const identity = await authenticateMcpRequest(c);
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
 
-  const server = new GittensoryMcp(c.env).createServer();
+  const server = new GittensoryMcp(c.env, identity).createServer();
   return createMcpHandler(server, { route: "/mcp", enableJsonResponse: true })(c.req.raw, c.env, getExecutionContext(c));
 }
 
 export class GittensoryMcp {
-  constructor(private readonly env: Env) {}
+  constructor(
+    private readonly env: Env,
+    private readonly identity: AuthIdentity = { kind: "static", actor: "mcp" },
+  ) {}
 
   createServer(): McpServer {
     const server = new McpServer({
@@ -463,6 +467,12 @@ export class GittensoryMcp {
     return server;
   }
 
+  private requireContributorAccess(login: string): void {
+    if (this.identity.kind === "session" && this.identity.actor.toLowerCase() !== login.toLowerCase()) {
+      throw new Error("Forbidden: session can only access the authenticated GitHub login.");
+    }
+  }
+
   private async getRepoContext(input: { owner: string; repo: string }): Promise<ToolPayload> {
     const fullName = `${input.owner}/${input.repo}`;
     const [repo, issues, pullRequests, recentMergedPullRequests, queueCounts] = await Promise.all([
@@ -515,6 +525,7 @@ export class GittensoryMcp {
   }
 
   private async getDecisionPack(login: string): Promise<ToolPayload> {
+    this.requireContributorAccess(login);
     const serving = await loadContributorDecisionPackForServing(this.env, login);
     if (serving.kind === "ready") {
       return {
@@ -529,6 +540,7 @@ export class GittensoryMcp {
   }
 
   private async explainRepoDecision(input: { login: string; owner: string; repo: string }): Promise<ToolPayload> {
+    this.requireContributorAccess(input.login);
     const fullName = `${input.owner}/${input.repo}`;
     const serving = await loadContributorDecisionPackForServing(this.env, input.login);
     if (serving.kind === "needs_refresh") {
@@ -687,6 +699,7 @@ export class GittensoryMcp {
   }
 
   private async agentPlanNextWork(input: z.infer<z.ZodObject<typeof agentPlanShape>>): Promise<ToolPayload> {
+    this.requireContributorAccess(input.login);
     const bundle = await planNextWork(this.env, { ...input, surface: "mcp" });
     return {
       summary: `Gittensory base-agent plan for ${input.login}.`,
@@ -695,6 +708,7 @@ export class GittensoryMcp {
   }
 
   private async agentStartRun(input: z.infer<z.ZodObject<typeof agentRunShape>>): Promise<ToolPayload> {
+    this.requireContributorAccess(input.actorLogin);
     const bundle = await startAgentRun(this.env, {
       objective: input.objective,
       actorLogin: input.actorLogin,
@@ -721,6 +735,7 @@ export class GittensoryMcp {
   }
 
   private async agentExplainNextAction(input: z.infer<z.ZodObject<typeof agentPlanShape>>): Promise<ToolPayload> {
+    this.requireContributorAccess(input.login);
     const bundle = await explainBlockersWithAgent(this.env, { ...input, surface: "mcp" });
     return {
       summary: `Gittensory base-agent next-action explanation for ${input.login}.`,
@@ -740,6 +755,7 @@ export class GittensoryMcp {
   }
 
   private async analyzeLocalBranch(input: z.infer<z.ZodObject<typeof localBranchAnalysisShape>>) {
+    this.requireContributorAccess(input.login);
     const [context, repo, issues, pullRequests, recentMergedPullRequests, snapshot] = await Promise.all([
       this.loadContributorFastContext(input.login),
       getRepository(this.env, input.repoFullName),
@@ -846,8 +862,8 @@ function authoritativeContributorRepoStats(
   return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
-async function isAuthorizedMcpRequest(c: AppContext): Promise<boolean> {
-  return Boolean(await authenticatePrivateToken(c.env, extractBearerToken(c.req.header("authorization"))));
+async function authenticateMcpRequest(c: AppContext): Promise<AuthIdentity | null> {
+  return authenticatePrivateToken(c.env, extractBearerToken(c.req.header("authorization")));
 }
 
 function getExecutionContext(c: AppContext): ExecutionContext<unknown> {

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { persistSignalSnapshot } from "../../src/db/repositories";
 import { handleMcpRequest } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -40,6 +42,62 @@ describe("api route guards and error branches", () => {
     const logout = await app.request("/v1/auth/logout", { method: "POST", headers: authHeaders }, env);
     expect(logout.status).toBe(200);
     expect((await app.request("/v1/auth/session", { headers: authHeaders }, env)).status).toBe(401);
+  });
+
+  it("limits GitHub-backed sessions to their own private contributor advisory data", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "attacker", id: 7 });
+    const sessionHeaders = { authorization: `Bearer ${token}`, "content-type": "application/json" };
+
+    await persistSignalSnapshot(env, {
+      id: "victim-decision-pack",
+      signalType: "contributor-decision-pack",
+      targetKey: "victim",
+      payload: {
+        status: "ready",
+        source: "computed",
+        login: "victim",
+        generatedAt: "2026-05-29T00:00:00.000Z",
+        stale: false,
+        freshness: "fresh",
+        rebuildEnqueued: false,
+        scoringModelSnapshotId: "scoring-1",
+        profile: {},
+        outcomeHistory: {},
+        roleContexts: [],
+        repoDecisions: [{ repoFullName: "owner/private-repo", recommendation: "avoid", scoreBlockers: ["private score blocker"] }],
+        topActions: [{ actionKind: "open_new_direct_pr", repoFullName: "owner/private-repo", priorityScore: 50, rationale: "private next action" }],
+        cleanupFirst: [],
+        pursueRepos: [],
+        avoidRepos: [{ repoFullName: "owner/private-repo", recommendation: "avoid" }],
+        maintainerLaneRepos: [],
+        scoreBlockers: ["private score blocker"],
+        dataQuality: { signalFidelity: { status: "ready" } },
+        summary: "private advisory summary",
+        nextActions: ["sensitive next action"],
+      } as never,
+      generatedAt: "2026-05-29T00:00:00.000Z",
+    });
+
+    const ownDecisionPack = await app.request("/v1/contributors/attacker/decision-pack", { headers: sessionHeaders }, env);
+    expect(ownDecisionPack.status).toBe(202);
+
+    const victimDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: sessionHeaders }, env);
+    expect(victimDecisionPack.status).toBe(403);
+    await expect(victimDecisionPack.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
+
+    const victimRepoDecision = await app.request("/v1/contributors/victim/repos/owner/private-repo/decision", { headers: sessionHeaders }, env);
+    expect(victimRepoDecision.status).toBe(403);
+    await expect(victimRepoDecision.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
+
+    const maintainerPacket = await app.request("/v1/repos/owner/private-repo/pulls/1/maintainer-packet", { headers: sessionHeaders }, env);
+    expect(maintainerPacket.status).toBe(403);
+    await expect(maintainerPacket.json()).resolves.toMatchObject({ error: "static_token_required" });
+
+    const staticTokenDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: apiHeaders(env) }, env);
+    expect(staticTokenDecisionPack.status).toBe(200);
+    await expect(staticTokenDecisionPack.json()).resolves.toMatchObject({ login: "victim", summary: "private advisory summary" });
   });
 
   it("keeps OAuth setup, CORS, and rate limits explicit", async () => {


### PR DESCRIPTION
### Motivation
- Prevent GitHub OAuth-backed session tokens from being used to read private advisory/maintainer data for arbitrary users/repos by enforcing stricter request-level authorization on sensitive API and MCP surfaces.

### Description
- Add protected-route helpers `requireStaticProtectedApiToken` and `requireContributorAccess` and gate the maintainer-packet endpoint with `requireStaticProtectedApiToken` in `src/api/routes.ts` so only static service tokens may access maintainer packets.
- Require `requireContributorAccess` for `/v1/contributors/:login/decision-pack` and `/v1/contributors/:login/repos/:owner/:repo/decision` so session tokens can read only the session owner's advisory data in `src/api/routes.ts`.
- Propagate authenticated MCP identity into `GittensoryMcp` via `authenticateMcpRequest` and the `GittensoryMcp` constructor in `src/mcp/server.ts`, add `requireContributorAccess` there, and enforce the same self-login restriction across MCP tools (`getDecisionPack`, `explainRepoDecision`, agent tools, and local-analysis paths).
- Add an integration regression test that seeds a victim decision pack and verifies an attacker session cannot read the victim data while a static API token still can in `test/integration/routes-errors.test.ts`.

### Testing
- Ran `npm run typecheck` and it completed successfully with no type errors.
- Ran `npx vitest run test/integration/routes-errors.test.ts --reporter=verbose` and the new and existing integration assertions passed.
- Ran `npx vitest run test/integration/api.test.ts --reporter=dot` and the suite passed.
- Ran `git diff --check` and there were no whitespace or diff-check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1957e34d38832cb78a342448c8109e)