### PR TITLE
fix(app): redact tokens in miner dashboard change text

### DIFF
--- a/src/services/miner-dashboard-recommendations.ts
+++ b/src/services/miner-dashboard-recommendations.ts
@@ -43,6 +43,7 @@ const REASON_LIMIT = 3;
 const FORBIDDEN_PUBLIC_TEXT =
   /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|private keys?|raw[-_\s]?trust(?: scores?)?|trust[-_\s]?scores?|reward(?:[-_\s]?(?:estimate|prediction|claim|score))?s?|payouts?|farming(?:[-_\s]?language)?|private[-_\s]?reviewability|private[-_\s]?scoreability|scoreability|public[-_\s]?score[-_\s]?(?:estimate|prediction)|estimated[-_\s]?score|score[-_\s]?estimate)\b/gi;
 const LOCAL_PATH = /(?:\/(?:Users|home|root|tmp|var)\/[^\s,;:)]+|[A-Za-z]:\\Users\\[^\s,;:)]+)/g;
+const FORBIDDEN_TOKEN = /\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
 
 export function previousDecisionPackFromSnapshots(currentPack: ContributorDecisionPack, snapshots: SignalSnapshotRecord[]): ContributorDecisionPack | undefined {
   const current = asRecord(currentPack);
@@ -383,6 +384,7 @@ function numberValue(record: DashboardRecord | undefined, key: string): number |
 function sanitizePublicText(value: string): string {
   return value
     .replace(LOCAL_PATH, "[local path]")
+    .replace(FORBIDDEN_TOKEN, "private context")
     .replace(FORBIDDEN_PUBLIC_TEXT, "private context")
     .replace(/\s+/g, " ")
     .trim();

--- a/test/unit/miner-dashboard-recommendations.test.ts
+++ b/test/unit/miner-dashboard-recommendations.test.ts
@@ -54,7 +54,7 @@ describe("miner dashboard recommendation metadata", () => {
           {
             repoFullName: "JSONbored/gittensory",
             actionKind: "open_new_direct_pr",
-            rerunWhen: "Rerun when queue changes, not wallet hotkey scoreability reward estimate.",
+            rerunWhen: "Rerun when queue changes, not wallet hotkey scoreability reward estimate ghp_abcd1234EFGH5678ijkl.",
           },
         ],
       },


### PR DESCRIPTION
Closes #448.

`sanitizePublicText` (the public-safety boundary for miner-dashboard change labels and rerun reasons) stripped local paths and sensitive words but had **no rule for secret tokens** (`ghp_`/`github_pat_`/`gts_`/`glpat-`/`sk-`), unlike the sibling sanitizers in `agent-action-explanation-card.ts`, `weekly-value-report.ts`, and `control-panel-roles.ts`. Its own test already declared those tokens forbidden, but the assertion only passed because no fixture injected one.

## Changes
- Add a `FORBIDDEN_TOKEN` redaction step to `sanitizePublicText`, matching the established pattern.
- Add a `ghp_…` token to the `rerunWhen` fixture so the existing public-safety assertion actually exercises token redaction.

## Verification
- `npx vitest run test/unit/miner-dashboard-recommendations.test.ts` → 10/10 pass.