### PR TITLE
fix(api): require app roles for command feedback

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -954,13 +954,15 @@ export function createApp() {
   });
 
   app.get("/v1/app/commands/usefulness", async (c) => {
-    const identity = await authenticateRequestIdentity(c);
-    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
     const days = Number(c.req.query("days") ?? 30);
     return c.json(await getCommandUsefulnessSummary(c.env, { windowDays: clampInteger(days, 1, 180) }));
   });
 
   app.post("/v1/app/commands/feedback", async (c) => {
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
     const identity = await authenticateRequestIdentity(c);
     if (!identity) return c.json({ error: "unauthorized" }, 401);
     const body = await c.req.json().catch(() => null);

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1248,6 +1248,16 @@ describe("api routes", () => {
     expect(unknownOverview.status).toBe(200);
     await expect(unknownOverview.json()).resolves.toMatchObject({ roleSummary: { roles: [], onboarding: { status: "needs_setup" } } });
     expect((await app.request("/v1/app/operator-dashboard", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
+    expect((await app.request("/v1/app/commands/usefulness", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
+    expect(
+      (
+        await app.request("/v1/app/commands/feedback", {
+          method: "POST",
+          headers: unknownHeaders,
+          body: JSON.stringify({ answerId: "missing-answer", vote: "useful" }),
+        }, unknownEnv)
+      ).status,
+    ).toBe(403);
     expect((await app.request("/v1/app/analytics/daily-rollups", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/mcp-compatibility", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/weekly-value-report", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);


### PR DESCRIPTION
### Motivation
- Prevent unauthorised OAuth/browser sessions from reading app command usefulness analytics or submitting feedback recorded as `maintainer` feedback.
- The global protected-route middleware allows any authenticated session to hit `/v1/app/*`, so these role-sensitive endpoints must perform route-level role checks.

### Description
- Add a role guard using `requireAppRole(c, ["maintainer","owner","operator"])` to `GET /v1/app/commands/usefulness` in `src/api/routes.ts` to restrict analytics access.
- Add the same `requireAppRole(...)` guard to `POST /v1/app/commands/feedback` in `src/api/routes.ts` to restrict feedback submission and prevent low-privilege sessions from being recorded as maintainers while preserving static service-token access.
- Update `test/integration/api.test.ts` to assert that a no-role session receives `403` for both the usefulness and feedback endpoints.

### Testing
- Ran the affected integration test file with `npm test -- --run test/integration/api.test.ts` and all tests in that file passed.
- Ran type checking with `npm run typecheck` and `tsc` completed successfully with no errors.
- Ran `git diff --check` (no issues) as part of validation prior to committing the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfd39526c832c8562cc56928f4002)