### PR TITLE
fix(backfill): stop PR detail re-queue loop when a batch makes no progress

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -523,8 +523,16 @@ export async function backfillOpenPullRequestDetails(
     });
   });
   const refreshedDetailStates = await listPullRequestDetailSyncStates(env, repo.fullName);
+  const refreshedStateByPull = new Map(refreshedDetailStates.map((state) => [state.pullNumber, state.status]));
   const completedCount = refreshedDetailStates.filter((state) => openPullNumbers.has(state.pullNumber) && state.status === "complete").length;
-  const nextCursor = batch.length < incompleteOpenPullRequests.length ? 0 : undefined;
+  // Only keep cursoring over the oldest incomplete PRs if this batch actually shrank the incomplete
+  // list. The cursor is fixed at 0, so a full batch of persistently-"partial" PRs (e.g. repeated
+  // detail-fetch failures) never completes and never drops out; without this guard `nextCursor` would
+  // stay 0 and re-queue the identical failing batch forever, starving every later PR. Stop as "partial"
+  // when no progress is made; a later backfill run can retry once the transient failures clear.
+  const incompleteAfter = openPullRequests.filter((pr) => refreshedStateByPull.get(pr.number) !== "complete").length;
+  const madeProgress = incompleteAfter < incompleteOpenPullRequests.length;
+  const nextCursor = batch.length < incompleteOpenPullRequests.length && madeProgress ? 0 : undefined;
   const status: RepoSyncSegmentRecord["status"] = nextCursor !== undefined ? "running" : completedCount >= openPullRequests.length ? "complete" : "partial";
   await Promise.all(
     (["pull_request_files", "pull_request_reviews", "check_summaries"] as const).map((segment) =>

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1817,6 +1817,46 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("stops PR detail backfill instead of re-queuing forever when a full batch makes no progress", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITHUB_PUBLIC_TOKEN: "public-token",
+      JOBS: {
+        async send(message: import("../../src/types").JobMessage) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    await seedRegisteredRepo(env);
+    for (let number = 1; number <= 13; number += 1) {
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+        number,
+        title: `PR ${number}`,
+        state: "open",
+        user: { login: "oktofeesh1" },
+        head: { sha: `sha-${number}` },
+        labels: [],
+        body: "",
+      });
+    }
+    // Every PR's file sync fails on both GraphQL and REST, so all 13 stay "partial" and the front-12
+    // batch never completes. Without a progress guard nextCursor would stay 0 and re-queue forever.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.github.com/graphql") return new Response("graphql failure", { status: 503 });
+      if (url.includes("/pulls/") && url.includes("/files")) return new Response("file failure", { status: 503 });
+      if (url.includes("/pulls/") && url.includes("/reviews")) return Response.json([]);
+      if (url.includes("/commits/") && url.includes("/check-runs")) return Response.json({ check_runs: [] });
+      return new Response("not found", { status: 404 });
+    });
+
+    const firstBatch = await backfillOpenPullRequestDetails(env, { repoFullName: "JSONbored/gittensory", mode: "light", cursor: 0 });
+
+    expect(firstBatch.status).toBe("partial");
+    expect(firstBatch.nextCursor).toBeUndefined();
+    expect(sent).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "backfill-pr-details" })]));
+  });
+
   it("records segment partial, hard error, and GitHub rate-limit states from paged fetches", async () => {
     for (const [mode, responseStatus] of [
       ["partial-after-page", 500],


### PR DESCRIPTION
## Summary
`backfillOpenPullRequestDetails` (`src/github/backfill.ts`) processes open PRs' detail data (files, reviews, checks) in fixed-size batches, always starting from the front of the *incomplete* list (`cursor = 0` by design), and re-queues itself while the incomplete list is larger than one batch:

```ts
const nextCursor = batch.length < incompleteOpenPullRequests.length ? 0 : undefined;   // no progress check
```

`nextCursor` was set to `0` (continue) whenever `incompleteOpenPullRequests.length > batchSize`, **without checking whether the batch completed any PR**. A PR stays incomplete ("partial") whenever its detail fetch warns -- e.g. file sync fails on both REST and GraphQL (`backfill.ts`: `File sync failed for #N`), which happens for real PRs (changed-files API limits, deleted source branch). If at least `batchSize` such PRs sit at the front of the number-sorted incomplete list, the batch is always those same PRs, they never complete to drop out, the incomplete count never shrinks, and `nextCursor` stays `0` forever: the job re-queues itself every 20s indefinitely, the `pull_request_files`/`pull_request_reviews`/`check_summaries` segments stay `"running"`, and **every PR past the stuck front is never synced**. `PR_DETAIL_BATCH_SIZE` is `{ light: 12, full: 40, resume: 40 }`; once triggered the stall never self-heals.

Downstream consumers that rely on PR detail data (changed-files / review / check evidence -> reviewability, preflight `missingTests`, scoring) then silently operate on missing data for most of the repo's PRs, while the queue does unbounded busy-work.

## Scope
- `src/github/backfill.ts` -- add a no-progress guard: compute `incompleteAfter` from the refreshed detail states and `madeProgress = incompleteAfter < incompleteOpenPullRequests.length`; only keep cursoring (`nextCursor = 0`) when the batch actually shrank the incomplete list. When a full batch makes no progress, terminate as `"partial"` instead of re-queuing the identical failing batch. A later backfill run can retry once transient failures clear.
- `test/unit/backfill.test.ts` -- fail-on-revert: a repo whose front-12 PRs all fail file sync (no batch completes) now returns a terminal result (`status: "partial"`, no `nextCursor`, no re-queue) instead of `status: "running"` + `nextCursor: 0` + a `backfill-pr-details` re-queue.

## Validation
- `npx tsc --noEmit` -- clean.
- `npx vitest run test/unit/backfill.test.ts` -- 56/56 (the existing normal-case light-mode test, where each round completes some PRs, is unchanged -- progress is still made so cursoring continues as before).
- Full suite -- 1159 passed, 1 skipped (excluding the two unparseable upstream test files and one unrelated `mcp-cli` timeout that passes in isolation).
- Branch coverage 97.02% (above the 97% gate); backfill.ts 100% line.

## Safety
- Behavior is unchanged for the normal case (each round completes at least one PR, so `madeProgress` is true and cursoring continues exactly as before, terminating when the incomplete list reaches one batch).
- Only the pathological case changes: a full batch of persistently-"partial" PRs now stops as `"partial"` rather than looping forever. No persisted-data clobbering; the same segments and counts are written, just with a terminal status.

## Notes
A complementary hardening (left out to keep this focused) would be a per-PR retry cap so a chronically-failing PR is eventually dropped from the incomplete set.