### PR TITLE
fix(docs): clarify MCP metadata upload boundary

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
@@ -48,8 +48,10 @@ function BetaOnboarding() {
 
       <h2>Miner journey</h2>
       <p>
-        Miners and contributors use the local MCP package. Metadata stays on your machine; private
-        scoreability and blockers appear only in authenticated MCP/API responses.
+        Miners and contributors use the local MCP package. Source contents stay on your machine but
+        branch metadata (such as branch names, SHAs, changed file paths, commit messages, validation
+        details, labels, body text, linked issues, and scenario notes) is sent to authenticated
+        Gittensory MCP/API responses for analysis and packet preparation.
       </p>
       <ol>
         <li>

--- a/test/unit/docs-beta-onboarding.test.ts
+++ b/test/unit/docs-beta-onboarding.test.ts
@@ -9,6 +9,7 @@ const BETA_ONBOARDING_PATH = resolve(
 
 describe("docs beta onboarding page", () => {
   const source = readFileSync(BETA_ONBOARDING_PATH, "utf8");
+  const normalizedSource = source.replace(/\s+/g, " ");
 
   it("documents miner MCP flow through packet", () => {
     expect(source).toMatch(/gittensory-mcp login/);
@@ -16,6 +17,15 @@ describe("docs beta onboarding page", () => {
     expect(source).toMatch(/agent plan/);
     expect(source).toMatch(/preflight/);
     expect(source).toMatch(/agent packet/);
+  });
+
+  it("states the local MCP privacy boundary for source contents and uploaded branch metadata", () => {
+    expect(source).toMatch(/Source contents stay on your machine/);
+    expect(source).toMatch(/branch metadata/);
+    expect(source).toMatch(/changed file paths/);
+    expect(source).toMatch(/commit messages/);
+    expect(normalizedSource).toMatch(/authenticated Gittensory MCP\/API responses/);
+    expect(source).not.toMatch(/Metadata stays on your machine/);
   });
 
   it("documents maintainer GitHub App setup, preview, and commands", () => {


### PR DESCRIPTION
### Motivation
- The beta onboarding page incorrectly implied that all metadata stays local, while MCP commands (`analyze-branch`, `preflight`, `agent packet`) send branch metadata to authenticated MCP/API endpoints for analysis and packet preparation.

### Description
- Replaced the misleading sentence in `apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx` to state that source contents remain local but branch metadata (branch names, SHAs, changed file paths, commit messages, validation details, labels, body text, linked issues, and scenario notes) is uploaded to authenticated MCP/API flows.
- Added a unit assertion in `test/unit/docs-beta-onboarding.test.ts` that checks for the clarified privacy boundary and ensures the old phrase `Metadata stays on your machine` does not reappear.

### Testing
- Ran the unit test file with `npm run test:unit -- docs-beta-onboarding.test.ts`, and the test run completed successfully with all unit tests passing (55 test files, 703 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1a21a01c832c980e88282de2fca2)