### PR TITLE
feat(extension): detect GitHub issue pages

### DIFF
--- a/apps/gittensory-extension/content.js
+++ b/apps/gittensory-extension/content.js
@@ -1,14 +1,21 @@
-const target = matchPullRequestTarget(location.pathname);
+const target = matchGitHubPageTarget(location.pathname);
 
-if (target) {
+if (target?.kind === "pull_request") {
   mountOverlay(target);
 }
 
-function matchPullRequestTarget(pathname) {
-  const match = String(pathname ?? "").match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/);
+function matchGitHubPageTarget(pathname) {
+  const match = String(pathname ?? "").match(/^\/([^/]+)\/([^/]+)\/(pull|issues)\/(\d+)(?:\/|$)/);
   if (!match) return null;
-  const [, owner, repo, pullNumber] = match;
-  return { owner, repo, pullNumber: Number(pullNumber) };
+  const [, owner, repo, surface, number] = match;
+  if (surface === "pull") return { kind: "pull_request", owner, repo, pullNumber: Number(number) };
+  return { kind: "issue", owner, repo, issueNumber: Number(number) };
+}
+
+function matchPullRequestTarget(pathname) {
+  const target = matchGitHubPageTarget(pathname);
+  if (target?.kind !== "pull_request") return null;
+  return { owner: target.owner, repo: target.repo, pullNumber: target.pullNumber };
 }
 
 function mountOverlay(target) {
@@ -176,6 +183,7 @@ function renderActions(body, actions) {
 
 if (globalThis.__GITTENSORY_EXTENSION_TEST__) {
   globalThis.__gittensoryContentInternals = {
+    matchGitHubPageTarget,
     matchPullRequestTarget,
     renderPullContext,
     renderSection,

--- a/apps/gittensory-extension/manifest.json
+++ b/apps/gittensory-extension/manifest.json
@@ -11,7 +11,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/pull/*"],
+      "matches": ["https://github.com/*/*/pull/*", "https://github.com/*/*/issues/*"],
       "js": ["content.js"],
       "css": ["styles.css"],
       "run_at": "document_idle"

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -5,9 +5,22 @@ import { describe, expect, it, vi } from "vitest";
 const contentScript = readFileSync("apps/gittensory-extension/content.js", "utf8");
 
 describe("extension content script", () => {
-  it("matches only GitHub pull request routes", () => {
+  it("detects GitHub pull request and issue routes while only mounting pull overlays", () => {
     const internals = loadContentInternals();
 
+    expect(internals.matchGitHubPageTarget("/JSONbored/gittensory/pull/146")).toEqual({
+      kind: "pull_request",
+      owner: "JSONbored",
+      repo: "gittensory",
+      pullNumber: 146,
+    });
+    expect(internals.matchGitHubPageTarget("/JSONbored/gittensory/issues/145")).toEqual({
+      kind: "issue",
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(internals.matchGitHubPageTarget("/JSONbored/gittensory/pulls")).toBeNull();
     expect(internals.matchPullRequestTarget("/JSONbored/gittensory/pull/146")).toEqual({
       owner: "JSONbored",
       repo: "gittensory",
@@ -76,6 +89,9 @@ function loadContentInternals() {
   const vmContext = createContext(context);
   new Script(contentScript).runInContext(vmContext);
   return vmContext.__gittensoryContentInternals as {
+    matchGitHubPageTarget: (
+      pathname: string,
+    ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;
     matchPullRequestTarget: (pathname: string) => { owner: string; repo: string; pullNumber: number } | null;
     renderPullContext: (payload: unknown) => string;
   };


### PR DESCRIPTION
## Summary

- Closes #145.
- Extend the MV3 content-script scaffold so GitHub issue pages are detected alongside PR pages.
- Preserve the existing behavior that only PR pages mount the private overlay or call the pull-context API; issue pages are recognized as scaffold targets without adding UI, comments, source upload, or duplicated intelligence logic.

## Scope Summary

This PR only updates extension URL detection, the MV3 content-script match list, and focused content-script tests. It does not add visible extension UI states, does not rebuild or commit the downloadable extension zip, does not change extension auth/API behavior, and does not touch docs, dependencies, backend, or release notes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. `npm run test:ci` passed locally after rerunning outside the sandbox. A first sandboxed coverage attempt hit known MCP/local-scorer sandbox failures and was discarded.
- Targeted checks also passed: `npm run test -- test/unit/extension-content.test.ts test/unit/extension-auth.test.ts test/unit/routes-extension.test.ts` and `npm run typecheck`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI, frontend, docs, or extension overlay state changed. Issue pages are now detected by the content-script scaffold, but the script intentionally does not mount an issue-page overlay or call a new API. PR overlay rendering is unchanged, so screenshots are not applicable for this non-visible route-detection change.

| State / title | JPG/PNG evidence |
| ------------- | ---------------- |
| Not applicable | No visible UI change |

## Notes

- This is a small replacement for the non-visible scaffold gap left after the prior closed scaffold attempt.
- It deliberately avoids the generated extension zip artifact that blocked the prior closed scaffold attempt.
- Screenshot-backed visible extension states remain separate work for #243/#244.
