### PR TITLE
feat(mcp): add shell completion command for bash, zsh, and fish

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -43,6 +43,9 @@ gittensory-mcp cache clear
 gittensory-mcp init-client --print codex
 gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
+gittensory-mcp completion bash
+gittensory-mcp completion zsh
+gittensory-mcp completion fish
 gittensory-mcp decision-pack --login jsonbored --json
 gittensory-mcp repo-decision --login jsonbored --repo we-promise/sure --json
 gittensory-mcp analyze-branch --login jsonbored --json
@@ -69,6 +72,21 @@ Add `--json` for machine-readable output:
   "apiVersion": "0.1.0",
   "node": "v22.12.0"
 }
+```
+
+### Shell completion
+
+`gittensory-mcp completion <bash|zsh|fish>` prints a tab-completion script for your shell. It completes top-level commands and the subcommands of `profile`, `cache`, and `agent`. Add `--json` to get `{ "shell": "...", "script": "..." }` for tooling.
+
+```sh
+# bash (add to ~/.bashrc)
+source <(gittensory-mcp completion bash)
+
+# zsh (add to a file on your fpath, or to ~/.zshrc)
+source <(gittensory-mcp completion zsh)
+
+# fish
+gittensory-mcp completion fish > ~/.config/fish/completions/gittensory-mcp.fish
 ```
 
 For near-term what-if scoreability, pass the situational assumptions explicitly:

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -23,6 +23,25 @@ const decisionPackCacheMaxBytes = 512 * 1024;
 const changelogPath = new URL("../CHANGELOG.md", import.meta.url);
 const cliArgs = process.argv.slice(2);
 const defaultProfileName = "default";
+// Single source of truth for shell-completion: top-level command -> its subcommands (if any).
+const CLI_COMMAND_SPEC = {
+  login: [],
+  logout: [],
+  whoami: [],
+  status: [],
+  changelog: [],
+  version: [],
+  doctor: [],
+  "init-client": [],
+  "decision-pack": [],
+  "repo-decision": [],
+  "analyze-branch": [],
+  preflight: [],
+  profile: ["list", "create", "switch", "remove"],
+  cache: ["status", "clear"],
+  agent: ["plan", "status", "explain", "packet"],
+};
+const COMPLETION_SHELLS = ["bash", "zsh", "fish"];
 const configPath =
   process.env.GITTENSORY_CONFIG_PATH ??
   (process.env.GITTENSORY_CONFIG_DIR
@@ -518,6 +537,7 @@ async function runCli(args) {
   const command = args[0];
   if (command === "--help" || command === "help") return printHelp();
   if (command === "--version" || command === "-v" || command === "version") return printVersion(parseOptions(args.slice(1)));
+  if (command === "completion") return completionCommand(args.slice(1));
   if (command === "agent") return runAgentCli(args.slice(1));
   if (command === "cache") return runCacheCli(args.slice(1));
   const options = parseOptions(args.slice(1));
@@ -761,10 +781,90 @@ function printVersion(options) {
   process.stdout.write(`${packageName}/${packageVersion} (api ${currentApiVersion}, node ${process.version})\n`);
 }
 
+function completionCommand(args) {
+  const shell = args[0] && !args[0].startsWith("--") ? args[0] : undefined;
+  const options = parseOptions(args.filter((arg) => arg.startsWith("--")));
+  if (!shell) throw new Error(`Usage: gittensory-mcp completion <${COMPLETION_SHELLS.join("|")}> [--json]`);
+  if (!COMPLETION_SHELLS.includes(shell)) throw new Error(`Unsupported shell: ${shell}. Supported shells: ${COMPLETION_SHELLS.join(", ")}.`);
+  const script = buildCompletionScript(shell);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ shell, script }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${script}\n`);
+}
+
+function buildCompletionScript(shell) {
+  const topLevel = [...Object.keys(CLI_COMMAND_SPEC), "help"];
+  const withSubcommands = Object.entries(CLI_COMMAND_SPEC).filter(([, subcommands]) => subcommands.length > 0);
+  if (shell === "bash") return buildBashCompletion(topLevel, withSubcommands);
+  if (shell === "zsh") return buildZshCompletion(topLevel, withSubcommands);
+  return buildFishCompletion(topLevel, withSubcommands);
+}
+
+function buildBashCompletion(topLevel, withSubcommands) {
+  const subcommandCases = withSubcommands
+    .map(([command, subcommands]) => `      ${command}) COMPREPLY=( $(compgen -W "${subcommands.join(" ")}" -- "$cur") ); return 0;;`)
+    .join("\n");
+  return `# gittensory-mcp bash completion. Add to ~/.bashrc:
+#   source <(gittensory-mcp completion bash)
+_gittensory_mcp() {
+  local cur prev cword
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  prev="\${COMP_WORDS[COMP_CWORD-1]}"
+  cword=\$COMP_CWORD
+  local commands="${topLevel.join(" ")}"
+  if [ "\$cword" -eq 1 ]; then
+    COMPREPLY=( $(compgen -W "\$commands --help --version" -- "$cur") )
+    return 0
+  fi
+  case "\${COMP_WORDS[1]}" in
+${subcommandCases}
+      *) COMPREPLY=( $(compgen -W "--json --login --repo --profile --base --cwd" -- "$cur") ); return 0;;
+  esac
+}
+complete -F _gittensory_mcp gittensory-mcp`;
+}
+
+function buildZshCompletion(topLevel, withSubcommands) {
+  const subcommandCases = withSubcommands
+    .map(([command, subcommands]) => `      ${command}) _values 'subcommand' ${subcommands.join(" ")} ;;`)
+    .join("\n");
+  return `#compdef gittensory-mcp
+# gittensory-mcp zsh completion. Add to your fpath, or:
+#   source <(gittensory-mcp completion zsh)
+_gittensory_mcp() {
+  local -a commands
+  commands=(${topLevel.join(" ")})
+  if (( CURRENT == 2 )); then
+    _describe 'command' commands
+    return
+  fi
+  case $words[2] in
+${subcommandCases}
+  esac
+}
+_gittensory_mcp "$@"`;
+}
+
+function buildFishCompletion(topLevel, withSubcommands) {
+  const topLevelLines = topLevel
+    .map((command) => `complete -c gittensory-mcp -n __fish_use_subcommand -a ${command} -d 'gittensory-mcp command'`)
+    .join("\n");
+  const subcommandLines = withSubcommands
+    .map(([command, subcommands]) => `complete -c gittensory-mcp -n '__fish_seen_subcommand_from ${command}' -a '${subcommands.join(" ")}'`)
+    .join("\n");
+  return `# gittensory-mcp fish completion. Save to:
+#   ~/.config/fish/completions/gittensory-mcp.fish
+${topLevelLines}
+${subcommandLines}`;
+}
+
 function printHelp() {
   process.stdout.write(`Usage:
   gittensory-mcp --stdio
   gittensory-mcp version [--json]
+  gittensory-mcp completion bash|zsh|fish [--json]
   gittensory-mcp login [--profile name] [--github-token <token>] [--json]
   gittensory-mcp logout [--profile name] [--all] [--json]
   gittensory-mcp whoami [--profile name] [--json]

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -924,6 +924,35 @@ describe("gittensory-mcp CLI", () => {
     expect(() => run(["bogus-command"])).toThrow(/Unknown command: bogus-command/);
     expect(() => run(["bogus-command"])).toThrow(/gittensory-mcp --help/);
   });
+
+  it("prints shell completion scripts for bash, zsh, and fish", () => {
+    const bash = run(["completion", "bash"]);
+    expect(bash).toContain("_gittensory_mcp()");
+    expect(bash).toContain("complete -F _gittensory_mcp gittensory-mcp");
+    expect(bash).toContain("analyze-branch");
+    expect(bash).toContain("version");
+    expect(bash).toContain("plan status explain packet");
+
+    const zsh = run(["completion", "zsh"]);
+    expect(zsh).toContain("#compdef gittensory-mcp");
+    expect(zsh).toContain("_describe 'command' commands");
+    expect(zsh).toContain("list create switch remove");
+
+    const fish = run(["completion", "fish"]);
+    expect(fish).toContain("complete -c gittensory-mcp");
+    expect(fish).toContain("__fish_seen_subcommand_from agent");
+  });
+
+  it("emits completion as machine-readable json", () => {
+    const payload = JSON.parse(run(["completion", "zsh", "--json"])) as { shell: string; script: string };
+    expect(payload.shell).toBe("zsh");
+    expect(payload.script).toContain("#compdef gittensory-mcp");
+  });
+
+  it("rejects missing or unsupported completion shells", () => {
+    expect(() => run(["completion"])).toThrow(/Usage: gittensory-mcp completion <bash\|zsh\|fish>/);
+    expect(() => run(["completion", "powershell"])).toThrow(/Unsupported shell: powershell/);
+  });
 });
 
 function run(args: string[], env: Record<string, string> = {}) {


### PR DESCRIPTION
## Summary

Adds `gittensory-mcp completion <bash|zsh|fish>` — a standard CLI feature that prints a tab-completion script for the user's shell:

```sh
# bash (~/.bashrc)
source <(gittensory-mcp completion bash)

# zsh (~/.zshrc or fpath)
source <(gittensory-mcp completion zsh)

# fish
gittensory-mcp completion fish > ~/.config/fish/completions/gittensory-mcp.fish
```

It completes the top-level commands and the subcommands of `profile`, `cache`, and `agent`. `--json` returns `{ "shell": "...", "script": "..." }` for tooling. A missing or unsupported shell errors with the supported list.

## Design

The scripts are generated from a single `CLI_COMMAND_SPEC` (top-level command → subcommands) so completion stays in sync with the CLI surface rather than drifting from a hand-maintained list.

## Why no linked issue

Additive, self-contained CLI ergonomics. No public-behavior, auth/session, schema, deploy, or frontend-architecture change, so per CONTRIBUTING this does not require an issue first. Happy to file one if preferred.

## Changes

- `packages/gittensory-mcp/bin/gittensory-mcp.js` — `completion` dispatch; `completionCommand()` + `buildCompletionScript()` and per-shell generators; `CLI_COMMAND_SPEC`/`COMPLETION_SHELLS` constants; help-text usage line.
- `test/unit/mcp-cli.test.ts` — cover all three shells, the JSON form, and the missing/unsupported-shell errors.
- `packages/gittensory-mcp/README.md` — document the command with install snippets.

## Contract notes

No MCP tool or HTTP/OpenAPI contract changes. Local CLI command only; the `--json` payload is additive.

## Validation

Run locally from the repo root (environment note: portable **Node v20.18.1**; CI runs Node 22):

- `npm run build:mcp` → **pass** (exit 0)
- `npm run typecheck` (`tsc --noEmit`) → **pass** (exit 0)
- Focused `test/unit/mcp-cli.test.ts` → my new cases pass:
  - `prints shell completion scripts for bash, zsh, and fish` ✓
  - `emits completion as machine-readable json` ✓
  - `rejects missing or unsupported completion shells` ✓
- Smoke-tested each generated script (bash `complete -F`, zsh `#compdef`, fish `complete -c`) and the `--json` output.

Honest caveat (unrelated to this change): in a full `mcp-cli.test.ts` run, one **pre-existing** test (`rejects unsafe server-provided packet markdown before non-json output`, which does `git init` + subprocess work) times out at its 10s limit under the slow portable Node on Windows. It passes on CI (Linux/Node 22); my three cases and the other 36 tests pass locally. CI on this PR gives the authoritative full-gate result.

During development I caught and fixed a temporal-dead-zone bug (the command-spec constants are referenced by `runCli`, which is invoked at module load, so they must be declared before that call) before pushing.

## Security / privacy

No auth, cookie, CORS, GitHub App output, identity, or contributor-evidence changes. The generated scripts contain only static command/subcommand names already shown in `--help`.
