### PR TITLE
ci(release): allow MCP scorer scripts in publish smoke

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -52,7 +52,7 @@ jobs:
           set -euo pipefail
           PACK_JSON="$(npm pack --workspace @jsonbored/gittensory-mcp --json)"
           TARBALL="$(node -e 'const fs=require("fs"); const input=fs.readFileSync(0,"utf8"); process.stdout.write(JSON.parse(input)[0].filename)' <<< "$PACK_JSON")"
-          UNEXPECTED_FILES="$(tar -tzf "$TARBALL" | grep -Ev '^(package/(bin|lib)/.+|package/(package.json|README.md|CHANGELOG.md|LICENSE))$' || true)"
+          UNEXPECTED_FILES="$(tar -tzf "$TARBALL" | grep -Ev '^(package/(bin|lib|scripts)/.+|package/(package.json|README.md|CHANGELOG.md|LICENSE))$' || true)"
           if [ -n "$UNEXPECTED_FILES" ]; then
             printf '%s\n' "$UNEXPECTED_FILES"
             echo "Unexpected file in package tarball"


### PR DESCRIPTION
## Summary
- Fix the MCP publish workflow tarball allowlist so the package scorer scripts are accepted during the release smoke test.

## What changed
- Allows `package/scripts/*` in the publish workflow tarball contents check.

## Why
- `@jsonbored/gittensory-mcp@0.3.0` intentionally ships `scripts/gittensor-score-preview.mjs` and `scripts/gittensor-score-preview.py`; the local package check allowed them, but the trusted publish workflow still rejected them.

## Validation
- `npm run actionlint`
- `npm run test:mcp-pack`
- Ran the publish-workflow tarball allowlist check against `npm pack --workspace @jsonbored/gittensory-mcp`.

## Notes
- After this lands, move `mcp-v0.3.0` to the fixed main commit because the first tag workflow failed before npm publish.
