### PR TITLE
feat(github-app): add advisory context and opt-in gate

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -3403,13 +3403,29 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "publicAudienceMode": {
+                "type": "string",
+                "enum": [
+                  "oss_maintainer",
+                  "gittensor_only"
+                ]
+              },
+              "gateCheckMode": {
+                "type": "string",
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               }
             },
             "required": [
               "installed",
               "publicSurface",
               "commentMode",
+              "publicAudienceMode",
               "checkRunMode",
+              "gateCheckMode",
               "quietByDefault",
               "behavior",
               "warnings"
@@ -7616,14 +7632,30 @@
           "updatedAt": {
             "type": "string",
             "nullable": true
+          },
+          "publicAudienceMode": {
+            "type": "string",
+            "enum": [
+              "oss_maintainer",
+              "gittensor_only"
+            ]
+          },
+          "gateCheckMode": {
+            "type": "string",
+            "enum": [
+              "off",
+              "enabled"
+            ]
           }
         },
         "required": [
           "repoFullName",
           "commentMode",
+          "publicAudienceMode",
           "publicSignalLevel",
           "checkRunMode",
           "checkRunDetailLevel",
+          "gateCheckMode",
           "autoLabelEnabled",
           "gittensorLabel",
           "createMissingLabel",
@@ -7684,12 +7716,28 @@
                     },
                     "autoLabelEnabled": {
                       "type": "boolean"
+                    },
+                    "publicAudienceMode": {
+                      "type": "string",
+                      "enum": [
+                        "oss_maintainer",
+                        "gittensor_only"
+                      ]
+                    },
+                    "gateCheckMode": {
+                      "type": "string",
+                      "enum": [
+                        "off",
+                        "enabled"
+                      ]
                     }
                   },
                   "required": [
                     "publicSurface",
                     "commentMode",
+                    "publicAudienceMode",
                     "checkRunMode",
+                    "gateCheckMode",
                     "autoLabelEnabled"
                   ]
                 }
@@ -7735,7 +7783,8 @@
                   "enum": [
                     "comment",
                     "label",
-                    "check_run"
+                    "check_run",
+                    "gate_check"
                   ]
                 },
                 "enabled": {
@@ -8124,14 +8173,30 @@
                   "defaultAllowed",
                   "commandOverrides"
                 ]
+              },
+              "publicAudienceMode": {
+                "type": "string",
+                "enum": [
+                  "oss_maintainer",
+                  "gittensor_only"
+                ]
+              },
+              "gateCheckMode": {
+                "type": "string",
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               }
             },
             "required": [
               "publicSurface",
               "commentMode",
+              "publicAudienceMode",
               "publicSignalLevel",
               "checkRunMode",
               "checkRunDetailLevel",
+              "gateCheckMode",
               "autoLabelEnabled",
               "gittensorLabel",
               "createMissingLabel",

--- a/migrations/0022_github_app_gate_settings.sql
+++ b/migrations/0022_github_app_gate_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repository_settings ADD COLUMN public_audience_mode TEXT NOT NULL DEFAULT 'oss_maintainer';
+ALTER TABLE repository_settings ADD COLUMN gate_check_mode TEXT NOT NULL DEFAULT 'off';

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -425,9 +425,11 @@ const agentExplainBlockersSchema = z.union([localBranchAnalysisSchema, agentPlan
 
 const repositorySettingsSchema = z.object({
   commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]).default("detected_contributors_only"),
+  publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]).default("oss_maintainer"),
   publicSignalLevel: z.enum(["minimal", "standard"]).default("standard"),
   checkRunMode: z.enum(["off", "enabled"]).default("off"),
   checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]).default("standard"),
+  gateCheckMode: z.enum(["off", "enabled"]).default("off"),
   autoLabelEnabled: z.boolean().default(true),
   gittensorLabel: z.string().trim().min(1).max(50).default("gittensor"),
   createMissingLabel: z.boolean().default(true),
@@ -2170,9 +2172,11 @@ export function createApp() {
       await upsertRepositorySettings(c.env, {
         repoFullName: fullName,
         commentMode: parsed.data.commentMode,
+        publicAudienceMode: parsed.data.publicAudienceMode,
         publicSignalLevel: parsed.data.publicSignalLevel,
         checkRunMode: parsed.data.checkRunMode,
         checkRunDetailLevel: parsed.data.checkRunDetailLevel,
+        gateCheckMode: parsed.data.gateCheckMode,
         autoLabelEnabled: parsed.data.autoLabelEnabled,
         gittensorLabel: parsed.data.gittensorLabel,
         createMissingLabel: parsed.data.createMissingLabel,

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, not, or, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, not, or, sql, type SQL } from "drizzle-orm";
 import { getDb } from "./client";
 import {
   advisories,
@@ -200,6 +200,16 @@ export async function markInstallationDeleted(env: Env, installationId: number):
     .where(eq(repositories.installationId, installationId));
 }
 
+export async function markRepositoriesRemovedFromInstallation(env: Env, installationId: number, repoFullNames: string[]): Promise<void> {
+  const names = [...new Set(repoFullNames.filter(Boolean))];
+  if (names.length === 0) return;
+  const db = getDb(env.DB);
+  await db
+    .update(repositories)
+    .set({ isInstalled: false, installationId: null, updatedAt: nowIso() })
+    .where(and(eq(repositories.installationId, installationId), inArray(repositories.fullName, names)));
+}
+
 export async function getInstallation(env: Env, installationId: number): Promise<InstallationRecord | null> {
   const db = getDb(env.DB);
   const [row] = await db.select().from(installations).where(eq(installations.id, installationId)).limit(1);
@@ -359,9 +369,11 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     return {
       repoFullName: fullName,
       commentMode: "detected_contributors_only",
+      publicAudienceMode: "oss_maintainer",
       publicSignalLevel: "standard",
       checkRunMode: "off",
       checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
       autoLabelEnabled: true,
       gittensorLabel: "gittensor",
       createMissingLabel: true,
@@ -376,9 +388,11 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
   return {
     repoFullName: row.repoFullName,
     commentMode: parseCommentMode(row.commentMode),
+    publicAudienceMode: parsePublicAudienceMode(row.publicAudienceMode),
     publicSignalLevel: row.publicSignalLevel === "minimal" ? "minimal" : "standard",
     checkRunMode: parseCheckRunMode(row.checkRunMode),
     checkRunDetailLevel: parseCheckRunDetailLevel(row.checkRunDetailLevel),
+    gateCheckMode: parseGateCheckMode(row.gateCheckMode),
     autoLabelEnabled: row.autoLabelEnabled,
     gittensorLabel: row.gittensorLabel,
     createMissingLabel: row.createMissingLabel,
@@ -397,9 +411,11 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
   const resolved: RepositorySettings = {
     repoFullName: settings.repoFullName,
     commentMode: settings.commentMode ?? "detected_contributors_only",
+    publicAudienceMode: settings.publicAudienceMode ?? "oss_maintainer",
     publicSignalLevel: settings.publicSignalLevel ?? "standard",
     checkRunMode: settings.checkRunMode ?? "off",
     checkRunDetailLevel: settings.checkRunDetailLevel ?? "minimal",
+    gateCheckMode: settings.gateCheckMode ?? "off",
     autoLabelEnabled: settings.autoLabelEnabled ?? true,
     gittensorLabel: settings.gittensorLabel ?? "gittensor",
     createMissingLabel: settings.createMissingLabel ?? true,
@@ -416,9 +432,11 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     .values({
       repoFullName: resolved.repoFullName,
       commentMode: resolved.commentMode,
+      publicAudienceMode: resolved.publicAudienceMode,
       publicSignalLevel: resolved.publicSignalLevel,
       checkRunMode: resolved.checkRunMode,
       checkRunDetailLevel: resolved.checkRunDetailLevel,
+      gateCheckMode: resolved.gateCheckMode,
       autoLabelEnabled: resolved.autoLabelEnabled,
       gittensorLabel: resolved.gittensorLabel,
       createMissingLabel: resolved.createMissingLabel,
@@ -434,9 +452,11 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       target: repositorySettings.repoFullName,
       set: {
         commentMode: resolved.commentMode,
+        publicAudienceMode: resolved.publicAudienceMode,
         publicSignalLevel: resolved.publicSignalLevel,
         checkRunMode: resolved.checkRunMode,
         checkRunDetailLevel: resolved.checkRunDetailLevel,
+        gateCheckMode: resolved.gateCheckMode,
         autoLabelEnabled: resolved.autoLabelEnabled,
         gittensorLabel: resolved.gittensorLabel,
         createMissingLabel: resolved.createMissingLabel,
@@ -4215,6 +4235,10 @@ function parseCommentMode(value: string): RepositorySettings["commentMode"] {
   return "off";
 }
 
+function parsePublicAudienceMode(value: string): RepositorySettings["publicAudienceMode"] {
+  return value === "gittensor_only" ? "gittensor_only" : "oss_maintainer";
+}
+
 function parseCheckRunMode(value: string): RepositorySettings["checkRunMode"] {
   return value === "enabled" ? "enabled" : "off";
 }
@@ -4222,6 +4246,10 @@ function parseCheckRunMode(value: string): RepositorySettings["checkRunMode"] {
 function parseCheckRunDetailLevel(value: string): RepositorySettings["checkRunDetailLevel"] {
   if (value === "minimal" || value === "deep") return value;
   return "standard";
+}
+
+function parseGateCheckMode(value: string): RepositorySettings["gateCheckMode"] {
+  return value === "enabled" ? "enabled" : "off";
 }
 
 function parsePublicSurface(value: string): RepositorySettings["publicSurface"] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -36,9 +36,11 @@ export const repositories = sqliteTable("repositories", {
 export const repositorySettings = sqliteTable("repository_settings", {
   repoFullName: text("repo_full_name").primaryKey(),
   commentMode: text("comment_mode").notNull().default("detected_contributors_only"),
+  publicAudienceMode: text("public_audience_mode").notNull().default("oss_maintainer"),
   publicSignalLevel: text("public_signal_level").notNull().default("standard"),
   checkRunMode: text("check_run_mode").notNull().default("off"),
   checkRunDetailLevel: text("check_run_detail_level").notNull().default("minimal"),
+  gateCheckMode: text("gate_check_mode").notNull().default("off"),
   autoLabelEnabled: integer("auto_label_enabled", { mode: "boolean" }).notNull().default(true),
   gittensorLabel: text("gittensor_label").notNull().default("gittensor"),
   createMissingLabel: integer("create_missing_label", { mode: "boolean" }).notNull().default(true),

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/core";
 import type { Advisory, GitHubWebhookPayload } from "../types";
 import { signRs256Jwt } from "../utils/crypto";
-import { formatCheckRunOutput } from "../rules/advisory";
+import { evaluateGateCheck, formatCheckRunOutput, formatGateCheckOutput, type GateCheckConclusion } from "../rules/advisory";
 
 type CheckRunResponse = {
   id: number;
@@ -19,6 +19,11 @@ type CheckRunListResponse = {
 export type CheckRunOutcome =
   | { kind: "published"; id: number; html_url?: string }
   | { kind: "permission_missing"; warning: string };
+
+export const GITTENSORY_CONTEXT_CHECK_NAME = "Gittensory Context";
+export const GITTENSORY_GATE_CHECK_NAME = "Gittensory Gate";
+
+type GitHubCheckConclusion = Advisory["conclusion"] | GateCheckConclusion | "skipped";
 
 export async function createInstallationToken(env: Env, installationId: number): Promise<string> {
   const jwt = await createAppJwt(env);
@@ -71,20 +76,47 @@ export async function createOrUpdateCheckRun(
   advisory: Advisory,
   detailLevel: "minimal" | "standard" | "deep" = "minimal",
 ): Promise<CheckRunOutcome | null> {
+  return createOrUpdateNamedCheckRun(env, installationId, repoFullName, advisory, {
+    name: GITTENSORY_CONTEXT_CHECK_NAME,
+    conclusion: advisory.conclusion,
+    output: formatCheckRunOutput(advisory, detailLevel),
+  });
+}
+
+export async function createOrUpdateGateCheckRun(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  advisory: Advisory,
+): Promise<CheckRunOutcome | null> {
+  const gate = evaluateGateCheck(advisory);
+  return createOrUpdateNamedCheckRun(env, installationId, repoFullName, advisory, {
+    name: GITTENSORY_GATE_CHECK_NAME,
+    conclusion: gate.conclusion,
+    output: formatGateCheckOutput(gate),
+  });
+}
+
+async function createOrUpdateNamedCheckRun(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  advisory: Advisory,
+  check: { name: string; conclusion: GitHubCheckConclusion; output: { title: string; summary: string; text: string } },
+): Promise<CheckRunOutcome | null> {
   if (!advisory.headSha) return null;
   const [owner, repo] = repoFullName.split("/");
   if (!owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
 
   const token = await createInstallationToken(env, installationId);
   const octokit = new Octokit({ auth: token });
-  const output = formatCheckRunOutput(advisory, detailLevel);
 
   try {
     const existing = await octokit.request("GET /repos/{owner}/{repo}/commits/{ref}/check-runs", {
       owner,
       repo,
       ref: advisory.headSha,
-      check_name: "Gittensory",
+      check_name: check.name,
       filter: "latest",
       per_page: 1,
     });
@@ -94,10 +126,10 @@ export async function createOrUpdateCheckRun(
         owner,
         repo,
         check_run_id: existingCheckRun.id,
-        name: "Gittensory",
+        name: check.name,
         status: "completed",
-        conclusion: advisory.conclusion,
-        output,
+        conclusion: check.conclusion,
+        output: check.output,
       });
       const data = response.data as CheckRunResponse;
       return publishedOutcome(data);
@@ -106,11 +138,11 @@ export async function createOrUpdateCheckRun(
     const response = await octokit.request("POST /repos/{owner}/{repo}/check-runs", {
       owner,
       repo,
-      name: "Gittensory",
+      name: check.name,
       head_sha: advisory.headSha,
       status: "completed",
-      conclusion: advisory.conclusion,
-      output,
+      conclusion: check.conclusion,
+      output: check.output,
     });
     const data = response.data as CheckRunResponse;
     return publishedOutcome(data);
@@ -132,6 +164,7 @@ function publishedOutcome(data: CheckRunResponse): CheckRunOutcome {
 }
 
 function isCheckRunPermissionError(error: unknown): boolean {
+  /* v8 ignore next -- Octokit wraps thrown fetch values in HttpError objects before this helper sees them. */
   if (typeof error !== "object" || error === null) return false;
   const e = error as { status?: number; message?: string };
   if (e.status === 403) return true;

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -645,11 +645,11 @@ export const OPTIONAL_CHECK_RUN_PERMISSION: Record<string, string> = {
   checks: "write",
 };
 
-export const REQUIRED_INSTALLATION_EVENTS = ["issues", "issue_comment", "pull_request", "repository"] as const;
+export const REQUIRED_INSTALLATION_EVENTS = ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"] as const;
 export const OPTIONAL_VISIBLE_INSTALLATION_EVENTS = ["installation_target"] as const;
 
 type InstallationModeImpact = {
-  mode: "comment" | "label" | "check_run";
+  mode: "comment" | "label" | "check_run" | "gate_check";
   enabled: boolean;
   affectedRepoCount: number;
   requiredPermissions: Array<{ permission: string; requiredAccess: string; missing: boolean; optional: boolean }>;
@@ -708,13 +708,14 @@ export async function buildInstallationRepairDiagnostics(env: Env, health: Insta
   const commentRepoCount = installedSettings.filter(usesCommentMode).length;
   const labelRepoCount = installedSettings.filter(usesLabelMode).length;
   const checkRunRepoCount = installedSettings.filter((settings) => settings.checkRunMode === "enabled").length;
+  const gateCheckRepoCount = installedSettings.filter((settings) => settings.gateCheckMode === "enabled").length;
   const missingPermissions = new Set(health.missingPermissions);
   const missingEvents = new Set(health.missingEvents);
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
-    ...(checkRunRepoCount > 0 ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
+    ...(checkRunRepoCount > 0 || gateCheckRepoCount > 0 ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
   };
-  const optionalPermissions = checkRunRepoCount > 0 ? {} : OPTIONAL_CHECK_RUN_PERMISSION;
+  const optionalPermissions = checkRunRepoCount > 0 || gateCheckRepoCount > 0 ? {} : OPTIONAL_CHECK_RUN_PERMISSION;
   const modeImpacts: InstallationModeImpact[] = [
     buildPermissionModeImpact({
       mode: "comment",
@@ -746,6 +747,19 @@ export async function buildInstallationRepairDiagnostics(env: Env, health: Insta
         checkRunRepoCount > 0
           ? "Check run mode is enabled for at least one installed repo, so Checks: write is required."
           : "Checks: write is optional unless check run mode is enabled for an installed repo.",
+    }),
+    buildPermissionModeImpact({
+      mode: "gate_check",
+      enabled: gateCheckRepoCount > 0,
+      affectedRepoCount: gateCheckRepoCount,
+      permission: "checks",
+      requiredAccess: "write",
+      missing: gateCheckRepoCount > 0 && missingPermissions.has("checks"),
+      optional: gateCheckRepoCount === 0,
+      summary:
+        gateCheckRepoCount > 0
+          ? "Gate check mode is enabled for at least one installed repo, so Checks: write is required."
+          : "Checks: write is optional unless gate check mode is enabled for an installed repo.",
     }),
   ];
   const eventDiagnostics: InstallationEventDiagnostic[] = REQUIRED_INSTALLATION_EVENTS.map((event) => ({
@@ -820,7 +834,9 @@ function summarizeRepairSettings(settings: RepositorySettings) {
   return {
     publicSurface: settings.publicSurface,
     commentMode: settings.commentMode,
+    publicAudienceMode: settings.publicAudienceMode,
     checkRunMode: settings.checkRunMode,
+    gateCheckMode: settings.gateCheckMode,
     autoLabelEnabled: settings.autoLabelEnabled,
   };
 }

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -208,15 +208,29 @@ export function buildPublicAgentCommandComment(args: {
   });
   const body = [
     AGENT_COMMAND_COMMENT_MARKER,
-    `### ${COMMAND_TITLES[args.command.name]}`,
+    "",
+    "> [!NOTE]",
+    `> **${COMMAND_TITLES[args.command.name]}**`,
+    "> Gittensory updated this command response in place from cached public-safe context.",
+    "",
+    "| Signal | State |",
+    "| --- | --- |",
+    `| Command | \`@gittensory ${args.command.name}\` |`,
+    `| Scope | ${repoFullName}#${args.issue.number} |`,
+    `| Actor | ${args.actorKind} |`,
     "",
     `Command: \`@gittensory ${args.command.name}\``,
-    `Scope: ${repoFullName}#${args.issue.number}`,
+    "",
+    "<details>",
+    "<summary>Command result</summary>",
     "",
     ...renderPublicAnswerCard(card),
+    "",
+    "</details>",
     ...feedbackPromptSections(args.answerId),
     "",
-    "_Advisory context only. Public comments exclude non-public contributor signals and private planning internals._",
+    "---",
+    "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers.",
   ].join("\n");
   return sanitizePublicComment(body);
 }

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -1,8 +1,11 @@
 import { Octokit } from "@octokit/core";
 import { createInstallationToken } from "./app";
 
-export const PR_INTELLIGENCE_COMMENT_MARKER = "<!-- gittensory-pr-intelligence -->";
-export const AGENT_COMMAND_COMMENT_MARKER = "<!-- gittensory-agent-command -->";
+export const PR_PANEL_COMMENT_MARKER = "<!-- gittensory-pr-panel:v1 -->";
+export const PR_INTELLIGENCE_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
+export const AGENT_COMMAND_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
+const LEGACY_PR_INTELLIGENCE_COMMENT_MARKER = "<!-- gittensory-pr-intelligence -->";
+const LEGACY_AGENT_COMMAND_COMMENT_MARKER = "<!-- gittensory-agent-command -->";
 
 type IssueComment = {
   id: number;
@@ -54,7 +57,8 @@ async function createOrUpdateIssueCommentWithMarker(
     per_page: 100,
   });
   const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
-  const existing = (comments.data as IssueComment[]).find((comment) => isGittensoryBotComment(comment, botLogin) && comment.body?.includes(marker));
+  const markers = markerAliases(marker);
+  const existing = (comments.data as IssueComment[]).find((comment) => isGittensoryBotComment(comment, botLogin) && markers.some((candidate) => comment.body?.includes(candidate)));
   if (existing) {
     const response = await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
       owner,
@@ -75,4 +79,8 @@ async function createOrUpdateIssueCommentWithMarker(
 
 function isGittensoryBotComment(comment: IssueComment, botLogin: string): boolean {
   return comment.user?.type === "Bot" && comment.user.login?.toLowerCase() === botLogin.toLowerCase();
+}
+
+function markerAliases(_marker: string): string[] {
+  return [PR_PANEL_COMMENT_MARKER, LEGACY_PR_INTELLIGENCE_COMMENT_MARKER, LEGACY_AGENT_COMMAND_COMMENT_MARKER];
 }

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -537,9 +537,11 @@ export const RepositorySettingsSchema = z
   .object({
     repoFullName: z.string(),
     commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
+    publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
     publicSignalLevel: z.enum(["minimal", "standard"]),
     checkRunMode: z.enum(["off", "enabled"]),
     checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]),
+    gateCheckMode: z.enum(["off", "enabled"]),
     autoLabelEnabled: z.boolean(),
     gittensorLabel: z.string(),
     createMissingLabel: z.boolean(),
@@ -564,9 +566,11 @@ export const RepoSettingsPreviewSchema = z
     settings: z.object({
       publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]),
       commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
+      publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
       publicSignalLevel: z.enum(["minimal", "standard"]),
       checkRunMode: z.enum(["off", "enabled"]),
       checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]),
+      gateCheckMode: z.enum(["off", "enabled"]),
       autoLabelEnabled: z.boolean(),
       gittensorLabel: z.string(),
       createMissingLabel: z.boolean(),
@@ -918,7 +922,9 @@ export const InstallationRepairSchema = z
         settings: z.object({
           publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]),
           commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
+          publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
           checkRunMode: z.enum(["off", "enabled"]),
+          gateCheckMode: z.enum(["off", "enabled"]),
           autoLabelEnabled: z.boolean(),
         }),
       }),
@@ -929,7 +935,7 @@ export const InstallationRepairSchema = z
     optionalEvents: z.array(z.string()),
     modeImpacts: z.array(
       z.object({
-        mode: z.enum(["comment", "label", "check_run"]),
+        mode: z.enum(["comment", "label", "check_run", "gate_check"]),
         enabled: z.boolean(),
         affectedRepoCount: z.number(),
         requiredPermissions: z.array(z.object({ permission: z.string(), requiredAccess: z.string(), missing: z.boolean(), optional: z.boolean() })),
@@ -1794,7 +1800,9 @@ export const RegistrationReadinessSchema = z
       installed: z.boolean(),
       publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]),
       commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
+      publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
       checkRunMode: z.enum(["off", "enabled"]),
+      gateCheckMode: z.enum(["off", "enabled"]),
       quietByDefault: z.boolean(),
       behavior: z.string(),
       warnings: z.array(z.string()),

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -30,6 +30,7 @@ import {
   listRepoSyncSegments,
   listRepositories,
   markInstallationDeleted,
+  markRepositoriesRemovedFromInstallation,
   persistAdvisory,
   recordAgentCommandFeedback,
   recordAuditEvent,
@@ -58,7 +59,7 @@ import {
   refreshInstallationHealth,
 } from "../github/backfill";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot, fetchOfficialGittensorMiner, type GittensorContributorSnapshot, type OfficialGittensorMinerDetection } from "../gittensor/api";
-import { createOrUpdateCheckRun, getInstallationId } from "../github/app";
+import { createOrUpdateCheckRun, createOrUpdateGateCheckRun, getInstallationId } from "../github/app";
 import { createOrUpdateAgentCommandComment, createOrUpdatePrIntelligenceComment } from "../github/comments";
 import {
   buildMaintainerQueueDigest,
@@ -592,7 +593,34 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
     }
 
     await upsertInstallation(env, payload);
-    if (eventName === "installation" && (payload.action === "created" || payload.action === "added")) {
+    if (eventName === "installation_repositories" && payload.installation?.id) {
+      const addedRepos = payload.repositories_added?.map((repo) => repo.full_name).filter(Boolean) ?? [];
+      const removedRepos = payload.repositories_removed?.map((repo) => repo.full_name).filter(Boolean) ?? [];
+      for (const repo of payload.repositories_added ?? []) await upsertRepositoryFromGitHub(env, repo, payload.installation.id);
+      await markRepositoriesRemovedFromInstallation(env, payload.installation.id, removedRepos);
+      await Promise.all([
+        ...addedRepos.slice(0, 50).map((repoFullName) =>
+          recordGithubProductUsage(env, "github_installation_repository_added", {
+            actor: payload.installation?.account?.login,
+            repoFullName,
+            targetKey: payload.installation?.id ? `installation:${payload.installation.id}` : repoFullName,
+            outcome: "completed",
+            metadata: { action: payload.action, repoCount: addedRepos.length, truncatedRepos: Math.max(addedRepos.length - 50, 0) },
+          }),
+        ),
+        ...removedRepos.slice(0, 50).map((repoFullName) =>
+          recordGithubProductUsage(env, "github_installation_repository_removed", {
+            actor: payload.installation?.account?.login,
+            repoFullName,
+            targetKey: payload.installation?.id ? `installation:${payload.installation.id}` : repoFullName,
+            outcome: "completed",
+            metadata: { action: payload.action, repoCount: removedRepos.length, truncatedRepos: Math.max(removedRepos.length - 50, 0) },
+          }),
+        ),
+      ]);
+    }
+
+    if (eventName === "installation" && payload.action === "created") {
       const installedRepos = payload.repositories?.map((repo) => repo.full_name).filter(Boolean) ?? (payload.repository?.full_name ? [payload.repository.full_name] : [undefined]);
       await Promise.all(
         installedRepos.slice(0, 50).map((repoFullName) =>
@@ -710,6 +738,19 @@ async function maybePublishPrPublicSurface(
   webhook: { deliveryId: string; authorType?: string | undefined },
 ): Promise<void> {
   const author = pr.authorLogin ?? null;
+  if (settings.gateCheckMode === "enabled" && advisory.headSha) {
+    const gateCheckResult = await createOrUpdateGateCheckRun(env, installationId, repoFullName, advisory);
+    if (gateCheckResult?.kind === "permission_missing") {
+      await recordAuditEvent(env, {
+        eventType: "github_app.gate_check_permission_missing",
+        actor: author,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "error",
+        detail: gateCheckResult.warning,
+        metadata: { deliveryId: webhook.deliveryId, repoFullName },
+      });
+    }
+  }
   // Cheap, network-free skip checks (also avoids the miner lookup when it would be wasted).
   const prelim = decidePublicSurface({
     settings,
@@ -722,17 +763,19 @@ async function maybePublishPrPublicSurface(
     await auditPrVisibilitySkip(env, repoFullName, pr.number, author, prelim.skipReason ?? "skipped", webhook.deliveryId);
     return;
   }
+  if (prelim.actions.length === 1 && prelim.actions[0] === "none") return;
   if (!author) return;
 
+  const requireOfficialMiner = settings.publicAudienceMode === "gittensor_only";
   const official = await getCachedOfficialMinerDetection(env, author, {
     targetKey: `${repoFullName}#${pr.number}`,
     deliveryId: webhook.deliveryId,
   });
-  if (official.status === "unavailable") {
+  if (requireOfficialMiner && official.status === "unavailable") {
     await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
     return;
   }
-  if (official.status !== "confirmed") {
+  if (requireOfficialMiner && official.status !== "confirmed") {
     await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
     return;
   }
@@ -741,7 +784,7 @@ async function maybePublishPrPublicSurface(
     authorLogin: author,
     authorType: webhook.authorType ?? null,
     authorAssociation: pr.authorAssociation ?? null,
-    minerStatus: "confirmed",
+    minerStatus: official.status,
   });
 
   const [contributorPullRequests, contributorIssues, repoIssues, repoPullRequests, repoBounties, github, cachedRepoStats] = await Promise.all([
@@ -753,10 +796,13 @@ async function maybePublishPrPublicSurface(
     fetchPublicContributorProfile(author),
     listContributorRepoStats(env, author),
   ]);
-  const repoStats = authoritativeContributorRepoStats(official.snapshot, cachedRepoStats);
-  const detection = officialGittensorContributorDetection(official.snapshot, pr, contributorPullRequests, contributorIssues, repoStats);
+  const repoStats = official.status === "confirmed" ? authoritativeContributorRepoStats(official.snapshot, cachedRepoStats) : cachedRepoStats;
+  const detection =
+    official.status === "confirmed"
+      ? officialGittensorContributorDetection(official.snapshot, pr, contributorPullRequests, contributorIssues, repoStats)
+      : detectGittensorContributor(author, pr, contributorPullRequests, contributorIssues, repoStats);
 
-  const profile = buildContributorProfile(author, github, contributorPullRequests, contributorIssues, repoStats, official.snapshot);
+  const profile = buildContributorProfile(author, github, contributorPullRequests, contributorIssues, repoStats, official.status === "confirmed" ? official.snapshot : null);
   const collisions = buildCollisionReport(repoFullName, repoIssues, repoPullRequests);
   const queueHealth = buildQueueHealth(repo, repoIssues, repoPullRequests, collisions);
   const preflight = buildPreflightResult(
@@ -815,6 +861,8 @@ async function maybePublishPrPublicSurface(
       publicSurface: settings.publicSurface,
       label: decision.willLabel ? settings.gittensorLabel : null,
       checkRunMode: settings.checkRunMode,
+      gateCheckMode: settings.gateCheckMode,
+      publicAudienceMode: settings.publicAudienceMode,
     },
   });
   await recordGithubProductUsage(env, "pr_public_surface_published", {
@@ -826,6 +874,8 @@ async function maybePublishPrPublicSurface(
       publicSurface: settings.publicSurface,
       labelApplied: decision.willLabel,
       checkRunMode: settings.checkRunMode,
+      gateCheckMode: settings.gateCheckMode,
+      publicAudienceMode: settings.publicAudienceMode,
     },
   });
 }

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -9,6 +9,17 @@ import type {
 } from "../types";
 import { nowIso } from "../utils/json";
 
+export type GateCheckConclusion = "success" | "failure" | "action_required";
+
+export type GateCheckEvaluation = {
+  enabled: boolean;
+  conclusion: GateCheckConclusion;
+  title: string;
+  summary: string;
+  blockers: AdvisoryFinding[];
+  warnings: AdvisoryFinding[];
+};
+
 export function buildRepositoryAdvisory(repo: RepositoryRecord | null, fullName: string): Advisory {
   const findings: AdvisoryFinding[] = [];
   if (!repo) {
@@ -114,6 +125,48 @@ export function formatCheckRunOutput(
   }
 
   return { title, summary, text: publicLines.join("\n") };
+}
+
+export function evaluateGateCheck(advisoryResult: Advisory): GateCheckEvaluation {
+  const blockers = advisoryResult.findings.filter((finding) => isGateBlocker(finding.code));
+  const brokenEvaluation = blockers.some((finding) => isEvaluationBlocker(finding.code));
+  if (blockers.length === 0) {
+    return {
+      enabled: true,
+      conclusion: "success",
+      title: "Gittensory Gate passed",
+      summary: "No configured merge-blocking hygiene issue was found.",
+      blockers,
+      warnings: advisoryResult.findings.filter((finding) => finding.severity === "warning"),
+    };
+  }
+  return {
+    enabled: true,
+    conclusion: brokenEvaluation ? "action_required" : "failure",
+    title: "Gittensory Gate is blocking merge",
+    summary: `${blockers.length} configured merge-blocking issue${blockers.length === 1 ? "" : "s"} found.`,
+    blockers,
+    warnings: advisoryResult.findings.filter((finding) => finding.severity === "warning" && !blockers.includes(finding)),
+  };
+}
+
+export function formatGateCheckOutput(gate: GateCheckEvaluation): { title: string; summary: string; text: string } {
+  if (gate.conclusion === "success") {
+    return {
+      title: gate.title,
+      summary: "Gittensory Gate is an opt-in merge gate. This PR passed the configured public hygiene checks.",
+      text: "No configured merge-blocking issue was found.",
+    };
+  }
+  const blockerLines = gate.blockers.slice(0, 8).map((finding) => {
+    const action = finding.action ? ` Action: ${sanitizeForCheckRun(finding.action)}` : "";
+    return `- ${sanitizeForCheckRun(finding.title)}.${action}`;
+  });
+  return {
+    title: gate.title,
+    summary: "Gittensory Gate is an opt-in merge gate. Fix the listed public hygiene issue before merge, or disable the gate for this repo.",
+    text: blockerLines.length > 0 ? blockerLines.join("\n") : "A configured merge-blocking issue was found.",
+  };
 }
 
 function addRepoFindings(repo: RepositoryRecord, findings: AdvisoryFinding[]): void {
@@ -301,4 +354,12 @@ function conclusionForSeverity(severity: AdvisorySeverity, findings: AdvisoryFin
   if (severity === "warning") return "neutral";
   if (severity === "critical") return "action_required";
   return "success";
+}
+
+function isGateBlocker(code: string): boolean {
+  return code === "missing_linked_issue" || code === "duplicate_pr_risk" || isEvaluationBlocker(code);
+}
+
+function isEvaluationBlocker(code: string): boolean {
+  return code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached";
 }

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1213,6 +1213,7 @@ export function detectGittensorContributor(
 export function shouldPublishPrIntelligenceComment(settings: RepositorySettings, detection: ContributorDetection): boolean {
   if (settings.commentMode === "off") return false;
   if (settings.publicSurface !== "comment_and_label" && settings.publicSurface !== "comment_only") return false;
+  if (settings.publicAudienceMode === "oss_maintainer") return settings.commentMode === "all_prs" || detection.detected || detection.source !== "official_gittensor_api";
   return detection.detected && detection.source === "official_gittensor_api";
 }
 
@@ -3453,41 +3454,100 @@ export function buildPublicPrIntelligenceComment(args: {
     /* v8 ignore next -- Public findings may omit actions; public comment tests cover sanitized action inclusion. */
     ...(publicFindings.length > 0 ? publicFindings.flatMap((finding) => (finding.action ? [finding.action] : [])) : []),
   ].filter((step) => !containsPrivatePublicTerm(step));
+  const gateEnabled = args.settings.gateCheckMode === "enabled";
+  const missingRequiredIssue = args.settings.requireLinkedIssue && args.pr.linkedIssues.length === 0;
+  const gateBlocking = gateEnabled && (missingRequiredIssue || collisionCount > 0 || !args.repo);
+  const confirmedMiner = args.detection.source === "official_gittensor_api";
+  const genericOssMode = args.settings.publicAudienceMode === "oss_maintainer";
+  const alert = gateBlocking
+    ? missingRequiredIssue
+      ? "WARNING"
+      : "CAUTION"
+    : args.preflight.findings.some((finding) => finding.severity === "warning")
+      ? "IMPORTANT"
+      : "TIP";
+  const panelTitle = gateBlocking
+    ? "Gittensory Gate is blocking merge"
+    : args.preflight.findings.some((finding) => finding.severity === "warning")
+      ? "Gittensory found maintainer review notes"
+      : "Gittensory PR readiness looks good";
+  const panelSummary = gateBlocking
+    ? missingRequiredIssue
+      ? "This repository requires linked issues, but this PR does not reference one yet."
+      : collisionCount > 0
+        ? "This PR overlaps with cached open work and should be resolved before merge."
+        : "Gittensory cannot evaluate the repo state closely enough for the enabled gate."
+    : genericOssMode
+      ? "Public GitHub metadata was checked for review readiness. Gittensor-specific context appears only when confirmed."
+      : "Confirmed Gittensor contributor context was checked from public metadata and Gittensory cache.";
+  const rows: Array<[string, string]> = [
+    ["Linked issue", linkedIssues],
+    ["Duplicate risk", collisionCount > 0 ? `${collisionCount} possible overlap${collisionCount === 1 ? "" : "s"}` : "No cached overlap"],
+    ["Review burden", args.preflight.reviewBurden],
+    ["Queue level", args.queueHealth.level],
+    ["Contributor context", confirmedMiner ? "Confirmed Gittensor contributor" : args.detection.detected ? "Cached OSS contributor activity" : "Public profile only"],
+    ["Gate result", gateEnabled ? (gateBlocking ? "Failing" : "Passing") : "Advisory only"],
+  ];
+  const maintainerNotes =
+    publicFindings.length > 0
+      ? publicFindings.map((finding) => `- ${sanitizePanelText(finding.title)}: ${sanitizePanelText(finding.publicText ?? finding.detail)}`)
+      : ["- No public-safe advisory findings were generated from cached metadata."];
+  const footer = confirmedMiner || args.settings.publicAudienceMode === "gittensor_only"
+    ? "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers. Learn more about [Gittensor](https://gittensor.io) contribution workflows."
+    : "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers.";
   return [
-    "<!-- gittensory-pr-intelligence -->",
-    "## Gittensory contribution context",
+    "<!-- gittensory-pr-panel:v1 -->",
     "",
-    "_Advisory context generated from public GitHub metadata and Gittensory's registered-repo cache. This is not an endorsement._",
+    `> [!${alert}]`,
+    `> **${panelTitle}**`,
+    `> ${panelSummary}`,
     "",
-    "### Contributor context",
-    `- Author: \`${args.pr.authorLogin ?? "unknown"}\``,
-    `- Confirmed Gittensor miner: ${args.detection.source === "official_gittensor_api" ? "yes" : "not confirmed"}`,
-    `- Role context: ${roleContext.role}${roleContext.maintainerLane ? " (maintainer lane)" : ""}`,
-    `- Gittensory signal: ${args.detection.detected ? args.detection.reason : "No confirmed Gittensor miner activity detected."}`,
-    `- Prior cached PRs/issues: ${args.detection.priorPullRequests} PR(s), ${args.detection.priorIssues} issue(s)`,
-    `- Public profile languages: ${args.profile.github.topLanguages.length > 0 ? args.profile.github.topLanguages.join(", ") : "not available"}`,
+    "| Signal | State |",
+    "| --- | --- |",
+    ...rows.map(([signal, state]) => `| ${escapeTableCell(signal)} | ${escapeTableCell(state)} |`),
     "",
-    "### PR hygiene",
-    `- Linked issues: ${linkedIssues}`,
-    `- Lane context: ${buildLaneAdvice(args.repo, args.pr.repoFullName).summary}`,
-    `- Review burden: ${args.preflight.reviewBurden}`,
+    "<details>",
+    "<summary>Review context</summary>",
     "",
-    "### Duplicate/WIP risk",
-    `- Collision clusters found: ${collisionCount}`,
-    `- Queue level: ${args.queueHealth.level}`,
+    `- Author: \`${sanitizePanelText(args.pr.authorLogin ?? "unknown")}\``,
+    `- Role context: ${sanitizePanelText(roleContext.role)}${roleContext.maintainerLane ? " (maintainer lane)" : ""}`,
+    `- Public audience mode: ${args.settings.publicAudienceMode.replace(/_/g, " ")}`,
+    `- Lane context: ${sanitizePanelText(buildLaneAdvice(args.repo, args.pr.repoFullName).summary)}`,
+    `- Cached prior PRs/issues: ${args.detection.priorPullRequests} PR(s), ${args.detection.priorIssues} issue(s)`,
+    `- Public profile languages: ${args.profile.github.topLanguages.length > 0 ? sanitizePanelText(args.profile.github.topLanguages.join(", ")) : "not available"}`,
+    ...(confirmedMiner ? ["- Gittensor context: official public API confirms this GitHub user."] : []),
     "",
-    "### Maintainer notes",
-    ...(publicFindings.length > 0
-      ? publicFindings.map((finding) => `- ${finding.title}: ${finding.publicText ?? finding.detail}`)
-      : ["- No public-safe advisory findings were generated from cached metadata."]),
+    "</details>",
     "",
-    "### Contributor next steps",
+    "<details>",
+    "<summary>Maintainer notes</summary>",
+    "",
+    ...maintainerNotes,
+    "",
+    "</details>",
+    "",
+    "<details>",
+    "<summary>Contributor next steps</summary>",
+    "",
     ...(nextSteps.length > 0 ? [...new Set(nextSteps)].map((step) => `- ${step}`) : ["- Keep the PR focused and include validation evidence before maintainer review."]),
+    "",
+    "</details>",
+    "",
+    "---",
+    footer,
   ].join("\n");
 }
 
 function containsPrivatePublicTerm(value: string): boolean {
   return /\b(reward|payout|farming|wallet|hotkey|trust score|raw trust|estimated score|scoreability|likely_duplicate|reviewability\s*\d|\/100)\b/i.test(value);
+}
+
+function sanitizePanelText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function escapeTableCell(value: string): string {
+  return sanitizePanelText(value).replace(/\|/g, "\\|");
 }
 
 /**

--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -32,7 +32,9 @@ export type GithubAppBehavior = {
   installed: boolean;
   publicSurface: RepositorySettings["publicSurface"];
   commentMode: RepositorySettings["commentMode"];
+  publicAudienceMode: RepositorySettings["publicAudienceMode"];
   checkRunMode: RepositorySettings["checkRunMode"];
+  gateCheckMode: RepositorySettings["gateCheckMode"];
   quietByDefault: boolean;
   behavior: string;
   warnings: string[];
@@ -122,13 +124,15 @@ function buildGithubAppBehavior(repo: RepositoryRecord | null, settings: Reposit
     installed,
     publicSurface: settings.publicSurface,
     commentMode: settings.commentMode,
+    publicAudienceMode: settings.publicAudienceMode,
     checkRunMode: settings.checkRunMode,
+    gateCheckMode: settings.gateCheckMode,
     quietByDefault,
     behavior: !installed
       ? "Gittensory would stay silent because the GitHub App is not installed."
       : settings.publicSurface === "off"
-        ? "Gittensory stays quiet: no public comments or labels, confirmed-miner detection only."
-        : `Gittensory posts ${settings.publicSurface.replace(/_/g, " ")} for confirmed Gittensor miner PRs only, ${quietByDefault ? "quiet by default" : "for all PRs"}.`,
+        ? `Gittensory stays quiet: no public comments or labels${settings.gateCheckMode === "enabled" ? ", with the opt-in gate check still enabled" : ""}.`
+        : `Gittensory posts ${settings.publicSurface.replace(/_/g, " ")} in ${settings.publicAudienceMode.replace(/_/g, " ")} mode, ${quietByDefault ? "quiet by default" : "for all PRs"}.`,
     warnings,
   };
 }

--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -15,7 +15,7 @@ import {
 } from "./engine";
 
 export function hasVisiblePrSurface(settings: RepositorySettings): boolean {
-  return settings.publicSurface !== "off" || settings.checkRunMode === "enabled";
+  return settings.publicSurface !== "off" || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled";
 }
 
 export function shouldPublishPrComment(settings: RepositorySettings): boolean {
@@ -23,7 +23,8 @@ export function shouldPublishPrComment(settings: RepositorySettings): boolean {
   return settings.publicSurface === "comment_and_label" || settings.publicSurface === "comment_only";
 }
 
-export function shouldApplyPrLabel(settings: RepositorySettings): boolean {
+export function shouldApplyPrLabel(settings: RepositorySettings, minerStatus: PublicSurfaceMinerStatus = "not_checked"): boolean {
+  if (settings.publicAudienceMode === "oss_maintainer" && minerStatus !== "confirmed") return false;
   return settings.autoLabelEnabled && (settings.publicSurface === "comment_and_label" || settings.publicSurface === "label_only");
 }
 
@@ -83,11 +84,15 @@ export function decidePublicSurface(input: PublicSurfaceDecisionInput): PublicSu
   if (!settings.includeMaintainerAuthors && input.authorAssociation && ["OWNER", "MEMBER", "COLLABORATOR"].includes(input.authorAssociation)) {
     return skipDecision("maintainer_author");
   }
-  if (input.minerStatus === "unavailable") return skipDecision("miner_detection_unavailable");
-  if (input.minerStatus === "not_found") return skipDecision("not_official_gittensor_miner");
+  if (settings.publicAudienceMode === "gittensor_only") {
+    if (input.minerStatus === "unavailable") return skipDecision("miner_detection_unavailable");
+    if (input.minerStatus === "not_found") return skipDecision("not_official_gittensor_miner");
+  }
 
   const willComment = shouldPublishPrComment(settings);
-  const willLabel = shouldApplyPrLabel(settings);
+  const willLabel =
+    shouldApplyPrLabel(settings, input.minerStatus) ||
+    (settings.publicAudienceMode === "oss_maintainer" && input.minerStatus === "not_checked" && settings.autoLabelEnabled && (settings.publicSurface === "comment_and_label" || settings.publicSurface === "label_only"));
   const willCheckRun = settings.checkRunMode === "enabled";
   const actions: PublicSurfaceAction[] = [
     ...(willComment ? (["comment"] as const) : []),
@@ -169,9 +174,11 @@ export type RepoSettingsPreview = {
   settings: {
     publicSurface: RepositorySettings["publicSurface"];
     commentMode: RepositorySettings["commentMode"];
+    publicAudienceMode: RepositorySettings["publicAudienceMode"];
     publicSignalLevel: RepositorySettings["publicSignalLevel"];
     checkRunMode: RepositorySettings["checkRunMode"];
     checkRunDetailLevel: RepositorySettings["checkRunDetailLevel"];
+    gateCheckMode: RepositorySettings["gateCheckMode"];
     autoLabelEnabled: boolean;
     gittensorLabel: string;
     createMissingLabel: boolean;
@@ -274,9 +281,11 @@ export function buildRepoSettingsPreview(args: {
     settings: {
       publicSurface: settings.publicSurface,
       commentMode: settings.commentMode,
+      publicAudienceMode: settings.publicAudienceMode,
       publicSignalLevel: settings.publicSignalLevel,
       checkRunMode: settings.checkRunMode,
       checkRunDetailLevel: settings.checkRunDetailLevel,
+      gateCheckMode: settings.gateCheckMode,
       autoLabelEnabled: settings.autoLabelEnabled,
       gittensorLabel: settings.gittensorLabel,
       createMissingLabel: settings.createMissingLabel,
@@ -290,7 +299,7 @@ export function buildRepoSettingsPreview(args: {
     decision,
     previewComment,
     appliedLabel: decision.willLabel ? settings.gittensorLabel : null,
-    checkRun: decision.willCheckRun ? { willCreate: true, title: "Gittensory context posted", detailLevel: settings.checkRunDetailLevel } : null,
+    checkRun: decision.willCheckRun ? { willCreate: true, title: "Gittensory Context", detailLevel: settings.checkRunDetailLevel } : null,
     installPreview,
     warnings,
     summary: decision.skipped
@@ -312,6 +321,9 @@ function buildWarnings(settings: RepositorySettings, decision: PublicSurfaceDeci
   if (settings.checkRunMode === "enabled" && missing.has("checks")) {
     warnings.push("Check runs are enabled but GitHub App permission Checks: write is missing. Set repository permission checks to write, then approve the change.");
   }
+  if (settings.gateCheckMode === "enabled" && missing.has("checks")) {
+    warnings.push("Gate checks are enabled but GitHub App permission Checks: write is missing. Set repository permission checks to write, then approve the change.");
+  }
   for (const event of installation.missingEvents) {
     warnings.push(`The GitHub App is not subscribed to the ${event} webhook event; subscribe to it so Gittensory receives the relevant deliveries.`);
   }
@@ -332,7 +344,7 @@ function buildRepoInstallPreview(args: {
   const missing = activeMissingPermissions(args.settings, args.decision, args.installation);
   const missingEvents = args.installation?.missingEvents ?? [];
   const permissionStatus: RepoInstallPreviewStatus = !args.installation || args.installation.status === "broken" ? "blocked" : missing.length > 0 || missingEvents.length > 0 || args.installation.status === "needs_attention" ? "needs_attention" : "ready";
-  const publicOutputStatus: RepoInstallPreviewStatus = args.settings.commentMode === "all_prs" ? "needs_attention" : "ready";
+  const publicOutputStatus: RepoInstallPreviewStatus = args.settings.commentMode === "all_prs" || args.settings.gateCheckMode === "enabled" ? "needs_attention" : "ready";
   const commandAuthorizationStatus: RepoInstallPreviewStatus = !args.installation ? "blocked" : new Set(args.installation.missingPermissions).has("issues") ? "needs_attention" : "ready";
   const manualControlStatus: RepoInstallPreviewStatus = args.settings.commentMode === "all_prs" ? "needs_attention" : "ready";
   const checklist: RepoInstallPreviewChecklistItem[] = [
@@ -350,7 +362,7 @@ function buildRepoInstallPreview(args: {
       status: publicOutputStatus,
       label: "Public outputs",
       summary: publicOutputSummary(args.decision),
-      action: publicOutputStatus === "ready" ? "Review the rendered public preview before enabling this repo." : "Review all-PR mode carefully; confirmed-miner-only output is quieter for first enablement.",
+      action: publicOutputStatus === "ready" ? "Review the rendered public preview before enabling this repo." : "Review all-PR or gate mode carefully; advisory-only output is quieter for first enablement.",
     },
     {
       id: "private-context",
@@ -389,7 +401,7 @@ function buildRepoInstallPreview(args: {
       category: "manual_control",
       status: manualControlStatus,
       label: "Manual controls",
-      summary: "Public surface mode, comments, labels, check runs, maintainer-author inclusion, and linked-issue requirements remain repo-controlled settings.",
+      summary: "Public audience, public surface mode, comments, labels, context checks, gate checks, maintainer-author inclusion, and linked-issue requirements remain repo-controlled settings.",
       action: manualControlStatus === "ready" ? "Enable only the specific public surface you want after previewing it." : "Switch away from all-PR mode unless broad public output is intentional.",
     },
   ];
@@ -422,7 +434,7 @@ function buildRepoInstallPreview(args: {
       missingEvents,
       summary: permissionSummary(args.installation, missing, missingEvents),
     },
-    publicOutputs: publicOutputsFor(args.decision, args.appliedLabel),
+    publicOutputs: publicOutputsFor(args.decision, args.appliedLabel, args.settings),
     privateOnlyContext: [
       "Decision packs, blocker details, maintainer packet evidence, and scoring evidence stay authenticated-only.",
       "This preview uses cached metadata and the supplied sample PR fields; it does not upload repository source.",
@@ -451,8 +463,8 @@ function buildRepoInstallPreview(args: {
 
 function requiredInstallPermissions(settings: RepositorySettings, decision: PublicSurfaceDecision): string[] {
   const permissions = new Set(["metadata: read", "pull_requests: read"]);
-  if (decision.willComment || decision.willLabel || shouldPublishPrComment(settings) || shouldApplyPrLabel(settings)) permissions.add("issues: write");
-  if (decision.willCheckRun || settings.checkRunMode === "enabled") permissions.add("checks: write");
+  if (decision.willComment || decision.willLabel || shouldPublishPrComment(settings) || shouldApplyPrLabel(settings, "confirmed")) permissions.add("issues: write");
+  if (decision.willCheckRun || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled") permissions.add("checks: write");
   return [...permissions];
 }
 
@@ -460,8 +472,8 @@ function activeMissingPermissions(settings: RepositorySettings, decision: Public
   if (!installation) return [];
   const missing = new Set(installation.missingPermissions);
   const active: string[] = [];
-  if ((decision.willComment || decision.willLabel || shouldPublishPrComment(settings) || shouldApplyPrLabel(settings)) && missing.has("issues")) active.push("issues");
-  if ((decision.willCheckRun || settings.checkRunMode === "enabled") && missing.has("checks")) active.push("checks");
+  if ((decision.willComment || decision.willLabel || shouldPublishPrComment(settings) || shouldApplyPrLabel(settings, "confirmed")) && missing.has("issues")) active.push("issues");
+  if ((decision.willCheckRun || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled") && missing.has("checks")) active.push("checks");
   return active;
 }
 
@@ -475,12 +487,14 @@ function permissionSummary(installation: InstallationHealthSummary | null, missi
   return "Required permissions and webhook events are ready for the previewed behavior.";
 }
 
-function publicOutputsFor(decision: PublicSurfaceDecision, appliedLabel: string | null): string[] {
-  if (decision.skipped) return [`No public output for this sample: ${decision.summary}`];
+function publicOutputsFor(decision: PublicSurfaceDecision, appliedLabel: string | null, settings: RepositorySettings): string[] {
+  const gateOutput = settings.gateCheckMode === "enabled" ? ["Opt-in Gittensory Gate check run."] : [];
+  if (decision.skipped) return [`No comment or label for this sample: ${decision.summary}`, ...gateOutput];
   const outputs = [
     ...(decision.willComment ? ["One sanitized sticky PR comment."] : []),
     ...(decision.willLabel ? [`Configured label "${appliedLabel ?? "gittensor"}".`] : []),
-    ...(decision.willCheckRun ? ["Minimal GitHub check run."] : []),
+    ...(decision.willCheckRun ? ["Non-blocking Gittensory Context check run."] : []),
+    ...gateOutput,
   ];
   return outputs.length > 0 ? outputs : ["No public comment, label, or check run for this sample."];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,8 @@ export type GitHubWebhookPayload = {
   };
   repository?: GitHubRepositoryPayload;
   repositories?: GitHubRepositoryPayload[];
+  repositories_added?: GitHubRepositoryPayload[];
+  repositories_removed?: GitHubRepositoryPayload[];
   pull_request?: GitHubPullRequestPayload;
   issue?: GitHubIssuePayload;
   comment?: GitHubIssueCommentPayload;
@@ -342,9 +344,11 @@ export type BountyRecord = {
 export type RepositorySettings = {
   repoFullName: string;
   commentMode: "off" | "detected_contributors_only" | "all_prs";
+  publicAudienceMode: "oss_maintainer" | "gittensor_only";
   publicSignalLevel: "minimal" | "standard";
   checkRunMode: "off" | "enabled";
   checkRunDetailLevel: "minimal" | "standard" | "deep";
+  gateCheckMode: "off" | "enabled";
   autoLabelEnabled: boolean;
   gittensorLabel: string;
   createMissingLabel: boolean;

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -498,7 +498,8 @@ describe("api routes", () => {
     };
     expect(minerPreviewBody.decision.skipped).toBe(false);
     expect(minerPreviewBody.decision.willComment).toBe(true);
-    expect(minerPreviewBody.previewComment).toContain("Gittensory contribution context");
+    expect(minerPreviewBody.previewComment).toContain("<!-- gittensory-pr-panel:v1 -->");
+    expect(minerPreviewBody.previewComment).toContain("Confirmed Gittensor contributor");
     expect(minerPreviewBody.previewComment).not.toMatch(/wallet|hotkey|trust score|scoreability|payout/i);
     expect(minerPreviewBody.installPreview).toMatchObject({
       status: "ready",
@@ -1338,7 +1339,7 @@ describe("api routes", () => {
       missingPermissions: ["checks"],
       missingEvents: [],
       permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-      events: ["issues", "issue_comment", "pull_request", "repository"],
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:01:00.000Z",
     });
     const repairWithChecks = await app.request("/v1/installations/777/repair", { headers: apiHeaders(env) }, env);
@@ -1357,7 +1358,7 @@ describe("api routes", () => {
           account: { login: "JSONbored", id: 1, type: "User" },
           repository_selection: "selected",
           permissions: { metadata: "read", pull_requests: "read", issues: "write", checks: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -2044,10 +2045,10 @@ describe("api routes", () => {
         endpoint: "GitHub issue comment",
         decision: { status: "ready", willComment: true, willLabel: false, willCheckRun: false },
         sanitizer: { passed: true, forbiddenTerms: [] },
-        body: expect.stringContaining("### Gittensory preflight"),
+        body: expect.stringContaining("**Gittensory preflight**"),
       },
     });
-    expect(commandResponsePreviewBody.preview.body).toContain("Scope: entrius/allways-ui#12");
+    expect(commandResponsePreviewBody.preview.body).toContain("| Scope | entrius/allways-ui#12 |");
     expect(commandResponsePreviewBody.preview.body).not.toMatch(/wallet|hotkey|raw trust|payout|reward estimate|farming|scoreability|public score estimate/i);
 
     const nonMinerPreview = await app.request(
@@ -2150,7 +2151,7 @@ describe("api routes", () => {
     );
     expect(helpPreview.status).toBe(200);
     await expect(helpPreview.json()).resolves.toMatchObject({
-      preview: { decision: { status: "ready", willComment: true }, body: expect.stringContaining("### Gittensory command help") },
+      preview: { decision: { status: "ready", willComment: true }, body: expect.stringContaining("**Gittensory command help**") },
     });
 
     const maintainerCommandPreview = await app.request(
@@ -2169,7 +2170,7 @@ describe("api routes", () => {
     );
     expect(maintainerCommandPreview.status).toBe(200);
     await expect(maintainerCommandPreview.json()).resolves.toMatchObject({
-      preview: { decision: { status: "ready", willComment: true }, body: expect.stringContaining("### Gittensory maintainer queue summary") },
+      preview: { decision: { status: "ready", willComment: true }, body: expect.stringContaining("**Gittensory maintainer queue summary**") },
     });
 
     const maintainerMinerContextPreview = await app.request(
@@ -3585,7 +3586,7 @@ describe("api routes", () => {
       missingPermissions: ["issues"],
       missingEvents: [],
       permissions: { metadata: "read", pull_requests: "read" },
-      events: ["issues", "issue_comment", "pull_request", "repository"],
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-23T00:00:00.000Z",
     });
     await upsertRepoSyncSegment(env, {
@@ -5496,7 +5497,7 @@ async function seedSignalData(env: Env): Promise<void> {
     missingPermissions: [],
     missingEvents: [],
     permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-    events: ["issues", "issue_comment", "pull_request", "repository"],
+    events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
     checkedAt: freshAt,
   });
   await upsertIssueFromGitHub(env, "entrius/allways-ui", {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -306,7 +306,7 @@ describe("GitHub backfill", () => {
           account: { login: "JSONbored", id: 1, type: "User" },
           repository_selection: "selected",
           permissions: { checks: "write", metadata: "read", pull_requests: "read", issues: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -316,7 +316,7 @@ describe("GitHub backfill", () => {
     expect(result.installations[0]).toMatchObject({
       status: "needs_attention",
       missingPermissions: ["pull_requests", "issues"],
-      missingEvents: ["issues", "issue_comment", "repository"],
+      missingEvents: ["issues", "issue_comment", "repository", "installation_repositories"],
       repairSteps: expect.arrayContaining(["Update the GitHub App permissions and subscribed events."]),
     });
 
@@ -326,7 +326,7 @@ describe("GitHub backfill", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { checks: "write", metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
     });
     const refreshed = await refreshInstallationHealth(env);
@@ -342,7 +342,7 @@ describe("GitHub backfill", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
     });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
@@ -358,7 +358,7 @@ describe("GitHub backfill", () => {
           account: { login: "JSONbored", id: 1, type: "User" },
           repository_selection: "selected",
           permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -399,7 +399,7 @@ describe("GitHub backfill", () => {
       missingPermissions: [],
       missingEvents: [],
       permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-      events: ["issues", "issue_comment", "pull_request", "repository"],
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:00:00.000Z",
     });
 
@@ -443,7 +443,7 @@ describe("GitHub backfill", () => {
       missingPermissions: ["issues"],
       missingEvents: [],
       permissions: { metadata: "read", pull_requests: "read" },
-      events: ["issues", "issue_comment", "pull_request", "repository"],
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:00:00.000Z",
     });
 
@@ -476,7 +476,7 @@ describe("GitHub backfill", () => {
           target_type: "User",
           repository_selection: "selected",
           permissions: { checks: "write", metadata: "read", pull_requests: "read", issues: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -504,7 +504,7 @@ describe("GitHub backfill", () => {
           account: { login: "JSONbored", id: 1, type: "User" },
           repository_selection: "selected",
           permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -531,7 +531,7 @@ describe("GitHub backfill", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
     });
     vi.stubGlobal("fetch", async () => new Response("installation unavailable", { status: 503 }));
@@ -2149,7 +2149,7 @@ describe("GitHub backfill", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
     });
     await upsertRepositoryFromGitHub(
@@ -2197,7 +2197,7 @@ describe("GitHub backfill", () => {
           permissions: {},
           events: [],
           missingPermissions: ["metadata", "pull_requests", "issues"],
-          missingEvents: ["issues", "issue_comment", "pull_request", "repository"],
+          missingEvents: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         }),
       ]),
     );

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { createInstallationToken, createOrUpdateCheckRun, getAppInstallation, getInstallationId } from "../../src/github/app";
+import { createInstallationToken, createOrUpdateCheckRun, createOrUpdateGateCheckRun, getAppInstallation, getInstallationId } from "../../src/github/app";
 import type { Advisory } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -23,7 +23,7 @@ describe("GitHub check runs", () => {
       }
       if (url.includes("/check-runs")) {
         const body = JSON.parse(String(init?.body)) as { name: string; conclusion: string; output: { title: string; text: string } };
-        expect(body.name).toBe("Gittensory");
+        expect(body.name).toBe("Gittensory Context");
         expect(body.conclusion).toBe("neutral");
         expect(body.output.title).toBe("Gittensory context posted");
         expect(body.output.text).not.toMatch(/linked issue|reviewability|reward|farming|wallet|hotkey|trust score/i);
@@ -87,7 +87,7 @@ describe("GitHub check runs", () => {
       }
       if (url.includes("/check-runs/42")) {
         const body = JSON.parse(String(init?.body)) as { name: string; conclusion: string; output: { title: string; text: string } };
-        expect(body.name).toBe("Gittensory");
+        expect(body.name).toBe("Gittensory Context");
         expect(body.conclusion).toBe("success");
         expect(body.output.title).toBe("Gittensory context checked");
         expect(body.output.text).not.toMatch(/reviewability|reward|farming|wallet|hotkey|trust score/i);
@@ -148,6 +148,45 @@ describe("GitHub check runs", () => {
 
     expect(result).toMatchObject({ kind: "permission_missing" });
     expect((result as { kind: string; warning: string }).warning).toMatch(/Checks: write/i);
+  });
+
+  it("creates a failing opt-in Gittensory Gate check for merge blockers", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let capturedBody: { name?: string; conclusion?: string; output?: { title?: string; text?: string } } = {};
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) {
+        capturedBody = JSON.parse(String(init?.body)) as typeof capturedBody;
+        return Response.json({ id: 88, html_url: "https://github.com/checks/88" }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdateGateCheckRun(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "JSONbored/gittensory", {
+      id: "gate-advisory",
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#9",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 9,
+      headSha: "gate123",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "Gittensory advisory available",
+      summary: "1 advisory finding generated.",
+      findings: [{ code: "missing_linked_issue", title: "No linked issue detected", severity: "warning", detail: "No closing reference.", action: "Link the issue before merge." }],
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    });
+
+    expect(result).toMatchObject({ kind: "published", id: 88 });
+    expect(capturedBody).toMatchObject({
+      name: "Gittensory Gate",
+      conclusion: "failure",
+      output: { title: "Gittensory Gate is blocking merge" },
+    });
+    expect(capturedBody.output?.text).toContain("Link the issue before merge.");
+    expect(capturedBody.output?.text).not.toMatch(/reward|wallet|hotkey|trust score|reviewability|farming/i);
   });
 
   it("publishes check run with standard detail level and includes public-safe finding text", async () => {
@@ -254,6 +293,35 @@ describe("GitHub check runs", () => {
     };
 
     await expect(createOrUpdateCheckRun(env, 123, "JSONbored/gittensory", advisory)).rejects.toThrow();
+  });
+
+  it("rethrows non-object check-run errors", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) throw "network interrupted";
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const advisory: Advisory = {
+      id: "advisory-string-error",
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#8",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 8,
+      headSha: "string-error",
+      conclusion: "neutral",
+      severity: "warning",
+      title: "Gittensory advisory available",
+      summary: "1 advisory finding generated.",
+      findings: [],
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    };
+
+    await expect(createOrUpdateCheckRun(env, 123, "JSONbored/gittensory", advisory)).rejects.toMatchObject({ cause: "network interrupted" });
   });
 
   it("skips check creation when no head SHA is available", async () => {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -130,8 +130,8 @@ describe("GitHub mention commands", () => {
         summary: "done",
       },
     });
-    expect(body).toContain("<!-- gittensory-agent-command -->");
-    expect(body).toContain("Scope: this repository#12");
+    expect(body).toContain("<!-- gittensory-pr-panel:v1 -->");
+    expect(body).toContain("| Scope | this repository#12 |");
     expect(body).toContain("**Findings**");
     expect(body).toContain("**Evidence**");
     expect(body).toContain("**Next actions**");
@@ -184,7 +184,7 @@ describe("GitHub mention commands", () => {
       actorKind: "author",
       bundle,
     });
-    expect(preflight).toContain("### Gittensory preflight");
+    expect(preflight).toContain("**Gittensory preflight**");
     expect(preflight).toContain("**Preflight summary**");
     expect(preflight).toContain("Run local branch preflight first.");
 
@@ -196,7 +196,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       bundle: blockerBundle(),
     });
-    expect(blockers).toContain("### Gittensory readiness blockers");
+    expect(blockers).toContain("**Gittensory readiness blockers**");
     expect(blockers).toContain("**Readiness blockers**");
     expect(blockers).toContain("Resolve queue pressure before opening more work.");
     expect(blockers).toContain("Open pull request queue pressure");
@@ -210,7 +210,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       bundle: duplicateBundle(),
     });
-    expect(duplicateCheck).toContain("### Gittensory duplicate & WIP check");
+    expect(duplicateCheck).toContain("**Gittensory duplicate & WIP check**");
     expect(duplicateCheck).toContain("**Duplicate & WIP caution**");
     expect(duplicateCheck).toContain("possible overlap with existing work");
     expect(duplicateCheck).not.toMatch(/\blikely_duplicate\b/i);
@@ -223,7 +223,7 @@ describe("GitHub mention commands", () => {
       actorKind: "author",
       bundle,
     });
-    expect(nextAction).toContain("### Gittensory next step");
+    expect(nextAction).toContain("**Gittensory next step**");
     expect(nextAction).toContain("**Recommended next step**");
     expect(nextAction).toContain("After tests pass.");
 
@@ -235,7 +235,7 @@ describe("GitHub mention commands", () => {
       actorKind: "author",
       bundle: askCitedBundle(),
     });
-    expect(ask).toContain("### Gittensory contribution context Q&A");
+    expect(ask).toContain("**Gittensory contribution context Q&A**");
     expect(ask).toContain("**Contribution context Q&A**");
     expect(ask).toContain("Question: what should I improve for contribution quality?");
     const askFindings = publicCardFindings(ask);
@@ -373,7 +373,7 @@ describe("GitHub mention commands", () => {
       officialMiner: minerSnapshot(),
     });
     expect(minerContext).toContain("confirmed by the official Gittensor API");
-    expect(minerContext).toContain("Scope: owner/repo#22");
+    expect(minerContext).toContain("| Scope | owner/repo#22 |");
 
     const refresh = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory blockers")!,
@@ -798,7 +798,7 @@ describe("GitHub mention commands", () => {
         summary: "done",
       },
     });
-    expect(withPrFallbackScope).toContain("Scope: owner/from-pr#5");
+    expect(withPrFallbackScope).toContain("| Scope | owner/from-pr#5 |");
     expect(withPrFallbackScope).toContain("After tests pass.");
 
   });
@@ -1082,7 +1082,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       bundle: preflightBundle(),
     });
-    expect(reviewability).toContain("### Gittensory PR readiness");
+    expect(reviewability).toContain("**Gittensory PR readiness**");
     expect(reviewability).toContain("Command: `@gittensory reviewability`");
     expect(reviewability).toContain("**PR readiness**");
     expect(reviewability).toContain("Run local branch preflight first.");
@@ -1096,7 +1096,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       bundle: repoFitBundle(),
     });
-    expect(repoFit).toContain("### Gittensory repository fit");
+    expect(repoFit).toContain("**Gittensory repository fit**");
     expect(repoFit).toContain("**Repository fit**");
     expect(repoFit).toContain("Target: `owner/repo`");
     expect(repoFit).toContain("Use local branch preflight before posting.");
@@ -1110,7 +1110,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       bundle: packetBundle(),
     });
-    expect(packet).toContain("### Gittensory public packet");
+    expect(packet).toContain("**Gittensory public packet**");
     expect(packet).toContain("**Public packet**");
     expect(packet).toContain("public-safe PR packet prepared from metadata only.");
     expect(packet).toContain("Use this as public PR-thread guidance only");
@@ -1316,7 +1316,7 @@ describe("GitHub mention commands", () => {
       actorKind: "maintainer",
       maintainerDigest: digest,
     });
-    expect(queueSummary).toContain("### Gittensory maintainer queue summary");
+    expect(queueSummary).toContain("**Gittensory maintainer queue summary**");
     expect(queueSummary).toContain("**Queue summary**");
     expect(queueSummary).toContain("Authenticated control panel: https://gittensory.test/app?view=maintainer&repo=owner%2Frepo");
     expect(queueSummary).toContain("Feedback on this response is tracked separately");

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -65,6 +65,70 @@ describe("GitHub PR intelligence comments", () => {
     expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/101"))).toBe(true);
   });
 
+  it("updates a legacy PR intelligence comment into the unified panel", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
+        return Response.json([{ id: 101, body: "<!-- gittensory-pr-intelligence -->\nold body", user: { login: "gittensory[bot]", type: "Bot" } }]);
+      }
+      if (url.includes("/issues/comments/101") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body)) as { body: string };
+        expect(body.body).toContain(PR_INTELLIGENCE_COMMENT_MARKER);
+        expect(body.body).toContain("new unified body");
+        return Response.json({ id: 101, html_url: "https://github.com/comment/101" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\nnew unified body`,
+    );
+
+    expect(result?.id).toBe(101);
+    expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/101"))).toBe(true);
+    expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
+  });
+
+  it("updates a legacy agent-command comment into the unified panel", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
+        return Response.json([{ id: 202, body: "<!-- gittensory-agent-command -->\nold command body", user: { login: "gittensory[bot]", type: "Bot" } }]);
+      }
+      if (url.includes("/issues/comments/202") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body)) as { body: string };
+        expect(body.body).toContain(PR_INTELLIGENCE_COMMENT_MARKER);
+        expect(body.body).toContain("command result");
+        return Response.json({ id: 202, html_url: "https://github.com/comment/202" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\ncommand result`,
+    );
+
+    expect(result?.id).toBe(202);
+    expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/202"))).toBe(true);
+    expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
+  });
+
   it("ignores user-authored marker comments and creates the app sticky comment", async () => {
     const privateKey = await generatePrivateKeyPem();
     const calls: string[] = [];

--- a/test/unit/policy-sanitizer.test.ts
+++ b/test/unit/policy-sanitizer.test.ts
@@ -48,9 +48,11 @@ function settingsFor(repoFullName: string, overrides: Partial<RepositorySettings
   return {
     repoFullName,
     commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
     publicSignalLevel: "standard",
     checkRunMode: "off",
     checkRunDetailLevel: "standard",
+    gateCheckMode: "off",
     autoLabelEnabled: true,
     gittensorLabel: "gittensor",
     createMissingLabel: true,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -8,6 +8,7 @@ import {
   getAgentRun,
   getContributorScoringProfile,
   getLatestUpstreamRulesetSnapshot,
+  getRepository,
   listUpstreamDriftReports,
   listInstallationHealth,
   listProductUsageDailyRollups,
@@ -155,7 +156,6 @@ describe("queue processors", () => {
     expect(await listProductUsageEvents(env, { limit: 10 })).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ eventName: "github_installation_created", repoFullName: "<redacted-actor>/gittensory", metadata: expect.objectContaining({ action: "created" }) }),
-        expect.objectContaining({ eventName: "github_installation_created", repoFullName: "<redacted-actor>/gittensory", metadata: expect.objectContaining({ action: "added" }) }),
       ]),
     );
   });
@@ -616,7 +616,7 @@ describe("queue processors", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
       repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }],
     });
@@ -629,7 +629,7 @@ describe("queue processors", () => {
           account: { login: "JSONbored", id: 1, type: "User" },
           repository_selection: "selected",
           permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-          events: ["issues", "issue_comment", "pull_request", "repository"],
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -637,6 +637,149 @@ describe("queue processors", () => {
 
     await processJob(env, { type: "refresh-installation-health", requestedBy: "test" });
     expect(await listInstallationHealth(env)).toMatchObject([{ status: "healthy", registeredInstalledCount: 1 }]);
+  });
+
+  it("syncs repositories added to and removed from an existing installation", async () => {
+    const env = createTestEnv();
+    const installation = { id: 123, account: { login: "JSONbored", id: 1, type: "User" } };
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "installation-repo-added",
+      eventName: "installation_repositories",
+      payload: {
+        action: "added",
+        installation,
+        repositories_added: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+      },
+    });
+
+    expect(await getRepository(env, "JSONbored/gittensory")).toMatchObject({ isInstalled: true, installationId: 123 });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "installation-repo-removed",
+      eventName: "installation_repositories",
+      payload: {
+        action: "removed",
+        installation,
+        repositories_removed: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+      },
+    });
+
+    expect(await getRepository(env, "JSONbored/gittensory")).toMatchObject({ isInstalled: false, installationId: null });
+    expect(await listProductUsageEvents(env, { limit: 10 })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventName: "github_installation_repository_added", repoFullName: "<redacted-actor>/gittensory" }),
+        expect.objectContaining({ eventName: "github_installation_repository_removed", repoFullName: "<redacted-actor>/gittensory" }),
+      ]),
+    );
+  });
+
+  it("publishes an opt-in gate check without requiring comment output", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      requireLinkedIssue: true,
+    });
+    const calls = { minerList: 0, gateChecks: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://api.gittensor.io/miners") {
+        calls.minerList += 1;
+        return Response.json([]);
+      }
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && (init?.method ?? "GET") === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { name?: string; conclusion?: string; output?: { title?: string } };
+        expect(body).toMatchObject({ name: "Gittensory Gate", conclusion: "failure", output: { title: "Gittensory Gate is blocking merge" } });
+        calls.gateChecks += 1;
+        return Response.json({ id: 900 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-only",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 42, title: "Gate without issue", state: "open", user: { login: "contributor" }, head: { sha: "gate123" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    expect(calls).toEqual({ minerList: 0, gateChecks: 1 });
+  });
+
+  it("audits opt-in gate check permission failures without blocking webhook processing", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      requireLinkedIssue: true,
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate403/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-permission-missing",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 42, title: "Gate without issue", state: "open", user: { login: "contributor" }, head: { sha: "gate403" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    const audit = await env.DB.prepare("select event_type, actor, target_key, outcome, detail from audit_events where event_type = ?")
+      .bind("github_app.gate_check_permission_missing")
+      .first<{ event_type: string; actor: string; target_key: string; outcome: string; detail: string }>();
+
+    expect(audit).toMatchObject({
+      event_type: "github_app.gate_check_permission_missing",
+      actor: "contributor",
+      target_key: "JSONbored/gittensory#42",
+      outcome: "error",
+    });
+    expect(audit?.detail).toMatch(/Checks: write permission is missing/i);
   });
 
   it("processes GitHub webhook jobs for PRs, issues, comments-off, comment-attempt, and deleted installs", async () => {
@@ -708,8 +851,8 @@ describe("queue processors", () => {
       if (url.includes("/issues/3/comments") && method === "GET") return Response.json([]);
       if (url.includes("/issues/3/comments") && method === "POST") {
         const body = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
-        expect(body.body).toContain("<!-- gittensory-pr-intelligence -->");
-        expect(body.body).toContain("Confirmed Gittensor miner: yes");
+        expect(body.body).toContain("<!-- gittensory-pr-panel:v1 -->");
+        expect(body.body).toContain("Confirmed Gittensor contributor");
         expect(body.body).not.toMatch(/reviewability|likely_duplicate|reward|scoreability|estimated score|wallet|hotkey|trust score|payout|farming/i);
         visibleCalls.comments += 1;
         return Response.json({ id: 1, html_url: "https://github.com/comment/1" }, { status: 201 });
@@ -741,7 +884,7 @@ describe("queue processors", () => {
         account: { login: "JSONbored", id: 1, type: "User" },
         repository_selection: "selected",
         permissions: { metadata: "read", pull_requests: "read", issues: "write" },
-        events: ["issues", "issue_comment", "pull_request", "repository"],
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       },
       repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
     };
@@ -779,6 +922,7 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       commentMode: "detected_contributors_only",
+      publicAudienceMode: "gittensor_only",
       publicSignalLevel: "standard",
       publicSurface: "comment_and_label",
       autoLabelEnabled: true,
@@ -826,6 +970,7 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       commentMode: "all_prs",
+      publicAudienceMode: "gittensor_only",
       publicSignalLevel: "minimal",
       publicSurface: "comment_and_label",
       autoLabelEnabled: true,
@@ -964,6 +1109,60 @@ describe("queue processors", () => {
       detail: string;
     }>();
     expect(skipped.results.map((event) => event.detail)).toEqual(expect.arrayContaining(["bot_author", "maintainer_author"]));
+  });
+
+  it("audits advisory context check permission failures without blocking webhook processing", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "enabled",
+      gateCheckMode: "off",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.endsWith("/users/contributor")) return Response.json({ login: "contributor" });
+      if (url.includes("/users/contributor/repos")) return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/context403/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "context-permission-missing",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
+        pull_request: { number: 24, title: "Context check", state: "open", user: { login: "contributor" }, head: { sha: "context403" }, labels: [], body: "No issue needed." },
+      },
+    });
+
+    const audit = await env.DB.prepare("select event_type, actor, target_key, outcome, detail from audit_events where event_type = ?")
+      .bind("github_app.check_run_permission_missing")
+      .first<{ event_type: string; actor: string; target_key: string; outcome: string; detail: string }>();
+
+    expect(audit).toMatchObject({
+      event_type: "github_app.check_run_permission_missing",
+      actor: "contributor",
+      target_key: "JSONbored/gittensory#24",
+      outcome: "error",
+    });
+    expect(audit?.detail).toMatch(/Checks: write permission is missing/i);
   });
 
   it("audits disabled public-surface skips without miner lookup", async () => {
@@ -1196,6 +1395,7 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
       commentMode: "all_prs",
+      publicAudienceMode: "gittensor_only",
       publicSurface: "comment_and_label",
       autoLabelEnabled: true,
       checkRunMode: "off",
@@ -1258,6 +1458,10 @@ describe("queue processors", () => {
 
   it("fails closed when official miner detection is unavailable", async () => {
     const env = createTestEnv();
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      publicAudienceMode: "gittensor_only",
+    });
     const payload = {
       action: "opened",
       installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
@@ -1417,7 +1621,7 @@ describe("queue processors", () => {
       if (url.includes("/issues/") && url.includes("/comments") && method === "POST") {
         calls.commentsCreated += 1;
         const body = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
-        expect(body.body).toContain("<!-- gittensory-agent-command -->");
+        expect(body.body).toContain("<!-- gittensory-pr-panel:v1 -->");
         expect(body.body).toContain("@gittensory");
         expect(body.body).not.toMatch(/wallet|hotkey|estimated score|reward estimate|payout|farming|raw trust score|private reviewability|reviewability internals|scoreability|public score estimate/i);
         return Response.json({ id: 1001 }, { status: 201 });
@@ -1640,7 +1844,7 @@ describe("queue processors", () => {
       if (url.includes("/issues/90/comments") && method === "POST") {
         calls.commentsCreated += 1;
         const body = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
-        expect(body.body).toContain("### Gittensory maintainer queue summary");
+        expect(body.body).toContain("**Gittensory maintainer queue summary**");
         expect(body.body).toContain("Open PRs: 4");
         expect(body.body).toContain("confirmed-miner PRs: 1");
         expect(body.body).toContain("Authenticated control panel: https://gittensory.aethereal.dev/app?view=maintainer&repo=JSONbored%2Fgittensory");
@@ -1726,7 +1930,7 @@ describe("queue processors", () => {
       if (url.includes("/issues/") && url.includes("/comments") && method === "POST") {
         calls.commentsCreated += 1;
         const body = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
-        expect(body.body).toContain("<!-- gittensory-agent-command -->");
+        expect(body.body).toContain("<!-- gittensory-pr-panel:v1 -->");
         expect(body.body).not.toMatch(/wallet|hotkey|estimated score|reward estimate|payout|farming|raw trust score|private reviewability|public score estimate/i);
         return Response.json({ id: 9191 }, { status: 201 });
       }

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -37,9 +37,11 @@ function settingsFor(repoFullName: string, overrides: Partial<RepositorySettings
   return {
     repoFullName,
     commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
     publicSignalLevel: "standard",
     checkRunMode: "enabled",
     checkRunDetailLevel: "standard",
+    gateCheckMode: "off",
     autoLabelEnabled: true,
     gittensorLabel: "gittensor",
     createMissingLabel: true,

--- a/test/unit/repo-policy-readiness.test.ts
+++ b/test/unit/repo-policy-readiness.test.ts
@@ -15,9 +15,11 @@ function settings(overrides: Partial<RepositorySettings> = {}): RepositorySettin
   return {
     repoFullName: "owner/repo",
     commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
     publicSignalLevel: "standard",
     checkRunMode: "enabled",
     checkRunDetailLevel: "standard",
+    gateCheckMode: "off",
     autoLabelEnabled: true,
     gittensorLabel: "gittensor",
     createMissingLabel: true,

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildIssueAdvisory, buildPullRequestAdvisory, buildRepositoryAdvisory, formatCheckRunOutput } from "../../src/rules/advisory";
+import {
+  buildIssueAdvisory,
+  buildPullRequestAdvisory,
+  buildRepositoryAdvisory,
+  evaluateGateCheck,
+  formatCheckRunOutput,
+  formatGateCheckOutput,
+} from "../../src/rules/advisory";
 import type { IssueRecord, PullRequestRecord, RepositoryRecord } from "../../src/types";
 
 const repo: RepositoryRecord = {
@@ -107,6 +114,82 @@ describe("advisory rules", () => {
     const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests: [otherPr] });
 
     expect(advisory.findings.map((finding) => finding.code)).toContain("duplicate_pr_risk");
+  });
+
+  it("keeps weak queue warnings advisory-only for the opt-in gate", () => {
+    const pr: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 12,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "contributor",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: [],
+      linkedIssues: [4],
+    };
+    const otherOpenPullRequests = Array.from({ length: 10 }, (_, index): PullRequestRecord => ({
+      ...pr,
+      number: 100 + index,
+      linkedIssues: [20 + index],
+    }));
+
+    const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests });
+    const gate = evaluateGateCheck(advisory);
+    const output = formatGateCheckOutput(gate);
+
+    expect(advisory.findings.map((finding) => finding.code)).toContain("busy_pr_queue");
+    expect(gate.conclusion).toBe("success");
+    expect(gate.blockers).toEqual([]);
+    expect(gate.warnings.map((finding) => finding.code)).not.toContain("busy_pr_queue");
+    expect(output.title).toBe("Gittensory Gate passed");
+    expect(output.text).toContain("No configured merge-blocking issue");
+  });
+
+  it("maps broken evaluation state to action_required gate output", () => {
+    const advisory = buildPullRequestAdvisory(null, null);
+    const gate = evaluateGateCheck(advisory);
+    const output = formatGateCheckOutput(gate);
+
+    expect(gate.conclusion).toBe("action_required");
+    expect(gate.blockers.map((finding) => finding.code)).toEqual(["repo_not_registered", "pr_not_cached"]);
+    expect(output.title).toBe("Gittensory Gate is blocking merge");
+    expect(output.text).toContain("Repository registration is unknown");
+    expect(output.text).toContain("Action: Refresh the Gittensor registry snapshot.");
+  });
+
+  it("formats and sanitizes gate blockers without leaking private scoring terms", () => {
+    const advisory = buildPullRequestAdvisory(repo, null);
+    const gate = evaluateGateCheck({
+      ...advisory,
+      findings: [
+        {
+          code: "missing_linked_issue",
+          title: "No linked issue near reward wallet trust score",
+          severity: "warning" as const,
+          detail: "Private score estimate detail.",
+        },
+      ],
+    });
+    const output = formatGateCheckOutput(gate);
+
+    expect(gate.conclusion).toBe("failure");
+    expect(output.text).toContain("No linked issue near");
+    expect(output.text).not.toMatch(/reward|wallet|trust score|score estimate/i);
+  });
+
+  it("keeps defensive gate output fallback public-safe", () => {
+    const output = formatGateCheckOutput({
+      enabled: true,
+      conclusion: "failure",
+      title: "Gittensory Gate is blocking merge",
+      summary: "A configured merge-blocking issue was found.",
+      blockers: [],
+      warnings: [],
+    });
+
+    expect(output.text).toBe("A configured merge-blocking issue was found.");
+    expect(output.text).not.toMatch(/reward|wallet|hotkey|trust score|payout|farming/i);
   });
 
   it("keeps private reviewability context out of check output", () => {

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -33,9 +33,11 @@ function settings(overrides: Partial<RepositorySettings> = {}): RepositorySettin
   return {
     repoFullName: repo.fullName,
     commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
     publicSignalLevel: "standard",
     checkRunMode: "off",
     checkRunDetailLevel: "standard",
+    gateCheckMode: "off",
     autoLabelEnabled: true,
     gittensorLabel: "gittensor",
     createMissingLabel: true,
@@ -69,8 +71,9 @@ describe("decidePublicSurface", () => {
     expect(decidePublicSurface({ settings: settings(), authorLogin: "robot", authorType: "Bot", minerStatus: "confirmed" }).skipReason).toBe("bot_author");
     expect(decidePublicSurface({ settings: settings(), authorLogin: "app[bot]", minerStatus: "confirmed" }).skipReason).toBe("bot_author");
     expect(decidePublicSurface({ settings: settings(), authorLogin: "owner", authorAssociation: "OWNER", minerStatus: "confirmed" }).skipReason).toBe("maintainer_author");
-    expect(decidePublicSurface({ settings: settings(), authorLogin: "x", minerStatus: "not_found" }).skipReason).toBe("not_official_gittensor_miner");
-    expect(decidePublicSurface({ settings: settings(), authorLogin: "x", minerStatus: "unavailable" }).skipReason).toBe("miner_detection_unavailable");
+    expect(decidePublicSurface({ settings: settings({ publicAudienceMode: "gittensor_only" }), authorLogin: "x", minerStatus: "not_found" }).skipReason).toBe("not_official_gittensor_miner");
+    expect(decidePublicSurface({ settings: settings({ publicAudienceMode: "gittensor_only" }), authorLogin: "x", minerStatus: "unavailable" }).skipReason).toBe("miner_detection_unavailable");
+    expect(decidePublicSurface({ settings: settings(), authorLogin: "x", minerStatus: "not_found" })).toMatchObject({ skipped: false, willComment: true, willLabel: false });
   });
 
   it("includes maintainer authors when configured", () => {
@@ -102,7 +105,9 @@ describe("buildRepoSettingsPreview", () => {
     const preview = buildRepoSettingsPreview({ ...base, settings: settings(), installation: healthyInstall, sample: { authorLogin: "miner", minerStatus: "confirmed" } });
     expect(preview.decision.willComment).toBe(true);
     expect(preview.appliedLabel).toBe("gittensor");
-    expect(preview.previewComment).toContain("Gittensory contribution context");
+    expect(preview.previewComment).toContain("<!-- gittensory-pr-panel:v1 -->");
+    expect(preview.previewComment).toContain("Gittensory");
+    expect(preview.previewComment).toContain("Confirmed Gittensor contributor");
     expect(preview.warnings).toHaveLength(0);
     expect(preview.installPreview).toMatchObject({
       status: "ready",
@@ -176,8 +181,22 @@ describe("buildRepoSettingsPreview", () => {
     expect(withoutChecks.warnings.some((warning) => /Checks: write/.test(warning))).toBe(false);
   });
 
+  it("explains a missing Checks: write permission when the opt-in gate is enabled", () => {
+    const preview = buildRepoSettingsPreview({
+      ...base,
+      settings: settings({ publicSurface: "off", commentMode: "off", autoLabelEnabled: false, gateCheckMode: "enabled" }),
+      installation: { ...healthyInstall, status: "needs_attention", missingPermissions: ["checks"] },
+      sample: { authorLogin: "contributor", minerStatus: "not_found" },
+    });
+
+    expect(preview.decision).toMatchObject({ skipped: false, actions: ["none"] });
+    expect(preview.warnings.some((warning) => /Gate checks are enabled.*Checks: write/.test(warning))).toBe(true);
+    expect(preview.installPreview.permissions).toMatchObject({ status: "needs_attention", missing: ["checks"] });
+    expect(preview.installPreview.publicOutputs).toEqual(expect.arrayContaining(["Opt-in Gittensory Gate check run."]));
+  });
+
   it("shows a quiet skip for a non-miner author with no rendered comment", () => {
-    const preview = buildRepoSettingsPreview({ ...base, settings: settings(), installation: healthyInstall, sample: { authorLogin: "drive-by", minerStatus: "not_found" } });
+    const preview = buildRepoSettingsPreview({ ...base, settings: settings({ publicAudienceMode: "gittensor_only" }), installation: healthyInstall, sample: { authorLogin: "drive-by", minerStatus: "not_found" } });
     expect(preview.decision).toMatchObject({ skipped: true, skipReason: "not_official_gittensor_miner" });
     expect(preview.previewComment).toBeNull();
     expect(preview.appliedLabel).toBeNull();
@@ -245,7 +264,7 @@ describe("buildRepoSettingsPreview", () => {
     expect(preview.installPreview.status).toBe("needs_attention");
     expect(preview.installPreview.checklist.find((item) => item.id === "public-outputs")).toMatchObject({
       status: "needs_attention",
-      action: expect.stringContaining("confirmed-miner-only"),
+      action: expect.stringContaining("advisory-only"),
     });
     expect(preview.installPreview.checklist.find((item) => item.id === "manual-controls")).toMatchObject({
       status: "needs_attention",

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -50,7 +50,7 @@ describe("signal coverage edge cases", () => {
     const inactiveRepo = repo("owner/inactive", { emissionShare: 0 });
     const missingRepo = { ...directRepo, isRegistered: false, registryConfig: null };
     const emptyTrusted = repo("owner/empty-trusted", { labelMultipliers: {}, trustedLabelPipeline: true });
-    const settings = repoSettings(directRepo.fullName);
+    const settings = { ...repoSettings(directRepo.fullName), publicAudienceMode: "gittensor_only" as const };
 
     expect(buildLaneAdvice(null, "missing/repo").lane).toBe("unknown");
     expect(buildLaneAdvice(missingRepo, missingRepo.fullName).lane).toBe("unknown");
@@ -591,8 +591,8 @@ describe("signal coverage edge cases", () => {
       settings: { ...repoSettings(directRepo.fullName), publicSignalLevel: "minimal", requireLinkedIssue: true },
     });
 
-    expect(comment).toContain("Confirmed Gittensor miner: yes");
-    expect(comment).toContain("Linked issues: None detected");
+    expect(comment).toContain("Confirmed Gittensor contributor");
+    expect(comment).toContain("| Linked issue | None detected |");
     expect(comment).not.toMatch(/reward|score|wallet|hotkey|trust score|farming|critical private/i);
 
     const maintainerComment = buildPublicPrIntelligenceComment({
@@ -608,6 +608,128 @@ describe("signal coverage edge cases", () => {
 
     expect(maintainerComment).toContain("maintainer lane");
     expect(maintainerComment).not.toMatch(/reward|score|wallet|hotkey|trust score|farming/i);
+  });
+
+  it("renders opt-in gate panel states for collision and repo evaluation blockers", () => {
+    const directRepo = repo("owner/gate");
+    const existingIssue = issue(directRepo.fullName, 7, "Cache refresh websocket reconnect failure");
+    const existingPr = pr(directRepo.fullName, 8, "Cache refresh websocket reconnect fix", { authorLogin: "other", linkedIssues: [7] });
+    const currentPr = pr(directRepo.fullName, 9, "Cache refresh websocket reconnect fix", { authorLogin: "dev", linkedIssues: [7], body: "Fixes #7" });
+    const collisions = buildCollisionReport(directRepo.fullName, [existingIssue], [existingPr, currentPr]);
+    const queueHealth = buildQueueHealth(directRepo, [existingIssue], [existingPr, currentPr], collisions);
+    const preflight = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: currentPr.title, body: currentPr.body ?? undefined, linkedIssues: currentPr.linkedIssues },
+      directRepo,
+      [existingIssue],
+      [existingPr, currentPr],
+    );
+    const profile = buildContributorProfile("dev", { login: "dev", topLanguages: ["TypeScript"], source: "github" }, [currentPr], []);
+    const detection = { detected: true, source: "github_cache" as const, reason: "cached contributor", priorPullRequests: 1, priorMergedPullRequests: 0, priorIssues: 0 };
+    const gateSettings = { ...repoSettings(directRepo.fullName), gateCheckMode: "enabled" as const };
+
+    const collisionComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: currentPr,
+      profile,
+      detection,
+      queueHealth,
+      collisions,
+      preflight,
+      settings: gateSettings,
+    });
+
+    expect(collisionComment).toContain("> [!CAUTION]");
+    expect(collisionComment).toContain("overlaps with cached open work");
+    expect(collisionComment).toContain("| Gate result | Failing |");
+    expect(collisionComment).toContain("Cached OSS contributor activity");
+    expect(collisionComment).toContain("Check overlapping issues/PRs before review continues.");
+    expect(collisionComment).not.toContain("gittensor.io");
+
+    const repoBlockedComment = buildPublicPrIntelligenceComment({
+      repo: null,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection: { detected: false, reason: "no cache", priorPullRequests: 0, priorMergedPullRequests: 0, priorIssues: 0 },
+      queueHealth: buildQueueHealth(null, [], [], buildCollisionReport(directRepo.fullName, [], [])),
+      collisions: buildCollisionReport(directRepo.fullName, [], []),
+      preflight: buildPreflightResult(
+        { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+        null,
+        [],
+        [],
+      ),
+      settings: gateSettings,
+    });
+
+    expect(repoBlockedComment).toContain("> [!CAUTION]");
+    expect(repoBlockedComment).toContain("cannot evaluate the repo state");
+    expect(repoBlockedComment).toContain("Public profile only");
+    expect(repoBlockedComment).toContain("Gate result | Failing");
+
+    const missingIssueComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: { ...currentPr, linkedIssues: [], body: "No linked issue yet." },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [existingIssue], [currentPr], buildCollisionReport(directRepo.fullName, [existingIssue], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [existingIssue], [currentPr]),
+      preflight: buildPreflightResult(
+        { repoFullName: directRepo.fullName, title: currentPr.title, body: "No linked issue yet.", linkedIssues: [] },
+        directRepo,
+        [existingIssue],
+        [currentPr],
+      ),
+      settings: { ...gateSettings, requireLinkedIssue: true },
+    });
+
+    expect(missingIssueComment).toContain("> [!WARNING]");
+    expect(missingIssueComment).toContain("requires linked issues");
+    expect(missingIssueComment).toContain("| Linked issue | None detected |");
+    expect(missingIssueComment).toContain("Link the issue being solved");
+
+    const passingGateComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: buildPreflightResult(
+        { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+        directRepo,
+        [],
+        [currentPr],
+      ),
+      settings: gateSettings,
+    });
+
+    expect(passingGateComment).toContain("> [!TIP]");
+    expect(passingGateComment).toContain("| Gate result | Passing |");
+    expect(passingGateComment).toContain("Public GitHub metadata was checked");
+
+    const advisoryOnlyComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: {
+        ...buildPreflightResult(
+          { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+          directRepo,
+          [],
+          [currentPr],
+        ),
+        findings: [{ code: "public_warning", severity: "warning", title: "Validation note missing", detail: "Validation evidence is not cached yet." }],
+      },
+      settings: { ...repoSettings(directRepo.fullName), gateCheckMode: "off" },
+    });
+
+    expect(advisoryOnlyComment).toContain("> [!IMPORTANT]");
+    expect(advisoryOnlyComment).toContain("Gittensory found maintainer review notes");
+    expect(advisoryOnlyComment).toContain("Validation note missing");
+    expect(advisoryOnlyComment).toContain("| Gate result | Advisory only |");
   });
 
   it("audits label ordering and suspicious configured labels deterministically", () => {
@@ -726,9 +848,11 @@ function repoSettings(repoFullName: string): RepositorySettings {
   return {
     repoFullName,
     commentMode: "detected_contributors_only",
+    publicAudienceMode: "oss_maintainer",
     publicSignalLevel: "standard",
     checkRunMode: "off",
     checkRunDetailLevel: "minimal",
+    gateCheckMode: "off",
     autoLabelEnabled: true,
     gittensorLabel: "gittensor",
     createMissingLabel: true,

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -1559,9 +1559,11 @@ describe("v2 signal builders", () => {
       settings: {
         repoFullName: repo.fullName,
         commentMode: "detected_contributors_only",
+        publicAudienceMode: "oss_maintainer",
         publicSignalLevel: "standard",
         checkRunMode: "off",
         checkRunDetailLevel: "minimal",
+        gateCheckMode: "off",
         autoLabelEnabled: true,
         gittensorLabel: "gittensor",
         createMissingLabel: true,
@@ -1573,7 +1575,7 @@ describe("v2 signal builders", () => {
       },
     });
     expect(comment).toContain("Author: `unknown`");
-    expect(comment).toContain("No confirmed Gittensor miner activity detected.");
+    expect(comment).toContain("Public profile only");
     expect(comment).not.toMatch(/wallet|raw trust score|ranking/i);
   });
 });

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -319,9 +319,11 @@ describe("world-class backend signals", () => {
     const settings = {
       repoFullName: repo.fullName,
       commentMode: "detected_contributors_only" as const,
+      publicAudienceMode: "gittensor_only" as const,
       publicSignalLevel: "standard" as const,
       checkRunMode: "off" as const,
       checkRunDetailLevel: "minimal" as const,
+      gateCheckMode: "off" as const,
       autoLabelEnabled: true,
       gittensorLabel: "gittensor",
       createMissingLabel: true,
@@ -347,7 +349,7 @@ describe("world-class backend signals", () => {
 
     expect(detection.detected).toBe(true);
     expect(shouldPublishPrIntelligenceComment(settings, detection)).toBe(true);
-    expect(comment).toContain("<!-- gittensory-pr-intelligence -->");
+    expect(comment).toContain("<!-- gittensory-pr-panel:v1 -->");
     expect(comment).not.toMatch(/wallet|raw trust score|ranking|farming|reward/i);
   });
 
@@ -362,9 +364,11 @@ describe("world-class backend signals", () => {
     const settings: RepositorySettings = {
       repoFullName: repo.fullName,
       commentMode: "detected_contributors_only",
+      publicAudienceMode: "gittensor_only",
       publicSignalLevel: "standard",
       checkRunMode: "off",
       checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
       autoLabelEnabled: true,
       gittensorLabel: "gittensor",
       createMissingLabel: true,
@@ -440,9 +444,11 @@ describe("world-class backend signals", () => {
     const settings: RepositorySettings = {
       repoFullName: repo.fullName,
       commentMode: "off",
+      publicAudienceMode: "gittensor_only",
       publicSignalLevel: "minimal",
       checkRunMode: "off",
       checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
       autoLabelEnabled: true,
       gittensorLabel: "gittensor",
       createMissingLabel: true,
@@ -493,9 +499,11 @@ describe("world-class backend signals", () => {
     const settings: RepositorySettings = {
       repoFullName: repo.fullName,
       commentMode: "all_prs",
+      publicAudienceMode: "gittensor_only",
       publicSignalLevel: "minimal",
       checkRunMode: "off",
       checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
       autoLabelEnabled: true,
       gittensorLabel: "gittensor",
       createMissingLabel: true,
@@ -508,7 +516,7 @@ describe("world-class backend signals", () => {
 
     const comment = buildPublicPrIntelligenceComment({ repo, pr: currentPr, profile, detection, queueHealth, collisions, preflight, settings });
 
-    expect(comment).toContain("Linked issues: Not required by this repo setting");
+    expect(comment).toContain("| Linked issue | Not required by this repo setting |");
     expect(comment).toContain("Public profile languages: not available");
     expect(comment).not.toMatch(/trust score|wallet|ranking/i);
   });


### PR DESCRIPTION
## Summary
- Adds the GitHub App readiness model for advisory PR context plus an opt-in enforceable gate.
- Moves PR and command output into one sticky, update-in-place PR panel.
- Adds general OSS maintainer mode so Gittensory can provide useful PR readiness context outside confirmed Gittensor contributors.

## What changed
- Added `publicAudienceMode` and `gateCheckMode` repository settings plus migration `migrations/0022_github_app_gate_settings.sql`.
- Split public checks into `Gittensory Context` and opt-in `Gittensory Gate`.
- Added conservative gate blockers for missing required linked issues, duplicate linked-issue PRs, and broken repo/app evaluation state.
- Updated sticky PR panel/comment rendering with GitHub Markdown alerts, in-place legacy marker migration, sanitized footer attribution, and command-result reuse.
- Handled `installation_repositories` added/removed webhook events so install state stays current.
- Regenerated `apps/gittensory-ui/public/openapi.json` and expanded unit/integration coverage.

## Why
- The default app behavior should be adoption-friendly and advisory.
- Repos that want branch-protection enforcement need a separate, explicit check that only fails on clear configured blockers.
- External maintainers should get immediate utility from PR readiness comments without needing Gittensor-specific setup.

## Validation
- `npm run test:ci`
- `npm run typecheck`
- `git diff --check`

## Notes
- `Gittensory Gate` remains off by default and is intended for explicit repo opt-in.
- Soft signals such as busy queues, contributor uncertainty, or eligibility ambiguity remain advisory.