### PR TITLE
fix(auth): restrict GitHub OAuth sessions to admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,15 @@ wrangler secret put GITHUB_WEBHOOK_SECRET
 wrangler secret put GITHUB_APP_PRIVATE_KEY
 wrangler secret put GITHUB_PUBLIC_TOKEN
 wrangler secret put GITHUB_OAUTH_CLIENT_ID
+wrangler secret put ADMIN_GITHUB_LOGINS
 wrangler secret put GITTENSORY_API_TOKEN
 wrangler secret put GITTENSORY_MCP_TOKEN
 wrangler secret put INTERNAL_JOB_TOKEN
 ```
 
 `GITHUB_PUBLIC_TOKEN` is a server-side token used to raise public GitHub API rate limits during registered-repo backfill. It is not a contributor token.
+
+`ADMIN_GITHUB_LOGINS` is a comma- or whitespace-separated allowlist of GitHub logins that may exchange GitHub OAuth/device-flow credentials for Gittensory API sessions. Leave it unset to disable OAuth session issuance.
 
 The production API origin is `https://gittensory-api.aethereal.dev`. The `workers.dev` deployment URL is treated as an internal fallback, not the public integration target.
 

--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -1,4 +1,4 @@
-import { createSessionForGitHubUser } from "./security";
+import { createSessionForGitHubUser, isAuthorizedGitHubSessionLogin } from "./security";
 import { recordAuditEvent } from "../db/repositories";
 import type { JsonValue } from "../types";
 
@@ -101,6 +101,15 @@ export async function createSessionFromGitHubToken(
       detail: user.message ?? "github_user_validation_failed",
     });
     throw new Error("github_user_validation_failed");
+  }
+  if (!isAuthorizedGitHubSessionLogin(env, user.login)) {
+    await recordAuditEvent(env, {
+      eventType: "auth.github_session",
+      actor: user.login,
+      outcome: "denied",
+      detail: "github_user_not_authorized",
+    });
+    throw new Error("github_user_not_authorized");
   }
   const scopes = Array.isArray(metadata.scopes) ? metadata.scopes.filter((scope): scope is string => typeof scope === "string") : [];
   const githubUser = user.id === undefined ? { login: user.login } : { login: user.login, id: user.id };

--- a/src/auth/security.ts
+++ b/src/auth/security.ts
@@ -55,8 +55,24 @@ export async function authenticateSessionToken(env: Env, token: string | undefin
   const session = await getAuthSessionByTokenHash(env, await hashToken(token));
   if (!session) return null;
   if (session.revokedAt || Date.parse(session.expiresAt) <= Date.now()) return null;
+  if (!isAuthorizedGitHubSessionLogin(env, session.login)) return null;
   await touchAuthSession(env, session.id);
   return { kind: "session", actor: session.login, session };
+}
+
+export function isAuthorizedGitHubSessionLogin(env: Env, login: string): boolean {
+  const allowedLogins = parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS);
+  if (allowedLogins.size === 0) return false;
+  return allowedLogins.has(login.toLowerCase());
+}
+
+function parseGitHubLoginList(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(/[\s,]+/)
+      .map((login) => login.trim().toLowerCase())
+      .filter(Boolean),
+  );
 }
 
 export async function createSessionForGitHubUser(

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -65,6 +65,7 @@ export function createTestEnv(overrides: Partial<Env> = {}): Env {
     GITTENSORY_MCP_TOKEN: "test-mcp-token",
     GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
     GITHUB_APP_PRIVATE_KEY: "test-private-key",
+    ADMIN_GITHUB_LOGINS: "jsonbored",
     ...overrides,
   };
 }

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -158,7 +158,7 @@ describe("private-beta auth and rate limiting", () => {
   });
 
   it("polls GitHub device flow and creates a session only after authorization", async () => {
-    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" });
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id", ADMIN_GITHUB_LOGINS: "jsonbored,scopefree" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("access_token")) return Response.json({ error: "authorization_pending", error_description: "waiting" });
@@ -212,7 +212,17 @@ describe("private-beta auth and rate limiting", () => {
     await expect(createSessionFromGitHubToken(env, "bad-token")).rejects.toThrow(/github_user_validation_failed/);
 
     vi.stubGlobal("fetch", async () => Response.json({ login: "no-id-user" }));
-    await expect(createSessionFromGitHubToken(env, "valid-token")).resolves.toMatchObject({ login: "no-id-user", scopes: [] });
+    await expect(createSessionFromGitHubToken(createTestEnv({ ADMIN_GITHUB_LOGINS: "no-id-user" }), "valid-token")).resolves.toMatchObject({ login: "no-id-user", scopes: [] });
+  });
+
+  it("requires GitHub OAuth sessions to come from configured admin logins", async () => {
+    vi.stubGlobal("fetch", async () => Response.json({ login: "external-attacker", id: 99 }));
+    await expect(createSessionFromGitHubToken(createTestEnv(), "attacker-token")).rejects.toThrow(/github_user_not_authorized/);
+    await expect(createSessionFromGitHubToken(createTestEnv({ ADMIN_GITHUB_LOGINS: "" }), "attacker-token")).rejects.toThrow(/github_user_not_authorized/);
+
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    const { token } = await createSessionForGitHubUser(env, { login: "external-attacker", id: 99 });
+    await expect(authenticatePrivateToken(env, token)).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
### Motivation
- The OAuth/device-flow path previously allowed any valid GitHub account to exchange a GitHub token for a Gittensory session, which then granted access to private API routes protected by `authenticatePrivateToken`.
- The change closes this privilege-escalation by enforcing an explicit allowlist so only configured admin logins can mint and use OAuth-backed sessions.

### Description
- Require allowlisted logins before issuing OAuth sessions by checking `isAuthorizedGitHubSessionLogin` inside `createSessionFromGitHubToken` and auditing denials, returning `github_user_not_authorized` for disallowed logins.
- Revalidate stored session actors during authentication by adding an allowlist check to `authenticateSessionToken` so previously-minted non-admin sessions stop authorizing protected routes.
- Add parsing helpers and an `ADMIN_GITHUB_LOGINS` allowlist environment variable with comma/whitespace-separated format in `src/auth/security.ts` and document the variable in `README.md`.
- Update test environment defaults and unit/integration tests in `test/helpers/d1.ts` and `test/unit/auth.test.ts` to cover allowed and denied OAuth issuance behaviors.

### Testing
- Ran targeted tests with `npm test -- --run test/unit/auth.test.ts test/integration/routes-errors.test.ts` and the test run passed (all tests in those files succeeded).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19579482c4832c9ec0597a2a4fc9b1)