### PR TITLE
fix(signals): rank contributor opportunities before the per-repo cap

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1246,7 +1246,11 @@ export function buildContributorOpportunities(
     const rankable = qualityByIssue
       ? availableIssues.filter((issue) => qualityByIssue.get(issue.number)?.status !== "do_not_use")
       : availableIssues;
-    for (const issue of rankable.slice(0, 5)) {
+    // Score every eligible issue, then keep this repo's best 5 by score -- the cap must select the
+    // strongest-fit issues (mirroring the issue-quality report's score-descending order), not the
+    // arbitrary first 5 in DB order.
+    const repoOpportunities: ContributorOpportunity[] = [];
+    for (const issue of rankable) {
       const quality = qualityByIssue?.get(issue.number);
       const bounty = bountyByIssue.get(bountyIssueKey(repo.fullName, issue.number)) ?? null;
       const bountyLifecycle = bounty ? classifyBountyLifecycle(bounty, issue) : null;
@@ -1277,7 +1281,7 @@ export function buildContributorOpportunities(
       );
       const baseFit = score >= 70 ? "good" : score >= 40 ? "caution" : "hold";
       const downgradeToCaution = (bountyPenalty > 0 || quality?.status === "needs_proof") && baseFit === "good";
-      opportunities.push({
+      repoOpportunities.push({
         repoFullName: repo.fullName,
         issueNumber: issue.number,
         title: issue.title,
@@ -1302,6 +1306,8 @@ export function buildContributorOpportunities(
         ],
       });
     }
+    repoOpportunities.sort((left, right) => right.score - left.score || (left.issueNumber ?? 0) - (right.issueNumber ?? 0));
+    opportunities.push(...repoOpportunities.slice(0, 5));
   }
 
   /* v8 ignore next -- Repo-name tie ordering is deterministic presentation fallback after scored opportunity ranking. */

--- a/test/unit/issue-quality.test.ts
+++ b/test/unit/issue-quality.test.ts
@@ -238,6 +238,28 @@ describe("buildContributorOpportunities x issue quality", () => {
     expect(opportunities[0]?.reasons).toEqual(expect.arrayContaining(["Issue quality report rates this issue as ready."]));
   });
 
+  it("surfaces the highest-quality issue even when it sits beyond the first 5 in DB order", () => {
+    const repo = issueDiscoveryRepo("owner/deep-ready");
+    // Six available issues in DB order; the only "ready" one is last (index 5), the rest are "hold".
+    const issues = [1, 2, 3, 4, 5, 6].map((n) => issue(repo.fullName, n, `Issue ${n}`, { body: "x".repeat(220), labels: ["bug"] }));
+    const quality: IssueQualityReport = {
+      repoFullName: repo.fullName,
+      generatedAt: now(),
+      lane: { repoFullName: repo.fullName, lane: "issue_discovery", issueDiscoveryShare: 1, directPrShare: 0, summary: "", contributorGuidance: "", maintainerGuidance: "" },
+      issues: [
+        ...[1, 2, 3, 4, 5].map((n) => ({ number: n, title: `Issue ${n}`, status: "hold" as const, score: 30, reasons: [], warnings: [] })),
+        { number: 6, title: "Issue 6", status: "ready" as const, score: 92, reasons: [], warnings: [] },
+      ],
+      summary: "",
+    };
+    const opportunities = buildContributorOpportunities(sampleProfile(), [repo], issues, [], [], new Map([[repo.fullName, quality]]));
+    // The "ready" issue #6 (highest score) must be surfaced and ranked first, even though it is the
+    // 6th available issue -- the per-repo cap selects the best, not the arbitrary first 5.
+    expect(opportunities.map((o) => o.issueNumber)).toContain(6);
+    expect(opportunities[0]?.issueNumber).toBe(6);
+    expect(opportunities[0]?.reasons).toEqual(expect.arrayContaining(["Issue quality report rates this issue as ready."]));
+  });
+
   it("downgrades needs_proof issues to caution and adds a warning", () => {
     const repo = issueDiscoveryRepo("owner/caution");
     const issues = [issue(repo.fullName, 1, "Vague candidate", { body: "x".repeat(220), labels: ["bug"] })];


### PR DESCRIPTION
## Summary
`buildContributorOpportunities` (`src/signals/engine.ts`) selected the issues to surface per repo by taking the **first 5** of an **unsorted** list (`rankable.slice(0, 5)`, raw DB order), then scoring only those. The list is named `rankable` but was never ranked before the cap, so issues at index 5+ were dropped before their opportunity score was ever computed.

This discards the ranking the issue-quality producer goes to effort to build: `buildIssueQualityReport` scores each issue and returns them **sorted best-first**, but the consumer keyed the report by issue number for per-issue lookups and ignored the ordering. The quality signal therefore only adjusted the *score of whichever 5 issues came first*, never *which 5 were chosen*. A "ready", high-fit issue that the system itself ranked #1 was invisible if it happened to be the 6th available issue in DB order. Closes #393.

This is not cosmetic: these opportunities feed `buildContributorFit` and the contributor decision pack (`queue/processors.ts`, `services/decision-pack.ts`), and the global top-25 ranking was drawn from a biased per-repo sample — steering miners toward lower-fit issues while hiding the highest-value work.

## Scope
- `src/signals/engine.ts` — score every eligible (`rankable`) issue per repo, then keep that repo's top 5 by computed opportunity score (tie-break on issue number, mirroring the producer's order), instead of capping the raw list to 5 before scoring. The existing global sort + top-25 cap are unchanged.
- `test/unit/issue-quality.test.ts` — fail-on-revert: a "ready" issue sitting 6th in DB order (behind five "hold" issues) must now surface and rank first.

## Validation
- `npx tsc --noEmit` — clean.
- `npx vitest run` (full suite) — 1066 passed, 1 skipped; no other assertions affected.
- Branch coverage 97.15% (above the 97% gate); engine.ts 98.02% branch.

## Safety
- Behavior is unchanged for any repo with <= 5 eligible issues (scoring all then taking top 5 is identical to scoring the same set). The only change is which issues survive the cap when a repo has more than 5 — now the best-scoring ones, as intended.
- No public schema / API surface change; the opportunity object shape, scoring formula, and global ranking are untouched. The no-quality-report path also benefits (it now caps by lane/label fit rather than DB order).

## Notes
The fix selects by the consumer's own opportunity score (lane fit + label-history overlap + quality adjustment − queue/bounty penalties), which is the value the pipeline ultimately ranks on, so per-repo selection and global ranking are now consistent.