### PR TITLE
fix(gittensor): guard Gittensor repo name normalization

### DIFF
--- a/src/gittensor/api.ts
+++ b/src/gittensor/api.ts
@@ -44,7 +44,7 @@ type GittensorMinerDetailResponse = GittensorMinerSummaryResponse & {
 };
 
 type GittensorRepositoryEvaluationResponse = {
-  repositoryFullName?: string;
+  repositoryFullName?: unknown;
   totalOpenPrs?: number | string;
   totalClosedPrs?: number | string;
   totalMergedPrs?: number | string;
@@ -264,7 +264,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 
 function toRepositoryEvaluation(repo: GittensorRepositoryEvaluationResponse): GittensorContributorSnapshot["repositories"][number] {
   return {
-    repoFullName: repo.repositoryFullName ?? "",
+    repoFullName: asString(repo.repositoryFullName),
     pullRequests: asNumber(repo.totalPrs),
     mergedPullRequests: asNumber(repo.totalMergedPrs),
     openPullRequests: asNumber(repo.totalOpenPrs),
@@ -304,6 +304,10 @@ function toIssue(issue: NonNullable<GittensorMinerIssuesResponse["issues"]>[numb
     solvedByPullRequest: issue.solved_by_pr ?? null,
     labels: (issue.labels ?? []).flatMap((label) => (label.name ? [label.name] : [])),
   };
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
 }
 
 function asNumber(value: unknown, fallback = 0): number {

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1066,12 +1066,12 @@ export function buildContributorProfile(
   // only fold in stat-derived dominant labels for repos that have no cached authored records --
   // otherwise a shared repo's labels are double-counted (consistent with how reposTouched dedups and
   // unlinkedOpenPullRequests maxes the same two sources).
-  const cachedLabelRepos = new Set([...authoredPullRequests, ...authoredIssues].map((record) => record.repoFullName.toLowerCase()));
+  const cachedLabelRepos = new Set([...authoredPullRequests, ...authoredIssues].map((record) => normalizedRepoName(record.repoFullName)));
   const dominantLabels = topItems(
     [
       ...authoredPullRequests.flatMap((record) => record.labels),
       ...authoredIssues.flatMap((record) => record.labels),
-      ...matchingStats.filter((stat) => !cachedLabelRepos.has(stat.repoFullName.toLowerCase())).flatMap((stat) => stat.dominantLabels),
+      ...matchingStats.filter((stat) => !cachedLabelRepos.has(normalizedRepoName(stat.repoFullName))).flatMap((stat) => stat.dominantLabels),
     ],
     8,
   );
@@ -1122,12 +1122,12 @@ function buildGittensorContributorProfile(
     .sort();
   // The snapshot labels already cover snapshot.repositories; only fold in stat-derived dominant labels
   // for repos the snapshot does not cover, so shared repos are not double-counted.
-  const snapshotRepos = new Set(snapshot.repositories.map((repo) => repo.repoFullName.toLowerCase()));
+  const snapshotRepos = new Set(snapshot.repositories.map((repo) => normalizedRepoName(repo.repoFullName)));
   const dominantLabels = topItems(
     [
       ...snapshot.pullRequests.flatMap((pr) => (pr.label ? [pr.label] : [])),
       ...snapshot.issueLabels,
-      ...matchingStats.filter((stat) => !snapshotRepos.has(stat.repoFullName.toLowerCase())).flatMap((stat) => stat.dominantLabels),
+      ...matchingStats.filter((stat) => !snapshotRepos.has(normalizedRepoName(stat.repoFullName))).flatMap((stat) => stat.dominantLabels),
     ],
     8,
   );
@@ -4183,6 +4183,10 @@ function sameLogin(value: string | null | undefined, login: string): boolean {
 
 function sameRepo(left: string | null | undefined, right: string | null | undefined): boolean {
   return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+}
+
+function normalizedRepoName(value: unknown): string {
+  return typeof value === "string" ? value.toLowerCase() : "";
 }
 
 function topItems(items: string[], limit: number): string[] {

--- a/test/unit/gittensor-api.test.ts
+++ b/test/unit/gittensor-api.test.ts
@@ -151,7 +151,7 @@ describe("Gittensor API contributor snapshots", () => {
       if (url.endsWith("/miners/123")) {
         return Response.json({
           repositories: [
-            { repositoryFullName: undefined, totalPrs: "bad", totalOpenIssues: "1", totalClosedIssues: null, isEligible: true },
+            { repositoryFullName: { malformed: true }, totalPrs: "bad", totalOpenIssues: "1", totalClosedIssues: null, isEligible: true },
             { repositoryFullName: "owner/repo", totalPrs: "3", totalMergedPrs: "2", totalOpenIssues: "0", totalClosedIssues: "0", totalScore: "bad" },
           ],
         });

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -146,6 +146,28 @@ describe("signal coverage edge cases", () => {
     expect(profile.registeredRepoActivity.dominantLabels).toContain("uncached-label");
   });
 
+  it("treats malformed official snapshot repo names as absent during label dedupe", () => {
+    const snapshot = officialSnapshot();
+    snapshot.repositories[0]!.repoFullName = { malformed: true } as unknown as string;
+    snapshot.pullRequests = [{ repoFullName: "owner/readiness", number: 1, title: "Fix it", state: "MERGED", label: "snapshot-label", score: 1, baseScore: 1, tokenScore: 1 }];
+
+    const profile = buildContributorProfile(
+      "jsonbored",
+      { login: "jsonbored", topLanguages: [], source: "github" },
+      [],
+      [],
+      [
+        { login: "jsonbored", repoFullName: { malformed: true } as unknown as string, pullRequests: 1, mergedPullRequests: 0, openPullRequests: 0, issues: 0, stalePullRequests: 0, unlinkedPullRequests: 0, dominantLabels: ["malformed-stat-label"] },
+        { login: "jsonbored", repoFullName: "owner/uncached", pullRequests: 1, mergedPullRequests: 0, openPullRequests: 0, issues: 0, stalePullRequests: 0, unlinkedPullRequests: 0, dominantLabels: ["uncached-label"] },
+      ],
+      snapshot,
+    );
+
+    expect(profile.registeredRepoActivity.dominantLabels).toContain("snapshot-label");
+    expect(profile.registeredRepoActivity.dominantLabels).not.toContain("malformed-stat-label");
+    expect(profile.registeredRepoActivity.dominantLabels).toContain("uncached-label");
+  });
+
   it("separates cached outcome history, maintainer role sources, and contributor detections", () => {
     const directRepo = repo("owner/direct");
     const ownerRepo = repo("owner/project");


### PR DESCRIPTION
### Motivation
- Upstream Gittensor JSON can include non-string `repositoryFullName` values which caused `.toLowerCase()` calls to throw and crash contributor profile builds. 
- The change aims to treat external Gittensor repo names as untrusted JSON and safely coerce or ignore malformed values so profile construction remains available.

### Description
- Treat `repositoryFullName` as `unknown` and add `asString()` in `src/gittensor/api.ts` so non-string values map to the existing empty-string fallback before entering snapshots. 
- Replace direct `.toLowerCase()` usages with a new `normalizedRepoName()` helper in `src/signals/engine.ts` and use it when deduping repo names for label aggregation. 
- Add regression tests that exercise malformed/malformed-object repo names in `test/unit/gittensor-api.test.ts` and `test/unit/signals-coverage.test.ts` to ensure malformed upstream payloads are treated as absent rather than crashing.

### Testing
- Ran `npx vitest run test/unit/gittensor-api.test.ts test/unit/signals-coverage.test.ts` and the targeted tests passed. 
- Ran the repository unit test command `npm run test:unit -- test/unit/gittensor-api.test.ts test/unit/signals-coverage.test.ts` and the run succeeded. 
- Ran type checking with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236f2137e4832cba427401f0567c0e)