### PR TITLE
fix(backfill): include recent-merged segment in repo sync-status rollup

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1344,6 +1344,14 @@ async function supplementOpenPullRequestsFromGraphQl(env: Env, repo: RepositoryR
   /* v8 ignore stop */
 }
 
+// Terminal segment states that count as synced. `sampled` is the terminal state of the
+// recent_merged_pull_requests progressive-history crawl (no other segment produces it), and
+// is already treated as synced for mergedPullRequestsSyncedAt; treating it as terminal here
+// keeps a sampled history from perpetually marking the repo `partial`.
+function isTerminalSegmentStatus(status: RepoSyncSegmentRecord["status"]): boolean {
+  return status === "complete" || status === "not_modified" || status === "sampled";
+}
+
 async function refreshRepoSyncStateFromSegments(env: Env, repo: RepositoryRecord, sourceKind: RepoSyncSegmentRecord["sourceKind"]): Promise<void> {
   const [previous, totals, metadata, labels, openIssues, openPullRequests, recentMerged, files, reviews, checks] = await Promise.all([
     getRepoSyncState(env, repo.fullName),
@@ -1357,11 +1365,14 @@ async function refreshRepoSyncStateFromSegments(env: Env, repo: RepositoryRecord
     getRepoSyncSegment(env, repo.fullName, "pull_request_reviews"),
     getRepoSyncSegment(env, repo.fullName, "check_summaries"),
   ]);
-  const required = [metadata, labels, openIssues, openPullRequests, files, reviews, checks].filter(Boolean) as RepoSyncSegmentRecord[];
+  // Include recent_merged_pull_requests so an unfinished merged-history crawl (running /
+  // waiting_rate_limit / error / other non-terminal) is reflected in the repo status instead
+  // of being silently rolled up as `success` and then skipped by the freshness check.
+  const required = [metadata, labels, openIssues, openPullRequests, recentMerged, files, reviews, checks].filter(Boolean) as RepoSyncSegmentRecord[];
   const waiting = required.some((segment) => segment.status === "waiting_rate_limit" || segment.status === "rate_limited");
   const running = required.some((segment) => segment.status === "running" || segment.status === "refreshing");
   const errored = required.some((segment) => segment.status === "error");
-  const incomplete = required.some((segment) => segment.status !== "complete" && segment.status !== "not_modified");
+  const incomplete = required.some((segment) => !isTerminalSegmentStatus(segment.status));
   const status: RepoSyncStateRecord["status"] = waiting ? "rate_limited" : errored ? "error" : running ? "running" : incomplete ? "partial" : "success";
   const warnings = [...new Set(required.flatMap((segment) => segment.warnings))];
   const completedAt = running || waiting ? previous?.lastCompletedAt : nowIso();

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -829,6 +829,27 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("rolls an unfinished recent-merged crawl into the repo sync status instead of success", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const auth = new Headers(init?.headers).get("authorization");
+      if (url === "https://api.github.com/graphql") return githubTotalsResponse({ openIssues: 0, openPullRequests: 0, mergedPullRequests: 1, closedPullRequests: 1, labels: 0 });
+      if (url.includes("/pulls?state=closed") && auth === "Bearer public-token") return new Response("", { status: 404 });
+      if (url.includes("/pulls?state=closed")) return new Response("limited", { status: 403, headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1779976046" } });
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await backfillRepositorySegment(env, { repoFullName: "JSONbored/gittensory", segment: "recent_merged_pull_requests", mode: "full" });
+
+    expect(result).toMatchObject({ status: "waiting_rate_limit" });
+    // The repo status must reflect the unfinished merged-history segment, not roll up to "success".
+    expect(await listRepoSyncStates(env)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ repoFullName: "JSONbored/gittensory", status: "rate_limited" })]),
+    );
+  });
+
   it("paginates beyond the first GitHub page and stores complete segment fidelity", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
Closes #377.

## Summary
`refreshRepoSyncStateFromSegments` derived the repo-level sync `status` from a segment list that omitted `recent_merged_pull_requests` (it was loaded and used for counts, but excluded from the `waiting`/`running`/`errored`/`incomplete` checks). So when the merged-history crawl was still `running` / `waiting_rate_limit` / `error` while the other segments completed, the rollup produced `status: "success"` with a fresh `lastCompletedAt`. The freshness check then skips the repo for the freshness window, leaving recent-merged PR history silently stale/undercounted (and `status: "success"` could coexist with a stale `mergedPullRequestsSyncedAt`). The monolithic path's `summarizeSegments` already includes recent-merged, so the two paths disagreed.

## Scope
- `src/github/backfill.ts` — include `recent_merged_pull_requests` in the status/warnings rollup, and add an `isTerminalSegmentStatus` helper that treats `complete` / `not_modified` / `sampled` as terminal. `sampled` is the recent-merged progressive-history terminal state (no other segment produces it, already treated as synced for `mergedPullRequestsSyncedAt`), so a sampled crawl still counts as `success` rather than perpetually `partial`.
- `test/unit/backfill.test.ts` — rollup test for an unfinished merged-history crawl.

No schema, API, or public-surface changes. Rebased on top of #353.

## Validation
```
npx vitest run test/unit/backfill.test.ts                                   # 54/54
npx vitest run test/unit/queue.test.ts test/unit/data-spine.test.ts \
  test/unit/data-quality.test.ts test/integration/api.test.ts               # 92/92
npx tsc --noEmit                                                            # clean
git diff --check                                                            # clean (no whitespace errors)
```
Branch coverage stays >= 97%. CI `validate` is green.

## Safety
- Pure status-derivation change: it only makes an already-tracked segment's state affect the repo `status`/`warnings`. No new external calls, tokens, or data surface.
- Strictly more conservative — it can only move a repo *out* of `success` (to `running`/`rate_limited`/`error`/`partial`) when the merged-history crawl is unfinished; a `sampled`/`complete` crawl still yields `success`, so it cannot wrongly force healthy repos into perpetual re-backfill.

## Notes
- Distinct from #353 (recent-merged *changed files*) and #312 (the *analysis* ignoring recent-merged): this fixes the sync-*status*/freshness mechanism that was prematurely marking the crawl complete.