### PR TITLE
Fix pending-PR projection double-counting merge-ready PRs

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -348,7 +348,15 @@ function buildScenarioPreviews(
   contributorEvidence: ContributorEvidenceRecord | null | undefined,
   current: ScoreCore,
 ): ScoreScenarioPreview[] {
-  const userPendingCount = nonNegative(input.pendingMergedPrCount) + nonNegative(input.pendingClosedPrCount) + nonNegative(input.approvedPrCount);
+  // Count each pending open PR at most once. `approvedPrCount` and
+  // `pendingMergedPrCount` are the same merge-ready set — detectPendingPrScenario
+  // sets both to `mergeReady.length` — so they must be folded with `max`, not
+  // added, or the merge-ready PRs get double-subtracted from the open-PR
+  // projection. Closed/likely-close PRs are a disjoint set and add on top. This
+  // mirrors the canonical reduction in pending-pr-scenarios.ts
+  // (currentOpen - pendingMergedPrCount - pendingClosedPrCount).
+  const mergeReadyPending = Math.max(nonNegative(input.pendingMergedPrCount), nonNegative(input.approvedPrCount));
+  const userPendingCount = mergeReadyPending + nonNegative(input.pendingClosedPrCount);
   const observedApprovedCount = nonNegative(input.observedApprovedPrCount);
   const observedStaleCloseCount = nonNegative(input.observedStalePrCount);
   const observedClosedCount = nonNegative(input.observedClosedPrCount);
@@ -407,12 +415,12 @@ function buildScenarioPreviews(
       computeScoreCore(afterPendingInput, repo, snapshot, contributorEvidence),
       [
         userPendingCount > 0
-          ? `${userPendingCount} user-supplied pending approved/merged/closed PR(s) are treated as no longer open for this scenario.`
+          ? `${userPendingCount} pending merged/closed PR(s) are treated as no longer open for this scenario${input.pendingScenarioObserved ? "" : " (caller-supplied)"}.`
           : "No pending merge/close count was supplied; this scenario preserves current open PR pressure.",
         ...(input.projectedCredibility !== undefined
           ? [`Projected credibility is user-supplied as ${roundScore(projectedCredibility)}.`]
           : userPendingCount > 0
-            ? [`Projected credibility is raised to the current floor ${current.gates.credibilityFloor} because pending merges were supplied by the caller.`]
+            ? [`Projected credibility is raised to the current floor ${current.gates.credibilityFloor} because pending merges are expected to land.`]
             : []),
         ...(input.scenarioNotes ?? []),
       ],

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -486,6 +486,60 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     expect(JSON.stringify(preview)).not.toMatch(/guaranteed payout|wallet|hotkey|farming/i);
   });
 
+  it("does not double-count merge-ready PRs supplied as both pendingMerged and approved", () => {
+    const preview = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 60,
+        totalTokenScore: 90,
+        sourceLines: 50,
+        openPrCount: 6,
+        credibility: 1,
+        // The GitHub-observed detector reports the same merge-ready set as both
+        // pendingMergedPrCount and approvedPrCount; they must not be added twice.
+        pendingMergedPrCount: 3,
+        approvedPrCount: 3,
+        pendingClosedPrCount: 0,
+      },
+    });
+    const afterPending = preview.scenarioPreviews.find((scenario) => scenario.name === "afterPendingMerges");
+    // 3 merge-ready PRs leave the queue once: 6 - 3 = 3 open (not the buggy 6 - 6 = 0).
+    expect(afterPending?.gates.openPrCount).toBe(3);
+    // 3 still exceeds openPrThreshold (2 + floor(90/300) = 2) -> gate stays blocked.
+    expect(afterPending?.scoreEstimate.openPrMultiplier).toBe(0);
+    expect(afterPending?.effectiveEstimatedScore).toBe(0);
+    // Scenario note reports the de-duplicated count (3), never the doubled 6.
+    const note = afterPending?.assumptions.join(" ") ?? "";
+    expect(note).toMatch(/3 pending merged\/closed PR/);
+    expect(note).not.toMatch(/6 pending/);
+
+    // GitHub-observed path: same merge-ready set, note must still read 3, not 6.
+    const observed = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 60,
+        totalTokenScore: 90,
+        sourceLines: 50,
+        openPrCount: 6,
+        credibility: 1,
+        pendingMergedPrCount: 3,
+        approvedPrCount: 3,
+        pendingClosedPrCount: 0,
+        expectedOpenPrCountAfterMerge: 3,
+        pendingScenarioObserved: true,
+      },
+    });
+    const observedAfterPending = observed.scenarioPreviews.find((scenario) => scenario.name === "afterPendingMerges");
+    expect(observedAfterPending?.source).toBe("github_observed");
+    const observedNote = observedAfterPending?.assumptions.join(" ") ?? "";
+    expect(observedNote).toMatch(/3 pending merged\/closed PR/);
+    expect(observedNote).not.toMatch(/6 pending|user-supplied/);
+  });
+
   it("warns on metadata-only weak previews without using public reward or wallet language", () => {
     const preview = buildScorePreview({
       repo: null,


### PR DESCRIPTION
Closes #220.

## Problem
`buildScenarioPreviews` computed `userPendingCount` as `pendingMergedPrCount + pendingClosedPrCount + approvedPrCount`. But `approvedPrCount` and `pendingMergedPrCount` are the **same merge-ready set** — `detectPendingPrScenario` sets both to `mergeReady.length` (`pending-pr-scenarios.ts:130/151`) — so the merge-ready PRs were subtracted twice from the open-PR projection. The canonical reduction (`pending-pr-scenarios.ts:135`) is `currentOpen - pendingMergedPrCount - pendingClosedPrCount`, never `+ approvedPrCount`. The result: `afterPendingMerges` / `bestReasonableCase` over-relieved the open-PR gate (reporting it cleared when it was not) and the scenario note reported a doubled PR count.

## Fix
- Fold the two merge-ready fields with `max` instead of adding them: `mergeReadyPending = max(pendingMergedPrCount, approvedPrCount)`, then `userPendingCount = mergeReadyPending + pendingClosedPrCount`. This avoids the double-count when both are supplied (the GitHub-observed path always supplies both equal) while still counting a caller who supplies only one of them.
- Corrected the `afterPendingMerges` scenario note to report the de-duplicated count and not hardcode "user-supplied"/"by the caller" wording on the `github_observed` path.

## Tests
Added a fail-on-revert test: `openPrCount=6`, `pendingMergedPrCount=3`, `approvedPrCount=3` (no `expectedOpenPrCountAfterMerge`) -> `afterPendingMerges` projects 3 open PRs (gate still blocked, score 0), not the buggy 0; and both the user-supplied and github-observed notes read "3 pending merged/closed PR(s)", never 6.

`vitest run test/unit/scoring.test.ts` 18/18; `pending-pr-scenarios` + `local-branch` + `contributor-open-pr-monitor` 53/53; `tsc --noEmit` clean.