### PR TITLE
feat(mcp): add version command and clearer unknown-command guidance

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -27,6 +27,8 @@ npm link --workspace @jsonbored/gittensory-mcp
 ## Commands
 
 ```sh
+gittensory-mcp version
+gittensory-mcp version --json
 gittensory-mcp login
 gittensory-mcp logout
 gittensory-mcp whoami
@@ -51,6 +53,8 @@ gittensory-mcp agent status <run-id> --json
 gittensory-mcp agent explain <run-id> --json
 gittensory-mcp --stdio
 ```
+
+`gittensory-mcp version` (aliases `--version` and `-v`) prints the installed package version, the targeted API version, and the Node.js runtime version. Add `--json` for machine-readable output.
 
 For near-term what-if scoreability, pass the situational assumptions explicitly:
 

--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -54,7 +54,22 @@ gittensory-mcp agent explain <run-id> --json
 gittensory-mcp --stdio
 ```
 
-`gittensory-mcp version` (aliases `--version` and `-v`) prints the installed package version, the targeted API version, and the Node.js runtime version. Add `--json` for machine-readable output.
+`gittensory-mcp version` (aliases `--version` and `-v`) prints the installed package version, the targeted API version, and the Node.js runtime version:
+
+```text
+@jsonbored/gittensory-mcp/0.4.0 (api 0.1.0, node v22.12.0)
+```
+
+Add `--json` for machine-readable output:
+
+```json
+{
+  "name": "@jsonbored/gittensory-mcp",
+  "version": "0.4.0",
+  "apiVersion": "0.1.0",
+  "node": "v22.12.0"
+}
+```
 
 For near-term what-if scoreability, pass the situational assumptions explicitly:
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -726,7 +726,7 @@ function printVersion(options) {
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     return;
   }
-  process.stdout.write(`${packageName}/${packageVersion} (node ${process.version})\n`);
+  process.stdout.write(`${packageName}/${packageVersion} (api ${currentApiVersion}, node ${process.version})\n`);
 }
 
 function printHelp() {

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -485,6 +485,7 @@ await server.connect(new StdioServerTransport());
 async function runCli(args) {
   const command = args[0];
   if (command === "--help" || command === "help") return printHelp();
+  if (command === "--version" || command === "-v" || command === "version") return printVersion(parseOptions(args.slice(1)));
   if (command === "agent") return runAgentCli(args.slice(1));
   if (command === "cache") return runCacheCli(args.slice(1));
   const options = parseOptions(args.slice(1));
@@ -498,7 +499,7 @@ async function runCli(args) {
   if (command === "init-client") return initClient(options);
   if (command === "decision-pack") return decisionPackCli(options);
   if (command === "repo-decision") return repoDecisionCli(options);
-  if (command !== "analyze-branch" && command !== "preflight") throw new Error(`Unknown command: ${command}`);
+  if (command !== "analyze-branch" && command !== "preflight") throw new Error(`Unknown command: ${command}. Run \`gittensory-mcp --help\` to list commands.`);
   const contributorLogin = options.login ?? process.env.GITTENSORY_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!contributorLogin) throw new Error("Pass --login <github-login> or set GITTENSORY_LOGIN.");
   const result = await analyzeCurrentBranch({
@@ -719,9 +720,19 @@ function isUnsafePublicPacketText(value) {
   return /\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:\\Users\\/i.test(value);
 }
 
+function printVersion(options) {
+  const payload = { name: packageName, version: packageVersion, apiVersion: currentApiVersion, node: process.version };
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${packageName}/${packageVersion} (node ${process.version})\n`);
+}
+
 function printHelp() {
   process.stdout.write(`Usage:
   gittensory-mcp --stdio
+  gittensory-mcp version [--json]
   gittensory-mcp login [--profile name] [--github-token <token>] [--json]
   gittensory-mcp logout [--profile name] [--all] [--json]
   gittensory-mcp whoami [--profile name] [--json]

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -900,6 +900,26 @@ describe("gittensory-mcp CLI", () => {
   it("rejects unsupported client snippets", () => {
     expect(() => run(["init-client", "--print", "other"])).toThrow(/Unsupported client/);
   });
+
+  it("reports the package version via version, --version, and -v", () => {
+    const expected = "@jsonbored/gittensory-mcp/0.4.0";
+    expect(run(["version"]).trim()).toContain(expected);
+    expect(run(["--version"]).trim()).toContain(expected);
+    expect(run(["-v"]).trim()).toContain(expected);
+  });
+
+  it("emits machine-readable version output with --json", () => {
+    const payload = JSON.parse(run(["version", "--json"])) as { name: string; version: string; apiVersion: string; node: string };
+    expect(payload.name).toBe("@jsonbored/gittensory-mcp");
+    expect(payload.version).toBe("0.4.0");
+    expect(payload.apiVersion).toBe("0.1.0");
+    expect(payload.node).toBe(process.version);
+  });
+
+  it("guides unknown commands to --help", () => {
+    expect(() => run(["bogus-command"])).toThrow(/Unknown command: bogus-command/);
+    expect(() => run(["bogus-command"])).toThrow(/gittensory-mcp --help/);
+  });
 });
 
 function run(args: string[], env: Record<string, string> = {}) {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -903,9 +903,13 @@ describe("gittensory-mcp CLI", () => {
 
   it("reports the package version via version, --version, and -v", () => {
     const expected = "@jsonbored/gittensory-mcp/0.4.0";
-    expect(run(["version"]).trim()).toContain(expected);
-    expect(run(["--version"]).trim()).toContain(expected);
-    expect(run(["-v"]).trim()).toContain(expected);
+    for (const flag of ["version", "--version", "-v"]) {
+      const plain = run([flag]).trim();
+      expect(plain).toContain(expected);
+      // The plain form reports all three values the README documents.
+      expect(plain).toContain("api 0.1.0");
+      expect(plain).toContain(`node ${process.version}`);
+    }
   });
 
   it("emits machine-readable version output with --json", () => {


### PR DESCRIPTION
## Summary

The `gittensory-mcp` CLI defines a `packageVersion` constant but exposes **no way to query it** — the conventional `--version` flag was missing, so users and tooling had no quick way to confirm which CLI build is installed (e.g. for bug reports).

This adds a `version` command with `--version` and `-v` aliases:

```
$ gittensory-mcp version
@jsonbored/gittensory-mcp/0.4.0 (node v22.x.x)

$ gittensory-mcp version --json
{
  "name": "@jsonbored/gittensory-mcp",
  "version": "0.4.0",
  "apiVersion": "0.1.0",
  "node": "v22.x.x"
}
```

It reports the installed package version, the targeted API version, and the Node.js runtime — useful context for diagnostics and issue reports. The `--json` form keeps output parseable for tooling.

As a tightly-related ergonomics touch, the unknown-command error now points at `gittensory-mcp --help` so a mistyped command guides the user to the command list.

## Why no linked issue

Low-risk, additive CLI ergonomics only. No public-behavior, auth/session, schema, deploy, or frontend-architecture change, so per CONTRIBUTING this does not require an issue first. Happy to file one if maintainers prefer.

## Changes

- `packages/gittensory-mcp/bin/gittensory-mcp.js` — `version`/`--version`/`-v` dispatch in `runCli`, new `printVersion()`, help-text usage line, and the improved unknown-command message.
- `test/unit/mcp-cli.test.ts` — cover all three aliases (plain output), the `--json` payload shape, and the unknown-command guidance.
- `packages/gittensory-mcp/README.md` — document the new command and aliases.

## Contract notes

No MCP tool or HTTP/OpenAPI contract changes. This only adds a local CLI command surface; stable JSON output is preserved and the new `--json` payload is additive.

## Validation

Intended gate (CONTRIBUTING required checks):

```sh
npm run build:mcp
npm run test:mcp-pack
npm run typecheck
npm run test:coverage
npm run test:ci
```

Transparency note: my local authoring environment had no Node runtime available, so I could not execute the gate locally before opening this PR. The change was prepared against the existing CLI dispatch/test patterns and is intended to be validated by CI on this PR (and I will run the full gate locally as well). If any check needs adjustment I'll follow up promptly.

## Security / privacy

No auth, cookie, CORS, GitHub App output, identity, or contributor-evidence changes. The `version` output contains only static package/API/runtime version strings — no tokens, paths, wallet/hotkey, or scoring context.
