### PR TITLE
fix(analytics): redact actor components in usage metadata

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3128,18 +3128,41 @@ function boundedProductUsageField(value: unknown, maxLength: number): string | n
   return safe ? safe : null;
 }
 
-function buildProductUsageActorRedactor(actor: unknown): RegExp | null {
+type ProductUsageActorRedactor = {
+  pattern: RegExp;
+};
+
+function buildProductUsageActorRedactor(actor: unknown): ProductUsageActorRedactor | null {
   const normalized = typeof actor === "string" ? actor.trim() : "";
   if (!normalized || normalized.length > PRODUCT_USAGE_ACTOR_REDACTION_MAX_CHARS) return null;
-  return new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(normalized)}(?=$|[^A-Za-z0-9])`, "gi");
+  return { pattern: new RegExp(escapeRegExp(normalized), "gi") };
 }
 
-function redactProductUsageActor(value: string | null, actorRedactor: RegExp | null): string | null {
-  return value && actorRedactor ? value.replace(actorRedactor, "$1<redacted-actor>") : value;
+function redactProductUsageActor(value: string | null, actorRedactor: ProductUsageActorRedactor | null): string | null {
+  if (!value || !actorRedactor) return value;
+  return value.replace(actorRedactor.pattern, (match, offset: number, source: string) => {
+    const previous = offset > 0 ? source[offset - 1] : undefined;
+    const next = source[offset + match.length];
+    const hasLeftBoundary = isProductUsageActorTokenBoundary(previous) || isProductUsageCamelBoundaryBefore(previous, match);
+    const hasRightBoundary = isProductUsageActorTokenBoundary(next) || isProductUsageCamelBoundaryAfter(next);
+    return hasLeftBoundary && hasRightBoundary ? "<redacted-actor>" : match;
+  });
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isProductUsageActorTokenBoundary(value: string | undefined): boolean {
+  return value === undefined || !/[A-Za-z0-9]/.test(value);
+}
+
+function isProductUsageCamelBoundaryBefore(previous: string | undefined, match: string): boolean {
+  return Boolean(previous && /[a-z0-9]/.test(previous) && /^[A-Z]/.test(match));
+}
+
+function isProductUsageCamelBoundaryAfter(next: string | undefined): boolean {
+  return Boolean(next && /[A-Z]/.test(next));
 }
 
 async function upsertProductUsageDailyRollup(env: Env, day: string, generatedAt: string): Promise<ProductUsageDailyRollupRecord> {
@@ -3410,7 +3433,7 @@ const PRODUCT_USAGE_LOCAL_PATH = /(?:\/Users|\/home|\/tmp)\/[^\s"',;)]*|[A-Za-z]
 const PRODUCT_USAGE_TOKEN_VALUE = /\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
 const PRODUCT_USAGE_BEARER_VALUE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi;
 
-function sanitizeProductUsageMetadata(value: Record<string, unknown> | null | undefined, actorRedactor: RegExp | null): Record<string, JsonValue> {
+function sanitizeProductUsageMetadata(value: Record<string, unknown> | null | undefined, actorRedactor: ProductUsageActorRedactor | null): Record<string, JsonValue> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const output: Record<string, JsonValue> = {};
   for (const [key, entryValue] of Object.entries(value).slice(0, PRODUCT_USAGE_METADATA_MAX_KEYS)) {
@@ -3423,7 +3446,7 @@ function sanitizeProductUsageMetadata(value: Record<string, unknown> | null | un
   return output;
 }
 
-function sanitizeProductUsageJson(value: unknown, depth: number, actorRedactor: RegExp | null): JsonValue | undefined {
+function sanitizeProductUsageJson(value: unknown, depth: number, actorRedactor: ProductUsageActorRedactor | null): JsonValue | undefined {
   if (value === undefined || typeof value === "function" || typeof value === "symbol") return undefined;
   if (value === null) return null;
   if (typeof value === "boolean") return value;

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -76,6 +76,38 @@ describe("product usage events", () => {
     expect(JSON.stringify(row)).not.toMatch(/"ab"|\bab\/|\bab:|for ab\b/i);
   });
 
+  it("redacts short actor components from metadata keys and camelCase values", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+
+    await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "local_branch_analysis_completed",
+      actor: "bob",
+      repoFullName: "bob/private-tool",
+      targetKey: "bob:JSONbored/gittensory:feature-x",
+      metadata: {
+        viewer: "bob",
+        note: "for bob, but bobcat stays readable",
+        bobKey: "owner key redacted too",
+        nested: { forBob: "bob owns this" },
+      },
+    });
+
+    const [row] = await listProductUsageEvents(env);
+    expect(row).toBeDefined();
+    if (!row) throw new Error("expected product usage event");
+    expect(row.repoFullName).toBe("<redacted-actor>/private-tool");
+    expect(row.targetKey).toBe("<redacted-actor>:JSONbored/gittensory:feature-x");
+    expect(row.metadata).toMatchObject({
+      viewer: "<redacted-actor>",
+      note: "for <redacted-actor>, but bobcat stays readable",
+      "<redacted-actor>Key": "owner key redacted too",
+      nested: { "for<redacted-actor>": "<redacted-actor> owns this" },
+    });
+    expect(row.metadata).not.toHaveProperty("bobKey");
+    expect(JSON.stringify(row)).not.toMatch(/\bbob\b|bobKey|forBob/i);
+  });
+
   it("bounds actor redaction patterns while still covering long valid handles", async () => {
     const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
     const actor = "a".repeat(200);


### PR DESCRIPTION
## Summary
- tighten product usage actor redaction so short actors are removed from metadata keys and camelCase components
- keep the existing guard against broad substring redaction so unrelated words like `bobcat` remain readable
- add a regression test for `bob` in repo, target, metadata key, nested key, and metadata value fields

## Why
A Codex Security finding reported that short actor identifiers could leak through persisted product usage telemetry fields. Current `main` already redacts short standalone actors in `repoFullName`, `targetKey`, and simple metadata values, but metadata keys like `bobKey` and camelCase components like `forBob` could still retain the actor string. This closes that remaining privacy gap without redacting arbitrary substrings inside unrelated words.

## Validation
- `npm run test:unit -- test/unit/product-usage.test.ts`
- `npm run typecheck`
- `npm run validate`
- `npm run test:ci`
