### PR TITLE
fix(extension): enforce repo access for pull context

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1139,8 +1139,10 @@ export function createApp() {
     const pullNumber = Number(c.req.query("pullNumber") ?? "");
     if (!owner || !repoName || !Number.isInteger(pullNumber) || pullNumber <= 0) return c.json({ error: "valid_owner_repo_pull_required" }, 400);
     const fullName = `${owner}/${repoName}`;
-    const [repo, pullRequest, issues, pullRequests, files, reviews, checks, recentMergedPullRequests] = await Promise.all([
-      getRepository(c.env, fullName),
+    const repo = await getRepository(c.env, fullName);
+    const repoForbidden = await requireExtensionPullContextRepoAccess(c, identity, fullName, repo);
+    if (repoForbidden) return repoForbidden;
+    const [pullRequest, issues, pullRequests, files, reviews, checks, recentMergedPullRequests] = await Promise.all([
       getPullRequest(c.env, fullName, pullNumber),
       listIssues(c.env, fullName),
       listPullRequests(c.env, fullName),
@@ -3384,6 +3386,24 @@ async function requireCommandPreviewRepoAccess(
   /* v8 ignore next -- The broad route role guard already authenticates protected preview requests. */
   if (!identity) return c.json({ error: "unauthorized" }, 401);
   if (identity.kind !== "session" || !repoFullName) return null;
+  return requireSessionRepoAccess(c, identity, repoFullName, repo);
+}
+
+async function requireExtensionPullContextRepoAccess(
+  c: ProtectedRouteContext,
+  identity: Extract<AuthIdentity, { kind: "session" }>,
+  repoFullName: string,
+  repo: RepositoryRecord | null,
+): Promise<Response | null> {
+  return requireSessionRepoAccess(c, identity, repoFullName, repo);
+}
+
+async function requireSessionRepoAccess(
+  c: ProtectedRouteContext,
+  identity: Extract<AuthIdentity, { kind: "session" }>,
+  repoFullName: string,
+  repo: RepositoryRecord | null,
+): Promise<Response | null> {
   const summary = await loadControlPanelRoleSummary(c.env, identity.actor);
   if (summary.roles.includes("operator")) return null;
   const scope = await loadControlPanelAccessScope(c.env, identity.actor);

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1549,6 +1549,13 @@ describe("api routes", () => {
       ownerEnv,
     );
     expect(ownerExtensionMissingPull.status).toBe(400);
+    const forbiddenVictimExtensionContext = await app.request(
+      "/v1/extension/pull-context?owner=victim-org&repo=secret-repo&pullNumber=42",
+      { headers: { authorization: `Bearer ${ownerExtensionSessionBody.token}` } },
+      ownerEnv,
+    );
+    expect(forbiddenVictimExtensionContext.status).toBe(403);
+    await expect(forbiddenVictimExtensionContext.json()).resolves.toMatchObject({ error: "forbidden_repo" });
     const ownerRepoPreview = await app.request(
       "/v1/app/commands/preview",
       {


### PR DESCRIPTION
### Motivation
- Prevent object-authorization leakage where an extension-scoped session could request private maintainer sidebar context for arbitrary repositories by supplying owner/repo/pullNumber query parameters.

### Description
- Require per-repository session authorization for the `/v1/extension/pull-context` route before loading pull/issue/PR artifacts by checking repo scope ownership and operator role. (modified `src/api/routes.ts`)
- Introduce a shared session repository-access helper `requireSessionRepoAccess` and a wrapper `requireExtensionPullContextRepoAccess` so extension context access follows the same rules as existing command-preview repo checks. (modified `src/api/routes.ts`)
- Add an integration regression test that asserts an owner-scoped extension token cannot read a different org's private PR context, returning `forbidden_repo` when unauthorized. (modified `test/integration/api.test.ts`)

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npx vitest run test/integration/api.test.ts --reporter=verbose` and the integration suite passed (1 file, 24 tests). 
- Local checks (`git diff --check`) showed no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211a68770c832c88cc82025cee8c87)