### PR TITLE
feat(analytics): classify recommendation outcome sources

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -2369,11 +2369,15 @@
               },
               "maintainerLaneTotal": {
                 "type": "number"
+              },
+              "rejected": {
+                "type": "number"
               }
             },
             "required": [
               "total",
               "accepted",
+              "rejected",
               "ignored",
               "stale",
               "merged",
@@ -2416,6 +2420,21 @@
           },
           "privateSummary": {
             "type": "string"
+          },
+          "sources": {
+            "type": "object",
+            "properties": {
+              "explicit": {
+                "type": "number"
+              },
+              "inferred": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "explicit",
+              "inferred"
+            ]
           }
         },
         "required": [
@@ -2423,6 +2442,7 @@
           "generatedAt",
           "windowDays",
           "totals",
+          "sources",
           "states",
           "repos",
           "maintainerLane",
@@ -2448,6 +2468,7 @@
         "type": "string",
         "enum": [
           "accepted",
+          "rejected",
           "ignored",
           "stale",
           "merged",
@@ -2503,12 +2524,16 @@
               "mixed",
               "neutral"
             ]
+          },
+          "rejected": {
+            "type": "number"
           }
         },
         "required": [
           "repoFullName",
           "total",
           "accepted",
+          "rejected",
           "ignored",
           "stale",
           "merged",

--- a/migrations/0024_agent_recommendation_outcome_source.sql
+++ b/migrations/0024_agent_recommendation_outcome_source.sql
@@ -1,0 +1,4 @@
+ALTER TABLE agent_recommendation_outcomes ADD COLUMN source TEXT NOT NULL DEFAULT 'inferred';
+
+CREATE INDEX IF NOT EXISTS agent_recommendation_outcomes_actor_source_idx
+  ON agent_recommendation_outcomes(actor_login, source, updated_at);

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -61,6 +61,7 @@ import type {
   AgentContextSnapshotRecord,
   AgentRecommendationOutcomeConfidence,
   AgentRecommendationOutcomeRecord,
+  AgentRecommendationOutcomeSource,
   AgentRecommendationOutcomeState,
   AgentRecommendationOutcomeSummary,
   AgentRecommendationOutcomeTargetType,
@@ -1738,6 +1739,14 @@ function recommendationOutcomeTotals(
   };
 }
 
+function recommendationOutcomeSources(outcomes: AgentRecommendationOutcomeRecord[]): AgentRecommendationOutcomeSummary["sources"] {
+  const explicit = outcomes.filter((outcome) => outcome.source === "explicit").length;
+  return {
+    explicit,
+    inferred: outcomes.length - explicit,
+  };
+}
+
 function summarizeRecommendationOutcomeRepos(outcomes: AgentRecommendationOutcomeRecord[]): AgentRecommendationOutcomeSummary["repos"] {
   const byRepo = new Map<string, AgentRecommendationOutcomeRecord[]>();
   for (const outcome of outcomes) {
@@ -2648,6 +2657,10 @@ export async function listAgentContextSnapshots(env: Env, runId: string): Promis
 }
 
 export async function upsertAgentRecommendationOutcome(env: Env, outcome: AgentRecommendationOutcomeRecord): Promise<AgentRecommendationOutcomeRecord> {
+  const source = normalizeAgentRecommendationOutcomeSource(outcome.source);
+  const existing = source === "inferred" ? await getAgentRecommendationOutcome(env, outcome.actionId) : null;
+  if (existing?.source === "explicit") return existing;
+
   const now = outcome.updatedAt ?? nowIso();
   const values = {
     id: outcome.id ?? `outcome:${outcome.actionId}`,
@@ -2660,6 +2673,7 @@ export async function upsertAgentRecommendationOutcome(env: Env, outcome: AgentR
     targetRepoFullName: outcome.targetRepoFullName ? boundedString(outcome.targetRepoFullName, 200) : null,
     targetPullNumber: outcome.targetPullNumber ?? null,
     targetIssueNumber: outcome.targetIssueNumber ?? null,
+    source,
     outcomeState: outcome.outcomeState,
     outcomeTargetType: outcome.outcomeTargetType,
     outcomeRepoFullName: outcome.outcomeRepoFullName ? boundedString(outcome.outcomeRepoFullName, 200) : null,
@@ -2687,6 +2701,7 @@ export async function upsertAgentRecommendationOutcome(env: Env, outcome: AgentR
         targetRepoFullName: values.targetRepoFullName,
         targetPullNumber: values.targetPullNumber,
         targetIssueNumber: values.targetIssueNumber,
+        source: values.source,
         outcomeState: values.outcomeState,
         outcomeTargetType: values.outcomeTargetType,
         outcomeRepoFullName: values.outcomeRepoFullName,
@@ -2744,11 +2759,13 @@ export async function getAgentRecommendationOutcomeSummary(
   const maintainerStates = outcomeStateBuckets(maintainer);
   const repos = summarizeRecommendationOutcomeRepos(outcomes);
   const totals = recommendationOutcomeTotals(nonMaintainer, maintainer.length);
+  const sources = recommendationOutcomeSources(nonMaintainer);
   return {
     login: actorLogin,
     generatedAt,
     windowDays,
     totals,
+    sources,
     states,
     repos,
     maintainerLane: {
@@ -3448,6 +3465,7 @@ function toAgentRecommendationOutcomeRecord(row: typeof agentRecommendationOutco
     targetRepoFullName: row.targetRepoFullName,
     targetPullNumber: row.targetPullNumber,
     targetIssueNumber: row.targetIssueNumber,
+    source: parseAgentRecommendationOutcomeSource(row.source),
     outcomeState: parseAgentRecommendationOutcomeState(row.outcomeState),
     outcomeTargetType: parseAgentRecommendationOutcomeTargetType(row.outcomeTargetType),
     outcomeRepoFullName: row.outcomeRepoFullName,
@@ -4280,6 +4298,14 @@ function parseAgentSafetyClass(value: string): AgentSafetyClass {
 function parseAgentRecommendationOutcomeState(value: string): AgentRecommendationOutcomeState {
   if (value === "accepted" || value === "rejected" || value === "ignored" || value === "stale" || value === "merged" || value === "closed" || value === "improved") return value;
   return "ignored";
+}
+
+function normalizeAgentRecommendationOutcomeSource(value: AgentRecommendationOutcomeSource | null | undefined): AgentRecommendationOutcomeSource {
+  return value === "explicit" ? "explicit" : "inferred";
+}
+
+function parseAgentRecommendationOutcomeSource(value: string): AgentRecommendationOutcomeSource {
+  return value === "explicit" ? "explicit" : "inferred";
 }
 
 function parseAgentRecommendationOutcomeTargetType(value: string): AgentRecommendationOutcomeTargetType {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -491,6 +491,7 @@ export const agentRecommendationOutcomes = sqliteTable(
     targetRepoFullName: text("target_repo_full_name"),
     targetPullNumber: integer("target_pull_number"),
     targetIssueNumber: integer("target_issue_number"),
+    source: text("source").notNull().default("inferred"),
     surface: text("surface"),
     snapshotId: text("snapshot_id"),
     outcomeState: text("outcome_state").notNull(),
@@ -510,6 +511,7 @@ export const agentRecommendationOutcomes = sqliteTable(
   (table) => ({
     action: uniqueIndex("agent_recommendation_outcomes_action_unique").on(table.actionId),
     actorState: index("agent_recommendation_outcomes_actor_state_idx").on(table.actorLogin, table.outcomeState, table.updatedAt),
+    actorSource: index("agent_recommendation_outcomes_actor_source_idx").on(table.actorLogin, table.source, table.updatedAt),
     target: index("agent_recommendation_outcomes_target_idx").on(table.targetRepoFullName, table.targetPullNumber, table.targetIssueNumber),
     maintainer: index("agent_recommendation_outcomes_maintainer_idx").on(table.actorLogin, table.maintainerLane, table.updatedAt),
   }),

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1598,7 +1598,7 @@ export const ContributorStrategySchema = z
 
 export const DecisionPackFreshnessSchema = z.enum(["fresh", "stale", "rebuilding", "missing"]).openapi("DecisionPackFreshness");
 
-export const AgentRecommendationOutcomeStateSchema = z.enum(["accepted", "ignored", "stale", "merged", "closed", "improved"]).openapi("AgentRecommendationOutcomeState");
+export const AgentRecommendationOutcomeStateSchema = z.enum(["accepted", "rejected", "ignored", "stale", "merged", "closed", "improved"]).openapi("AgentRecommendationOutcomeState");
 
 export const AgentRecommendationOutcomeStateBucketSchema = z
   .object({
@@ -1612,6 +1612,7 @@ export const AgentRecommendationOutcomeRepoSummarySchema = z
     repoFullName: z.string(),
     total: z.number(),
     accepted: z.number(),
+    rejected: z.number(),
     ignored: z.number(),
     stale: z.number(),
     merged: z.number(),
@@ -1633,6 +1634,7 @@ export const AgentRecommendationOutcomeSummarySchema = z
     totals: z.object({
       total: z.number(),
       accepted: z.number(),
+      rejected: z.number(),
       ignored: z.number(),
       stale: z.number(),
       merged: z.number(),
@@ -1641,6 +1643,10 @@ export const AgentRecommendationOutcomeSummarySchema = z
       positive: z.number(),
       negative: z.number(),
       maintainerLaneTotal: z.number(),
+    }),
+    sources: z.object({
+      explicit: z.number(),
+      inferred: z.number(),
     }),
     states: z.array(AgentRecommendationOutcomeStateBucketSchema),
     repos: z.array(AgentRecommendationOutcomeRepoSummarySchema),

--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -1079,6 +1079,7 @@ function emptyRecommendationOutcomeFeedback(login: string): AgentRecommendationO
       negative: 0,
       maintainerLaneTotal: 0,
     },
+    sources: { explicit: 0, inferred: 0 },
     states: [],
     repos: [],
     maintainerLane: { total: 0, states: [] },

--- a/src/services/recommendation-outcomes.ts
+++ b/src/services/recommendation-outcomes.ts
@@ -248,6 +248,7 @@ function baseOutcome(
     targetRepoFullName: action.targetRepoFullName,
     targetPullNumber: action.targetPullNumber,
     targetIssueNumber: action.targetIssueNumber,
+    source: "inferred",
     outcomeState: outcome.outcomeState,
     outcomeTargetType: outcome.outcomeTargetType,
     outcomeRepoFullName: outcome.outcomeRepoFullName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -711,6 +711,7 @@ export type AgentContextSnapshotRecord = {
 export type AgentRecommendationOutcomeState = "accepted" | "rejected" | "ignored" | "stale" | "merged" | "closed" | "improved";
 export type AgentRecommendationOutcomeTargetType = "pull_request" | "issue" | "repository" | "none";
 export type AgentRecommendationOutcomeConfidence = "high" | "medium" | "low";
+export type AgentRecommendationOutcomeSource = "explicit" | "inferred";
 
 export type AgentRecommendationOutcomeRecord = {
   id?: string | undefined;
@@ -723,6 +724,7 @@ export type AgentRecommendationOutcomeRecord = {
   targetRepoFullName?: string | null | undefined;
   targetPullNumber?: number | null | undefined;
   targetIssueNumber?: number | null | undefined;
+  source: AgentRecommendationOutcomeSource;
   outcomeState: AgentRecommendationOutcomeState;
   outcomeTargetType: AgentRecommendationOutcomeTargetType;
   outcomeRepoFullName?: string | null | undefined;
@@ -776,6 +778,10 @@ export type AgentRecommendationOutcomeSummary = {
     positive: number;
     negative: number;
     maintainerLaneTotal: number;
+  };
+  sources: {
+    explicit: number;
+    inferred: number;
   };
   states: AgentRecommendationOutcomeStateBucket[];
   repos: AgentRecommendationOutcomeRepoSummary[];

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2146,6 +2146,7 @@ describe("api routes", () => {
       targetRepoFullName: "JSONbored/gittensory",
       targetPullNumber: null,
       targetIssueNumber: null,
+      source: "inferred",
       outcomeState: "merged",
       outcomeTargetType: "pull_request",
       outcomeRepoFullName: "JSONbored/gittensory",

--- a/test/unit/decision-pack.test.ts
+++ b/test/unit/decision-pack.test.ts
@@ -378,6 +378,7 @@ describe("decision-pack service", () => {
           negative: 0,
           maintainerLaneTotal: 1,
         },
+        sources: { explicit: 1, inferred: 0 },
         states: [{ state: "accepted", count: 1 }],
         repos: [],
         maintainerLane: { total: 1, states: [{ state: "merged", count: 1 }] },

--- a/test/unit/recommendation-outcomes.test.ts
+++ b/test/unit/recommendation-outcomes.test.ts
@@ -51,6 +51,7 @@ describe("recommendation outcome feedback", () => {
 
     const summary = await getAgentRecommendationOutcomeSummary(env, "dev", { now: "2026-06-01T00:00:00.000Z", windowDays: 90 });
     expect(summary.totals).toMatchObject({ total: 6, merged: 1, closed: 2, stale: 1, ignored: 1, improved: 1, positive: 2, negative: 4, maintainerLaneTotal: 1 });
+    expect(summary.sources).toEqual({ explicit: 0, inferred: 6 });
     expect(summary.maintainerLane).toMatchObject({ total: 1, states: [{ state: "merged", count: 1 }] });
     expect(summary.repos.find((repo) => repo.repoFullName === "dev/own")).toMatchObject({ total: 0, maintainerLaneTotal: 1, signal: "neutral" });
   });
@@ -75,6 +76,55 @@ describe("recommendation outcome feedback", () => {
     expect(merged.outcomes.find((outcome) => outcome.targetRepoFullName === "owner/later")).toMatchObject({ outcomeState: "merged", outcomePullNumber: 31 });
     const rows = await listAgentRecommendationOutcomes(env, { actorLogin: "dev" });
     expect(rows.filter((row) => row.targetRepoFullName === "owner/later")).toHaveLength(1);
+  });
+
+  it("keeps explicit rejected outcomes in private state buckets when inferred sweeps rerun", async () => {
+    const env = createTestEnv();
+    const run = runRecord("run-explicit-rejected", "dev", "2026-05-01T00:00:00.000Z");
+    const explicitAction = action(run, 0, { targetRepoFullName: "owner/rejected", targetPullNumber: 42 });
+    await createAgentRun(env, run);
+    await replaceAgentActions(env, run.id, [explicitAction]);
+
+    await upsertAgentRecommendationOutcome(env, {
+      actionId: explicitAction.id,
+      runId: run.id,
+      actorLogin: "dev",
+      actionType: explicitAction.actionType,
+      targetRepoFullName: "owner/rejected",
+      targetPullNumber: 42,
+      targetIssueNumber: null,
+      source: "explicit",
+      outcomeState: "rejected",
+      outcomeTargetType: "pull_request",
+      outcomeRepoFullName: "owner/rejected",
+      outcomePullNumber: 42,
+      outcomeIssueNumber: null,
+      maintainerLane: false,
+      confidence: "high",
+      reason: "User marked the recommendation as not useful.",
+      detectedAt: "2026-05-04T00:00:00.000Z",
+      updatedAt: "2026-05-04T00:00:00.000Z",
+      metadata: { feedbackVote: "not_useful" },
+    });
+
+    await upsertPullRequestFromGitHub(env, "owner/rejected", pr(42, { state: "open", created_at: "2026-05-02T00:00:00.000Z", updated_at: "2026-05-02T00:00:00.000Z" }));
+    const rerun = await evaluateRecommendationOutcomes(env, "dev", { now: "2026-06-01T00:00:00.000Z" });
+    expect(rerun.outcomes).toHaveLength(1);
+    expect(rerun.outcomes[0]).toMatchObject({ source: "explicit", outcomeState: "rejected", reason: "User marked the recommendation as not useful." });
+
+    const summary = await getAgentRecommendationOutcomeSummary(env, "dev", { now: "2026-06-01T00:00:00.000Z" });
+    expect(summary.states).toEqual([{ state: "rejected", count: 1 }]);
+    expect(summary.totals).toMatchObject({ total: 1, rejected: 1, positive: 0, negative: 1 });
+    expect(summary.sources).toEqual({ explicit: 1, inferred: 0 });
+    expect(summary.repos).toEqual([
+      expect.objectContaining({
+        repoFullName: "owner/rejected",
+        total: 1,
+        rejected: 1,
+        negative: 1,
+        signal: "negative",
+      }),
+    ]);
   });
 
   it("classifies linked PRs, later issues, payload targets, no-target, and defensive timestamp branches", () => {
@@ -482,6 +532,7 @@ describe("recommendation outcome feedback", () => {
       targetRepoFullName: "owner/legacy",
       targetPullNumber: null,
       targetIssueNumber: null,
+      source: "inferred",
       outcomeState: "accepted",
       outcomeTargetType: "repository",
       outcomeRepoFullName: "owner/legacy",

--- a/test/unit/recommendation-quality-report.test.ts
+++ b/test/unit/recommendation-quality-report.test.ts
@@ -263,6 +263,7 @@ function outcome(
     targetRepoFullName: options.repo === null ? null : options.repo ?? "owner/repo",
     targetPullNumber: null,
     targetIssueNumber: null,
+    source: "inferred",
     outcomeState,
     outcomeTargetType: "repository",
     outcomeRepoFullName: options.repo === null ? null : options.repo ?? "owner/repo",


### PR DESCRIPTION
## Summary

- Closes #302.
- Add persisted recommendation outcome `source` classification so inferred lifecycle outcomes stay distinct from explicit feedback.
- Preserve explicit rejected outcomes when inferred reevaluation runs, and expose rejected/source counts in the private recommendation outcome summary/OpenAPI contract.

## Scope Summary

This PR only touches the recommendation outcome persistence/schema path, private summary contract, generated OpenAPI JSON, and targeted regression fixtures. It does not add command-feedback route ingestion, role-aware rollups, UI behavior, dependencies, or release notes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. `npm run test:ci` passed locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI, frontend, docs, or extension behavior changed. The generated OpenAPI JSON was updated and checked; screenshots are not applicable.

| State / title | JPG/PNG evidence |
| ------------- | ---------------- |
| Not applicable | No visible UI change |

## Notes

- Adds migration `0024_agent_recommendation_outcome_source.sql`, avoiding the stale `0020` migration numbering that blocked the previous closed attempt.
- Existing persisted outcomes default to `inferred`.
- Inferred updates no longer overwrite an explicit outcome for the same recommendation action.
