### PR TITLE
fix(github-app): link contributor context to Gittensor profile

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3762,8 +3762,8 @@ function contributorContextPanelResult(
     };
   }
   const minerLink = profile.gittensor?.githubId
-    ? `[official public miner data](${gittensorMinerApiUrl(profile.gittensor.githubId)})`
-    : "official public API confirmation";
+    ? `[Gittensor profile](${gittensorMinerDashboardUrl(profile.gittensor.githubId)})`
+    : "official public Gittensor confirmation";
   return {
     result: "✅ Confirmed Gittensor contributor",
     evidence: `${githubLink}; ${minerLink}; ${detection.priorPullRequests} PR(s), ${detection.priorIssues} issue(s).`,
@@ -3858,8 +3858,8 @@ function githubProfileUrl(login: string): string {
   return `https://github.com/${encodeURIComponent(login)}`;
 }
 
-function gittensorMinerApiUrl(githubId: string): string {
-  return `https://api.gittensor.io/miners/${encodeURIComponent(githubId)}`;
+function gittensorMinerDashboardUrl(githubId: string): string {
+  return `https://gittensor.io/miners/details?githubId=${encodeURIComponent(githubId)}`;
 }
 
 function relatedWorkDetails(pr: PullRequestRecord, prCollisionClusters: CollisionCluster[], preflightCollisions: CollisionCluster[]): string[] {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -952,7 +952,7 @@ describe("signal coverage edge cases", () => {
     expect(comment).toContain("> | Open PR queue | ❌ 3/10 |");
     expect(comment).toContain("> | Gate result | ⚠️ Skipped | PR closed before full evaluation. | No action. |");
     expect(comment).toContain("[JSONbored](https://github.com/JSONbored)");
-    expect(comment).toContain("[official public miner data](https://api.gittensor.io/miners/49853598)");
+    expect(comment).toContain("[Gittensor profile](https://gittensor.io/miners/details?githubId=49853598)");
     expect(comment).toContain("Official Gittensor activity: 29 PR(s), 6 issue(s).");
     expect(comment).not.toMatch(/wallet|hotkey|payout|trust score|private score/i);
   });


### PR DESCRIPTION
## Summary
- update public PR panel contributor context to link the Gittensor dashboard profile route instead of raw API JSON
- keep the GitHub profile link and public contribution counts unchanged

## Why
Maintainers need a quick human-readable profile view from the Gate/panel, not raw API data.

## Validation
- `npx vitest run test/unit/signals-coverage.test.ts test/unit/signals.test.ts test/unit/signals-v2.test.ts`
- `npm run test:ci`