### PR TITLE
fix(extension): prevent leaking private reviewability in public-safe packet

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2722,7 +2722,7 @@ function normalizeOrigin(value: string | undefined): string | null {
   }
 }
 
-function buildExtensionPublicSafePacket(args: { repoFullName: string; pullNumber: number; contributor: string; reviewability: { action: string; noiseSources: string[]; maintainerNextSteps: string[] } }): string {
+function buildExtensionPublicSafePacket(args: { repoFullName: string; pullNumber: number; contributor: string; reviewability: { action: string; noiseSources?: string[]; maintainerNextSteps?: string[] } }): string {
   const lines = [
     "# Public-safe PR packet",
     "",
@@ -2732,19 +2732,34 @@ function buildExtensionPublicSafePacket(args: { repoFullName: string; pullNumber
     `- Contributor: ${args.contributor}`,
     "",
     "## Review readiness",
-    `- Current action: ${args.reviewability.action.replace(/_/g, " ")}`,
-    ...args.reviewability.maintainerNextSteps.slice(0, 4).map((step) => `- ${step}`),
+    ...extensionPublicReviewReadinessLines(args.reviewability.action),
     "",
     "## Queue caution",
-    ...(args.reviewability.noiseSources.length > 0
-      ? args.reviewability.noiseSources.slice(0, 4).map((source) => `- ${source}`)
-      : ["- No high-noise warning is visible from cached metadata."]),
+    "- Use only public GitHub context when discussing prioritization or next steps.",
+    "- Keep private reviewability signals in the extension and out of public comments.",
     "",
     "## Safety",
     "- Keep public comments limited to linked context, validation status, and maintainer-ready next steps.",
   ];
   const markdown = sanitizePublicComment(lines.join("\n"));
   return ensureExtensionPublicSafeText(markdown);
+}
+
+function extensionPublicReviewReadinessLines(action: string): string[] {
+  switch (action) {
+    case "review_now":
+      return ["- Public status: ready for maintainer review.", "- Suggested next step: review the technical diff and public checks."];
+    case "maintainer_lane":
+      return ["- Public status: maintainer follow-up recommended.", "- Suggested next step: verify the public diff and repository impact."];
+    case "likely_duplicate":
+      return ["- Public status: possible overlap to verify.", "- Suggested next step: compare against linked public issues, active PRs, and recent merges."];
+    case "close_or_redirect":
+      return ["- Public status: triage may be needed before review.", "- Suggested next step: confirm whether the public PR context is still current and actionable."];
+    case "needs_author":
+      return ["- Public status: author input may be needed before deep review.", "- Suggested next step: ask for missing public context, tests, or validation details."];
+    default:
+      return ["- Public status: keep monitoring the public PR context.", "- Suggested next step: watch for public tests, checks, linked context, or related changes before prioritizing review."];
+  }
 }
 
 function buildExtensionPrivateBlockers(reviewability: { noiseSources: string[]; maintainerNextSteps: string[]; privateSummary: string }) {

--- a/test/unit/routes-extension.test.ts
+++ b/test/unit/routes-extension.test.ts
@@ -23,19 +23,20 @@ describe("extension packet helper internals", () => {
     expect(blockers).toEqual([{ id: "blocker-1", detail: "No private blocker detail is currently cached." }]);
   });
 
-  it("sanitizes extension packet markdown before returning it", () => {
+  it("builds extension packet markdown from public-safe allowlisted text", () => {
     const markdown = __routesInternals.buildExtensionPublicSafePacket({
       repoFullName: "owner/repo",
       pullNumber: 12,
       contributor: "alice",
       reviewability: {
-        action: "review_now",
-        noiseSources: ["avoid payout language in public"],
-        maintainerNextSteps: ["remove wallet references"],
+        action: "needs_author",
+        noiseSources: ["Contributor repo-specific closed PR rate is 40%.", "avoid payout language in public"],
+        maintainerNextSteps: ["remove wallet references", "Contributor repo-specific closed PR rate is 40%."],
       },
     });
     expect(markdown).toContain("# Public-safe PR packet");
-    expect(markdown).not.toMatch(/wallet|payout|hotkey|reward estimate|estimated score|raw trust score/i);
+    expect(markdown).toContain("author input may be needed before deep review");
+    expect(markdown).not.toMatch(/closed PR rate|repo-specific|wallet|payout|hotkey|reward estimate|estimated score|raw trust score/i);
   });
 
   it("authenticates request identity from browser session cookie fallback", async () => {


### PR DESCRIPTION
### Motivation
- The extension previously built a copyable `public_safe` PR packet by directly including `reviewability.noiseSources` and `reviewability.maintainerNextSteps`, which can contain private contributor outcome metrics and risk wording that must not be exposed publicly. 

### Description
- Replace inclusion of private `noiseSources`/`maintainerNextSteps` with a deterministic, allowlisted mapping so the public packet only contains repository/link context and generic, public-safe review-readiness lines generated by `extensionPublicReviewReadinessLines`. 
- Add static queue-caution lines that explicitly advise keep private signals in the extension and out of public comments. 
- Narrow the runtime `reviewability` parameter shape for the public builder to make usage explicit and avoid accidental inclusion of private fields. 
- Update unit test `test/unit/routes-extension.test.ts` to assert that private risk wording (e.g. repo-specific closed PR rates) and forbidden terms are omitted from the generated public packet. 

### Testing
- Ran `npx vitest run test/unit/routes-extension.test.ts` and the updated unit tests passed (all tests in the file succeeded). 
- Ran `npm run typecheck` (`tsc --noEmit`) and static type checks passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e64f13810832c95c9752768a90215)