### PR TITLE
fix(app): summarize all changed groups despite label cap

### DIFF
--- a/src/services/miner-dashboard-recommendations.ts
+++ b/src/services/miner-dashboard-recommendations.ts
@@ -166,11 +166,11 @@ function buildRecommendationChange(args: {
   addChanged(labels, "policy_context", "Repo policy changed", manifestSummary(args.previousDecision), manifestSummary(args.currentDecision));
 
   const limited = labels.slice(0, CHANGE_LABEL_LIMIT);
-  if (limited.length === 0) {
+  if (labels.length === 0) {
     return { status: "unchanged", summary: "No tracked evidence changed since the previous run.", labels: [] };
   }
 
-  const changedGroups = [...new Set(limited.map((label) => GROUP_TITLES[label.kind]))].join(", ");
+  const changedGroups = [...new Set(labels.map((label) => GROUP_TITLES[label.kind]))].join(", ");
   return {
     status: "changed",
     summary: `Changed since the previous run: ${changedGroups}.`,

--- a/test/unit/miner-dashboard-recommendations.test.ts
+++ b/test/unit/miner-dashboard-recommendations.test.ts
@@ -83,6 +83,49 @@ describe("miner dashboard recommendation metadata", () => {
     expect(JSON.stringify({ change: enriched?.change, rerunReasons: enriched?.rerunReasons })).not.toMatch(FORBIDDEN_PUBLIC_CHANGE_TEXT);
   });
 
+  it("keeps every changed group in the summary even when displayed labels are truncated", () => {
+    const previous = decisionPack({
+      generatedAt: "2026-06-01T00:00:00.000Z",
+      repoDecisions: [
+        repoDecision({
+          recommendation: "watch",
+          priorityScore: 35,
+          queue: { openPullRequests: 0, openIssues: 1, mergedPullRequests: 0, closedUnmergedPullRequests: 0 },
+          outcome: { openPullRequests: 0, mergedPullRequests: 1, closedPullRequests: 0 },
+          scoreBlockers: [],
+          manifestSummary: { linkedIssuePolicy: "optional", issueDiscoveryPolicy: "allowed", wantedPathCount: 1, blockedPathCount: 0 },
+        }),
+      ],
+      topActions: [action({ actionKind: "file_issue_discovery", lane: "issue-discovery", recommendation: "watch", priorityScore: 35 })],
+      dataQuality: { signalFidelity: { status: "complete" } },
+    });
+    const current = decisionPack({
+      generatedAt: "2026-06-02T00:00:00.000Z",
+      repoDecisions: [
+        repoDecision({
+          recommendation: "pursue",
+          priorityScore: 82,
+          queue: { openPullRequests: 3, openIssues: 4, mergedPullRequests: 1, closedUnmergedPullRequests: 0 },
+          outcome: { openPullRequests: 2, mergedPullRequests: 0, closedPullRequests: 1 },
+          scoreBlockers: [{ code: "open_pr_pressure" }],
+          manifestSummary: { linkedIssuePolicy: "required", issueDiscoveryPolicy: "restricted", wantedPathCount: 2, blockedPathCount: 1 },
+        }),
+      ],
+      topActions: [action({ actionKind: "open_new_direct_pr", lane: "direct-pr", recommendation: "pursue", priorityScore: 82 })],
+      dataQuality: { signalFidelity: { status: "degraded" } },
+    });
+
+    const [enriched] = buildMinerDashboardNextActions(current, previous);
+
+    // Displayed labels stay capped at CHANGE_LABEL_LIMIT, and validation/policy fall outside the cap.
+    expect(enriched?.change.labels).toHaveLength(6);
+    expect(enriched?.change.labels.map((label) => label.kind)).not.toContain("validation_state");
+    // The summary must still reflect every changed group, not just the displayed slice.
+    expect(enriched?.change.summary).toBe(
+      "Changed since the previous run: Repo state, Contributor state, Validation state, Policy/context state.",
+    );
+  });
+
   it("marks unchanged recommendations when tracked evidence is stable", () => {
     const previous = decisionPack({ generatedAt: "2026-06-01T00:00:00.000Z" });
     const current = decisionPack({ generatedAt: "2026-06-02T00:00:00.000Z" });


### PR DESCRIPTION
Closes #450.

`buildRecommendationChange` caps change-evidence labels at `CHANGE_LABEL_LIMIT = 6` but built the human-readable `summary` from the **already-truncated** slice. Labels are appended in a fixed group order (`repo_state` ×5 → `contributor_state` ×2 → `validation_state` ×1 → `policy_context` ×2), so whenever ≥6 repo/contributor fields change, the validation/policy groups were dropped from the summary too — affirmatively hiding that validation blockers or repo policy changed.

## Changes
- Derive `changedGroups` from the full `labels` set (display cap still applies to the returned `labels: limited`); empty-check uses `labels.length`.
- Add a fixture with 9 changes across all four groups: asserts displayed labels stay capped at 6 (validation truncated) while the summary still names all four groups.

## Verification
- `npx vitest run test/unit/miner-dashboard-recommendations.test.ts` → 11/11 pass.