### PR TITLE
feat(analytics): add role-aware recommendation quality rollups

### DIFF
--- a/src/services/recommendation-quality-report.ts
+++ b/src/services/recommendation-quality-report.ts
@@ -1,8 +1,10 @@
 import { listAgentRecommendationOutcomes } from "../db/repositories";
-import type { AgentActionType, AgentRecommendationOutcomeRecord, AgentRecommendationOutcomeState, JsonValue, ProductUsageRole } from "../types";
+import type { AgentActionType, AgentRecommendationOutcomeRecord, AgentRecommendationOutcomeState, AgentSurface, JsonValue, ProductUsageRole } from "../types";
 import { nowIso } from "../utils/json";
 
 export type RecommendationQualityRole = Extract<ProductUsageRole, "miner" | "maintainer" | "owner" | "operator">;
+export type RecommendationQualityLane = "contributor" | "maintainer";
+export type RecommendationQualitySurface = AgentSurface | "unknown";
 
 export type RecommendationQualityTotals = {
   total: number;
@@ -27,6 +29,16 @@ export type RecommendationQualityFailureCategory = {
   detail: string;
 };
 
+export type RecommendationQualityRollup = {
+  role: RecommendationQualityRole;
+  surface: RecommendationQualitySurface;
+  lane: RecommendationQualityLane;
+  outcomeCategory: AgentRecommendationOutcomeState;
+  periodStart: string;
+  periodEnd: string;
+  count: number;
+};
+
 export type RecommendationQualityRoleSurface = RecommendationQualityTotals & {
   role: RecommendationQualityRole;
   label: string;
@@ -48,6 +60,7 @@ export type RecommendationQualityReport = {
   totals: RecommendationQualityTotals;
   trends: RecommendationQualityTrendBucket[];
   failureCategories: RecommendationQualityFailureCategory[];
+  rollups: RecommendationQualityRollup[];
   roleSurfaces: RecommendationQualityRoleSurface[];
   warnings: string[];
   publicExport: {
@@ -84,6 +97,7 @@ export function buildRecommendationQualityReportFromOutcomes(
   const roleSurfaces = ROLE_ORDER.map((role) => roleSurface(role, sorted.filter((outcome) => roleForOutcome(outcome) === role))).filter((surface) => surface.total > 0 || surface.maintainerLaneTotal > 0);
   const failureCategories = failureCategoryRows(sorted);
   const trends = trendBuckets(sorted, options.generatedAt, options.windowDays);
+  const rollups = qualityRollups(sorted, options.generatedAt, options.windowDays);
   const sparse = totals.total > 0 && totals.total < 5;
   const warnings = [
     ...(totals.total === 0 ? ["No recommendation outcomes have been evaluated in this window."] : []),
@@ -102,6 +116,7 @@ export function buildRecommendationQualityReportFromOutcomes(
     totals,
     trends,
     failureCategories,
+    rollups,
     roleSurfaces,
     warnings,
     publicExport: {
@@ -206,22 +221,83 @@ function trendBuckets(
   generatedAt: string,
   windowDays: number,
 ): RecommendationQualityTrendBucket[] {
+  return trendPeriods(generatedAt, windowDays).map((period) => {
+    const bucketOutcomes = outcomes.filter((outcome) => {
+      const timestamp = Date.parse(outcomeTimestamp(outcome));
+      return Number.isFinite(timestamp) && timestamp >= period.startMs && timestamp <= period.endMs;
+    });
+    return {
+      periodStart: period.periodStart,
+      periodEnd: period.periodEnd,
+      ...qualityTotals(bucketOutcomes),
+    };
+  });
+}
+
+function qualityRollups(
+  outcomes: AgentRecommendationOutcomeRecord[],
+  generatedAt: string,
+  windowDays: number,
+): RecommendationQualityRollup[] {
+  const periods = trendPeriods(generatedAt, windowDays);
+  const byKey = new Map<string, RecommendationQualityRollup>();
+  for (const outcome of outcomes) {
+    const timestamp = Date.parse(outcomeTimestamp(outcome));
+    if (!Number.isFinite(timestamp)) continue;
+    const period = periods.find((candidate) => timestamp >= candidate.startMs && (candidate.last ? timestamp <= candidate.endMs : timestamp < candidate.endMs));
+    if (!period) continue;
+    const role = roleForOutcome(outcome);
+    const surface = surfaceForOutcome(outcome);
+    const lane = laneForOutcome(outcome);
+    const outcomeCategory = outcome.outcomeState;
+    const key = [period.periodStart, period.periodEnd, role, surface, lane, outcomeCategory].join("|");
+    const existing = byKey.get(key);
+    byKey.set(key, {
+      role,
+      surface,
+      lane,
+      outcomeCategory,
+      periodStart: period.periodStart,
+      periodEnd: period.periodEnd,
+      count: (existing?.count ?? 0) + 1,
+    });
+  }
+  return [...byKey.values()].sort(
+    (left, right) =>
+      left.periodStart.localeCompare(right.periodStart) ||
+      roleSortValue(left.role) - roleSortValue(right.role) ||
+      left.surface.localeCompare(right.surface) ||
+      left.lane.localeCompare(right.lane) ||
+      left.outcomeCategory.localeCompare(right.outcomeCategory),
+  );
+}
+
+function trendPeriods(
+  generatedAt: string,
+  windowDays: number,
+): Array<{ periodStart: string; periodEnd: string; startMs: number; endMs: number; last: boolean }> {
   const bucketCount = Math.min(6, Math.max(1, Math.ceil(windowDays / 7)));
   const now = Date.parse(generatedAt);
   const bucketMs = Math.max(1, Math.ceil((windowDays * 24 * 60 * 60 * 1000) / bucketCount));
   return Array.from({ length: bucketCount }, (_, index) => {
     const periodStartMs = now - bucketMs * (bucketCount - index);
     const periodEndMs = index === bucketCount - 1 ? now : periodStartMs + bucketMs;
-    const bucketOutcomes = outcomes.filter((outcome) => {
-      const timestamp = Date.parse(outcomeTimestamp(outcome));
-      return Number.isFinite(timestamp) && timestamp >= periodStartMs && timestamp <= periodEndMs;
-    });
     return {
       periodStart: new Date(periodStartMs).toISOString(),
       periodEnd: new Date(periodEndMs).toISOString(),
-      ...qualityTotals(bucketOutcomes),
+      startMs: periodStartMs,
+      endMs: periodEndMs,
+      last: index === bucketCount - 1,
     };
   });
+}
+
+function surfaceForOutcome(outcome: AgentRecommendationOutcomeRecord): RecommendationQualitySurface {
+  return outcome.surface ?? "unknown";
+}
+
+function laneForOutcome(outcome: AgentRecommendationOutcomeRecord): RecommendationQualityLane {
+  return outcome.maintainerLane ? "maintainer" : "contributor";
 }
 
 function roleForOutcome(outcome: AgentRecommendationOutcomeRecord): RecommendationQualityRole {
@@ -267,6 +343,10 @@ function roleLabel(role: RecommendationQualityRole): string {
   if (role === "maintainer") return "Maintainer guidance";
   if (role === "owner") return "Repo-owner guidance";
   return "Operator guidance";
+}
+
+function roleSortValue(role: RecommendationQualityRole): number {
+  return ROLE_ORDER.indexOf(role);
 }
 
 function signalFor(totals: RecommendationQualityTotals): "positive" | "negative" | "mixed" {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2143,6 +2143,7 @@ describe("api routes", () => {
       runId: "api-quality-run",
       actorLogin: "quality-user",
       actionType: "prepare_pr_packet",
+      surface: "api",
       targetRepoFullName: "JSONbored/gittensory",
       targetPullNumber: null,
       targetIssueNumber: null,
@@ -2178,6 +2179,9 @@ describe("api routes", () => {
         visibility: "operator_only",
         publicExport: expect.objectContaining({ available: false }),
         totals: expect.objectContaining({ total: 1, positive: 1, negative: 0 }),
+        rollups: expect.arrayContaining([
+          expect.objectContaining({ role: "miner", surface: "api", lane: "contributor", outcomeCategory: "merged", count: 1 }),
+        ]),
         roleSurfaces: expect.arrayContaining([expect.objectContaining({ role: "miner", positive: 1 })]),
       }),
     });

--- a/test/unit/recommendation-quality-report.test.ts
+++ b/test/unit/recommendation-quality-report.test.ts
@@ -43,6 +43,69 @@ describe("recommendation quality report", () => {
     expect(JSON.stringify(report)).not.toMatch(FORBIDDEN_REPORT_TERMS);
   });
 
+  it("rolls up private quality by role, surface, lane, outcome category, and time bucket", () => {
+    const report = buildRecommendationQualityReportFromOutcomes(
+      [
+        outcome("miner-api-accepted", "accepted", {
+          surface: "api",
+          metadata: { role: "miner" },
+          updatedAt: "2026-05-20T00:00:00.000Z",
+        }),
+        outcome("miner-mcp-stale", "stale", {
+          surface: "mcp",
+          metadata: { role: "miner" },
+          updatedAt: "2026-05-28T00:00:00.000Z",
+        }),
+        outcome("miner-maintainer-rejected", "rejected", {
+          surface: "github_comment",
+          metadata: { role: "miner" },
+          maintainerLane: true,
+          updatedAt: "2026-05-29T00:00:00.000Z",
+        }),
+        outcome("outside-window", "merged", {
+          surface: "api",
+          metadata: { role: "miner" },
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        }),
+      ],
+      { generatedAt: "2026-06-01T00:00:00.000Z", windowDays: 14 },
+    );
+
+    expect(report.rollups).toEqual([
+      {
+        role: "miner",
+        surface: "api",
+        lane: "contributor",
+        outcomeCategory: "accepted",
+        periodStart: "2026-05-18T00:00:00.000Z",
+        periodEnd: "2026-05-25T00:00:00.000Z",
+        count: 1,
+      },
+      {
+        role: "miner",
+        surface: "github_comment",
+        lane: "maintainer",
+        outcomeCategory: "rejected",
+        periodStart: "2026-05-25T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
+        count: 1,
+      },
+      {
+        role: "miner",
+        surface: "mcp",
+        lane: "contributor",
+        outcomeCategory: "stale",
+        periodStart: "2026-05-25T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
+        count: 1,
+      },
+    ]);
+    expect(report.rollups.filter((rollup) => rollup.role === "miner" && rollup.surface === "github_comment")).toEqual([
+      expect.objectContaining({ lane: "maintainer", outcomeCategory: "rejected", count: 1 }),
+    ]);
+    expect(JSON.stringify(report.rollups)).not.toMatch(FORBIDDEN_REPORT_TERMS);
+  });
+
   it("counts rejected outcomes as negative recommendations", () => {
     const rejectedOnly = buildRecommendationQualityReportFromOutcomes(
       [outcome("rejected", "rejected", { actionType: "monitor_existing_pr", repo: "owner/rejected", updatedAt: "2026-05-30T00:00:00.000Z" })],
@@ -238,6 +301,10 @@ describe("recommendation quality report", () => {
       windowDays: 1,
       totals: { total: 0 },
     });
+    await expect(buildRecommendationQualityReport(env, { now: "2026-06-01T00:00:00.000Z" })).resolves.toMatchObject({
+      windowDays: 90,
+      totals: { total: 0 },
+    });
   });
 });
 
@@ -246,6 +313,7 @@ function outcome(
   outcomeState: AgentRecommendationOutcomeRecord["outcomeState"],
   options: {
     actionType?: AgentRecommendationOutcomeRecord["actionType"];
+    surface?: AgentRecommendationOutcomeRecord["surface"];
     repo?: string | null;
     updatedAt?: string;
     reason?: string;
@@ -260,6 +328,7 @@ function outcome(
     runId: `run:${id}`,
     actorLogin: "dev",
     actionType: options.actionType ?? "choose_next_work",
+    surface: options.surface ?? null,
     targetRepoFullName: options.repo === null ? null : options.repo ?? "owner/repo",
     targetPullNumber: null,
     targetIssueNumber: null,


### PR DESCRIPTION
## Summary

- Closes #303.
- Add private recommendation quality rollup rows keyed by role, surface, lane, outcome category, and report time bucket.
- Keep maintainer-lane and contributor-lane outcomes separated in the authenticated operator quality report.

## Scope Summary

This PR only enhances the existing private recommendation quality report and its tests. It does not add migrations, product-usage rollup storage, visible UI behavior, dependencies, or release notes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. `npm run test:ci` passed locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI, frontend, docs, or extension behavior changed. The private operator payload shape is covered by integration tests; screenshots are not applicable.

| State / title | JPG/PNG evidence |
| ------------- | ---------------- |
| Not applicable | No visible UI change |

## Notes

- This avoids the stale migration-numbering and unrelated extension artifact problems that blocked the previous closed #303 attempt.
- Rollups are computed from already-private recommendation outcome records and remain `operator_only`.
- The operator-dashboard integration assertion verifies authenticated access to the new rollup rows and sanitizer coverage remains in place.
