### PR TITLE
fix(ui): proxy github stats through api

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -11899,6 +11899,46 @@
           "maintainerNextSteps",
           "privateSummary"
         ]
+      },
+      "PublicRepoStats": {
+        "type": "object",
+        "properties": {
+          "repoFullName": {
+            "type": "string"
+          },
+          "htmlUrl": {
+            "type": "string"
+          },
+          "stargazers_count": {
+            "type": "number"
+          },
+          "forks_count": {
+            "type": "number"
+          },
+          "fetched_at": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "github",
+              "cache",
+              "stale_cache"
+            ]
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "repoFullName",
+          "htmlUrl",
+          "stargazers_count",
+          "forks_count",
+          "fetched_at",
+          "source",
+          "stale"
+        ]
       }
     },
     "parameters": {},
@@ -14487,6 +14527,46 @@
             "GittensorySessionCookie": []
           }
         ]
+      }
+    },
+    "/v1/public/github/repos/{owner}/{repo}/stats": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public GitHub repository stars/forks for website chrome",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRepoStats"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid GitHub repository"
+          },
+          "503": {
+            "description": "GitHub repository stats are unavailable"
+          }
+        }
       }
     }
   },

--- a/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
+++ b/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
@@ -4,6 +4,7 @@ import { Github, Star, GitFork, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
+import { getApiOrigin } from "@/lib/api/origin";
 import { apiFetch, notifyApiFailure, notifyApiRecovered } from "@/lib/api/request";
 
 const REPO = "jsonbored/gittensory";
@@ -35,10 +36,9 @@ function writeCache(stats: RepoStats) {
 
 async function fetchRepo(): Promise<RepoStats> {
   const result = await apiFetch<{ stargazers_count?: number; forks_count?: number }>(
-    `https://api.github.com/repos/${REPO}`,
+    `${getApiOrigin()}/v1/public/github/repos/jsonbored/gittensory/stats`,
     {
       label: "GitHub stats",
-      headers: { Accept: "application/vnd.github+json" },
       timeoutMs: 6000,
       silentStatus: true, // GitHub failures shouldn't poison the Gittensory API status pill
     },

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -100,7 +100,7 @@ import {
   refreshInstallationHealthForInstallation,
 } from "../github/backfill";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
-import { fetchPublicContributorProfile } from "../github/public";
+import { fetchPublicContributorProfile, fetchPublicRepoStats } from "../github/public";
 import {
   buildPublicAgentCommandComment,
   buildMaintainerQueueDigest,
@@ -571,6 +571,17 @@ export function createApp() {
   app.get("/v1/mcp/compatibility", (c) => c.json(buildMcpCompatibilityMetadata(nowIso())));
   app.get("/openapi.json", (c) => c.json(buildOpenApiSpec()));
   app.all("/mcp", handleMcpRequest);
+
+  app.get("/v1/public/github/repos/:owner/:repo/stats", async (c) => {
+    try {
+      const stats = await fetchPublicRepoStats(c.env, c.req.param("owner"), c.req.param("repo"));
+      c.header("Cache-Control", stats.stale ? "public, max-age=60, stale-while-revalidate=3600" : "public, max-age=600, stale-while-revalidate=86400");
+      return c.json(stats);
+    } catch (error) {
+      if (error instanceof Error && error.message === "invalid_github_repo") return c.json({ error: "invalid_github_repo" }, 400);
+      return c.json({ error: "github_repo_stats_unavailable" }, 503);
+    }
+  });
 
   app.get("/v1/auth/github/start", async (c) => {
     try {
@@ -3566,6 +3577,7 @@ function toIsoQueryDate(value: string): string | undefined {
 function requiresApiToken(path: string): boolean {
   if (path === "/health") return false;
   if (path === "/v1/mcp/compatibility") return false;
+  if (/^\/v1\/public\/github\/repos\/[^/]+\/[^/]+\/stats$/.test(path)) return false;
   if (path === "/openapi.json") return false;
   if (path === "/mcp") return false;
   if (path.startsWith("/v1/auth/")) return false;

--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -11,6 +11,16 @@ export type PublicContributorProfile = {
   source: "github" | "unavailable";
 };
 
+export type PublicRepoStats = {
+  repoFullName: string;
+  htmlUrl: string;
+  stargazers_count: number;
+  forks_count: number;
+  fetched_at: string;
+  source: "github" | "cache" | "stale_cache";
+  stale: boolean;
+};
+
 type GitHubUserResponse = {
   login: string;
   name?: string | null;
@@ -25,6 +35,23 @@ type GitHubUserResponse = {
 type GitHubRepoResponse = {
   language?: string | null;
 };
+
+type GitHubPublicRepoResponse = {
+  full_name?: string;
+  html_url?: string;
+  stargazers_count?: number;
+  forks_count?: number;
+};
+
+type RepoStatsCacheEntry = {
+  stats: PublicRepoStats;
+  freshUntilMs: number;
+  staleUntilMs: number;
+};
+
+const REPO_STATS_CACHE_TTL_MS = 1000 * 60 * 10;
+const REPO_STATS_STALE_TTL_MS = 1000 * 60 * 60 * 24;
+const repoStatsCache = new Map<string, RepoStatsCacheEntry>();
 
 export async function fetchPublicContributorProfile(login: string): Promise<PublicContributorProfile> {
   const safeLogin = encodeURIComponent(login);
@@ -69,4 +96,60 @@ export async function fetchPublicContributorProfile(login: string): Promise<Publ
       source: "unavailable",
     };
   }
+}
+
+export async function fetchPublicRepoStats(env: Pick<Env, "GITHUB_PUBLIC_TOKEN">, owner: string, repo: string): Promise<PublicRepoStats> {
+  const repoFullName = publicRepoFullName(owner, repo);
+  const cacheKey = repoFullName.toLowerCase();
+  const nowMs = Date.now();
+  const cached = repoStatsCache.get(cacheKey);
+  if (cached && cached.freshUntilMs > nowMs) return { ...cached.stats, source: "cache", stale: false };
+
+  try {
+    const stats = await fetchRepoStatsFromGitHub(env, repoFullName, nowMs);
+    repoStatsCache.set(cacheKey, { stats, freshUntilMs: nowMs + REPO_STATS_CACHE_TTL_MS, staleUntilMs: nowMs + REPO_STATS_STALE_TTL_MS });
+    return stats;
+  } catch (error) {
+    if (cached && cached.staleUntilMs > nowMs) return { ...cached.stats, source: "stale_cache", stale: true };
+    throw error;
+  }
+}
+
+export function clearPublicRepoStatsCacheForTests(): void {
+  repoStatsCache.clear();
+}
+
+function publicRepoFullName(owner: string, repo: string): string {
+  const ownerName = owner.trim();
+  const repoName = repo.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]{0,38}$/.test(ownerName)) throw new Error("invalid_github_repo");
+  if (!/^[A-Za-z0-9._-]{1,100}$/.test(repoName) || repoName === "." || repoName === "..") throw new Error("invalid_github_repo");
+  return `${ownerName}/${repoName}`;
+}
+
+async function fetchRepoStatsFromGitHub(env: Pick<Env, "GITHUB_PUBLIC_TOKEN">, repoFullName: string, nowMs: number): Promise<PublicRepoStats> {
+  const [owner, repo] = repoFullName.split("/") as [string, string];
+  const response = await fetch(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "user-agent": "gittensory/0.1",
+      "x-github-api-version": "2022-11-28",
+      ...(env.GITHUB_PUBLIC_TOKEN ? { authorization: `Bearer ${env.GITHUB_PUBLIC_TOKEN}` } : {}),
+    },
+  });
+  if (!response.ok) throw new Error(`github_repo_stats_unavailable:${response.status}`);
+  const body = (await response.json()) as GitHubPublicRepoResponse;
+  return {
+    repoFullName: typeof body.full_name === "string" && body.full_name ? body.full_name : repoFullName,
+    htmlUrl: typeof body.html_url === "string" && body.html_url ? body.html_url : `https://github.com/${repoFullName}`,
+    stargazers_count: finiteCount(body.stargazers_count),
+    forks_count: finiteCount(body.forks_count),
+    fetched_at: new Date(nowMs).toISOString(),
+    source: "github",
+    stale: false,
+  };
+}
+
+function finiteCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : 0;
 }

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -78,6 +78,18 @@ export const RepositorySchema = z
   })
   .openapi("Repository");
 
+export const PublicRepoStatsSchema = z
+  .object({
+    repoFullName: z.string(),
+    htmlUrl: z.string(),
+    stargazers_count: z.number(),
+    forks_count: z.number(),
+    fetched_at: z.string(),
+    source: z.enum(["github", "cache", "stale_cache"]),
+    stale: z.boolean(),
+  })
+  .openapi("PublicRepoStats");
+
 export const WorkboardItemSchema = z
   .object({
     repoFullName: z.string(),

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -44,6 +44,7 @@ import {
   PullRequestReviewIntelligenceSchema,
   PullRequestReviewabilitySchema,
   PreflightResultSchema,
+  PublicRepoStatsSchema,
   QueueHealthSchema,
   ReadinessSchema,
   RegistryChangeReportSchema,
@@ -82,6 +83,7 @@ export function buildOpenApiSpec() {
   registry.register("McpCompatibility", McpCompatibilitySchema);
   registry.register("RegistrySnapshot", RegistrySnapshotSchema);
   registry.register("Repository", RepositorySchema);
+  registry.register("PublicRepoStats", PublicRepoStatsSchema);
   registry.register("Advisory", AdvisorySchema);
   registry.register("ActionPortfolio", ActionPortfolioSchema);
   registry.register("WorkboardItem", WorkboardItemSchema);
@@ -163,6 +165,16 @@ export function buildOpenApiSpec() {
     path: "/v1/mcp/compatibility",
     responses: {
       200: { description: "Public-safe API and MCP compatibility metadata", content: { "application/json": { schema: McpCompatibilitySchema } } },
+    },
+  });
+  registry.registerPath({
+    method: "get",
+    path: "/v1/public/github/repos/{owner}/{repo}/stats",
+    request: { params: z.object({ owner: z.string(), repo: z.string() }) },
+    responses: {
+      200: { description: "Public GitHub repository stars/forks for website chrome", content: { "application/json": { schema: PublicRepoStatsSchema } } },
+      400: { description: "Invalid GitHub repository" },
+      503: { description: "GitHub repository stats are unavailable" },
     },
   });
   registry.registerPath({
@@ -860,7 +872,7 @@ function applySecurityMetadata(document: GeneratedOpenApiDocument): GeneratedOpe
 }
 
 function isProtectedPath(path: string): boolean {
-  if (path === "/health" || path === "/openapi.json" || path === "/mcp" || path === "/v1/mcp/compatibility") return false;
+  if (path === "/health" || path === "/openapi.json" || path === "/mcp" || path === "/v1/mcp/compatibility" || path === "/v1/public/github/repos/{owner}/{repo}/stats") return false;
   if (path.startsWith("/v1/auth/")) return path === "/v1/auth/extension/session";
   if (path === "/v1/github/webhook") return false;
   return path.startsWith("/v1/");

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -34,6 +34,7 @@ import {
   upsertAgentRecommendationOutcome,
 } from "../../src/db/repositories";
 import { createApp } from "../../src/api/routes";
+import { clearPublicRepoStatsCacheForTests } from "../../src/github/public";
 import { BURDEN_FORECAST_MAX_AGE_MS } from "../../src/services/burden-forecast";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
@@ -53,6 +54,7 @@ describe("api routes", () => {
   });
 
   afterEach(() => {
+    clearPublicRepoStatsCacheForTests();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
@@ -100,6 +102,70 @@ describe("api routes", () => {
     const unauthenticatedSpec = await app.request("/openapi.json", {}, env);
     expect(unauthenticatedSpec.status).toBe(200);
     await expect(unauthenticatedSpec.json()).resolves.toMatchObject({ info: { title: "Gittensory API" } });
+  });
+
+  it("serves public GitHub repo stats without relying on browser GitHub quota", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    const calls: Array<{ url: string; authorization?: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      const authorization = headers.get("authorization");
+      calls.push({ url: input.toString(), ...(authorization ? { authorization } : {}) });
+      return Response.json({ full_name: "JSONbored/gittensory", html_url: "https://github.com/JSONbored/gittensory", stargazers_count: 12, forks_count: 3 });
+    });
+
+    const response = await app.request("/v1/public/github/repos/JSONbored/gittensory/stats", { headers: { origin: "https://gittensory.aethereal.dev" } }, env);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://gittensory.aethereal.dev");
+    expect(response.headers.get("cache-control")).toContain("max-age=600");
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "JSONbored/gittensory",
+      htmlUrl: "https://github.com/JSONbored/gittensory",
+      stargazers_count: 12,
+      forks_count: 3,
+      source: "github",
+      stale: false,
+    });
+    expect(calls).toEqual([{ url: "https://api.github.com/repos/JSONbored/gittensory", authorization: "Bearer public-token" }]);
+
+    const cached = await app.request("/v1/public/github/repos/JSONbored/gittensory/stats", {}, env);
+    expect(cached.status).toBe(200);
+    await expect(cached.json()).resolves.toMatchObject({ stargazers_count: 12, forks_count: 3, source: "cache", stale: false });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("serves stale public repo stats instead of failing during transient GitHub errors", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async () => Response.json({ full_name: "JSONbored/gittensory", html_url: "https://github.com/JSONbored/gittensory", stargazers_count: 21, forks_count: 4 }));
+
+    const fresh = await app.request("/v1/public/github/repos/JSONbored/gittensory/stats", {}, env);
+    expect(fresh.status).toBe(200);
+
+    vi.advanceTimersByTime(11 * 60 * 1000);
+    vi.stubGlobal("fetch", async () => Response.json({ message: "rate limited" }, { status: 403 }));
+    const stale = await app.request("/v1/public/github/repos/JSONbored/gittensory/stats", {}, env);
+    expect(stale.status).toBe(200);
+    expect(stale.headers.get("cache-control")).toContain("max-age=60");
+    await expect(stale.json()).resolves.toMatchObject({ stargazers_count: 21, forks_count: 4, source: "stale_cache", stale: true });
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    const unavailable = await app.request("/v1/public/github/repos/JSONbored/gittensory/stats", {}, env);
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.json()).resolves.toMatchObject({ error: "github_repo_stats_unavailable" });
+  });
+
+  it("rejects invalid public GitHub repo stats paths before calling GitHub", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/v1/public/github/repos/-bad/gittensory/stats", {}, env);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_github_repo" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("serves registry drift through the canonical registry change endpoint", async () => {

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -6,6 +6,7 @@ describe("OpenAPI contract", () => {
     const spec = buildOpenApiSpec();
     expect(spec.paths["/health"]).toBeDefined();
     expect(spec.paths["/v1/mcp/compatibility"]).toBeDefined();
+    expect(spec.paths["/v1/public/github/repos/{owner}/{repo}/stats"]).toBeDefined();
     expect(spec.paths["/v1/registry/snapshot"]).toBeDefined();
     expect(spec.paths["/v1/registry/changes"]).toBeDefined();
     expect(spec.paths["/v1/readiness"]).toBeDefined();
@@ -84,6 +85,7 @@ describe("OpenAPI contract", () => {
 
     expect(spec.components?.schemas?.ContributorProfile).toBeDefined();
     expect(spec.components?.schemas?.McpCompatibility).toBeDefined();
+    expect(spec.components?.schemas?.PublicRepoStats).toBeDefined();
     expect(spec.components?.schemas?.ContributorDecisionPack).toBeDefined();
     expect(spec.components?.schemas?.DecisionPackRefreshNeeded).toBeDefined();
     expect(spec.components?.schemas?.RepoDecisionResponse).toBeDefined();
@@ -118,6 +120,7 @@ describe("OpenAPI contract", () => {
     expect(spec.components?.securitySchemes?.GittensorySessionCookie).toBeDefined();
     expect(spec.paths["/health"]?.get?.security).toBeUndefined();
     expect(spec.paths["/v1/mcp/compatibility"]?.get?.security).toBeUndefined();
+    expect(spec.paths["/v1/public/github/repos/{owner}/{repo}/stats"]?.get?.security).toBeUndefined();
     expect(spec.paths["/v1/auth/github/start"]?.get?.security).toBeUndefined();
     expect(spec.paths["/v1/repos"]?.get?.security).toEqual([{ GittensoryBearer: [] }, { GittensorySessionCookie: [] }]);
     expect(spec.paths["/v1/app/overview"]?.get?.security).toEqual([{ GittensoryBearer: [] }, { GittensorySessionCookie: [] }]);


### PR DESCRIPTION
## Summary
- Proxy the website GitHub repo stats chip through a public Gittensory API endpoint instead of calling GitHub directly from the browser.
- Cache fresh stats server-side and serve a bounded stale cache during transient GitHub failures or rate limits.
- Refresh the OpenAPI artifact and add regression coverage for the public stats endpoint.

## Why
Browser-side GitHub API calls can hit unauthenticated public rate limits and make the navbar show `unavailable` even when the Gittensory API is healthy. The Worker can use the configured public GitHub token and a small cache instead.

## Validation
- `npm test -- test/integration/api.test.ts test/unit/openapi.test.ts`
- `npm --workspace @jsonbored/gittensory-ui run typecheck`
- `npm run ui:openapi && npm run ui:openapi:check`
- `npm --workspace @jsonbored/gittensory-ui run lint`
- `npm run validate`
- `VITE_GITTENSORY_API_ORIGIN=http://127.0.0.1:8787 npm run ui:build`

## Notes
- The new route is public, read-only, and returns only stars/forks plus fetch/cache metadata.
- Public comments and UI output remain source-free and token-free.