### PR TITLE
ci(label): add deterministic type auto-labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest a UI, API, MCP, GitHub App, signal, docs, or operational improvement.
 title: "[Feature]: "
 labels:
-  - enhancement
+  - feature
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/type-label.yml
+++ b/.github/workflows/type-label.yml
@@ -1,0 +1,41 @@
+name: Type Label
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: type-label-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  label:
+    name: Apply type label
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Apply deterministic type label
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/github-type-label.mjs

--- a/scripts/github-type-label.d.mts
+++ b/scripts/github-type-label.d.mts
@@ -1,0 +1,34 @@
+export type TypeLabel = "bug" | "feature";
+
+export type TypeLabelDecision =
+  | {
+      action: "apply";
+      label: TypeLabel;
+      number: number;
+      title: string;
+    }
+  | {
+      action: "skip";
+      reason: string;
+      number?: number;
+      title?: string;
+      label?: TypeLabel;
+    };
+
+export function normalizeLabels(labels: unknown): string[];
+export function classifyTypeLabel(title: string, labels?: unknown): TypeLabel | null;
+export function getTypeLabelDecision(eventName: string, payload: unknown): TypeLabelDecision;
+export function readCurrentLabels(options: {
+  issueLabelsUrl: string;
+  headers: Record<string, string>;
+  fetchImpl?: typeof fetch;
+}): Promise<string[]>;
+export function applyTypeLabel(options: {
+  apiUrl?: string;
+  repository: string;
+  token: string;
+  number: number;
+  label: TypeLabel;
+  fetchImpl?: typeof fetch;
+}): Promise<{ applied: boolean; reason?: string }>;
+export function main(): Promise<void>;

--- a/scripts/github-type-label.mjs
+++ b/scripts/github-type-label.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const TYPE_LABELS = new Set(["bug", "feature"]);
+
+export function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) return [];
+  return labels
+    .map((label) => {
+      if (typeof label === "string") return label;
+      if (label && typeof label === "object" && typeof label.name === "string") return label.name;
+      return "";
+    })
+    .filter(Boolean)
+    .map((label) => label.toLowerCase());
+}
+
+export function classifyTypeLabel(title, labels = []) {
+  const normalizedLabels = normalizeLabels(labels);
+  if (normalizedLabels.some((label) => TYPE_LABELS.has(label))) return null;
+
+  const normalizedTitle = String(title ?? "").trim();
+  if (/^\[bug\]\s*:?\s*/i.test(normalizedTitle) || /^(?:fix|bug)(?:\([^)]+\))?:/i.test(normalizedTitle)) {
+    return "bug";
+  }
+  if (/^\[feature\]\s*:?\s*/i.test(normalizedTitle) || /^(?:feat|feature)(?:\([^)]+\))?:/i.test(normalizedTitle)) {
+    return "feature";
+  }
+  return null;
+}
+
+export function getTypeLabelDecision(eventName, payload) {
+  if (!payload || typeof payload !== "object") {
+    return { action: "skip", reason: "missing-event-payload" };
+  }
+
+  if (eventName === "issues") {
+    const issue = payload.issue;
+    if (!issue || typeof issue !== "object") return { action: "skip", reason: "missing-issue" };
+    if (issue.pull_request) return { action: "skip", reason: "issue-is-pull-request", number: numberOrUndefined(issue.number), title: stringOrEmpty(issue.title) };
+
+    const label = classifyTypeLabel(issue.title, issue.labels);
+    if (!label) return { action: "skip", reason: "no-type-label", number: numberOrUndefined(issue.number), title: stringOrEmpty(issue.title) };
+    return { action: "apply", label, number: issue.number, title: stringOrEmpty(issue.title) };
+  }
+
+  if (eventName === "pull_request_target") {
+    const pullRequest = payload.pull_request;
+    if (!pullRequest || typeof pullRequest !== "object") return { action: "skip", reason: "missing-pull-request" };
+
+    const label = classifyTypeLabel(pullRequest.title, pullRequest.labels);
+    if (!label) return { action: "skip", reason: "no-type-label", number: numberOrUndefined(pullRequest.number), title: stringOrEmpty(pullRequest.title) };
+    return { action: "apply", label, number: pullRequest.number, title: stringOrEmpty(pullRequest.title) };
+  }
+
+  return { action: "skip", reason: "unsupported-event" };
+}
+
+export async function applyTypeLabel({ apiUrl = "https://api.github.com", repository, token, number, label, fetchImpl = fetch }) {
+  const [owner, repo, ...extraParts] = String(repository ?? "").split("/");
+  if (!owner || !repo || extraParts.length > 0) throw new Error("GITHUB_REPOSITORY must be owner/repo");
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+  if (!Number.isInteger(number) || number <= 0) throw new Error("Issue or pull request number must be a positive integer");
+  if (!TYPE_LABELS.has(label)) throw new Error(`Unsupported type label: ${label}`);
+
+  const issueLabelsUrl = `${apiUrl.replace(/\/$/, "")}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${number}/labels`;
+  const headers = {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+    "x-github-api-version": "2022-11-28",
+  };
+
+  const labels = await readCurrentLabels({ issueLabelsUrl, headers, fetchImpl });
+  if (labels.some((currentLabel) => TYPE_LABELS.has(currentLabel))) {
+    return { applied: false, reason: "type-label-already-present" };
+  }
+
+  const response = await fetchImpl(issueLabelsUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ labels: [label] }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to apply ${label} to #${number}: ${response.status} ${text}`);
+  }
+  return { applied: true };
+}
+
+export async function readCurrentLabels({ issueLabelsUrl, headers, fetchImpl = fetch }) {
+  const labels = [];
+  let nextUrl = `${issueLabelsUrl}?per_page=100`;
+
+  while (nextUrl) {
+    const response = await fetchImpl(nextUrl, {
+      method: "GET",
+      headers,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to read labels: ${response.status} ${text}`);
+    }
+
+    labels.push(...normalizeLabels(await response.json()));
+    nextUrl = nextLink(response.headers.get("link"));
+  }
+
+  return labels;
+}
+
+export async function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
+
+  const payload = JSON.parse(await readFile(eventPath, "utf8"));
+  const decision = getTypeLabelDecision(process.env.GITHUB_EVENT_NAME ?? "", payload);
+  if (decision.action === "skip") {
+    console.log(`type-label: skipped ${decision.reason}`);
+    return;
+  }
+
+  const result = await applyTypeLabel({
+    apiUrl: process.env.GITHUB_API_URL,
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    token: process.env.GITHUB_TOKEN ?? "",
+    number: decision.number,
+    label: decision.label,
+  });
+  if (!result.applied) {
+    console.log(`type-label: skipped ${result.reason}`);
+    return;
+  }
+  console.log(`type-label: applied ${decision.label} to #${decision.number}`);
+}
+
+function numberOrUndefined(value) {
+  return Number.isInteger(value) ? value : undefined;
+}
+
+function stringOrEmpty(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function nextLink(linkHeader) {
+  if (!linkHeader) return "";
+  for (const part of linkHeader.split(",")) {
+    const match = part.trim().match(/^<([^>]+)>;\s*rel="next"$/);
+    if (match) return match[1];
+  }
+  return "";
+}
+
+const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+
+if (import.meta.url === entrypointUrl) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/test/unit/github-type-label.test.ts
+++ b/test/unit/github-type-label.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { applyTypeLabel, classifyTypeLabel, getTypeLabelDecision, readCurrentLabels } from "../../scripts/github-type-label.mjs";
+
+describe("GitHub type label classifier", () => {
+  it.each([
+    ["[Bug]: ensurePullRequestLabel misses labels beyond first page"],
+    ["fix(auth): trim bearer tokens in rate-limit keys"],
+    ["fix: handle stale queue rows"],
+    ["bug(api): preserve malformed request errors"],
+    ["bug: reject missing event payload"],
+  ])("classifies bug titles: %s", (title) => {
+    expect(classifyTypeLabel(title)).toBe("bug");
+  });
+
+  it.each([
+    ["[Feature]: add maintainer queue filters"],
+    ["feat(agent): add action portfolio"],
+    ["feat: add agent action explanation cards"],
+    ["feature(ui): add sidebar context panel"],
+    ["feature: add digest-ready queue notifications"],
+  ])("classifies feature titles: %s", (title) => {
+    expect(classifyTypeLabel(title)).toBe("feature");
+  });
+
+  it("does not overwrite an existing type label", () => {
+    expect(classifyTypeLabel("feat(api): add queue filters", [{ name: "bug" }])).toBeNull();
+    expect(classifyTypeLabel("fix(api): repair queue filters", [{ name: "feature" }])).toBeNull();
+  });
+
+  it("skips ambiguous titles", () => {
+    expect(classifyTypeLabel("Improve queue filters")).toBeNull();
+    expect(classifyTypeLabel("prefix fix: this should not match")).toBeNull();
+  });
+
+  it("ignores issue events that are actually pull request issue payloads", () => {
+    expect(
+      getTypeLabelDecision("issues", {
+        issue: {
+          number: 12,
+          title: "fix(api): trim input",
+          labels: [],
+          pull_request: { url: "https://api.github.com/repos/JSONbored/gittensory/pulls/12" },
+        },
+      }),
+    ).toMatchObject({ action: "skip", reason: "issue-is-pull-request" });
+  });
+
+  it("handles pull_request_target payloads directly", () => {
+    expect(
+      getTypeLabelDecision("pull_request_target", {
+        pull_request: {
+          number: 42,
+          title: "feat(mcp): add metadata boundary checks",
+          labels: [{ name: "size:S" }],
+        },
+      }),
+    ).toEqual({
+      action: "apply",
+      label: "feature",
+      number: 42,
+      title: "feat(mcp): add metadata boundary checks",
+    });
+  });
+
+  it("does not post when a current type label already exists", async () => {
+    const calls: string[] = [];
+    const result = await applyTypeLabel({
+      repository: "JSONbored/gittensory",
+      token: "token",
+      number: 42,
+      label: "feature",
+      fetchImpl: async (input, init) => {
+        calls.push(`${init?.method ?? "GET"} ${input.toString()}`);
+        if ((init?.method ?? "GET") === "GET") return Response.json([{ name: "bug" }]);
+        return new Response("unexpected post", { status: 500 });
+      },
+    });
+
+    expect(result).toEqual({ applied: false, reason: "type-label-already-present" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/repos/JSONbored/gittensory/issues/42/labels?per_page=100");
+  });
+
+  it("posts the target label when current labels have no type label", async () => {
+    const calls: string[] = [];
+    const result = await applyTypeLabel({
+      repository: "JSONbored/gittensory",
+      token: "token",
+      number: 42,
+      label: "feature",
+      fetchImpl: async (input, init) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${input.toString()}`);
+        if (method === "GET") return Response.json([{ name: "size:S" }]);
+        if (method === "POST") {
+          expect(JSON.parse(String(init?.body))).toEqual({ labels: ["feature"] });
+          return Response.json([{ name: "feature" }]);
+        }
+        return new Response("unexpected method", { status: 500 });
+      },
+    });
+
+    expect(result).toEqual({ applied: true });
+    expect(calls).toEqual([
+      "GET https://api.github.com/repos/JSONbored/gittensory/issues/42/labels?per_page=100",
+      "POST https://api.github.com/repos/JSONbored/gittensory/issues/42/labels",
+    ]);
+  });
+
+  it("reads paginated current labels before deciding to post", async () => {
+    const calls: string[] = [];
+    const labels = await readCurrentLabels({
+      issueLabelsUrl: "https://api.github.com/repos/JSONbored/gittensory/issues/42/labels",
+      headers: { authorization: "Bearer token" },
+      fetchImpl: async (input) => {
+        calls.push(input.toString());
+        if (input.toString().endsWith("page=2")) return Response.json([{ name: "feature" }]);
+        return Response.json([{ name: "size:S" }], {
+          headers: {
+            link: '<https://api.github.com/repos/JSONbored/gittensory/issues/42/labels?per_page=100&page=2>; rel="next"',
+          },
+        });
+      },
+    });
+
+    expect(labels).toEqual(["size:s", "feature"]);
+    expect(calls).toEqual([
+      "https://api.github.com/repos/JSONbored/gittensory/issues/42/labels?per_page=100",
+      "https://api.github.com/repos/JSONbored/gittensory/issues/42/labels?per_page=100&page=2",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic type-label workflow for issue and PR titles
- switch the feature issue template from `enhancement` to `feature`
- add classifier and API-write tests for no-op and pagination behavior

## What changed
- workflow runs on `issues` and `pull_request_target` with limited repository permissions
- script reads GitHub event JSON, skips already-typed items, paginates current labels, and only applies `bug` or `feature`
- tests cover bug/feature title forms, ambiguous no-ops, PR issue-event skipping, current-label reads, and pagination

## Why
- removes manual `bug`/`feature` triage without duplicating existing size labels or running contributor code

## Validation
- `npm run test:ci`
- Codex Security diff scan: no reportable findings