### PR TITLE
fix(ai): block public reward and ranking language

### DIFF
--- a/src/queue-intelligence.ts
+++ b/src/queue-intelligence.ts
@@ -46,9 +46,17 @@ export const FORBIDDEN_PUBLIC_COMMENT_WORDS = [
   "raw trust score",
   "payout",
   "reward estimate",
+  "estimated rewards",
+  "estimated reward",
+  "rewards",
+  "reward",
   "farming",
   "private reviewability",
   "public score estimate",
+  "private rankings",
+  "private ranking",
+  "rankings",
+  "ranking",
 ] as const;
 
 function computeDaysSince(isoDateString: string, now: Date): number {

--- a/src/services/ai-summaries.ts
+++ b/src/services/ai-summaries.ts
@@ -9,9 +9,9 @@ type AiSummaryVisibility = "private" | "public";
 
 const PRIVATE_CONTEXT_PATTERN =
   /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw trust scores?|trust scores?|private reviewability|private scoreability|public score estimates?)\b/gi;
-const PRIVATE_OUTCOME_PATTERN = /\b(payouts?|farming|reward estimates?|reward optimization)\b/gi;
+const PRIVATE_OUTCOME_PATTERN = /\b(payouts?|farming|rewards?|reward estimates?|reward optimization)\b/gi;
 const PUBLIC_FORBIDDEN_TEXT_PATTERN =
-  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw trust scores?|trust scores?|estimated scores?|score estimates?|public score estimates?|reward estimates?|payouts?|farming|private reviewability|private scoreability|reward optimization)\b/i;
+  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw trust scores?|trust scores?|estimated scores?|score estimates?|public score estimates?|estimated rewards?|rewards?|reward estimates?|payouts?|farming|private reviewability|private scoreability|private rankings?|rankings?|reward optimization)\b/i;
 
 export type AiSummaryResult =
   | { status: "disabled"; reason: string }
@@ -55,7 +55,7 @@ export async function summarizeAgentBundleWithAi(env: Env, bundle: AgentRunBundl
           role: "system",
           content:
             visibility === "public"
-              ? "Summarize deterministic Gittensory signals for a public GitHub comment. Do not mention rewards, payouts, wallets, hotkeys, raw trust scores, or private reviewability."
+              ? "Summarize deterministic Gittensory signals for a public GitHub comment. Do not mention rewards, rankings, payouts, wallets, hotkeys, raw trust scores, or private reviewability."
               : "Summarize deterministic Gittensory signals for an authenticated MCP/API user. Be concise and preserve scoreability blockers and next actions.",
         },
         { role: "user", content: prompt },
@@ -175,7 +175,7 @@ function sanitizeAiText(value: string, visibility: AiSummaryVisibility): string 
 function containsPublicForbiddenText(value: string): boolean {
   // Route every public AI output through the canonical public/private sanitizer (issue #151).
   // `sanitizePublicComment` throws on any forbidden public term (wallet, hotkey, raw trust score,
-  // payout, reward estimate, farming, private reviewability, public score estimate).
+  // payout, reward language, farming, private reviewability, public score estimate, or ranking language).
   try {
     sanitizePublicComment(value);
   } catch {
@@ -327,7 +327,7 @@ export async function rewritePublicPrIntelligenceComment(
     bundle: args.bundle,
     fallbackText: args.deterministicBody,
     instructions:
-      "Rewrite this deterministic Gittensory PR signal bundle as a short, friendly public GitHub comment with 3-5 bullet points. Only restate the facts provided. Never mention rewards, payouts, wallets, hotkeys, raw or estimated trust scores, score estimates, farming, or private reviewability, and never claim a guaranteed outcome.",
+      "Rewrite this deterministic Gittensory PR signal bundle as a short, friendly public GitHub comment with 3-5 bullet points. Only restate the facts provided. Never mention rewards, rankings, payouts, wallets, hotkeys, raw or estimated trust scores, score estimates, farming, or private reviewability, and never claim a guaranteed outcome.",
     actor: args.actor,
     route: args.route,
   });

--- a/test/unit/ai-summaries.test.ts
+++ b/test/unit/ai-summaries.test.ts
@@ -10,7 +10,7 @@ import { FORBIDDEN_PUBLIC_COMMENT_WORDS } from "../../src/queue-intelligence";
 import { createTestEnv } from "../helpers/d1";
 
 const PUBLIC_FORBIDDEN_TEXT =
-  /\b(wallets?|hotkeys?|raw trust scores?|trust scores?|payouts?|reward estimates?|farming|private reviewability|private scoreability|public score estimates?)\b/i;
+  /\b(wallets?|hotkeys?|raw trust scores?|trust scores?|payouts?|estimated rewards?|rewards?|reward estimates?|farming|private reviewability|private scoreability|private rankings?|rankings?|public score estimates?)\b/i;
 type AiRunRequest = { messages: Array<{ role: string; content: string }> };
 
 describe("Workers AI summaries", () => {
@@ -142,7 +142,22 @@ describe("Workers AI summaries", () => {
     expect(unsafe).toMatchObject({ status: "unsafe", reason: "public summary failed sanitizer" });
   });
 
-  it.each(["wallet", "hotkey", "raw trust score", "payout", "reward estimate", "farming", "private reviewability", "private scoreability", "public score estimate"])(
+  it.each([
+    "wallet",
+    "hotkey",
+    "raw trust score",
+    "payout",
+    "reward estimate",
+    "estimated reward",
+    "rewards",
+    "reward",
+    "farming",
+    "private reviewability",
+    "private scoreability",
+    "public score estimate",
+    "private ranking",
+    "ranking",
+  ])(
     "rejects unsafe public AI output containing %s",
     async (unsafeText) => {
       const run = vi.fn(async () => ({ response: `Do the next action because ${unsafeText} changed.` }));
@@ -332,6 +347,21 @@ describe("optional deterministic-summary rewrite layer", () => {
       const run = vi.fn(async () => ({ response: `Looks great, includes ${word} detail.` }));
       const result = await rewriteSignalBundleWithAi(publicEnv({}, run), rewriteReq());
       expect(result, `forbidden word: ${word}`).toMatchObject({ status: "unsafe", text: DETERMINISTIC_BODY });
+    }
+  });
+
+  it("rejects reward and ranking variants in public AI rewrites", async () => {
+    const unsafeOutputs = [
+      "The estimated reward is high.",
+      "Rewards look likely for this PR.",
+      "The private ranking looks strong.",
+      "This ranking should improve.",
+    ];
+
+    for (const output of unsafeOutputs) {
+      const run = vi.fn(async () => ({ response: output }));
+      const result = await rewriteSignalBundleWithAi(publicEnv({}, run), rewriteReq());
+      expect(result, `unsafe output: ${output}`).toMatchObject({ status: "unsafe", text: DETERMINISTIC_BODY });
     }
   });
 

--- a/test/unit/queue-intelligence.test.ts
+++ b/test/unit/queue-intelligence.test.ts
@@ -288,7 +288,7 @@ describe("sanitizePublicComment — sanitizer regression", () => {
 
   it("generatePublicComment output never matches forbidden language across all inputs (explicit regex)", () => {
     const forbiddenPattern =
-      /wallet|hotkey|raw trust score|payout|reward estimate|farming|private reviewability|public score estimate/i;
+      /wallet|hotkey|raw trust score|payout|reward|farming|private reviewability|public score estimate|ranking/i;
     const allChecksStatuses: Array<ChecksStatus> = ["passing", "failing", "pending"];
     const allRecommendations: Recommendation[] = [
       "review_now",


### PR DESCRIPTION
### Motivation
- Public AI rewrites could publish reward- or ranking-related phrasing not covered by the original sanitizer, allowing unsafe/public-forbidden language to reach GitHub comments. 
- The rewrite path must be hardened to reject bare/estimated reward and ranking terms so the deterministic fallback remains the authoritative public surface.

### Description
- Expanded the canonical forbidden public-comment list in `src/queue-intelligence.ts` to include bare and estimated reward variants and private/general ranking terms. 
- Strengthened the public-output defense-in-depth regex and private/outcome patterns in `src/services/ai-summaries.ts`, and updated the public AI prompt instructions to explicitly ban reward and ranking language. 
- Added regression coverage in `test/unit/ai-summaries.test.ts` and `test/unit/queue-intelligence.test.ts` to assert the AI rewrite path and public-comment generation reject reward/ranking variants.

### Testing
- Ran `npm test -- --runInBand test/unit/ai-summaries.test.ts test/unit/queue-intelligence.test.ts` which failed because Vitest does not accept the Jest `--runInBand` flag. 
- Ran `npm test -- test/unit/ai-summaries.test.ts test/unit/queue-intelligence.test.ts` and all tests in those files passed (`2 files, 70 tests`). 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1a25b134832c8edf80a75abdbfc0)