### PR TITLE
fix(mcp): remove default profile session cleanly

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1270,7 +1270,8 @@ function removeProfile(currentConfig, profileName) {
   delete profiles[profileName];
   const remaining = Object.keys(profiles);
   const activeProfile = currentConfig.activeProfile === profileName ? (profiles[defaultProfileName] ? defaultProfileName : remaining[0] ?? defaultProfileName) : currentConfig.activeProfile;
-  return normalizeConfig({ ...currentConfig, activeProfile, profiles });
+  const session = profileName === defaultProfileName ? undefined : currentConfig.session;
+  return normalizeConfig({ ...currentConfig, activeProfile, profiles, session });
 }
 
 function hasPersistedConfigState(currentConfig) {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -366,6 +366,38 @@ describe("gittensory-mcp CLI", () => {
     expect(requests).toEqual(expect.arrayContaining([expect.objectContaining({ url: "/v1/auth/session", authorization: "Bearer session-okto" })]));
   });
 
+  it("removes the default profile without rehydrating its legacy session token", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          apiUrl: "https://api.example.test",
+          activeProfile: "default",
+          profiles: {
+            default: { session: { token: "default-session-token", login: "default-user", scopes: [] } },
+            beta: { session: { token: "beta-session-token", login: "beta-user", scopes: [] } },
+          },
+          session: { token: "default-session-token", login: "default-user", scopes: [] },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const removed = JSON.parse(await runAsync(["profile", "remove", "default", "--json"], { GITTENSORY_CONFIG_DIR: tempDir })) as { status: string; removedProfile: string; activeProfile: string };
+    const saved = JSON.parse(readFileSync(configPath, "utf8")) as { activeProfile: string; profiles?: Record<string, unknown>; session?: unknown };
+
+    expect(removed).toMatchObject({ status: "removed", removedProfile: "default", activeProfile: "beta" });
+    expect(saved.activeProfile).toBe("beta");
+    expect(saved.profiles).not.toHaveProperty("default");
+    expect(saved.profiles).toHaveProperty("beta");
+    expect(saved.session).toBeUndefined();
+    expect(JSON.stringify(saved)).not.toContain("default-session-token");
+    expect(JSON.stringify(saved)).toContain("beta-session-token");
+  });
+
   it("logs out only the selected profile and reports missing profiles safely", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
     const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];


### PR DESCRIPTION
### Motivation

- Removing the `default` MCP profile could leave a legacy top-level `session` in the persisted config, and `normalizeConfig()` would rehydrate `profiles.default`, causing a removed bearer token to remain on disk.  This is a local credential-hygiene bug.  

### Description

- Clear the legacy top-level `session` when removing the `default` profile by updating `removeProfile()` to drop `session` for that case so `normalizeConfig()` cannot re-create `profiles.default`.  (change in `packages/gittensory-mcp/bin/gittensory-mcp.js`)  
- Add a regression test `removes the default profile without rehydrating its legacy session token` that seeds a config with both `profiles.default.session` and a legacy top-level `session`, invokes `profile remove default`, and asserts the default token is removed while other profiles remain. (added to `test/unit/mcp-cli.test.ts`)  

### Testing

- Ran the targeted unit test: `npm test -- test/unit/mcp-cli.test.ts -t "removes the default profile"`, which passed.  
- Ran type checks with `npm run typecheck` which completed successfully.  
- Verified manually with a small repro script that writes a config containing both `profiles.default.session` and the legacy `session`, runs `gittensory-mcp profile remove default --json` against that config, and confirmed the saved config no longer contains the default token.  
- A full run of `npm test -- test/unit/mcp-cli.test.ts` was attempted and reported two unrelated/flaky failures (decision-pack cache abort/timeout and an unsafe packet markdown timeout test); these failures are external to this change and the new regression test passes in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5f1d48d4832caf6362f7cac9ed01)