### PR TITLE
feat(config): add Gittensory repo focus manifest

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -1,0 +1,42 @@
+# Gittensory repo focus manifest — machine-readable contributor policy for this project.
+# Private maintainerNotes stay in authenticated API surfaces only.
+
+source: repo_file
+
+wantedPaths:
+  - src/
+  - packages/
+  - test/
+  - migrations/
+  - scripts/
+  - .github/workflows/
+  - wrangler.jsonc
+  - apps/gittensory-ui/
+
+blockedPaths:
+  - site/
+  - CNAME
+  - "**/lovable/**"
+
+preferredLabels:
+  - bug
+  - enhancement
+  - documentation
+
+linkedIssuePolicy: preferred
+
+testExpectations:
+  - npm run test:ci
+  - npm run typecheck
+  - npm run test:coverage
+
+issueDiscoveryPolicy: discouraged
+
+publicNotes:
+  - Prefer backend Workers, MCP, GitHub App, registry, and scoring work when scope allows.
+  - Focused control-panel UI changes are welcome when they use live API data or honest empty/error states and tie to safety, release readiness, or operator-facing analytics.
+  - Do not reintroduce GitHub Pages, VitePress, site/, CNAME, or lovable-only website work.
+
+maintainerNotes:
+  - Maintainer notes are private triage context and must not appear on public GitHub comments.
+  - Cosmetic UI-only polish without API wiring or maintainer-approved issue context should be redirected to backend or operator-facing work.

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -14626,6 +14626,67 @@
           }
         ]
       }
+    },
+    "/v1/repos/{owner}/{repo}/focus-manifest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Repo focus manifest and compiled policy for maintainers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Persist API-backed focus manifest for a repo",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed JSON request body"
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "agents": "^0.13.3",
         "drizzle-orm": "^0.45.0",
         "hono": "^4.12.23",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "agents": "^0.13.3",
     "drizzle-orm": "^0.45.0",
     "hono": "^4.12.23",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1572,6 +1572,36 @@ export function createApp() {
     return c.json(await buildGittensorConfigRecommendationResponse(c.env, fullName));
   });
 
+  app.get("/v1/repos/:owner/:repo/focus-manifest", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
+    const manifest = await loadRepoFocusManifest(c.env, fullName, { refresh: c.req.query("refresh") === "true" });
+    return c.json({ repoFullName: fullName, manifest, policy: compileFocusManifestPolicy(manifest) });
+  });
+
+  app.put("/v1/repos/:owner/:repo/focus-manifest", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
+    const body = await c.req.json().catch(() => null);
+    if (body === null) return c.json({ error: "invalid_json" }, 400);
+    const manifest = await upsertRepoFocusManifest(c.env, fullName, body, "api_record");
+    return c.json({ repoFullName: fullName, manifest, policy: compileFocusManifestPolicy(manifest) });
+  });
+
   app.get("/v1/app/self-dogfood/registration-pack", async (c) => {
     const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
     if (forbidden) return forbidden;
@@ -3571,6 +3601,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isIssueQualityPath(path)) return true;
   if (isRepoSettingsPreviewPath(path)) return true;
   if (isRepoOnboardingPackPreviewPath(path)) return true;
+  if (isRepoFocusManifestPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
   return false;
@@ -3590,6 +3621,10 @@ function isRepoContributorIssueDraftGeneratePath(path: string): boolean {
 
 function isIssueQualityPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-quality$/.test(path);
+}
+
+function isRepoFocusManifestPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/focus-manifest$/.test(path);
 }
 
 async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {

--- a/src/config/gittensory-repo-focus-manifest.ts
+++ b/src/config/gittensory-repo-focus-manifest.ts
@@ -1,0 +1,55 @@
+/**
+ * Bundled fallback for JSONbored/gittensory when the repo file is not yet reachable
+ * (local dev, pre-merge branches). Keep aligned with `.gittensory.yml` at repo root.
+ */
+export const GITTENSORY_REPO_FOCUS_MANIFEST_YAML = `# Gittensory repo focus manifest — machine-readable contributor policy for this project.
+# Private maintainerNotes stay in authenticated API surfaces only.
+
+source: repo_file
+
+wantedPaths:
+  - src/
+  - packages/
+  - test/
+  - migrations/
+  - scripts/
+  - .github/workflows/
+  - wrangler.jsonc
+  - apps/gittensory-ui/
+
+blockedPaths:
+  - site/
+  - CNAME
+  - "**/lovable/**"
+
+preferredLabels:
+  - bug
+  - enhancement
+  - documentation
+
+linkedIssuePolicy: preferred
+
+testExpectations:
+  - npm run test:ci
+  - npm run typecheck
+  - npm run test:coverage
+
+issueDiscoveryPolicy: discouraged
+
+publicNotes:
+  - Prefer backend Workers, MCP, GitHub App, registry, and scoring work when scope allows.
+  - Focused control-panel UI changes are welcome when they use live API data or honest empty/error states and tie to safety, release readiness, or operator-facing analytics.
+  - Do not reintroduce GitHub Pages, VitePress, site/, CNAME, or lovable-only website work.
+
+maintainerNotes:
+  - Maintainer notes are private triage context and must not appear on public GitHub comments.
+  - Cosmetic UI-only polish without API wiring or maintainer-approved issue context should be redirected to backend or operator-facing work.
+`;
+
+export const GITTENSOR_SELF_REPO_DEFAULT = "JSONbored/gittensory";
+
+export function resolveGittensorySelfRepoFullName(env: { GITTENSORY_DRIFT_ISSUE_REPO?: string }): string {
+  const configured = env.GITTENSORY_DRIFT_ISSUE_REPO?.trim();
+  if (configured && configured.includes("/")) return configured;
+  return GITTENSOR_SELF_REPO_DEFAULT;
+}

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -387,6 +387,23 @@ export function buildOpenApiSpec() {
   });
   registry.registerPath({
     method: "get",
+    path: "/v1/repos/{owner}/{repo}/focus-manifest",
+    responses: {
+      200: { description: "Repo focus manifest and compiled policy for maintainers", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      403: { description: "Insufficient role" },
+    },
+  });
+  registry.registerPath({
+    method: "put",
+    path: "/v1/repos/{owner}/{repo}/focus-manifest",
+    responses: {
+      200: { description: "Persist API-backed focus manifest for a repo", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      400: { description: "Malformed JSON request body" },
+      403: { description: "Insufficient role" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
     path: "/v1/app/self-dogfood/registration-pack",
     responses: {
       200: { description: "Private self-dogfood registration pack for the Gittensory repo", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -2,18 +2,24 @@ import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
 import { MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, type FocusManifest, type FocusManifestSource } from "./focus-manifest";
+import { GITTENSORY_REPO_FOCUS_MANIFEST_YAML, resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
 export const REPO_FOCUS_MANIFEST_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 export const REPO_FOCUS_MANIFEST_MAX_CONCURRENT_LOADS = 4;
+
+export const MANIFEST_FILE_CANDIDATES = [
+  ".gittensory.yml",
+  ".github/gittensory.yml",
+  ".gittensory.json",
+  ".github/gittensory.json",
+] as const;
 
 /**
  * Async source for the raw manifest text of a single repo. Returns null when no manifest is
  * published. Allows tests and the persisted-record path to swap out the public-GitHub fetcher.
  */
 export type RepoFocusManifestFetcher = (repoFullName: string) => Promise<string | null>;
-
-const MANIFEST_FILE_CANDIDATES = [".gittensory.json", ".github/gittensory.json"];
 
 /**
  * Fetch a maintainer-owned manifest file from the public GitHub raw endpoint. Network or HTTP
@@ -58,7 +64,10 @@ export async function loadRepoFocusManifest(
   }
   let manifest: FocusManifest;
   try {
-    const content = await fetcher(repoFullName);
+    let content = await fetcher(repoFullName);
+    if ((content === null || content === undefined) && isGittensorySelfRepo(repoFullName, env)) {
+      content = GITTENSORY_REPO_FOCUS_MANIFEST_YAML;
+    }
     manifest = content === null || content === undefined ? parseFocusManifest(null) : parseFocusManifestContent(content, "repo_file");
   } catch {
     manifest = parseFocusManifest(null);
@@ -177,4 +186,8 @@ function snapshotAgeMs(generatedAt: string | null | undefined): number {
   if (!generatedAt) return Number.POSITIVE_INFINITY;
   const parsed = Date.parse(generatedAt);
   return Number.isFinite(parsed) ? Date.now() - parsed : Number.POSITIVE_INFINITY;
+}
+
+function isGittensorySelfRepo(repoFullName: string, env: Env): boolean {
+  return repoFullName.toLowerCase() === resolveGittensorySelfRepoFullName(env).toLowerCase();
 }

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1,3 +1,4 @@
+import { parse as parseYaml } from "yaml";
 import type { JsonValue } from "../types";
 
 export type FocusManifestSource = "repo_file" | "api_record" | "none";
@@ -169,19 +170,28 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
 }
 
 /**
- * Parse raw manifest file/record content (JSON). Malformed JSON degrades to an empty manifest
- * with a warning rather than throwing, so a broken `.gittensory` config never breaks analysis.
+ * Parse raw manifest file/record content (JSON or YAML). Malformed content degrades to an empty
+ * manifest with a warning rather than throwing, so a broken `.gittensory` config never breaks analysis.
  */
 export function parseFocusManifestContent(content: string | null | undefined, source: FocusManifestSource = "repo_file"): FocusManifest {
   if (content === undefined || content === null || content.trim() === "") return emptyManifest(source);
   if (content.length > MAX_FOCUS_MANIFEST_BYTES || new TextEncoder().encode(content).byteLength > MAX_FOCUS_MANIFEST_BYTES) {
     return emptyManifest(source, [`Manifest content exceeded ${MAX_FOCUS_MANIFEST_BYTES} bytes; ignoring it and falling back to deterministic signals.`]);
   }
+  const trimmed = content.trim();
+  const looksLikeJson = trimmed.startsWith("{") || trimmed.startsWith("[");
   let parsed: unknown;
   try {
-    parsed = JSON.parse(content);
+    parsed = looksLikeJson ? JSON.parse(trimmed) : parseYaml(trimmed);
   } catch {
-    return emptyManifest(source, ["Manifest content was not valid JSON; ignoring it and falling back to deterministic signals."]);
+    return emptyManifest(source, [
+      looksLikeJson
+        ? "Manifest content was not valid JSON; ignoring it and falling back to deterministic signals."
+        : "Manifest content was not valid YAML; ignoring it and falling back to deterministic signals.",
+    ]);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return emptyManifest(source, ["Manifest must be a mapping of fields; ignoring malformed manifest and falling back to deterministic signals."]);
   }
   return parseFocusManifest(parsed, source);
 }

--- a/test/unit/contributor-issue-draft.test.ts
+++ b/test/unit/contributor-issue-draft.test.ts
@@ -220,10 +220,11 @@ describe("contributor issue drafts", () => {
 
   it("skips duplicate drafts during generation", async () => {
     const env = createTestEnv();
+    const repoFullName = "other-owner/other-repo";
     const title = "feat(issues): address focus-policy-missing policy readiness for repo";
     vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([openIssue(77, title)]);
 
-    const result = await generateContributorIssueDrafts(env, "JSONbored/gittensory", { dryRun: true, limit: 1 });
+    const result = await generateContributorIssueDrafts(env, repoFullName, { dryRun: true, limit: 1 });
     expect(result.skippedDuplicate).toBe(1);
     expect(result.drafts[0]?.status).toBe("skipped_duplicate");
   });

--- a/test/unit/focus-manifest-loader.test.ts
+++ b/test/unit/focus-manifest-loader.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestEnv } from "../helpers/d1";
+import type { JsonValue } from "../../src/types";
 import {
   fetchRepoFocusManifestFile,
   loadRepoFocusManifest,
@@ -119,18 +120,20 @@ describe("focus-manifest loader", () => {
   it("returns raw text from the first 200 OK candidate path", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       const stringUrl = String(url);
-      if (stringUrl.endsWith("/.gittensory.json")) return new Response("not found", { status: 404 });
-      if (stringUrl.endsWith("/.github/gittensory.json")) return new Response('{"wantedPaths":["src/"]}', { status: 200 });
+      if (stringUrl.endsWith("/.gittensory.yml")) return new Response("wantedPaths:\n  - src/\n", { status: 200 });
       return new Response("not found", { status: 404 });
     });
     const text = await fetchRepoFocusManifestFile("owner/repo");
-    expect(text).toBe('{"wantedPaths":["src/"]}');
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(text).toBe("wantedPaths:\n  - src/\n");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not read public manifest responses when Content-Length is too large", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       const stringUrl = String(url);
+      if (stringUrl.endsWith("/.gittensory.yml") || stringUrl.endsWith("/.github/gittensory.yml")) {
+        return new Response("not found", { status: 404 });
+      }
       if (stringUrl.endsWith("/.gittensory.json")) {
         return new Response('{"wantedPaths":["too-large/"]}', {
           status: 200,
@@ -141,7 +144,7 @@ describe("focus-manifest loader", () => {
     });
     const text = await fetchRepoFocusManifestFile("owner/repo");
     expect(text).toBe('{"wantedPaths":["src/"]}');
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
   });
 
   it("aborts public manifest streams that grow beyond the byte cap", async () => {
@@ -199,6 +202,22 @@ describe("focus-manifest loader", () => {
     expect(calls).toBe(2);
   });
 
+  it("falls back to bundled YAML for a configured self-repo alias when fetch is unavailable", async () => {
+    const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "fork/gittensory" });
+    const manifest = await loadRepoFocusManifest(env, "fork/gittensory", { fetcher: async () => null });
+    expect(manifest.present).toBe(true);
+    expect(manifest.wantedPaths).toContain("apps/gittensory-ui/");
+  });
+
+  it("does not persist an empty manifest from a failed fetch", async () => {
+    const env = createTestEnv();
+    await loadRepoFocusManifest(env, "owner/empty", { fetcher: async () => null });
+    const { listSignalSnapshots } = await import("../../src/db/repositories");
+    const { REPO_FOCUS_MANIFEST_SIGNAL } = await import("../../src/signals/focus-manifest-loader");
+    const snapshots = await listSignalSnapshots(env, REPO_FOCUS_MANIFEST_SIGNAL, "owner/empty");
+    expect(snapshots).toHaveLength(0);
+  });
+
   it("treats a cached snapshot with a missing or unparseable timestamp as stale", async () => {
     const env = createTestEnv();
     const { persistSignalSnapshot } = await import("../../src/db/repositories");
@@ -229,5 +248,26 @@ describe("focus-manifest loader", () => {
     const emptyTime = await loadRepoFocusManifest(env, "owner/emptytime", { fetcher });
     expect(emptyTime.wantedPaths).toEqual(["fresh/"]);
     expect(calls).toBe(2);
+  });
+
+  it("treats a cached array payload as a repo-file snapshot without an explicit api_record source", async () => {
+    const env = createTestEnv();
+    const { persistSignalSnapshot } = await import("../../src/db/repositories");
+    const { REPO_FOCUS_MANIFEST_SIGNAL } = await import("../../src/signals/focus-manifest-loader");
+    await persistSignalSnapshot(env, {
+      id: crypto.randomUUID(),
+      signalType: REPO_FOCUS_MANIFEST_SIGNAL,
+      targetKey: "owner/array-payload",
+      repoFullName: "owner/array-payload",
+      payload: ["wantedPaths", "src/"] as unknown as Record<string, JsonValue>,
+      generatedAt: new Date().toISOString(),
+    });
+    const manifest = await loadRepoFocusManifest(env, "owner/array-payload", {
+      fetcher: async () => {
+        throw new Error("should not fetch when a fresh repo-file cache snapshot exists");
+      },
+    });
+    expect(manifest.present).toBe(false);
+    expect(manifest.warnings.join(" ")).toMatch(/mapping/i);
   });
 });

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -122,11 +122,24 @@ describe("parseFocusManifestContent", () => {
   });
 
   it("warns when JSON content is not a mapping", () => {
-    for (const content of ['["a","b"]', '"string"']) {
+    for (const content of ['["a","b"]', "null", '"string"']) {
       const manifest = parseFocusManifestContent(content);
       expect(manifest.present).toBe(false);
       expect(manifest.warnings.join(" ")).toMatch(/must be a mapping/i);
     }
+  });
+
+  it("parses valid YAML content", () => {
+    const manifest = parseFocusManifestContent("wantedPaths:\n  - src/\nblockedPaths:\n  - dist/\n", "repo_file");
+    expect(manifest.present).toBe(true);
+    expect(manifest.wantedPaths).toEqual(["src/"]);
+    expect(manifest.blockedPaths).toEqual(["dist/"]);
+  });
+
+  it("warns instead of throwing on malformed YAML", () => {
+    const manifest = parseFocusManifestContent("wantedPaths: [unterminated", "repo_file");
+    expect(manifest.present).toBe(false);
+    expect(manifest.warnings.join(" ")).toMatch(/not valid YAML/i);
   });
 });
 

--- a/test/unit/gittensory-focus-manifest.test.ts
+++ b/test/unit/gittensory-focus-manifest.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  GITTENSORY_REPO_FOCUS_MANIFEST_YAML,
+  GITTENSOR_SELF_REPO_DEFAULT,
+  resolveGittensorySelfRepoFullName,
+} from "../../src/config/gittensory-repo-focus-manifest";
+import { createTestEnv } from "../helpers/d1";
+import {
+  buildFocusManifestGuidance,
+  compileFocusManifestPolicy,
+  isFocusManifestPublicSafe,
+  parseFocusManifestContent,
+} from "../../src/signals/focus-manifest";
+import { loadRepoFocusManifest, MANIFEST_FILE_CANDIDATES } from "../../src/signals/focus-manifest-loader";
+
+const FORBIDDEN_PUBLIC_LANGUAGE =
+  /wallet|hotkey|payout|reward estimate|raw trust score|public score estimate|private reviewability|farming/i;
+
+describe("resolveGittensorySelfRepoFullName", () => {
+  it("defaults to the Gittensory repo when drift issue repo is unset or invalid", () => {
+    expect(resolveGittensorySelfRepoFullName({})).toBe(GITTENSOR_SELF_REPO_DEFAULT);
+    expect(resolveGittensorySelfRepoFullName({ GITTENSORY_DRIFT_ISSUE_REPO: "invalid" })).toBe(GITTENSOR_SELF_REPO_DEFAULT);
+    expect(resolveGittensorySelfRepoFullName({ GITTENSORY_DRIFT_ISSUE_REPO: "  " })).toBe(GITTENSOR_SELF_REPO_DEFAULT);
+  });
+
+  it("returns a configured owner/repo drift target when present", () => {
+    expect(resolveGittensorySelfRepoFullName({ GITTENSORY_DRIFT_ISSUE_REPO: "acme/widget" })).toBe("acme/widget");
+    expect(resolveGittensorySelfRepoFullName({ GITTENSORY_DRIFT_ISSUE_REPO: "  org/repo  " })).toBe("org/repo");
+  });
+});
+
+describe("Gittensory repo focus manifest", () => {
+  it("keeps bundled YAML aligned with the committed .gittensory.yml file", () => {
+    const onDisk = readFileSync(resolve(process.cwd(), ".gittensory.yml"), "utf8").trim();
+    expect(GITTENSORY_REPO_FOCUS_MANIFEST_YAML.trim()).toBe(onDisk);
+  });
+
+  it("valid manifest fixture parses and compiles policy", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    expect(manifest.present).toBe(true);
+    expect(manifest.wantedPaths).toContain("src/");
+    expect(manifest.wantedPaths).toContain("apps/gittensory-ui/");
+    expect(manifest.blockedPaths).toContain("site/");
+    expect(manifest.blockedPaths).not.toContain("apps/gittensory-ui/");
+    expect(manifest.issueDiscoveryPolicy).toBe("discouraged");
+
+    const policy = compileFocusManifestPolicy(manifest);
+    const directPrLane = policy.publicSafe.contributionLanes.find((lane) => lane.id === "direct-pr");
+    expect(directPrLane?.preference).toBe("preferred");
+    expect(policy.publicSafe.issueDiscoveryPolicy).toBe("discouraged");
+    expect(policy.authenticated.maintainerContext.length).toBeGreaterThan(0);
+    expect(JSON.stringify(policy)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  });
+
+  it("malformed manifest fixture warns safely", () => {
+    const manifest = parseFocusManifestContent("wantedPaths: [\n  - src/\n", "repo_file");
+    expect(manifest.present).toBe(false);
+    expect(manifest.warnings.join(" ")).toMatch(/not valid YAML/i);
+  });
+
+  it("blocked path fixture flags retired static-site surfaces", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    const guidance = buildFocusManifestGuidance({
+      manifest,
+      changedPaths: ["site/docs/index.html"],
+    });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_blocked_path")).toBe(true);
+    expect(guidance.summary).toMatch(/blocked area/i);
+  });
+
+  it("focused control-panel UI changes align with wanted paths", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    const guidance = buildFocusManifestGuidance({
+      manifest,
+      changedPaths: ["apps/gittensory-ui/src/routes/app.operator.tsx"],
+    });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_preferred_path")).toBe(true);
+    expect(guidance.findings.some((finding) => finding.code === "manifest_blocked_path")).toBe(false);
+  });
+
+  it("recommendation influence prefers in-scope backend and UI paths separately from blocked surfaces", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    const backend = buildFocusManifestGuidance({ manifest, changedPaths: ["src/api/routes.ts"] });
+    const controlPanel = buildFocusManifestGuidance({ manifest, changedPaths: ["apps/gittensory-ui/src/app.tsx"] });
+    const retiredSite = buildFocusManifestGuidance({ manifest, changedPaths: ["site/index.html"] });
+    expect(backend.findings.some((finding) => finding.code === "manifest_preferred_path")).toBe(true);
+    expect(controlPanel.findings.some((finding) => finding.code === "manifest_preferred_path")).toBe(true);
+    expect(retiredSite.findings.some((finding) => finding.code === "manifest_blocked_path")).toBe(true);
+  });
+
+  it("public/private boundary regression keeps maintainer notes out of public guidance", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    const guidance = buildFocusManifestGuidance({ manifest, changedPaths: ["src/x.ts"] });
+    for (const step of guidance.publicNextSteps) {
+      expect(isFocusManifestPublicSafe(step)).toBe(true);
+      expect(step).not.toMatch(/maintainer notes are private/i);
+    }
+    expect(manifest.maintainerNotes.join(" ")).toMatch(/private triage/i);
+  });
+
+  it("loads bundled manifest for the Gittensory repo when fetch is unavailable", async () => {
+    const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "JSONbored/gittensory" });
+    const manifest = await loadRepoFocusManifest(env, "JSONbored/gittensory", { fetcher: async () => null });
+    expect(manifest.present).toBe(true);
+    expect(manifest.wantedPaths).toContain("packages/");
+    expect(manifest.wantedPaths).toContain("apps/gittensory-ui/");
+    expect(manifest.blockedPaths).toContain("site/");
+  });
+
+  it("flags lovable-only and CNAME paths as blocked surfaces", () => {
+    const manifest = parseFocusManifestContent(GITTENSORY_REPO_FOCUS_MANIFEST_YAML, "repo_file");
+    for (const changedPath of ["CNAME", "vendor/lovable/widget.ts"]) {
+      const guidance = buildFocusManifestGuidance({ manifest, changedPaths: [changedPath] });
+      expect(guidance.findings.some((finding) => finding.code === "manifest_blocked_path")).toBe(true);
+    }
+  });
+
+  it("prefers YAML manifest file candidates before JSON", () => {
+    expect(MANIFEST_FILE_CANDIDATES[0]).toBe(".gittensory.yml");
+    expect(MANIFEST_FILE_CANDIDATES).toContain(".gittensory.json");
+  });
+});

--- a/test/unit/routes-focus-manifest.test.ts
+++ b/test/unit/routes-focus-manifest.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+const FOCUS_MANIFEST_PATH = "/v1/repos/JSONbored/gittensory/focus-manifest";
+const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/focus-manifest";
+
+function apiHeaders(env: Env): Record<string, string> {
+  return {
+    authorization: `Bearer ${env.GITTENSORY_API_TOKEN}`,
+    "content-type": "application/json",
+  };
+}
+
+async function seedRegisteredInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
+    .bind(`${owner}/${name}`)
+    .run();
+}
+
+describe("focus-manifest route auth", () => {
+  it("rejects unauthenticated access", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(FOCUS_MANIFEST_PATH, {}, env);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects unauthorized session access", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    const { token } = await createSessionForGitHubUser(env, { login: "new-user", id: 2468 });
+    const response = await app.request(FOCUS_MANIFEST_PATH, { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_role" });
+  });
+
+  it("allows same-repo owner sessions to read and update focus manifests", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const cookie = `gittensory_session=${token}`;
+
+    const getResponse = await app.request(OWNED_REPO_PATH, { headers: { cookie } }, env);
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.json()).resolves.toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      manifest: { present: expect.any(Boolean) },
+      policy: { present: expect.any(Boolean) },
+    });
+
+    const putResponse = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "PUT",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ wantedPaths: ["src/"], blockedPaths: ["dist/"] }),
+      },
+      env,
+    );
+    expect(putResponse.status).toBe(200);
+    await expect(putResponse.json()).resolves.toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      manifest: { present: true, source: "api_record", wantedPaths: ["src/"] },
+    });
+  });
+
+  it("rejects cross-repo owner sessions with forbidden_repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { token: ownerToken } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const { token: otherOwnerToken } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+    const ownerCookie = `gittensory_session=${ownerToken}`;
+    const otherOwnerCookie = `gittensory_session=${otherOwnerToken}`;
+
+    const crossRepoGet = await app.request(OWNED_REPO_PATH, { headers: { cookie: otherOwnerCookie } }, env);
+    expect(crossRepoGet.status).toBe(403);
+    await expect(crossRepoGet.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    const crossRepoPut = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "PUT",
+        headers: { cookie: otherOwnerCookie, "content-type": "application/json" },
+        body: JSON.stringify({ wantedPaths: ["src/"] }),
+      },
+      env,
+    );
+    expect(crossRepoPut.status).toBe(403);
+    await expect(crossRepoPut.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    const ownRepoGet = await app.request(OWNED_REPO_PATH, { headers: { cookie: ownerCookie } }, env);
+    expect(ownRepoGet.status).toBe(200);
+  });
+
+  it("allows operator sessions to access any repo focus manifest", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const response = await app.request(OWNED_REPO_PATH, { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ repoFullName: "repo-owner/owned-repo" });
+  });
+
+  it("returns bundled manifest and policy for authorized static-token callers", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "JSONbored/gittensory" });
+    const response = await app.request(FOCUS_MANIFEST_PATH, { headers: apiHeaders(env) }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "JSONbored/gittensory",
+      manifest: {
+        present: true,
+        wantedPaths: expect.arrayContaining(["apps/gittensory-ui/"]),
+        blockedPaths: expect.arrayContaining(["site/"]),
+      },
+      policy: {
+        present: true,
+        publicSafe: expect.objectContaining({
+          contributionLanes: expect.arrayContaining([
+            expect.objectContaining({
+              id: "direct-pr",
+              discouragedPaths: expect.arrayContaining(["site/"]),
+            }),
+          ]),
+        }),
+      },
+    });
+  });
+
+  it("bypasses cached manifest when refresh=true", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "JSONbored/gittensory" });
+    const headers = apiHeaders(env);
+    const first = await app.request(FOCUS_MANIFEST_PATH, { headers }, env);
+    expect(first.status).toBe(200);
+    const refreshed = await app.request(`${FOCUS_MANIFEST_PATH}?refresh=true`, { headers }, env);
+    expect(refreshed.status).toBe(200);
+    await expect(refreshed.json()).resolves.toMatchObject({
+      manifest: { present: true, wantedPaths: expect.arrayContaining(["apps/gittensory-ui/"]) },
+    });
+  });
+
+  it("rejects malformed JSON on PUT with 400", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      FOCUS_MANIFEST_PATH,
+      { method: "PUT", headers: { ...apiHeaders(env), "content-type": "application/json" }, body: "not-json" },
+      env,
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_json" });
+  });
+
+  it("accepts an empty JSON object on PUT by falling back to defaults", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      FOCUS_MANIFEST_PATH,
+      { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({}) },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      manifest: { present: false, source: "api_record" },
+    });
+  });
+
+  it("persists API-backed manifest updates for authorized callers", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const response = await app.request(
+      FOCUS_MANIFEST_PATH,
+      {
+        method: "PUT",
+        headers: apiHeaders(env),
+        body: JSON.stringify({
+          wantedPaths: ["src/"],
+          blockedPaths: ["dist/"],
+          publicNotes: ["Keep changes focused."],
+        }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "JSONbored/gittensory",
+      manifest: {
+        present: true,
+        source: "api_record",
+        wantedPaths: ["src/"],
+        blockedPaths: ["dist/"],
+      },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #118

## Summary

- Adds a machine-readable **Gittensory repo focus manifest** at `.gittensory.yml` (wanted backend/MCP paths, blocked website/lovable areas, test expectations, public vs private notes).
- Extends focus-manifest parsing to support **YAML** (`.gittensory.yml` first, then JSON candidates) with safe malformed-manifest warnings.
- Bundles a self-repo fallback (`src/config/gittensory-repo-focus-manifest.ts`) so decision packs, preflight, and maintainer APIs work before the file is on `main`.
- Exposes maintainer-only `GET` / `PUT` `/v1/repos/{owner}/{repo}/focus-manifest` returning manifest + compiled policy.

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

-

**New / updated tests:** `test/unit/gittensory-focus-manifest.test.ts`, `test/unit/focus-manifest.test.ts`, `test/unit/focus-manifest-loader.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include screenshots or a short recording.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Parent roadmap: #82.
- Self-dogfood uses `GITTENSORY_DRIFT_ISSUE_REPO` when set; otherwise `JSONbored/gittensory`.
- `GITTENSORY_REPO_FOCUS_MANIFEST_YAML` must stay in sync with `.gittensory.yml` (enforced by unit test).
