### PR TITLE
fix(security): omit private maintainer notes from branch guidance

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -6029,12 +6029,6 @@
                   "type": "string"
                 }
               },
-              "maintainerNotes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "warnings": {
                 "type": "array",
                 "items": {
@@ -6055,7 +6049,6 @@
               "preferredLabelHits",
               "findings",
               "publicNextSteps",
-              "maintainerNotes",
               "warnings",
               "summary"
             ]

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1661,7 +1661,6 @@ export const LocalBranchAnalysisSchema = z
       preferredLabelHits: z.array(z.string()),
       findings: z.array(z.object({ code: z.string(), severity: z.enum(["info", "warning", "critical"]), title: z.string(), detail: z.string(), action: z.string().optional() })),
       publicNextSteps: z.array(z.string()),
-      maintainerNotes: z.array(z.string()),
       warnings: z.array(z.string()),
       summary: z.string(),
     }),

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -51,7 +51,6 @@ export type FocusManifestGuidance = {
   preferredLabelHits: string[];
   findings: FocusManifestFinding[];
   publicNextSteps: string[];
-  maintainerNotes: string[];
   warnings: string[];
   summary: string;
 };
@@ -249,7 +248,6 @@ export function buildFocusManifestGuidance(args: {
       preferredLabelHits: [],
       findings,
       publicNextSteps: [],
-      maintainerNotes: [],
       warnings: manifest.warnings,
       summary: "No maintainer focus manifest applied; using deterministic signals only.",
     };
@@ -351,7 +349,6 @@ export function buildFocusManifestGuidance(args: {
     preferredLabelHits,
     findings,
     publicNextSteps: safeNextSteps,
-    maintainerNotes: manifest.maintainerNotes,
     warnings: manifest.warnings,
     summary: summarize(manifest, matchedBlockedPaths, matchedWantedPaths),
   };

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -216,10 +216,10 @@ describe("buildFocusManifestGuidance", () => {
     expect(guidance.findings.some((finding) => finding.code === "manifest_issue_discovery_discouraged")).toBe(true);
   });
 
-  it("never leaks maintainer-private notes into public next steps", () => {
+  it("never exposes maintainer-private notes in contributor guidance", () => {
     const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["migrations/x.sql"] });
-    expect(guidance.maintainerNotes.join(" ")).toMatch(/ping @owner/);
-    expect(guidance.publicNextSteps.join(" ")).not.toMatch(/ping @owner/);
+    expect(guidance).not.toHaveProperty("maintainerNotes");
+    expect(JSON.stringify(guidance)).not.toMatch(/ping @owner/);
     expect(guidance.publicNextSteps.every(isFocusManifestPublicSafe)).toBe(true);
   });
 

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1204,6 +1204,8 @@ describe("local branch analysis", () => {
     expect(analysis.prPacket.markdown).toContain("## Maintainer Focus");
     expect(analysis.prPacket.markdown).toContain("Prefer small, focused PRs.");
     expect(analysis.prPacket.markdown).not.toMatch(/ping @owner/);
+    expect(JSON.stringify(analysis.manifestGuidance)).not.toMatch(/ping @owner/);
+    expect(JSON.stringify(analysis)).not.toMatch(/ping @owner/);
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/ping @owner/);
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
   });


### PR DESCRIPTION
### Motivation
- Prevent leaking maintainer-private `maintainerNotes` into contributor-facing branch analysis responses and persisted snapshots, since `maintainerNotes` are documented as private review context and must not be emitted to non-maintainers. 

### Description
- Remove `maintainerNotes` from the contributor-facing `FocusManifestGuidance` shape and from both the empty and present guidance return values in `src/signals/focus-manifest.ts` so guidance objects no longer carry private notes. 
- Remove `manifestGuidance.maintainerNotes` from the OpenAPI response schema in `src/openapi/schemas.ts` and regenerate the UI OpenAPI document at `apps/gittensory-ui/public/openapi.json` so the public contract no longer exposes the field. 
- Add/adjust regression tests in `test/unit/focus-manifest.test.ts` and `test/unit/local-branch.test.ts` to assert `maintainerNotes` is absent from guidance and that serialized analysis/pr-packet output does not contain private notes while public notes remain rendered. 

### Testing
- Ran typecheck with `npm run typecheck` and it succeeded. 
- Ran unit tests with `npm run test:unit -- test/unit/focus-manifest.test.ts test/unit/local-branch.test.ts` and all tests passed. 
- Regenerated and verified UI OpenAPI with `npm run ui:openapi` and checked it with `npm run ui:openapi:check`; the generated OpenAPI no longer documents `maintainerNotes` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df606519c832c92c357258264dfae)