### PR TITLE
Fix case-sensitive repoFullName match dropping maintainer-lane detection

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1352,16 +1352,16 @@ export function buildRoleContext(args: {
   const normalizedLogin = args.login.toLowerCase();
   const [owner] = args.repoFullName.split("/");
   const authoredAssociations = [
-    ...(args.pullRequests ?? []).filter((pr) => pr.repoFullName === args.repoFullName && sameLogin(pr.authorLogin, args.login)).map((pr) => pr.authorAssociation),
-    ...(args.issues ?? []).filter((issue) => issue.repoFullName === args.repoFullName && sameLogin(issue.authorLogin, args.login)).map((issue) => issue.authorAssociation),
+    ...(args.pullRequests ?? []).filter((pr) => sameRepo(pr.repoFullName, args.repoFullName) && sameLogin(pr.authorLogin, args.login)).map((pr) => pr.authorAssociation),
+    ...(args.issues ?? []).filter((issue) => sameRepo(issue.repoFullName, args.repoFullName) && sameLogin(issue.authorLogin, args.login)).map((issue) => issue.authorAssociation),
   ].filter(Boolean) as string[];
   const officialRepo = args.profile?.gittensor?.repositories.find((repo) => repo.repoFullName.toLowerCase() === args.repoFullName.toLowerCase());
   const touchedByOfficial = Boolean(officialRepo && officialRepo.pullRequests + officialRepo.openIssues + officialRepo.closedIssues > 0);
   const touchedByCache = Boolean(
     args.profile?.registeredRepoActivity.reposTouched.some((repo) => repo.toLowerCase() === args.repoFullName.toLowerCase()) ||
-      (args.pullRequests ?? []).some((pr) => pr.repoFullName === args.repoFullName && sameLogin(pr.authorLogin, args.login)) ||
+      (args.pullRequests ?? []).some((pr) => sameRepo(pr.repoFullName, args.repoFullName) && sameLogin(pr.authorLogin, args.login)) ||
       /* v8 ignore next -- Issue-authored cache fallback is defensive; PR and official contribution paths cover role detection behavior. */
-      (args.issues ?? []).some((issue) => issue.repoFullName === args.repoFullName && sameLogin(issue.authorLogin, args.login)),
+      (args.issues ?? []).some((issue) => sameRepo(issue.repoFullName, args.repoFullName) && sameLogin(issue.authorLogin, args.login)),
   );
 
   let role: ContributorRole = "unknown";

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -935,6 +935,16 @@ describe("v2 signal builders", () => {
       source: "unknown",
       normalContributorEvidenceAllowed: true,
     });
+    // Maintainer association must survive a repoFullName casing mismatch between the
+    // canonical name (e.g. the official source's "Org/Project") and the cached PR's
+    // "org/project". Case-sensitive matching here would drop the association and
+    // wrongly mark the maintainer's repo as outside-contributor evidence.
+    expect(buildRoleContext({ login: "dev", repo: null, repoFullName: "Org/Project", pullRequests: [memberPr], issues: [] })).toMatchObject({
+      role: "org_member",
+      maintainerLane: true,
+      source: "github_association",
+      association: "MEMBER",
+    });
   });
 
   it("branches repo fit recommendations across pursue, avoid, cleanup, unknown, and maintainer lanes", () => {


### PR DESCRIPTION
Closes #223.

## Problem
`buildRoleContext` derived a contributor maintainer association by filtering cached PRs/issues with a case-sensitive `pr.repoFullName === args.repoFullName`. That `authoredAssociations` list is the only signal that promotes someone to owner/member/collaborator and sets `maintainerLane`. Everywhere else repo names are compared case-insensitively (`sameRepo`, and even this same function uses `toLowerCase` for the official-repo and reposTouched checks).

The canonical `repoFullName` passed in by `buildContributorOutcomeHistory` takes the highest-priority source casing (often the official Gittensor source), while the cached PRs come from the GitHub webhook/backfill. The same function already filters those PRs with `sameRepo` (engine.ts:1452) precisely because the casing can differ. When it differs, `authoredAssociations` comes back empty, the maintainer association is lost, and `maintainerLane` silently becomes false, so the maintainer repo is mis-counted as normal outside-contributor reward evidence (wrong successLevel, reward-risk actions, and decision-pack routing).

## Fix
Use the existing case-insensitive `sameRepo` for the four `repoFullName` comparisons in `buildRoleContext` (the `authoredAssociations` PR/issue filters and the `touchedByCache` PR/issue filters). The change only broadens matching to recognize a maintainer that was previously missed; it never removes a correct match.

## Tests
Added a fail-on-revert assertion to the existing role-context test: `buildRoleContext({ repoFullName: "Org/Project", pullRequests: [pr with repoFullName "org/project", association MEMBER] })` must yield `role: "org_member"`, `maintainerLane: true`. The old case-sensitive code returned `role: "unknown"`.

`vitest run` signals (signals-v2 + signals + signals-coverage) 66/66; decision-pack + agent-orchestrator 46/46; `tsc --noEmit` clean.