### PR TITLE
fix(agents): Centralize public output safety invariants

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -307,9 +307,12 @@ function dedupeBulletLines(lines: string[]): string[] {
 
 export function sanitizePublicComment(value: string): string {
   const sanitized = value
-    .replace(/\b(raw trust score|trust score|wallet|hotkey|coldkey|seed phrase|mnemonic)\b/gi, "private context")
-    .replace(/\b(estimated score|score estimate|reward estimate|payout|farming|reviewability)\b/gi, "private context")
-    .replace(/\b(private ranking|private rankings)\b/gi, "private context")
+    .replace(/\b(raw[-_\s]?trust(?:[-_\s]?scores?)?|trust[-_\s]?scores?|wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?)\b/gi, "private context")
+    .replace(
+      /\b(estimated[-_\s]?scores?|score[-_\s]?estimates?|public[-_\s]?score[-_\s]?estimates?|reward\w*|payouts?|farming|private[-_\s]?reviewability|reviewability|private[-_\s]?scoreability|scoreability)\b/gi,
+      "private context",
+    )
+    .replace(/\b(private[-_\s]?rankings?|rankings?)\b/gi, "private context")
     .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");
   return sanitized.replace(/private context(?:,\s*private context)+/gi, "private context");
 }

--- a/src/services/agent-orchestrator.ts
+++ b/src/services/agent-orchestrator.ts
@@ -616,7 +616,10 @@ function summarizeRun(run: AgentRunRecord, actions: AgentActionRecord[]): string
 
 function sanitizePublicSummary(value: string): string {
   return value
-    .replace(/\b(reward|payout|farming|estimated score|raw trust score|wallet|hotkey|coldkey)\b/gi, "private signal")
+    .replace(
+      /\b(reward\w*|payouts?|farming|estimated[-_\s]?scores?|score[-_\s]?estimates?|public[-_\s]?score[-_\s]?estimates?|raw[-_\s]?trust(?:[-_\s]?scores?)?|trust[-_\s]?scores?|wallets?|hotkeys?|coldkeys?|private[-_\s]?reviewability|reviewability|private[-_\s]?scoreability|scoreability|private[-_\s]?rankings?|rankings?)\b/gi,
+      "private signal",
+    )
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/test/helpers/public-output.ts
+++ b/test/helpers/public-output.ts
@@ -1,0 +1,27 @@
+import { expect } from "vitest";
+
+export const PUBLIC_FORBIDDEN_CONCEPT_CASES = [
+  "wallet address",
+  "hotkey id",
+  "raw trust score",
+  "payout",
+  "reward estimate",
+  "farming",
+  "private reviewability",
+  "private scoreability",
+  "public score estimate",
+] as const;
+
+export const PUBLIC_FORBIDDEN_TEXT_PATTERN =
+  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw[-_\s]?trust(?:[-_\s]?scores?)?|trust[-_\s]?scores?|payouts?|reward\w*|farming|private[-_\s]?reviewability|reviewability|private[-_\s]?scoreability|scoreability|public[-_\s]?score[-_\s]?estimates?|estimated[-_\s]?scores?|score[-_\s]?estimates?|private[-_\s]?rankings?|rankings?)\b|\/100|\/Users\/|\/home\/|\/tmp\/|[A-Z]:\\Users\\/i;
+
+export function expectPublicOutputSafe(output: unknown): void {
+  const text = typeof output === "string" ? output : JSON.stringify(output);
+  expect(text).not.toMatch(PUBLIC_FORBIDDEN_TEXT_PATTERN);
+}
+
+export function expectPublicSanitizerCoversForbiddenConcepts(sanitize: (input: string) => string): void {
+  for (const unsafeText of PUBLIC_FORBIDDEN_CONCEPT_CASES) {
+    expectPublicOutputSafe(sanitize(`Unsafe fixture: ${unsafeText}.`));
+  }
+}

--- a/test/unit/agent-orchestrator.test.ts
+++ b/test/unit/agent-orchestrator.test.ts
@@ -18,6 +18,7 @@ import { persistRegistrySnapshot } from "../../src/registry/sync";
 import type { AgentRunRecord, JsonValue } from "../../src/types";
 import { nowIso } from "../../src/utils/json";
 import { createTestEnv } from "../helpers/d1";
+import { expectPublicOutputSafe, expectPublicSanitizerCoversForbiddenConcepts } from "../helpers/public-output";
 
 describe("agent orchestrator", () => {
   afterEach(() => {
@@ -120,7 +121,7 @@ describe("agent orchestrator", () => {
       approvalRequired: true,
       safetyClass: "private",
     });
-    expect(bundle.actions[0]?.publicSafeSummary).not.toMatch(/reward|wallet|hotkey|raw trust score|estimated score/i);
+    expectPublicOutputSafe(bundle.actions[0]?.publicSafeSummary);
     expect(bundle.contextSnapshots[0]).toMatchObject({
       scoringModelId: "scoring-1",
       freshnessWarnings: expect.arrayContaining(["we-promise/sure: partial signal coverage", "we-promise/sure: stale signal coverage"]),
@@ -316,7 +317,7 @@ describe("agent orchestrator", () => {
     expect(__agentOrchestratorInternals.rerunWhenForDecision(criticalDecision)).toMatch(/blockers/);
     expect(__agentOrchestratorInternals.sameRepo("Owner/Repo", "owner/repo")).toBe(true);
     expect(__agentOrchestratorInternals.jsonPayload({ keep: "yes", drop: undefined })).toEqual({ keep: "yes" });
-    expect(__agentOrchestratorInternals.sanitizePublicSummary("reward payout wallet hotkey raw trust score")).not.toMatch(/reward|payout|wallet|hotkey|raw trust score/i);
+    expectPublicSanitizerCoversForbiddenConcepts(__agentOrchestratorInternals.sanitizePublicSummary);
 
     const watchAction = __agentOrchestratorInternals.actionFromDecisionAction(run, action("open_new_direct_pr", "owner/avoid", "avoid_for_now", 1), avoidDecision, 0);
     const blockedAction = __agentOrchestratorInternals.actionFromDecisionAction(run, action("open_new_direct_pr", "owner/critical", "pursue", 77), criticalDecision, 1);

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync } from "node:crypto";
 import { createInstallationToken, createOrUpdateCheckRun, getAppInstallation, getInstallationId } from "../../src/github/app";
 import type { Advisory } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
+import { expectPublicOutputSafe } from "../helpers/public-output";
 
 describe("GitHub check runs", () => {
   afterEach(() => {
@@ -26,7 +27,7 @@ describe("GitHub check runs", () => {
         expect(body.name).toBe("Gittensory");
         expect(body.conclusion).toBe("neutral");
         expect(body.output.title).toBe("Gittensory context posted");
-        expect(body.output.text).not.toMatch(/linked issue|reviewability|reward|farming|wallet|hotkey|trust score/i);
+        expectPublicOutputSafe(body.output);
         return Response.json({ id: 42, html_url: "https://github.com/checks/42" }, { status: 201 });
       }
       return new Response("not found", { status: 404 });
@@ -90,7 +91,7 @@ describe("GitHub check runs", () => {
         expect(body.name).toBe("Gittensory");
         expect(body.conclusion).toBe("success");
         expect(body.output.title).toBe("Gittensory context checked");
-        expect(body.output.text).not.toMatch(/reviewability|reward|farming|wallet|hotkey|trust score/i);
+        expectPublicOutputSafe(body.output);
         return Response.json({ id: 42, html_url: "https://github.com/checks/42" });
       }
       return new Response("not found", { status: 404 });

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -5,6 +5,7 @@ import {
   parseGittensoryMentionCommand,
   sanitizePublicComment,
 } from "../../src/github/commands";
+import { expectPublicOutputSafe, expectPublicSanitizerCoversForbiddenConcepts } from "../helpers/public-output";
 
 describe("GitHub mention commands", () => {
   it("parses only explicit @gittensory commands", () => {
@@ -98,11 +99,10 @@ describe("GitHub mention commands", () => {
     expect(body).toContain("Scope: this repository#12");
     expect(body).not.toContain("Decision snapshot is stale");
     expect(body).not.toContain("background rebuild");
-    expect(body).not.toMatch(/wallet|hotkey|coldkey|estimated score|reward estimate|payout|farming|raw trust score|reviewability|private ranking/i);
+    expectPublicOutputSafe(body);
     expect(body).not.toMatch(/private context,\s*private context/i);
-    expect(sanitizePublicComment("wallet hotkey payout reviewability private ranking")).not.toMatch(
-      /wallet|hotkey|payout|reviewability|private ranking/i,
-    );
+    expectPublicSanitizerCoversForbiddenConcepts(sanitizePublicComment);
+    expectPublicOutputSafe(sanitizePublicComment("wallet hotkey payout reviewability private ranking"));
     expect(sanitizePublicComment("private ranking, wallet, payout")).toBe("private context");
   });
 

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildLocalBranchAnalysis, findCurrentBranchPullRequest } from "../../src/signals/local-branch";
 import type { ContributorOutcomeHistory, ContributorProfile, ContributorScoringProfile, IssueQualityReport } from "../../src/signals/engine";
 import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
+import { expectPublicOutputSafe } from "../helpers/public-output";
 
 describe("local branch analysis", () => {
   it("combines local preflight, private score preview, reward/risk, and a public-safe PR packet", () => {
@@ -52,7 +53,7 @@ describe("local branch analysis", () => {
     expect(analysis.prPacket.markdown).toContain("- Closes #7");
     expect(analysis.prPacket.markdown).toContain("- passed: npm test -- cache");
     expect(analysis.prPacket.markdown).toContain("metadata only");
-    expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
+    expectPublicOutputSafe(analysis.prPacket.markdown);
   });
 
   it("projects a blocked local branch into a useful after-pending-merge scenario", () => {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { PUBLIC_FORBIDDEN_CONCEPT_CASES, expectPublicOutputSafe } from "../helpers/public-output";
 
 const bin = join(process.cwd(), "packages/gittensory-mcp/bin/gittensory-mcp.js");
 let server: Server | null = null;
@@ -366,7 +367,8 @@ describe("gittensory-mcp CLI", () => {
     expect(output).toContain("# Public-safe PR packet");
     expect(output).toContain("## Validation");
     expect(output).toContain("Closes #39");
-    expect(output).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|raw[-_\s]?trust|private[-_\s]?reviewability|reviewability|export const packet/i);
+    expectPublicOutputSafe(output);
+    expect(output).not.toMatch(/export const packet/i);
   });
 
   it("rejects unsafe server-provided packet markdown before non-json output", async () => {
@@ -381,7 +383,15 @@ describe("gittensory-mcp CLI", () => {
     git(tempDir, "commit", "-m", "initial commit");
     git(tempDir, "checkout", "-b", "codex/public-safe-pr-packets");
 
-    for (const unsafePhrase of ["score: 1.15", "reward estimate", "wallet address", "hotkey id", "raw-trust: 0.7", "private-reviewability: ready", "raw_trust: 0.7", "private_reviewability: ready", "trust_score: 0.4"]) {
+    for (const unsafePhrase of [
+      ...PUBLIC_FORBIDDEN_CONCEPT_CASES,
+      "score: 1.15",
+      "raw-trust: 0.7",
+      "private-reviewability: ready",
+      "raw_trust: 0.7",
+      "private_reviewability: ready",
+      "trust_score: 0.4",
+    ]) {
       if (server) await new Promise<void>((resolve) => server?.close(() => resolve()));
       server = null;
       const url = await startFixtureServer({ packetMarkdown: `# Public-safe PR packet\n\n- ${unsafePhrase}\n` });

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildIssueAdvisory, buildPullRequestAdvisory, buildRepositoryAdvisory, formatCheckRunOutput } from "../../src/rules/advisory";
 import type { IssueRecord, PullRequestRecord, RepositoryRecord } from "../../src/types";
+import { expectPublicOutputSafe } from "../helpers/public-output";
 
 const repo: RepositoryRecord = {
   fullName: "JSONbored/gittensory",
@@ -126,7 +127,7 @@ describe("advisory rules", () => {
     const output = formatCheckRunOutput(advisory);
 
     expect(advisory.findings.map((finding) => finding.code)).not.toContain("private_reviewability_context");
-    expect(output.text).not.toMatch(/reviewability|likely_duplicate|needs_author|reward|farming|wallet|hotkey/i);
+    expectPublicOutputSafe(output);
     expect(output.title).toBe("Gittensory context checked");
   });
 


### PR DESCRIPTION
## Summary
- add a shared public-output safety helper with one forbidden-concept fixture list
- use the helper across GitHub comments, check runs, agent public summaries, PR packets, and public-safe CLI packet output
- harden public comment and agent-summary sanitizers for scoreability/private reviewability/public score-estimate variants

## Verification
- npx vitest run test/unit/github-commands.test.ts test/unit/agent-orchestrator.test.ts test/unit/github-app.test.ts test/unit/rules.test.ts test/unit/local-branch.test.ts test/unit/mcp-cli.test.ts --testNamePattern "sanitized|public-safe|check run|private reviewability|copy-paste|pure action"
- npx vitest run test/unit/github-commands.test.ts test/unit/agent-orchestrator.test.ts test/unit/github-app.test.ts test/unit/rules.test.ts test/unit/local-branch.test.ts test/unit/mcp-cli.test.ts
- npm run typecheck
- npm run test:coverage
- git diff --check
- npm run test:ci

Closes #107