### PR TITLE
test(coverage): widen branch buffer and add CI coverage-gate guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,17 @@ jobs:
         run: npm run typecheck
 
       - name: Test with coverage
+        id: coverage
         run: npm run test:coverage
+
+      - name: Coverage gate guidance
+        if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
+        run: |
+          echo "::error title=Coverage gate::Tests or the 97% coverage gate failed."
+          echo "The repo enforces 97% global coverage for lines, statements, functions, and branches."
+          echo "Review the per-file coverage table printed above to find undercovered files and branch arms."
+          echo "Run 'npm run test:coverage' locally and add tests for the missing branches, fallback paths, and sanitizer rules."
+          echo "See CONTRIBUTING.md (Testing & coverage): aim for 98%+ branch coverage locally so small CI variance does not fail near the threshold."
 
       - name: Worker runtime tests
         run: npm run test:workers

--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -84,6 +84,33 @@ describe("pending PR scenario detection", () => {
     expect(detection?.classified.find((entry) => entry.number === 12)?.classification).toBe("blocked");
   });
 
+  it("treats timed-out checks as failing work that blocks merge readiness", () => {
+    const classified = classifyOpenPullRequest({
+      pr: pr({ number: 77 }),
+      roleContext: outsideContributorRole,
+      reviews: [approvedReview(77)],
+      checks: [{ id: "c77", repoFullName: "entrius/allways-ui", pullNumber: 77, name: "ci", status: "completed", conclusion: "timed_out", payload: {} }],
+    });
+    expect(classified.classification).toBe("blocked");
+    expect(classified.reasons.join(" ")).toMatch(/failing or cancelled check/i);
+  });
+
+  it("counts stale approved PRs as pending closes and projects the post-cleanup open count", () => {
+    const staleDate = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const detection = detectPendingPrScenario({
+      login: "miner-a",
+      repoFullName: "entrius/allways-ui",
+      pullRequests: [pr({ number: 21, updatedAt: staleDate, createdAt: staleDate })],
+      roleContext: outsideContributorRole,
+      openPrCount: 2,
+      reviewsByPullNumber: new Map([[21, [approvedReview(21)]]]),
+      checksByPullNumber: new Map([[21, []]]),
+    });
+    expect(detection?.pendingMergedPrCount).toBe(0);
+    expect(detection?.pendingClosedPrCount).toBe(1);
+    expect(detection?.expectedOpenPrCountAfterMerge).toBe(1);
+  });
+
   it("does not treat draft, stale, or maintainer-lane PRs as likely-to-land", () => {
     const staleDate = new Date(Date.now() - 20 * 86_400_000).toISOString();
     const classified = [

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -263,4 +263,30 @@ describe("buildRepoSettingsPreview", () => {
     expect(preview.previewComment).not.toBeNull();
     expect(preview.previewComment ?? "").not.toMatch(/wallet|hotkey|trust score|raw trust|scoreability|payout|reward|farming|\/100|reviewability\s*\d/i);
   });
+
+  it("reports a generic needs-attention summary when health is degraded but no permission or event is missing", () => {
+    const preview = buildRepoSettingsPreview({
+      ...base,
+      settings: settings(),
+      installation: { ...healthyInstall, status: "needs_attention", missingPermissions: [], missingEvents: [] },
+      sample: { authorLogin: "miner", minerStatus: "confirmed" },
+    });
+    expect(preview.installPreview.status).toBe("needs_attention");
+    expect(preview.installPreview.permissions.summary).toMatch(/needs attention; review remediation/i);
+    expect(preview.installPreview.permissions.missing).toEqual([]);
+  });
+
+  it("requires no issues/checks write scope and lists a no-output sample when every public action is disabled", () => {
+    const preview = buildRepoSettingsPreview({
+      ...base,
+      settings: settings({ publicSurface: "label_only", autoLabelEnabled: false, commentMode: "off", checkRunMode: "off" }),
+      installation: healthyInstall,
+      sample: { authorLogin: "miner", minerStatus: "confirmed" },
+    });
+    expect(preview.decision).toMatchObject({ skipped: false, willComment: false, willLabel: false, willCheckRun: false, actions: ["none"] });
+    // requiredInstallPermissions keeps only read scopes when no public write action is enabled.
+    expect(preview.installPreview.permissions.required).toEqual(["metadata: read", "pull_requests: read"]);
+    expect(preview.installPreview.publicOutputs).toEqual(["No public comment, label, or check run for this sample."]);
+    expect(preview.installPreview.checklist.find((item) => item.id === "public-outputs")?.summary).toMatch(/no public output action is enabled/i);
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #84. The 97% global coverage gate (`vitest.config.ts`) and the 97%-gate/98%-local-target guidance (`CONTRIBUTING.md` + PR template) are already in place on `main`; this PR widens the branch-coverage buffer above the gate and makes coverage failures self-explanatory in CI.
- Adds a CI **Coverage gate guidance** step that fires only when the coverage step fails and points contributors at the per-file table, the 97% gate, the local `npm run test:coverage` workflow, and the CONTRIBUTING coverage section.
- Adds targeted, real-branch tests (no shallow line-padding) for previously-uncovered fallback/branch paths.
- Global branch coverage **97.02% → 97.09% (9671/9960)**; lines 99.65%, statements 99.08%, functions 98.43% — all above 97% with headroom.

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Closes #84)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` — clean (ran `github-actionlint .github/workflows/ci.yml` directly; the npm script's glob is a Windows-only shell limitation)
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` locally — 959 pass (1 skipped); branch **97.09%**, lines 99.65%, statements 99.08%, functions 98.43% (the 3 pre-existing Windows-only spawn failures `mcp-cli`, `github-type-label`, `mcp-release` were excluded locally and are unaffected)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Worker/MCP/UI/audit steps run in CI on Linux; the local environment has known Windows-only failures in `mcp-cli`/`mcp-release`/`type-label` tooling unrelated to this change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Settings-preview tests assert read-only scope and the existing forbidden-language sanitizer regression remains green.)
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (n/a)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (n/a — tests + CI only)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (n/a)
- [ ] Visible UI changes include screenshots or a short recording. (n/a)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog/snapshot files modified by this PR or the test run.)

## Notes

- **CI failure visibility:** the new `ci.yml` step uses `if: ${{ failure() && steps.coverage.conclusion == 'failure' }}` so it only fires for coverage failures (not typecheck/lint), emitting a `::error::` with the 97% policy, where to find the per-file table, the local repro command, and the CONTRIBUTING reference.
- **New tests cover real branches, not padding:**
  - `settings-preview`: a generic *needs-attention* summary when install health is degraded with no missing permission/event; a *qualifies-but-no-public-output* sample that keeps install scope read-only (`metadata: read`, `pull_requests: read`) and lists no public output (`requiredInstallPermissions` / `activeMissingPermissions` / `publicOutputsFor` / `publicOutputSummary` fallbacks).
  - `pending-pr-scenarios`: regression tests for **timed-out** checks blocking merge readiness and **stale approved** PRs counting as pending closes with a correct post-cleanup open-count projection.
- **Acceptance criteria:** `test:coverage` passes at ≥97% for all four metrics with branch headroom; the template/guidance already state the policy; the test run modifies no snapshot or generated changelog files (verified via `git status` — only the three intended files changed).
- Most of the binding remaining branches sit in integration-heavy `routes.ts`/`repositories.ts`; per the issue ("targeted tests around existing behavior rather than inflating coverage"), those are left for incremental follow-up rather than padded here.
