### PR TITLE
fix(signals): wire duplicate-risk collision count into the duplicate_risk score blocker

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -250,6 +250,7 @@ export function buildLocalBranchAnalysis(args: {
     outcomeHistory: args.outcomeHistory,
     repoOutcome,
     observedPullRequestScenarios,
+    duplicateRiskCount: preflight.collisions.filter((cluster) => cluster.risk === "high").length,
   });
   const scorePreview = buildScorePreview({
     input: scoreInput,
@@ -392,6 +393,7 @@ function buildLocalScoreInput(args: {
   outcomeHistory: ContributorOutcomeHistory;
   repoOutcome?: ContributorOutcomeHistory["repoOutcomes"][number] | undefined;
   observedPullRequestScenarios: ObservedPullRequestScenarios;
+  duplicateRiskCount: number;
 }): ScorePreviewInput {
   const scorer = args.input.localScorer;
   const testLineCount = args.changedFiles.filter((file) => isTestFile(file.path)).reduce((sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions), 0);
@@ -424,6 +426,7 @@ function buildLocalScoreInput(args: {
     observedDraftPrCount: args.observedPullRequestScenarios.draft,
     observedBlockedPrCount: args.observedPullRequestScenarios.blocked,
     observedMaintainerPrCount: args.observedPullRequestScenarios.maintainerLane,
+    duplicateRiskCount: args.duplicateRiskCount,
     expectedOpenPrCountAfterMerge: args.input.expectedOpenPrCountAfterMerge,
     projectedCredibility: args.input.projectedCredibility,
     scenarioNotes: args.input.scenarioNotes,

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -197,6 +197,7 @@ export function buildRepoRewardRisk(args: {
     existingContributorTokenScore: 0,
     credibility,
     metadataOnly: true,
+    duplicateRiskCount: collisions.summary.highRiskCount,
   };
   const currentPreview = buildScorePreview({
     input: { ...commonPreviewInput, openPrCount: currentOpenPrCount },

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -63,6 +63,35 @@ describe("local branch analysis", () => {
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
   });
 
+  it("surfaces a duplicate_risk reducer when the branch collides with a high-risk overlap cluster", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        title: "Fix dashboard cache refresh after reconnect",
+        body: "Fixes #7",
+        labels: ["bug"],
+        changedFiles: [{ path: "src/cache.ts", additions: 42, deletions: 4, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 48, totalTokenScore: 80, sourceLines: 46 },
+      },
+      repo,
+      // Issue #7 already has two open PRs targeting it -> a high-risk overlap cluster that
+      // also overlaps the branch (same dashboard-cache-refresh terms).
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Dashboard cache refresh fails after reconnect", state: "open", labels: ["bug"], linkedPrs: [21, 22] }],
+      pullRequests: [
+        { repoFullName: repo.fullName, number: 21, title: "Dashboard cache refresh fix after reconnect", state: "open", authorLogin: "other1", authorAssociation: "NONE", labels: ["bug"], linkedIssues: [7], body: "Fixes #7", updatedAt: "2026-05-20T00:00:00.000Z" },
+        { repoFullName: repo.fullName, number: 22, title: "Dashboard cache reconnect refresh fix", state: "open", authorLogin: "other2", authorAssociation: "NONE", labels: ["bug"], linkedIssues: [7], body: "Fixes #7", updatedAt: "2026-05-21T00:00:00.000Z" },
+      ],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    // The duplicate_risk reducer was dead before this fix: duplicateRiskCount had no producer.
+    expect(analysis.scorePreview.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ code: "duplicate_risk" })]));
+  });
+
   it("bounds local scorer warnings before adding local findings", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
## Summary
The score-preview gate emits a `duplicate_risk` reducer when `input.duplicateRiskCount > 0` (`src/scoring/preview.ts`), but **no production code ever set `duplicateRiskCount`** — a grep across `src/` returned only the type declaration and the consumer. So the reducer was dead code on every path; only `test/unit/scenario-blockers.test.ts` exercised it by passing the field directly to `buildScorePreview`.

The sibling reducer right above it, `stale_work`, *is* fed (`buildLocalScoreInput` sets `observedStalePrCount`). The two reducers were added together but only stale-work was wired to a producer. The duplicate-risk data the reducer needs is already computed on both producing paths and is even rendered into the contributor-facing "Overlap/WIP Check" packet — it was simply never converted into `duplicateRiskCount` for the score input. Closes #385.

## Scope
- `src/signals/local-branch.ts` — thread `duplicateRiskCount` into `buildLocalScoreInput` (new param + returned field), derived from the already-available `preflight.collisions` as the count of high-risk overlap clusters relevant to the branch.
- `src/signals/reward-risk.ts` — add `duplicateRiskCount: collisions.summary.highRiskCount` to `commonPreviewInput` (the count already drives `riskPenalty`).
- `test/unit/local-branch.test.ts` — fail-on-revert test: a branch colliding with a high-risk overlap cluster now yields a `duplicate_risk` reducer in `blockedBy`.

No behavior change to any path where there is no high-risk collision: `duplicateRiskCount` resolves to 0 there, exactly as before.

## Validation
- `npx tsc --noEmit` — clean.
- `npx vitest run` for the producer + consumer suites (local-branch, scenario-blockers, signals, signals-v2, decision-pack, agent-orchestrator) — all pass; the new test fails on revert.
- Branch coverage stays above the 97% gate.

## Safety
- Purely additive: a new optional count threaded from data the system already computes. When no high-risk collision exists the value is 0 and output is byte-identical to before.
- No public schema / API surface change; the contributor-facing packet is unchanged (the collision was already rendered there).

## Notes
Scoped to the two producing paths called out in the issue. Exposing `duplicateRiskCount` on the public `scorePreviewSchema` / MCP input (so external callers can supply it) is left out to keep this minimal and low-risk.