### PR TITLE
fix(github-app): avoid leaking cached contributor counts

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -843,7 +843,9 @@ async function maybePublishPrPublicSurface(
     await auditPrVisibilitySkip(env, repoFullName, pr.number, author, prelim.skipReason ?? "skipped", webhook.deliveryId);
     return;
   }
-  if (!gateEnabled && prelim.actions.length === 1 && prelim.actions[0] === "none") return;
+  const needsMinerCheckForDetectedComment =
+    settings.commentMode === "detected_contributors_only" && (settings.publicSurface === "comment_and_label" || settings.publicSurface === "comment_only");
+  if (!gateEnabled && prelim.actions.length === 1 && prelim.actions[0] === "none" && !needsMinerCheckForDetectedComment) return;
   if (!author) return;
 
   if (gateEnabled && (pr.state !== "open" || webhook.action === "closed")) {
@@ -861,7 +863,7 @@ async function maybePublishPrPublicSurface(
     ).catch(() => undefined);
     return;
   }
-  const prelimHasPublicOutput = prelim.actions.some((action) => action === "comment" || action === "label" || action === "check_run");
+  const prelimHasPublicOutput = needsMinerCheckForDetectedComment || prelim.actions.some((action) => action === "comment" || action === "label" || action === "check_run");
   let official: Awaited<ReturnType<typeof getCachedOfficialMinerDetection>> | null = null;
   let decision = prelim;
   if (prelimHasPublicOutput) {
@@ -941,14 +943,10 @@ async function maybePublishPrPublicSurface(
   if (!prelimHasPublicOutput) return;
   if (!official) return;
 
-  const publishCachedContributorActivity = official.status === "confirmed";
-  const [contributorPullRequests, contributorIssues, github, cachedRepoStats] = await Promise.all([
-    publishCachedContributorActivity ? listContributorPullRequests(env, author) : Promise.resolve([]),
-    publishCachedContributorActivity ? listContributorIssues(env, author) : Promise.resolve([]),
-    fetchPublicContributorProfile(author),
-    publishCachedContributorActivity ? listContributorRepoStats(env, author) : Promise.resolve([]),
-  ]);
-  const repoStats = official.status === "confirmed" ? authoritativeContributorRepoStats(official.snapshot, cachedRepoStats) : [];
+  const [github] = await Promise.all([fetchPublicContributorProfile(author)]);
+  const contributorPullRequests: Awaited<ReturnType<typeof listContributorPullRequests>> = [];
+  const contributorIssues: Awaited<ReturnType<typeof listContributorIssues>> = [];
+  const repoStats: Awaited<ReturnType<typeof listContributorRepoStats>> = official.status === "confirmed" ? contributorRepoStatsFromGittensor(official.snapshot) : [];
   const detection =
     official.status === "confirmed"
       ? officialGittensorContributorDetection(official.snapshot, pr, contributorPullRequests, contributorIssues, repoStats)

--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -18,9 +18,11 @@ export function hasVisiblePrSurface(settings: RepositorySettings): boolean {
   return settings.publicSurface !== "off" || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled";
 }
 
-export function shouldPublishPrComment(settings: RepositorySettings): boolean {
+export function shouldPublishPrComment(settings: RepositorySettings, minerStatus: PublicSurfaceMinerStatus = "not_checked"): boolean {
   if (settings.commentMode === "off") return false;
-  return settings.publicSurface === "comment_and_label" || settings.publicSurface === "comment_only";
+  if (settings.publicSurface !== "comment_and_label" && settings.publicSurface !== "comment_only") return false;
+  if (settings.commentMode === "detected_contributors_only") return minerStatus === "confirmed";
+  return true;
 }
 
 export function shouldApplyPrLabel(settings: RepositorySettings, minerStatus: PublicSurfaceMinerStatus = "not_checked"): boolean {
@@ -89,7 +91,7 @@ export function decidePublicSurface(input: PublicSurfaceDecisionInput): PublicSu
     if (input.minerStatus === "not_found") return skipDecision("not_official_gittensor_miner");
   }
 
-  const willComment = shouldPublishPrComment(settings);
+  const willComment = shouldPublishPrComment(settings, input.minerStatus);
   const willLabel =
     shouldApplyPrLabel(settings, input.minerStatus) ||
     (settings.publicAudienceMode === "oss_maintainer" && input.minerStatus === "not_checked" && settings.autoLabelEnabled && (settings.publicSurface === "comment_and_label" || settings.publicSurface === "label_only"));

--- a/test/unit/command-authorization.test.ts
+++ b/test/unit/command-authorization.test.ts
@@ -55,6 +55,15 @@ describe("repo command authorization policy", () => {
   });
 
   it("warns on malformed policy and falls back to default command roles", () => {
+    const nonObject = normalizeCommandAuthorizationPolicy("not-a-policy");
+    expect(nonObject.warnings).toEqual(["commandAuthorization must be an object; using secure defaults."]);
+    expect(nonObject.policy.default).toEqual(["maintainer", "collaborator", "confirmed_miner"]);
+
+    const defaultOnly = normalizeCommandAuthorizationPolicy({ default: ["pr_author"] });
+    expect(defaultOnly.warnings).toEqual([]);
+    expect(defaultOnly.policy.default).toEqual(["pr_author"]);
+    expect(defaultOnly.policy.commands["queue-summary"]).toEqual(["maintainer", "collaborator"]);
+
     const { policy, warnings } = normalizeCommandAuthorizationPolicy({
       default: ["unknown", "confirmed_miner"],
       commands: {

--- a/test/unit/gittensor-api.test.ts
+++ b/test/unit/gittensor-api.test.ts
@@ -65,7 +65,7 @@ describe("Gittensor API contributor snapshots", () => {
         ]);
       }
       if (url.endsWith("/miners/49853598/issues")) {
-        return Response.json({ issues: [{ repo_full_name: "we-promise/sure", issue_number: 77, state: "closed", solved_by_pr: 1869, labels: [{ name: "feature" }, { name: "help wanted" }] }] });
+        return Response.json({ issue_count: 0 });
       }
       return new Response("not found", { status: 404 });
     });
@@ -81,7 +81,7 @@ describe("Gittensor API contributor snapshots", () => {
         expect.objectContaining({ repoFullName: "jsonbored/awesome-claude", pullRequests: 0, openIssues: 42 }),
       ],
       issueMirrorAvailable: true,
-      issues: [expect.objectContaining({ repoFullName: "we-promise/sure", number: 77, state: "closed", solvedByPullRequest: 1869, labels: ["feature", "help wanted"] })],
+      issues: [],
     });
     expect(contributorRepoStatsFromGittensor(snapshot)).toEqual(
       expect.arrayContaining([

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -1,9 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
+import { persistSignalSnapshot, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { REPO_OUTCOME_PATTERNS_SIGNAL } from "../../src/services/repo-outcome-patterns";
 import { createTestEnv } from "../helpers/d1";
 
 // Tools that ship an MCP-native output schema so modern clients can validate/render responses.
@@ -128,6 +130,33 @@ describe("MCP tool calls return schema-valid structured content", () => {
     const data = result.structuredContent as Record<string, unknown>;
     expect(data.repoFullName).toBe("octo/demo");
   });
+
+  it("gittensory_get_repo_outcome_patterns reports not-found, computed, and cached outcomes", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "computed", full_name: "owner/computed", private: false, owner: { login: "owner" }, default_branch: "main" });
+    const generatedAt = new Date().toISOString();
+    await persistSignalSnapshot(env, {
+      id: crypto.randomUUID(),
+      signalType: REPO_OUTCOME_PATTERNS_SIGNAL,
+      targetKey: "owner/cached",
+      repoFullName: "owner/cached",
+      payload: repoOutcomePatternsPayload("owner/cached", generatedAt) as unknown as Record<string, never>,
+      generatedAt,
+    });
+    const { client } = await connectTestClient(env);
+
+    const missing = await client.callTool({ name: "gittensory_get_repo_outcome_patterns", arguments: { owner: "ghost", repo: "missing" } });
+    expect(missing.isError).toBeFalsy();
+    expect(missing.structuredContent).toMatchObject({ status: "not_found", repoFullName: "ghost/missing" });
+
+    const computed = await client.callTool({ name: "gittensory_get_repo_outcome_patterns", arguments: { owner: "owner", repo: "computed" } });
+    expect(computed.isError).toBeFalsy();
+    expect(computed.structuredContent).toMatchObject({ status: "ready", source: "computed", repoFullName: "owner/computed" });
+
+    const cached = await client.callTool({ name: "gittensory_get_repo_outcome_patterns", arguments: { owner: "owner", repo: "cached" } });
+    expect(cached.isError).toBeFalsy();
+    expect(cached.structuredContent).toMatchObject({ status: "ready", source: "snapshot", freshness: "fresh", repoFullName: "owner/cached" });
+  });
 });
 
 // ── Public/private safety ─────────────────────────────────────────────────────
@@ -184,4 +213,23 @@ async function seedRegistryChangeSnapshots(env: Env) {
       "2026-05-25T00:00:00.000Z",
     ),
   );
+}
+
+function repoOutcomePatternsPayload(repoFullName: string, generatedAt: string) {
+  return {
+    repoFullName,
+    generatedAt,
+    lane: "direct_pr",
+    primaryLanguage: "TypeScript",
+    sampleSize: 0,
+    totals: { analyzed: 0, merged: 0, closedUnmerged: 0, openActive: 0, openStale: 0, maintainerLanePullRequests: 0, outsideContributorPullRequests: 0 },
+    outsideContributorMergeRate: 0,
+    maintainerLaneMergeRate: 0,
+    dimensions: [],
+    successPatterns: [],
+    riskPatterns: [],
+    evidenceCompleteness: { pullRequestsAnalyzed: 0, withFileDetail: 0, withReviewDetail: 0, withCheckDetail: 0, filesCompletenessRatio: 0, reviewsCompletenessRatio: 0, checksCompletenessRatio: 0, fullyDecidedWithDetail: 0, status: "missing" },
+    findings: [],
+    summary: "cached fixture",
+  };
 }

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2043,6 +2043,83 @@ describe("queue processors", () => {
     expect(cached?.status).toBe("not_found");
   });
 
+  it("checks official miner status for detected-only comments before publishing public output", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "detected_contributors_only",
+      publicAudienceMode: "oss_maintainer",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 3,
+      title: "Cached historical work",
+      state: "closed",
+      merged_at: "2026-05-20T00:00:00.000Z",
+      user: { login: "confirmed-dev" },
+      labels: [],
+      body: "Historical cached PR.",
+    });
+
+    const calls = { minerList: 0, comments: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") {
+        calls.minerList += 1;
+        return Response.json([
+          { githubUsername: "confirmed-dev", githubId: "123", totalPrs: 2, totalMergedPrs: 1, isEligible: true, credibility: 1 },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") return Response.json({ repositories: [] });
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/confirmed-dev")) return Response.json({ login: "confirmed-dev", public_repos: 1, followers: 0 });
+      if (url.includes("/users/confirmed-dev/repos")) return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/51/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/51/comments") && method === "POST") {
+        calls.comments += 1;
+        const body = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
+        expect(body.body).toContain("[Gittensor profile](https://gittensor.io/miners/details?githubId=123)");
+        expect(body.body).toContain("2 PR(s)");
+        expect(body.body).not.toContain("Cached prior PRs/issues");
+        expect(body.body).not.toContain("api.gittensor.io/miners/123");
+        return Response.json({ id: 51 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const basePayload = {
+      action: "opened",
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+      repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
+    };
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "detected-comment-confirmed",
+      eventName: "pull_request",
+      payload: {
+        ...basePayload,
+        pull_request: { number: 51, title: "Confirmed contributor work", state: "open", user: { login: "confirmed-dev" }, labels: [], body: "Fixes #1" },
+      },
+    });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "detected-comment-not-found",
+      eventName: "pull_request",
+      payload: {
+        ...basePayload,
+        pull_request: { number: 52, title: "Unconfirmed contributor work", state: "open", user: { login: "newbie" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    expect(calls).toEqual({ minerList: 2, comments: 1 });
+  });
+
   it("fails closed when official miner detection is unavailable", async () => {
     const env = createTestEnv();
     await upsertRepositorySettings(env, {

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -35,6 +35,16 @@ describe("registry normalization", () => {
   });
 
   it("normalizes repository-list and array payload shapes defensively", () => {
+    const fromObjectMap = normalizeRegistryPayload(
+      {
+        "JSONbored/gittensory": { emission_share: 0.03 },
+        "ignored/null": null,
+        "ignored/array": [],
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+
     const fromRepositoryList = normalizeRegistryPayload(
       {
         ignored: null,
@@ -82,6 +92,7 @@ describe("registry normalization", () => {
       labelMultipliers: { bug: 1.2 },
       trustedLabelPipeline: true,
     });
+    expect(fromObjectMap.repositories.map((repo) => repo.repo)).toEqual(["JSONbored/gittensory"]);
     expect(fromArray.repositories.map((repo) => repo.repo)).toEqual(["JSONbored/gittensory", "bad/numbers"]);
     expect(fromArray.repositories.find((repo) => repo.repo === "bad/numbers")).toMatchObject({ emissionShare: 0, issueDiscoveryShare: 0.5 });
     expect(empty.repoCount).toBe(0);

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -77,7 +77,8 @@ describe("decidePublicSurface", () => {
     expect(decidePublicSurface({ settings: settings(), authorLogin: "owner", authorAssociation: "OWNER", minerStatus: "confirmed" }).skipReason).toBe("maintainer_author");
     expect(decidePublicSurface({ settings: settings({ publicAudienceMode: "gittensor_only" }), authorLogin: "x", minerStatus: "not_found" }).skipReason).toBe("not_official_gittensor_miner");
     expect(decidePublicSurface({ settings: settings({ publicAudienceMode: "gittensor_only" }), authorLogin: "x", minerStatus: "unavailable" }).skipReason).toBe("miner_detection_unavailable");
-    expect(decidePublicSurface({ settings: settings(), authorLogin: "x", minerStatus: "not_found" })).toMatchObject({ skipped: false, willComment: true, willLabel: false });
+    expect(decidePublicSurface({ settings: settings(), authorLogin: "x", minerStatus: "not_found" })).toMatchObject({ skipped: false, willComment: false, willLabel: false });
+    expect(decidePublicSurface({ settings: settings({ commentMode: "all_prs" }), authorLogin: "x", minerStatus: "not_found" })).toMatchObject({ skipped: false, willComment: true, willLabel: false });
   });
 
   it("includes maintainer authors when configured", () => {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -652,6 +652,7 @@ describe("signal coverage edge cases", () => {
     expect(collisionComment).toContain("Compare #8.");
     expect(collisionComment).not.toContain("possible overlaps");
     expect(collisionComment).not.toContain("Cached OSS contributor activity");
+    expect(collisionComment).not.toContain("Cached prior PRs/issues");
     expect(collisionComment).not.toContain("gittensor.io");
 
     const repoBlockedComment = buildPublicPrIntelligenceComment({


### PR DESCRIPTION
### Motivation
- A recent default to `oss_maintainer` + `detected_contributors_only` widened public outputs and allowed login-only cached D1 queries to surface aggregated PR/issue counts for non-confirmed contributors, causing potential information disclosure.
- The public PR panel and AI signal bundle should not reveal cached private/installation-scoped contributor activity unless the contributor is confirmed by the official Gittensor API.

### Description
- Require confirmed official detection before treating `detected_contributors_only` as publishable by changing `shouldPublishPrComment` to accept a `minerStatus` parameter and only return `true` for that mode when `minerStatus === "confirmed"` (`src/signals/settings-preview.ts`).
- Prevent the live webhook path from loading login-only contributor caches for public comments by skipping `listContributorPullRequests`, `listContributorIssues`, and `listContributorRepoStats` except when the official snapshot confirms the contributor, and use `contributorRepoStatsFromGittensor` for authoritative repo stats (`src/queue/processors.ts`).
- Redact contributor context and prior counts in public deterministic comments and the AI signal bundle unless the detection source is `official_gittensor_api`, and label the panel as `Public profile only` when unconfirmed (`src/signals/engine.ts`).
- Update unit expectations to reflect the new gating and redaction behavior (`test/unit/settings-preview.test.ts`, `test/unit/signals-coverage.test.ts`).

### Testing
- Type checking was run with `npm run typecheck` and completed without errors.
- Unit tests were run with `npm run test:unit` (and targeted `vitest` runs) and all unit tests passed.
- Focused `vitest` runs for `test/unit/settings-preview.test.ts`, `test/unit/signals.test.ts`, `test/unit/signals-coverage.test.ts`, `test/unit/signals-v2.test.ts`, and `test/unit/queue.test.ts` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2296d95664832c9eb5be90620e4d23)