### PR TITLE
docs(contributing): clarify setup and review evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## Scope
 
+- [ ] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
 - [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
 - [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
 - [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.
@@ -35,8 +36,17 @@ If any required check was skipped, explain why:
 - [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
 - [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
 - [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
-- [ ] Visible UI changes include screenshots or a short recording.
+- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
 - [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
+
+## UI Evidence
+
+Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.
+
+| State / title                         | JPG/PNG evidence                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------ |
+| Loaded state                          | `<a href="FULL_URL.png"><img src="FULL_URL.png" alt="Loaded state" width="240"></a>` |
+| Empty/error/mobile state, if relevant |                                                                                      |
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,14 @@ Do not open PRs for:
 
 Every PR should include:
 
+- A Conventional Commit-style title in the form `type(scope): short summary`.
 - A clear summary of what changed and why.
 - A linked issue or a short explanation for why no issue is needed.
 - The exact validation commands run from the repo root.
-- Screenshots or a short screen recording for visible UI changes.
+- JPG/JPEG or PNG screenshot evidence for visible UI, frontend, docs, or extension changes,
+  attached in the PR description as organized, captioned, clickable thumbnails. SVG screenshots
+  are not accepted as review evidence, and recordings are supplemental rather than a replacement
+  for screenshots. Do not commit review-only screenshots or recordings to the repository.
 - API/OpenAPI/MCP contract notes for schema or behavior changes.
 - Migration, deploy, secret, or Cloudflare configuration notes when relevant.
 - Security/privacy notes for auth, cookies, CORS, GitHub App output, user identity, or contributor
@@ -140,6 +144,18 @@ Frontend:
 - Signed-in app state comes from `GET /v1/auth/session`; do not restore app login through
   localStorage bearer tokens.
 - API Try It may still support manual bearer-token testing.
+- Visible UI changes need a `Screenshots` or `UI Evidence` section in the PR description. Use
+  GitHub-hosted JPG/JPEG or PNG screenshots only; SVG screenshots are not accepted as review
+  evidence. Recordings can be included as supplemental context, but screenshots are still expected
+  for visual review.
+- Arrange screenshots in a small table or grid with a short state/title such as "Loaded state",
+  "Empty state", "Error state", "Mobile layout", or "PR sidebar". Each screenshot should be a small
+  thumbnail that links to the full-size upload. Use HTML thumbnails like
+  `<a href="FULL_URL.jpg"><img src="FULL_URL.jpg" alt="Loaded state" width="240"></a>` instead of
+  large raw Markdown images.
+- Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing the
+  changed area. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**`
+  files unless they are real product assets.
 
 Cloudflare/deploy:
 
@@ -175,3 +191,9 @@ fix(ui): restore signed-out app empty state
 test(mcp): cover compatibility fallback
 docs(contributing): clarify review gates
 ```
+
+Use one of these types: `feat`, `fix`, `test`, `docs`, `refactor`, `build`, `ci`, `chore`, or
+`revert`. Keep the scope lowercase and specific, such as `api`, `ui`, `mcp`, `extension`, `auth`,
+`github`, `signals`, `data`, `docs`, or `release`. Avoid vague scopes or summaries such as
+`misc`, `general`, `updates`, `update stuff`, or `small tweaks`. Do not end PR titles with a
+trailing period. Release PR titles must use `chore(release): <version>`.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,42 @@
 
 Gittensory is a deterministic control plane for Gittensor OSS contribution work.
 
-It gives contributors and maintainers structured signals before work turns into noisy PRs: official Gittensor context, repo queue health, collision risk, branch preflight, scoreability, maintainer packet context, and public-safe PR guidance.
+It helps contributors plan cleaner work, helps maintainers review with less public noise, and keeps private scoring, wallet, hotkey, and reviewability context out of public GitHub output.
 
-It is not a Gittensor explorer, public leaderboard, reward-farming bot, or autonomous PR agent.
+It is not a Gittensor explorer, public leaderboard, reward-farming bot, wallet dashboard, or autonomous PR agent.
 
-## Product Map
+## Privacy Boundary
 
-| Surface | What it is | Start here |
-| --- | --- | --- |
-| MCP package | Local stdio tools for Codex, Claude Desktop, Cursor, and other MCP clients. | [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients) |
-| Web app | Operator UI, docs, API browser, roadmap, and workflow views. | [gittensory.aethereal.dev](https://gittensory.aethereal.dev/) |
-| Worker API | Protected Cloudflare Worker API with OpenAPI metadata. | [OpenAPI JSON](https://gittensory-api.aethereal.dev/openapi.json) |
-| GitHub App | Quiet maintainer automation for installed repos. | [Install](https://github.com/apps/gittensory/installations/new) and [setup docs](https://gittensory.aethereal.dev/docs/github-app) |
+Gittensory keeps sensitive context private by default.
 
-## Install MCP
+- MCP local branch analysis sends metadata, not source contents.
+- Public GitHub comments never include wallet, hotkey, reward estimate, private ranking, raw trust score, or reviewability context.
+- Optional AI summaries receive compact deterministic signal bundles, not raw source code.
+- Maintainer packets and scoring context stay on protected API/MCP surfaces.
+
+See [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security) for the full boundary.
+
+## Start Here
+
+| Audience                  | Start                                                                    | Useful next links                                                                                                                                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Miners and contributors   | [Quickstart](https://gittensory.aethereal.dev/docs/quickstart)           | [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients), [Miner workflow](https://gittensory.aethereal.dev/docs/miner-workflow), [Scoreability](https://gittensory.aethereal.dev/docs/scoreability) |
+| Maintainers               | [GitHub App](https://gittensory.aethereal.dev/docs/github-app)           | [Maintainer workflow](https://gittensory.aethereal.dev/docs/maintainer-workflow), [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security)                                                  |
+| Repo owners and operators | [Beta onboarding](https://gittensory.aethereal.dev/docs/beta-onboarding) | [Upstream drift](https://gittensory.aethereal.dev/docs/upstream-drift), [Troubleshooting](https://gittensory.aethereal.dev/docs/troubleshooting), [Roadmap](https://gittensory.aethereal.dev/roadmap)             |
+| Agent authors             | [Agents](https://gittensory.aethereal.dev/agents)                        | [API browser](https://gittensory.aethereal.dev/api), [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients)                                                                                        |
+
+## Surfaces
+
+| Surface           | Link                                                                                                                               |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Website           | [gittensory.aethereal.dev](https://gittensory.aethereal.dev/)                                                                      |
+| Docs              | [gittensory.aethereal.dev/docs](https://gittensory.aethereal.dev/docs)                                                             |
+| MCP package       | [@jsonbored/gittensory-mcp](https://www.npmjs.com/package/@jsonbored/gittensory-mcp)                                               |
+| API               | [API browser](https://gittensory.aethereal.dev/api) and [OpenAPI JSON](https://gittensory-api.aethereal.dev/openapi.json)          |
+| GitHub App        | [Install](https://github.com/apps/gittensory/installations/new) and [setup docs](https://gittensory.aethereal.dev/docs/github-app) |
+| Browser extension | [Extension page](https://gittensory.aethereal.dev/extension)                                                                       |
+
+## MCP Install
 
 ```sh
 npm install -g @jsonbored/gittensory-mcp@latest
@@ -39,6 +61,8 @@ gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
 ```
 
+For full editor setup and stdio configuration, use [MCP client setup](https://gittensory.aethereal.dev/docs/mcp-clients).
+
 Run base-agent commands:
 
 ```sh
@@ -46,26 +70,6 @@ gittensory-mcp agent plan --login jsonbored --json
 gittensory-mcp agent packet --login jsonbored --json
 gittensory-mcp agent status <run-id> --json
 ```
-
-## What It Helps With
-
-| For contributors | For maintainers |
-| --- | --- |
-| Pick cleaner repos and issues before opening work. | See private reviewability and queue context without public noise. |
-| Preflight local branches without uploading source contents. | Keep GitHub App output public-safe and low-volume. |
-| Understand score blockers, collision risk, and PR cleanup order. | Detect lane, label, config, sync, and maintainer-friction problems. |
-| Draft better public PR packets from deterministic signals. | Separate useful Gittensor work from review-load churn. |
-
-## Privacy Boundary
-
-Gittensory keeps sensitive context private by default.
-
-- MCP local branch analysis sends metadata, not source contents.
-- Public GitHub comments never include wallet, hotkey, reward estimate, private ranking, raw trust score, or reviewability context.
-- Optional AI summaries receive compact deterministic signal bundles, not raw source code.
-- Maintainer packets and scoring context are protected API/MCP surfaces.
-
-See [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security) for the full boundary.
 
 ## Local Development
 
@@ -75,15 +79,6 @@ npm run cf-typegen
 npm run db:migrate:local
 npm run dev
 ```
-
-Frontend:
-
-```sh
-npm run ui:dev
-npm run ui:build
-```
-
-Normal validation:
 
 ```sh
 npm run test:ci
@@ -96,19 +91,20 @@ npm run test:release
 npm run test:release:mcp
 ```
 
-## Links
+Frontend:
 
-| Need | Link |
-| --- | --- |
-| Docs | [gittensory.aethereal.dev/docs](https://gittensory.aethereal.dev/docs) |
-| Quickstart | [docs/quickstart](https://gittensory.aethereal.dev/docs/quickstart) |
-| Branch analysis | [docs/branch-analysis](https://gittensory.aethereal.dev/docs/branch-analysis) |
-| Scoreability | [docs/scoreability](https://gittensory.aethereal.dev/docs/scoreability) |
-| Troubleshooting | [docs/troubleshooting](https://gittensory.aethereal.dev/docs/troubleshooting) |
-| API | [openapi.json](https://gittensory-api.aethereal.dev/openapi.json) |
-| npm | [@jsonbored/gittensory-mcp](https://www.npmjs.com/package/@jsonbored/gittensory-mcp) |
+```sh
+npm run ui:dev
+npm run ui:build
+```
+
+## Project Links
+
+| Need         | Link                               |
+| ------------ | ---------------------------------- |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Security | [SECURITY.md](SECURITY.md) |
-| Support | [SUPPORT.md](SUPPORT.md) |
+| Security     | [SECURITY.md](SECURITY.md)         |
+| Support      | [SUPPORT.md](SUPPORT.md)           |
+| Changelog    | [CHANGELOG.md](CHANGELOG.md)       |
 
 Normal feature/fix PRs do not edit changelogs. Changelogs are release-prep artifacts.


### PR DESCRIPTION
## Summary
- reorganize the top-level README around audience-specific setup paths and current product surfaces
- keep the privacy boundary and MCP command examples visible from the repo landing page
- clarify PR title, validation, and visual evidence expectations in CONTRIBUTING.md and the PR template

## Why
- the restored local docs edits were useful review-policy hardening, but needed cleanup before they were safe to submit
- maintainers should have one obvious GitHub App/docs path, and contributors should get clearer evidence requirements before review starts

## Validation
- `git diff --check HEAD~1..HEAD`
- `npx prettier --check README.md CONTRIBUTING.md .github/pull_request_template.md`

## Notes
- docs-only change; no runtime behavior or generated API artifacts changed
