### PR TITLE
fix(api): restrict extension session scope

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -349,6 +349,7 @@ export function createApp() {
     if (!requiresApiToken(c.req.path)) return next();
     const identity = await authenticateRequestIdentity(c);
     if (!identity) return c.json({ error: "unauthorized" }, 401);
+    if (isExtensionScopedSession(identity) && c.req.path !== EXTENSION_PULL_CONTEXT_PATH) return c.json({ error: "insufficient_scope" }, 403);
     return next();
   });
 
@@ -468,12 +469,13 @@ export function createApp() {
   app.post("/v1/auth/extension/session", async (c) => {
     const identity = await authenticateRequestIdentity(c);
     if (!identity || identity.kind !== "session") return c.json({ error: "browser_session_required" }, 403);
+    if (isExtensionScopedSession(identity)) return c.json({ error: "browser_session_required" }, 403);
     const githubUser = identity.session.githubUserId === undefined ? { login: identity.session.login } : { login: identity.session.login, id: identity.session.githubUserId };
     const { token, session } = await createSessionForGitHubUser(
       c.env,
       githubUser,
       {
-        scopes: ["extension:pull_context"],
+        scopes: [EXTENSION_PULL_CONTEXT_SCOPE],
         metadata: {
           source: "browser_extension",
           parentSessionId: identity.session.id,
@@ -2031,11 +2033,18 @@ function contributorEvidenceFromProfile(profile: {
   };
 }
 
+const EXTENSION_PULL_CONTEXT_PATH = "/v1/extension/pull-context";
+const EXTENSION_PULL_CONTEXT_SCOPE = "extension:pull_context";
+
 type ProtectedRouteContext = {
   env: Env;
   req: { header: (name: string) => string | undefined | null };
   json: (object: { error: string }, status?: number) => Response;
 };
+
+function isExtensionScopedSession(identity: AuthIdentity): boolean {
+  return identity.kind === "session" && identity.session.scopes.includes(EXTENSION_PULL_CONTEXT_SCOPE);
+}
 
 async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {
   const bearer = await authenticatePrivateToken(c.env, extractBearerToken(c.req.header("authorization")));

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1160,6 +1160,25 @@ describe("api routes", () => {
     const extensionSessionBody = (await extensionSession.json()) as { token: string; login: string; scopes: string[] };
     expect(extensionSessionBody).toMatchObject({ login: "oktofeesh1", scopes: ["extension:pull_context"] });
 
+    const remintedExtensionSession = await app.request(
+      "/v1/auth/extension/session",
+      { method: "POST", headers: { authorization: `Bearer ${extensionSessionBody.token}` } },
+      env,
+    );
+    expect(remintedExtensionSession.status).toBe(403);
+
+    const extensionDecisionPack = await app.request(
+      "/v1/contributors/oktofeesh1/decision-pack",
+      { headers: { authorization: `Bearer ${extensionSessionBody.token}` } },
+      env,
+    );
+    expect(extensionDecisionPack.status).toBe(403);
+    await expect(extensionDecisionPack.json()).resolves.toMatchObject({ error: "insufficient_scope" });
+
+    const extensionOverview = await app.request("/v1/app/overview", { headers: { authorization: `Bearer ${extensionSessionBody.token}` } }, env);
+    expect(extensionOverview.status).toBe(403);
+    await expect(extensionOverview.json()).resolves.toMatchObject({ error: "insufficient_scope" });
+
     const fallbackOriginEnv = createTestEnv({ ADMIN_GITHUB_LOGINS: "oktofeesh1" });
     delete (fallbackOriginEnv as Partial<Env>).PUBLIC_API_ORIGIN;
     const { token: noIdToken } = await createSessionForGitHubUser(fallbackOriginEnv, { login: "oktofeesh1" });


### PR DESCRIPTION
### Motivation
- Scoped extension bearer tokens (`scopes: ["extension:pull_context"]`) were being accepted as full session identities and could access protected `/v1/*` APIs or remint sessions, violating the intended limited-extension boundary. 

### Description
- Add `EXTENSION_PULL_CONTEXT_PATH` and `EXTENSION_PULL_CONTEXT_SCOPE` constants and helper `isExtensionScopedSession` to identify extension-scoped sessions.  
- Enforce scope at global protected-route middleware by returning `insufficient_scope` for extension-scoped sessions on any protected route other than `"/v1/extension/pull-context"`.  
- Deny reminting of extension sessions by rejecting extension-scoped identities in the `POST /v1/auth/extension/session` handler.  
- Add integration assertions in `test/integration/api.test.ts` to confirm extension tokens cannot remint or access private routes but still access the extension pull-context route. 

### Testing
- Ran the integration subset with `npx vitest run test/integration/api.test.ts --reporter=verbose` and the modified test passed.  
- Ran full suite with `npm test` and all tests passed (`36 files, 435 tests passed, 1 skipped`).  
- Ran typecheck with `npm run typecheck` and it passed.  
- Attempted `npm test -- --runInBand` which failed because Vitest in this repo does not accept the Jest `--runInBand` option (this is an expected tooling mismatch, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca387a2e8832cb803bb285549dc2a)