### PR TITLE
Neutralize Markdown/mentions in maintainer queue digest titles

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -827,7 +827,18 @@ function normalizeLogin(value: string): string {
 
 function shortText(value: string, maxLength: number): string {
   const sanitized = publicBlockerDetail(value).replace(/\s+/g, " ").trim();
-  return sanitized.length > maxLength ? `${sanitized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...` : sanitized;
+  const safeText = neutralizePublicMarkdownText(sanitized);
+  return safeText.length > maxLength ? `${safeText.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...` : safeText;
+}
+
+function neutralizePublicMarkdownText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([\\`*_{}[\]()#+\-.!|])/g, "\\$1")
+    .replace(/@(?=[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)?)/gi, "@\u200B")
+    .replace(/\bhttps?:\/\//gi, (match) => `${match.slice(0, -2)}\u200B//`);
 }
 
 function pickActions(

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -992,6 +992,61 @@ describe("GitHub mention commands", () => {
     expect(defensiveSummary).toContain("Use the authenticated maintainer dashboard and private API");
     expect(defensiveDigest.needsAuthorPullRequests.find((pr) => pr.number === 18)?.reasons).toContain("Maintainer-authored PR; review as repo stewardship.");
   });
+
+  it("neutralizes attacker-controlled queue digest titles in public comments", () => {
+    const attackerTitle = "[x](http://e.test) ![i](http://e.test/i) @org/team <b>x</b>";
+    const digest = {
+      ...sampleMaintainerDigest(),
+      reviewNowPullRequests: [
+        {
+          number: 77,
+          title: attackerTitle,
+          authorLogin: "attacker",
+          linkedIssues: [7],
+          labels: [],
+          confirmedMiner: false,
+          ageDays: 0,
+          reasons: ["Linked issue is present."],
+          signals: [],
+        },
+      ],
+      duplicateClusters: [
+        {
+          id: "attacker-title",
+          risk: "high",
+          reason: "Likely_duplicate title cluster",
+          items: [{ type: "pull_request", number: 77, title: attackerTitle }],
+        },
+      ],
+    } satisfies ReturnType<typeof sampleMaintainerDigest>;
+
+    const reviewNow = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory review-now")!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 99, title: "Digest", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+      maintainerDigest: digest,
+    });
+    const duplicateClusters = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory duplicate-clusters")!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 99, title: "Digest", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+      maintainerDigest: digest,
+    });
+
+    for (const body of [reviewNow, duplicateClusters]) {
+      expect(body).not.toContain("[x](http://e.test)");
+      expect(body).not.toContain("![i](http://e.test/i)");
+      expect(body).not.toContain("@org/team");
+      expect(body).not.toContain("<b>x</b>");
+      expect(body).toContain("\\[x\\]");
+      expect(body).toContain("@\u200Borg/team");
+      expect(body).toContain("&lt;b&gt;x&lt;/b&gt;");
+    }
+  });
 });
 
 function completedRun(id: string) {


### PR DESCRIPTION
### Motivation
- The maintainer queue digest rendered attacker-controlled PR/issue titles directly into bot-authored GitHub comments, allowing Markdown links/images and @mentions to be published as trusted output.

### Description
- Escape and neutralize unsafe constructs in short digest snippets by introducing `neutralizePublicMarkdownText` and using it from `shortText` to escape HTML characters and Markdown metacharacters. 
- Neutralize `@`-mentions by inserting a zero-width space and break autolink schemes to prevent active links. 
- Apply neutralization before truncation so shortened titles remain safe. 
- Add a regression test that verifies `review-now` and `duplicate-clusters` outputs do not contain rendered links/images/mentions and instead show escaped or neutralized text (`src/github/commands.ts`, `test/unit/github-commands.test.ts`).

### Testing
- Ran `npm test -- --run test/unit/github-commands.test.ts` and the modified unit tests all passed (11 tests). 
- Ran `npm run typecheck` and `git diff --check`, both succeeded with no TypeScript or diff issues. 
- A full-suite `npm test` invocation timed out in this environment, but the targeted unit tests and typecheck validate the change locally in CI-like checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df2bdf788832cb03827276028179f)