### PR TITLE
fix: bound local scorer warning diagnostics

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -150,6 +150,7 @@ import { attachDataQuality, buildCoreSignalFidelity, buildFreshnessSloReport, bu
 import { buildContributorOpenPrMonitor } from "../signals/contributor-open-pr-monitor";
 import { buildPullRequestReviewability } from "../signals/reward-risk";
 import { buildLocalBranchAnalysis, findCurrentBranchPullRequest } from "../signals/local-branch";
+import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoSettingsPreview } from "../signals/settings-preview";
 import { buildGittensorConfigRecommendation, buildRegistrationReadiness, type InstallationHealthSummary } from "../signals/registration-readiness";
@@ -257,7 +258,7 @@ const localBranchScorerSchema = z
     sourceLines: z.number().min(0).optional(),
     testTokenScore: z.number().min(0).optional(),
     nonCodeTokenScore: z.number().min(0).optional(),
-    warnings: z.array(z.string()).optional(),
+    warnings: z.array(z.string().max(MAX_LOCAL_SCORER_WARNING_CHARS)).max(MAX_LOCAL_SCORER_WARNING_COUNT).optional(),
   })
   .strict();
 

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -18,6 +18,7 @@ import {
 import { buildRepoRewardRisk, type RepoRewardRisk, type RewardRiskAction } from "./reward-risk";
 import { buildLocalWorkspaceIntelligence, type LocalWorkspaceIntelligence } from "./local-workspace-intelligence";
 import { buildFocusManifestGuidance, parseFocusManifest, type FocusManifestGuidance } from "./focus-manifest";
+import { sanitizeLocalScorerWarnings } from "./local-scorer-diagnostics";
 
 export type LocalBranchChangedFile = {
   path: string;
@@ -704,6 +705,7 @@ function buildLocalFindings(
   githubBranchStatus: GitHubBranchStatus,
 ): LocalBranchAnalysis["localFindings"] {
   const failedValidation = (input.validation ?? []).filter((entry) => entry.status === "failed");
+  const localScorerWarnings = sanitizeLocalScorerWarnings(input.localScorer?.warnings);
   return [
     {
       code: "source_upload_disabled",
@@ -773,13 +775,13 @@ function buildLocalFindings(
           },
         ]
       : []),
-    ...(input.localScorer?.warnings?.length
+    ...(localScorerWarnings.length
       ? [
           {
             code: "local_scorer_warning",
             severity: "info" as const,
             title: "Local scorer diagnostics",
-            detail: input.localScorer.warnings.join(" "),
+            detail: localScorerWarnings.join(" "),
           },
         ]
       : []),

--- a/src/signals/local-scorer-diagnostics.ts
+++ b/src/signals/local-scorer-diagnostics.ts
@@ -1,0 +1,7 @@
+export const MAX_LOCAL_SCORER_WARNING_COUNT = 20;
+export const MAX_LOCAL_SCORER_WARNING_CHARS = 1000;
+
+export function sanitizeLocalScorerWarnings(warnings: string[] | undefined): string[] {
+  if (!warnings?.length) return [];
+  return warnings.slice(0, MAX_LOCAL_SCORER_WARNING_COUNT).map((warning) => warning.slice(0, MAX_LOCAL_SCORER_WARNING_CHARS));
+}

--- a/src/signals/local-workspace-intelligence.ts
+++ b/src/signals/local-workspace-intelligence.ts
@@ -1,5 +1,6 @@
 import type { LocalBranchAnalysis, LocalBranchAnalysisInput, LocalBranchChangedFile, LocalBranchValidation } from "./local-branch";
 import { isTestPath } from "./test-evidence";
+import { sanitizeLocalScorerWarnings } from "./local-scorer-diagnostics";
 
 export type LocalWorkspaceIntelligence = {
   version: 2;
@@ -87,7 +88,7 @@ export function buildLocalWorkspaceIntelligence(args: {
           localScorerDiagnostics: {
             mode: scorer.mode,
             ...(scorer.activeModel ? { activeModel: scorer.activeModel } : {}),
-            warnings: scorer.warnings ?? [],
+            warnings: sanitizeLocalScorerWarnings(scorer.warnings),
             metadataOnly: scorer.mode === "metadata_only",
           },
         }

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildLocalBranchAnalysis, findCurrentBranchPullRequest } from "../../src/signals/local-branch";
+import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../../src/signals/local-scorer-diagnostics";
 import type { ContributorOutcomeHistory, ContributorProfile, ContributorScoringProfile, IssueQualityReport } from "../../src/signals/engine";
 import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
 
@@ -60,6 +61,31 @@ describe("local branch analysis", () => {
     expect(analysis.prPacket.markdown).toContain("- passed: npm test -- cache");
     expect(analysis.prPacket.markdown).toContain("metadata only");
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
+  });
+
+  it("bounds local scorer warnings before adding local findings", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "src/scorer.ts", additions: 10, deletions: 0, status: "modified" }],
+        localScorer: {
+          mode: "metadata_only",
+          warnings: Array.from({ length: MAX_LOCAL_SCORER_WARNING_COUNT + 5 }, (_, index) => `${index}: ${"w".repeat(MAX_LOCAL_SCORER_WARNING_CHARS + 25)}`),
+        },
+      },
+      repo,
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    const finding = analysis.localFindings.find((entry) => entry.code === "local_scorer_warning");
+    expect(finding?.detail.length).toBeLessThanOrEqual(MAX_LOCAL_SCORER_WARNING_COUNT * MAX_LOCAL_SCORER_WARNING_CHARS + (MAX_LOCAL_SCORER_WARNING_COUNT - 1));
+    expect(analysis.workspaceIntelligence.localScorerDiagnostics?.warnings).toHaveLength(MAX_LOCAL_SCORER_WARNING_COUNT);
   });
 
   it("projects a blocked local branch into a useful after-pending-merge scenario", () => {

--- a/test/unit/local-workspace-intelligence.test.ts
+++ b/test/unit/local-workspace-intelligence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildLocalWorkspaceIntelligence } from "../../src/signals/local-workspace-intelligence";
+import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../../src/signals/local-scorer-diagnostics";
 import { hasLocalTestEvidence, isTestPath } from "../../src/signals/test-evidence";
 import { buildLocalDiffPreflightResult } from "../../src/signals/engine";
 import type { RepositoryRecord } from "../../src/types";
@@ -165,6 +166,37 @@ describe("local workspace intelligence v2", () => {
       warnings: expect.arrayContaining([expect.stringMatching(/not configured/i)]),
     });
     expect(intelligence.testEvidence.level).toBe("none");
+  });
+
+  it("bounds local scorer diagnostics before returning workspace intelligence", () => {
+    const intelligence = buildLocalWorkspaceIntelligence({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        localScorer: {
+          mode: "metadata_only",
+          warnings: Array.from({ length: MAX_LOCAL_SCORER_WARNING_COUNT + 5 }, (_, index) => `${index}: ${"w".repeat(MAX_LOCAL_SCORER_WARNING_CHARS + 25)}`),
+        },
+      },
+      analysis: {
+        baseFreshness: { status: "unknown", changedFileCount: 0, testFileCount: 0, passedValidationCount: 0, warnings: [] },
+        branchQualityBlockers: [],
+        accountStateBlockers: [],
+        recommendedRerunCondition: "Rerun after any branch, base, or PR state changes before opening/submitting.",
+        prPacket: {
+          titleSuggestion: "Local branch preflight",
+          markdown: "# Local branch preflight\n",
+          bodySections: [],
+          reviewerNotes: [],
+          validationSummary: { passed: 0, failed: 0, notRun: 0, commands: [] },
+          publicSafeWarnings: [],
+        },
+      },
+      changedFiles: [],
+    });
+
+    expect(intelligence.localScorerDiagnostics?.warnings).toHaveLength(MAX_LOCAL_SCORER_WARNING_COUNT);
+    expect(intelligence.localScorerDiagnostics?.warnings.every((warning) => warning.length <= MAX_LOCAL_SCORER_WARNING_CHARS)).toBe(true);
   });
 
   it("records test_files evidence when only test paths changed", () => {


### PR DESCRIPTION
### Motivation
- Prevent resource-exhaustion and storage amplification caused by unbounded `localScorer.warnings` being reflected, joined, and persisted in branch-analysis responses.

### Description
- Add `src/signals/local-scorer-diagnostics.ts` with `MAX_LOCAL_SCORER_WARNING_COUNT = 20`, `MAX_LOCAL_SCORER_WARNING_CHARS = 1000`, and `sanitizeLocalScorerWarnings()` to truncate and bound warnings.
- Constrain the API input schema so `localScorer.warnings` is `z.array(z.string().max(MAX_LOCAL_SCORER_WARNING_CHARS)).max(MAX_LOCAL_SCORER_WARNING_COUNT).optional()` in `src/api/routes.ts`.
- Use `sanitizeLocalScorerWarnings()` when building `workspaceIntelligence.localScorerDiagnostics` in `src/signals/local-workspace-intelligence.ts` and when building the `local_scorer_warning` finding detail in `src/signals/local-branch.ts` to avoid unbounded joins/allocations.
- Add regression tests that assert warnings are truncated and bounded in `test/unit/local-branch.test.ts` and `test/unit/local-workspace-intelligence.test.ts`.

### Testing
- Ran TypeScript typecheck with `npm run typecheck` and it succeeded. 
- Ran unit tests `npx vitest run test/unit/local-branch.test.ts test/unit/local-workspace-intelligence.test.ts` and both test files passed (37 tests total).
- Ran `git diff --check` and there were no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df5536600832cae888766387aff14)