### PR TITLE
Fix saturation-model contribution bonus capped at 5 instead of MAX_CONTRIBUTION_BONUS (25)

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -211,9 +211,7 @@ function computeScoreCore(
   const densityMultiplier = clamp(rawDensity || 0, 0, constant(constants, "MAX_CODE_DENSITY_MULTIPLIER", 1.15));
   const densityTokenGatePassed = sourceTokenScore >= constant(constants, "MIN_TOKEN_SCORE_FOR_BASE_SCORE", 5);
   const baseTokenGatePassed = snapshot.activeModel === "pending_saturation_model" ? sourceTokenScore > 0 : densityTokenGatePassed;
-  const densityContributionBonus =
-    clamp(totalTokenScore / constant(constants, "CONTRIBUTION_SCORE_FOR_FULL_BONUS", 1500), 0, 1) *
-    constant(constants, "MAX_CONTRIBUTION_BONUS", 25);
+  const densityContributionBonus = contributionBonusRamp(totalTokenScore, constants);
   const saturationContributionBonusValue = saturationContributionBonus(totalTokenScore, constants);
   const saturationBaseScore = saturationScore(sourceTokenScore, totalTokenScore, constants);
   const densityBaseScore =
@@ -559,8 +557,17 @@ function saturationScore(sourceTokenScore: number, totalTokenScore: number, cons
 }
 
 function saturationContributionBonus(totalTokenScore: number, constants: Record<string, number>): number {
-  const contributionBonusCap = Math.min(constant(constants, "MAX_CONTRIBUTION_BONUS", 5), 5);
-  return clamp(totalTokenScore / constant(constants, "CONTRIBUTION_SCORE_FOR_FULL_BONUS", 1500), 0, 1) * contributionBonusCap;
+  return contributionBonusRamp(totalTokenScore, constants);
+}
+
+// Shared contribution-bonus ramp used by both scoring models so the saturation
+// and density bonuses cannot drift: clamp(totalTokenScore / FULL_BONUS, 0, 1)
+// scaled by MAX_CONTRIBUTION_BONUS (default 25).
+function contributionBonusRamp(totalTokenScore: number, constants: Record<string, number>): number {
+  return (
+    clamp(totalTokenScore / constant(constants, "CONTRIBUTION_SCORE_FOR_FULL_BONUS", 1500), 0, 1) *
+    constant(constants, "MAX_CONTRIBUTION_BONUS", 25)
+  );
 }
 
 function nonNegative(value: number | undefined): number {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -143,15 +143,15 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     });
 
     expect(preview.activeModel).toBe("pending_saturation_model");
-    expect(preview.scoreEstimate.baseScore).toBeCloseTo(20.803, 3);
-    expect(preview.scoreEstimate.contributionBonus).toBe(5);
+    expect(preview.scoreEstimate.baseScore).toBeCloseTo(40.803, 3);
+    expect(preview.scoreEstimate.contributionBonus).toBe(25);
     expect(preview.scoreEstimate.pendingSaturationScore).toBe(preview.scoreEstimate.baseScore);
-    expect(preview.scoreEstimate.estimatedMergedScore).toBeCloseTo(33.2016, 3);
+    expect(preview.scoreEstimate.estimatedMergedScore).toBeCloseTo(65.1216, 3);
     expect(preview.gates.baseTokenGatePassed).toBe(true);
     expect(JSON.stringify(preview.scoreEstimate)).not.toMatch(/reward estimate|wallet|hotkey|farming|payout/i);
   });
 
-  it("keeps pending saturation projection bonus capped for density-era snapshots", () => {
+  it("projects the saturation-model score with the full contribution bonus for density-era snapshots", () => {
     const densitySnapshot: ScoringModelSnapshotRecord = {
       ...snapshot,
       activeModel: "current_density_model",
@@ -175,8 +175,36 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     });
 
     expect(preview.scoreEstimate.contributionBonus).toBe(25);
-    expect(preview.scoreEstimate.pendingSaturationScore).toBeCloseTo(20.803, 3);
-    expect(preview.underlyingPotentialScore).toBeLessThan(30);
+    expect(preview.scoreEstimate.pendingSaturationScore).toBeCloseTo(40.803, 3);
+    expect(preview.underlyingPotentialScore).toBeCloseTo(40.803, 3);
+  });
+
+  it("scores the saturation contribution bonus identically to the density bonus and keeps full-bonus work a strong fit", () => {
+    const input = {
+      repoFullName: repo.fullName,
+      sourceTokenScore: 58,
+      totalTokenScore: 1500,
+      sourceLines: 120,
+      openPrCount: 0,
+      credibility: 1,
+    };
+    const saturationPreview = buildScorePreview({
+      repo,
+      snapshot: { ...snapshot, activeModel: "pending_saturation_model" as const },
+      input,
+    });
+    const densityPreview = buildScorePreview({
+      repo,
+      snapshot: { ...snapshot, activeModel: "current_density_model" as const },
+      input,
+    });
+
+    // Same MAX_CONTRIBUTION_BONUS, same full ramp -> both models must agree on the bonus.
+    expect(saturationPreview.scoreEstimate.contributionBonus).toBe(densityPreview.scoreEstimate.contributionBonus);
+    expect(saturationPreview.scoreEstimate.contributionBonus).toBe(25);
+    // A full-bonus contribution must not fall below the strong_fit threshold (>= 30)
+    // because the contribution bonus was clipped.
+    expect(saturationPreview.effectiveEstimatedScore).toBeGreaterThanOrEqual(30);
   });
 
   it("keeps lane math tied to the recorded model snapshot and clamps score gates", () => {


### PR DESCRIPTION
Closes #180.

## Problem
`saturationContributionBonus` (the active `pending_saturation_model` path) capped the token-contribution bonus at a literal `5`, via both a wrong fallback default (`MAX_CONTRIBUTION_BONUS` defaulted to `5`) and a redundant `Math.min(..., 5)`. Its density-model twin correctly scales by the full `MAX_CONTRIBUTION_BONUS` (25), so identical inputs produced a bonus of `5` under saturation vs `25` under density — understating `baseScore`, `estimatedMergedScore`, and `underlyingPotentialScore` for every active-model preview (e.g. a full-bonus contribution scored 20.8 instead of 40.8, dropping from `strong_fit` to `reasonable_fit`).

## Fix
- Factor the contribution-bonus ramp into a single shared `contributionBonusRamp` helper used by both models, so they cannot drift.
- Scale by `MAX_CONTRIBUTION_BONUS` (default 25) in both paths; drop the `5` cap and wrong default.

## Tests
- Correct the saturation-model test that ratified the bug (`contributionBonus` 5 -> 25, `baseScore` 20.803 -> 40.803, `estimatedMergedScore` 33.2016 -> 65.1216).
- Update the density-era projection test (`pendingSaturationScore`/`underlyingPotentialScore` now 40.803).
- Add coverage asserting the saturation and density bonuses are equal for identical inputs, and that a full-bonus contribution stays at/above the `strong_fit` threshold.

`vitest run test/unit/scoring.test.ts` passes (13/13); `tsc --noEmit` clean.