### PR TITLE
fix(mcp): redact absolute paths in PR drafts

### DIFF
--- a/src/services/pr-body-draft.ts
+++ b/src/services/pr-body-draft.ts
@@ -51,9 +51,13 @@ export const EXCLUDED_PRIVATE_PR_BODY_FIELDS = [
 // Residual private/financial terms that sanitizePublicComment does not rewrite on its own
 // (e.g. a bare "reward"/"score"/"ranking"); scrubbed to a neutral phrase as defense-in-depth.
 const RESIDUAL_PRIVATE_TERMS = /\b(reward\w*|score\w*|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability|wallet|hotkey|coldkey|mnemonic)\b/gi;
-const LOCAL_PATH_PATTERN = /(?:\/Users\/|\/home\/|\/tmp\/|[A-Za-z]:\\Users\\)[^\s"';]*/g;
+const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![:/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
+const LOCAL_PATH_PATTERN = new RegExp(LOCAL_PATH_SOURCE, "g");
 // Final guard used to drop anything that still looks unsafe after scrubbing.
-const FORBIDDEN_PR_BODY_LANGUAGE = /\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Za-z]:\\Users\\/i;
+const FORBIDDEN_PR_BODY_LANGUAGE = new RegExp(
+  String.raw`\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|${LOCAL_PATH_SOURCE}`,
+  "i",
+);
 
 function sanitizeLine(line: string): string {
   return sanitizePublicComment(line)

--- a/test/unit/pr-body-draft.test.ts
+++ b/test/unit/pr-body-draft.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { buildPublicPrBodyDraft, EXCLUDED_PRIVATE_PR_BODY_FIELDS, type PrBodyDraftSource } from "../../src/services/pr-body-draft";
 
-const FORBIDDEN_PUBLIC_LANGUAGE =
-  /\b(wallet|hotkey|coldkey|mnemonic|raw trust score|raw[-_\s]?trust|trust score|payout|reward estimate|reward|farming|private reviewability|reviewability|public score estimate|scoreability|ranking)\b|\/Users\/|\/home\/|\/tmp\/|[A-Za-z]:\\Users\\/i;
+const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![:/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
+const FORBIDDEN_PUBLIC_LANGUAGE = new RegExp(
+  String.raw`\b(wallet|hotkey|coldkey|mnemonic|raw trust score|raw[-_\s]?trust|trust score|payout|reward estimate|reward|farming|private reviewability|reviewability|public score estimate|scoreability|ranking)\b|${LOCAL_PATH_SOURCE}`,
+  "i",
+);
 
 function source(overrides: Partial<PrBodyDraftSource> = {}): PrBodyDraftSource {
   return {
@@ -159,7 +162,47 @@ describe("buildPublicPrBodyDraft — source-upload guard", () => {
     );
     expect(draft.sourceUploadDisabled).toBe(true);
     const blob = JSON.stringify(draft);
-    expect(blob).not.toMatch(/\/Users\/|\/home\/|\/tmp\/|[A-Za-z]:\\Users\\/);
+    expect(blob).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+    expect(blob).toContain("src/ok.ts");
+  });
+
+  it("redacts nonstandard absolute paths from public draft metadata", () => {
+    const draft = buildPublicPrBodyDraft(
+      source({
+        prPacket: {
+          ...source().prPacket,
+          titleSuggestion: "Fix build under /workspace/customer-x",
+          bodySections: [
+            {
+              heading: "Changed Paths",
+              lines: [
+                "- /var/folders/alice/work/private-repo/src/cache.ts (modified, +1/-0)",
+                "- /opt/company/secret-project/src/cache.ts (modified, +1/-0)",
+                "- /private/tmp/gittensory/src/cache.ts (modified, +1/-0)",
+                "- \\\\fileserver\\share\\secret-project\\src\\cache.ts (modified, +1/-0)",
+                "- src/ok.ts (modified, +1/-0)",
+              ],
+            },
+          ],
+          validationSummary: {
+            passed: 2,
+            failed: 0,
+            notRun: 0,
+            commands: [
+              { command: "npm test -- --root /workspace/customer-x", status: "passed", summary: "logs in C:/Users/Alice/AppData/Local/Temp/gittensory" },
+              { command: "node C:\\Users\\Alice\\private-repo\\scripts\\check.mjs", status: "passed", summary: "ok" },
+            ],
+          },
+          publicSafeWarnings: ["Reviewed from /opt/company/secret-project before posting."],
+        },
+      }),
+    );
+    const blob = JSON.stringify(draft);
+    expect(blob).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+    expect(blob).not.toMatch(/customer-x|private-repo|secret-project|Alice|fileserver/);
+    expect(blob).toContain("[local path]");
+    expect(blob).toContain("src/ok.ts");
+    expect(draft.markdown).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
   });
 
   it("lists the private analysis fields it deliberately excludes", () => {


### PR DESCRIPTION
### Motivation
- The PR-body drafter previously used a narrow path scrubber that only matched a few prefixes (`/Users/`, `/home/`, `/tmp/`, Windows `C:\Users\...`), allowing other absolute local paths to leak into public markdown.
- The public-safe drafting tool returns rendered markdown for copy/paste, so any missed absolute path in the draft is a privacy leak that must be redacted or cause the line to be dropped.

### Description
- Replace the ad-hoc `LOCAL_PATH_PATTERN` with a broader `LOCAL_PATH_SOURCE`/`LOCAL_PATH_PATTERN` `RegExp` that detects generic Unix absolute paths, Windows drive paths with either slash style, and UNC paths while avoiding relative repo paths and URLs.
- Update `FORBIDDEN_PR_BODY_LANGUAGE` to reuse the same `LOCAL_PATH_SOURCE` so any residual absolute path triggers the forbidden-language guard and prevents emission of the unsafe line.
- Keep the sanitized replacement behavior in `sanitizeLine` (`.replace(LOCAL_PATH_PATTERN, "[local path]")`) to show `[local path]` where appropriate and preserve relative repo paths like `src/ok.ts` and external URLs.
- Extend unit tests in `test/unit/pr-body-draft.test.ts` with a regression that asserts nonstandard absolute paths across titles, changed-path entries, validation commands/summaries, and warnings are redacted or cause blocks to be filtered, while retaining valid relative paths.

### Testing
- Ran unit tests with `npx vitest run test/unit/pr-body-draft.test.ts`, which reported: `1 passed (1)` test file and `17 passed (17)` tests. (All assertions in the updated `pr-body-draft` tests passed.)
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) which completed with no errors.
- Ran `git diff --check` which produced no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2281a27aa0832c9c25a2de876647ab)