### PR TITLE
chore(deps): remove unused root packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",
-        "@hono/zod-validator": "^0.7.4",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@octokit/core": "^7.0.6",
         "agents": "^0.7.9",
@@ -27,7 +26,6 @@
         "@types/node": "^24.10.1",
         "@vitest/coverage-v8": "^4.1.7",
         "drizzle-kit": "^0.31.7",
-        "fast-check": "^4.8.0",
         "git-cliff": "^2.13.1",
         "github-actionlint": "^1.7.12",
         "node-addon-api": "^8.5.0",
@@ -2153,16 +2151,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@hono/zod-validator": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.6.tgz",
-      "integrity": "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "hono": ">=3.9.0",
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -8974,29 +8962,6 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
     },
-    "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.17.0"
-      }
-    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -11870,23 +11835,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",
-    "@hono/zod-validator": "^0.7.4",
     "@modelcontextprotocol/sdk": "1.26.0",
     "@octokit/core": "^7.0.6",
     "agents": "^0.7.9",
@@ -69,7 +68,6 @@
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "^4.1.7",
     "drizzle-kit": "^0.31.7",
-    "fast-check": "^4.8.0",
     "git-cliff": "^2.13.1",
     "github-actionlint": "^1.7.12",
     "node-addon-api": "^8.5.0",


### PR DESCRIPTION
## Summary
- Remove two unused root workspace dependencies.
- Leave the Lovable/TanStack UI package untouched.
- Keep native build helper packages because clean install proved `sharp` needs them when it falls back to source builds.

## What changed
- Removed `@hono/zod-validator` from root dependencies.
- Removed `fast-check` from root devDependencies.
- Updated `package-lock.json` to drop their unused transitive entries.

## Why
- These packages are no longer imported by backend/API/MCP code or validation scripts after the frontend migration and current backend cleanup.
- This keeps the non-UI dependency surface smaller without changing website code or Cloudflare/TanStack behavior.

## Validation
- `npm ci`
- `npm run test:ci`
- `npm run test:smoke:production`
