### PR TITLE
fix(backfill): exclude open PRs from GraphQL open issue totals

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -780,7 +780,10 @@ async function refreshRepoGithubTotals(
   const snapshot: RepoGithubTotalsSnapshotRecord = {
     id: crypto.randomUUID(),
     repoFullName: repo.fullName,
-    openIssuesTotal: repository.issues?.totalCount ?? 0,
+    openIssuesTotal: Math.max(
+      0,
+      (repository.issues?.totalCount ?? 0) - (repository.openPullRequests?.totalCount ?? 0),
+    ),
     openPullRequestsTotal: repository.openPullRequests?.totalCount ?? 0,
     mergedPullRequestsTotal: repository.mergedPullRequests?.totalCount ?? 0,
     closedUnmergedPullRequestsTotal: repository.closedPullRequests?.totalCount ?? 0,
@@ -1071,6 +1074,7 @@ async function supplementOpenIssuesFromGraphQl(env: Env, repo: RepositoryRecord,
         issues(states: OPEN, first: 100${after}) {
           pageInfo { hasNextPage endCursor }
           nodes {
+            __typename
             number
             title
             state
@@ -1089,6 +1093,7 @@ async function supplementOpenIssuesFromGraphQl(env: Env, repo: RepositoryRecord,
     const response = await githubGraphQl<GitHubOpenIssuesResponse>(env, query, token);
     const issues = response.data?.repository?.issues;
     for (const issue of issues?.nodes ?? []) {
+      if (issue?.__typename === "PullRequest") continue;
       if (!issue?.number || existingNumbers.has(issue.number)) continue;
       const payload: GitHubIssuePayload = {
         number: issue.number,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -865,7 +865,7 @@ describe("GitHub backfill", () => {
 
     const result = await enqueueRepositoryOpenDataBackfill(env, { repoFullName: "JSONbored/gittensory", requestedBy: "api", mode: "resume", force: true });
 
-    expect(result).toMatchObject({ status: "queued", totals: { openIssuesTotal: 2911, openPullRequestsTotal: 167 } });
+    expect(result).toMatchObject({ status: "queued", totals: { openIssuesTotal: 2744, openPullRequestsTotal: 167 } });
     expect(await listRepoSyncStates(env)).toMatchObject([{ status: "running", openIssuesCount: 1100, openPullRequestsCount: 167, lastCompletedAt: "2026-05-24T00:00:00.000Z" }]);
     expect(sent).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary

Closes #80. Exclude open pull requests from GraphQL-derived open issue totals and skip `PullRequest` nodes when supplementing open issues from GraphQL.

## Changes

- Set `openIssuesTotal` to `issues.open - openPullRequests.open`.
- Skip `__typename === PullRequest` in `supplementOpenIssuesFromGraphQl`.
- Update backfill unit test expectation for combined totals.

## Test plan

- [ ] `npm test -- test/unit/backfill.test.ts`
