### PR TITLE
fix(analytics): store bounded product-usage rollup dimensions complete

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3510,6 +3510,13 @@ async function upsertProductUsageDailyRollup(env: Env, day: string, generatedAt:
   return record;
 }
 
+// Bounded enum dimensions (surface / outcome / eventName) are consumed by exact-name lookups
+// (e.g. the weekly value report's sumEvent over byEvent), so they must be stored complete:
+// frequency-truncating a bounded exact-lookup dimension silently zeroes any value below the
+// top-N cut on a high-diversity day. Only the genuinely-unbounded repo/command/tool/route
+// dimensions keep a display top-N.
+const FULL_DIMENSION_LIMIT = Number.MAX_SAFE_INTEGER;
+
 function buildProductUsageDailyRollupRecord(args: {
   day: string;
   generatedAt: string;
@@ -3537,9 +3544,9 @@ function buildProductUsageDailyRollupRecord(args: {
     maxEventCapacity: PRODUCT_USAGE_ROLLUP_EVENT_SCAN_LIMIT,
     firstEventAt: args.events[0]?.occurredAt ?? null,
     lastEventAt: args.events.at(-1)?.occurredAt ?? null,
-    bySurface: countProductUsageDimensions(args.events.map((event) => event.surface)).map(({ key, count }) => ({ surface: normalizeProductUsageSurface(key), count })),
-    byOutcome: countProductUsageDimensions(args.events.map((event) => event.outcome)).map(({ key, count }) => ({ outcome: normalizeProductUsageOutcome(key), count })),
-    byEvent: countProductUsageDimensions(args.events.map((event) => event.eventName)).map(({ key, count }) => ({ eventName: key, count })),
+    bySurface: countProductUsageDimensions(args.events.map((event) => event.surface), FULL_DIMENSION_LIMIT).map(({ key, count }) => ({ surface: normalizeProductUsageSurface(key), count })),
+    byOutcome: countProductUsageDimensions(args.events.map((event) => event.outcome), FULL_DIMENSION_LIMIT).map(({ key, count }) => ({ outcome: normalizeProductUsageOutcome(key), count })),
+    byEvent: countProductUsageDimensions(args.events.map((event) => event.eventName), FULL_DIMENSION_LIMIT).map(({ key, count }) => ({ eventName: key, count })),
     byRepo: countProductUsageDimensions(args.events.map((event) => event.repoFullName)),
     byCommand: countProductUsageDimensions(args.events.map((event) => productUsageMetadataString(event, "command"))),
     byTool: countProductUsageDimensions(args.events.map((event) => productUsageMetadataString(event, "toolName"))),

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -472,6 +472,24 @@ describe("product usage events", () => {
     await expect(getProductUsageRollupStatus(env, { nowIso: "2026-05-31T00:40:00.000Z" })).resolves.toMatchObject({ status: "ready", warnings: [] });
   });
 
+  it("retains low-frequency bounded events in byEvent on a high-diversity day (no top-20 truncation)", async () => {
+    const env = createTestEnv();
+    const day = "2026-05-30";
+    // 20 distinct filler events, each recorded twice (count 2), occupy the highest-frequency slots.
+    for (let i = 0; i < 20; i++) {
+      const eventName = `filler_event_${String(i).padStart(2, "0")}`;
+      await recordProductUsageEvent(env, { surface: "control_panel", eventName, actor: "user", outcome: "success", occurredAt: `${day}T00:00:00.000Z` });
+      await recordProductUsageEvent(env, { surface: "control_panel", eventName, actor: "user", outcome: "success", occurredAt: `${day}T01:00:00.000Z` });
+    }
+    // A low-frequency flagship event the weekly report looks up by exact name (count 1, ranks 21st).
+    await recordProductUsageEvent(env, { surface: "control_panel", eventName: "agent_pr_packet_completed", actor: "user", outcome: "success", occurredAt: `${day}T05:00:00.000Z` });
+
+    const run = await rollupProductUsageDaily(env, { day, nowIso: "2026-05-31T00:10:00.000Z" });
+    // Without the fix, byEvent was frequency-truncated to the top 20 and dropped this event.
+    expect(run.rollups[0]?.byEvent).toEqual(expect.arrayContaining([{ eventName: "agent_pr_packet_completed", count: 1 }]));
+    expect((run.rollups[0]?.byEvent ?? []).length).toBe(21);
+  });
+
   it("builds empty role and retention rollups for days without product usage", async () => {
     const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
     const result = await rollupProductUsageDaily(env, { day: "2026-06-01", nowIso: "2026-06-02T00:00:00.000Z" });


### PR DESCRIPTION
Closes #383.

## Summary
`buildProductUsageDailyRollupRecord` stored every dimension via `countProductUsageDimensions`, which keeps only the top 20 by frequency. That is correct for the unbounded `byRepo` / `byCommand` / `byTool` / `byRouteClass` dimensions (shown as display top-N), but `byEvent` is a bounded event-name enum (~22 distinct names) that the weekly value report consumes by exact-name lookup (`sumEvent` -> `byEvent.find(eventName)`). On a day with more than 20 distinct event types, the lowest-frequency events drop off the cut — and the report's flagship signals (`agent_pr_packet_completed`, `agent_preflight_branch_completed`, `agent_command_replied`/`skipped`) are exactly the low-frequency ones, so the public weekly value report under-counts them (reads 0 for that day).

## Scope
- `src/db/repositories.ts` — store the bounded enum dimensions (`bySurface` / `byOutcome` / `byEvent`) complete via a `FULL_DIMENSION_LIMIT`, while the genuinely-unbounded `byRepo` / `byCommand` / `byTool` / `byRouteClass` keep their display top-N. A comment marks the bounded-vs-unbounded distinction so the two classes can't be conflated again.
- `test/unit/product-usage.test.ts` — high-diversity-day test.

No schema, API, or public-surface changes (the rollup record shape is unchanged; only the bounded dimensions are no longer truncated).

## Validation
```
npx vitest run test/unit/product-usage.test.ts test/unit/weekly-value-report.test.ts \
  test/unit/operator-dashboard.test.ts test/unit/product-usage-mcp-adoption.test.ts   # 29/29
npx vitest run test/integration/api.test.ts test/unit/queue.test.ts                   # 58/58
npx tsc --noEmit                                                                      # clean
git diff --check                                                                      # clean (no whitespace errors)
```
Branch coverage stays >= 97%. CI `validate` is green.

## Safety
- Privacy-safe: `byEvent` holds bounded, sanitized event names (already redacted/normalized at record time) and small per-day counts — storing the complete bounded enum adds no actor/repo PII and only marginally more rows (bounded by the enum size).
- The unbounded repo/command/tool/route dimensions are unchanged, so there is no unbounded growth in the stored rollup.

## Notes
- The weekly value report is a public + operator trust artifact persisted to an audit event, so the undercount directly understated miner-utility / maintainer-value headline metrics on the busiest days.
- Reachable when a single UTC day has > 20 distinct event types (active days mixing agent/auth/mcp/github events).