### PR TITLE
docs(contributing): clarify review and deploy guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,14 +1,19 @@
 name: Bug report
-description: Report a backend, API, MCP, GitHub App, or signal issue.
+description: Report a UI, API, MCP, GitHub App, deploy, or signal issue.
 title: "[Bug]: "
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include secrets, tokens, wallet details, hotkeys, coldkeys, private maintainer evidence, private scoring output, or local absolute paths.
+        Security issues must be reported privately through GitHub Security Advisories.
   - type: textarea
     id: summary
     attributes:
       label: Summary
-      description: What is wrong?
+      description: What is wrong, and what user or maintainer workflow does it affect?
     validations:
       required: true
   - type: dropdown
@@ -16,9 +21,12 @@ body:
     attributes:
       label: Area
       options:
+        - Frontend UI
         - REST API
         - MCP
         - GitHub App
+        - Auth/session
+        - Cloudflare deploy/runtime
         - Registry sync
         - GitHub backfill
         - Signal logic
@@ -30,18 +38,34 @@ body:
     id: expected
     attributes:
       label: Expected behavior
+      description: What should have happened?
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
       label: Actual behavior
+      description: What happened instead?
     validations:
       required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Include exact route, endpoint, command, sanitized request shape, or GitHub App event path.
+    validations:
+      required: false
   - type: textarea
     id: validation
     attributes:
       label: Validation
-      description: Include commands, status codes, or sanitized logs. Do not include secrets, wallet details, or private tokens.
+      description: Include commands, status codes, screenshots, or sanitized logs. Remove secrets, tokens, and local paths.
     validations:
       required: false
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Public-safety check
+      options:
+        - label: I removed secrets, tokens, wallet details, private keys, local paths, and private scoring output.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Contribution guidelines
+    url: https://github.com/JSONbored/gittensory/blob/main/CONTRIBUTING.md
+    about: Read this before opening a PR or proposing larger work.
+  - name: Code of Conduct
+    url: https://github.com/JSONbored/gittensory/blob/main/CODE_OF_CONDUCT.md
+    about: Expected behavior for issues, PRs, reviews, and support discussions.
+  - name: Support guide
+    url: https://github.com/JSONbored/gittensory/blob/main/SUPPORT.md
+    about: Use this for non-sensitive support details and issue hygiene.
   - name: Security issue
     url: https://github.com/JSONbored/gittensory/security/advisories/new
     about: Please report security issues privately. Do not open a public issue with secrets or sensitive data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,21 +1,52 @@
 name: Feature request
-description: Suggest a backend signal, API, MCP, GitHub App, or operational improvement.
+description: Suggest a UI, API, MCP, GitHub App, signal, docs, or operational improvement.
 title: "[Feature]: "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep requests concrete. Broad redesigns, framework swaps, GitHub Pages/VitePress restoration, reward-farming features, and public private-signal exposure are out of scope.
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What contributor, maintainer, or repo-owner problem should this solve?
+      description: What contributor, maintainer, operator, or repo-owner problem should this solve?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend UI
+        - REST API
+        - MCP
+        - GitHub App
+        - Auth/session
+        - Cloudflare deploy/runtime
+        - Registry/backfill
+        - Signal logic
+        - Tests/CI
+        - Documentation
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: Proposal
-      description: Describe the backend behavior, signal, or API shape.
+      description: Describe the behavior, signal, UI, API shape, or operational change.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What would prove this is done and production-safe?
+      placeholder: |
+        - ...
+        - ...
     validations:
       required: true
   - type: checkboxes
@@ -23,7 +54,11 @@ body:
     attributes:
       label: Boundaries
       options:
-        - label: This is backend-only.
-        - label: This does not require storing user PATs.
-        - label: This does not expose wallet details, raw trust scores, or private rankings publicly.
+        - label: This does not restore GitHub Pages, VitePress, `site/`, or `CNAME`.
+          required: true
+        - label: This does not require storing user PATs or adding a non-GitHub identity provider.
+          required: true
+        - label: This does not expose wallet details, raw trust scores, private rankings, or reward estimates publicly.
+          required: true
         - label: This does not auto-close, auto-merge, rewrite contributor work, or label PRs outside the confirmed-miner policy.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,42 @@
 
 -
 
+## Scope
+
+- [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
+- [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
+- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.
+
 ## Validation
 
-- [ ] `npm run test:ci`
-- [ ] Changelog updated only if this is a release-prep change
+- [ ] `git diff --check`
+- [ ] `npm run actionlint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test:coverage`
+- [ ] `npm run test:workers`
+- [ ] `npm run build:mcp`
+- [ ] `npm run test:mcp-pack`
+- [ ] `npm run ui:openapi:check`
+- [ ] `npm run ui:lint`
+- [ ] `npm run ui:typecheck`
+- [ ] `npm run ui:build`
+- [ ] `npm audit --audit-level=moderate`
+- [ ] Coverage remains at or above 97% for statements, branches, functions, and lines.
+
+If any required check was skipped, explain why:
+
+-
 
 ## Safety
 
-- [ ] Backend-only change
-- [ ] No secrets, wallet details, user PATs, raw trust scores, or private rankings exposed
-- [ ] Public text avoids compensation-seeking or optimization-tactic language
-- [ ] OpenAPI/MCP behavior updated where needed
-- [ ] Public docs/changelogs updated where needed
+- [ ] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
+- [ ] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
+- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
+- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
+- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
+- [ ] Visible UI changes include screenshots or a short recording.
+- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
+
+## Notes
+
+-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code Of Conduct
+
+Gittensory is maintained as a direct, technical, evidence-first project. We expect contributors,
+maintainers, and users to keep discussions focused on the work, the proof, and the production
+impact.
+
+## Expected Behavior
+
+- Be respectful and specific when giving or receiving feedback.
+- Keep criticism technical and actionable.
+- Assume public issues and PRs are permanent public records.
+- Use private reporting channels for security issues or sensitive evidence.
+- Remove secrets, tokens, wallet details, private keys, local paths, and private scoring output
+  before posting logs, screenshots, or reproduction steps.
+- Respect maintainer scope decisions when a PR is closed, split, or redirected.
+
+## Unacceptable Behavior
+
+- Harassment, threats, personal attacks, slurs, or sexualized language.
+- Spam, reward-farming noise, generated bulk submissions, or intentionally low-effort PRs.
+- Posting secrets, private contributor evidence, private maintainer evidence, wallet details,
+  hotkeys, coldkeys, raw trust scores, or private rankings publicly.
+- Misrepresenting Gittensory output as guaranteed compensation, guaranteed ranking, or financial
+  advice.
+- Evading review boundaries by reopening closed work without addressing the stated reason.
+- Attempting to bypass authentication, rate limits, GitHub App permissions, or Cloudflare Worker
+  controls.
+
+## Enforcement
+
+Maintainers may edit or delete comments, close issues or PRs, block users, or report abuse when
+behavior violates this Code of Conduct, the contribution guidelines, or GitHub's terms.
+
+For security issues, use GitHub private vulnerability reporting:
+
+https://github.com/JSONbored/gittensory/security/advisories/new
+
+For non-sensitive support, use GitHub issues and follow `SUPPORT.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,166 @@
 # Contributing
 
-Gittensory is a backend-only project. Contributions should improve the API, GitHub App, MCP
-surface, registry/backfill jobs, signal logic, tests, or operational safety.
+Gittensory is a Cloudflare Workers, TanStack Start, GitHub App, and MCP project for
+Gittensor OSS contribution intelligence. Contributions need to protect that scope: private
+signals stay private, public GitHub output stays sanitized, and production surfaces must stay
+wired to real backend behavior.
 
-## Scope
+This project is maintained with a high review bar. PRs that ignore these guidelines, mix
+unrelated work, reintroduce retired architecture, or repeatedly fail the required gates may be
+closed without an extended review cycle.
 
-Accepted contribution areas:
+## What We Accept
 
-- deterministic signal builders for contributors, maintainers, and repo owners
-- GitHub App webhook, check-run, and sanitized comment behavior
-- registry, bounty, issue, PR, label, queue, and collision ingestion
-- Cloudflare Worker, D1, Queue, and scheduled job reliability
-- MCP tools and the thin npm MCP wrapper
-- test coverage, invariants, fixtures, OpenAPI/MCP contracts, and CI hardening
+Focused contributions are welcome in these areas:
 
-Out of scope:
+- Backend API behavior, auth/session handling, OpenAPI contracts, and API error states.
+- GitHub App webhook, check-run, command, sanitized comment, and installation-health behavior.
+- Registry, bounty, issue, PR, label, queue, collision, and GitHub backfill ingestion.
+- Deterministic signal builders for contributors, maintainers, repository owners, and operators.
+- The Lovable/TanStack Start frontend under `apps/gittensory-ui`, as long as it preserves the
+  current product structure and stays wired to live API data or honest empty/error states.
+- Cloudflare Worker, D1, Queue, scheduled job, deploy, and production smoke reliability.
+- MCP server/client behavior, CLI ergonomics, compatibility metadata, and npm package hygiene.
+- Tests, fixtures, invariants, OpenAPI/MCP contract checks, CI hardening, docs, and developer
+  experience improvements.
 
-- frontend UI work
-- public leaderboards
-- public wallet or raw trust-score exposure
-- auto-closing, auto-merging, rewriting contributor work, or applying labels outside the explicit confirmed-miner GitHub App policy
-- storing contributor PATs
-- public text that implies compensation estimates or optimization tactics
+## What We Do Not Accept
 
-## Quality Bar
+Do not open PRs for:
 
-- Run `npm run test:ci` before opening a PR.
-- Add or update tests for behavior changes.
-- Keep API and MCP responses structured and machine-readable.
-- Keep public GitHub comments advisory, sanitized, and non-spammy.
-- Keep GitHub App labels limited to configured labels for officially confirmed Gittensor miner PRs.
-- Prefer deterministic, evidence-based rules over opaque scoring.
-- Use Conventional Commit style for release-quality changelog output.
-- Do not update changelogs in ordinary PRs unless the PR is explicitly preparing a release.
+- GitHub Pages, VitePress, `site/`, `CNAME`, or any old static-docs production surface.
+- Broad rewrites, framework swaps, or redesigns without a maintainer-approved issue.
+- Production mock/demo data, silent fallback data, or UI claims that are not backed by live API
+  behavior.
+- Public leaderboards, raw wallet details, raw trust scores, private rankings, or public reward
+  estimates.
+- Auto-closing, auto-merging, rewriting contributor work, or applying labels outside the explicit
+  confirmed-miner GitHub App policy.
+- Storing contributor GitHub PATs or adding non-GitHub identity providers. Browser auth is GitHub
+  OAuth; CLI/MCP auth is GitHub Device Flow.
+- Large dependency major upgrades bundled with unrelated product changes.
+- Changelog edits in ordinary feature/fix PRs. Changelogs are updated during release prep.
+- Low-effort reward-farming changes, spam, generated bulk edits, or PRs that do not explain the
+  product impact.
 
-## Pull Request Checklist
+## Before Opening A PR
 
-- The change is backend-only.
-- Tests cover the new behavior or regression.
-- Public surfaces do not expose secrets, wallet details, raw trust scores, or private rankings.
-- Public text avoids compensation-seeking or optimization-tactic language.
-- OpenAPI and MCP schemas stay aligned with behavior.
+- Search existing issues and PRs to avoid duplicate work.
+- Open an issue first for risky changes, public behavior changes, auth/session changes, schema
+  migrations, major dependency upgrades, deploy changes, or frontend architecture changes.
+- Keep the PR narrow. If the change spans backend, UI, MCP, and deploy behavior, explain why it
+  cannot be split safely.
+- Do not include secrets, tokens, private keys, webhook payload secrets, wallet details, hotkeys,
+  coldkeys, private maintainer evidence, local absolute paths, or private scoring output.
+
+## Required PR Contents
+
+Every PR should include:
+
+- A clear summary of what changed and why.
+- A linked issue or a short explanation for why no issue is needed.
+- The exact validation commands run from the repo root.
+- Screenshots or a short screen recording for visible UI changes.
+- API/OpenAPI/MCP contract notes for schema or behavior changes.
+- Migration, deploy, secret, or Cloudflare configuration notes when relevant.
+- Security/privacy notes for auth, cookies, CORS, GitHub App output, user identity, or contributor
+  evidence changes.
+
+## Required Gates
+
+Run the full gate before asking for review unless the PR is docs-only and you clearly say which
+checks were skipped and why:
+
+```sh
+git diff --check
+npm run actionlint
+npm run typecheck
+npm run test:coverage
+npm run test:workers
+npm run build:mcp
+npm run test:mcp-pack
+npm run ui:openapi:check
+npm run ui:lint
+npm run ui:typecheck
+npm run ui:build
+npm audit --audit-level=moderate
+```
+
+`npm run test:ci` runs the normal combined gate. Coverage must stay at or above 97% for
+statements, branches, functions, and lines.
+
+Maintainer/release smoke checks:
+
+```sh
+npm run test:smoke:production
+npm run test:smoke:browser:install
+npm run test:smoke:browser
+```
+
+The browser smoke path is manual until it is stable enough to make required on every PR.
+
+## Test Expectations
+
+Tests should prove behavior, not just exercise lines for coverage.
+
+- Backend/API tests should cover success, denied, invalid input, missing auth, scoped auth,
+  rate-limit, persistence, and error-shaping paths.
+- Auth tests should cover browser cookie sessions, bearer sessions, logout/revocation, GitHub
+  OAuth callback failures, and Device Flow compatibility.
+- CORS tests should prove trusted credentialed origins work and untrusted origins do not.
+- OpenAPI tests should prove protected/public metadata matches actual middleware behavior.
+- Frontend tests and build checks should prevent production mock fallbacks, broken route
+  hydration, stale OpenAPI artifacts, and localStorage-only app login regressions.
+- MCP tests should cover CLI behavior, package contents, compatibility metadata, fallback
+  behavior, and machine-readable JSON output.
+- Worker tests should cover runtime-specific behavior that Node-only tests cannot represent.
+
+## Area-Specific Notes
+
+Backend/API:
+
+- Keep responses structured and machine-readable.
+- Keep contributor-scoped endpoints scoped to the authenticated GitHub identity.
+- Public `/openapi.json` is allowed; protected data endpoints must stay protected.
+
+Frontend:
+
+- The production frontend is the TanStack Start app in `apps/gittensory-ui`.
+- Use the existing design system and route structure unless a maintainer explicitly approves a
+  larger redesign.
+- Signed-in app state comes from `GET /v1/auth/session`; do not restore app login through
+  localStorage bearer tokens.
+- API Try It may still support manual bearer-token testing.
+
+Cloudflare/deploy:
+
+- Production UI deploys through the `gittensory-ui` Cloudflare Worker on
+  `https://gittensory.aethereal.dev/`.
+- Production API deploys through the `gittensory-api` Cloudflare Worker on
+  `https://gittensory-api.aethereal.dev/`.
+- Cloudflare Workers Builds owns automatic UI deployments from GitHub. GitHub Actions UI deploy is
+  manual validation/fallback only.
+- Do not re-add GitHub Pages or static-site deployment workflows.
+
+MCP:
+
+- Preserve backwards compatibility where practical.
+- Keep CLI output stable and JSON output parseable.
+- MCP package releases are prepared separately and published from protected `mcp-vX.Y.Z` tags.
+
+Public GitHub surfaces:
+
+- Keep public comments advisory, sanitized, and low-noise.
+- Keep labels limited to configured labels for officially confirmed Gittensor miner PRs.
+- Never publish private reviewability, scoring, wallet, hotkey, or reward/risk context.
+
+## Commit And PR Titles
+
+Use Conventional Commit style for PR titles and release-quality commit messages:
+
+```text
+feat(api): add maintainer queue signal
+fix(ui): restore signed-out app empty state
+test(mcp): cover compatibility fallback
+docs(contributing): clarify review gates
+```

--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ The frontend is a TanStack Start app imported from the Lovable `gittensory-docs`
 
 Cloudflare Workers Builds owns automatic frontend deployments from GitHub. The `.github/workflows/ui-deploy.yml` workflow is a manual validation fallback only.
 
+GitHub Pages and VitePress are retired. Do not add `site/`, `.vitepress`, `CNAME`, `gh-pages`, or Pages deployment workflows back to this repository.
+
+## Contributing
+
+Read `CONTRIBUTING.md` before opening an issue or PR. The contribution policy defines accepted areas, out-of-scope work, required PR contents, and the full validation gate.
+
+The normal PR gate is:
+
+```sh
+npm run test:ci
+```
+
+Coverage must stay at or above 97% for statements, branches, functions, and lines. Production smoke is available for release/maintainer validation:
+
+```sh
+npm run test:smoke:production
+```
+
 ## Changelog And Releases
 
 Normal feature/fix PRs do not edit changelogs. Keep PR titles Conventional Commit
@@ -213,6 +231,8 @@ npm run test:ci
 
 ## Support And Security
 
+- Contribution policy: `CONTRIBUTING.md`
+- Code of Conduct: `CODE_OF_CONDUCT.md`
 - Public support: `SUPPORT.md`
 - Security policy: `SECURITY.md`
 - Privacy and terms: `apps/gittensory-ui/src/routes/docs.privacy-security.tsx`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,8 @@ include only the minimum reproduction details needed to verify the issue.
 ## Privacy Posture
 
 - Gittensory does not store user GitHub PATs.
+- Browser auth uses GitHub OAuth and an HttpOnly Gittensory session cookie. CLI/MCP auth uses the
+  existing GitHub Device Flow and bearer session token.
 - Public PR comments are sanitized and only posted for officially confirmed Gittensor miners when
   the installed repository settings allow them.
 - Detailed contributor evidence belongs in authenticated API and MCP responses only.
@@ -21,6 +23,10 @@ include only the minimum reproduction details needed to verify the issue.
   public comments or public issue templates.
 - GitHub App private keys, webhook secrets, MCP tokens, API tokens, and internal job tokens must be
   stored as Cloudflare secrets.
+- `GITHUB_OAUTH_CLIENT_SECRET` is an API Worker runtime secret. Do not put it on the UI Worker,
+  in GitHub issue/PR text, in screenshots, or in public logs.
+- GitHub Pages and VitePress are retired; production traffic should go through the Cloudflare UI
+  and API Workers.
 
 ## Supported Version
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,9 +2,11 @@
 
 Use GitHub issues for public, non-sensitive support:
 
+- frontend route, hydration, signed-out/signed-in app, or API Try It problems
 - MCP install, auth, or local branch-analysis problems
 - GitHub App install health, permissions, or comment/label behavior
 - API contract, data freshness, or signal-quality bugs
+- Cloudflare Worker deploy/runtime behavior
 - documentation gaps
 
 Do not post secrets, private keys, webhook payload secrets, wallet details, hotkeys, coldkeys,
@@ -12,16 +14,19 @@ raw session tokens, private maintainer evidence, or private scoring output in pu
 
 For security issues, use the guidance in `SECURITY.md`.
 
+For conduct issues, use the expectations in `CODE_OF_CONDUCT.md`.
+
 ## Useful Issue Details
 
 - Gittensory MCP version from `gittensory-mcp status`
 - command used, with tokens and local paths removed
 - sanitized error message
 - repository owner/name when relevant
-- whether the problem is MCP, API, GitHub App, docs, or data freshness
+- frontend route or API endpoint when relevant
+- whether the problem is UI, MCP, API, GitHub App, Cloudflare deploy/runtime, docs, or data freshness
 
 ## Expected Response Posture
 
-Gittensory is maintained as a backend and agent-integration project. Support should keep the same
-boundaries as the product: no public wallet data, no raw trust scores, no public reward estimates,
-and no source-code upload by default.
+Gittensory is maintained as a Cloudflare Worker, frontend, GitHub App, and agent-integration
+project. Support should keep the same boundaries as the product: no public wallet data, no raw
+trust scores, no public reward estimates, and no source-code upload by default.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "packages/*"
   ],
   "type": "module",
-  "description": "Deterministic base-agent backend for Gittensor OSS contribution mining.",
+  "description": "Deterministic base-agent platform for Gittensor OSS contribution intelligence.",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",

--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
   ],
   "postUpdateOptions": ["npmDedupe"],
   "prBodyNotes": [
-    "Dependency PRs must keep `npm run test:ci` passing and preserve the 95% global coverage gate.",
+    "Dependency PRs must keep `npm run test:ci` passing and preserve the 97% global coverage gate.",
     "GitHub Actions updates must remain SHA-pinned."
   ],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## Summary
- modernize contributor-facing docs now that the production frontend lives in this repo
- add a project Code of Conduct and link it from support/issue surfaces
- make GitHub templates more explicit about accepted scope, required evidence, 97% coverage, and retired GitHub Pages/VitePress paths

## What changed
- rewrote `CONTRIBUTING.md` around accepted areas, out-of-scope work, PR contents, required gates, test focus, and closure expectations
- added `CODE_OF_CONDUCT.md`
- updated PR and issue templates for UI, Cloudflare, auth/session, safety, screenshots, and validation expectations
- updated README, SUPPORT, SECURITY, Renovate, and package metadata for the Cloudflare Worker frontend and 97% coverage gate

## Why
- the old docs still described Gittensory as backend-only and did not reflect the imported TanStack Start frontend or Cloudflare Workers deployment model
- review templates needed stronger upfront filtering so low-scope, unsafe, or stale-architecture PRs are easier to close quickly

## Validation
- `git diff --check`
- `npm run actionlint`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml renovate.json`
- `npm run test:ci`
