### PR TITLE
fix(ci): bound PR issue reference fetching

### DIFF
--- a/scripts/github-type-label.d.mts
+++ b/scripts/github-type-label.d.mts
@@ -42,12 +42,13 @@ export function ensureRepositoryLabel(options: {
   label: TypeLabel;
   fetchImpl?: typeof fetch;
 }): Promise<{ created: boolean; reason?: string }>;
-export function extractClosingIssueNumbers(text: unknown): number[];
+export function extractClosingIssueNumbers(text: unknown, options?: { maxCount?: number }): number[];
 export function fetchReferencedIssues(options: {
   apiUrl?: string;
   repository: string;
   token: string;
   body: unknown;
+  maxReferences?: number;
   fetchImpl?: typeof fetch;
 }): Promise<IssueReference[]>;
 export function applyTypeLabel(options: {

--- a/scripts/github-type-label.mjs
+++ b/scripts/github-type-label.mjs
@@ -7,6 +7,7 @@ const PRIORITY_LABEL = "gittensor:priority";
 const AUTO_TYPE_LABELS = new Set([BUG_LABEL, FEATURE_LABEL]);
 const SCORING_LABELS = new Set([BUG_LABEL, FEATURE_LABEL, PRIORITY_LABEL]);
 const FEATURE_SOURCE_LABELS = new Set(["feature", FEATURE_LABEL]);
+const MAX_CLOSING_ISSUE_REFERENCES = 5;
 const LABEL_DEFINITIONS = {
   [BUG_LABEL]: { color: "d73a4a", description: "Gittensor-scored bug fix" },
   [FEATURE_LABEL]: { color: "0e8a16", description: "Gittensor-scored feature linked to a feature issue" },
@@ -134,23 +135,27 @@ export async function ensureRepositoryLabel({ apiUrl = "https://api.github.com",
   throw new Error(`Failed to create repository label ${label}: ${created.status} ${createdText}`);
 }
 
-export function extractClosingIssueNumbers(text) {
+export function extractClosingIssueNumbers(text, { maxCount = MAX_CLOSING_ISSUE_REFERENCES } = {}) {
   const body = String(text ?? "");
+  const limit = Number.isInteger(maxCount) && maxCount > 0 ? maxCount : 0;
+  if (limit === 0) return [];
+
   const numbers = new Set();
   const closingRef = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
   for (const match of body.matchAll(closingRef)) {
     const number = Number.parseInt(match[1], 10);
     if (Number.isSafeInteger(number) && number > 0) numbers.add(number);
+    if (numbers.size >= limit) break;
   }
   return [...numbers];
 }
 
-export async function fetchReferencedIssues({ apiUrl = "https://api.github.com", repository, token, body, fetchImpl = fetch }) {
+export async function fetchReferencedIssues({ apiUrl = "https://api.github.com", repository, token, body, maxReferences = MAX_CLOSING_ISSUE_REFERENCES, fetchImpl = fetch }) {
   const [owner, repo, ...extraParts] = String(repository ?? "").split("/");
   if (!owner || !repo || extraParts.length > 0) throw new Error("GITHUB_REPOSITORY must be owner/repo");
   if (!token) throw new Error("GITHUB_TOKEN is required");
 
-  const numbers = extractClosingIssueNumbers(body);
+  const numbers = extractClosingIssueNumbers(body, { maxCount: maxReferences });
   const headers = {
     accept: "application/vnd.github+json",
     authorization: `Bearer ${token}`,
@@ -163,6 +168,7 @@ export async function fetchReferencedIssues({ apiUrl = "https://api.github.com",
     const response = await fetchImpl(issueUrl, { method: "GET", headers });
     if (!response.ok) {
       const text = await response.text();
+      if (response.status === 404) continue;
       throw new Error(`Failed to read referenced issue #${number}: ${response.status} ${text}`);
     }
     issues.push(await response.json());
@@ -197,15 +203,14 @@ export async function main() {
 
   const payload = JSON.parse(await readFile(eventPath, "utf8"));
   const eventName = process.env.GITHUB_EVENT_NAME ?? "";
-  const issueReferences =
-    eventName === "pull_request_target"
-      ? await fetchReferencedIssues({
-          apiUrl: process.env.GITHUB_API_URL,
-          repository: process.env.GITHUB_REPOSITORY ?? "",
-          token: process.env.GITHUB_TOKEN ?? "",
-          body: payload.pull_request?.body ?? "",
-        })
-      : [];
+  const issueReferences = shouldFetchReferencedIssues(eventName, payload)
+    ? await fetchReferencedIssues({
+        apiUrl: process.env.GITHUB_API_URL,
+        repository: process.env.GITHUB_REPOSITORY ?? "",
+        token: process.env.GITHUB_TOKEN ?? "",
+        body: payload.pull_request?.body ?? "",
+      })
+    : [];
   const decision = getTypeLabelDecision(eventName, payload, { issueReferences });
   if (decision.action === "skip") {
     console.log(`type-label: skipped ${decision.reason}`);
@@ -232,6 +237,14 @@ function numberOrUndefined(value) {
 
 function stringOrEmpty(value) {
   return typeof value === "string" ? value : "";
+}
+
+function shouldFetchReferencedIssues(eventName, payload) {
+  if (eventName !== "pull_request_target") return false;
+  const pullRequest = payload?.pull_request;
+  if (!pullRequest || typeof pullRequest !== "object") return false;
+  if (hasScoringLabel(normalizeLabels(pullRequest.labels))) return false;
+  return isFeatureTitle(String(pullRequest.title ?? "").trim());
 }
 
 function classifyPullRequestLabel(pullRequest, issueReferences) {

--- a/test/unit/github-type-label.test.ts
+++ b/test/unit/github-type-label.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   applyTypeLabel,
   classifyTypeLabel,
@@ -8,6 +10,7 @@ import {
   fetchReferencedIssues,
   getTypeLabelDecision,
   readCurrentLabels,
+  main,
 } from "../../scripts/github-type-label.mjs";
 
 describe("GitHub type label classifier", () => {
@@ -250,6 +253,79 @@ describe("GitHub type label classifier", () => {
 
     expect(issues).toEqual([{ number: 12, title: "[Feature]: add metadata boundary checks", labels: [{ name: "feature" }] }]);
     expect(calls).toEqual(["GET https://api.github.com/repos/JSONbored/gittensory/issues/12"]);
+  });
+
+  it("caps closing issue references before authenticated fetches", async () => {
+    const calls: string[] = [];
+    const issues = await fetchReferencedIssues({
+      repository: "JSONbored/gittensory",
+      token: "token",
+      body: "Closes #1 fixes #2 resolves #3 closes #4 fixes #5 resolves #6",
+      maxReferences: 3,
+      fetchImpl: async (input, init) => {
+        calls.push(`${init?.method ?? "GET"} ${input.toString()}`);
+        return Response.json({ number: calls.length, title: "[Feature]: accepted", labels: [{ name: "feature" }] });
+      },
+    });
+
+    expect(issues).toHaveLength(3);
+    expect(calls).toEqual([
+      "GET https://api.github.com/repos/JSONbored/gittensory/issues/1",
+      "GET https://api.github.com/repos/JSONbored/gittensory/issues/2",
+      "GET https://api.github.com/repos/JSONbored/gittensory/issues/3",
+    ]);
+  });
+
+  it("ignores missing referenced issues instead of failing the workflow", async () => {
+    const issues = await fetchReferencedIssues({
+      repository: "JSONbored/gittensory",
+      token: "token",
+      body: "Closes #12 fixes #404",
+      fetchImpl: async (input) => {
+        if (input.toString().endsWith("/issues/404")) return new Response("not found", { status: 404 });
+        return Response.json({ number: 12, title: "[Feature]: add metadata boundary checks", labels: [{ name: "feature" }] });
+      },
+    });
+
+    expect(issues).toEqual([{ number: 12, title: "[Feature]: add metadata boundary checks", labels: [{ name: "feature" }] }]);
+  });
+
+  it("does not fetch issue references for non-feature pull requests", async () => {
+    const originalEnv = { ...process.env };
+    const originalFetch = globalThis.fetch;
+    const eventDir = mkdtempSync(join(tmpdir(), "type-label-"));
+    const eventPath = join(eventDir, "event.json");
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        pull_request: {
+          number: 101,
+          title: "chore: update documentation",
+          body: "Closes #1 fixes #2 resolves #3",
+          labels: [],
+        },
+      }),
+    );
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchMock = vi.fn(async () => {
+      throw new Error("fetch should not run for non-feature pull requests");
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    process.env.GITHUB_EVENT_PATH = eventPath;
+    process.env.GITHUB_EVENT_NAME = "pull_request_target";
+    process.env.GITHUB_REPOSITORY = "JSONbored/gittensory";
+    process.env.GITHUB_TOKEN = "token";
+
+    try {
+      await main();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith("type-label: skipped no-type-label");
+    } finally {
+      process.env = originalEnv;
+      globalThis.fetch = originalFetch;
+      log.mockRestore();
+      rmSync(eventDir, { recursive: true, force: true });
+    }
   });
 
   it("creates a missing auto reward label before applying it", async () => {


### PR DESCRIPTION
### Motivation
- Prevent unbounded, attacker-controlled processing of closing references in PR bodies that can exhaust the workflow's GitHub API quota and runtime. 
- Avoid failing the workflow when a PR body contains invalid issue references (e.g., 404s). 
- Avoid performing any authenticated issue lookups for pull requests that are not unlabeled feature PR candidates.

### Description
- Add `MAX_CLOSING_ISSUE_REFERENCES` and cap parsing in `extractClosingIssueNumbers` to stop extracting more than a safe number of references. 
- Add a `maxReferences` option to `fetchReferencedIssues` and pass the capped list into the per-issue authenticated fetch loop. 
- Treat `404` results when fetching referenced issues as ignorable (skip that reference) and preserve throwing on other unexpected response codes. 
- Add `shouldFetchReferencedIssues` to early-skip referenced-issue fetching unless the `pull_request_target` payload looks like an unlabeled feature PR candidate. 
- Update the declaration file `scripts/github-type-label.d.mts` and add regression unit tests in `test/unit/github-type-label.test.ts` covering capped fetches, 404 handling, and non-feature PR early skipping. 

### Testing
- Ran the unit tests with `npx vitest run test/unit/github-type-label.test.ts` and all tests passed (27 tests, all green). 
- Ran TypeScript type checking with `npm run typecheck` (`tsc --noEmit`) and it succeeded. 
- Added targeted unit tests for capped extraction, 404-ignore behavior, and the early-skip path which passed under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235a83a610832cab3af81c5bcba448)