### PR TITLE
fix(security): escape release issue commit subjects

### DIFF
--- a/scripts/mcp-release-core.mjs
+++ b/scripts/mcp-release-core.mjs
@@ -185,7 +185,10 @@ export function buildMcpReleaseIssue(report) {
   const title = `MCP release due: ${report.proposedVersion}`;
   const npmVersion = report.publishedVersion ?? "unknown";
   const latestTag = report.latestTag ?? "none";
-  const commits = report.commits.length > 0 ? report.commits.map((commit) => `- \`${shortSha(commit.sha)}\` ${commit.subject}`).join("\n") : "- No unreleased MCP-related commits detected.";
+  const commits =
+    report.commits.length > 0
+      ? report.commits.map((commit) => `- \`${shortSha(commit.sha)}\` ${escapeIssueMarkdownText(commit.subject)}`).join("\n")
+      : "- No unreleased MCP-related commits detected.";
   const changedFiles = report.changedFiles.length > 0 ? report.changedFiles.map((file) => `- \`${file}\``).join("\n") : "- No MCP-related changed files detected.";
 
   const body = `${MCP_RELEASE_DUE_MARKER}
@@ -225,6 +228,13 @@ ${changedFiles}
 `;
 
   return { title, body };
+}
+
+function escapeIssueMarkdownText(value) {
+  return String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/@/g, "@\u200b")
+    .replace(/([\\`*_{}[\]()#+.!|>-])/g, "\\$1");
 }
 
 export function normalizeNewlines(value) {

--- a/test/unit/mcp-release.test.ts
+++ b/test/unit/mcp-release.test.ts
@@ -83,6 +83,22 @@ describe("MCP release changelog detection", () => {
     expect(issue.body).toContain("- [ ] Tag `mcp-v0.4.0`");
   });
 
+  it("escapes untrusted commit subjects in the release-due issue", () => {
+    const maliciousSubject = "feat(mcp): notify @octocat [SECURITY ACTION REQUIRED](https://evil.example/phish) #123";
+    const report = buildMcpReleaseReport({
+      latestTag: { tag: "mcp-v0.3.0", version: "0.3.0" },
+      packageVersion: "0.4.0",
+      publishedVersion: "0.3.0",
+      commits: [commit(maliciousSubject, ["src/mcp/server.ts"])],
+    });
+    const issue = buildMcpReleaseIssue(report);
+
+    expect(issue.body).not.toContain(maliciousSubject);
+    expect(issue.body).toContain("@\u200boctocat");
+    expect(issue.body).toContain("\\[SECURITY ACTION REQUIRED\\]\\(https://evil\\.example/phish\\)");
+    expect(issue.body).toContain("\\#123");
+  });
+
   it("only updates the bot-owned release reminder issue", () => {
     expect(
       isReleaseWatchIssue({


### PR DESCRIPTION
### Motivation

- The scheduled MCP release-watch workflow was rendering untrusted commit subjects directly into a bot-authored GitHub issue body, allowing mentions, links, and Markdown to be abused as notification/spoofing vectors. 
- The change aims to neutralize attacker-controlled commit/PR titles before they are interpolated into release reminder Markdown.

### Description

- Escape commit subjects before rendering them into the release issue by adding `escapeIssueMarkdownText` and applying it when building the commits list in `buildMcpReleaseIssue` in `scripts/mcp-release-core.mjs`.
- `escapeIssueMarkdownText` replaces control characters, neutralizes `@` mentions with a zero-width break, and escapes common Markdown metacharacters to prevent links, formatting, and issue references from rendering.
- Add a unit regression test in `test/unit/mcp-release.test.ts` that verifies a malicious subject (mention, link, and issue reference) is not present raw and is properly neutralized in the generated issue body.

### Testing

- Ran `npx vitest run test/unit/mcp-release.test.ts` and the modified release-due tests passed.
- Ran `git diff --check` to validate no trailing whitespace or diff issues (clean).
- Ran the full unit suite via `npm run test:unit`, where the MCP release tests passed but unrelated CLI tests failed due to a local test server timeout/`ECONNREFUSED` issue that is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9f404680832c8080ddd7d55ecd43)