### PR TITLE
fix(ui): render app subroutes directly

### DIFF
--- a/apps/gittensory-ui/src/routes/app.commands.tsx
+++ b/apps/gittensory-ui/src/routes/app.commands.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { CommandsPanel } from "@/components/site/app-panels/commands-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/commands")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/workbench", search: { tab: "commands" } });
-  },
+  component: CommandsRoute,
 });
+
+function CommandsRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Commands"
+        title="@gittensory command catalog"
+        description="Preview maintainer command behavior against live API contracts without rerouting through the workbench."
+      />
+      <CommandsPanel />
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.digest.tsx
+++ b/apps/gittensory-ui/src/routes/app.digest.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DigestPanel } from "@/components/site/app-panels/digest-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/digest")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/workbench", search: { tab: "digest" } });
-  },
+  component: DigestRoute,
 });
+
+function DigestRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Digest"
+        title="Contribution digest"
+        description="Review live digest data and store subscription preferences directly on the digest route."
+      />
+      <DigestPanel />
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.maintainer.tsx
+++ b/apps/gittensory-ui/src/routes/app.maintainer.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { MaintainerPanel } from "@/components/site/app-panels/maintainer-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/maintainer")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/repos", search: { tab: "maintainer" } });
-  },
+  component: MaintainerRoute,
 });
+
+function MaintainerRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Maintainer"
+        title="Maintainer console"
+        description="Inspect install health, public-surface previews, and quiet-by-default maintainer controls directly."
+      />
+      <MaintainerPanel />
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.miner.tsx
+++ b/apps/gittensory-ui/src/routes/app.miner.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { MinerPanel } from "@/components/site/app-panels/miner-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/miner")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/workbench", search: { tab: "miner" } });
-  },
+  component: MinerRoute,
 });
+
+function MinerRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Miner"
+        title="Miner dashboard"
+        description="Plan next actions, inspect scoreability, and review live contributor context directly."
+      />
+      <MinerPanel />
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.owner.tsx
+++ b/apps/gittensory-ui/src/routes/app.owner.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { OwnerPanel } from "@/components/site/app-panels/owner-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/owner")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/repos", search: { tab: "owner" } });
-  },
+  component: OwnerRoute,
 });
+
+function OwnerRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Owner"
+        title="Repository owner surface"
+        description="Review registration readiness, config recommendations, and repo-owner signals directly."
+      />
+      <OwnerPanel />
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.playground.tsx
+++ b/apps/gittensory-ui/src/routes/app.playground.tsx
@@ -1,7 +1,21 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PlaygroundPanel } from "@/components/site/app-panels/playground-panel";
+import { PageHeader } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/app/playground")({
-  beforeLoad: () => {
-    throw redirect({ to: "/app/workbench", search: { tab: "playground" } });
-  },
+  component: PlaygroundRoute,
 });
+
+function PlaygroundRoute() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Playground"
+        title="Agent tool playground"
+        description="Run preflight, planning, and blocker-explanation tools directly from the playground route."
+      />
+      <PlaygroundPanel />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace redirect-only app subroutes with direct route components.
- Keep the existing workbench/repos tab surfaces intact while allowing direct refreshes on canonical subroute URLs.

## Validation
- git diff --check
- npm run ui:typecheck
- npm run ui:lint
- npm run ui:build

## Notes
- This removes the 307 responses from /app/commands, /app/digest, /app/maintainer, /app/miner, /app/owner, and /app/playground.