### PR TITLE
fix(gittensor): drop empty-name repos from contributor snapshot

### DIFF
--- a/src/gittensor/api.ts
+++ b/src/gittensor/api.ts
@@ -243,7 +243,7 @@ async function buildGittensorContributorSnapshot(miner: ConfirmedGittensorMinerS
       solvedIssues: asNumber(source.totalSolvedIssues),
       validSolvedIssues: asNumber(source.totalValidSolvedIssues),
     },
-    repositories: (detail.repositories ?? []).map(toRepositoryEvaluation).filter((repo) => repo.pullRequests + repo.openIssues + repo.closedIssues > 0),
+    repositories: (detail.repositories ?? []).map(toRepositoryEvaluation).filter((repo) => repo.repoFullName && repo.pullRequests + repo.openIssues + repo.closedIssues > 0),
     pullRequests: pullRequests.map(toPullRequest).filter((pr) => pr.repoFullName && pr.number > 0),
     issueMirrorAvailable: issuesResult.status === "fulfilled",
     issues: issues.map(toIssue).filter((issue) => issue.repoFullName && issue.number > 0),

--- a/test/unit/gittensor-api.test.ts
+++ b/test/unit/gittensor-api.test.ts
@@ -177,11 +177,11 @@ describe("Gittensor API contributor snapshots", () => {
       issues: [],
       issueLabels: ["bug"],
       pullRequests: [expect.objectContaining({ repoFullName: "owner/repo", number: 7, title: "Fix it", score: 0, baseScore: 1 })],
-      repositories: [
-        expect.objectContaining({ repoFullName: "", pullRequests: 0, openIssues: 1, closedIssues: 0 }),
-        expect.objectContaining({ repoFullName: "owner/repo", pullRequests: 3, mergedPullRequests: 2, totalScore: 0 }),
-      ],
+      repositories: [expect.objectContaining({ repoFullName: "owner/repo", pullRequests: 3, mergedPullRequests: 2, totalScore: 0 })],
     });
+    // The malformed-name repo (empty repoFullName) must be dropped, like the PR/issue lists, so it cannot
+    // leak into reposTouched / evidenceScore.
+    expect(snapshot?.repositories.map((repo) => repo.repoFullName)).toEqual(["owner/repo"]);
   });
 
   it("returns null when the miner list has no matching GitHub identity", async () => {


### PR DESCRIPTION
## Summary
`buildGittensorContributorSnapshot` (`src/gittensor/api.ts:246`) filtered the snapshot's repositories list by activity only, not by a valid `repoFullName` -- unlike the pull-request and issue lists right beside it, which both require a non-empty `repoFullName`:

```ts
repositories: (...).map(toRepositoryEvaluation).filter((repo) => repo.pullRequests + repo.openIssues + repo.closedIssues > 0), // no name guard
pullRequests: (...).filter((pr) => pr.repoFullName && pr.number > 0),    // guarded
issues: (...).filter((issue) => issue.repoFullName && issue.number > 0), // guarded
```

#437 made `repositoryFullName` an untrusted `unknown` and coerces malformed/missing values to `""` (`asString`), but did not add the empty-name filter to the repositories list. So a malformed repo evaluation with nonzero stats leaks in as `{ repoFullName: "", ... }`. Closes #444.

## Observable impact
`snapshot.repositories` feeds `buildGittensorContributorProfile` (`src/signals/engine.ts`):
- `reposTouched` (engine.ts:1119) keeps the empty-name repo (nonzero stats), so it leaks into `registeredRepoActivity.reposTouched` as `""`.
- `evidenceScore = clamp(... + reposTouched.length * 10 + ..., 0, 100)` (engine.ts:1137): one phantom repo adds +10 on a 0-100 scale, which can bump `trustSignals.level` a tier (`new` < 25, `emerging` 25-59, `established` >= 60).

Reachable because #437 itself treats upstream Gittensor repository names as untrusted JSON that can be malformed.

## Scope
- `src/gittensor/api.ts` -- add `repo.repoFullName &&` to the repositories filter, matching the PR/issue lists and #437's intent.
- `test/unit/gittensor-api.test.ts` -- the #437 malformed-payload test asserted the empty-name repo was included; updated to assert it is dropped (repositories is `["owner/repo"]` only) with an explicit no-leak check.

## Validation
- `npx tsc --noEmit` -- clean.
- `npx vitest run test/unit/gittensor-api.test.ts` -- 8/8.
- Full suite -- 1207 passed, 1 skipped (excluding the two unparseable upstream test files and one unrelated `mcp-cli` timeout that passes in isolation).
- Branch coverage at/above the 97% gate; gittensor/api.ts 100% line.

## Safety
- Behavior is unchanged for well-formed snapshots (valid repo names pass the added guard exactly as before). Only malformed/empty-name entries are now dropped, consistent with the PR/issue lists.
- No response-shape change; the snapshot simply no longer contains phantom `""`-named repositories.