### PR TITLE
fix(scoring): exclude closed PRs from open pressure cleanup

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -277,8 +277,9 @@ function buildScenarioPreviews(
 ): ScoreScenarioPreview[] {
   const userPendingCount = nonNegative(input.pendingMergedPrCount) + nonNegative(input.pendingClosedPrCount) + nonNegative(input.approvedPrCount);
   const observedApprovedCount = nonNegative(input.observedApprovedPrCount);
-  const observedCloseCount = nonNegative(input.observedStalePrCount) + nonNegative(input.observedClosedPrCount);
-  const combinedPendingCount = userPendingCount + observedApprovedCount + observedCloseCount;
+  const observedStaleCloseCount = nonNegative(input.observedStalePrCount);
+  const observedClosedCount = nonNegative(input.observedClosedPrCount);
+  const combinedPendingCount = userPendingCount + observedApprovedCount + observedStaleCloseCount;
   const expectedOpenPrCountAfterMerge =
     input.expectedOpenPrCountAfterMerge !== undefined ? nonNegative(input.expectedOpenPrCountAfterMerge) : Math.max(0, current.gates.openPrCount - userPendingCount);
   const projectedCredibility =
@@ -295,7 +296,7 @@ function buildScenarioPreviews(
   };
   const afterStaleInput = {
     ...input,
-    openPrCount: Math.max(0, current.gates.openPrCount - observedCloseCount),
+    openPrCount: Math.max(0, current.gates.openPrCount - observedStaleCloseCount),
     credibility: current.gates.credibilityObserved,
   };
   const cleanGatesInput = {
@@ -363,10 +364,11 @@ function buildScenarioPreviews(
       afterStaleInput,
       computeScoreCore(afterStaleInput, repo, snapshot, contributorEvidence),
       [
-        observedCloseCount > 0
-          ? `${observedCloseCount} GitHub-observed stale or closed PR(s) are treated as no longer open if they close or withdraw.`
-          : "No GitHub-observed stale or closed PRs were available for this scenario.",
-        "Credibility is not increased in this scenario because stale or closed PR cleanup is not the same as merged work.",
+        observedStaleCloseCount > 0
+          ? `${observedStaleCloseCount} GitHub-observed stale open PR(s) are treated as no longer open if they close or withdraw.`
+          : "No GitHub-observed stale open PRs were available for this scenario.",
+        ...(observedClosedCount > 0 ? [`${observedClosedCount} GitHub-observed already-closed PR(s) are excluded because they no longer contribute to open PR pressure.`] : []),
+        "Credibility is not increased in this scenario because stale cleanup is not the same as merged work.",
         ...observedScenarioNotes(input),
       ],
       repo,

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -415,7 +415,7 @@ function observedPullRequestNotes(scenarios: Omit<ObservedPullRequestScenarios, 
   return [
     ...(scenarios.approvedOrMergeable > 0 ? [`${scenarios.approvedOrMergeable} cached approved or mergeable open PR(s) can be modeled as likely-to-land.`] : []),
     ...(scenarios.stale > 0 ? [`${scenarios.stale} cached stale open PR(s) can be modeled as cleanup-first rather than likely-to-land.`] : []),
-    ...(scenarios.closed > 0 ? [`${scenarios.closed} cached closed PR(s) can be modeled as no longer open.`] : []),
+    ...(scenarios.closed > 0 ? [`${scenarios.closed} cached already-closed PR(s) are excluded from open PR pressure projections.`] : []),
   ];
 }
 

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -207,7 +207,8 @@ describe("local branch analysis", () => {
 
     expect(analysis.observedPullRequestScenarios).toMatchObject({ approvedOrMergeable: 1, stale: 1, closed: 1, draft: 1, blocked: 1, maintainerLane: 1 });
     expect(analysis.scenarioScorePreview.afterApprovedPrsMerge).toMatchObject({ source: "github_observed", gates: { openPrCount: 5, credibilityObserved: 0.8 } });
-    expect(analysis.scenarioScorePreview.afterStalePrsClose).toMatchObject({ source: "github_observed", gates: { openPrCount: 4, credibilityObserved: 0.2 } });
+    expect(analysis.scenarioScorePreview.afterStalePrsClose).toMatchObject({ source: "github_observed", gates: { openPrCount: 5, credibilityObserved: 0.2 } });
+    expect(analysis.scenarioScorePreview.afterStalePrsClose?.assumptions.join(" ")).toMatch(/already-closed PR.*excluded/);
     expect(analysis.scenarioScorePreview.afterApprovedPrsMerge?.assumptions.join(" ")).toMatch(/draft PR.*excluded|blocked PR.*excluded|maintainer-lane PR.*outside-contributor/);
     expect(analysis.scorePreview.effectiveEstimatedScore).toBe(0);
     expect(analysis.scorePreview.underlyingPotentialScore).toBeGreaterThan(0);

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -163,6 +163,7 @@ IGNORED = "not numeric"
         projectedCredibility: 0.5,
         observedApprovedPrCount: 1,
         observedStalePrCount: 1,
+        observedClosedPrCount: 1,
         observedDraftPrCount: 1,
         observedBlockedPrCount: 1,
         observedMaintainerPrCount: 1,
@@ -171,10 +172,13 @@ IGNORED = "not numeric"
     const userSupplied = preview.scenarioPreviews.find((scenario) => scenario.name === "afterPendingMerges");
     const approved = preview.scenarioPreviews.find((scenario) => scenario.name === "afterApprovedPrsMerge");
     const stale = preview.scenarioPreviews.find((scenario) => scenario.name === "afterStalePrsClose");
+    const bestReasonable = preview.scenarioPreviews.find((scenario) => scenario.name === "bestReasonableCase");
 
     expect(userSupplied).toMatchObject({ source: "user_supplied", gates: { openPrCount: 4, credibilityObserved: 0.5 } });
     expect(approved).toMatchObject({ source: "github_observed", gates: { openPrCount: 4, credibilityObserved: 0.8 } });
     expect(stale).toMatchObject({ source: "github_observed", gates: { openPrCount: 4, credibilityObserved: 0.2 } });
+    expect(stale?.assumptions.join(" ")).toMatch(/already-closed PR.*excluded/);
+    expect(bestReasonable?.gates.openPrCount).toBe(2);
     expect(approved?.assumptions.join(" ")).toMatch(/draft PR.*excluded|blocked PR.*excluded|maintainer-lane PR.*outside-contributor/);
     expect(preview.effectiveEstimatedScore).toBe(0);
     expect(preview.underlyingPotentialScore).toBeGreaterThan(0);


### PR DESCRIPTION
### Motivation
- Observed already-closed unmerged PRs were being included in the projected reductions to `openPrCount`, causing double-counting and overly optimistic gate projections. 
- The goal is to ensure only open PRs that can reasonably be closed or merged (e.g., stale or approved/mergeable open PRs) reduce current open-PR pressure while preserving closed-PR history for notes.

### Description
- Split the combined observed-close logic in `buildScenarioPreviews` into `observedStaleCloseCount` and `observedClosedCount` and exclude `observedClosedCount` from open-PR reduction math in `src/scoring/preview.ts`.
- Change `afterStaleInput.openPrCount` and `bestReasonableInput.openPrCount` to subtract only the stale open PRs (and other genuine candidates) rather than already-closed PRs in `src/scoring/preview.ts`.
- Update scenario assumption text to explicitly state that already-closed PRs are excluded from open-pressure projections and keep closed PRs as observed history in `src/signals/local-branch.ts`.
- Adjust unit tests in `test/unit/scoring.test.ts` and `test/unit/local-branch.test.ts` to assert that closed PRs are reported in observed scenarios but do not reduce `afterStalePrsClose` open PR counts or get double-counted in the best-reasonable projection.

### Testing
- Ran the targeted unit tests with `npm test -- test/unit/scoring.test.ts test/unit/local-branch.test.ts` and they passed (2 files, 22 tests passed).
- Ran `npm run typecheck` and `git diff --check` which succeeded with no type errors reported.
- Ran the full test suite with `npm test`, which shows 3 failing integration tests in `test/integration/api.test.ts` related to readiness/freshness SLO expectations that are unrelated to this scoring logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a6a7415e4832c99d6b8d64bd181f2)