### PR TITLE
fix(advisory): keep private advisory text out of check runs

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -85,7 +85,8 @@ export function buildIssueAdvisory(repo: RepositoryRecord | null, issue: IssueRe
   return advisory("issue", targetKey, repoFullName, findings, "Issue advisory generated.", undefined, issue?.number);
 }
 
-const CHECK_RUN_FORBIDDEN_TERMS = /\b(reward|payout|farming|estimated score|raw trust score|wallet|hotkey|coldkey|reviewability|scoreability|private signal)\b/gi;
+const CHECK_RUN_FORBIDDEN_TERMS =
+  /\b(?:rewards?|payouts?|farming|estimated\s+scores?|raw\s+trust\s+scores?|trust\s+scores?|score\s+estimates?|reward\s+estimates?|wallets?|hotkeys?|coldkeys?|reviewability|scoreability|private\s+signals?)\b/gi;
 
 function sanitizeForCheckRun(text: string): string {
   return text.replace(CHECK_RUN_FORBIDDEN_TERMS, "[context]").replace(/\s+/g, " ").trim();
@@ -102,26 +103,17 @@ export function formatCheckRunOutput(
     return { title, summary, text: "No detailed findings are published in check runs." };
   }
 
-  const publicLines = advisoryResult.findings.map((f) => {
+  const publicLines = advisoryResult.findings.flatMap((f) => {
+    if (!f.publicText) return [];
     const label = f.severity === "warning" ? "⚠️" : "ℹ️";
-    const text = f.publicText ? sanitizeForCheckRun(f.publicText) : sanitizeForCheckRun(f.title);
-    return `${label} ${text}`;
+    return [`${label} ${sanitizeForCheckRun(f.publicText)}`];
   });
 
-  if (detailLevel === "standard") {
-    return { title, summary, text: publicLines.join("\n") };
+  if (publicLines.length === 0) {
+    return { title, summary, text: "No detailed findings are published in check runs." };
   }
 
-  // deep: include action hints for findings that carry publicText
-  const deepLines = advisoryResult.findings.flatMap((f) => {
-    const label = f.severity === "warning" ? "⚠️" : "ℹ️";
-    const text = f.publicText ? sanitizeForCheckRun(f.publicText) : sanitizeForCheckRun(f.title);
-    const lines = [`${label} ${text}`];
-    if (f.publicText && f.action) lines.push(`  → ${sanitizeForCheckRun(f.action)}`);
-    return lines;
-  });
-
-  return { title, summary, text: deepLines.join("\n") };
+  return { title, summary, text: publicLines.join("\n") };
 }
 
 function addRepoFindings(repo: RepositoryRecord, findings: AdvisoryFinding[]): void {

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -176,15 +176,23 @@ describe("GitHub check runs", () => {
       severity: "warning",
       title: "Gittensory advisory available",
       summary: "1 advisory finding generated.",
-      findings: [{ code: "missing_linked_issue", title: "No linked issue detected", severity: "warning", detail: "No closing reference." }],
+      findings: [
+        {
+          code: "missing_linked_issue",
+          title: "No linked issue detected",
+          severity: "warning",
+          detail: "No closing reference.",
+          publicText: "Public PR context is available for maintainer review.",
+        },
+      ],
       generatedAt: "2026-05-22T00:00:00.000Z",
     };
 
     const result = await createOrUpdateCheckRun(env, 123, "JSONbored/gittensory", advisory, "standard");
 
     expect(result).toMatchObject({ kind: "published", id: 77 });
-    expect(capturedBody.output?.text).toMatch(/⚠️/);
-    expect(capturedBody.output?.text).not.toMatch(/reward|wallet|hotkey|trust score|reviewability|farming/i);
+    expect(capturedBody.output?.text).toMatch(/⚠️ Public PR context is available/);
+    expect(capturedBody.output?.text).not.toMatch(/No linked issue|reward|wallet|hotkey|trust score|reviewability|farming/i);
   });
 
   it("returns permission_missing for message-based 422 permission errors", async () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -229,17 +229,51 @@ describe("advisory rules", () => {
           title: "reward wallet hotkey trust score reviewability",
           severity: "warning" as const,
           detail: "private detail",
-          publicText: "reward and farming content near wallet hotkey",
+          publicText: "rewards and farming content near wallets hotkeys with trust score and score estimate",
           action: "Check your scoreability and reviewability",
         },
       ],
     };
     for (const level of ["minimal", "standard", "deep"] as const) {
       const out = formatCheckRunOutput(poisoned, level);
-      expect(out.title).not.toMatch(/reward|wallet|hotkey|trust score|reviewability|scoreability|farming/i);
-      expect(out.summary).not.toMatch(/reward|wallet|hotkey|trust score|reviewability|scoreability|farming/i);
-      expect(out.text).not.toMatch(/reward|wallet|hotkey|trust score|reviewability|scoreability|farming/i);
+      expect(out.title).not.toMatch(/rewards?|wallets?|hotkeys?|trust score|score estimate|reviewability|scoreability|farming/i);
+      expect(out.summary).not.toMatch(/rewards?|wallets?|hotkeys?|trust score|score estimate|reviewability|scoreability|farming/i);
+      expect(out.text).not.toMatch(/rewards?|wallets?|hotkeys?|trust score|score estimate|reviewability|scoreability|farming/i);
     }
+  });
+
+  it("formatCheckRunOutput publishes only explicit public finding text", () => {
+    const advisory = buildPullRequestAdvisory(repo, null);
+    const output = formatCheckRunOutput(
+      {
+        ...advisory,
+        findings: [
+          {
+            code: "private_title",
+            title: "Maintainer allocation is configured",
+            severity: "info" as const,
+            detail: "Private allocation detail",
+            action: "Deep action exposes trust score and rewards estimate.",
+          },
+          {
+            code: "public_text",
+            title: "Private score estimate title",
+            severity: "warning" as const,
+            detail: "Private detail",
+            publicText: "Safe public repo context with trust score and rewards variants removed.",
+            action: "Do not publish this trust score action.",
+          },
+        ],
+      },
+      "deep",
+    );
+
+    expect(output.text).toContain("Safe public repo context");
+    expect(output.text).not.toContain("Maintainer allocation is configured");
+    expect(output.text).not.toContain("Private score estimate title");
+    expect(output.text).not.toContain("Deep action exposes");
+    expect(output.text).not.toContain("Do not publish this");
+    expect(output.text).not.toMatch(/trust score|rewards|score estimate/i);
   });
 
   it("classifies critical-severity findings as action_required", () => {
@@ -250,7 +284,8 @@ describe("advisory rules", () => {
     };
     const output = formatCheckRunOutput(withCritical, "standard");
     expect(output.title).toBe("Gittensory context posted");
-    expect(output.text).toMatch(/ℹ️|⚠️|Critical finding/);
+    expect(output.text).toContain("No detailed findings are published");
+    expect(output.text).not.toContain("Critical finding");
   });
 
   it("separates issue-discovery-only issues from clean split-lane issue advisories", () => {


### PR DESCRIPTION
### Motivation
- Prevent private or sensitive advisory text from being leaked to public GitHub check runs by ensuring only explicitly public content is published.
- Strengthen sanitization to match more variants of reward/score/wallet terminology that previously slipped through the narrow denylist.
- Remove an implicit fallback that published private finding titles and deep-mode actions to public check outputs.

### Description
- Replace the narrow forbidden-terms regex with a broader `CHECK_RUN_FORBIDDEN_TERMS` that covers plural forms and score/estimate/trust variants and related phrases in `src/rules/advisory.ts`.
- Change `formatCheckRunOutput` to publish only findings that include explicit `publicText` and to omit private `title` and `action` fallbacks, returning the minimal message when no `publicText` is present in `src/rules/advisory.ts`.
- Update unit tests to assert the new behavior and sanitization: extend the forbidden-term assertions and add tests ensuring only explicit `publicText` is published (`test/unit/rules.test.ts`), and adjust the GitHub check-run test to require `publicText` in published output (`test/unit/github-app.test.ts`).

### Testing
- Ran the targeted unit tests with `npx vitest run test/unit/rules.test.ts test/unit/github-app.test.ts` and they passed (27 tests total passed).
- Ran the TypeScript checker with `npm run typecheck` and it completed without errors.
- Ran `git diff --check` and there were no whitespace or diff-check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2097123b8c832c9c26f449a0486429)