### PR TITLE
Harden cached solved issue counts

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1426,7 +1426,11 @@ function cachedSolvedIssueCounts(issues: IssueRecord[], pullRequests: PullReques
   let solvedIssues = 0;
   let validSolvedIssues = 0;
   for (const issue of issues) {
-    const state = classifyIssueDiscoveryLifecycle(issue, pullRequests, [], lane).state;
+    if (issue.state === "open") continue;
+
+    // Issue linkedPrs can be parsed from contributor-controlled issue body text. Cache-derived
+    // outcome counts only trust solver links carried by the merged PR record itself.
+    const state = classifyIssueDiscoveryLifecycle({ ...issue, linkedPrs: [] }, pullRequests, [], lane).state;
     if (state === "valid_solved") {
       validSolvedIssues += 1;
       solvedIssues += 1;

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -760,19 +760,31 @@ describe("v2 signal builders", () => {
     });
     // acme/widgets is an issue-discovery lane (valid_solved); acme/tools is direct-PR (solved).
     const repositories = [mkRepo("acme/widgets", 1), mkRepo("acme/tools", 0)];
-    const allIssues = [mkIssue("acme/widgets", 7, 100), mkIssue("acme/tools", 8, 101)];
-    const prs = [mkSolvingPr("acme/widgets", 100, 7), mkSolvingPr("acme/tools", 101, 8)];
+    const poisonedIssue: IssueRecord = {
+      ...mkIssue("acme/widgets", 9, 102),
+      state: "open",
+      title: "Open self-linked report",
+    };
+    const poisonedPr: PullRequestRecord = {
+      ...mkSolvingPr("acme/widgets", 102, 999),
+      linkedIssues: [],
+      body: "Previously merged work",
+    };
+    const allIssues = [mkIssue("acme/widgets", 7, 100), mkIssue("acme/tools", 8, 101), poisonedIssue];
+    const prs = [mkSolvingPr("acme/widgets", 100, 7), mkSolvingPr("acme/tools", 101, 8), poisonedPr];
     const profile = buildContributorProfile("cachedev", { login: "cachedev", topLanguages: ["TypeScript"], source: "github" }, prs, allIssues);
     const history = buildContributorOutcomeHistory({ login: "cachedev", profile, repositories, pullRequests: prs, issues: allIssues, repoStats: [] });
 
     const discovery = history.repoOutcomes.find((entry) => entry.repoFullName === "acme/widgets");
     const direct = history.repoOutcomes.find((entry) => entry.repoFullName === "acme/tools");
     // Without the cache fallback these were hardcoded to 0 even though the contributor's own
-    // merged PRs solved their issues.
-    expect(discovery).toMatchObject({ solvedIssues: 1, validSolvedIssues: 1 });
+    // merged PRs solved their issues. Open issues with only contributor-controlled issue-body
+    // PR text must not inflate the cached solved evidence.
+    expect(discovery).toMatchObject({ solvedIssues: 1, validSolvedIssues: 1, openIssues: 1 });
     expect(direct).toMatchObject({ solvedIssues: 1, validSolvedIssues: 0 });
     expect(history.totals.solvedIssues).toBe(2);
     expect(history.totals.validSolvedIssues).toBe(1);
+    expect(history.reconciliation?.repos.find((entry) => entry.repoFullName === "acme/widgets")?.cached).toMatchObject({ solvedIssues: 1, validSolvedIssues: 1, openIssues: 1 });
     expect(discovery?.strengths.join(" ")).toMatch(/valid solved issue-discovery report/);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent contributor-controlled issue body text from inflating cached `solvedIssues` / `validSolvedIssues` when official Gittensor data is unavailable by hardening the cache fallback logic.
- Close a reconciliation integrity gap where an attacker could mention a merged PR number in an open issue body and have that open/unvalidated issue counted as solved evidence.

### Description
- Skip open issues in the cache-derived solved-count pass so only non-open issues contribute to `solvedIssues` and `validSolvedIssues`.
- Clear `linkedPrs` on cached issues before running the lifecycle classifier so outcome counts only trust solver linkage present on PR records, not text-parsed `PR #123` mentions.
- Add a regression test that creates an open issue which mentions a merged PR (a poisoned case) and asserts it does not increase cached outcome or reconciliation solved counts while legitimate closed linked issues still count.

### Testing
- Ran type checking with `npm run typecheck` and it succeeded with no errors.
- Ran the targeted unit test with `npx vitest run test/unit/signals-v2.test.ts -t "derives solved and valid-solved issue-discovery counts"` and it passed.
- Ran the full unit suite with `npx vitest run test/unit/signals-v2.test.ts` and all tests passed (28/28).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f61897368832cba25e701836d875a)