### PR TITLE
fix(processors): PR public-surface skip ordering

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -817,6 +817,21 @@ async function maybePublishPrPublicSurface(
 ): Promise<void> {
   const author = pr.authorLogin ?? null;
   const gateEnabled = settings.gateCheckMode === "enabled" && Boolean(advisory.headSha);
+  // Cheap, network-free skip checks (also avoids the miner lookup when it would be wasted).
+  const prelim = decidePublicSurface({
+    settings,
+    authorLogin: author,
+    authorType: webhook.authorType ?? null,
+    authorAssociation: pr.authorAssociation ?? null,
+    minerStatus: "not_checked",
+  });
+  if (prelim.skipped) {
+    await auditPrVisibilitySkip(env, repoFullName, pr.number, author, prelim.skipReason ?? "skipped", webhook.deliveryId);
+    return;
+  }
+  if (!gateEnabled && prelim.actions.length === 1 && prelim.actions[0] === "none") return;
+  if (!author) return;
+
   if (gateEnabled && (pr.state !== "open" || webhook.action === "closed")) {
     const gateCheckResult = await createOrUpdateSkippedGateCheckRun(env, installationId, repoFullName, advisory, "PR closed before full evaluation.");
     if (gateCheckResult?.kind === "permission_missing") {
@@ -832,6 +847,34 @@ async function maybePublishPrPublicSurface(
     ).catch(() => undefined);
     return;
   }
+  const prelimHasPublicOutput = prelim.actions.some((action) => action === "comment" || action === "label" || action === "check_run");
+  let official: Awaited<ReturnType<typeof getCachedOfficialMinerDetection>> | null = null;
+  let decision = prelim;
+  if (prelimHasPublicOutput) {
+    const requireOfficialMiner = settings.publicAudienceMode === "gittensor_only";
+    official = await getCachedOfficialMinerDetection(env, author, {
+      targetKey: `${repoFullName}#${pr.number}`,
+      deliveryId: webhook.deliveryId,
+    });
+    if (requireOfficialMiner && official.status === "unavailable") {
+      await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
+      return;
+    }
+    if (requireOfficialMiner && official.status !== "confirmed") {
+      await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
+      return;
+    }
+    decision = decidePublicSurface({
+      settings,
+      authorLogin: author,
+      authorType: webhook.authorType ?? null,
+      authorAssociation: pr.authorAssociation ?? null,
+      minerStatus: official.status,
+    });
+
+    if (!gateEnabled && decision.actions.length === 1 && decision.actions[0] === "none") return;
+  }
+
   let pendingGateCheckRunId: number | undefined;
   if (gateEnabled) {
     const pendingGateResult = await createOrUpdatePendingGateCheckRun(env, installationId, repoFullName, advisory);
@@ -881,41 +924,8 @@ async function maybePublishPrPublicSurface(
     }
   }
 
-  // Cheap, network-free skip checks (also avoids the miner lookup when it would be wasted).
-  const prelim = decidePublicSurface({
-    settings,
-    authorLogin: author,
-    authorType: webhook.authorType ?? null,
-    authorAssociation: pr.authorAssociation ?? null,
-    minerStatus: "not_checked",
-  });
-  if (prelim.skipped) {
-    await auditPrVisibilitySkip(env, repoFullName, pr.number, author, prelim.skipReason ?? "skipped", webhook.deliveryId);
-    return;
-  }
-  if (prelim.actions.length === 1 && prelim.actions[0] === "none") return;
-  if (!author) return;
-
-  const requireOfficialMiner = settings.publicAudienceMode === "gittensor_only";
-  const official = await getCachedOfficialMinerDetection(env, author, {
-    targetKey: `${repoFullName}#${pr.number}`,
-    deliveryId: webhook.deliveryId,
-  });
-  if (requireOfficialMiner && official.status === "unavailable") {
-    await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
-    return;
-  }
-  if (requireOfficialMiner && official.status !== "confirmed") {
-    await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
-    return;
-  }
-  const decision = decidePublicSurface({
-    settings,
-    authorLogin: author,
-    authorType: webhook.authorType ?? null,
-    authorAssociation: pr.authorAssociation ?? null,
-    minerStatus: official.status,
-  });
+  if (!prelimHasPublicOutput) return;
+  if (!official) return;
 
   const publishCachedContributorActivity = official.status === "confirmed";
   const [contributorPullRequests, contributorIssues, github, cachedRepoStats] = await Promise.all([

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1338,7 +1338,17 @@ describe("queue processors", () => {
       autoLabelEnabled: false,
       checkRunMode: "off",
     });
-    const calls = { fetch: 0 };
+    const calls = { fetch: 0, repoWideReads: 0 };
+    const originalDb = env.DB;
+    env.DB = new Proxy(originalDb, {
+      get(target, prop, receiver) {
+        if (prop !== "prepare") return Reflect.get(target, prop, receiver);
+        return (sql: string) => {
+          if (/from\s+["`]?issues["`]?/i.test(sql) || /from\s+["`]?bounties["`]?/i.test(sql)) calls.repoWideReads += 1;
+          return target.prepare(sql);
+        };
+      },
+    }) as D1Database;
     vi.stubGlobal("fetch", async () => {
       calls.fetch += 1;
       return new Response("unexpected fetch", { status: 500 });
@@ -1356,7 +1366,7 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls.fetch).toBe(0);
+    expect(calls).toEqual({ fetch: 0, repoWideReads: 0 });
     const skipped = await env.DB.prepare("select actor, target_key, detail, metadata_json from audit_events where event_type = ?").bind("github_app.pr_visibility_skipped").all<{
       actor: string;
       target_key: string;


### PR DESCRIPTION
### Motivation
- Prevent expensive repository-wide reads and pairwise collision/readiness analysis from running for PR webhook events that should be cheaply skipped by public-surface rules.  
- Preserve existing gate-only behavior where gate checks must still run even if no public output is configured.

### Description
- Moved the cheap, network-free `decidePublicSurface` prelim skip checks to the top of `maybePublishPrPublicSurface` in `src/queue/processors.ts` so skipped events return before miner lookups and repo-wide reads.  
- Only perform miner detection and the more expensive public-output flow when the prelim decision indicates a potential public output (`comment`, `label`, or `check_run`), while still allowing gate behavior to run when `gateCheckMode` is enabled.  
- Added early returns to avoid calling `listIssues`, `listPullRequests`, `listBountiesByRepo`, and `buildCollisionReport` for skipped events.  
- Extended `test/unit/queue.test.ts` to assert that when `publicSurface` is `off` there are no network fetches and no repo-wide issue/bounty reads before the skip audit is recorded.

### Testing
- Ran `npm run typecheck` and `git diff --check` with no errors.  
- Ran the unit tests for the queue processor with `npm test -- --run test/unit/queue.test.ts`, and the modified test suite passed (`46 passed`).  
- The changes were validated by the added regression assertion that counts repo-wide DB reads and confirms none occur for a disabled public surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2331c10b34832c85c5ca5e2f4d483c)