### PR TITLE
ci(changelog): skip MCP release maintenance entries

### DIFF
--- a/cliff.mcp.toml
+++ b/cliff.mcp.toml
@@ -36,6 +36,7 @@ commit_parsers = [
   { message = "^test", group = "Tests" },
   { message = "^docs\\(changelog\\)", skip = true },
   { message = "^chore\\(release\\)", skip = true },
+  { message = "^ci\\(release\\)", skip = true },
   { message = "^ci\\(changelog\\)", skip = true },
   { message = "^ci", group = "CI" },
   { message = "^build", group = "Build" },

--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -45,12 +45,6 @@
 ## mcp-v0.1.4 - 2026-05-26
 
 
-### CI
-
-- Fix mcp publish tarball allowlist
-
-
-
 ### Features
 
 - Add public registration polish gates


### PR DESCRIPTION
## Summary
- Skip MCP release-maintenance CI commits in the MCP changelog config and regenerate the changelog.

## What changed
- Adds `ci(release)` to the MCP changelog skip rules.
- Regenerates `packages/gittensory-mcp/CHANGELOG.md` so release maintenance entries stay out of package-facing notes.

## Why
- Moving `mcp-v0.3.0` over the publish workflow fix caused `npm run changelog:check:mcp` to include release plumbing in the package changelog.

## Validation
- `npm run actionlint`
- `git diff --check`
- `npm run changelog:check:mcp`

## Notes
- After this lands, move `mcp-v0.3.0` to the fixed main commit and rerun the trusted publish workflow.
