### PR TITLE
feat(control-panel): complete usage and value analytics dashboard

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-shell.tsx
+++ b/apps/gittensory-ui/src/components/site/app-shell.tsx
@@ -77,7 +77,7 @@ const GROUPS: NavGroup[] = [
         to: "/app/analytics",
         label: "Analytics",
         icon: BarChart3,
-        roles: ["operator", "maintainer"],
+        roles: ["operator"],
       },
       { to: "/app/operator", label: "Operator", icon: Wrench, roles: ["operator"] },
     ],

--- a/apps/gittensory-ui/src/components/site/usage-analytics-panels.tsx
+++ b/apps/gittensory-ui/src/components/site/usage-analytics-panels.tsx
@@ -1,0 +1,353 @@
+import { Stat, StatusPill } from "@/components/site/control-primitives";
+
+type WeeklyMetric = {
+  id: string;
+  label: string;
+  value: number;
+  detail: string;
+};
+
+type RoleRow = {
+  role: string;
+  count: number;
+  activeActors: number;
+  activeRepos: number;
+};
+
+type RetentionWindow = {
+  window: string;
+  activeActors: number;
+  retainedActors: number;
+  retentionRate: number;
+  capped: boolean;
+  byRole: Array<{
+    role: string;
+    activeActors: number;
+    retainedActors: number;
+    retentionRate: number;
+  }>;
+};
+
+type CommandBucket = {
+  command: string;
+  feedbackCount: number;
+  usefulCount: number;
+  notUsefulCount: number;
+  usefulnessRate: number | null;
+};
+
+export function WeeklyValueMetricsPanel({
+  metrics,
+  warnings,
+}: {
+  metrics: WeeklyMetric[];
+  warnings: string[];
+}) {
+  if (metrics.length === 0) return null;
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Weekly value metrics</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Rollup-backed adoption and ecosystem value without raw secrets or source data.
+          </p>
+        </div>
+        <StatusPill status={warnings.length > 0 ? "degraded" : "ready"}>
+          {warnings.length > 0 ? `${warnings.length} warning(s)` : "rollup-backed"}
+        </StatusPill>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {metrics.map((metric) => (
+          <Stat
+            key={metric.id}
+            label={metric.label}
+            value={String(metric.value)}
+            hint={<span className="text-muted-foreground">{metric.detail}</span>}
+          />
+        ))}
+      </div>
+      {warnings.length > 0 ? (
+        <ul className="mt-4 space-y-1 text-token-xs text-muted-foreground">
+          {warnings.slice(0, 4).map((warning) => (
+            <li key={warning}>· {warning}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+export function AdoptionRetentionPanel({
+  byRole,
+  retention,
+  activationByRole,
+}: {
+  byRole: RoleRow[];
+  retention: RetentionWindow[];
+  activationByRole: Array<{
+    role: string;
+    firstUsefulActionActors: number;
+    doctorPassActors: number;
+  }>;
+}) {
+  if (byRole.length === 0 && retention.length === 0) return null;
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <h2 className="font-display text-token-lg font-semibold">Adoption & retention</h2>
+      <p className="mt-1 text-token-xs text-muted-foreground">
+        Active miners and maintainers from hashed rollups — no wallets, hotkeys, or private source
+        data.
+      </p>
+      <div className="mt-4 grid gap-4 lg:grid-cols-3">
+        <DimensionList
+          title="Active by role"
+          rows={byRole.map((row) => ({ key: row.role, count: row.activeActors }))}
+        />
+        <DimensionList
+          title="Activation funnel"
+          rows={activationByRole.map((row) => ({
+            key: row.role,
+            count: row.firstUsefulActionActors,
+            hint: `${row.doctorPassActors} doctor pass`,
+          }))}
+        />
+        <div className="rounded-token border border-border bg-background/40 p-3">
+          <div className="text-token-xs font-medium uppercase text-muted-foreground">
+            Retention windows
+          </div>
+          <div className="mt-3 space-y-3">
+            {retention.length > 0 ? (
+              retention.map((window) => (
+                <div key={window.window} className="text-token-sm">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-muted-foreground">
+                      {formatRetentionWindow(window.window)}
+                    </span>
+                    <span className="font-mono text-mint">
+                      {formatPercent(window.retentionRate)}
+                    </span>
+                  </div>
+                  <div className="mt-1 font-mono text-token-2xs text-muted-foreground">
+                    {window.retainedActors}/{window.activeActors} actors
+                    {window.capped ? " · capped scan" : ""}
+                  </div>
+                  {window.byRole.length > 0 ? (
+                    <div className="mt-2 space-y-1">
+                      {window.byRole.slice(0, 4).map((row) => (
+                        <div
+                          key={`${window.window}-${row.role}`}
+                          className="flex justify-between text-token-xs"
+                        >
+                          <span>{row.role}</span>
+                          <span className="font-mono">{formatPercent(row.retentionRate)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <div className="text-token-xs text-muted-foreground">No retention rollups yet</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type CommandUsefulnessTotals = Omit<CommandBucket, "command"> & { answerCount: number };
+
+export function CommandUsefulnessPanel({
+  totals,
+  commands,
+  windowDays,
+}: {
+  totals: CommandUsefulnessTotals;
+  commands: CommandBucket[];
+  windowDays: number;
+}) {
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <h2 className="font-display text-token-lg font-semibold">Command usefulness</h2>
+      <p className="mt-1 text-token-xs text-muted-foreground">
+        Maintainer feedback on GitHub command answers — separate from security audit events.
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Stat
+          label="Feedback"
+          value={String(totals.feedbackCount)}
+          hint={<span>last {windowDays} days</span>}
+        />
+        <Stat
+          label="Useful votes"
+          value={String(totals.usefulCount)}
+          hint={<span className="text-mint">positive signal</span>}
+        />
+        <Stat
+          label="Usefulness rate"
+          value={
+            totals.usefulnessRate === null ? "—" : `${Math.round(totals.usefulnessRate * 100)}%`
+          }
+          hint={<span>answers: {totals.answerCount}</span>}
+        />
+        <Stat
+          label="Not useful"
+          value={String(totals.notUsefulCount)}
+          hint={<span>improvement signal</span>}
+        />
+      </div>
+      {commands.length > 0 ? (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[480px] text-left text-token-sm">
+            <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="py-2 pr-4 font-medium">Command</th>
+                <th className="py-2 pr-4 font-medium">Feedback</th>
+                <th className="py-2 pr-4 font-medium">Useful</th>
+                <th className="py-2 font-medium">Rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {commands.slice(0, 8).map((row) => (
+                <tr key={row.command} className="border-b border-border/60 last:border-0">
+                  <td className="py-2 pr-4 font-mono text-token-xs">{row.command}</td>
+                  <td className="py-2 pr-4 font-mono">{row.feedbackCount}</td>
+                  <td className="py-2 pr-4 font-mono">{row.usefulCount}</td>
+                  <td className="py-2 font-mono">
+                    {row.usefulnessRate === null ? "—" : `${Math.round(row.usefulnessRate * 100)}%`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="mt-4 text-token-xs text-muted-foreground">
+          No command feedback recorded in this window.
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function ProductUsageBreakdownPanel({
+  byEvent,
+  bySurface,
+  byTool = [],
+}: {
+  byEvent: Array<{ eventName: string; count: number }>;
+  bySurface: Array<{ surface: string; count: number }>;
+  byTool?: Array<{ key: string; count: number }>;
+}) {
+  const highlights = pickUsageHighlights(byEvent, byTool);
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <h2 className="font-display text-token-lg font-semibold">Product usage breakdown</h2>
+      <p className="mt-1 text-token-xs text-muted-foreground">
+        MCP commands, GitHub commands, PR packets, quiet skips, decision-pack tools, and drift
+        signals (7-day window).
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {highlights.map((item) => (
+          <Stat
+            key={item.id}
+            label={item.label}
+            value={String(item.value)}
+            hint={<span>{item.detail}</span>}
+          />
+        ))}
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <DimensionList
+          title="Top events"
+          rows={byEvent.slice(0, 6).map((row) => ({ key: row.eventName, count: row.count }))}
+        />
+        <DimensionList
+          title="By surface"
+          rows={bySurface.slice(0, 6).map((row) => ({ key: row.surface, count: row.count }))}
+        />
+      </div>
+    </section>
+  );
+}
+
+function DimensionList({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: Array<{ key: string; count: number; hint?: string }>;
+}) {
+  return (
+    <div className="rounded-token border border-border bg-background/40 p-3">
+      <div className="text-token-xs font-medium uppercase text-muted-foreground">{title}</div>
+      <div className="mt-3 space-y-2">
+        {rows.length > 0 ? (
+          rows.map((row) => (
+            <div key={row.key} className="flex items-center justify-between gap-3 text-token-sm">
+              <span className="min-w-0 truncate font-mono text-token-xs">{row.key}</span>
+              <span className="shrink-0 font-mono text-mint">{row.count}</span>
+            </div>
+          ))
+        ) : (
+          <div className="text-token-xs text-muted-foreground">No data</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function pickUsageHighlights(
+  byEvent: Array<{ eventName: string; count: number }>,
+  byTool: Array<{ key: string; count: number }>,
+) {
+  const sum = (names: string[]) =>
+    byEvent
+      .filter((row) => names.includes(row.eventName))
+      .reduce((total, row) => total + row.count, 0);
+  const mcp = sum(["mcp_request", "mcp_tool_called"]);
+  const github = sum(["agent_command_replied", "agent_command_skipped"]);
+  const quietSkips = sum(["agent_command_skipped"]);
+  const prPackets = sum(["agent_pr_packet_completed"]);
+  const preflights = sum(["agent_preflight_branch_completed", "local_branch_analysis_completed"]);
+  const decisionPacks = byTool
+    .filter((row) => row.key.includes("decision_pack"))
+    .reduce((total, row) => total + row.count, 0);
+  const driftSignals = sum(["upstream_drift_detected", "upstream_drift_filed"]);
+  return [
+    { id: "mcp", label: "MCP usage", value: mcp, detail: "requests + tool calls" },
+    { id: "github", label: "GitHub commands", value: github, detail: "replies + quiet skips" },
+    { id: "quiet", label: "Quiet skips", value: quietSkips, detail: "intentional no-reply" },
+    { id: "packets", label: "PR packets", value: prPackets, detail: "completed packets" },
+    {
+      id: "preflight",
+      label: "PR preflights",
+      value: preflights,
+      detail: "branch preflight events",
+    },
+    {
+      id: "decision",
+      label: "Decision packs",
+      value: decisionPacks,
+      detail: "MCP decision-pack tool calls",
+    },
+    {
+      id: "drift",
+      label: "Drift incidents",
+      value: driftSignals,
+      detail: "upstream drift product events",
+    },
+  ];
+}
+
+function formatRetentionWindow(window: string): string {
+  if (window === "previous_7_days") return "7-day retention";
+  if (window === "previous_30_days") return "30-day retention";
+  return window.replaceAll("_", " ");
+}
+
+function formatPercent(rate: number): string {
+  return `${Math.round(rate * 1000) / 10}%`;
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -3,6 +3,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { BoundaryBadge, Stat, StatusPill } from "@/components/site/control-primitives";
 import { StateBoundary } from "@/components/site/state-views";
 import { TrendChart } from "@/components/site/trend-chart";
+import {
+  AdoptionRetentionPanel,
+  CommandUsefulnessPanel,
+  ProductUsageBreakdownPanel,
+  WeeklyValueMetricsPanel,
+} from "@/components/site/usage-analytics-panels";
 import { useApiResource } from "@/lib/api/use-api-resource";
 
 export const Route = createFileRoute("/app/analytics")({
@@ -12,6 +18,12 @@ export const Route = createFileRoute("/app/analytics")({
 type OperatorDashboard = {
   metrics: Array<{ label: string; value: string; delta: string }>;
   noiseReduction: Array<{ label: string; value: number; spark: number[] }>;
+  usageSummary?: {
+    totalEvents: number;
+    activeActors: number;
+    byEvent: Array<{ eventName: string; count: number }>;
+    bySurface: Array<{ surface: string; count: number }>;
+  };
   usageRollupStatus?: {
     status: "empty" | "ready" | "partial" | "stale" | "incomplete";
     latestRollupDay?: string | null;
@@ -23,11 +35,53 @@ type OperatorDashboard = {
     totalEvents: number;
     activeActors: number;
     activeRepos: number;
+    byRole: Array<{ role: string; count: number; activeActors: number; activeRepos: number }>;
+    activationByRole: Array<{
+      role: string;
+      firstUsefulActionActors: number;
+      doctorPassActors: number;
+    }>;
+    retention: Array<{
+      window: string;
+      activeActors: number;
+      retainedActors: number;
+      retentionRate: number;
+      capped: boolean;
+      byRole: Array<{
+        role: string;
+        activeActors: number;
+        retainedActors: number;
+        retentionRate: number;
+      }>;
+    }>;
+    byTool?: Array<{ key: string; count: number }>;
     activation: {
       fullyActivatedActors: number;
       githubActivatedRepos: number;
     };
   }>;
+  weeklyValueReport?: {
+    metrics: Array<{ id: string; label: string; value: number; detail: string }>;
+    warnings: string[];
+    freshness: { status: string; latestRollupDay?: string | null };
+  };
+  commandUsefulness?: {
+    windowDays: number;
+    totals: {
+      feedbackCount: number;
+      usefulCount: number;
+      notUsefulCount: number;
+      answerCount: number;
+      usefulnessRate: number | null;
+    };
+    commands: Array<{
+      command: string;
+      feedbackCount: number;
+      usefulCount: number;
+      notUsefulCount: number;
+      usefulnessRate: number | null;
+    }>;
+  };
   mcpCompatibilityAdoption?: {
     totalEvents: number;
     activeActors: number;
@@ -43,6 +97,7 @@ type OperatorDashboard = {
       count: number;
     }>;
   };
+  upstreamDrift?: { status?: string; openReportCount?: number } | null;
 };
 
 function ProductAnalytics() {
@@ -51,6 +106,10 @@ function ProductAnalytics() {
     "Product analytics",
   );
   const data = dashboard.status === "ready" ? dashboard.data : null;
+  const latestRollup =
+    data?.usageRollups && data.usageRollups.length > 0
+      ? [...data.usageRollups].sort((a, b) => b.day.localeCompare(a.day))[0]
+      : null;
 
   return (
     <StateBoundary
@@ -72,10 +131,11 @@ function ProductAnalytics() {
                 Analytics
               </div>
               <h1 className="mt-1 font-display text-token-2xl font-semibold tracking-tight">
-                Product analytics
+                Usage & value analytics
               </h1>
               <p className="mt-1 max-w-2xl text-token-sm text-muted-foreground">
-                Aggregate deployment, session, digest, and installation metrics from the live API.
+                Operator-facing adoption, activation, retention, and ecosystem value from product
+                usage rollups — not security audit logs or private source data.
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -91,6 +151,11 @@ function ProductAnalytics() {
               >
                 {data.usageRollupStatus?.status ?? "Live API"}
               </StatusPill>
+              {data.upstreamDrift?.status ? (
+                <StatusPill status={data.upstreamDrift.status === "current" ? "ready" : "warn"}>
+                  Drift · {data.upstreamDrift.status}
+                </StatusPill>
+              ) : null}
               <BoundaryBadge boundary="private-api" />
             </div>
           </header>
@@ -105,6 +170,37 @@ function ProductAnalytics() {
               />
             ))}
           </section>
+
+          {data.weeklyValueReport ? (
+            <WeeklyValueMetricsPanel
+              metrics={data.weeklyValueReport.metrics}
+              warnings={data.weeklyValueReport.warnings}
+            />
+          ) : null}
+
+          {data.usageSummary ? (
+            <ProductUsageBreakdownPanel
+              byEvent={data.usageSummary.byEvent}
+              bySurface={data.usageSummary.bySurface}
+              byTool={latestRollup?.byTool}
+            />
+          ) : null}
+
+          {latestRollup ? (
+            <AdoptionRetentionPanel
+              byRole={latestRollup.byRole}
+              retention={latestRollup.retention}
+              activationByRole={latestRollup.activationByRole}
+            />
+          ) : null}
+
+          {data.commandUsefulness ? (
+            <CommandUsefulnessPanel
+              totals={data.commandUsefulness.totals}
+              commands={data.commandUsefulness.commands}
+              windowDays={data.commandUsefulness.windowDays}
+            />
+          ) : null}
 
           <section className="rounded-token border border-border bg-transparent p-5">
             <h2 className="font-display text-token-lg font-semibold">Operational trend signals</h2>
@@ -218,6 +314,13 @@ function ProductAnalytics() {
                   {data.usageRollupStatus?.latestRollupDay ?? "current"}
                 </StatusPill>
               </div>
+              {data.usageRollupStatus?.warnings.length ? (
+                <ul className="mt-3 space-y-1 text-token-xs text-amber-200/90">
+                  {data.usageRollupStatus.warnings.slice(0, 4).map((warning) => (
+                    <li key={warning}>· {warning}</li>
+                  ))}
+                </ul>
+              ) : null}
               <div className="mt-4 overflow-x-auto">
                 <table className="w-full min-w-[680px] text-left text-token-sm">
                   <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -137,6 +137,7 @@ import {
   LATEST_RECOMMENDED_MCP_VERSION,
   MINIMUM_SUPPORTED_MCP_VERSION,
 } from "../services/mcp-compatibility";
+import { buildOperatorDashboardPayload } from "../services/operator-dashboard";
 import {
   buildWeeklyValueReport,
   formatWeeklyValueReportMarkdown,
@@ -832,87 +833,7 @@ export function createApp() {
   app.get("/v1/app/operator-dashboard", async (c) => {
     const forbidden = await requireAppRole(c, ["operator"]);
     if (forbidden) return forbidden;
-    const usageSince = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-    const [
-      repositories,
-      installations,
-      health,
-      registry,
-      scoring,
-      upstreamDrift,
-      activeSessions,
-      digestSubscriptions,
-      rateLimits,
-      usageSummary,
-      usageRollups,
-      usageRollupStatus,
-      mcpCompatibilityAdoption,
-      commandUsefulness,
-    ] = await Promise.all([
-      listRepositories(c.env),
-      listInstallations(c.env),
-      listInstallationHealth(c.env),
-      getLatestRegistrySnapshot(c.env),
-      getLatestScoringModelSnapshot(c.env),
-      loadUpstreamStatus(c.env),
-      countActiveAuthSessions(c.env),
-      countActiveDigestSubscriptions(c.env),
-      listLatestGitHubRateLimitObservations(c.env, 20),
-      summarizeProductUsageEvents(c.env, usageSince),
-      listProductUsageDailyRollups(c.env, { limit: 14 }),
-      getProductUsageRollupStatus(c.env),
-      summarizeMcpCompatibilityAdoption(c.env, usageSince),
-      getCommandUsefulnessSummary(c.env),
-    ]);
-    const weeklyValueReport = buildWeeklyValueReport({
-      generatedAt: nowIso(),
-      variant: "operator",
-      days: 7,
-      repositories,
-      installations,
-      health,
-      registry,
-      scoring,
-      upstreamDrift,
-      usageSummary,
-      usageRollups,
-      usageRollupStatus,
-      activeSessions,
-      digestSubscriptions,
-    });
-    const installedRepos = repositories.filter((repo) => repo.isInstalled).length;
-    const registeredRepos = repositories.filter((repo) => repo.isRegistered).length;
-    return c.json({
-      generatedAt: nowIso(),
-      metrics: [
-        { label: "Active sessions", value: String(activeSessions), delta: "browser + CLI/MCP" },
-        { label: "Installations", value: String(installations.length), delta: `${installedRepos} installed repos` },
-        { label: "Registered repos", value: String(registeredRepos), delta: registry ? `${registry.repoCount} in latest registry` : "registry missing" },
-        { label: "Digest subscriptions", value: String(digestSubscriptions), delta: "store-only" },
-        { label: "Product events", value: String(usageSummary.totalEvents), delta: "last 7 days" },
-        { label: "Active users", value: String(usageSummary.activeActors), delta: "hashed, last 7 days" },
-        { label: "Activation rollups", value: usageRollupStatus.status, delta: usageRollupStatus.latestRollupDay ?? "not generated" },
-        { label: "MCP stale clients", value: String(mcpCompatibilityAdoption.staleEvents + mcpCompatibilityAdoption.incompatibleEvents), delta: `${mcpCompatibilityAdoption.totalEvents} MCP event(s)` },
-        { label: "Command usefulness", value: `${commandUsefulness.totals.usefulCount}/${commandUsefulness.totals.feedbackCount}`, delta: usefulnessDelta(commandUsefulness.totals.usefulnessRate) },
-        { label: "Install issues", value: String(health.filter((record) => record.status !== "healthy").length), delta: "current health cache" },
-        { label: "Rate-limit events", value: String(rateLimits.length), delta: "latest observations" },
-      ],
-      noiseReduction: [
-        { label: "Healthy installations", value: health.filter((record) => record.status === "healthy").length, spark: sparklineFromCounts(health.filter((record) => record.status === "healthy").length, Math.max(health.length, 1)) },
-        { label: "Registered coverage", value: registeredRepos, spark: sparklineFromCounts(registeredRepos, Math.max(repositories.length, 1)) },
-        { label: "Installed coverage", value: installedRepos, spark: sparklineFromCounts(installedRepos, Math.max(repositories.length, 1)) },
-      ],
-      weeklyReport: weeklyValueReport.summary,
-      weeklyValueReport,
-      usageSummary,
-      usageRollups,
-      usageRollupStatus,
-      mcpCompatibilityAdoption,
-      commandUsefulness,
-      registry,
-      scoringModel: scoring,
-      upstreamDrift,
-    });
+    return c.json(await buildOperatorDashboardPayload(c.env));
   });
 
   app.get("/v1/app/notification-model", async (c) => {
@@ -2657,10 +2578,6 @@ function sampleMinerSnapshot(login: string) {
     pullRequests: [],
     issueLabels: [],
   };
-}
-
-function usefulnessDelta(rate: number | null): string {
-  return rate === null ? "no feedback yet" : `${Math.round(rate * 100)}% useful over 30 days`;
 }
 
 function clampInteger(value: number, min: number, max: number): number {

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -1,0 +1,186 @@
+import {
+  countActiveAuthSessions,
+  countActiveDigestSubscriptions,
+  getCommandUsefulnessSummary,
+  getLatestScoringModelSnapshot,
+  getProductUsageRollupStatus,
+  listInstallationHealth,
+  listInstallations,
+  listLatestGitHubRateLimitObservations,
+  listProductUsageDailyRollups,
+  listRepositories,
+  summarizeMcpCompatibilityAdoption,
+  summarizeProductUsageEvents,
+} from "../db/repositories";
+import { getLatestRegistrySnapshot } from "../registry/sync";
+import type {
+  CommandUsefulnessSummary,
+  InstallationHealthRecord,
+  McpCompatibilityAdoptionSummary,
+  ProductUsageDailyRollupRecord,
+  ProductUsageRollupStatus,
+  ProductUsageSummary,
+  RegistrySnapshot,
+  RepositoryRecord,
+  ScoringModelSnapshotRecord,
+  WeeklyValueReport,
+} from "../types";
+import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
+import { nowIso } from "../utils/json";
+import { buildWeeklyValueReport } from "./weekly-value-report";
+
+export type OperatorDashboardMetric = {
+  label: string;
+  value: string;
+  delta: string;
+};
+
+export type OperatorDashboardNoiseMetric = {
+  label: string;
+  value: number;
+  spark: number[];
+};
+
+export type OperatorDashboardPayload = {
+  generatedAt: string;
+  metrics: OperatorDashboardMetric[];
+  noiseReduction: OperatorDashboardNoiseMetric[];
+  weeklyReport: string[];
+  weeklyValueReport: WeeklyValueReport;
+  usageSummary: ProductUsageSummary;
+  usageRollups: ProductUsageDailyRollupRecord[];
+  usageRollupStatus: ProductUsageRollupStatus;
+  mcpCompatibilityAdoption: McpCompatibilityAdoptionSummary;
+  commandUsefulness: CommandUsefulnessSummary;
+  registry: RegistrySnapshot | null;
+  scoringModel: ScoringModelSnapshotRecord | null;
+  upstreamDrift: UpstreamStatus;
+};
+
+const USAGE_WINDOW_DAYS = 7;
+
+export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorDashboardPayload> {
+  const usageSince = new Date(Date.now() - USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const [
+    repositories,
+    installations,
+    health,
+    registry,
+    scoring,
+    upstreamDrift,
+    activeSessions,
+    digestSubscriptions,
+    rateLimits,
+    usageSummary,
+    usageRollups,
+    usageRollupStatus,
+    mcpCompatibilityAdoption,
+    commandUsefulness,
+  ] = await Promise.all([
+    listRepositories(env),
+    listInstallations(env),
+    listInstallationHealth(env),
+    getLatestRegistrySnapshot(env),
+    getLatestScoringModelSnapshot(env),
+    loadUpstreamStatus(env),
+    countActiveAuthSessions(env),
+    countActiveDigestSubscriptions(env),
+    listLatestGitHubRateLimitObservations(env, 20),
+    summarizeProductUsageEvents(env, usageSince),
+    listProductUsageDailyRollups(env, { limit: 14 }),
+    getProductUsageRollupStatus(env),
+    summarizeMcpCompatibilityAdoption(env, usageSince),
+    getCommandUsefulnessSummary(env),
+  ]);
+  const weeklyValueReport = buildWeeklyValueReport({
+    generatedAt: nowIso(),
+    variant: "operator",
+    days: USAGE_WINDOW_DAYS,
+    repositories,
+    installations,
+    health,
+    registry,
+    scoring,
+    upstreamDrift,
+    usageSummary,
+    usageRollups,
+    usageRollupStatus,
+    activeSessions,
+    digestSubscriptions,
+  });
+  const installedRepos = repositories.filter((repo: RepositoryRecord) => repo.isInstalled).length;
+  const registeredRepos = repositories.filter((repo: RepositoryRecord) => repo.isRegistered).length;
+  return {
+    generatedAt: nowIso(),
+    metrics: [
+      { label: "Active sessions", value: String(activeSessions), delta: "browser + CLI/MCP" },
+      { label: "Installations", value: String(installations.length), delta: `${installedRepos} installed repos` },
+      { label: "Registered repos", value: String(registeredRepos), delta: registry ? `${registry.repoCount} in latest registry` : "registry missing" },
+      { label: "Digest subscriptions", value: String(digestSubscriptions), delta: "store-only" },
+      { label: "Product events", value: String(usageSummary.totalEvents), delta: "last 7 days" },
+      { label: "Active users", value: String(usageSummary.activeActors), delta: "hashed, last 7 days" },
+      { label: "Activation rollups", value: usageRollupStatus.status, delta: usageRollupStatus.latestRollupDay ?? "not generated" },
+      {
+        label: "MCP stale clients",
+        value: String(mcpCompatibilityAdoption.staleEvents + mcpCompatibilityAdoption.incompatibleEvents),
+        delta: `${mcpCompatibilityAdoption.totalEvents} MCP event(s)`,
+      },
+      {
+        label: "Command usefulness",
+        value: `${commandUsefulness.totals.usefulCount}/${commandUsefulness.totals.feedbackCount}`,
+        delta: usefulnessDelta(commandUsefulness.totals.usefulnessRate),
+      },
+      {
+        label: "Install issues",
+        value: String(health.filter((record: InstallationHealthRecord) => record.status !== "healthy").length),
+        delta: "current health cache",
+      },
+      { label: "Rate-limit events", value: String(rateLimits.length), delta: "latest observations" },
+    ],
+    noiseReduction: [
+      {
+        label: "Healthy installations",
+        value: health.filter((record: InstallationHealthRecord) => record.status === "healthy").length,
+        spark: sparklineFromCounts(
+          health.filter((record: InstallationHealthRecord) => record.status === "healthy").length,
+          Math.max(health.length, 1),
+        ),
+      },
+      {
+        label: "Registered coverage",
+        value: registeredRepos,
+        spark: sparklineFromCounts(registeredRepos, Math.max(repositories.length, 1)),
+      },
+      {
+        label: "Installed coverage",
+        value: installedRepos,
+        spark: sparklineFromCounts(installedRepos, Math.max(repositories.length, 1)),
+      },
+    ],
+    weeklyReport: weeklyValueReport.summary,
+    weeklyValueReport,
+    usageSummary,
+    usageRollups,
+    usageRollupStatus,
+    mcpCompatibilityAdoption,
+    commandUsefulness,
+    registry,
+    scoringModel: scoring,
+    upstreamDrift,
+  };
+}
+
+export function latestUsageRollup(rollups: ProductUsageDailyRollupRecord[]): ProductUsageDailyRollupRecord | null {
+  if (rollups.length === 0) return null;
+  return [...rollups].sort((a, b) => b.day.localeCompare(a.day))[0] ?? null;
+}
+
+function usefulnessDelta(rate: number | null): string {
+  return rate === null ? "no feedback yet" : `${Math.round(rate * 100)}% useful over 30 days`;
+}
+
+function sparklineFromCounts(value: number, total: number): number[] {
+  const safeTotal = Math.max(total, 1);
+  const ratio = Math.min(1, Math.max(0, value / safeTotal));
+  return [Math.round(ratio * 40), Math.round(ratio * 55), Math.round(ratio * 70), Math.round(ratio * 85), Math.round(ratio * 100)];
+}

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildOperatorDashboardPayload, latestUsageRollup } from "../../src/services/operator-dashboard";
+import type { ProductUsageDailyRollupRecord } from "../../src/types";
+import { createTestEnv } from "../helpers/d1";
+
+const FORBIDDEN_EXPORT_TERMS =
+  /wallet|hotkey|raw trust|trust[-\s]?score|payout|reward[-\s]?estimate|farming|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)|\/Users|github_pat|ghp_/i;
+
+describe("operator dashboard payload", () => {
+  it("builds operator metrics from product usage rollups without sensitive strings", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt" });
+    const payload = await buildOperatorDashboardPayload(env);
+    const serialized = JSON.stringify(payload);
+
+    expect(payload.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Product events" }),
+        expect.objectContaining({ label: "Command usefulness" }),
+        expect.objectContaining({ label: "Activation rollups" }),
+      ]),
+    );
+    expect(payload.weeklyValueReport.variant).toBe("operator");
+    expect(payload.usageSummary).toMatchObject({ totalEvents: expect.any(Number), activeActors: expect.any(Number) });
+    expect(payload.commandUsefulness.totals).toMatchObject({ feedbackCount: expect.any(Number) });
+    expect(serialized).not.toMatch(FORBIDDEN_EXPORT_TERMS);
+  });
+
+  it("picks the newest rollup day for adoption insights", () => {
+    const rollups: ProductUsageDailyRollupRecord[] = [
+      rollup("2026-05-28"),
+      rollup("2026-05-30"),
+      rollup("2026-05-29"),
+    ];
+    expect(latestUsageRollup(rollups)?.day).toBe("2026-05-30");
+    expect(latestUsageRollup([])).toBeNull();
+  });
+});
+
+function rollup(day: string): ProductUsageDailyRollupRecord {
+  return {
+    day,
+    status: "complete",
+    totalEvents: 1,
+    activeActors: 1,
+    activeSessions: 1,
+    activeRepos: 1,
+    sourceEventCount: 1,
+    maxEventCapacity: 1000,
+    bySurface: [],
+    byOutcome: [],
+    byEvent: [],
+    byRepo: [],
+    byCommand: [],
+    byTool: [],
+    byRouteClass: [],
+    activation: {
+      loginActors: 1,
+      doctorPassActors: 1,
+      firstUsefulActionActors: 1,
+      fullyActivatedActors: 1,
+      githubInstalledRepos: 1,
+      githubFirstCommandRepos: 1,
+      githubUsefulMaintainerRepos: 1,
+      githubActivatedRepos: 1,
+    },
+    byRole: [{ role: "miner", count: 1, activeActors: 1, activeRepos: 0 }],
+    activationByRole: [
+      {
+        role: "miner",
+        loginActors: 1,
+        doctorPassActors: 1,
+        firstUsefulActionActors: 1,
+        fullyActivatedActors: 1,
+        githubInstalledRepos: 0,
+        githubFirstCommandRepos: 0,
+        githubUsefulMaintainerRepos: 0,
+        githubActivatedRepos: 0,
+      },
+    ],
+    activationBySurface: [],
+    retention: [],
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+}


### PR DESCRIPTION
Fixes #134

## Summary

- Completes the operator **Usage & value analytics** dashboard at `/app/analytics` using hashed `product_usage_*` rollups (not `audit_events` or raw source).
- Adds shared UI panels for weekly value metrics, product usage breakdown (MCP, GitHub commands, quiet skips, PR packets, decision packs, drift), adoption/retention by role, and command usefulness feedback.
- Extracts `buildOperatorDashboardPayload` in `src/services/operator-dashboard.ts` and adds `test/unit/operator-dashboard.test.ts` for payload shape and redaction.
- Restricts Analytics navigation to **operator** only so it matches `GET /v1/app/operator-dashboard` auth.

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

Verified locally with `npm run test:ci` on **Node v24.15.0** (repo requires Node >= 22 per `.nvmrc`). Fixes CI **UI check** failure on [run 26912190264](https://github.com/JSONbored/gittensory/actions/runs/26912190264) (`prettier/prettier` in `usage-analytics-panels.tsx` and `app.analytics.tsx`).

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None.

**Coverage summary (`npm run test:coverage`):** statements 99.08%, branches 97.00%, functions 98.40%, lines 99.66%. **New tests:** `test/unit/operator-dashboard.test.ts` (2 cases).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include screenshots or a short recording.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Weekly report **generation/export** remains on `/app/operator` and existing scheduled/internal jobs; `/app/analytics` displays rollup-backed metrics from `GET /v1/app/operator-dashboard`.
- Existing coverage: `test/unit/product-usage.test.ts`, `test/unit/weekly-value-report.test.ts`, `test/integration/api.test.ts` (operator-dashboard paths). New: `test/unit/operator-dashboard.test.ts`.
- Add a screenshot of `/app/analytics` (operator session) before merge if reviewers require UI proof.

## UI Evidence

<table>
  <tr>
    <td align="center"><b>Loaded — operator analytics</b><br/>
      <a href="https://github.com/user-attachments/assets/dec92394-1142-4c4a-8361-8a97123b4a50"><img src="https://github.com/user-attachments/assets/dec92394-1142-4c4a-8361-8a97123b4a50" width="360" alt="Loaded analytics"/></a>
    </td>
    <td align="center"><b>Empty — no rollup metrics yet</b><br/>
      <a href="https://github.com/user-attachments/assets/31b203a5-3b25-43f7-9571-d863caeee39f"><img src="https://github.com/user-attachments/assets/31b203a5-3b25-43f7-9571-d863caeee39f" width="360" alt="Empty analytics"/></a>
    </td>
    <td align="center"><b>Error — dashboard unavailable</b><br/>
      <a href="https://github.com/user-attachments/assets/7ca09743-f610-4d58-bcaf-816aee7ac715"><img src="https://github.com/user-attachments/assets/7ca09743-f610-4d58-bcaf-816aee7ac715" width="360" alt="Error analytics"/></a>
    </td>
  </tr>
</table>
