### PR TITLE
fix(ui): don't redact valid repo/login names in miner commands

### DIFF
--- a/apps/gittensory-ui/src/lib/miner-commands.ts
+++ b/apps/gittensory-ui/src/lib/miner-commands.ts
@@ -92,7 +92,10 @@ function sanitizeMinerCommand(command: string): string {
       (_, prefix) => `${prefix}<local-path>`,
     )
     .replace(
-      /\b(?:wallet|hotkey|coldkey|mnemonic|raw[-_\s]?trust|private[-_\s]?reviewability|trust[-_\s]?score)\b(?:\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s"'`,;)]+))?/gi,
+      // Only redact actual `term=value` / `term: value` secret leakage. The assignment is required so
+      // that legitimate login/repo names containing these words (e.g. a repo named "wallet-adapter" or
+      // login "trust-score" -- already validated upstream) are not corrupted into broken commands.
+      /\b(?:wallet|hotkey|coldkey|mnemonic|raw[-_\s]?trust|private[-_\s]?reviewability|trust[-_\s]?score)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s"'`,;)]+)/gi,
       "[redacted]",
     );
 }

--- a/test/unit/miner-dashboard-commands.test.ts
+++ b/test/unit/miner-dashboard-commands.test.ts
@@ -88,4 +88,24 @@ describe("miner dashboard command actions", () => {
       /\/Users|\/home|wallet|hotkey|raw trust|private reviewability/i,
     );
   });
+
+  it("keeps legitimate repo/login names that contain sensitive words", () => {
+    const commands = buildMinerCommandActions({
+      login: "trust-score",
+      repoFullName: "metamask/wallet-adapter",
+    });
+
+    const preflight = commands.find((command) => command.id === "preflight");
+    expect(preflight).toMatchObject({
+      command:
+        "gittensory-mcp preflight --login trust-score --repo metamask/wallet-adapter --base origin/main --json",
+      copyable: true,
+      state: "ready",
+    });
+    // The real names survive; nothing is redacted out of a runnable command.
+    expect(preflight?.command).not.toContain("[redacted]");
+
+    const plan = commands.find((command) => command.id === "plan");
+    expect(plan).toMatchObject({ command: "gittensory-mcp agent plan --login trust-score --json", copyable: true });
+  });
 });


### PR DESCRIPTION
Closes #456.
<img width="2320" height="334" alt="pr457-miner-command-real-section-wide" src="https://github.com/user-attachments/assets/73be1104-8e9d-490c-9473-f207b3327e58" />

`sanitizeMinerCommand`'s private-term redaction had an **optional** value-assignment group, so it matched *bare standalone words* (`wallet`, `hotkey`, `coldkey`, `mnemonic`, `trust-score`, …). Since `login`/`repoFullName` are already validated by `safeGitHubLogin`/`safeRepoFullName`, a legitimate name containing one of those words got corrupted while the command stayed marked `copyable: true, state: "ready"` — so the user copies a broken command with `[redacted]` in place of their real repo/login. Common in a Bittensor/crypto ecosystem (e.g. `metamask/wallet-adapter`).

## Changes
- Require the `term=value` / `term: value` form so only real secret leakage is redacted, not validated names.
- Add a test with login `trust-score` and repo `metamask/wallet-adapter` asserting the names survive and the command stays runnable.

## Verification
- Full unit suite green (1247 passed). The new test fails against the old code (old output redacted `wallet-adapter` → `[redacted]-adapter`).