### PR TITLE
Scope installation repair refresh to target single installation and mark route as expensive

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -93,6 +93,7 @@ import {
   enrichInstallationHealth,
   refreshContributorActivity,
   refreshInstallationHealth,
+  refreshInstallationHealthForInstallation,
 } from "../github/backfill";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
 import { fetchPublicContributorProfile } from "../github/public";
@@ -1444,10 +1445,8 @@ export function createApp() {
   app.post("/v1/installations/:id/repair/refresh", async (c) => {
     const installationId = Number(c.req.param("id"));
     if (!Number.isFinite(installationId)) return c.json({ error: "invalid_installation_id" }, 400);
-    const refreshed = await refreshInstallationHealth(c.env);
-    if (!refreshed.installations.some((installation) => installation.installationId === installationId)) {
-      return c.json({ error: "installation_not_found" }, 404);
-    }
+    const refreshed = await refreshInstallationHealthForInstallation(c.env, installationId);
+    if (!refreshed) return c.json({ error: "installation_not_found" }, 404);
     const health = await getInstallationHealth(c.env, installationId);
     if (!health) return c.json({ error: "installation_health_not_found" }, 404);
     return c.json({ ...(await buildInstallationRepairDiagnostics(c.env, health)), refreshed: true });

--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -104,6 +104,7 @@ export function routeClassForPath(path: string): RateLimitClass {
     path.includes("/scoring/preview") ||
     path.includes("/decision-pack") ||
     path.includes("/open-pr-monitor") ||
+    /^\/v1\/installations\/[^/]+\/repair\/refresh$/.test(path) ||
     path.includes("/upstream/") ||
     path.includes("/internal/jobs/generate-signal-snapshots") ||
     path.includes("/internal/jobs/build-contributor-decision-packs") ||

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -197,6 +197,12 @@ export async function markInstallationDeleted(env: Env, installationId: number):
     .where(eq(repositories.installationId, installationId));
 }
 
+export async function getInstallation(env: Env, installationId: number): Promise<InstallationRecord | null> {
+  const db = getDb(env.DB);
+  const [row] = await db.select().from(installations).where(eq(installations.id, installationId)).limit(1);
+  return row ? toInstallationRecord(row) : null;
+}
+
 export async function listInstallations(env: Env): Promise<InstallationRecord[]> {
   const db = getDb(env.DB);
   const rows = await db.select().from(installations).orderBy(desc(installations.updatedAt)).limit(100);

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -5,6 +5,7 @@ import {
   countOpenPullRequests,
   countRecentMergedPullRequests,
   countRepoLabels,
+  getInstallation,
   getLatestRepoGithubTotalsSnapshot,
   getRepoSyncSegment,
   getRepoSyncState,
@@ -826,6 +827,17 @@ function summarizeRepairSettings(settings: RepositorySettings) {
 
 export async function refreshInstallationHealth(env: Env) {
   const [installations, repositories] = await Promise.all([listInstallations(env), listRepositories(env)]);
+  return refreshInstallationHealthRecords(env, installations, repositories);
+}
+
+export async function refreshInstallationHealthForInstallation(env: Env, installationId: number) {
+  const [installation, repositories] = await Promise.all([getInstallation(env, installationId), listRepositories(env)]);
+  if (!installation) return null;
+  const refreshed = await refreshInstallationHealthRecords(env, [installation], repositories);
+  return refreshed.installations[0] ?? null;
+}
+
+async function refreshInstallationHealthRecords(env: Env, installations: InstallationRecord[], repositories: RepositoryRecord[]) {
   const health = [];
   for (const installation of installations) {
     const { installation: currentInstallation, errorSummary } = await refreshStoredInstallation(env, installation);

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { RateLimiter } from "../../src/auth/rate-limit";
 import { createSessionForGitHubUser } from "../../src/auth/security";
-import { persistSignalSnapshot } from "../../src/db/repositories";
+import { persistSignalSnapshot, upsertInstallation } from "../../src/db/repositories";
 import { handleMcpRequest } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -405,6 +405,37 @@ describe("api route guards and error branches", () => {
         }, env)
       ).status,
     ).toBe(401);
+  });
+
+  it("does not globally refresh installations for a missing repair refresh target", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    await upsertInstallation(env, {
+      installation: {
+        id: 101,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+        events: ["issues", "issue_comment", "pull_request", "repository"],
+      },
+    });
+    await upsertInstallation(env, {
+      installation: {
+        id: 102,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+        events: ["issues", "issue_comment", "pull_request", "repository"],
+      },
+    });
+    const fetchSpy = vi.fn(async () => new Response("unexpected", { status: 500 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await app.request("/v1/installations/999/repair/refresh", { method: "POST", headers: apiHeaders(env) }, env);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: "installation_not_found" });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("covers private route errors, internal guards, and manual job runners", async () => {

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -86,6 +86,7 @@ describe("private-beta auth and rate limiting", () => {
     expect(routeClassForPath("/v1/upstream/status")).toBe("expensive");
     expect(routeClassForPath("/v1/contributors/jsonbored/decision-pack")).toBe("expensive");
     expect(routeClassForPath("/v1/contributors/jsonbored/open-pr-monitor")).toBe("expensive");
+    expect(routeClassForPath("/v1/installations/999/repair/refresh")).toBe("expensive");
     expect(routeClassForPath("/v1/internal/jobs/generate-signal-snapshots")).toBe("expensive");
     expect(routeClassForPath("/v1/internal/jobs/build-contributor-decision-packs")).toBe("expensive");
     expect(routeClassForPath("/v1/internal/jobs/refresh-upstream-drift")).toBe("expensive");


### PR DESCRIPTION
### Motivation
- Prevent `POST /v1/installations/:id/repair/refresh` from triggering a global refresh that issues live GitHub App fetches for every stored installation and can exhaust API quota. 
- Ensure absent installation ids return `404` before any expensive work runs. 
- Apply stricter rate limiting by classifying the repair refresh path as an `expensive` route.

### Description
- Add `getInstallation` DB helper to look up a single installation by id (`src/db/repositories.ts`).
- Introduce `refreshInstallationHealthForInstallation` and shared `refreshInstallationHealthRecords` to scope refresh work to a single installation and reuse the global refresh logic (`src/github/backfill.ts`).
- Update the repair refresh route to call `refreshInstallationHealthForInstallation` and return `installation_not_found` before performing any live refreshes (`src/api/routes.ts`).
- Classify `/v1/installations/:id/repair/refresh` as an `expensive` route in `routeClassForPath` to ensure tighter rate limiting (`src/auth/rate-limit.ts`).
- Add regression coverage asserting a missing repair refresh target does not call out to `fetch` and update the rate-limit classification unit test (`test/integration/routes-errors.test.ts`, `test/unit/auth.test.ts`).

### Testing
- Ran `tsc --noEmit` (`npm run typecheck`) and it succeeded. 
- Ran targeted Vitest suites: `test/unit/backfill.test.ts`, `test/unit/auth.test.ts`, `test/integration/routes-errors.test.ts`, and `test/integration/api.test.ts`, and all tests passed. 
- Ran `git diff --check` to ensure no whitespace/format issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f618a8528832ca3e5106f68ff4d94)