### PR TITLE
Handle installation_repositories webhooks to link added and unlink removed repos

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -184,6 +184,17 @@ export async function markInstallationDeleted(env: Env, installationId: number):
     .where(eq(repositories.installationId, installationId));
 }
 
+export async function markInstallationRepositoryRemoved(env: Env, repoFullName: string, installationId?: number): Promise<void> {
+  const db = getDb(env.DB);
+  // Only unlink the row if it still belongs to this installation (guards against a repo
+  // that was already re-installed under a different installation in a race).
+  const condition =
+    installationId !== undefined
+      ? and(eq(repositories.fullName, repoFullName), eq(repositories.installationId, installationId))
+      : eq(repositories.fullName, repoFullName);
+  await db.update(repositories).set({ isInstalled: false, installationId: null, updatedAt: nowIso() }).where(condition);
+}
+
 export async function listInstallations(env: Env): Promise<InstallationRecord[]> {
   const db = getDb(env.DB);
   const rows = await db.select().from(installations).orderBy(desc(installations.updatedAt)).limit(100);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -28,6 +28,7 @@ import {
   listRepoSyncSegments,
   listRepositories,
   markInstallationDeleted,
+  markInstallationRepositoryRemoved,
   persistAdvisory,
   recordAgentCommandFeedback,
   recordAuditEvent,
@@ -574,7 +575,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
     }
 
     await upsertInstallation(env, payload);
-    if (eventName === "installation" && (payload.action === "created" || payload.action === "added")) {
+    if (eventName === "installation" && payload.action === "created") {
       const installedRepos = payload.repositories?.map((repo) => repo.full_name).filter(Boolean) ?? (payload.repository?.full_name ? [payload.repository.full_name] : [undefined]);
       await Promise.all(
         installedRepos.slice(0, 50).map((repoFullName) =>
@@ -587,6 +588,46 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
           }),
         ),
       );
+    }
+
+    // CR with GitHub webhook contract: repos added to / removed from an *existing*
+    // installation arrive on the `installation_repositories` event (actions
+    // "added"/"removed") in `repositories_added` / `repositories_removed`, not on
+    // the `installation` event's `repositories` array. Without this branch the
+    // added repos are never upserted with their installation linkage.
+    if (eventName === "installation_repositories") {
+      const installationId = payload.installation?.id;
+      const addedRepos = payload.repositories_added ?? [];
+      const removedRepos = payload.repositories_removed ?? [];
+      for (const repo of addedRepos) {
+        if (repo.full_name) await upsertRepositoryFromGitHub(env, repo, installationId ?? undefined);
+      }
+      for (const repo of removedRepos) {
+        if (repo.full_name) await markInstallationRepositoryRemoved(env, repo.full_name, installationId ?? undefined);
+      }
+      if (addedRepos.length > 0) {
+        await Promise.all(
+          addedRepos.slice(0, 50).map((repo) =>
+            recordGithubProductUsage(env, "github_installation_created", {
+              actor: payload.installation?.account?.login,
+              repoFullName: repo.full_name,
+              targetKey: installationId ? `installation:${installationId}` : repo.full_name,
+              outcome: "completed",
+              metadata: { action: payload.action, repoCount: addedRepos.length, truncatedRepos: Math.max(addedRepos.length - 50, 0) },
+            }),
+          ),
+        );
+      }
+      await recordWebhookEvent(env, {
+        deliveryId,
+        eventName,
+        action: payload.action,
+        installationId,
+        repositoryFullName: payload.repository?.full_name,
+        payloadHash: "processed",
+        status: "processed",
+      });
+      return;
     }
 
     const installationId = getInstallationId(payload);

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,9 @@ export type GitHubWebhookPayload = {
   };
   repository?: GitHubRepositoryPayload;
   repositories?: GitHubRepositoryPayload[];
+  // `installation_repositories` event: repos added/removed from an existing installation.
+  repositories_added?: GitHubRepositoryPayload[];
+  repositories_removed?: GitHubRepositoryPayload[];
   pull_request?: GitHubPullRequestPayload;
   issue?: GitHubIssuePayload;
   comment?: GitHubIssueCommentPayload;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6,6 +6,7 @@ import {
   getBurdenForecast,
   getContributorEvidence,
   getAgentRun,
+  getRepository,
   getContributorScoringProfile,
   getLatestUpstreamRulesetSnapshot,
   listUpstreamDriftReports,
@@ -113,18 +114,18 @@ describe("queue processors", () => {
     });
     await processJob(env, {
       type: "github-webhook",
-      deliveryId: "installation-added-single-repo",
-      eventName: "installation",
+      deliveryId: "installation-repositories-added-single-repo",
+      eventName: "installation_repositories",
       payload: {
         action: "added",
-        installation: { account: { login: "JSONbored", id: 1, type: "User" } } as never,
-        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
+        installation: { id: 456, account: { login: "JSONbored", id: 1, type: "User" } },
+        repositories_added: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }],
       },
     });
     await processJob(env, {
       type: "github-webhook",
-      deliveryId: "installation-added-empty",
-      eventName: "installation",
+      deliveryId: "installation-repositories-added-empty",
+      eventName: "installation_repositories",
       payload: {
         action: "added",
         installation: { id: 789, account: { login: "JSONbored", id: 1, type: "User" } },
@@ -158,6 +159,48 @@ describe("queue processors", () => {
         expect.objectContaining({ eventName: "github_installation_created", repoFullName: "<redacted-actor>/gittensory", metadata: expect.objectContaining({ action: "added" }) }),
       ]),
     );
+  });
+
+  it("links repos added to and unlinks repos removed from an existing installation", async () => {
+    const env = createTestEnv();
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "ir-install-created",
+      eventName: "installation",
+      payload: {
+        action: "created",
+        installation: { id: 999, account: { login: "acme", id: 7, type: "Organization" } },
+        repositories: [{ name: "a", full_name: "acme/a", private: false, owner: { login: "acme" } }],
+      },
+    });
+    // Repo added to the already-installed app arrives on installation_repositories/added.
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "ir-added",
+      eventName: "installation_repositories",
+      payload: {
+        action: "added",
+        installation: { id: 999, account: { login: "acme", id: 7, type: "Organization" } },
+        repositories_added: [{ name: "b", full_name: "acme/b", private: false, owner: { login: "acme" } }],
+      },
+    });
+    expect(await getRepository(env, "acme/b")).toMatchObject({ fullName: "acme/b", isInstalled: true, installationId: 999 });
+    expect(await listProductUsageEvents(env, { limit: 20 })).toEqual(
+      expect.arrayContaining([expect.objectContaining({ eventName: "github_installation_created", metadata: expect.objectContaining({ action: "added" }) })]),
+    );
+
+    // Repo removed from the installation must have its linkage cleared.
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "ir-removed",
+      eventName: "installation_repositories",
+      payload: {
+        action: "removed",
+        installation: { id: 999, account: { login: "acme", id: 7, type: "Organization" } },
+        repositories_removed: [{ name: "b", full_name: "acme/b", private: false, owner: { login: "acme" } }],
+      },
+    });
+    expect(await getRepository(env, "acme/b")).toMatchObject({ fullName: "acme/b", isInstalled: false, installationId: null });
   });
 
   it("runs queued agent jobs through the queue processor", async () => {


### PR DESCRIPTION
Closes #257.

## Problem
`processGitHubWebhook` had no handler for the `installation_repositories` event, which is what GitHub sends when a maintainer adds/removes repos from an already-installed app. The webhook entrypoint enqueues every delivery (no allowlist), so these events reached the processor and fell through: their repos live in `repositories_added` / `repositories_removed`, not `repositories`, so the added repos were never upserted with their installation linkage. The `installation` event's `payload.action === "added"` branch was also dead code (GitHub's `installation` event never emits `added`).

Result: a repo added to an existing installation got no row and no installationId association (so it was invisible to installation health / backfill / registration until some unrelated activity webhook lazily upserted it), and repo removals never cleared the linkage.

## Fix
- Add `repositories_added` / `repositories_removed` to `GitHubWebhookPayload` (types.ts).
- Add an `installation_repositories` branch in `processGitHubWebhook`: on `added`, upsert each `repositories_added` repo with the installation id and record a `github_installation_created` usage event; on `removed`, clear the installation linkage for each `repositories_removed` repo.
- New `markInstallationRepositoryRemoved` DB helper (repositories.ts), mirroring `markInstallationDeleted` but scoped to a single repo (only unlinks if it still belongs to the installation).
- Remove the dead `|| payload.action === "added"` disjunct on the `installation` event.

## Tests
Added a queue-processor test: an `installation_repositories`/`added` delivery upserts the added repo with `isInstalled: true` + the installation id and records the usage event, and a `removed` delivery clears `isInstalled`/`installationId`. Updated the existing installation test, which sent a fictional `installation`/`added` event (the dead path), to use the GitHub-correct `installation_repositories`/`added` event.

`vitest run` queue 35/35; product-usage + github-app + backfill 71/71; `tsc --noEmit` clean.