### PR TITLE
fix(signals): derive cache-only contributor outcome totals consistently

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1536,17 +1536,26 @@ export function buildContributorOutcomeHistory(args: {
       };
     })
     .filter((outcome) => outcome.pullRequests + outcome.issues > 0 || outcome.maintainerLane);
+  // When official Gittensor totals are absent, derive every PR/issue total from the same
+  // login-scoped, internally-consistent repoOutcomes (each repo keeps pullRequests >=
+  // merged + open + closed and issues = openIssues + closedIssues). Previously pullRequests/
+  // mergedPullRequests fell back to registeredRepoActivity and openPullRequests to an
+  // unfiltered repoStats sum, breaking the invariant and letting closedPullRequestRate exceed 1.
+  const sumOutcomes = (pick: (outcome: (typeof repoOutcomes)[number]) => number): number => repoOutcomes.reduce((sum, outcome) => sum + pick(outcome), 0);
+  const gittensorTotals = args.profile.gittensor?.totals;
+  const openIssues = gittensorTotals?.openIssues ?? sumOutcomes((outcome) => outcome.openIssues);
+  const closedIssues = gittensorTotals?.closedIssues ?? sumOutcomes((outcome) => outcome.closedIssues);
   const totals = {
-    pullRequests: args.profile.gittensor?.totals.pullRequests ?? args.profile.registeredRepoActivity.pullRequests,
-    mergedPullRequests: args.profile.gittensor?.totals.mergedPullRequests ?? args.profile.registeredRepoActivity.mergedPullRequests,
-    openPullRequests: args.profile.gittensor?.totals.openPullRequests ?? args.repoStats.reduce((sum, stat) => sum + stat.openPullRequests, 0),
-    closedPullRequests: args.profile.gittensor?.totals.closedPullRequests ?? repoOutcomes.reduce((sum, outcome) => sum + outcome.closedPullRequests, 0),
+    pullRequests: gittensorTotals?.pullRequests ?? sumOutcomes((outcome) => outcome.pullRequests),
+    mergedPullRequests: gittensorTotals?.mergedPullRequests ?? sumOutcomes((outcome) => outcome.mergedPullRequests),
+    openPullRequests: gittensorTotals?.openPullRequests ?? sumOutcomes((outcome) => outcome.openPullRequests),
+    closedPullRequests: gittensorTotals?.closedPullRequests ?? sumOutcomes((outcome) => outcome.closedPullRequests),
     closedPullRequestRate: 0,
-    issues: args.profile.registeredRepoActivity.issues,
-    openIssues: args.profile.gittensor?.totals.openIssues ?? repoOutcomes.reduce((sum, outcome) => sum + outcome.openIssues, 0),
-    closedIssues: args.profile.gittensor?.totals.closedIssues ?? repoOutcomes.reduce((sum, outcome) => sum + outcome.closedIssues, 0),
-    solvedIssues: args.profile.gittensor?.totals.solvedIssues ?? repoOutcomes.reduce((sum, outcome) => sum + outcome.solvedIssues, 0),
-    validSolvedIssues: args.profile.gittensor?.totals.validSolvedIssues ?? repoOutcomes.reduce((sum, outcome) => sum + outcome.validSolvedIssues, 0),
+    issues: openIssues + closedIssues,
+    openIssues,
+    closedIssues,
+    solvedIssues: gittensorTotals?.solvedIssues ?? sumOutcomes((outcome) => outcome.solvedIssues),
+    validSolvedIssues: gittensorTotals?.validSolvedIssues ?? sumOutcomes((outcome) => outcome.validSolvedIssues),
     credibility: args.profile.gittensor?.credibility ?? 0,
     issueCredibility: args.profile.gittensor?.issueCredibility ?? 0,
   };

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -740,6 +740,47 @@ describe("v2 signal builders", () => {
     expect(history.reconciliation?.repos[0]?.discrepancyReasons).toEqual(expect.arrayContaining([expect.stringContaining("Official source unavailable")]));
   });
 
+  it("derives cache-only totals consistently and login-scoped (pullRequests = merged + open + closed)", () => {
+    const widgetRepo: RepositoryRecord = {
+      fullName: "acme/widgets",
+      owner: "acme",
+      name: "widgets",
+      isInstalled: true,
+      isRegistered: true,
+      isPrivate: false,
+      defaultBranch: "main",
+      registryConfig: { repo: "acme/widgets", emissionShare: 0.02, issueDiscoveryShare: 0, labelMultipliers: {}, trustedLabelPipeline: false, maintainerCut: 0, raw: {} },
+    };
+    const mk = (number: number, state: string, extra: Partial<PullRequestRecord> = {}): PullRequestRecord => ({
+      repoFullName: "acme/widgets",
+      number,
+      title: `PR ${number}`,
+      state,
+      authorLogin: "dev",
+      authorAssociation: "NONE",
+      labels: [],
+      linkedIssues: [],
+      body: "",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      ...extra,
+    });
+    const prs = [mk(1, "merged", { mergedAt: "2026-05-01T00:00:00.000Z" }), mk(2, "open"), mk(3, "closed")];
+    const profile = buildContributorProfile("dev", { login: "dev", topLanguages: ["TypeScript"], source: "github" }, prs, []);
+    // repoStats includes a DIFFERENT login that must not leak into this contributor's totals.
+    const repoStats: ContributorRepoStatRecord[] = [
+      { login: "dev", repoFullName: "acme/widgets", pullRequests: 3, mergedPullRequests: 1, openPullRequests: 1, issues: 0, stalePullRequests: 0, unlinkedPullRequests: 0, dominantLabels: [] },
+      { login: "stranger", repoFullName: "acme/tools", pullRequests: 5, mergedPullRequests: 0, openPullRequests: 5, issues: 0, stalePullRequests: 0, unlinkedPullRequests: 0, dominantLabels: [] },
+    ];
+    const history = buildContributorOutcomeHistory({ login: "dev", profile, repositories: [widgetRepo], pullRequests: prs, issues: [], repoStats });
+
+    const t = history.totals;
+    // Invariant, login-scoping, and bounded rate were all broken by the mixed-source fallbacks.
+    expect(t.pullRequests).toBe(t.mergedPullRequests + t.openPullRequests + t.closedPullRequests);
+    expect(t.issues).toBe(t.openIssues + t.closedIssues);
+    expect(t.closedPullRequestRate).toBeLessThanOrEqual(1);
+    expect(t.openPullRequests).toBe(1); // the stranger's 5 open PRs are excluded
+  });
+
   it("derives solved and valid-solved issue-discovery counts from cache when official data is absent", () => {
     const mkRepo = (fullName: string, issueDiscoveryShare: number): RepositoryRecord => {
       const [owner, name] = fullName.split("/") as [string, string];


### PR DESCRIPTION
Closes #380.

## Summary
In `buildContributorOutcomeHistory`, the per-repo `repoOutcomes` are internally consistent (each repo keeps `pullRequests >= merged + open + closed` and `issues = openIssues + closedIssues`), and the totals already sum `repoOutcomes` for `closedPullRequests` / `openIssues` / `closedIssues` / `solvedIssues`. But the cache fallbacks for `pullRequests` / `mergedPullRequests` used `registeredRepoActivity` (a separate `Math.max` aggregate), `openPullRequests` used an unfiltered `repoStats` sum, and `issues` used `registeredRepoActivity.issues` with no official fallback. So for a cache-only contributor (no official Gittensor snapshot) the totals were internally inconsistent: `pullRequests != merged + open + closed`, `closedPullRequestRate = rate(closed, pullRequests)` could exceed 1, and `openPullRequests` was the only `repoStats` access not scoped to the subject login.

## Scope
- `src/signals/engine.ts` — when official totals are absent, derive every PR/issue total by summing the same login-scoped, internally-consistent `repoOutcomes` (via a `sumOutcomes` helper), and compute `issues` as `openIssues + closedIssues`. Fixes the invariant, the out-of-range rate, and the login-scoping of `openPullRequests` in one consolidation.
- `test/unit/signals-v2.test.ts` — cache-only totals consistency + login-scoping test.

No schema, API, or public-surface changes.

## Validation
```
npx vitest run test/unit/signals.test.ts test/unit/signals-v2.test.ts \
  test/unit/signals-coverage.test.ts test/unit/decision-pack.test.ts \
  test/unit/agent-orchestrator.test.ts                                       # 125/125
npx tsc --noEmit                                                            # clean
git diff --check                                                            # clean (no whitespace errors)
```
Branch coverage stays >= 97%. CI `validate` is green.

## Safety
- Pure aggregation change scoped to the cache-only fallback path; the official-data path is unchanged in behavior except that `issues` is now `openIssues + closedIssues` (consistent with the per-repo definition) instead of a separate `registeredRepoActivity` value. No new external calls, tokens, or data surface.
- The new totals are derived from the already-computed, login-scoped `repoOutcomes`, so they cannot include another contributor's rows, and `closedPullRequestRate` is now bounded by a denominator consistent with its numerator.

## Notes
- Reachable for any contributor without an official Gittensor snapshot (new/unranked contributors). `closedPullRequestRate` gates the >= 0.35 high-closure-risk / avoid-repo strategy thresholds, so the inconsistent rate could mis-classify a contributor.