### PR TITLE
fix(github-app): align PR panel and install health

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -645,8 +645,8 @@ export const OPTIONAL_CHECK_RUN_PERMISSION: Record<string, string> = {
   checks: "write",
 };
 
-export const REQUIRED_INSTALLATION_EVENTS = ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"] as const;
-export const OPTIONAL_VISIBLE_INSTALLATION_EVENTS = ["installation_target"] as const;
+export const REQUIRED_INSTALLATION_EVENTS = ["issues", "issue_comment", "pull_request", "repository"] as const;
+export const OPTIONAL_VISIBLE_INSTALLATION_EVENTS = ["installation_target", "installation_repositories"] as const;
 
 type InstallationModeImpact = {
   mode: "comment" | "label" | "check_run" | "gate_check";
@@ -667,13 +667,21 @@ type InstallationEventDiagnostic = {
 
 export function enrichInstallationHealth(health: InstallationHealthRecord) {
   const missingPermissions = new Set(health.missingPermissions);
-  const missingEvents = new Set(health.missingEvents);
+  const requiredEventSet = new Set<string>(REQUIRED_INSTALLATION_EVENTS);
+  const normalizedMissingEvents = health.missingEvents.filter((event) => requiredEventSet.has(event));
+  const missingEvents = new Set(normalizedMissingEvents);
+  const status =
+    health.status === "needs_attention" && missingPermissions.size === 0 && missingEvents.size === 0 && !health.errorSummary
+      ? "healthy"
+      : health.status;
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
     ...(missingPermissions.has("checks") ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
   };
   return {
     ...health,
+    status,
+    missingEvents: normalizedMissingEvents,
     requiredPermissions,
     optionalPermissions: OPTIONAL_CHECK_RUN_PERMISSION,
     requiredEvents: [...REQUIRED_INSTALLATION_EVENTS],
@@ -710,7 +718,8 @@ export async function buildInstallationRepairDiagnostics(env: Env, health: Insta
   const checkRunRepoCount = installedSettings.filter((settings) => settings.checkRunMode === "enabled").length;
   const gateCheckRepoCount = installedSettings.filter((settings) => settings.gateCheckMode === "enabled").length;
   const missingPermissions = new Set(health.missingPermissions);
-  const missingEvents = new Set(health.missingEvents);
+  const requiredEventSet = new Set<string>(REQUIRED_INSTALLATION_EVENTS);
+  const missingEvents = new Set(health.missingEvents.filter((event) => requiredEventSet.has(event)));
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
     ...(checkRunRepoCount > 0 || gateCheckRepoCount > 0 ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
@@ -762,13 +771,25 @@ export async function buildInstallationRepairDiagnostics(env: Env, health: Insta
           : "Checks: write is optional unless gate check mode is enabled for an installed repo.",
     }),
   ];
-  const eventDiagnostics: InstallationEventDiagnostic[] = REQUIRED_INSTALLATION_EVENTS.map((event) => ({
-    event,
-    missing: missingEvents.has(event),
-    optional: false,
-    summary: `Gittensory expects the ${event} webhook event for installation health and GitHub App automation.`,
-    action: missingEvents.has(event) ? `Subscribe to the ${event} webhook event, then approve or reinstall the app.` : "No change needed.",
-  }));
+  const eventDiagnostics: InstallationEventDiagnostic[] = [
+    ...REQUIRED_INSTALLATION_EVENTS.map((event) => ({
+      event,
+      missing: missingEvents.has(event),
+      optional: false,
+      summary: `Gittensory expects the ${event} webhook event for installation health and GitHub App automation.`,
+      action: missingEvents.has(event) ? `Subscribe to the ${event} webhook event, then approve or reinstall the app.` : "No change needed.",
+    })),
+    ...OPTIONAL_VISIBLE_INSTALLATION_EVENTS.map((event) => ({
+      event,
+      missing: missingEvents.has(event),
+      optional: true,
+      summary:
+        event === "installation_repositories"
+          ? "GitHub sends installation repository add/remove events automatically; it is not a selectable subscription event in the app settings UI."
+          : `The ${event} webhook event can appear in GitHub metadata, but it is not required for Gittensory PR automation.`,
+      action: "No manual subscription is required.",
+    })),
+  ];
   return {
     generatedAt: nowIso(),
     installation: enrichInstallationHealth(health),

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -75,7 +75,7 @@ import {
 import { ensurePullRequestLabel } from "../github/labels";
 import { fetchPublicContributorProfile } from "../github/public";
 import { refreshRegistry } from "../registry/sync";
-import { buildIssueAdvisory, buildPullRequestAdvisory } from "../rules/advisory";
+import { buildIssueAdvisory, buildPullRequestAdvisory, evaluateGateCheck } from "../rules/advisory";
 import { getOrCreateScoringModelSnapshot, refreshScoringModelSnapshot } from "../scoring/model";
 import { buildAndPersistContributorDecisionPack, loadDecisionPackSharedInputs } from "../services/decision-pack";
 import {
@@ -794,20 +794,21 @@ async function maybePublishPrPublicSurface(
     minerStatus: official.status,
   });
 
+  const publishCachedContributorActivity = official.status === "confirmed";
   const [contributorPullRequests, contributorIssues, repoIssues, repoPullRequests, repoBounties, github, cachedRepoStats] = await Promise.all([
-    listContributorPullRequests(env, author),
-    listContributorIssues(env, author),
+    publishCachedContributorActivity ? listContributorPullRequests(env, author) : Promise.resolve([]),
+    publishCachedContributorActivity ? listContributorIssues(env, author) : Promise.resolve([]),
     listIssues(env, repoFullName),
     listPullRequests(env, repoFullName),
     listBountiesByRepo(env, repoFullName),
     fetchPublicContributorProfile(author),
-    listContributorRepoStats(env, author),
+    publishCachedContributorActivity ? listContributorRepoStats(env, author) : Promise.resolve([]),
   ]);
-  const repoStats = official.status === "confirmed" ? authoritativeContributorRepoStats(official.snapshot, cachedRepoStats) : cachedRepoStats;
+  const repoStats = official.status === "confirmed" ? authoritativeContributorRepoStats(official.snapshot, cachedRepoStats) : [];
   const detection =
     official.status === "confirmed"
       ? officialGittensorContributorDetection(official.snapshot, pr, contributorPullRequests, contributorIssues, repoStats)
-      : detectGittensorContributor(author, pr, contributorPullRequests, contributorIssues, repoStats);
+      : { detected: false, reason: "Official Gittensor API did not confirm this GitHub user.", priorPullRequests: 0, priorMergedPullRequests: 0, priorIssues: 0 };
 
   const profile = buildContributorProfile(author, github, contributorPullRequests, contributorIssues, repoStats, official.status === "confirmed" ? official.snapshot : null);
   const collisions = buildCollisionReport(repoFullName, repoIssues, repoPullRequests);
@@ -854,7 +855,7 @@ async function maybePublishPrPublicSurface(
   }
 
   if (decision.willComment) {
-    const commentArgs = { repo, pr, profile, detection, queueHealth, collisions, preflight, settings };
+    const commentArgs = { repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: settings.gateCheckMode === "enabled" ? evaluateGateCheck(advisory) : undefined };
     const deterministicBody = buildPublicPrIntelligenceComment(commentArgs);
     // Optional AI rewrite (issue #151): disabled by default, source-free bundle only, quota-limited,
     // sanitizer-gated, and falls back to the deterministic body on any non-ok outcome.

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3426,13 +3426,17 @@ export function buildPublicPrIntelligenceComment(args: {
   collisions: CollisionReport;
   preflight: PreflightResult;
   settings: RepositorySettings;
+  gate?: PublicPrPanelGateEvaluation | undefined;
 }): string {
   const publicFindings = args.preflight.findings
     .filter((finding) => finding.severity !== "critical")
     .filter((finding) => args.settings.requireLinkedIssue || finding.code !== "missing_linked_issue")
     .filter((finding) => !containsPrivatePublicTerm([finding.code, finding.title, finding.detail, finding.publicText, finding.action].filter(Boolean).join(" ")))
     .slice(0, args.settings.publicSignalLevel === "minimal" ? 2 : 5);
-  const collisionCount = args.collisions.clusters.length;
+  const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
+  const linkedDuplicatePrs = linkedIssueDuplicatePullRequests(args.pr, prCollisionClusters);
+  const scopedOverlapCount = Math.max(prCollisionClusters.length, args.preflight.collisions.length);
+  const hasRelatedWork = linkedDuplicatePrs.length > 0 || scopedOverlapCount > 0;
   const linkedIssues =
     args.pr.linkedIssues.length > 0
       ? args.pr.linkedIssues.map((issue) => `#${issue}`).join(", ")
@@ -3450,44 +3454,62 @@ export function buildPublicPrIntelligenceComment(args: {
   const nextSteps = [
     ...(roleContext.maintainerLane ? ["Treat this as maintainer-lane context rather than normal contributor-lane activity."] : []),
     ...(args.settings.requireLinkedIssue && args.pr.linkedIssues.length === 0 ? ["Link the issue being solved, or explain why this is a no-issue PR."] : []),
-    ...(collisionCount > 0 ? ["Check overlapping issues/PRs before review continues."] : []),
+    ...(linkedDuplicatePrs.length > 0 ? [`Resolve the same-issue overlap with ${formatPrRefs(linkedDuplicatePrs)}, or explain why both PRs should stay open.`] : []),
+    ...(linkedDuplicatePrs.length === 0 && hasRelatedWork ? ["Review the scoped related-work signal before deep review; it is not a merge blocker by itself."] : []),
     /* v8 ignore next -- Public findings may omit actions; public comment tests cover sanitized action inclusion. */
     ...(publicFindings.length > 0 ? publicFindings.flatMap((finding) => (finding.action ? [finding.action] : [])) : []),
   ].filter((step) => !containsPrivatePublicTerm(step));
   const gateEnabled = args.settings.gateCheckMode === "enabled";
   const missingRequiredIssue = args.settings.requireLinkedIssue && args.pr.linkedIssues.length === 0;
-  const gateBlocking = gateEnabled && (missingRequiredIssue || collisionCount > 0 || !args.repo);
-  const confirmedMiner = args.detection.source === "official_gittensor_api";
+  const fallbackGateConclusion = !gateEnabled
+    ? "success"
+    : missingRequiredIssue || linkedDuplicatePrs.length > 0 || !args.repo
+      ? "failure"
+      : "success";
+  const gateConclusion = args.gate?.conclusion ?? fallbackGateConclusion;
+  const gateBlocking = gateEnabled && gateConclusion !== "success";
+  const confirmedMiner = isOfficialContributorDetection(args.detection);
   const genericOssMode = args.settings.publicAudienceMode === "oss_maintainer";
   const alert = gateBlocking
-    ? missingRequiredIssue
+    ? gateConclusion === "action_required"
+      ? "IMPORTANT"
+      : missingRequiredIssue
       ? "WARNING"
       : "CAUTION"
-    : args.preflight.findings.some((finding) => finding.severity === "warning")
+    : args.preflight.findings.some((finding) => finding.severity === "warning") || hasRelatedWork
       ? "IMPORTANT"
       : "TIP";
   const panelTitle = gateBlocking
     ? "Gittensory Gate is blocking merge"
-    : args.preflight.findings.some((finding) => finding.severity === "warning")
+    : args.preflight.findings.some((finding) => finding.severity === "warning") || hasRelatedWork
       ? "Gittensory found maintainer review notes"
       : "Gittensory PR readiness looks good";
   const panelSummary = gateBlocking
-    ? missingRequiredIssue
+    ? args.gate?.summary ?? (missingRequiredIssue
       ? "This repository requires linked issues, but this PR does not reference one yet."
-      : collisionCount > 0
-        ? "This PR overlaps with cached open work and should be resolved before merge."
-        : "Gittensory cannot evaluate the repo state closely enough for the enabled gate."
+      : linkedDuplicatePrs.length > 0
+        ? `Another open PR references the same linked issue: ${formatPrRefs(linkedDuplicatePrs)}.`
+        : "Gittensory cannot evaluate the repo state closely enough for the enabled gate.")
+    : linkedDuplicatePrs.length > 0
+      ? `Same-issue duplicate risk found against ${formatPrRefs(linkedDuplicatePrs)}. Maintainers should resolve the overlap before review continues.`
+      : hasRelatedWork
+        ? "Scoped related-work signals were found for this PR. They are advisory unless the gate reports a blocker."
     : genericOssMode
       ? "Public GitHub metadata was checked for review readiness. Gittensor-specific context appears only when confirmed."
       : "Confirmed Gittensor contributor context was checked from public metadata and Gittensory cache.";
-  const rows: Array<[string, string]> = [
-    ["Linked issue", linkedIssues],
-    ["Duplicate risk", collisionCount > 0 ? `${collisionCount} possible overlap${collisionCount === 1 ? "" : "s"}` : "No cached overlap"],
-    ["Review burden", args.preflight.reviewBurden],
-    ["Queue level", args.queueHealth.level],
-    ["Contributor context", confirmedMiner ? "Confirmed Gittensor contributor" : args.detection.detected ? "Cached OSS contributor activity" : "Public profile only"],
-    ["Gate result", gateEnabled ? (gateBlocking ? "Failing" : "Passing") : "Advisory only"],
+  const rows: Array<[string, string, string]> = [
+    [
+      "Linked issue",
+      linkedIssues,
+      args.pr.linkedIssues.length > 0 ? "Ready for issue-scoped review." : args.settings.requireLinkedIssue ? "Required before merge." : "Optional for this repo.",
+    ],
+    ["Duplicate risk", duplicateRiskStatus(linkedDuplicatePrs, scopedOverlapCount), duplicateRiskAction(linkedDuplicatePrs, scopedOverlapCount, gateBlocking)],
+    ["Review burden", titleCase(args.preflight.reviewBurden), "Estimated from public PR metadata."],
+    ["Repo queue", titleCase(args.queueHealth.level), "Repo-wide context only; this does not block the gate."],
+    ["Contributor context", confirmedMiner ? "Confirmed Gittensor contributor" : "Public profile only", confirmedMiner ? "Official public API confirmed this GitHub user." : "Cached contributor activity is not published."],
+    ["Gate result", gateStatus(gateEnabled, gateConclusion), gateEnabled ? gateAction(gateConclusion) : "No required check is being enforced."],
   ];
+  const overlapDetails = relatedWorkDetails(args.pr, prCollisionClusters, args.preflight.collisions);
   const maintainerNotes =
     publicFindings.length > 0
       ? publicFindings.map((finding) => `- ${sanitizePanelText(finding.title)}: ${sanitizePanelText(finding.publicText ?? finding.detail)}`)
@@ -3498,13 +3520,15 @@ export function buildPublicPrIntelligenceComment(args: {
   return [
     "<!-- gittensory-pr-panel:v1 -->",
     "",
-    `> [!${alert}]`,
-    `> **${panelTitle}**`,
-    `> ${panelSummary}`,
-    "",
-    "| Signal | State |",
-    "| --- | --- |",
-    ...rows.map(([signal, state]) => `| ${escapeTableCell(signal)} | ${escapeTableCell(state)} |`),
+    ...formatAlertBlock([
+      `[!${alert}]`,
+      `## ${panelTitle}`,
+      panelSummary,
+      "",
+      "| Signal | Status | Action |",
+      "| --- | --- | --- |",
+      ...rows.map(([signal, state, action]) => `| ${escapeTableCell(signal)} | ${escapeTableCell(state)} | ${escapeTableCell(action)} |`),
+    ]),
     "",
     "<details>",
     "<summary>Review context</summary>",
@@ -3513,9 +3537,9 @@ export function buildPublicPrIntelligenceComment(args: {
     `- Role context: ${sanitizePanelText(roleContext.role)}${roleContext.maintainerLane ? " (maintainer lane)" : ""}`,
     `- Public audience mode: ${args.settings.publicAudienceMode.replace(/_/g, " ")}`,
     `- Lane context: ${sanitizePanelText(buildLaneAdvice(args.repo, args.pr.repoFullName).summary)}`,
-    `- Cached prior PRs/issues: ${args.detection.priorPullRequests} PR(s), ${args.detection.priorIssues} issue(s)`,
     `- Public profile languages: ${args.profile.github.topLanguages.length > 0 ? sanitizePanelText(args.profile.github.topLanguages.join(", ")) : "not available"}`,
-    ...(confirmedMiner ? ["- Gittensor context: official public API confirms this GitHub user."] : []),
+    ...(confirmedMiner ? [`- Official Gittensor activity: ${args.detection.priorPullRequests} PR(s), ${args.detection.priorIssues} issue(s).`] : ["- Contributor context: public profile only."]),
+    ...overlapDetails,
     "",
     "</details>",
     "",
@@ -3536,6 +3560,86 @@ export function buildPublicPrIntelligenceComment(args: {
     "---",
     footer,
   ].join("\n");
+}
+
+type PublicPrPanelGateEvaluation = {
+  conclusion: "success" | "failure" | "action_required";
+  summary: string;
+};
+
+function isOfficialContributorDetection(detection: ContributorDetection): boolean {
+  return detection.source === "official_gittensor_api";
+}
+
+function pullRequestSpecificCollisionClusters(report: CollisionReport, pr: PullRequestRecord): CollisionCluster[] {
+  return report.clusters.filter((cluster) => cluster.items.some((item) => item.type === "pull_request" && item.number === pr.number));
+}
+
+function linkedIssueDuplicatePullRequests(pr: PullRequestRecord, clusters: CollisionCluster[]): number[] {
+  const linkedIssues = new Set(pr.linkedIssues);
+  if (linkedIssues.size === 0) return [];
+  const duplicates = clusters.flatMap((cluster) =>
+    cluster.items.flatMap((item) => {
+      if (item.type !== "pull_request" || item.number === pr.number) return [];
+      return (item.linkedIssues ?? []).some((issue) => linkedIssues.has(issue)) ? [item.number] : [];
+    }),
+  );
+  return [...new Set(duplicates)].sort((left, right) => left - right);
+}
+
+function duplicateRiskStatus(linkedDuplicatePrs: number[], scopedOverlapCount: number): string {
+  if (linkedDuplicatePrs.length > 0) return `Clear same-issue overlap: ${formatPrRefs(linkedDuplicatePrs)}`;
+  if (scopedOverlapCount > 0) return `${displayScopedCount(scopedOverlapCount)} scoped related-work signal${scopedOverlapCount === 1 ? "" : "s"}`;
+  return "No PR-specific duplicate found";
+}
+
+function duplicateRiskAction(linkedDuplicatePrs: number[], scopedOverlapCount: number, gateBlocking: boolean): string {
+  if (linkedDuplicatePrs.length > 0) return gateBlocking ? "Resolve before merge." : "Maintainer should reconcile before review.";
+  if (scopedOverlapCount > 0) return "Advisory review only.";
+  return "No action needed.";
+}
+
+function displayScopedCount(count: number): string {
+  return count > 9 ? "9+" : String(count);
+}
+
+function gateStatus(gateEnabled: boolean, conclusion: PublicPrPanelGateEvaluation["conclusion"]): string {
+  if (!gateEnabled) return "Advisory only";
+  if (conclusion === "success") return "Passing";
+  return conclusion === "action_required" ? "Action required" : "Failing";
+}
+
+function gateAction(conclusion: PublicPrPanelGateEvaluation["conclusion"]): string {
+  if (conclusion === "success") return "No configured blocker found.";
+  if (conclusion === "action_required") return "Fix app/repo state, then re-run.";
+  return "Fix configured blocker before merge.";
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatPrRefs(numbers: number[]): string {
+  return numbers.map((number) => `#${number}`).join(", ");
+}
+
+function relatedWorkDetails(pr: PullRequestRecord, prCollisionClusters: CollisionCluster[], preflightCollisions: CollisionCluster[]): string[] {
+  const clusters = [...new Map([...prCollisionClusters, ...preflightCollisions].map((cluster) => [cluster.id, cluster])).values()];
+  if (clusters.length === 0) return ["- PR-specific overlap: none found."];
+  const summaries = clusters.slice(0, 4).map((cluster) => {
+    const refs = cluster.items
+      .filter((item) => !(item.type === "pull_request" && item.number === pr.number))
+      .slice(0, 4)
+      .map((item) => `${item.type === "issue" ? "issue" : item.type === "recent_merged_pull_request" ? "merged PR" : "PR"} #${item.number}`)
+      .join(", ");
+    return `- PR-specific overlap: ${sanitizePanelText(cluster.reason)}${refs ? ` (${refs})` : ""}`;
+  });
+  if (clusters.length > summaries.length) summaries.push(`- Additional scoped related-work signals hidden: ${clusters.length - summaries.length}.`);
+  return summaries;
+}
+
+function formatAlertBlock(lines: string[]): string[] {
+  return lines.map((line) => (line.length > 0 ? `> ${line}` : ">"));
 }
 
 function containsPrivatePublicTerm(value: string): boolean {
@@ -3567,6 +3671,8 @@ export function buildPublicCommentSignalBundle(args: {
   preflight: PreflightResult;
   settings: RepositorySettings;
 }): Record<string, JsonValue> {
+  const confirmedMiner = isOfficialContributorDetection(args.detection);
+  const prCollisionCount = pullRequestSpecificCollisionClusters(args.collisions, args.pr).length;
   const roleContext = buildRoleContext({
     login: args.pr.authorLogin ?? args.profile.login,
     repo: args.repo,
@@ -3582,17 +3688,17 @@ export function buildPublicCommentSignalBundle(args: {
     .slice(0, args.settings.publicSignalLevel === "minimal" ? 2 : 5)
     .map((finding) => finding.title);
   return {
-    confirmedMiner: args.detection.source === "official_gittensor_api",
-    minerSignalDetected: args.detection.detected,
-    priorPullRequests: args.detection.priorPullRequests,
-    priorIssues: args.detection.priorIssues,
+    confirmedMiner,
+    minerSignalDetected: confirmedMiner,
+    priorPullRequests: confirmedMiner ? args.detection.priorPullRequests : 0,
+    priorIssues: confirmedMiner ? args.detection.priorIssues : 0,
     role: roleContext.role,
     maintainerLane: roleContext.maintainerLane,
     linkedIssueCount: args.pr.linkedIssues.length,
     requireLinkedIssue: args.settings.requireLinkedIssue,
     laneSummary: buildLaneAdvice(args.repo, args.pr.repoFullName).summary,
     reviewBurden: args.preflight.reviewBurden,
-    collisionClusters: args.collisions.clusters.length,
+    collisionClusters: prCollisionCount,
     queueLevel: args.queueHealth.level,
     topLanguages: args.profile.github.topLanguages.slice(0, 6),
     publicFindingTitles,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -29,6 +29,7 @@ import {
   backfillRepositorySegment,
   buildInstallationRepairDiagnostics,
   enqueueRepositoryOpenDataBackfill,
+  enrichInstallationHealth,
   refreshContributorActivity,
   refreshInstallationHealth,
 } from "../../src/github/backfill";
@@ -316,7 +317,7 @@ describe("GitHub backfill", () => {
     expect(result.installations[0]).toMatchObject({
       status: "needs_attention",
       missingPermissions: ["pull_requests", "issues"],
-      missingEvents: ["issues", "issue_comment", "repository", "installation_repositories"],
+      missingEvents: ["issues", "issue_comment", "repository"],
       repairSteps: expect.arrayContaining(["Update the GitHub App permissions and subscribed events."]),
     });
 
@@ -331,6 +332,28 @@ describe("GitHub backfill", () => {
     });
     const refreshed = await refreshInstallationHealth(env);
     expect(refreshed.installations).toEqual(expect.arrayContaining([expect.objectContaining({ installationId: 124, status: "healthy" })]));
+  });
+
+  it("normalizes stale automatic installation repository event health", () => {
+    const health = enrichInstallationHealth({
+      installationId: 125,
+      accountLogin: "JSONbored",
+      repositorySelection: "selected",
+      installedReposCount: 2,
+      registeredInstalledCount: 2,
+      status: "needs_attention",
+      missingPermissions: [],
+      missingEvents: ["installation_repositories"],
+      permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+      events: ["issues", "issue_comment", "pull_request", "repository"],
+      checkedAt: "2026-06-05T00:00:00.000Z",
+    });
+
+    expect(health).toMatchObject({
+      status: "healthy",
+      missingEvents: [],
+      optionalVisibleEvents: expect.arrayContaining(["installation_repositories"]),
+    });
   });
 
   it("requires Checks write only for repos with check runs enabled", async () => {
@@ -2197,7 +2220,7 @@ describe("GitHub backfill", () => {
           permissions: {},
           events: [],
           missingPermissions: ["metadata", "pull_requests", "issues"],
-          missingEvents: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+          missingEvents: ["issues", "issue_comment", "pull_request", "repository"],
         }),
       ]),
     );

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -17,11 +17,14 @@ import {
   buildLocalDiffPreflightResult,
   buildMaintainerPacket,
   buildPreflightResult,
+  buildPublicCommentSignalBundle,
   buildPublicPrIntelligenceComment,
   buildQueueHealth,
   buildRoleContext,
   detectGittensorContributor,
   shouldPublishPrIntelligenceComment,
+  type CollisionCluster,
+  type CollisionReport,
 } from "../../src/signals/engine";
 import {
   buildContributorRewardRiskStrategy,
@@ -639,10 +642,12 @@ describe("signal coverage edge cases", () => {
     });
 
     expect(collisionComment).toContain("> [!CAUTION]");
-    expect(collisionComment).toContain("overlaps with cached open work");
-    expect(collisionComment).toContain("| Gate result | Failing |");
-    expect(collisionComment).toContain("Cached OSS contributor activity");
-    expect(collisionComment).toContain("Check overlapping issues/PRs before review continues.");
+    expect(collisionComment).toContain("Another open PR references the same linked issue: #8.");
+    expect(collisionComment).toContain("> | Gate result | Failing | Fix configured blocker before merge. |");
+    expect(collisionComment).toContain("Public profile only");
+    expect(collisionComment).toContain("Resolve the same-issue overlap with #8");
+    expect(collisionComment).not.toContain("possible overlaps");
+    expect(collisionComment).not.toContain("Cached OSS contributor activity");
     expect(collisionComment).not.toContain("gittensor.io");
 
     const repoBlockedComment = buildPublicPrIntelligenceComment({
@@ -664,7 +669,7 @@ describe("signal coverage edge cases", () => {
     expect(repoBlockedComment).toContain("> [!CAUTION]");
     expect(repoBlockedComment).toContain("cannot evaluate the repo state");
     expect(repoBlockedComment).toContain("Public profile only");
-    expect(repoBlockedComment).toContain("Gate result | Failing");
+    expect(repoBlockedComment).toContain("> | Gate result | Failing | Fix configured blocker before merge. |");
 
     const missingIssueComment = buildPublicPrIntelligenceComment({
       repo: directRepo,
@@ -684,7 +689,7 @@ describe("signal coverage edge cases", () => {
 
     expect(missingIssueComment).toContain("> [!WARNING]");
     expect(missingIssueComment).toContain("requires linked issues");
-    expect(missingIssueComment).toContain("| Linked issue | None detected |");
+    expect(missingIssueComment).toContain("> | Linked issue | None detected | Required before merge. |");
     expect(missingIssueComment).toContain("Link the issue being solved");
 
     const passingGateComment = buildPublicPrIntelligenceComment({
@@ -704,7 +709,7 @@ describe("signal coverage edge cases", () => {
     });
 
     expect(passingGateComment).toContain("> [!TIP]");
-    expect(passingGateComment).toContain("| Gate result | Passing |");
+    expect(passingGateComment).toContain("> | Gate result | Passing | No configured blocker found. |");
     expect(passingGateComment).toContain("Public GitHub metadata was checked");
 
     const advisoryOnlyComment = buildPublicPrIntelligenceComment({
@@ -729,7 +734,164 @@ describe("signal coverage edge cases", () => {
     expect(advisoryOnlyComment).toContain("> [!IMPORTANT]");
     expect(advisoryOnlyComment).toContain("Gittensory found maintainer review notes");
     expect(advisoryOnlyComment).toContain("Validation note missing");
-    expect(advisoryOnlyComment).toContain("| Gate result | Advisory only |");
+    expect(advisoryOnlyComment).toContain("> | Gate result | Advisory only | No required check is being enforced. |");
+
+    const actionRequiredComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: buildPreflightResult(
+        { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+        directRepo,
+        [],
+        [currentPr],
+      ),
+      settings: gateSettings,
+      gate: { conclusion: "action_required", summary: "Gittensory cannot evaluate this PR until installation state is repaired." },
+    });
+    expect(actionRequiredComment).toContain("> [!IMPORTANT]");
+    expect(actionRequiredComment).toContain("Gittensory cannot evaluate this PR until installation state is repaired.");
+    expect(actionRequiredComment).toContain("> | Gate result | Action required | Fix app/repo state, then re-run. |");
+
+    const duplicateAdvisoryComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: currentPr,
+      profile,
+      detection,
+      queueHealth,
+      collisions,
+      preflight,
+      settings: { ...repoSettings(directRepo.fullName), gateCheckMode: "off" },
+    });
+    expect(duplicateAdvisoryComment).toContain("Same-issue duplicate risk found against #8.");
+    expect(duplicateAdvisoryComment).toContain("> | Duplicate risk | Clear same-issue overlap: #8 | Maintainer should reconcile before review. |");
+
+    const scopedClusters: CollisionCluster[] = Array.from({ length: 12 }, (_, index) => ({
+      id: `scoped-${index}`,
+      risk: "medium",
+      reason: "Titles share 2 meaningful terms.",
+      items: [{ type: "issue", number: index + 100, title: `Related issue ${index}`, authorLogin: "reporter", labels: [], linkedIssues: [] }],
+    }));
+    const scopedComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: {
+        ...buildPreflightResult(
+          { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+          directRepo,
+          [],
+          [currentPr],
+        ),
+        collisions: scopedClusters,
+        findings: [],
+      },
+      settings: { ...repoSettings(directRepo.fullName), gateCheckMode: "off" },
+    });
+    expect(scopedComment).toContain("> | Duplicate risk | 9+ scoped related-work signals | Advisory review only. |");
+    expect(scopedComment).toContain("Additional scoped related-work signals hidden: 8.");
+  });
+
+  it("does not present global repo collision clusters as PR duplicate risk", () => {
+    const directRepo = repo("owner/noisy");
+    const unrelatedIssues = Array.from({ length: 12 }, (_, index) => issue(directRepo.fullName, index + 1, `Unrelated cache issue ${index + 1}`));
+    const unrelatedPullRequests = unrelatedIssues.map((record, index) =>
+      pr(directRepo.fullName, index + 10, `Unrelated cache fix ${index + 1}`, { linkedIssues: [record.number], body: `Fixes #${record.number}` }),
+    );
+    const currentPr = pr(directRepo.fullName, 99, "Isolated docs cleanup", { authorLogin: "dev", linkedIssues: [999], body: "Fixes #999" });
+    const collisions = buildCollisionReport(directRepo.fullName, unrelatedIssues, [...unrelatedPullRequests, currentPr]);
+    const queueHealth = buildQueueHealth(directRepo, unrelatedIssues, [...unrelatedPullRequests, currentPr], collisions);
+    const preflight = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: currentPr.title, body: currentPr.body ?? undefined, linkedIssues: currentPr.linkedIssues },
+      directRepo,
+      unrelatedIssues,
+      [...unrelatedPullRequests, currentPr],
+    );
+
+    expect(collisions.summary.clusterCount).toBeGreaterThan(0);
+    expect(preflight.collisions).toHaveLength(0);
+
+    const comment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: currentPr,
+      profile: buildContributorProfile("dev", { login: "dev", topLanguages: ["Markdown"], source: "github" }, [], []),
+      detection: { detected: false, reason: "no official context", priorPullRequests: 0, priorMergedPullRequests: 0, priorIssues: 0 },
+      queueHealth,
+      collisions,
+      preflight,
+      settings: { ...repoSettings(directRepo.fullName), gateCheckMode: "enabled" },
+    });
+
+    expect(comment).toContain("> | Duplicate risk | No PR-specific duplicate found | No action needed. |");
+    expect(comment).toContain("> | Gate result | Passing | No configured blocker found. |");
+    expect(comment).not.toContain("possible overlap");
+    expect(comment).not.toContain("12");
+  });
+
+  it("covers PR panel edge formatting without publishing unconfirmed cache counts", () => {
+    const directRepo = repo("owner/edge");
+    const currentPr = pr(directRepo.fullName, 9, "Fix edge state", { authorLogin: "dev", linkedIssues: [1], body: "Fixes #1" });
+    const profile = buildContributorProfile("dev", { login: "dev", topLanguages: [], source: "github" }, [], []);
+    const basePreflight = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: currentPr.title, body: currentPr.body ?? undefined, linkedIssues: currentPr.linkedIssues },
+      directRepo,
+      [],
+      [currentPr],
+    );
+    const officialComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: currentPr,
+      profile,
+      detection: { detected: true, source: "official_gittensor_api", reason: "official", priorPullRequests: 4, priorMergedPullRequests: 2, priorIssues: 3 },
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: basePreflight,
+      settings: { ...repoSettings(directRepo.fullName), publicAudienceMode: "gittensor_only", gateCheckMode: "off" },
+    });
+    expect(officialComment).toContain("Confirmed Gittensor contributor context was checked");
+    expect(officialComment).toContain("Official Gittensor activity: 4 PR(s), 3 issue(s).");
+
+    const selfItem = { type: "pull_request" as const, number: currentPr.number, title: currentPr.title, authorLogin: "dev", linkedIssues: currentPr.linkedIssues };
+    const edgeCollisions: CollisionReport = {
+      repoFullName: directRepo.fullName,
+      generatedAt: new Date().toISOString(),
+      summary: { clusterCount: 3, highRiskCount: 0, itemsReviewed: 4 },
+      clusters: [
+        { id: "self-only", risk: "medium", reason: "Only this PR is present.", items: [selfItem] },
+        { id: "other-no-linked", risk: "medium", reason: "Other PR lacks linked issue metadata.", items: [selfItem, { type: "pull_request" as const, number: 10, title: "Other edge fix" }] },
+        { id: "recent-merged", risk: "medium", reason: "Recent merged work is related.", items: [selfItem, { type: "recent_merged_pull_request" as const, number: 11, title: "Merged edge fix" }] },
+      ],
+    };
+    const edgeComment = buildPublicPrIntelligenceComment({
+      repo: directRepo,
+      pr: currentPr,
+      profile,
+      detection: { detected: true, source: "github_cache", reason: "cached", priorPullRequests: 7, priorMergedPullRequests: 1, priorIssues: 2 },
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], edgeCollisions),
+      collisions: edgeCollisions,
+      preflight: basePreflight,
+      settings: { ...repoSettings(directRepo.fullName), gateCheckMode: "off" },
+    });
+    expect(edgeComment).toContain("PR-specific overlap: Only this PR is present.");
+    expect(edgeComment).toContain("merged PR #11");
+
+    const bundle = buildPublicCommentSignalBundle({
+      repo: directRepo,
+      pr: currentPr,
+      profile,
+      detection: { detected: true, source: "github_cache", reason: "cached", priorPullRequests: 7, priorMergedPullRequests: 1, priorIssues: 2 },
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], edgeCollisions),
+      collisions: edgeCollisions,
+      preflight: basePreflight,
+      settings: repoSettings(directRepo.fullName),
+    });
+    expect(bundle).toMatchObject({ confirmedMiner: false, minerSignalDetected: false, priorPullRequests: 0, priorIssues: 0, collisionClusters: 3 });
   });
 
   it("audits label ordering and suspicious configured labels deterministically", () => {


### PR DESCRIPTION
## Summary
- Fixes GitHub App install health so automatic repository-installation webhooks are not treated as manually required settings.
- Reworks the sticky PR panel so gate state, duplicate risk, and public contributor context are accurate and easier to read.

## What changed
- Removes `installation_repositories` from required subscribed events and reports it as optional automatic GitHub context.
- Normalizes stale health rows that only flagged the automatic event as missing.
- Makes PR comments use one cohesive GitHub alert block with a clearer Signal/Status/Action table.
- Counts only PR-specific related-work signals instead of global repo collision clusters.
- Aligns comment gate state with the actual conservative gate evaluation.
- Redacts cached contributor activity from public comments and AI signal bundles unless official public Gittensor detection confirms the author.

## Why
The app was working after reinstall, but the public surface was still giving bad guidance: it asked for an event GitHub does not expose as a selectable subscription, showed global collision totals as if they belonged to the current PR, and could make the comment look more severe than the check run.

## Validation
- `git diff --check`
- `npm run actionlint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:coverage`
- `npm run test:workers`
- `npm run build:mcp && npm run test:mcp-pack`
- `npm run ui:openapi:check && npm run ui:version-audit && npm run ui:lint && npm run ui:typecheck`
- `npm run ui:build`
- `npm audit --audit-level=moderate`

## Notes
- `installation_repositories` webhook handling still exists; it is just no longer listed as a manually required app setting.
- The gate remains conservative: clear blockers can fail, related-work noise stays advisory unless the configured gate says otherwise.
