### PR TITLE
fix(settings): require only pull_requests:read for PR comment/label output

### DIFF
--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -481,11 +481,11 @@ function writesPrPublicSurface(settings: RepositorySettings, decision: PublicSur
 }
 
 function requiredInstallPermissions(settings: RepositorySettings, decision: PublicSurfaceDecision): string[] {
-  // PR conversation comments and PR labels are gated by GitHub on the Pull requests permission (write),
-  // matching REQUIRED_INSTALLATION_PERMISSIONS; reading PR metadata only needs read.
-  const writesPrSurface = writesPrPublicSurface(settings, decision);
-  const permissions = new Set(["metadata: read", writesPrSurface ? "pull_requests: write" : "pull_requests: read"]);
-  if (writesPrSurface) permissions.add("issues: write");
+  // PR conversation comments and PR labels use GitHub Issues endpoints, so they require issues:write, not
+  // pull_requests:write -- the app only reads PRs. This matches REQUIRED_INSTALLATION_PERMISSIONS
+  // (pull_requests: read) and avoids asking maintainers for broader PR-write scope than the app uses.
+  const permissions = new Set(["metadata: read", "pull_requests: read"]);
+  if (writesPrPublicSurface(settings, decision)) permissions.add("issues: write");
   if (decision.willCheckRun || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled") permissions.add("checks: write");
   return [...permissions];
 }
@@ -494,9 +494,8 @@ function activeMissingPermissions(settings: RepositorySettings, decision: Public
   if (!installation) return [];
   const missing = new Set(installation.missingPermissions);
   const active: string[] = [];
-  const writesPrSurface = writesPrPublicSurface(settings, decision);
-  if (writesPrSurface && missing.has("pull_requests")) active.push("pull_requests");
-  if (writesPrSurface && missing.has("issues")) active.push("issues");
+  // Comment/label output is gated on issues:write (Issues endpoints), not pull_requests:write.
+  if (writesPrPublicSurface(settings, decision) && missing.has("issues")) active.push("issues");
   if ((decision.willCheckRun || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled") && missing.has("checks")) active.push("checks");
   return active;
 }

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -116,7 +116,7 @@ describe("buildRepoSettingsPreview", () => {
     expect(preview.warnings).toHaveLength(0);
     expect(preview.installPreview).toMatchObject({
       status: "ready",
-      permissions: { status: "ready", required: expect.arrayContaining(["metadata: read", "pull_requests: write", "issues: write"]) },
+      permissions: { status: "ready", required: expect.arrayContaining(["metadata: read", "pull_requests: read", "issues: write"]) },
       publicOutputs: expect.arrayContaining(["One sanitized sticky PR comment.", 'Configured label "gittensor".']),
       checklist: expect.arrayContaining([
         expect.objectContaining({ id: "permissions", status: "ready" }),
@@ -166,16 +166,18 @@ describe("buildRepoSettingsPreview", () => {
     });
   });
 
-  it("explains a missing Pull requests: write permission for PR comment/label output", () => {
+  it("requires only pull_requests:read for PR comment/label output (no PR write overprivilege)", () => {
+    // Installation grants issues:write (everything comment/label output actually needs) but is missing
+    // pull_requests; the app only reads PRs, so this must NOT be flagged as a comment/label blocker.
     const preview = buildRepoSettingsPreview({
       ...base,
       settings: settings(),
-      installation: { ...healthyInstall, status: "needs_attention", missingPermissions: ["pull_requests"] },
+      installation: { ...healthyInstall, missingPermissions: ["pull_requests"] },
       sample: { authorLogin: "miner", minerStatus: "confirmed" },
     });
-    // PR comments/labels need pull_requests: write; the preview must require it and surface it as missing.
-    expect(preview.installPreview.permissions.required).toContain("pull_requests: write");
-    expect(preview.installPreview.permissions).toMatchObject({ status: "needs_attention", missing: ["pull_requests"] });
+    expect(preview.installPreview.permissions.required).toContain("pull_requests: read");
+    expect(preview.installPreview.permissions.required).not.toContain("pull_requests: write");
+    expect(preview.installPreview.permissions.missing).not.toContain("pull_requests");
   });
 
   it("explains a missing optional Checks: write permission only when check runs are enabled", () => {


### PR DESCRIPTION
## Summary
`src/signals/settings-preview.ts` contradicted itself on the GitHub App permissions a repo needs to publish PR comments/labels. Two PRs reached opposite conclusions and both merged:

- #427 (`fix(github-app): avoid PR write overprivilege`) established that PR comments/labels use GitHub **Issues** endpoints (need `issues: write`) and the app only **reads** PRs, so it set `REQUIRED_INSTALLATION_PERMISSIONS.pull_requests = "read"` and rewrote `buildWarnings` to require only `issues: write`.
- #420 (merged after) changed the *other* two helpers in the same file to require/flag `pull_requests: write`.

The result was a live self-contradiction:
- `buildWarnings`: "Comments and labels use GitHub Issues endpoints and require GitHub App permission **Issues: write**".
- `requiredInstallPermissions`: listed `pull_requests: write` for comment/label, with a comment claiming it "matches REQUIRED_INSTALLATION_PERMISSIONS" -- which now reads `pull_requests: read`, making the comment provably false.
- `activeMissingPermissions`: flagged a missing `pull_requests` permission as a comment/label blocker.

So the maintainer permission checklist (`installPreview.permissions.required`/`.missing`) told maintainers to grant `pull_requests: write` -- a scope the app never uses -- re-introducing exactly the overprivilege #427 removed, and disagreeing with the same preview's warning text and the app's declared baseline. Closes #433.

## Scope
- `src/signals/settings-preview.ts`:
  - `requiredInstallPermissions` -- keep `pull_requests: read` as the baseline (no `write` upgrade); comment/label outputs add `issues: write` (unchanged). Replaced the now-false "gated on the Pull requests permission (write)" comment.
  - `activeMissingPermissions` -- drop the `missing.has("pull_requests")` check for comment/label output; keep the `issues`/`checks` checks, mirroring `buildWarnings`.
  - The three permission helpers in this file now agree, matching `REQUIRED_INSTALLATION_PERMISSIONS` (`pull_requests: read`) and #427.
- `test/unit/settings-preview.test.ts`:
  - Healthy comment/label preview now asserts `pull_requests: read` (was `write`).
  - Fail-on-revert: an installation missing `pull_requests` but with `issues: write` granted lists `pull_requests: read` (not `write`) in `required` and is **not** flagged as missing `pull_requests` for comment/label output.

## Validation
- `npx tsc --noEmit` -- clean.
- `npx vitest run test/unit/settings-preview.test.ts test/integration/api.test.ts` -- 48/48 (the #427 assertions of `pull_requests: read` now pass alongside these).
- Full suite -- 1158 passed, 1 skipped (excluding the two unparseable upstream test files and one unrelated `mcp-cli` timeout that passes in isolation).
- Branch coverage at/above the 97% gate.

## Safety
- No response-shape change: `installPreview.permissions` keeps the same fields; only the (now correct) `pull_requests` level changes, and only for comment/label-output previews.
- Strictly reduces the permission ask (least privilege): maintainers are no longer told to grant PR write the app does not use.
- Aligns settings-preview with the app's actual baseline and with #427's stated decision.

## Notes
This reverts the source change from #420, which had landed after #427 and reached the opposite conclusion on the same question; #427's overprivilege decision is the authoritative one.