### PR TITLE
test(ci): freeze freshness fixture time

### DIFF
--- a/test/unit/data-quality.test.ts
+++ b/test/unit/data-quality.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildCoreSignalFidelity, buildFreshnessSloReport, buildRepoDataQuality, buildSignalFidelity, freshnessAuditMetadata } from "../../src/signals/data-quality";
 import type { PullRequestDetailSyncStateRecord, RepoGithubTotalsSnapshotRecord, RepoSyncSegmentRecord, RepoSyncStateRecord } from "../../src/types";
 
+const TEST_NOW_MS = Date.parse("2026-05-25T01:00:00.000Z");
+
 describe("sync data quality", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("marks capped and partial segments as degraded instead of complete", () => {
     const state = repoState({ status: "capped", warnings: ["GitHub sync reached local cap of 100 item(s)."] });
     const quality = buildRepoDataQuality("owner/repo", state, [

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -26,6 +26,7 @@ import { createTestEnv } from "../helpers/d1";
 
 describe("queue processors", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -283,6 +284,9 @@ describe("queue processors", () => {
   });
 
   it("marks fidelity repair completed when only signal refreshes are needed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T01:00:00.000Z"));
+
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       JOBS: {
@@ -331,6 +335,9 @@ describe("queue processors", () => {
   });
 
   it("queues signal repair and emits alertable audit state when freshness SLOs breach", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T13:00:00.000Z"));
+
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       JOBS: {


### PR DESCRIPTION
## Summary
- Freeze freshness-related unit fixture clocks so fixed May 2026 sync data does not age into stale state as wall-clock time moves forward.
- Keep production freshness checks unchanged.

## What changed
- Added deterministic fake timers around data-quality tests that use fixed freshness fixtures.
- Added deterministic fake timers around queue repair tests that audit freshness SLO metadata.
- Restored timers after each affected test path.

## Why
- The 97% coverage gate was failing on current main because fixed fixture timestamps were being compared against the real current date.
- The tests are intended to validate freshness behavior, not depend on the day they run.

## Validation
- `npm run test:unit -- test/unit/data-quality.test.ts test/unit/queue.test.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run test:ci`
- `npm run test:smoke:production`
