### PR TITLE
fix(upstream): count distinct affected repos across drift reports instead of summing

### DIFF
--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -603,7 +603,17 @@ function semanticPayload(payload: RulesetPayload): Record<string, JsonValue> {
 }
 
 type RulesetRegistryRepo = RulesetPayload["registry"]["repositories"][number];
-type RegistryHyperparameterDriftPayload = RegistryHyperparameterDriftSummary & { events: RegistryHyperparameterDriftEvent[] };
+// `affectedRepos` is the pre-cap list of distinct affected repositories, kept on the stored payload
+// (not the public summary) so multi-report aggregation can union repos across reports instead of
+// summing per-report counts. Mirrors how `affectedFields`/`affectedSurfaces` are unioned.
+type RegistryHyperparameterDriftPayload = RegistryHyperparameterDriftSummary & {
+  events: RegistryHyperparameterDriftEvent[];
+  affectedRepos: string[];
+};
+
+function uniqueRepoNames(events: RegistryHyperparameterDriftEvent[]): string[] {
+  return [...new Set(events.map((event) => event.repoFullName))].sort((left, right) => left.localeCompare(right));
+}
 
 const REGISTRY_DRIFT_FIELD_ORDER: RegistryHyperparameterDriftField[] = [
   "repo",
@@ -654,6 +664,7 @@ function buildRegistryHyperparameterDrift(previous: RulesetRegistryRepo[], curre
   return {
     ...summarizeRegistryHyperparameterDriftEvents(events),
     events: capped,
+    affectedRepos: uniqueRepoNames(events),
     omittedEvents: Math.max(events.length - capped.length, 0),
   };
 }
@@ -710,7 +721,10 @@ function summarizeRegistryHyperparameterDriftReports(reports: UpstreamDriftRepor
     totalEvents: sum(payloads.map((payload) => payload.totalEvents)) || fallbackSummary.totalEvents,
     omittedEvents: sum(payloads.map((payload) => payload.omittedEvents)),
     highImpactCount: sum(payloads.map((payload) => payload.highImpactCount)) || fallbackSummary.highImpactCount,
-    affectedRepoCount: sum(payloads.map((payload) => payload.affectedRepoCount)) || fallbackSummary.affectedRepoCount,
+    // Distinct repos across reports, not the sum of per-report unique counts -- a repo affected in
+    // several open reports must be counted once. Union the pre-cap repo lists (same approach as
+    // affectedFields/affectedSurfaces below).
+    affectedRepoCount: new Set(payloads.flatMap((payload) => payload.affectedRepos)).size || fallbackSummary.affectedRepoCount,
     affectedFields: uniqueSorted(payloads.flatMap((payload) => payload.affectedFields), REGISTRY_DRIFT_FIELD_ORDER),
     affectedSurfaces: uniqueSorted(
       payloads.flatMap((payload) => payload.affectedSurfaces),
@@ -726,6 +740,7 @@ function readRegistryHyperparameterDriftPayload(value: JsonValue | undefined): R
   const fallback = summarizeRegistryHyperparameterDriftEvents(events);
   const affectedFields = arrayPayload(payload.affectedFields).flatMap(readRegistryHyperparameterDriftField);
   const affectedSurfaces = arrayPayload(payload.affectedSurfaces).flatMap(readRegistryDriftSurface);
+  const affectedRepos = arrayPayload(payload.affectedRepos).filter((entry): entry is string => typeof entry === "string");
   return {
     events,
     totalEvents: numberPayload(payload.totalEvents) ?? fallback.totalEvents,
@@ -734,6 +749,9 @@ function readRegistryHyperparameterDriftPayload(value: JsonValue | undefined): R
     affectedRepoCount: numberPayload(payload.affectedRepoCount) ?? fallback.affectedRepoCount,
     affectedFields: affectedFields.length > 0 ? affectedFields : fallback.affectedFields,
     affectedSurfaces: affectedSurfaces.length > 0 ? affectedSurfaces : fallback.affectedSurfaces,
+    // Legacy payloads predate `affectedRepos`; derive it from the stored (capped) events so the
+    // reports aggregator can still union repos rather than fall back to summing.
+    affectedRepos: affectedRepos.length > 0 ? affectedRepos : uniqueRepoNames(events),
   };
 }
 
@@ -766,6 +784,7 @@ function emptyRegistryHyperparameterDriftPayload(): RegistryHyperparameterDriftP
     affectedRepoCount: 0,
     affectedFields: [],
     affectedSurfaces: [],
+    affectedRepos: [],
   };
 }
 

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -605,11 +605,40 @@ describe("upstream ruleset drift tracking", () => {
         totalEvents: 4,
         omittedEvents: 1,
         highImpactCount: 3,
-        affectedRepoCount: 3,
+        // Distinct repos across reports, not the sum of per-report counts: only `owner/repo` and
+        // `owner/missing-values` are identifiable (the summary-only payload reports a count with no
+        // repo identity to union), so the deduped count is 2 -- previously this summed to 3.
+        affectedRepoCount: 2,
         affectedFields: ["repo", "maintainerCut"],
         affectedSurfaces: ["maintainer_economics"],
       },
     });
+  });
+
+  it("counts distinct affected repos across open drift reports instead of summing per-report counts", async () => {
+    const env = createTestEnv();
+    await persistUpstreamRulesetSnapshot(env, ruleset("current", "current-hash", "pending_saturation_model", 1, 0.01, new Date().toISOString()));
+    const driftEvent = (repoFullName: string) => ({
+      repoFullName,
+      field: "maintainerCut",
+      previous: 0.1,
+      current: 0.2,
+      severity: "high",
+      affectedSurfaces: ["maintainer_economics"],
+      summary: `${repoFullName} maintainerCut changed`,
+    });
+    await upsertUpstreamDriftReport(
+      env,
+      driftReport("registry-drift-a", { affectedAreas: ["registry"], payload: { registryHyperparameterDrift: { events: [driftEvent("owner/x"), driftEvent("owner/y"), driftEvent("owner/z")] } } }),
+    );
+    await upsertUpstreamDriftReport(
+      env,
+      driftReport("registry-drift-b", { affectedAreas: ["registry"], payload: { registryHyperparameterDrift: { events: [driftEvent("owner/z"), driftEvent("owner/w")] } } }),
+    );
+
+    const status = await loadUpstreamStatus(env);
+    // owner/z is affected in both reports: 4 distinct repos (x, y, z, w), not 3 + 2 = 5.
+    expect(status.registryHyperparameterDrift.affectedRepoCount).toBe(4);
   });
 
   it("builds low-severity source drift reports from legacy or partial ruleset payloads", async () => {


### PR DESCRIPTION
## Summary
`summarizeRegistryHyperparameterDriftReports` (`src/upstream/ruleset.ts`) aggregated the registry hyperparameter drift summary across all open drift reports but **summed** each report's `affectedRepoCount` instead of counting distinct repositories:

```ts
affectedRepoCount: sum(payloads.map((p) => p.affectedRepoCount)) || fallbackSummary.affectedRepoCount,
```

Each `payload.affectedRepoCount` is the unique-repo count **within one report** (`new Set(repos).size`). Summing across reports counts a repository once for every report it appears in, so a repo whose hyperparameters drift across several open reports is over-counted. The sibling fields in the same function (`affectedFields`, `affectedSurfaces`) are correctly **deduplicated** across reports with `uniqueSorted(payloads.flatMap(...))` -- the repo count was the lone outlier. This value is returned as `UpstreamStatus.registryHyperparameterDrift.affectedRepoCount` from `GET /v1/upstream/status`, so dashboards/operators saw an inflated count. Closes #396.

## Scope
- `src/upstream/ruleset.ts` -- the aggregator now unions repositories across reports instead of summing per-report counts. To union exactly (robust to the 100-event per-report cap, matching how `affectedFields`/`affectedSurfaces` union pre-cap payload lists), the stored drift payload now carries a pre-cap `affectedRepos: string[]`. This is kept on the **internal** payload only -- the public `RegistryHyperparameterDriftSummary` type and its OpenAPI schema are unchanged. Legacy payloads (predating the field) derive `affectedRepos` from their stored events, so older data still dedups rather than sums.
- `test/unit/upstream-ruleset.test.ts` -- new fail-on-revert test (two reports `{x,y,z}` and `{z,w}` yield 4 distinct repos, not 3 + 2 = 5); updated the malformed-payload assertion to the deduped value (3 -> 2) with a rationale comment.

## Validation
- `npx tsc --noEmit` -- clean.
- `npx vitest run test/unit/upstream-ruleset.test.ts` -- 28/28 pass.
- Full suite -- 1065 pass, 1 skipped (one unrelated `mcp-cli` timeout under parallel load that passes 37/37 in isolation).
- Branch coverage 97.15% (above the 97% gate); `ruleset.ts` 98.89% branch / 100% line.

## Safety
- Public API shape is byte-compatible: `registryHyperparameterDrift` still exposes the same fields with the same types; only the (now correct, smaller-or-equal) `affectedRepoCount` value changes when reports share repos.
- No new public field; `affectedRepos` lives only on the stored payload and is defaulted to `[]` for empty/legacy payloads.

## Notes
The additive fields next to it (`totalEvents`, `omittedEvents`, `highImpactCount`) remain summed -- those count distinct events per report and are genuinely additive; only repositories recur across reports and must be unioned.