### PR TITLE
feat(extension): add public-safe packet copy and private blocker actions in GitHub overlay

### DIFF
--- a/apps/gittensory-extension/content.js
+++ b/apps/gittensory-extension/content.js
@@ -49,6 +49,7 @@ async function load(container, target) {
       `,
     )
     .join("");
+  renderActions(body, response.payload?.actions);
 }
 
 function escapeHtml(value) {
@@ -66,4 +67,55 @@ function escapeHtml(value) {
         return "&#39;";
     }
   });
+}
+
+function renderActions(body, actions) {
+  const list = Array.isArray(actions) ? actions : [];
+  if (list.length === 0) return;
+  const container = document.createElement("section");
+  container.className = "gittensory-overlay__panel";
+  container.innerHTML = `
+    <div class="gittensory-overlay__panel-head">
+      <strong>Actions</strong>
+      <span>extension</span>
+    </div>
+    <div class="gittensory-overlay__actions"></div>
+  `;
+  const actionsNode = container.querySelector(".gittensory-overlay__actions");
+  if (!actionsNode) return;
+  for (const action of list) {
+    if (action?.id === "copy_public_safe_packet" && typeof action?.markdown === "string") {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "Copy public-safe packet";
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(action.markdown);
+          button.textContent = "Copied";
+          window.setTimeout(() => {
+            button.textContent = "Copy public-safe packet";
+          }, 1400);
+        } catch {
+          button.textContent = "Copy failed";
+        }
+      });
+      actionsNode.appendChild(button);
+      continue;
+    }
+    if (action?.id === "view_private_blockers" && Array.isArray(action?.blockers)) {
+      const details = document.createElement("details");
+      const summary = document.createElement("summary");
+      summary.textContent = "Private blockers";
+      details.appendChild(summary);
+      const listNode = document.createElement("ul");
+      for (const blocker of action.blockers.slice(0, 8)) {
+        const item = document.createElement("li");
+        item.textContent = String(blocker?.detail ?? "");
+        listNode.appendChild(item);
+      }
+      details.appendChild(listNode);
+      actionsNode.appendChild(details);
+    }
+  }
+  body.appendChild(container);
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1125,6 +1125,7 @@ export function createApp() {
         hasPublicPacket: publicSafePacketMarkdown.length > 0,
         blockerCount: privateBlockers.length,
       },
+    });
     await recordRouteProductUsage(c, {
       surface: "browser_extension",
       eventName: "pull_context_viewed",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -769,6 +769,19 @@ export function createApp() {
       outcomeHistory: contributorContext?.outcomeHistory,
     });
     const publicSafePacketMarkdown = buildExtensionPublicSafePacket({
+<<<<<<< Updated upstream
+=======
+      repoFullName: fullName,
+      pullNumber,
+      reviewability,
+      contributor: contributor ?? "unknown",
+    });
+    const privateBlockers = buildExtensionPrivateBlockers(reviewability);
+    await recordRouteProductUsage(c, {
+      surface: "browser_extension",
+      eventName: "pull_context_viewed",
+      identity,
+>>>>>>> Stashed changes
       repoFullName: fullName,
       pullNumber,
       reviewability,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1135,6 +1135,16 @@ export function createApp() {
       clientName: "browser_extension",
       metadata: { hasContributorContext: Boolean(contributorContext), hasCachedPullRequest: Boolean(pullRequest) },
     });
+    await recordRouteProductUsage(c, {
+      surface: "browser_extension",
+      eventName: "pull_context_viewed",
+      identity,
+      repoFullName: fullName,
+      targetKey: `${fullName}#${pullNumber}`,
+      outcome: "success",
+      clientName: "browser_extension",
+      metadata: { hasContributorContext: Boolean(contributorContext), hasCachedPullRequest: Boolean(pullRequest) },
+    });
     return c.json({
       generatedAt: nowIso(),
       repoFullName: fullName,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -769,19 +769,6 @@ export function createApp() {
       outcomeHistory: contributorContext?.outcomeHistory,
     });
     const publicSafePacketMarkdown = buildExtensionPublicSafePacket({
-<<<<<<< Updated upstream
-=======
-      repoFullName: fullName,
-      pullNumber,
-      reviewability,
-      contributor: contributor ?? "unknown",
-    });
-    const privateBlockers = buildExtensionPrivateBlockers(reviewability);
-    await recordRouteProductUsage(c, {
-      surface: "browser_extension",
-      eventName: "pull_context_viewed",
-      identity,
->>>>>>> Stashed changes
       repoFullName: fullName,
       pullNumber,
       reviewability,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1135,16 +1135,6 @@ export function createApp() {
       clientName: "browser_extension",
       metadata: { hasContributorContext: Boolean(contributorContext), hasCachedPullRequest: Boolean(pullRequest) },
     });
-    await recordRouteProductUsage(c, {
-      surface: "browser_extension",
-      eventName: "pull_context_viewed",
-      identity,
-      repoFullName: fullName,
-      targetKey: `${fullName}#${pullNumber}`,
-      outcome: "success",
-      clientName: "browser_extension",
-      metadata: { hasContributorContext: Boolean(contributorContext), hasCachedPullRequest: Boolean(pullRequest) },
-    });
     return c.json({
       generatedAt: nowIso(),
       repoFullName: fullName,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -86,6 +86,7 @@ import {
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
 import { fetchPublicContributorProfile } from "../github/public";
 import { handleGitHubWebhook } from "../github/webhook";
+import { sanitizePublicComment } from "../github/commands";
 import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
 import { generateSignalSnapshots } from "../queue/processors";
@@ -767,11 +768,44 @@ export function createApp() {
       profile: contributorContext?.profile,
       outcomeHistory: contributorContext?.outcomeHistory,
     });
+    const publicSafePacketMarkdown = buildExtensionPublicSafePacket({
+      repoFullName: fullName,
+      pullNumber,
+      reviewability,
+      contributor: contributor ?? "unknown",
+    });
+    const privateBlockers = buildExtensionPrivateBlockers(reviewability);
+    await recordAuditEvent(c.env, {
+      eventType: "extension.pull_context_view",
+      actor: contributor ?? "unknown",
+      route: c.req.path,
+      outcome: "success",
+      metadata: {
+        redacted: true,
+        hasPublicPacket: publicSafePacketMarkdown.length > 0,
+        blockerCount: privateBlockers.length,
+      },
+    });
     return c.json({
       generatedAt: nowIso(),
       repoFullName: fullName,
       pullNumber,
       reviewability,
+      actions: [
+        {
+          id: "copy_public_safe_packet",
+          label: "Copy public-safe packet",
+          visibility: "public_safe",
+          markdown: publicSafePacketMarkdown,
+        },
+        {
+          id: "view_private_blockers",
+          label: "View private blockers",
+          visibility: "private",
+          requiresAuth: true,
+          blockers: privateBlockers,
+        },
+      ],
       panels: [
         { label: "Reviewability", badge: reviewability.action, rows: [{ k: "action", v: reviewability.action }, { k: "score", v: String(reviewability.score) }] },
         { label: "Contributor", badge: contributor ?? "unknown", rows: [{ k: "author", v: contributor ?? "unknown" }, { k: "prs", v: String(contributorContext?.contributorPullRequests.length ?? 0) }] },
@@ -2163,4 +2197,43 @@ function normalizeOrigin(value: string | undefined): string | null {
   } catch {
     return null;
   }
+}
+
+function buildExtensionPublicSafePacket(args: { repoFullName: string; pullNumber: number; contributor: string; reviewability: { action: string; noiseSources: string[]; maintainerNextSteps: string[] } }): string {
+  const lines = [
+    "# Public-safe PR packet",
+    "",
+    "## Linked context",
+    `- Repository: ${args.repoFullName}`,
+    `- Pull request: #${args.pullNumber}`,
+    `- Contributor: ${args.contributor}`,
+    "",
+    "## Review readiness",
+    `- Current action: ${args.reviewability.action.replace(/_/g, " ")}`,
+    ...args.reviewability.maintainerNextSteps.slice(0, 4).map((step) => `- ${step}`),
+    "",
+    "## Queue caution",
+    ...(args.reviewability.noiseSources.length > 0
+      ? args.reviewability.noiseSources.slice(0, 4).map((source) => `- ${source}`)
+      : ["- No high-noise warning is visible from cached metadata."]),
+    "",
+    "## Safety",
+    "- Keep public comments limited to linked context, validation status, and maintainer-ready next steps.",
+  ];
+  const markdown = sanitizePublicComment(lines.join("\n"));
+  return ensureExtensionPublicSafeText(markdown);
+}
+
+function buildExtensionPrivateBlockers(reviewability: { noiseSources: string[]; maintainerNextSteps: string[]; privateSummary: string }) {
+  const items = [...reviewability.noiseSources.slice(0, 5), ...reviewability.maintainerNextSteps.slice(0, 3)];
+  if (items.length === 0) items.push("No private blocker detail is currently cached.");
+  return items.map((detail, index) => ({ id: `blocker-${index + 1}`, detail: sanitizePublicComment(detail) }));
+}
+
+function ensureExtensionPublicSafeText(text: string): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (/\b(wallet|hotkey|coldkey|raw trust score|trust score|estimated score|score estimate|reward estimate|payout|farming|private reviewability|reviewability\s*\d|\/100)\b/i.test(compact)) {
+    return "# Public-safe PR packet\n\n- Public-safe packet unavailable. Regenerate after private context is sanitized.";
+  }
+  return text;
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2237,3 +2237,10 @@ function ensureExtensionPublicSafeText(text: string): string {
   }
   return text;
 }
+
+export const __routesInternals = {
+  buildExtensionPublicSafePacket,
+  buildExtensionPrivateBlockers,
+  ensureExtensionPublicSafeText,
+  authenticateRequestIdentity,
+};

--- a/src/auth/security.ts
+++ b/src/auth/security.ts
@@ -157,6 +157,10 @@ function serializeCookie(name: string, value: string, options: CookieOptions): s
   return parts.join("; ");
 }
 
+export const __securityInternals = {
+  serializeCookie,
+};
+
 function shouldUseSecureCookie(requestUrl: string): boolean {
   try {
     const hostname = new URL(requestUrl).hostname;

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1027,6 +1027,41 @@ describe("api routes", () => {
       repoFit: [],
     });
 
+    await persistSignalSnapshot(env, {
+      id: "lane-pack",
+      signalType: "contributor-decision-pack",
+      targetKey: "lane-user",
+      payload: {
+        status: "ready",
+        source: "computed",
+        login: "lane-user",
+        generatedAt: new Date().toISOString(),
+        stale: false,
+        freshness: "fresh",
+        rebuildEnqueued: false,
+        scoringModelSnapshotId: "scoring-1",
+        repoDecisions: [],
+        topActions: [],
+        pursueRepos: [{ repoFullName: "owner/pursue", recommendation: "watch" }],
+        cleanupFirst: [{ repoFullName: "owner/cleanup", recommendation: "cleanup_first" }],
+        maintainerLaneRepos: [{ repoFullName: "owner/maintainer", recommendation: "maintainer_lane" }],
+        avoidRepos: [{ repoFullName: "owner/avoid", recommendation: "avoid_for_now" }],
+        scoreBlockers: [],
+        dataQuality: { signalFidelity: { status: "ok" } },
+      } as never,
+      generatedAt: new Date().toISOString(),
+    });
+    const minerWithLaneBuckets = await app.request("/v1/app/miner-dashboard?login=lane-user", { headers: apiHeaders(env) }, env);
+    expect(minerWithLaneBuckets.status).toBe(200);
+    await expect(minerWithLaneBuckets.json()).resolves.toMatchObject({
+      repoFit: expect.arrayContaining([
+        expect.objectContaining({ repoFullName: "owner/pursue", lane: "pursue" }),
+        expect.objectContaining({ repoFullName: "owner/cleanup", lane: "cleanup-first" }),
+        expect.objectContaining({ repoFullName: "owner/maintainer", lane: "maintainer-lane" }),
+        expect.objectContaining({ repoFullName: "owner/avoid", lane: "avoid" }),
+      ]),
+    });
+
     await recordGitHubRateLimitObservation(env, {
       id: "rate-limit-healthy",
       repoFullName: "entrius/allways-ui",

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1267,12 +1267,29 @@ describe("api routes", () => {
       env,
     );
     expect(extensionContext.status).toBe(200);
-    await expect(extensionContext.json()).resolves.toMatchObject({
+    const extensionPayload = (await extensionContext.json()) as {
+      repoFullName: string;
+      pullNumber: number;
+      reviewability: { repoFullName: string; pullNumber: number };
+      actions: Array<{ id: string; markdown?: string; blockers?: Array<{ detail: string }> }>;
+      panels: Array<{ label: string }>;
+    };
+    expect(extensionPayload).toMatchObject({
       repoFullName: "entrius/allways-ui",
       pullNumber: 12,
       reviewability: { repoFullName: "entrius/allways-ui", pullNumber: 12 },
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "copy_public_safe_packet", visibility: "public_safe" }),
+        expect.objectContaining({ id: "view_private_blockers", visibility: "private", requiresAuth: true }),
+      ]),
       panels: expect.arrayContaining([expect.objectContaining({ label: "Reviewability" }), expect.objectContaining({ label: "Boundary" })]),
     });
+    const packet = extensionPayload.actions.find((action) => action.id === "copy_public_safe_packet")?.markdown ?? "";
+    expect(packet).toContain("# Public-safe PR packet");
+    expect(packet).not.toMatch(/wallet|hotkey|coldkey|reward estimate|payout|farming|raw trust score|estimated score|score estimate|private reviewability/i);
+    const blockers = extensionPayload.actions.find((action) => action.id === "view_private_blockers")?.blockers ?? [];
+    expect(blockers.length).toBeGreaterThan(0);
+    expect(JSON.stringify(blockers)).not.toMatch(/wallet|hotkey|coldkey|payout|farming|guaranteed payout/i);
 
     const missingPullContext = await app.request(
       "/v1/extension/pull-context?owner=entrius&repo=allways-ui&pullNumber=99",
@@ -1283,6 +1300,7 @@ describe("api routes", () => {
     await expect(missingPullContext.json()).resolves.toMatchObject({
       repoFullName: "entrius/allways-ui",
       pullNumber: 99,
+      actions: expect.arrayContaining([expect.objectContaining({ id: "copy_public_safe_packet" }), expect.objectContaining({ id: "view_private_blockers" })]),
       panels: expect.arrayContaining([expect.objectContaining({ label: "Contributor", badge: "unknown" })]),
     });
   });

--- a/test/unit/routes-extension.test.ts
+++ b/test/unit/routes-extension.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { __routesInternals } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { createTestEnv } from "../helpers/d1";
+
+describe("extension packet helper internals", () => {
+  it("falls back when extension packet text contains forbidden public terms", () => {
+    const result = __routesInternals.ensureExtensionPublicSafeText("# Public-safe PR packet\n\n- reviewability 91/100");
+    expect(result).toContain("Public-safe packet unavailable");
+  });
+
+  it("keeps safe extension packet text unchanged", () => {
+    const text = "# Public-safe PR packet\n\n- Repository: owner/repo\n- Keep public comments focused on linked context.";
+    expect(__routesInternals.ensureExtensionPublicSafeText(text)).toBe(text);
+  });
+
+  it("builds private blocker fallback when no blocker signals are present", () => {
+    const blockers = __routesInternals.buildExtensionPrivateBlockers({
+      noiseSources: [],
+      maintainerNextSteps: [],
+      privateSummary: "",
+    });
+    expect(blockers).toEqual([{ id: "blocker-1", detail: "No private blocker detail is currently cached." }]);
+  });
+
+  it("sanitizes extension packet markdown before returning it", () => {
+    const markdown = __routesInternals.buildExtensionPublicSafePacket({
+      repoFullName: "owner/repo",
+      pullNumber: 12,
+      contributor: "alice",
+      reviewability: {
+        action: "review_now",
+        noiseSources: ["avoid payout language in public"],
+        maintainerNextSteps: ["remove wallet references"],
+      },
+    });
+    expect(markdown).toContain("# Public-safe PR packet");
+    expect(markdown).not.toMatch(/wallet|payout|hotkey|reward estimate|estimated score|raw trust score/i);
+  });
+
+  it("authenticates request identity from browser session cookie fallback", async () => {
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 7 });
+    const identity = await __routesInternals.authenticateRequestIdentity({
+      env,
+      req: {
+        header(name: string) {
+          if (name.toLowerCase() === "cookie") return `gittensory_session=${token}`;
+          return undefined;
+        },
+      },
+      json: (_payload: { error: string }, status?: number) => Response.json({}, status === undefined ? undefined : { status }),
+    });
+    expect(identity).toMatchObject({ kind: "session", actor: "jsonbored" });
+  });
+});

--- a/test/unit/security-internals.test.ts
+++ b/test/unit/security-internals.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { __securityInternals } from "../../src/auth/security";
+
+describe("security internals", () => {
+  it("serializes cookies with optional HttpOnly and Secure flags", () => {
+    const minimal = __securityInternals.serializeCookie("a", "b", {
+      maxAge: 10,
+      path: "/",
+      httpOnly: false,
+      sameSite: "Lax",
+      secure: false,
+    });
+    expect(minimal).toContain("a=b");
+    expect(minimal).not.toContain("HttpOnly");
+    expect(minimal).not.toContain("Secure");
+
+    const strict = __securityInternals.serializeCookie("a", "b", {
+      maxAge: 10,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Strict",
+      secure: true,
+    });
+    expect(strict).toContain("HttpOnly");
+    expect(strict).toContain("Secure");
+    expect(strict).toContain("SameSite=Strict");
+  });
+});


### PR DESCRIPTION
## Summary
This change implements issue #147 by extending the browser extension and API to support:
- Copyable **public-safe PR packet** content from the GitHub overlay
- Authenticated **private blocker details** in the same overlay

The implementation reuses existing public-safety sanitization behavior and keeps extension output within public/private boundaries.
## Related issue 
Closes: #147 
## Change Type
- [x] Feature
- [x] Security hardening (public/private output boundary enforcement)
- [x] API enhancement
- [x] Extension UI enhancement
- [x] Tests added/updated
- [ ] Breaking change

## Real Behavior Proof
### 1) Extension context now includes action payloads
`GET /v1/extension/pull-context?...` returns:
- `actions[]` containing:
  - `id: "copy_public_safe_packet"`
  - `id: "view_private_blockers"`

### 2) Public-safe packet output is sanitized
Integration checks confirm packet content excludes sensitive terms such as:
- wallet / hotkey / coldkey
- reward estimate / payout / farming
- raw trust score / estimated score / score estimate
- private reviewability

### 3) Private blockers remain auth-scoped
Extension context remains accessible only through extension-scoped session flow; private blocker details are surfaced only in that authenticated context.

### 4) Extension UI behavior
Overlay now renders:
- “Copy public-safe packet” button (clipboard copy)
- “Private blockers” expandable panel
## Checklist
- [x] Implemented API support for extension packet/blocker actions
- [x] Implemented extension UI actions
- [x] Enforced public-safe text boundaries
- [x] Kept private blocker data behind authenticated extension session
- [x] Added/updated automated tests
- [x] Verified local typecheck and tests pass
