### PR TITLE
fix(mcp): include completion command in shell completions

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -30,6 +30,7 @@ const CLI_COMMAND_SPEC = {
   whoami: [],
   status: [],
   changelog: [],
+  completion: [],
   version: [],
   doctor: [],
   "init-client": [],

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -930,16 +930,19 @@ describe("gittensory-mcp CLI", () => {
     expect(bash).toContain("_gittensory_mcp()");
     expect(bash).toContain("complete -F _gittensory_mcp gittensory-mcp");
     expect(bash).toContain("analyze-branch");
+    expect(bash).toContain("local commands=\"login logout whoami status changelog completion version doctor");
     expect(bash).toContain("version");
     expect(bash).toContain("plan status explain packet");
 
     const zsh = run(["completion", "zsh"]);
     expect(zsh).toContain("#compdef gittensory-mcp");
     expect(zsh).toContain("_describe 'command' commands");
+    expect(zsh).toContain("commands=(login logout whoami status changelog completion version doctor");
     expect(zsh).toContain("list create switch remove");
 
     const fish = run(["completion", "fish"]);
     expect(fish).toContain("complete -c gittensory-mcp");
+    expect(fish).toContain("complete -c gittensory-mcp -n __fish_use_subcommand -a completion");
     expect(fish).toContain("__fish_seen_subcommand_from agent");
   });
 


### PR DESCRIPTION
### Motivation
- The `completion` top-level command is handled by the CLI dispatcher but was not present in the `CLI_COMMAND_SPEC` used to generate shell completion scripts, so tab-completion did not offer `completion` at the top level.
- The change keeps the single source-of-truth for completions in sync with the CLI dispatcher so generated scripts accurately reflect available top-level commands.

### Description
- Add `completion` to `CLI_COMMAND_SPEC` in `packages/gittensory-mcp/bin/gittensory-mcp.js` so it appears in generated top-level completion lists.
- Update `test/unit/mcp-cli.test.ts` to assert that `completion` appears in the generated bash, zsh, and fish completion outputs.
- No runtime behavior other than completion script generation was modified.

### Testing
- Ran the targeted completion test: `npm test -- --run test/unit/mcp-cli.test.ts -t "prints shell completion scripts"` and it passed.
- Ran the completion-related tests: `npm test -- --run test/unit/mcp-cli.test.ts -t "completion"` and they passed (3 tests ran, 37 skipped).
- Ran the full unit test file `npm test -- --run test/unit/mcp-cli.test.ts`; one unrelated test `rejects unsafe server-provided packet markdown before non-json output` timed out at its existing 10000ms limit, causing the full file run to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228a2ea3c4832cbd2c1da906ed763d)