### PR TITLE
fix(analytics): hide operator metrics from public weekly summary

### DIFF
--- a/src/services/weekly-value-report.ts
+++ b/src/services/weekly-value-report.ts
@@ -144,12 +144,20 @@ export function buildWeeklyValueReport(args: WeeklyValueReportInputs): WeeklyVal
     activeSessions: args.activeSessions ?? 0,
     digestSubscriptions: args.digestSubscriptions ?? 0,
   });
-  const summary = [
-    `Adoption: ${args.usageSummary.activeActors} active user(s), ${aggregate.activeRepos} active repo(s), ${aggregate.totalEvents} product event(s) in the last ${days} day(s).`,
-    `Usage: ${aggregate.mcpEvents} MCP event(s), ${aggregate.githubCommandEvents} GitHub command event(s), ${aggregate.prPreflights} PR preflight event(s), and ${aggregate.prPackets} PR packet event(s).`,
-    `Maintainer value: ${aggregate.quietSkips} quiet skip(s), ${aggregate.maintainerSignals} maintainer-value signal(s), and ${aggregate.driftDetections} open drift report(s).`,
-    `Coverage: ${registeredRepos} registered repo(s), ${installedRepos} installed repo(s), ${args.installations.length} GitHub App installation(s).`,
-  ].map(sanitizeReportText);
+  const summary = (
+    variant === "public"
+      ? [
+          `Adoption: ${args.usageSummary.activeActors} active user(s) and ${aggregate.activeRepos} active repo(s) in the last ${days} day(s).`,
+          `Usage: ${aggregate.mcpEvents} MCP event(s), ${aggregate.githubCommandEvents} GitHub command event(s), ${aggregate.prPreflights} PR preflight event(s), and ${aggregate.prPackets} PR packet event(s).`,
+          `Maintainer value: ${aggregate.quietSkips} quiet skip(s), ${aggregate.maintainerSignals} maintainer-value signal(s), and ${aggregate.driftDetections} open drift report(s).`,
+        ]
+      : [
+          `Adoption: ${args.usageSummary.activeActors} active user(s), ${aggregate.activeRepos} active repo(s), ${aggregate.totalEvents} product event(s) in the last ${days} day(s).`,
+          `Usage: ${aggregate.mcpEvents} MCP event(s), ${aggregate.githubCommandEvents} GitHub command event(s), ${aggregate.prPreflights} PR preflight event(s), and ${aggregate.prPackets} PR packet event(s).`,
+          `Maintainer value: ${aggregate.quietSkips} quiet skip(s), ${aggregate.maintainerSignals} maintainer-value signal(s), and ${aggregate.driftDetections} open drift report(s).`,
+          `Coverage: ${registeredRepos} registered repo(s), ${installedRepos} installed repo(s), ${args.installations.length} GitHub App installation(s).`,
+        ]
+  ).map(sanitizeReportText);
   return {
     generatedAt: args.generatedAt,
     variant,

--- a/test/unit/weekly-value-report.test.ts
+++ b/test/unit/weekly-value-report.test.ts
@@ -68,11 +68,12 @@ describe("weekly value reports", () => {
     expect(report.operatorDetails).toBeUndefined();
     expect(report.summary).toEqual(
       expect.arrayContaining([
-        expect.stringContaining("4 active user(s), 2 active repo(s), 18 product event(s)"),
+        expect.stringContaining("4 active user(s) and 2 active repo(s)"),
         expect.stringContaining("3 MCP event(s), 3 GitHub command event(s), 3 PR preflight event(s), and 3 PR packet event(s)"),
         expect.stringContaining("1 quiet skip(s), 5 maintainer-value signal(s)"),
       ]),
     );
+    expect(report.summary).not.toEqual(expect.arrayContaining([expect.stringMatching(/product event|registered repo|installed repo|GitHub App installation/i)]));
     expect(report.metrics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "active_users", value: 4, visibility: "public" }),
@@ -80,6 +81,7 @@ describe("weekly value reports", () => {
       ]),
     );
     expect(report.metrics.some((metric) => metric.visibility === "operator")).toBe(false);
+    expect(report.metrics.map((metric) => metric.id)).not.toEqual(expect.arrayContaining(["product_events", "registered_repos", "installed_repos", "installations"]));
     expect(report.warnings).toEqual(
       expect.arrayContaining(["Product usage rollups have 1 freshness warning(s).", "Registry data has 1 warning(s).", "Scoring model data has 1 warning(s)."]),
     );
@@ -125,6 +127,12 @@ describe("weekly value reports", () => {
       topCommands: [{ key: "Bearer <redacted-token>", count: 1 }],
       topTools: [{ key: "<redacted>", count: 1 }],
     });
+    expect(report.summary).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("2 product event(s)"),
+        expect.stringContaining("1 registered repo(s), 1 installed repo(s), 1 GitHub App installation(s)"),
+      ]),
+    );
     expect(report.metrics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "active_sessions", value: 3, visibility: "operator" }),


### PR DESCRIPTION
### Motivation

- The public `weekly-value-report` response built summary strings that included operator-only aggregate values (product event and deployment coverage counts) before filtering structured metrics, causing information disclosure to non-operator roles.

### Description

- Update `buildWeeklyValueReport` in `src/services/weekly-value-report.ts` to build the `summary` text differently by `variant`, omitting operator-only counts from the `public` summary while preserving them for `operator` reports.
- Keep the structured `metrics` array unchanged except that the public variant continues to filter out metrics with `visibility === "operator"`.
- Add unit assertions in `test/unit/weekly-value-report.test.ts` to verify public summaries do not contain operator-only values and that operator reports still include those values.

### Testing

- Ran `npx vitest run test/unit/weekly-value-report.test.ts --reporter=dot` and the unit tests passed (4 tests).
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors.
- Ran `git diff --check` to ensure no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df5533eb8832c983139a241821680)