### PR TITLE
fix(registration): align dogfood pack lane strategy with config recommendation

### DIFF
--- a/src/services/self-dogfood-registration-pack.ts
+++ b/src/services/self-dogfood-registration-pack.ts
@@ -44,9 +44,11 @@ export function buildSelfDogfoodRegistrationPack(args: {
   gittensorConfigRecommendation: GittensorConfigRecommendation;
 }): SelfDogfoodRegistrationPack {
   const { registrationReadiness: readiness, gittensorConfigRecommendation: recommendation } = args;
-  const issueDiscoveryReady =
-    readiness.issueDiscoveryReadiness.ready && readiness.issueDiscoveryReadiness.recommendation === "enabled";
-  const directPrFirst = !issueDiscoveryReady && readiness.recommendedRegistrationMode !== "issue_discovery";
+  // Keep the lane strategy consistent with the config recommendation shown in the same pack: direct-PR-first
+  // exactly when the recommendation advises direct_pr (issue-discovery share 0). Deriving this from the
+  // readiness report's current-lane mode instead contradicts the recommendation when a repo is currently
+  // registered for issue-discovery/split but the recommendation advises reverting to direct-PR.
+  const directPrFirst = recommendation.recommended.participationMode === "direct_pr";
 
   return {
     kind: "gittensory_self_dogfood_registration_pack",

--- a/test/unit/self-dogfood-registration-pack.test.ts
+++ b/test/unit/self-dogfood-registration-pack.test.ts
@@ -224,22 +224,49 @@ describe("resolveSelfDogfoodRepoFullName", () => {
 });
 
 describe("buildSelfDogfoodRegistrationPack", () => {
-  it("ready fixture recommends direct-PR-first with actionable areas", () => {
+  it("excellent fixture recommends a bounded issue-discovery lane, matching the config recommendation", () => {
     const repo = repoFor("octo/ready", configFor({ repo: "octo/ready" }));
     const issues: IssueRecord[] = [{ repoFullName: repo.fullName, number: 4, title: "Fix flaky cache test", state: "open", labels: ["bug"], linkedPrs: [] }];
     const pack = packFromRepo(repo, issues);
 
+    // Config/intake are excellent, so the recommendation is "split" (a bounded issue-discovery lane).
+    // directPrFirst must follow that recommendation, not the repo's current direct-PR lane.
+    expect(pack.gittensorConfigRecommendation.recommended.participationMode).toBe("split");
     expect(pack).toMatchObject({
       kind: "gittensory_self_dogfood_registration_pack",
       privateOnly: true,
       advisoryOnly: true,
-      directPrFirst: true,
+      directPrFirst: false,
       registrationReadiness: { ready: true, recommendedRegistrationMode: "direct_pr" },
     });
-    expect(pack.actionableAreas.some((area) => area.area === "direct_pr" && area.status === "ready")).toBe(true);
+    expect(pack.contributorLaneStrategy).toMatch(/bounded issue-discovery lane/i);
     expect(pack.maintainerEconomicsNote).toMatch(/maintainer-economics/i);
     expect(pack.minerScoreabilityNote).toMatch(/scoreability/i);
     expect(pack.rerunHint).toMatch(/Rerun this pack/i);
+  });
+
+  it("keeps direct-PR-first when the recommendation is direct_pr even if the repo is currently issue-discovery", () => {
+    // Repo is currently registered for issue discovery (recommendedRegistrationMode), but degraded config/
+    // intake make the recommendation revert to direct_pr. The lane strategy must match the recommendation.
+    const pack = buildSelfDogfoodRegistrationPack({
+      repoFullName: "octo/reverting",
+      registrationReadiness: readinessFixture({ recommendedRegistrationMode: "issue_discovery" }),
+      gittensorConfigRecommendation: recommendationFixture({
+        recommended: {
+          participationMode: "direct_pr",
+          issueDiscoveryShare: 0,
+          directPrShare: 1,
+          maintainerCut: 0,
+          requireLinkedIssue: false,
+          labelMultipliers: "start_without_trusted_label_multipliers",
+          publicSurface: "comment_and_label",
+          confirmedMinerLabel: "gittensor",
+        },
+      }),
+    });
+
+    expect(pack.directPrFirst).toBe(true);
+    expect(pack.contributorLaneStrategy).toMatch(/direct-PR-first/i);
   });
 
   it("not-ready fixture surfaces registration blockers", () => {


### PR DESCRIPTION
## Summary
`buildSelfDogfoodRegistrationPack` (`src/services/self-dogfood-registration-pack.ts`) derived `directPrFirst` from the registration **readiness** report's current-lane mode, but the same pack also returns the config **recommendation**. The two diverge, so the pack's `contributorLaneStrategy` text and `directPrFirst` flag could contradict the `gittensorConfigRecommendation` shown beside them. Closes #442.

```ts
// before
const issueDiscoveryReady = readiness.issueDiscoveryReadiness.ready && readiness.issueDiscoveryReadiness.recommendation === "enabled";
const directPrFirst = !issueDiscoveryReady && readiness.recommendedRegistrationMode !== "issue_discovery";
```

`readiness.recommendedRegistrationMode` reflects the repo's **current** lane (`laneToMode(lane)`), while the recommendation reflects the **advised** config (`participationMode` is `direct_pr` unless intake + config are excellent). So a repo currently registered for issue discovery but with degraded health gets `recommendedRegistrationMode: "issue_discovery"` -> `directPrFirst: false` -> "Issue-discovery intake is strong enough to keep a bounded issue-discovery lane", while the same pack recommends `participationMode: "direct_pr"`. The inverse also happens (an excellent direct-PR repo recommended `split` reported `directPrFirst: true`).

## Scope
- `src/services/self-dogfood-registration-pack.ts` -- derive `directPrFirst = recommendation.recommended.participationMode === "direct_pr"` so the lane strategy text and flag always match the recommendation in the same pack (removed the now-unused readiness-based computation).
- `test/unit/self-dogfood-registration-pack.test.ts`:
  - Corrected the excellent-config fixture test: its recommendation is `split`, so `directPrFirst` is now `false` (matching the recommendation) -- the old assertion `true` encoded the contradiction.
  - Added fail-on-revert: a currently-issue-discovery repo whose recommendation is `direct_pr` must report `directPrFirst: true` and direct-PR-first text (old code returned `false`).

## Validation
- `npx tsc --noEmit` -- clean.
- `npx vitest run` for the dogfood pack + route suites -- 16/16.
- Full suite -- 1208 passed, 1 skipped (excluding the two unparseable upstream test files and one unrelated `mcp-cli` timeout that passes in isolation).
- Branch coverage 97.02% (above the 97% gate).

## Safety
- No response-shape change; only the (now consistent) `directPrFirst` flag and `contributorLaneStrategy` text change, and only when the readiness current-lane mode diverged from the recommendation.
- The recommendation already drives the pack's config tradeoffs, so the lane strategy now agrees with the rest of the pack rather than contradicting it.