### PR TITLE
fix(label): tolerate forbidden fork label writes

### DIFF
--- a/scripts/github-type-label.mjs
+++ b/scripts/github-type-label.mjs
@@ -86,6 +86,9 @@ export async function applyTypeLabel({ apiUrl = "https://api.github.com", reposi
 
   if (!response.ok) {
     const text = await response.text();
+    if (isLabelWriteForbidden(response.status, text)) {
+      return { applied: false, reason: "label-write-forbidden" };
+    }
     throw new Error(`Failed to apply ${label} to #${number}: ${response.status} ${text}`);
   }
   return { applied: true };
@@ -152,6 +155,10 @@ function nextLink(linkHeader) {
     if (match) return match[1];
   }
   return "";
+}
+
+function isLabelWriteForbidden(status, text) {
+  return status === 403 && /resource not accessible by integration/i.test(text);
 }
 
 const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";

--- a/test/unit/github-type-label.test.ts
+++ b/test/unit/github-type-label.test.ts
@@ -107,6 +107,54 @@ describe("GitHub type label classifier", () => {
     ]);
   });
 
+  it("does not fail the workflow when GitHub forbids a fork PR label write", async () => {
+    const calls: string[] = [];
+    const result = await applyTypeLabel({
+      repository: "JSONbored/gittensory",
+      token: "token",
+      number: 263,
+      label: "feature",
+      fetchImpl: async (input, init) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${input.toString()}`);
+        if (method === "GET") return Response.json([{ name: "size:S" }]);
+        if (method === "POST") {
+          return Response.json(
+            {
+              message: "Resource not accessible by integration",
+              documentation_url: "https://docs.github.com/rest/issues/labels#add-labels-to-an-issue",
+              status: "403",
+            },
+            { status: 403 },
+          );
+        }
+        return new Response("unexpected method", { status: 500 });
+      },
+    });
+
+    expect(result).toEqual({ applied: false, reason: "label-write-forbidden" });
+    expect(calls).toEqual([
+      "GET https://api.github.com/repos/JSONbored/gittensory/issues/263/labels?per_page=100",
+      "POST https://api.github.com/repos/JSONbored/gittensory/issues/263/labels",
+    ]);
+  });
+
+  it("still fails on unexpected label write errors", async () => {
+    await expect(
+      applyTypeLabel({
+        repository: "JSONbored/gittensory",
+        token: "token",
+        number: 42,
+        label: "feature",
+        fetchImpl: async (_input, init) => {
+          const method = init?.method ?? "GET";
+          if (method === "GET") return Response.json([{ name: "size:S" }]);
+          return new Response("server error", { status: 500 });
+        },
+      }),
+    ).rejects.toThrow("Failed to apply feature to #42: 500 server error");
+  });
+
   it("reads paginated current labels before deciding to post", async () => {
     const calls: string[] = [];
     const labels = await readCurrentLabels({


### PR DESCRIPTION
## Summary
- prevent Type Label from failing when GitHub refuses a fork PR label write with `Resource not accessible by integration`
- keep unexpected label API failures fatal
- add regression coverage for the fork-token 403 and normal write failures

## What changed
- `scripts/github-type-label.mjs` now treats the specific GitHub 403 integration-denial response as a non-failing skip
- `test/unit/github-type-label.test.ts` covers the PR #263-style 403 and verifies unrelated write errors still throw

## Why
- fork PRs can produce a red `Apply type label` check even when the classifier is correct and the workflow is otherwise safe
- `entrius/gittensor` avoids write-on-fork risk by splitting same-repo and fork PR jobs; `e35ventura/taopedia-articles` avoids PR label mutation and keeps PR workflows read-only, so this patch keeps Gittensory's deterministic labeler but makes the denied write path non-disruptive

## Validation
- `node --check scripts/github-type-label.mjs`
- `npm run test -- test/unit/github-type-label.test.ts`
- `npm run actionlint`
- `npm run test:ci`

## Notes
- this does not add a PAT or app token to force labels onto fork PRs
- if GitHub refuses the write, the workflow reports a clean skip instead of a failed check