### PR TITLE
fix(engine): Maintainer-authored issues can be scored ready for outside contributors

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1911,6 +1911,9 @@ export function buildIssueQualityReport(
         ...(linkedWorkCount === 0 ? ["No active PR is linked in cached metadata."] : []),
       ];
       const warnings = [
+        ...(isMaintainerAssociation(issue.authorAssociation)
+            ? ["Issue was opened by a maintainer-associated account."]
+            : []),
         ...(bodyLength < 80 ? ["Issue body is thin; contributor may need more proof before acting."] : []),
         ...(linkedPrs.length > 0 ? [`${linkedPrs.length} active PR(s) already reference this issue.`] : []),
         ...(linkedMergedPrs.length > 0 ? [`${linkedMergedPrs.length} merged PR(s) already reference this issue.`] : []),
@@ -1923,6 +1926,8 @@ export function buildIssueQualityReport(
       const status: IssueQualityReport["issues"][number]["status"] =
         linkedWorkCount > 0 || issueCollisions.some((cluster) => cluster.risk === "high")
           ? "do_not_use"
+          : isMaintainerAssociation(issue.authorAssociation)
+            ? "needs_proof"
           : warnings.some((warning) => /thin|stale|direct-PR/i.test(warning))
             ? "needs_proof"
             : score < 45


### PR DESCRIPTION
## Summary

Closes #186.

Downgrade maintainer-associated authored issues in issue quality reports.

## Changes

- `src/signals/engine.ts`: maintainer warning + `needs_proof` status in `buildIssueQualityReport`.

## Test plan

- [ ] Unit test: OWNER-authored issue is not `ready`.
