### PR TITLE
fix(mcp): enforce workspace roots for structured local status

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -571,8 +571,9 @@ server.registerTool(
   },
   async (input) => {
     let git = null;
+    const workspaceInput = await withClientWorkspaceRoots(input);
     try {
-      git = collectLocalBranchMetadata({ cwd: input.cwd ?? process.cwd(), baseRef: input.baseRef, repoFullName: input.repoFullName, login: "local" });
+      git = collectLocalBranchMetadata({ cwd: workspaceInput.cwd, baseRef: input.baseRef, repoFullName: input.repoFullName, login: "local", workspaceRoots: workspaceInput.workspaceRoots });
     } catch (error) {
       git = { error: error instanceof Error ? error.message : "local_status_failed" };
     }

--- a/test/unit/mcp-discovery.test.ts
+++ b/test/unit/mcp-discovery.test.ts
@@ -1,8 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { mkdtempSync, rmSync } from "node:fs";
+import { ListRootsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const bin = join(process.cwd(), "packages/gittensory-mcp/bin/gittensory-mcp.js");
@@ -32,6 +35,48 @@ async function disconnect() {
   await client.close().catch(() => undefined);
   if (configDir) rmSync(configDir, { recursive: true, force: true });
 }
+
+
+describe("MCP workspace root boundaries", () => {
+  it("applies client-advertised roots to structured local status cwd requests", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gittensory-roots-"));
+    const advertisedWorkspace = join(tempRoot, "advertised-workspace");
+    const privateRepo = join(tempRoot, "private-repo-outside-root");
+    const localConfigDir = join(tempRoot, "config");
+    mkdirSync(advertisedWorkspace, { recursive: true });
+    mkdirSync(privateRepo, { recursive: true });
+    mkdirSync(localConfigDir, { recursive: true });
+    execFileSync("git", ["init"], { cwd: privateRepo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "security@example.com"], { cwd: privateRepo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Security Test"], { cwd: privateRepo, stdio: "ignore" });
+
+    const rootedTransport = new StdioClientTransport({
+      command: "node",
+      args: [bin, "--stdio"],
+      env: {
+        ...process.env,
+        GITTENSORY_CONFIG_DIR: localConfigDir,
+        GITTENSORY_API_TIMEOUT_MS: "1000",
+      },
+    });
+    const rootedClient = new Client({ name: "roots-boundary-test", version: "0.0.1" }, { capabilities: { roots: {} } });
+    rootedClient.setRequestHandler(ListRootsRequestSchema, async () => ({
+      roots: [{ uri: pathToFileURL(advertisedWorkspace).href, name: "advertised-workspace" }],
+    }));
+
+    try {
+      await rootedClient.connect(rootedTransport);
+      const result = await rootedClient.callTool({ name: "gittensory_local_status_structured", arguments: { cwd: privateRepo } });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({
+        git: { error: "Selected workspace is outside the MCP roots exposed by the client." },
+      });
+    } finally {
+      await rootedClient.close().catch(() => undefined);
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("MCP resource discovery", () => {
   beforeEach(connect);


### PR DESCRIPTION
### Motivation
- The new `gittensory_local_status_structured` tool accepted an arbitrary `cwd` and called `collectLocalBranchMetadata()` without applying client-advertised MCP workspace roots, allowing metadata disclosure outside the declared workspace boundary.
- The change restores the same workspace-root mediation used by the legacy `gittensory_local_status` tool to preserve the MCP privacy boundary.

### Description
- Call `withClientWorkspaceRoots(input)` inside `gittensory_local_status_structured` and pass `workspaceRoots` into `collectLocalBranchMetadata()` so resolveWorkspaceCwd enforces client roots. 
- Add a regression test in `test/unit/mcp-discovery.test.ts` that advertises a single workspace root and verifies a `cwd` outside that root is rejected with the workspace-boundary error. 
- Add necessary imports and small test scaffolding to simulate a rooted MCP client and local git repo for the regression test.

### Testing
- Ran `npm --workspace @jsonbored/gittensory-mcp run build` and the build check completed successfully. 
- Ran `npx vitest run test/unit/mcp-discovery.test.ts` and the test suite passed (`1 file, 16 tests passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed without errors, and `git diff --check` reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2281a83b88832c8cefd891657c1312)