### PR TITLE
fix(mcp): shell-quote doctor next commands

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1886,7 +1886,7 @@ function doctorNextCommand(byName, context) {
   const auth = byName.get("auth");
   if (auth?.status === "fail") {
     return {
-      command: `gittensory-mcp login --profile ${context.profileName}`,
+      command: `gittensory-mcp login --profile ${shellArg(context.profileName ?? "default")}`,
       reason: "Authenticate the active profile so doctor, plan, preflight, and packet commands can call the API.",
     };
   }
@@ -1920,9 +1920,15 @@ function doctorNextCommand(byName, context) {
     };
   }
   return {
-    command: `gittensory-mcp preflight --login ${context.login ?? "<github-login>"} --repo ${context.repoFullName ?? "owner/repo"} --json`,
+    command: `gittensory-mcp preflight --login ${shellArg(context.login ?? "<github-login>")} --repo ${shellArg(context.repoFullName ?? "owner/repo")} --json`,
     reason: "Run branch preflight next; source upload remains disabled.",
   };
+}
+
+function shellArg(value) {
+  const text = String(value ?? "");
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, `'"'"'`)}'`;
 }
 
 function initClient(options) {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -93,6 +93,27 @@ describe("gittensory-mcp CLI", () => {
     expect(localScorer?.detail).not.toMatch(join(process.cwd(), "test/fixtures"));
   });
 
+  it("shell-quotes doctor next command values derived from local repo metadata", async () => {
+    tempDir = createPacketRepo();
+    git(tempDir, "remote", "set-url", "origin", "git@github.com:owner/repo$(touch /tmp/av_pwned).git");
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_CONFIG_DIR: tempDir,
+      GITTENSOR_SCORE_PREVIEW_CMD: `node ${join(process.cwd(), "test/fixtures/local-scorer/scorer-success.mjs")}`,
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+
+    const payload = JSON.parse(await runAsync(["doctor", "--cwd", tempDir, "--json"], env)) as { nextCommand: { command: string } };
+    expect(payload.nextCommand.command).toBe("gittensory-mcp preflight --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
+    expect(payload.nextCommand.command).not.toContain("--repo owner/repo$(");
+
+    const humanOutput = await runAsync(["doctor", "--cwd", tempDir], env);
+    expect(humanOutput).toContain("gittensory-mcp preflight --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
+    expect(humanOutput).not.toContain("--repo owner/repo$(");
+  });
+
   it("uses doctor as a first-run auth checklist when no local session is configured", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
     const url = await startFixtureServer();


### PR DESCRIPTION
### Motivation
- The doctor checklist emitted copy-pastable shell commands using untrusted `login` and `repoFullName` values which could contain shell metacharacters and enable command-substitution when pasted into a shell.

### Description
- Add a `shellArg` helper and use it in `doctorNextCommand` to quote dynamic values in generated commands (profile, `--login`, and `--repo`) in `packages/gittensory-mcp/bin/gittensory-mcp.js` to prevent shell injection.
- Update the login and preflight recommendation strings to call `shellArg` so safe plain tokens remain unquoted while unsafe values are single-quoted with internal single-quotes escaped.
- Add a regression test `shell-quotes doctor next command values derived from local repo metadata` to `test/unit/mcp-cli.test.ts` that sets a crafted remote containing command-substitution and asserts both JSON and human doctor output include the quoted repo argument.

### Testing
- Ran `npm test -- test/unit/mcp-cli.test.ts` and all tests passed (`Tests 44 passed`).
- Ran `npm run build:mcp` which completed successfully (type-check step passed). 
- Verified `git diff --check`/lint-style check showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236d295c2c832c821cab7aad20ef18)