### PR TITLE
feat(api): expose MCP compatibility metadata

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -14,6 +14,7 @@ const packageVersion = "0.2.0";
 const npmRegistryUrl = (process.env.GITTENSORY_NPM_REGISTRY_URL ?? "https://registry.npmjs.org").replace(/\/+$/, "");
 const upgradeCommand = `npm install -g ${packageName}@latest`;
 const npxFallbackCommand = `npx ${packageName}@latest <command>`;
+const compatibilityPath = "/v1/mcp/compatibility";
 const changelogPath = new URL("../CHANGELOG.md", import.meta.url);
 const configPath =
   process.env.GITTENSORY_CONFIG_PATH ??
@@ -717,12 +718,14 @@ async function status(options) {
   } catch (error) {
     health = { status: "unreachable", error: sanitizeDiagnosticText(error instanceof Error ? error.message : "health_check_failed") };
   }
-  const pkg = await inspectInstallVersion();
-  const apiCompatibility = evaluateApiCompatibility(health);
+  const compatibility = await inspectApiCompatibility(health);
+  const pkg = await inspectInstallVersion(compatibilityLatestRecommendedVersion(compatibility.report) ?? compatibilityLatestRecommendedVersion(health));
+  const apiCompatibility = compatibility.evaluation;
   const payload = {
     apiUrl,
     package: pkg,
     apiCompatibility,
+    compatibility: compatibility.report,
     api: health,
     auth,
     config: { configured: existsSync(configPath) },
@@ -744,6 +747,10 @@ async function status(options) {
     }
     if (apiCompatibility.status === "incompatible") {
       process.stdout.write(`API requires at least ${packageName}@${apiCompatibility.minVersion}. Upgrade with:\n  ${apiCompatibility.upgradeCommand}\n`);
+    } else if (apiCompatibility.status === "compatible") {
+      process.stdout.write(`API compatibility: compatible (minimum ${packageName}@${apiCompatibility.minVersion}).\n`);
+    } else if (apiCompatibility.status === "unavailable") {
+      process.stdout.write(`API compatibility: unavailable (${apiCompatibility.reason ?? "unknown"}).\n`);
     }
   }
 }
@@ -782,7 +789,8 @@ async function doctor(options) {
     add("api_health", "fail", error instanceof Error ? error.message : "health_check_failed", "Check GITTENSORY_API_URL or network access.");
   }
 
-  const pkg = await inspectInstallVersion();
+  const compatibility = await inspectApiCompatibility(health);
+  const pkg = await inspectInstallVersion(compatibilityLatestRecommendedVersion(compatibility.report) ?? compatibilityLatestRecommendedVersion(health));
   if (pkg.state === "stale") {
     add("version", "warn", `Installed ${packageVersion} is behind npm latest ${pkg.latestVersion}.`, `${pkg.upgradeCommand} (no-install fallback: ${pkg.npxFallback})`);
   } else if (pkg.state === "unavailable") {
@@ -797,13 +805,15 @@ async function doctor(options) {
     add("version", "pass", `Installed ${packageVersion} matches npm latest ${pkg.latestVersion}.`);
   }
 
-  const apiCompatibility = evaluateApiCompatibility(health);
+  const apiCompatibility = compatibility.evaluation;
   if (apiCompatibility.status === "incompatible") {
     add("api_compatibility", "fail", `API requires at least ${packageName}@${apiCompatibility.minVersion}; local is ${packageVersion}.`, apiCompatibility.upgradeCommand);
   } else if (apiCompatibility.status === "compatible") {
     add("api_compatibility", "pass", `Local ${packageVersion} meets the API minimum ${apiCompatibility.minVersion}.`);
   } else if (apiCompatibility.reason === "api_unreachable") {
     add("api_compatibility", "warn", "API compatibility check was unavailable because API health was unreachable.");
+  } else if (apiCompatibility.reason === "compatibility_endpoint_unavailable") {
+    add("api_compatibility", "warn", "API compatibility endpoint was unavailable; compatibility could not be confirmed.");
   } else if (apiCompatibility.status === "unknown") {
     add("api_compatibility", "warn", `API reported an unsupported minimum client version (${apiCompatibility.minVersion}).`);
   } else {
@@ -1229,12 +1239,15 @@ function classifyVersionState(latestStatus, latestVersion, comparison) {
 
 // Shared by `status` and `doctor`: compares the local install against npm latest and
 // produces deterministic upgrade guidance. Never throws and never returns sensitive data.
-async function inspectInstallVersion() {
+async function inspectInstallVersion(apiRecommendedVersion) {
   let latest;
   try {
     latest = await fetchLatestPackageVersion();
   } catch (error) {
     latest = { status: "unavailable", error: sanitizeDiagnosticText(error instanceof Error ? error.message : "npm_version_check_failed") };
+  }
+  if (latest.status === "unavailable" && typeof apiRecommendedVersion === "string" && apiRecommendedVersion.length > 0) {
+    latest = { status: "api", version: apiRecommendedVersion };
   }
   const latestVersion = typeof latest.version === "string" ? latest.version : null;
   const comparison = latestVersion ? compareSemver(packageVersion, latestVersion) : null;
@@ -1253,18 +1266,57 @@ async function inspectInstallVersion() {
   });
 }
 
-// Optional API compatibility check. The backend MAY advertise a minimum supported client
-// version via `minMcpVersion`/`minClientVersion` on /health; when it does not, this degrades
-// gracefully to "unavailable" instead of failing.
-function evaluateApiCompatibility(health) {
-  if (!health || health.status === "unreachable") return { status: "unavailable", reason: "api_unreachable" };
-  const minVersion =
-    typeof health.minMcpVersion === "string" ? health.minMcpVersion : typeof health.minClientVersion === "string" ? health.minClientVersion : null;
-  if (!minVersion) return { status: "unavailable", reason: "not_reported" };
+async function inspectApiCompatibility(health) {
+  try {
+    const report = await apiFetch(compatibilityPath, { method: "GET" }, { auth: false, timeoutMs: 5000 });
+    return { report, evaluation: evaluateApiCompatibility(report, "compatibility_endpoint") };
+  } catch (error) {
+    const report = {
+      status: "unavailable",
+      reason: "compatibility_endpoint_unavailable",
+      error: sanitizeDiagnosticText(error instanceof Error ? error.message : "compatibility_check_failed"),
+    };
+    const fallback = evaluateApiCompatibility(health, "health");
+    return {
+      report,
+      evaluation: fallback.reason === "not_reported" ? evaluateApiCompatibility(report, "compatibility_endpoint") : fallback,
+    };
+  }
+}
+
+// Prefer the first-class compatibility endpoint, but keep supporting older APIs that only
+// advertise `minMcpVersion`/`minClientVersion` on /health.
+function evaluateApiCompatibility(report, source) {
+  if (!report || report.status === "unreachable") return { status: "unavailable", reason: "api_unreachable", source };
+  if (report.status === "unavailable") {
+    return stripUndefined({ status: "unavailable", reason: report.reason ?? "compatibility_unavailable", source, detail: report.error });
+  }
+  const minVersion = compatibilityMinimumVersion(report);
+  if (!minVersion) return { status: "unavailable", reason: "not_reported", source };
   const comparison = compareSemver(packageVersion, minVersion);
-  if (comparison === null) return { status: "unknown", minVersion };
-  if (comparison < 0) return stripUndefined({ status: "incompatible", minVersion, upgradeCommand });
-  return { status: "compatible", minVersion };
+  const latestRecommendedVersion = compatibilityLatestRecommendedVersion(report);
+  const apiVersion = typeof report.apiVersion === "string" ? report.apiVersion : undefined;
+  const warnings = Array.isArray(report.compatibilityWarnings) ? report.compatibilityWarnings : Array.isArray(report.warnings) ? report.warnings : [];
+  const breakingChanges = Array.isArray(report.breakingChanges) ? report.breakingChanges : [];
+  if (comparison === null) return stripUndefined({ status: "unknown", source, minVersion, latestRecommendedVersion, apiVersion, warnings, breakingChanges });
+  if (comparison < 0) return stripUndefined({ status: "incompatible", source, minVersion, latestRecommendedVersion, apiVersion, warnings, breakingChanges, upgradeCommand });
+  return stripUndefined({ status: "compatible", source, minVersion, latestRecommendedVersion, apiVersion, warnings, breakingChanges });
+}
+
+function compatibilityMinimumVersion(report) {
+  if (typeof report?.mcp?.minimumSupportedVersion === "string") return report.mcp.minimumSupportedVersion;
+  if (typeof report?.minimumSupportedMcpVersion === "string") return report.minimumSupportedMcpVersion;
+  if (typeof report?.minMcpVersion === "string") return report.minMcpVersion;
+  if (typeof report?.minClientVersion === "string") return report.minClientVersion;
+  return null;
+}
+
+function compatibilityLatestRecommendedVersion(report) {
+  if (typeof report?.mcp?.latestRecommendedVersion === "string") return report.mcp.latestRecommendedVersion;
+  if (typeof report?.mcp?.latestPackageVersion === "string") return report.mcp.latestPackageVersion;
+  if (typeof report?.latestRecommendedMcpVersion === "string") return report.latestRecommendedMcpVersion;
+  if (typeof report?.latestPackageVersion === "string") return report.latestPackageVersion;
+  return null;
 }
 
 async function analyzeCurrentBranch(input) {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -80,6 +80,7 @@ import {
   loadContributorDecisionPackForServing,
   repoDecisionFromPack,
 } from "../services/decision-pack";
+import { buildMcpCompatibilityMetadata } from "../services/mcp-compatibility";
 import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
 import {
@@ -316,6 +317,7 @@ export function createApp() {
   });
 
   app.get("/health", (c) => c.json({ status: "ok", service: "gittensory-api", time: nowIso() }));
+  app.get("/v1/mcp/compatibility", (c) => c.json(buildMcpCompatibilityMetadata(nowIso())));
   app.get("/openapi.json", (c) => c.json(buildOpenApiSpec()));
   app.all("/mcp", handleMcpRequest);
 
@@ -1474,6 +1476,7 @@ async function requireContributorAccess(c: ProtectedRouteContext, login: string)
 
 function requiresApiToken(path: string): boolean {
   if (path === "/health") return false;
+  if (path === "/v1/mcp/compatibility") return false;
   if (path === "/mcp") return false;
   if (path.startsWith("/v1/auth/")) return false;
   if (path === "/v1/github/webhook") return false;

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1561,3 +1561,34 @@ export const HealthSchema = z
     time: z.string(),
   })
   .openapi("Health");
+
+export const McpCompatibilitySchema = z
+  .object({
+    status: z.literal("ok"),
+    service: z.literal("gittensory-api"),
+    apiVersion: z.string(),
+    mcp: z.object({
+      packageName: z.string(),
+      minimumSupportedVersion: z.string(),
+      latestRecommendedVersion: z.string(),
+      latestPackageVersion: z.string(),
+      supportedVersionRange: z.string(),
+      upgradeCommand: z.string(),
+      npxFallbackCommand: z.string(),
+    }),
+    compatibilityWarnings: z.array(
+      z.object({
+        code: z.string(),
+        message: z.string(),
+      }),
+    ),
+    breakingChanges: z.array(
+      z.object({
+        version: z.string(),
+        summary: z.string(),
+        mitigation: z.string().optional(),
+      }),
+    ),
+    generatedAt: z.string(),
+  })
+  .openapi("McpCompatibility");

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -34,6 +34,7 @@ import {
   MaintainerCutReadinessSchema,
   MaintainerLaneReportSchema,
   MaintainerNoiseReportSchema,
+  McpCompatibilitySchema,
   PullRequestMaintainerPacketSchema,
   PullRequestReviewIntelligenceSchema,
   PullRequestReviewabilitySchema,
@@ -70,6 +71,7 @@ import {
 export function buildOpenApiSpec() {
   const registry = new OpenAPIRegistry();
   registry.register("Health", HealthSchema);
+  registry.register("McpCompatibility", McpCompatibilitySchema);
   registry.register("RegistrySnapshot", RegistrySnapshotSchema);
   registry.register("Repository", RepositorySchema);
   registry.register("Advisory", AdvisorySchema);
@@ -139,6 +141,13 @@ export function buildOpenApiSpec() {
     path: "/health",
     responses: {
       200: { description: "Service health", content: { "application/json": { schema: HealthSchema } } },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/mcp/compatibility",
+    responses: {
+      200: { description: "Public-safe API and MCP compatibility metadata", content: { "application/json": { schema: McpCompatibilitySchema } } },
     },
   });
   registry.registerPath({

--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -1,0 +1,53 @@
+export const GITTENSORY_API_VERSION = "0.1.0";
+export const GITTENSORY_MCP_PACKAGE_NAME = "@jsonbored/gittensory-mcp";
+export const MINIMUM_SUPPORTED_MCP_VERSION = "0.2.0";
+export const LATEST_RECOMMENDED_MCP_VERSION = "0.2.0";
+
+export type CompatibilityWarning = {
+  code: string;
+  message: string;
+};
+
+export type BreakingChangeNotice = {
+  version: string;
+  summary: string;
+  mitigation?: string;
+};
+
+export type McpCompatibilityMetadata = {
+  status: "ok";
+  service: "gittensory-api";
+  apiVersion: string;
+  mcp: {
+    packageName: string;
+    minimumSupportedVersion: string;
+    latestRecommendedVersion: string;
+    latestPackageVersion: string;
+    supportedVersionRange: string;
+    upgradeCommand: string;
+    npxFallbackCommand: string;
+  };
+  compatibilityWarnings: CompatibilityWarning[];
+  breakingChanges: BreakingChangeNotice[];
+  generatedAt: string;
+};
+
+export function buildMcpCompatibilityMetadata(generatedAt: string): McpCompatibilityMetadata {
+  return {
+    status: "ok",
+    service: "gittensory-api",
+    apiVersion: GITTENSORY_API_VERSION,
+    mcp: {
+      packageName: GITTENSORY_MCP_PACKAGE_NAME,
+      minimumSupportedVersion: MINIMUM_SUPPORTED_MCP_VERSION,
+      latestRecommendedVersion: LATEST_RECOMMENDED_MCP_VERSION,
+      latestPackageVersion: LATEST_RECOMMENDED_MCP_VERSION,
+      supportedVersionRange: `>=${MINIMUM_SUPPORTED_MCP_VERSION}`,
+      upgradeCommand: `npm install -g ${GITTENSORY_MCP_PACKAGE_NAME}@latest`,
+      npxFallbackCommand: `npx ${GITTENSORY_MCP_PACKAGE_NAME}@latest <command>`,
+    },
+    compatibilityWarnings: [],
+    breakingChanges: [],
+    generatedAt,
+  };
+}

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -45,12 +45,47 @@ describe("api routes", () => {
     expect(health.status).toBe(200);
     await expect(health.json()).resolves.toMatchObject({ status: "ok", service: "gittensory-api" });
 
+    const compatibility = await app.request("/v1/mcp/compatibility", {}, env);
+    expect(compatibility.status).toBe(200);
+    const compatibilityPayload = await compatibility.json();
+    expect(compatibilityPayload).toMatchObject({
+      status: "ok",
+      service: "gittensory-api",
+      apiVersion: "0.1.0",
+      mcp: {
+        packageName: "@jsonbored/gittensory-mcp",
+        minimumSupportedVersion: "0.2.0",
+        latestRecommendedVersion: "0.2.0",
+        latestPackageVersion: "0.2.0",
+      },
+      compatibilityWarnings: [],
+      breakingChanges: [],
+    });
+    expect(JSON.stringify(compatibilityPayload)).not.toMatch(/token|admin|wallet|hotkey|raw trust|scoreability|private repo|local-path/i);
+
     const unauthenticatedSpec = await app.request("/openapi.json", {}, env);
     expect(unauthenticatedSpec.status).toBe(401);
 
     const spec = await app.request("/openapi.json", { headers: apiHeaders(env) }, env);
     expect(spec.status).toBe(200);
     await expect(spec.json()).resolves.toMatchObject({ info: { title: "Gittensory API" } });
+  });
+
+  it("rejects malformed public and private API requests before external work", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+
+    const poll = await app.request("/v1/auth/github/device/poll", { method: "POST", body: "{", headers: { "content-type": "application/json" } }, env);
+    expect(poll.status).toBe(400);
+    await expect(poll.json()).resolves.toMatchObject({ error: "device_code_required" });
+
+    const session = await app.request("/v1/auth/github/session", { method: "POST", body: "{", headers: { "content-type": "application/json" } }, env);
+    expect(session.status).toBe(400);
+    await expect(session.json()).resolves.toMatchObject({ error: "github_token_required" });
+
+    const preview = await app.request("/v1/scoring/preview", { method: "POST", body: "{", headers: apiHeaders(env) }, env);
+    expect(preview.status).toBe(400);
+    await expect(preview.json()).resolves.toMatchObject({ error: "invalid_scoring_preview_request" });
   });
 
   it("serves registry drift through the canonical registry change endpoint", async () => {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -98,11 +98,21 @@ describe("gittensory-mcp CLI", () => {
         GITTENSORY_TOKEN: "session-token",
         GITTENSORY_CONFIG_DIR: tempDir,
       }),
-    ) as { package: { state: string; updateAvailable: boolean; upgradeCommand?: string } };
+    ) as {
+      package: { state: string; updateAvailable: boolean; upgradeCommand?: string };
+      apiCompatibility: { status: string; source: string; minVersion: string; latestRecommendedVersion: string; apiVersion: string };
+    };
 
     expect(payload.package.state).toBe("current");
     expect(payload.package.updateAvailable).toBe(false);
     expect(payload.package.upgradeCommand).toBeUndefined();
+    expect(payload.apiCompatibility).toMatchObject({
+      status: "compatible",
+      source: "compatibility_endpoint",
+      minVersion: "0.2.0",
+      latestRecommendedVersion: "0.2.0",
+      apiVersion: "0.1.0",
+    });
   });
 
   it("orders prerelease npm versions correctly (release outranks prerelease of the same core)", async () => {
@@ -135,7 +145,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("treats an unavailable npm registry as a warning, not a hard failure", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer({ npmStatus: 500 });
+    const url = await startFixtureServer({ npmStatus: 500, compatibilityStatus: 404 });
     const status = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -178,7 +188,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("reports API compatibility as unavailable when the API does not advertise a minimum version", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer();
+    const url = await startFixtureServer({ compatibilityStatus: 404 });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -188,6 +198,49 @@ describe("gittensory-mcp CLI", () => {
       }),
     ) as { apiCompatibility: { status: string } };
     expect(payload.apiCompatibility.status).toBe("unavailable");
+
+    const doctor = JSON.parse(
+      await runAsync(["doctor", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--json"], {
+        GITTENSORY_API_URL: url,
+        GITTENSORY_TOKEN: "session-token",
+        GITTENSORY_CONFIG_DIR: tempDir,
+        GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+      }),
+    ) as { checks: Array<{ name: string; status: string }> };
+    expect(doctor.checks).toEqual(expect.arrayContaining([expect.objectContaining({ name: "api_compatibility", status: "warn" })]));
+  });
+
+  it("falls back to legacy health compatibility when the endpoint is unavailable", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const url = await startFixtureServer({ compatibilityStatus: 503, minMcpVersion: "0.2.0" });
+    const payload = JSON.parse(
+      await runAsync(["status", "--json"], {
+        GITTENSORY_API_URL: url,
+        GITTENSORY_TOKEN: "session-token",
+        GITTENSORY_CONFIG_DIR: tempDir,
+        GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+      }),
+    ) as { apiCompatibility: { status: string; source: string; minVersion: string } };
+    expect(payload.apiCompatibility).toMatchObject({ status: "compatible", source: "health", minVersion: "0.2.0" });
+  });
+
+  it("uses API recommended package metadata when the npm registry is unavailable", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: "0.3.0" });
+    const payload = JSON.parse(
+      await runAsync(["status", "--json"], {
+        GITTENSORY_API_URL: url,
+        GITTENSORY_NPM_REGISTRY_URL: url,
+        GITTENSORY_TOKEN: "session-token",
+        GITTENSORY_CONFIG_DIR: tempDir,
+      }),
+    ) as { package: { state: string; latestStatus: string; latestVersion: string; upgradeCommand: string } };
+    expect(payload.package).toMatchObject({
+      state: "stale",
+      latestStatus: "api",
+      latestVersion: "0.3.0",
+      upgradeCommand: "npm install -g @jsonbored/gittensory-mcp@latest",
+    });
   });
 
   it("flags API compatibility mismatches with upgrade guidance", async () => {
@@ -571,7 +624,17 @@ async function capturePacketValidation(tempDir: string, validationArgs: string[]
   return (requests[0] as { validation: Array<{ command: string; status: string; exitCode?: number; summary?: string }> }).validation;
 }
 
-async function startFixtureServer(options: { latestVersion?: string; minMcpVersion?: string; npmStatus?: number; packetMarkdown?: string; onPacketRequest?: (body: unknown) => void } = {}) {
+async function startFixtureServer(
+  options: {
+    latestVersion?: string;
+    latestRecommendedMcpVersion?: string;
+    minMcpVersion?: string;
+    compatibilityStatus?: number;
+    npmStatus?: number;
+    packetMarkdown?: string;
+    onPacketRequest?: (body: unknown) => void;
+  } = {},
+) {
   server = createServer(async (request, response) => {
     response.setHeader("content-type", "application/json");
     if (request.url && request.url.includes("gittensory-mcp/latest")) {
@@ -581,6 +644,35 @@ async function startFixtureServer(options: { latestVersion?: string; minMcpVersi
         return;
       }
       response.end(JSON.stringify({ version: options.latestVersion ?? "0.2.0" }));
+      return;
+    }
+    if (request.url === "/v1/mcp/compatibility") {
+      if (options.compatibilityStatus && options.compatibilityStatus >= 400) {
+        response.statusCode = options.compatibilityStatus;
+        response.end(JSON.stringify({ error: "compatibility_unavailable" }));
+        return;
+      }
+      const minimumSupportedVersion = options.minMcpVersion ?? "0.2.0";
+      const latestRecommendedVersion = options.latestRecommendedMcpVersion ?? options.latestVersion ?? "0.2.0";
+      response.end(
+        JSON.stringify({
+          status: "ok",
+          service: "gittensory-api",
+          apiVersion: "0.1.0",
+          mcp: {
+            packageName: "@jsonbored/gittensory-mcp",
+            minimumSupportedVersion,
+            latestRecommendedVersion,
+            latestPackageVersion: latestRecommendedVersion,
+            supportedVersionRange: `>=${minimumSupportedVersion}`,
+            upgradeCommand: "npm install -g @jsonbored/gittensory-mcp@latest",
+            npxFallbackCommand: "npx @jsonbored/gittensory-mcp@latest <command>",
+          },
+          compatibilityWarnings: [],
+          breakingChanges: [],
+          generatedAt: "2026-05-30T00:00:00.000Z",
+        }),
+      );
       return;
     }
     if (request.url === "/health") {

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -5,6 +5,7 @@ describe("OpenAPI contract", () => {
   it("exports the modern private-beta backend contract only", () => {
     const spec = buildOpenApiSpec();
     expect(spec.paths["/health"]).toBeDefined();
+    expect(spec.paths["/v1/mcp/compatibility"]).toBeDefined();
     expect(spec.paths["/v1/registry/snapshot"]).toBeDefined();
     expect(spec.paths["/v1/registry/changes"]).toBeDefined();
     expect(spec.paths["/v1/readiness"]).toBeDefined();
@@ -63,6 +64,7 @@ describe("OpenAPI contract", () => {
     }
 
     expect(spec.components?.schemas?.ContributorProfile).toBeDefined();
+    expect(spec.components?.schemas?.McpCompatibility).toBeDefined();
     expect(spec.components?.schemas?.ContributorDecisionPack).toBeDefined();
     expect(spec.components?.schemas?.DecisionPackRefreshNeeded).toBeDefined();
     expect(spec.components?.schemas?.RepoDecisionResponse).toBeDefined();
@@ -83,5 +85,7 @@ describe("OpenAPI contract", () => {
     expect(JSON.stringify(spec.components?.schemas?.ContributorOutcomeHistory)).toContain("reconciliation");
     expect(JSON.stringify(spec.components?.schemas?.LocalBranchAnalysis)).toContain("baseFreshness");
     expect(JSON.stringify(spec.components?.schemas?.LocalBranchAnalysis)).toContain("recommendedRerunCondition");
+    expect(JSON.stringify(spec.components?.schemas?.McpCompatibility)).toContain("minimumSupportedVersion");
+    expect(JSON.stringify(spec.components?.schemas?.McpCompatibility)).toContain("compatibilityWarnings");
   });
 });


### PR DESCRIPTION
## Summary

Closes #86

- Add a public-safe `/v1/mcp/compatibility` endpoint with API version, MCP package compatibility metadata, warnings, and breaking-change notices.
- Wire `gittensory-mcp status` and `doctor` to consume the compatibility contract while preserving legacy `/health` fallback behavior.
- Cover endpoint schema, OpenAPI registration, CLI compatible/stale/incompatible states, graceful fallback, and no token/local-path leakage regressions.

## Validation

- [x] `npm run test:ci`
- [x] Changelog updated only if this is a release-prep change <!-- N/A: not release-prep; no changelog update needed -->

## Safety

- [x] Backend-only change
- [x] No secrets, wallet details, user PATs, raw trust scores, or private rankings exposed
- [x] Public text avoids compensation-seeking or optimization-tactic language
- [x] OpenAPI/MCP behavior updated where needed
- [x] Public docs/changelogs updated where needed <!-- OpenAPI updated; docs/changelog not needed for this non-release change -->