### PR TITLE
fix: sanitize public outcome pattern details

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -911,12 +911,23 @@ function publicBlockerLabel(code: string): string {
 }
 
 function publicBlockerDetail(value: string): string {
-  return sanitizePublicComment(
-    value
-      .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work")
-      .replace(/\bcheck_duplicate_risk\b/gi, "duplicate-risk review")
-      .replace(/\bopen_pr_pressure\b/gi, "open pull request pressure"),
+  return sanitizePublicInlineDetail(
+    sanitizePublicComment(
+      value
+        .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work")
+        .replace(/\bcheck_duplicate_risk\b/gi, "duplicate-risk review")
+        .replace(/\bopen_pr_pressure\b/gi, "open pull request pressure"),
+    ),
   );
+}
+
+function sanitizePublicInlineDetail(value: string): string {
+  return value
+    .replace(/[\u0000-\u001F\u007F]+/g, " ")
+    .replace(/@(?=[A-Za-z0-9_-])/g, "@\u200B")
+    .replace(/[\\`*_{}[\]()#+>|]/g, "\\$&")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function dedupeBulletLines(lines: string[]): string[] {

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -859,7 +859,10 @@ function normalizeLogin(value: string): string {
 }
 
 function shortText(value: string, maxLength: number): string {
-  const sanitized = publicBlockerDetail(value).replace(/\s+/g, " ").trim();
+  const sanitized = sanitizePublicComment(value)
+    .replace(/[\u0000-\u001F\u007F]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
   const safeText = neutralizePublicMarkdownText(sanitized);
   return safeText.length > maxLength ? `${safeText.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...` : safeText;
 }

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3580,11 +3580,12 @@ function outcomeSignal(mergeRate: number): RepoOutcomeSignal {
 }
 
 function describeDimension(dimension: RepoOutcomeDimensionKind, key: string): string {
+  const safeKey = sanitizeOutcomeDimensionKey(key);
   switch (dimension) {
     case "path":
-      return `PRs touching ${key}`;
+      return `PRs touching ${safeKey}`;
     case "label":
-      return `PRs labeled "${key}"`;
+      return `PRs labeled "${safeKey}"`;
     case "size":
       return `${key} PRs`;
     case "linked_issue":
@@ -3596,6 +3597,15 @@ function describeDimension(dimension: RepoOutcomeDimensionKind, key: string): st
     case "author_role":
       return key === "returning_contributor" ? "PRs from returning contributors" : "PRs from first-time or external authors";
   }
+}
+
+function sanitizeOutcomeDimensionKey(key: string): string {
+  return key
+    .replace(/[\u0000-\u001F\u007F]+/g, " ")
+    .replace(/@(?=[A-Za-z0-9_-])/g, "@\u200B")
+    .replace(/[\\`*_{}[\]()#+>|]/g, "\\$&")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function isCodeFile(file: string): boolean {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -647,6 +647,37 @@ describe("GitHub mention commands", () => {
     expect(duplicateViaRecommendation).toContain("**Duplicate & WIP caution**");
     expect(duplicateViaRecommendation).toMatch(/overlap|WIP|Concurrent/i);
 
+    const duplicateWithInjectedWhy = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory duplicate-check")!,
+      repo: null,
+      issue: { number: 27, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+      bundle: {
+        run: completedRun("run-duplicate-injection"),
+        actions: [
+          {
+            id: "duplicate-injection",
+            runId: "run-duplicate-injection",
+            actionType: "monitor_existing_pr",
+            status: "watch",
+            recommendation: "Compare duplicate risk",
+            why: ["PRs touching duplicate\n@octo-team/ [click](https://example.test) have high closure risk here."],
+            blockedBy: [],
+            riskImpact: "No extra risk",
+            publicSafeSummary: "Review linked issues before requesting detailed review.",
+            approvalRequired: true,
+            safetyClass: "private",
+            payload: {},
+          },
+        ],
+        contextSnapshots: [],
+        summary: "duplicate",
+      },
+    });
+    expect(duplicateWithInjectedWhy).toContain("PRs touching duplicate @​octo-team/ \\[click\\]\\(https://example.test\\)");
+    expect(duplicateWithInjectedWhy).not.toMatch(/\n@octo-team|@octo-team|[^\\]\[click\]\(https:\/\/example\.test\)/);
+
     const preflightWithRerun = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory preflight")!,
       repo: null,

--- a/test/unit/repo-outcome-patterns.test.ts
+++ b/test/unit/repo-outcome-patterns.test.ts
@@ -375,6 +375,26 @@ describe("buildRepoOutcomePatterns", () => {
     expect(missing.summary).toMatch(/evidence missing/);
   });
 
+  it("sanitizes untrusted path and label text before formatting outcome details", () => {
+    const pullRequests = [
+      closedPr(1, { labels: ["wip [click](https://example.test) @octo-team"] }),
+      closedPr(2, { labels: ["wip [click](https://example.test) @octo-team"] }),
+      closedPr(3, { labels: ["wip [click](https://example.test) @octo-team"] }),
+    ];
+    const files = [
+      file(1, "duplicate\n@octo-team/owned.md"),
+      file(2, "duplicate\n@octo-team/other.md"),
+      file(3, "duplicate\n@octo-team/more.md"),
+    ];
+
+    const result = buildRepoOutcomePatterns({ repo: repo(), repoFullName: REPO, pullRequests, files });
+    const details = result.riskPatterns.map((p) => p.detail);
+
+    expect(details).toContain("PRs touching duplicate @​octo-team/ have high closure risk here (0/3 merged).");
+    expect(details).toContain('PRs labeled "wip \\[click\\]\\(https://example.test\\) @​octo-team" have high closure risk here (0/3 merged).');
+    expect(details.join("\n")).not.toMatch(/duplicate\n@octo-team|@octo-team|[^\\]\[click\]\(https:\/\/example\.test\)/);
+  });
+
   it("never emits forbidden public-surface language", () => {
     const fixtures = [
       buildRepoOutcomePatterns(primaryFixture()),


### PR DESCRIPTION
### Motivation
- Prevent untrusted repo outcome pattern keys (file path buckets and labels) from being formatted into public-facing pattern detail strings that could include newlines, `@`-mentions, or raw markdown and appear in GitHub comments.
- Harden inline blocker/action text emitted in public command comments so attacker-controlled strings cannot inject mentions, control characters, or markdown control sequences.

### Description
- Add `sanitizeOutcomeDimensionKey` in `src/signals/engine.ts` and use it in `describeDimension` so outcome pattern keys are normalized and escaped before being interpolated into pattern `detail` text.
- Add `sanitizePublicInlineDetail` in `src/github/commands.ts` and pipe `publicBlockerDetail` output through it (after `sanitizePublicComment`) to neutralize control characters, GitHub mentions, and markdown metacharacters for inline bullet details.
- Add regression tests in `test/unit/repo-outcome-patterns.test.ts` and `test/unit/github-commands.test.ts` that exercise crafted path/label inputs and duplicate-check rendering to ensure injected newlines, mentions, and markdown links are neutralized.
- Preserve the existing `sanitizePublicComment` behavior for higher-level sanitization while applying additional inline escaping for bullet-detail contexts.

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/repo-outcome-patterns.test.ts test/unit/github-commands.test.ts` and all tests passed (both files ran and their tests succeeded).
- Ran the TypeScript typecheck with `npm run typecheck` and it completed successfully.
- Verified no formatting issues with `git diff --check` as part of the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfa936d78832c8402d894bfde26a1)