### PR TITLE
Classify changes-requested PRs as blocked before stale in observed scenarios

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -564,12 +564,16 @@ function buildObservedPullRequestScenarios(args: {
       draft += 1;
       continue;
     }
-    if (isStaleOpenPr(pr, args.nowMs)) {
-      stale += 1;
-      continue;
-    }
+    // CR with classifyOpenPullRequest (pending-pr-scenarios.ts): an actionable
+    // block (changes requested / bad mergeable state) takes precedence over age,
+    // so a changes-requested PR is never optimistically modeled as "stale, likely
+    // to close and free up an open-PR slot". Blocked must be checked before stale.
     if (isBlockedOpenPr(pr)) {
       blocked += 1;
+      continue;
+    }
+    if (isStaleOpenPr(pr, args.nowMs)) {
+      stale += 1;
       continue;
     }
     if (isApprovedOrMergeableOpenPr(pr)) approvedOrMergeable += 1;

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -410,6 +410,9 @@ describe("local branch analysis", () => {
         { ...basePr, repoFullName: otherRepo.fullName, number: 8, title: "Already merged branch", state: "closed", mergedAt: "2026-05-20T00:00:00.000Z" },
         { ...basePr, repoFullName: repo.fullName, number: 6, title: "Maintainer lane", state: "open", authorAssociation: "OWNER" },
         { ...basePr, repoFullName: repo.fullName, number: 7, title: "Someone else's approved PR", state: "open", authorLogin: "someone-else", reviewDecision: "APPROVED" },
+        // Both changes-requested AND stale: an actionable block takes precedence over age, so this
+        // must count as blocked (open-PR pressure stays), not stale (subtracted from projections).
+        { ...basePr, repoFullName: otherRepo.fullName, number: 9, title: "Blocked and stale", state: "open", reviewDecision: "CHANGES_REQUESTED", updatedAt: "2020-01-01T00:00:00.000Z" },
       ],
       profile,
       outcomeHistory: pressuredHistory,
@@ -417,7 +420,7 @@ describe("local branch analysis", () => {
       scoringProfile,
     });
 
-    expect(analysis.observedPullRequestScenarios).toMatchObject({ approvedOrMergeable: 1, stale: 1, closed: 1, draft: 1, blocked: 1, maintainerLane: 1 });
+    expect(analysis.observedPullRequestScenarios).toMatchObject({ approvedOrMergeable: 1, stale: 1, closed: 1, draft: 1, blocked: 2, maintainerLane: 1 });
     expect(analysis.scenarioScorePreview.afterApprovedPrsMerge).toMatchObject({ source: "github_observed", gates: { openPrCount: 5, credibilityObserved: 0.8 } });
     expect(analysis.scenarioScorePreview.afterStalePrsClose).toMatchObject({ source: "github_observed", gates: { openPrCount: 5, credibilityObserved: 0.2 } });
     expect(analysis.scenarioScorePreview.afterStalePrsClose?.assumptions.join(" ")).toMatch(/already-closed PR.*excluded/);


### PR DESCRIPTION
Closes #227.

## Problem
`buildObservedPullRequestScenarios` (local-branch.ts) classifies each open PR by checking `isStaleOpenPr` (no update in >=14 days) BEFORE `isBlockedOpenPr` (changes requested / bad mergeable state). The two predicates are independent, so a PR that is both changes-requested AND >=14 days old is counted as `stale`.

That inverts the authoritative classifier `classifyOpenPullRequest` (pending-pr-scenarios.ts:193-200), which checks blocked BEFORE stale. The two buckets are used asymmetrically downstream: `observedStalePrCount` is subtracted from open-PR pressure in the `afterStalePrsClose` and `bestReasonableCase` scenarios (preview.ts:355/372/389), while `observedBlockedPrCount` is only a note (preview.ts:466). So a changes-requested PR (blocked on the author) gets optimistically modeled as `stale, likely to close and free up a slot`, which can flip `openPrMultiplier` 0->1 and inflate the projected score.

## Fix
Reorder the classification in `buildObservedPullRequestScenarios` so `isBlockedOpenPr` is checked before `isStaleOpenPr`, matching `classifyOpenPullRequest`. A PR that is both blocked and stale now counts as blocked (open-PR pressure stays) instead of stale (subtracted). PRs that are only stale or only blocked are unaffected.

## Tests
Strengthened the existing observed-scenario test with a PR that is both `CHANGES_REQUESTED` and stale (updatedAt 2020). It must now count as blocked (`blocked: 2`, `stale: 1`) and the `afterStalePrsClose` projection must keep `openPrCount: 5`, not subtract it. With the old stale-first order this PR landed in `stale` (`blocked: 1`, `stale: 2`, `openPrCount: 4`), so the test is a genuine fail-on-revert.

`vitest run` local-branch + pending-pr-scenarios + scoring 59/59; `tsc --noEmit` clean.