### PR TITLE
fix(settings): settings preview PR write permission check

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1535,6 +1535,7 @@ export function createApp() {
           status: enriched.status,
           missingPermissions: enriched.missingPermissions,
           missingEvents: enriched.missingEvents,
+          permissions: enriched.permissions,
           permissionRemediation: enriched.permissionRemediation,
         }
       : null;

--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -134,6 +134,7 @@ export type InstallationHealthSummary = {
   status: "healthy" | "needs_attention" | "broken";
   missingPermissions: string[];
   missingEvents: string[];
+  permissions?: Record<string, string> | undefined;
   permissionRemediation: Array<{ permission: string; requiredAccess: string; currentAccess: string; ok: boolean; action: string }>;
 };
 
@@ -324,7 +325,12 @@ function buildWarnings(settings: RepositorySettings, decision: PublicSurfaceDeci
     warnings.push("Installation health is unknown for this repo; run refresh-installation-health to verify GitHub App permissions and subscribed events.");
     return warnings;
   }
-  const missing = new Set(installation.missingPermissions);
+  const missing = new Set(activeMissingPermissions(settings, decision, installation));
+  if (writesPrPublicSurface(settings, decision) && missing.has("pull_requests")) {
+    warnings.push(
+      "PR comments and labels require GitHub App permission Pull requests: write. Set Pull requests to write, then approve the change.",
+    );
+  }
   if ((decision.willComment || decision.willLabel) && missing.has("issues")) {
     warnings.push(
       "Comments and labels use GitHub Issues endpoints and require GitHub App permission Issues: write. Set Issues to write, then approve the change.",
@@ -495,10 +501,17 @@ function activeMissingPermissions(settings: RepositorySettings, decision: Public
   const missing = new Set(installation.missingPermissions);
   const active: string[] = [];
   const writesPrSurface = writesPrPublicSurface(settings, decision);
-  if (writesPrSurface && missing.has("pull_requests")) active.push("pull_requests");
+  const lacksPrWrite = installation.permissions ? !permissionSatisfies(installation.permissions.pull_requests, "write") : false;
+  if (writesPrSurface && (missing.has("pull_requests") || lacksPrWrite)) active.push("pull_requests");
   if (writesPrSurface && missing.has("issues")) active.push("issues");
   if ((decision.willCheckRun || settings.checkRunMode === "enabled" || settings.gateCheckMode === "enabled") && missing.has("checks")) active.push("checks");
   return active;
+}
+
+function permissionSatisfies(current: string | undefined, expected: string): boolean {
+  if (current === expected) return true;
+  const order: Record<string, number> = { read: 1, write: 2, admin: 3 };
+  return (order[current ?? ""] ?? 0) >= (order[expected] ?? Number.POSITIVE_INFINITY);
 }
 
 function permissionSummary(installation: InstallationHealthSummary | null, missing: string[], missingEvents: string[]): string {

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -59,6 +59,7 @@ const healthyInstall: InstallationHealthSummary = {
   status: "healthy",
   missingPermissions: [],
   missingEvents: [],
+  permissions: { metadata: "read", pull_requests: "write", issues: "write" },
   permissionRemediation: [{ permission: "issues", requiredAccess: "write", currentAccess: "write", ok: true, action: "No change needed." }],
 };
 
@@ -176,6 +177,18 @@ describe("buildRepoSettingsPreview", () => {
     // PR comments/labels need pull_requests: write; the preview must require it and surface it as missing.
     expect(preview.installPreview.permissions.required).toContain("pull_requests: write");
     expect(preview.installPreview.permissions).toMatchObject({ status: "needs_attention", missing: ["pull_requests"] });
+  });
+
+  it("detects Pull requests: read as insufficient for PR comment/label output", () => {
+    const preview = buildRepoSettingsPreview({
+      ...base,
+      settings: settings(),
+      installation: { ...healthyInstall, permissions: { metadata: "read", pull_requests: "read", issues: "write" } },
+      sample: { authorLogin: "miner", minerStatus: "confirmed" },
+    });
+    expect(preview.installPreview.permissions.required).toContain("pull_requests: write");
+    expect(preview.installPreview.permissions).toMatchObject({ status: "needs_attention", missing: ["pull_requests"] });
+    expect(preview.warnings.some((warning) => /Pull requests: write/.test(warning))).toBe(true);
   });
 
   it("explains a missing optional Checks: write permission only when check runs are enabled", () => {


### PR DESCRIPTION
### Motivation
- The settings-preview flow began requiring `pull_requests: write` for PR comments/labels but only checked `missingPermissions` produced from a read-level requirement map, leading to previews that could report `ready` even when the installation only had `pull_requests: read`.
- The preview also lacked the actual installation `permissions` map, so it could not independently detect that `pull_requests: read` is insufficient for public PR writes.

### Description
- Pass the installation `permissions` map into the settings-preview payload so preview logic can evaluate actual access levels by adding `permissions` to the route payload in `src/api/routes.ts`.
- Extend the `InstallationHealthSummary` type in `src/signals/settings-preview.ts` with an optional `permissions?: Record<string,string>` field and update preview logic to use the live permissions.
- Update `activeMissingPermissions` to treat `pull_requests` as missing when the previewed behavior writes PR comments/labels and the installation either lists `pull_requests` as missing or its permission level does not satisfy `write`, using a new `permissionSatisfies` helper.
- Use `activeMissingPermissions` in `buildWarnings` so the preview emits a specific warning when PR comment/label output lacks `Pull requests: write` and add a regression test in `test/unit/settings-preview.test.ts` to cover `pull_requests: read` being insufficient.

### Testing
- Ran `npx vitest run test/unit/settings-preview.test.ts` and all unit tests passed (`22 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) and TypeScript type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236f1f9088832c93b589b17987b734)