### PR TITLE
fix(mcp): report source upload env in config

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -125,7 +125,7 @@ gittensory-mcp logout --profile work
 
 Use `--profile <name>` on `login`, `logout`, `whoami`, `config`, `status`, and `doctor`, or set `GITTENSORY_PROFILE`. `logout` only clears the selected local profile unless `--all` is passed. Profile output redacts session tokens and local config paths.
 
-`gittensory-mcp config` prints the resolved effective configuration and the source that supplied each value (`environment`, `profile`, `config`, or `default`): the active API URL and its source, active profile and profile count, whether a config file is present and which environment variable steers its location, the cache-dir source, and whether a token is configured and where it came from. It never prints token values or local absolute paths. Add `--json` for machine-readable output.
+`gittensory-mcp config` prints the resolved effective configuration and the source that supplied each value (`environment`, `profile`, `config`, or `default`): the active API URL and its source, active profile and profile count, whether a config file is present and which environment variable steers its location, the cache-dir source, whether a token is configured and where it came from, and whether `GITTENSORY_UPLOAD_SOURCE` has enabled the unsupported source-upload setting. It never prints token values or local absolute paths. Add `--json` for machine-readable output.
 
 ## Base-Agent Mode
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -2018,6 +2018,16 @@ function resolvedTokenSource() {
   return "none";
 }
 
+function sourceUploadState() {
+  const enabled = /^(1|true|yes)$/i.test(process.env.GITTENSORY_UPLOAD_SOURCE ?? "false");
+  return {
+    default: false,
+    enabled,
+    source: enabled ? "GITTENSORY_UPLOAD_SOURCE" : "default",
+    supported: false,
+  };
+}
+
 // Report the resolved effective configuration and where each value came from, without leaking
 // local absolute paths or token values. Distinct from `status` (health/version), `doctor`
 // (diagnostic checks), and `whoami` (session identity): this answers "what config is in effect
@@ -2033,7 +2043,7 @@ function configCommand(options) {
     cacheDirSource: process.env.GITTENSORY_CACHE_DIR ? "GITTENSORY_CACHE_DIR" : "default",
     tokenConfigured: Boolean(getApiToken()),
     tokenSource: resolvedTokenSource(),
-    sourceUpload: { default: false, supported: false },
+    sourceUpload: sourceUploadState(),
     profile: profilePublicState(activeProfileName),
   };
   if (options.json) {
@@ -2045,7 +2055,11 @@ function configCommand(options) {
   process.stdout.write(`Config file: ${payload.configured ? "present" : "absent"} (location: ${payload.configPathSource})\n`);
   process.stdout.write(`Cache dir: ${payload.cacheDirSource}\n`);
   process.stdout.write(`Token: ${payload.tokenConfigured ? `configured (${payload.tokenSource})` : "not configured"}\n`);
-  process.stdout.write("Source upload: disabled (unsupported)\n");
+  process.stdout.write(
+    payload.sourceUpload.enabled
+      ? `Source upload: enabled via ${payload.sourceUpload.source} (unsupported; unset GITTENSORY_UPLOAD_SOURCE)\n`
+      : "Source upload: disabled (unsupported)\n",
+  );
 }
 
 function normalizeProfileName(value) {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -1076,7 +1076,7 @@ describe("gittensory-mcp CLI", () => {
       cacheDirSource: string;
       tokenConfigured: boolean;
       tokenSource: string;
-      sourceUpload: { default: boolean; supported: boolean };
+      sourceUpload: { default: boolean; enabled: boolean; source: string; supported: boolean };
     };
     // The run() harness sets GITTENSORY_CONFIG_DIR but no API URL or token.
     expect(payload.apiUrl).toBe("https://gittensory-api.aethereal.dev");
@@ -1088,7 +1088,7 @@ describe("gittensory-mcp CLI", () => {
     expect(payload.cacheDirSource).toBe("default");
     expect(payload.tokenConfigured).toBe(false);
     expect(payload.tokenSource).toBe("none");
-    expect(payload.sourceUpload).toEqual({ default: false, supported: false });
+    expect(payload.sourceUpload).toEqual({ default: false, enabled: false, source: "default", supported: false });
   });
 
   it("attributes config values to environment overrides without leaking secrets", () => {
@@ -1110,6 +1110,16 @@ describe("gittensory-mcp CLI", () => {
     } finally {
       rmSync(secretDir, { recursive: true, force: true });
     }
+  });
+
+  it("reports enabled unsupported source upload environment settings via config", () => {
+    const payload = JSON.parse(run(["config", "--json"], { GITTENSORY_UPLOAD_SOURCE: "true" })) as {
+      sourceUpload: { default: boolean; enabled: boolean; source: string; supported: boolean };
+    };
+    expect(payload.sourceUpload).toEqual({ default: false, enabled: true, source: "GITTENSORY_UPLOAD_SOURCE", supported: false });
+
+    const out = run(["config"], { GITTENSORY_UPLOAD_SOURCE: "true" });
+    expect(out).toContain("Source upload: enabled via GITTENSORY_UPLOAD_SOURCE (unsupported; unset GITTENSORY_UPLOAD_SOURCE)");
   });
 
   it("attributes API URL and token to a named profile from the config file", () => {


### PR DESCRIPTION
### Motivation

- The `config` command always reported source upload as disabled, which contradicted other checks that treat `GITTENSORY_UPLOAD_SOURCE` as an enabled-but-unsupported setting and caused confusing diagnostics. 
- The misreporting could mislead users auditing local privacy configuration even though the code still fails closed for actual uploads.

### Description

- Add `sourceUploadState()` to derive the source-upload posture from `GITTENSORY_UPLOAD_SOURCE` and return `{ default, enabled, source, supported }` instead of a hardcoded disabled object.  
- Use `sourceUploadState()` in `configCommand` payload so JSON output reflects the env var and its source.  
- Update human-readable `config` output to print a warning-style message when the env var enables the unsupported behavior while preserving the disabled message when unset.  
- Update `test/unit/mcp-cli.test.ts` to expect the expanded `sourceUpload` shape and add a unit test that verifies enabled-but-unsupported reporting, and update the package README to document that `config` reports `GITTENSORY_UPLOAD_SOURCE` posture.

### Testing

- Ran the updated unit test file with `npm test -- test/unit/mcp-cli.test.ts`, and all tests in that file passed (`48 passed`).  
- Ran type checking with `npm run typecheck`, which succeeded.  
- Verified formatting/lint checks with `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ef9ca6c8832c805ccd0a2ffe4cc4)