### PR TITLE
fix(auth): scope maintainer dashboard data

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -108,6 +108,7 @@ import {
 } from "../services/decision-pack";
 import {
   buildStaticControlPanelRoleSummary,
+  loadControlPanelAccessScope,
   loadControlPanelRoleSummary,
 } from "../services/control-panel-roles";
 import {
@@ -649,14 +650,29 @@ export function createApp() {
   });
 
   app.get("/v1/app/maintainer-dashboard", async (c) => {
-    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
-    if (forbidden) return forbidden;
-    const [repositories, installations, health, rateLimits] = await Promise.all([
+    const identity = await authenticateRequestIdentity(c);
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const summary = await getRoleSummaryForIdentity(c.env, identity);
+    if (!summary.roles.some((role) => ["maintainer", "owner", "operator"].includes(role))) return c.json({ error: "insufficient_role" }, 403);
+
+    const [allRepositories, allInstallations, allHealth, allRateLimits] = await Promise.all([
       listRepositories(c.env),
       listInstallations(c.env),
       listInstallationHealth(c.env),
       listLatestGitHubRateLimitObservations(c.env, 20),
     ]);
+    const scope = identity.kind === "session" && !summary.roles.includes("operator") ? await loadControlPanelAccessScope(c.env, identity.actor) : null;
+    const scopedRepoNames = new Set(scope?.repositoryFullNames.map((repo) => repo.toLowerCase()) ?? []);
+    const scopedInstallationIds = new Set(scope?.installationIds ?? []);
+    const scopedAccountLogins = new Set(scope?.accountLogins.map((login) => login.toLowerCase()) ?? []);
+    const repositories = scope ? allRepositories.filter((repo) => scopedRepoNames.has(repo.fullName.toLowerCase())) : allRepositories;
+    const installations = scope
+      ? allInstallations.filter((installation) => scopedInstallationIds.has(installation.id) || scopedAccountLogins.has(installation.accountLogin.toLowerCase()))
+      : allInstallations;
+    const health = scope
+      ? allHealth.filter((record) => scopedInstallationIds.has(record.installationId) || scopedAccountLogins.has(record.accountLogin.toLowerCase()))
+      : allHealth;
+    const rateLimits = scope ? allRateLimits.filter((record) => record.repoFullName !== undefined && record.repoFullName !== null && scopedRepoNames.has(record.repoFullName.toLowerCase())) : allRateLimits;
     const openPullRequests = (
       await Promise.all(repositories.slice(0, 12).map((repo) => listOpenPullRequests(c.env, repo.fullName).then((rows) => rows.map((pull) => ({ repoFullName: repo.fullName, pull })))))
     ).flat();

--- a/src/services/control-panel-roles.ts
+++ b/src/services/control-panel-roles.ts
@@ -3,7 +3,7 @@ import { getFreshOfficialMinerDetection, listAllPullRequests, listInstallations,
 import type { ControlPanelRoleCard, ControlPanelRoleName, ControlPanelRoleSummary, InstallationRecord, PullRequestRecord, RepositoryRecord } from "../types";
 import { nowIso } from "../utils/json";
 
-type RoleSummaryInputs = {
+export type RoleSummaryInputs = {
   login: string;
   generatedAt: string;
   confirmedMiner: boolean;
@@ -12,6 +12,26 @@ type RoleSummaryInputs = {
   installations: InstallationRecord[];
   pullRequests: PullRequestRecord[];
 };
+
+export type ControlPanelAccessScope = {
+  operator: boolean;
+  repositoryFullNames: string[];
+  installationIds: number[];
+  accountLogins: string[];
+};
+
+export async function loadControlPanelAccessScope(env: Env, login: string): Promise<ControlPanelAccessScope> {
+  const [repositories, installations, pullRequests] = await Promise.all([listRepositories(env), listInstallations(env), listAllPullRequests(env)]);
+  return buildControlPanelAccessScope({
+    login,
+    generatedAt: nowIso(),
+    confirmedMiner: false,
+    operator: isAuthorizedGitHubSessionLogin(env, login),
+    repositories,
+    installations,
+    pullRequests,
+  });
+}
 
 export async function loadControlPanelRoleSummary(env: Env, login: string): Promise<ControlPanelRoleSummary> {
   const [miner, repositories, installations, pullRequests] = await Promise.all([
@@ -29,6 +49,33 @@ export async function loadControlPanelRoleSummary(env: Env, login: string): Prom
     installations,
     pullRequests,
   });
+}
+
+export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPanelAccessScope {
+  const installedRepos = args.repositories.filter((repo) => repo.isInstalled);
+  const accountInstallations = args.installations.filter((installation) => !installation.suspendedAt && sameLogin(installation.accountLogin, args.login));
+  const accountInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
+  const ownedInstalledRepos = installedRepos.filter((repo) => sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId)));
+  const maintainerRepos = uniqueRepoNames(
+    args.pullRequests
+      .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))
+      .map((pull) => pull.repoFullName)
+      .filter((repoFullName) => installedRepos.some((repo) => sameRepo(repo.fullName, repoFullName))),
+  );
+  const scopedRepoNames = uniqueRepoNames([...ownedInstalledRepos.map((repo) => repo.fullName), ...maintainerRepos]);
+  const scopedInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
+  for (const repo of installedRepos) {
+    if (scopedRepoNames.some((repoFullName) => sameRepo(repo.fullName, repoFullName)) && repo.installationId !== undefined && repo.installationId !== null) {
+      scopedInstallationIds.add(repo.installationId);
+    }
+  }
+  const scopedAccountLogins = uniqueLogins(accountInstallations.map((installation) => installation.accountLogin));
+  return {
+    operator: args.operator,
+    repositoryFullNames: scopedRepoNames,
+    installationIds: [...scopedInstallationIds],
+    accountLogins: scopedAccountLogins,
+  };
 }
 
 export function buildControlPanelRoleSummary(args: RoleSummaryInputs): ControlPanelRoleSummary {
@@ -181,7 +228,15 @@ function roleCard(role: ControlPanelRoleName, status: ControlPanelRoleCard["stat
 }
 
 function uniqueRepos(values: string[]): string[] {
-  return [...new Set(values.filter(Boolean).map(sanitizeRoleText))].sort((a, b) => a.localeCompare(b));
+  return uniqueRepoNames(values).map(sanitizeRoleText);
+}
+
+function uniqueRepoNames(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+}
+
+function uniqueLogins(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
 }
 
 function sameLogin(value: string | null | undefined, login: string): boolean {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1107,6 +1107,46 @@ describe("api routes", () => {
       },
     });
     await upsertRepositoryFromGitHub(ownerEnv, { name: "owned-repo", full_name: "repo-owner/owned-repo", private: false, default_branch: "main", owner: { login: "repo-owner" } }, 777);
+    await upsertInstallation(ownerEnv, {
+      installation: {
+        id: 888,
+        account: { login: "victim-org", id: 888, type: "Organization" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+        events: ["issues", "pull_request", "repository"],
+      },
+    });
+    await upsertRepositoryFromGitHub(ownerEnv, { name: "secret-repo", full_name: "victim-org/secret-repo", private: true, default_branch: "main", owner: { login: "victim-org" } }, 888);
+    await upsertInstallationHealth(ownerEnv, {
+      installationId: 888,
+      accountLogin: "victim-org",
+      repositorySelection: "selected",
+      installedReposCount: 1,
+      registeredInstalledCount: 1,
+      status: "needs_attention",
+      missingPermissions: ["checks"],
+      missingEvents: [],
+      permissions: { metadata: "read" },
+      events: ["pull_request"],
+      checkedAt: "2026-05-31T12:00:00.000Z",
+      errorSummary: "victim install needs privileged recovery",
+    });
+    await recordGitHubRateLimitObservation(ownerEnv, {
+      id: "victim-rate-limit",
+      repoFullName: "victim-org/secret-repo",
+      resource: "graphql",
+      path: "/graphql",
+      statusCode: 403,
+      remaining: 0,
+      observedAt: "2026-05-31T12:00:00.000Z",
+    });
+    await upsertPullRequestFromGitHub(ownerEnv, "victim-org/secret-repo", {
+      number: 42,
+      title: "Victim confidential release plan",
+      state: "open",
+      html_url: "https://github.com/victim-org/secret-repo/pull/42",
+      labels: [],
+    });
     const { token: ownerToken } = await createSessionForGitHubUser(ownerEnv, { login: "repo-owner", id: 777 });
     const ownerHeaders = { cookie: `gittensory_session=${ownerToken}`, "content-type": "application/json" };
     const ownerRoles = await app.request("/v1/app/roles", { headers: ownerHeaders }, ownerEnv);
@@ -1115,7 +1155,16 @@ describe("api routes", () => {
       roles: ["maintainer", "owner"],
       evidence: { ownedInstalledRepos: 1, accountInstallations: 1, operator: false },
     });
-    expect((await app.request("/v1/app/maintainer-dashboard", { headers: ownerHeaders }, ownerEnv)).status).toBe(200);
+    const ownerMaintainerDashboard = await app.request("/v1/app/maintainer-dashboard", { headers: ownerHeaders }, ownerEnv);
+    expect(ownerMaintainerDashboard.status).toBe(200);
+    const ownerMaintainerDashboardBody = (await ownerMaintainerDashboard.json()) as { installations: unknown[]; health: unknown[]; reviewability: unknown[]; metrics: unknown[] };
+    expect(ownerMaintainerDashboardBody.installations).toEqual([expect.objectContaining({ id: 777, accountLogin: "repo-owner" })]);
+    expect(ownerMaintainerDashboardBody.health).toEqual([]);
+    expect(ownerMaintainerDashboardBody.reviewability).toEqual([]);
+    expect(ownerMaintainerDashboardBody.metrics).toEqual(expect.arrayContaining([expect.objectContaining({ label: "Rate-limit events", value: 0 })]));
+    expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("victim-org");
+    expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("Victim confidential release plan");
+    expect(JSON.stringify(ownerMaintainerDashboardBody)).not.toContain("victim install needs privileged recovery");
     expect((await app.request("/v1/app/operator-dashboard", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     const ownerExtensionSession = await app.request("/v1/auth/extension/session", { method: "POST", headers: ownerHeaders }, ownerEnv);
     expect(ownerExtensionSession.status).toBe(201);

--- a/test/unit/control-panel-roles.test.ts
+++ b/test/unit/control-panel-roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildControlPanelRoleSummary, loadControlPanelRoleSummary } from "../../src/services/control-panel-roles";
+import { buildControlPanelAccessScope, buildControlPanelRoleSummary, loadControlPanelRoleSummary } from "../../src/services/control-panel-roles";
 import type { InstallationRecord, PullRequestRecord, RepositoryRecord } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -91,6 +91,25 @@ describe("control panel role summaries", () => {
         }),
       ]),
     );
+  });
+
+  it("builds repository and installation scopes from role evidence", () => {
+    const scope = buildControlPanelAccessScope({
+      login: "repo-owner",
+      generatedAt: "2026-06-01T12:00:00.000Z",
+      confirmedMiner: false,
+      operator: false,
+      repositories: [repo("repo-owner/owned-repo", "repo-owner", 21), repo("victim-org/secret-repo", "victim-org", 99)],
+      installations: [installation(21, "repo-owner"), installation(99, "victim-org")],
+      pullRequests: [],
+    });
+
+    expect(scope).toMatchObject({
+      operator: false,
+      repositoryFullNames: ["repo-owner/owned-repo"],
+      installationIds: [21],
+      accountLogins: ["repo-owner"],
+    });
   });
 
   it("keeps onboarding available when cached miner lookup fails", async () => {


### PR DESCRIPTION
### Motivation
- The maintainer dashboard previously returned global maintainer/installation data when a session had a repo-scoped `maintainer`/`owner` role, allowing self-onboarded users to read other tenants' sensitive operational data.
- The intent is to preserve the existing role model and workflows while enforcing repository/installation scoping for non-operator user sessions.
- This change derives an access scope from the same evidence used for role classification and uses it to restrict dashboard outputs.

### Description
- Add a scoped access model and loader: introduce `ControlPanelAccessScope`, `buildControlPanelAccessScope`, and `loadControlPanelAccessScope` in `src/services/control-panel-roles.ts` to compute repository full names, installation IDs, and account logins that justify maintainer/owner access.
- Scope the maintainer dashboard: update `/v1/app/maintainer-dashboard` in `src/api/routes.ts` to authenticate the request, obtain the role summary, and for non-operator browser sessions filter `repositories`, `installations`, `installation health`, `rate-limit observations`, and `open PR` reviewability to the derived scope.
- Preserve operator behavior: operator sessions still see global maintainer/operator surfaces unchanged.
- Tests and small helpers: add `uniqueRepoNames`/`uniqueLogins` helpers and update unit and integration tests to cover the access-scope builder and assert that a repo-scoped owner cannot see another tenant's installation/health/PR/rate-limit data; modified files: `src/services/control-panel-roles.ts`, `src/api/routes.ts`, `test/unit/control-panel-roles.test.ts`, and `test/integration/api.test.ts`.

### Testing
- Ran the scoped unit and integration suites with `npx vitest run test/unit/control-panel-roles.test.ts test/integration/api.test.ts --config vitest.config.ts --reporter=verbose`, and all tests passed (`22` tests total passed).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it completed successfully.
- Verified there are no linting/diff issues with `git diff --check` (no reported problems).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd0521510832cbe388a3aef64f236)