### PR TITLE
feat(app): display decision snapshot replay details

### DIFF
--- a/apps/gittensory-ui/src/components/site/snapshot-replay.tsx
+++ b/apps/gittensory-ui/src/components/site/snapshot-replay.tsx
@@ -1,0 +1,190 @@
+import { useState, type ReactNode } from "react";
+
+import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { cn } from "@/lib/utils";
+import type { SnapshotReplayView, SnapshotReplayViewer } from "@/lib/snapshot-replay";
+
+const STATUS_PILL: Record<SnapshotReplayView["status"], Status> = {
+  populated: "ready",
+  stale: "stale",
+  missing: "info",
+};
+
+const STATUS_LABEL: Record<SnapshotReplayView["status"], string> = {
+  populated: "Replayable",
+  stale: "Stale evidence",
+  missing: "No evidence",
+};
+
+const VIEWER_LABEL: Record<SnapshotReplayViewer, string> = {
+  authenticated: "Authenticated",
+  public: "Public-safe",
+};
+
+/**
+ * Snapshot replay card with an audience toggle so reviewers can confirm the
+ * public-safe view withholds the private detail the authenticated view shows.
+ * The two views are precomputed by the caller; switching never re-derives or
+ * exposes withheld fields.
+ */
+export function SnapshotReplayCard({
+  authenticated,
+  publicSafe,
+}: {
+  authenticated: SnapshotReplayView;
+  publicSafe: SnapshotReplayView;
+}) {
+  const [viewer, setViewer] = useState<SnapshotReplayViewer>("authenticated");
+  const view = viewer === "public" ? publicSafe : authenticated;
+  return (
+    <div className="space-y-2">
+      <div
+        role="group"
+        aria-label="Snapshot replay audience"
+        className="inline-flex rounded-token border border-border p-0.5 text-token-2xs"
+      >
+        {(["authenticated", "public"] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setViewer(option)}
+            aria-pressed={viewer === option}
+            className={cn(
+              "rounded-[6px] px-2.5 py-1 font-mono uppercase tracking-wider transition-colors focus-ring",
+              viewer === option
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {VIEWER_LABEL[option]}
+          </button>
+        ))}
+      </div>
+      <SnapshotReplay view={view} />
+    </div>
+  );
+}
+
+/**
+ * Inspection-only replay view for a single decision snapshot (issue #285).
+ * Renders public-safe provenance, freshness/confidence context, evidence gaps,
+ * and counterfactuals, with private detail clearly separated and withheld for
+ * public viewers. It intentionally exposes no mutating actions.
+ */
+export function SnapshotReplay({ view }: { view: SnapshotReplayView }) {
+  return (
+    <section
+      data-testid="snapshot-replay"
+      data-status={view.status}
+      className="rounded-token border border-border bg-background/60 p-4"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            Decision snapshot replay
+          </div>
+          <div className="mt-0.5 truncate font-mono text-[12px] text-foreground/90">
+            {view.snapshotId ?? "unknown snapshot"}
+          </div>
+        </div>
+        <StatusPill status={STATUS_PILL[view.status]}>{STATUS_LABEL[view.status]}</StatusPill>
+      </header>
+
+      <p className="mt-2 text-token-xs text-muted-foreground">{view.notice}</p>
+
+      {view.status === "missing" ? null : (
+        <>
+          <dl className="mt-3 grid grid-cols-2 gap-3 text-token-sm">
+            <Field label="Action" value={view.actionType ?? "—"} />
+            <Field label="Repo" value={view.target.repoFullName ?? "—"} />
+            <Field label="Confidence" value={view.confidence} />
+            <Field label="Freshness" value={view.freshness} />
+            <Field label="Generated" value={view.generatedAt ?? "—"} />
+            <Field label="Scoring model" value={view.scoringModelId ?? "—"} />
+          </dl>
+
+          {view.sources.length > 0 && (
+            <div className="mt-3">
+              <SubHeading>Evidence sources</SubHeading>
+              <ul className="mt-1.5 space-y-1 text-token-xs text-foreground/90">
+                {view.sources.map((source) => (
+                  <li key={source.name} className="flex items-center justify-between gap-2">
+                    <span className="font-mono">{source.name}</span>
+                    <span className="text-muted-foreground">
+                      {source.freshness}
+                      {source.generatedAt ? ` · ${source.generatedAt}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {view.staleReasons.length > 0 && (
+            <div className="mt-3 rounded-token border border-warning/30 bg-warning/[0.04] p-3 text-token-xs text-warning">
+              <SubHeading>Evidence caveats</SubHeading>
+              <ul className="mt-1.5 list-disc space-y-1 pl-4">
+                {view.staleReasons.map((reason) => (
+                  <li key={reason}>{reason}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {view.counterfactuals.length > 0 && (
+            <div className="mt-3">
+              <SubHeading>Why not the alternatives</SubHeading>
+              <div className="mt-1.5 space-y-2">
+                {view.counterfactuals.map((cf) => (
+                  <div
+                    key={`${cf.repoFullName}-${cf.recommendation}`}
+                    className="rounded-token border border-border/70 p-2.5"
+                  >
+                    <div className="font-mono text-token-2xs text-muted-foreground">
+                      {cf.repoFullName} · chose {cf.recommendation}
+                    </div>
+                    <ul className="mt-1 space-y-1.5 text-token-xs text-foreground/90">
+                      {cf.alternatives.map((alt, index) => (
+                        <li key={`${alt.alternative}-${index}`}>
+                          <span className="text-foreground">{alt.publicSummary}</span>
+                          {alt.reason ? (
+                            <span className="mt-0.5 block text-muted-foreground">{alt.reason}</span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {view.withheldPrivateFields.length > 0 && (
+            <p className="mt-3 text-token-2xs text-muted-foreground">
+              Private detail withheld for this context: {view.withheldPrivateFields.join(", ")}.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-0.5 truncate font-mono text-[12px] text-foreground/90">{value}</dd>
+    </div>
+  );
+}
+
+function SubHeading({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/lib/snapshot-replay.ts
+++ b/apps/gittensory-ui/src/lib/snapshot-replay.ts
@@ -1,0 +1,314 @@
+// Decision snapshot replay view model.
+//
+// Turns a persisted recommendation snapshot envelope (see
+// `src/services/recommendation-snapshots.ts`) plus its run's counterfactual
+// reasons into a human-readable, inspection-only replay view for the control
+// panel (issue #285). It is deterministic and fails closed: malformed or
+// missing evidence is represented explicitly rather than silently omitted, and
+// private/authenticated detail is withheld for public viewers.
+//
+// This module is intentionally standalone (no imports) so it can be unit-tested
+// directly and reused by the UI without pulling in worker-side types.
+
+export type SnapshotReplayViewer = "public" | "authenticated";
+export type SnapshotReplayStatus = "populated" | "stale" | "missing";
+export type SnapshotReplayConfidence = "high" | "medium" | "low" | "unknown";
+export type SnapshotReplayFreshness =
+  | "fresh"
+  | "stale"
+  | "rebuilding"
+  | "missing"
+  | "degraded"
+  | "possibly_stale"
+  | "unknown";
+
+export type SnapshotReplaySource = {
+  name: string;
+  freshness: SnapshotReplayFreshness;
+  generatedAt: string | null;
+};
+
+export type SnapshotReplayCounterfactualAlternative = {
+  alternative: string;
+  group: string;
+  publicSummary: string;
+  // Private/authenticated-only detail. Always null/empty for public viewers.
+  reason: string | null;
+  facts: string[];
+  assumptions: string[];
+};
+
+export type SnapshotReplayCounterfactual = {
+  repoFullName: string;
+  recommendation: string;
+  alternatives: SnapshotReplayCounterfactualAlternative[];
+};
+
+export type SnapshotReplayTarget = {
+  repoFullName: string | null;
+  pullNumber: number | null;
+  issueNumber: number | null;
+};
+
+export type SnapshotReplayView = {
+  status: SnapshotReplayStatus;
+  viewer: SnapshotReplayViewer;
+  snapshotId: string | null;
+  actionType: string | null;
+  target: SnapshotReplayTarget;
+  generatedAt: string | null;
+  scoringModelId: string | null;
+  confidence: SnapshotReplayConfidence;
+  freshness: SnapshotReplayFreshness;
+  sources: SnapshotReplaySource[];
+  evidenceGaps: string[];
+  evidenceComplete: boolean;
+  staleReasons: string[];
+  counterfactuals: SnapshotReplayCounterfactual[];
+  withheldPrivateFields: string[];
+  notice: string;
+};
+
+export type BuildSnapshotReplayViewInput = {
+  snapshot: unknown;
+  counterfactuals?: unknown;
+  viewer: SnapshotReplayViewer;
+};
+
+const CONFIDENCE_VALUES: ReadonlySet<SnapshotReplayConfidence> = new Set([
+  "high",
+  "medium",
+  "low",
+  "unknown",
+]);
+const FRESHNESS_VALUES: ReadonlySet<SnapshotReplayFreshness> = new Set([
+  "fresh",
+  "stale",
+  "rebuilding",
+  "missing",
+  "degraded",
+  "possibly_stale",
+  "unknown",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+  );
+}
+
+function narrowConfidence(value: unknown): SnapshotReplayConfidence {
+  return typeof value === "string" && CONFIDENCE_VALUES.has(value as SnapshotReplayConfidence)
+    ? (value as SnapshotReplayConfidence)
+    : "unknown";
+}
+
+function narrowFreshness(value: unknown): SnapshotReplayFreshness {
+  return typeof value === "string" && FRESHNESS_VALUES.has(value as SnapshotReplayFreshness)
+    ? (value as SnapshotReplayFreshness)
+    : "unknown";
+}
+
+function readTarget(value: unknown): SnapshotReplayTarget {
+  if (!isRecord(value)) return { repoFullName: null, pullNumber: null, issueNumber: null };
+  return {
+    repoFullName: asString(value.repoFullName),
+    pullNumber: asNumber(value.pullNumber),
+    issueNumber: asNumber(value.issueNumber),
+  };
+}
+
+function readSources(value: unknown): SnapshotReplaySource[] {
+  if (!Array.isArray(value)) return [];
+  const sources: SnapshotReplaySource[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const name = asString(entry.name);
+    if (!name) continue;
+    sources.push({
+      name,
+      freshness: narrowFreshness(entry.freshness),
+      generatedAt: asString(entry.generatedAt),
+    });
+  }
+  return sources;
+}
+
+function sameRepo(a: string | null, b: string | null): boolean {
+  return Boolean(a) && Boolean(b) && a!.toLowerCase() === b!.toLowerCase();
+}
+
+function readCounterfactuals(
+  value: unknown,
+  targetRepoFullName: string | null,
+): SnapshotReplayCounterfactual[] {
+  if (!Array.isArray(value)) return [];
+  const result: SnapshotReplayCounterfactual[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const repoFullName = asString(entry.repoFullName);
+    if (targetRepoFullName && repoFullName && !sameRepo(repoFullName, targetRepoFullName)) continue;
+    const alternatives = readAlternatives(entry.rejectedAlternatives);
+    if (alternatives.length === 0) continue;
+    result.push({
+      repoFullName: repoFullName ?? "unknown",
+      recommendation: asString(entry.recommendation) ?? "unknown",
+      alternatives,
+    });
+  }
+  return result;
+}
+
+function readAlternatives(value: unknown): SnapshotReplayCounterfactualAlternative[] {
+  if (!Array.isArray(value)) return [];
+  const alternatives: SnapshotReplayCounterfactualAlternative[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const publicSummary = asString(entry.publicSummary);
+    const reason = asString(entry.reason);
+    // Skip entries that carry neither a public summary nor a private reason.
+    if (!publicSummary && !reason) continue;
+    alternatives.push({
+      alternative: asString(entry.alternative) ?? "alternative",
+      group: asString(entry.group) ?? "other",
+      publicSummary: publicSummary ?? "Alternative considered.",
+      reason,
+      facts: asStringList(entry.facts),
+      assumptions: asStringList(entry.assumptions),
+    });
+  }
+  return alternatives;
+}
+
+/**
+ * Project counterfactuals for the viewer. Public viewers keep only the
+ * public-safe summary; the private reason/facts/assumptions are withheld and
+ * the withholding is recorded explicitly.
+ */
+function projectCounterfactuals(
+  counterfactuals: SnapshotReplayCounterfactual[],
+  viewer: SnapshotReplayViewer,
+): { counterfactuals: SnapshotReplayCounterfactual[]; withheldPrivateFields: string[] } {
+  if (viewer === "authenticated") return { counterfactuals, withheldPrivateFields: [] };
+
+  let withheldPrivate = false;
+  const projected = counterfactuals.map((cf) => ({
+    ...cf,
+    alternatives: cf.alternatives.map((alt) => {
+      if (alt.reason || alt.facts.length > 0 || alt.assumptions.length > 0) withheldPrivate = true;
+      return { ...alt, reason: null, facts: [], assumptions: [] };
+    }),
+  }));
+  return {
+    counterfactuals: projected,
+    withheldPrivateFields: withheldPrivate ? ["counterfactual_detail"] : [],
+  };
+}
+
+function missingView(
+  viewer: SnapshotReplayViewer,
+  notice: string,
+  partial?: Partial<SnapshotReplayView>,
+): SnapshotReplayView {
+  return {
+    status: "missing",
+    viewer,
+    snapshotId: null,
+    actionType: null,
+    target: { repoFullName: null, pullNumber: null, issueNumber: null },
+    generatedAt: null,
+    scoringModelId: null,
+    confidence: "unknown",
+    freshness: "missing",
+    sources: [],
+    evidenceGaps: [],
+    evidenceComplete: false,
+    staleReasons: [],
+    counterfactuals: [],
+    withheldPrivateFields: [],
+    notice,
+    ...partial,
+  };
+}
+
+/**
+ * Build a public-safe-aware, inspection-only replay view for a single decision
+ * snapshot. Returns a `missing` view when no snapshot/provenance is present.
+ */
+export function buildSnapshotReplayView(input: BuildSnapshotReplayViewInput): SnapshotReplayView {
+  const { viewer, snapshot } = input;
+  if (!isRecord(snapshot)) {
+    return missingView(viewer, "No decision snapshot is available to replay.");
+  }
+
+  const snapshotId = asString(snapshot.snapshotId);
+  const actionType = asString(snapshot.actionType);
+  const target = readTarget(snapshot.target);
+  const generatedAt = asString(snapshot.generatedAt);
+
+  const provenance = isRecord(snapshot.provenance) ? snapshot.provenance : null;
+  if (!provenance) {
+    return missingView(viewer, "This snapshot has no provenance to replay.", {
+      snapshotId,
+      actionType,
+      target,
+      generatedAt,
+    });
+  }
+
+  const confidence = narrowConfidence(provenance.confidence);
+  const freshness = narrowFreshness(provenance.freshness);
+  const scoringModelId = asString(provenance.scoringModelId);
+  const sources = readSources(provenance.sources);
+  const evidenceGaps = asStringList(provenance.evidenceGaps);
+  const evidenceComplete = provenance.evidenceComplete === true;
+
+  const matchedCounterfactuals = readCounterfactuals(input.counterfactuals, target.repoFullName);
+  const { counterfactuals, withheldPrivateFields } = projectCounterfactuals(
+    matchedCounterfactuals,
+    viewer,
+  );
+
+  const staleReasons: string[] = [];
+  if (freshness !== "fresh") staleReasons.push(`Snapshot freshness is ${freshness}.`);
+  if (!evidenceComplete) staleReasons.push("Evidence is incomplete.");
+  for (const gap of evidenceGaps) staleReasons.push(`Evidence gap — ${gap}.`);
+
+  const status: SnapshotReplayStatus = staleReasons.length > 0 ? "stale" : "populated";
+  const notice =
+    status === "populated"
+      ? "All replayed evidence is fresh and complete."
+      : `Replaying with ${staleReasons.length} evidence caveat${staleReasons.length === 1 ? "" : "s"}.`;
+
+  return {
+    status,
+    viewer,
+    snapshotId,
+    actionType,
+    target,
+    generatedAt,
+    scoringModelId,
+    confidence,
+    freshness,
+    sources,
+    evidenceGaps,
+    evidenceComplete,
+    staleReasons,
+    counterfactuals,
+    withheldPrivateFields,
+    notice,
+  };
+}

--- a/apps/gittensory-ui/src/routes/app.runs.tsx
+++ b/apps/gittensory-ui/src/routes/app.runs.tsx
@@ -27,6 +27,10 @@ import { useSession } from "@/lib/api/session";
 import { EmptyState } from "@/components/site/state-views";
 import { useLocalStorage } from "@/lib/use-local-storage";
 import { cn } from "@/lib/utils";
+import { SnapshotReplayCard } from "@/components/site/snapshot-replay";
+import { buildSnapshotReplayView, type SnapshotReplayView } from "@/lib/snapshot-replay";
+
+type SnapshotReplayPair = { authenticated: SnapshotReplayView; publicSafe: SnapshotReplayView };
 
 const SIGNAL: Record<string, Status> = {
   ready: "ready",
@@ -58,6 +62,7 @@ interface AgentRun {
   created_at: string;
   summary?: string;
   recommendations?: string[];
+  snapshotReplays: SnapshotReplayPair[];
 }
 
 type AgentRunBundleResponse = {
@@ -81,11 +86,13 @@ type AgentRunBundle = {
     actionType: string;
     targetRepoFullName?: string | null;
     recommendation?: string | null;
+    payload?: Record<string, unknown> | undefined;
   }>;
   contextSnapshots: Array<{
     scoringModelId?: string | null;
     decisionPackVersion?: string | null;
     freshnessWarnings?: string[];
+    payload?: Record<string, unknown> | undefined;
   }>;
   summary: string;
 };
@@ -386,6 +393,24 @@ function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
     bundle.contextSnapshots[0]?.scoringModelId ??
     bundle.contextSnapshots[0]?.decisionPackVersion ??
     "live";
+  const counterfactuals = bundle.contextSnapshots.flatMap((snapshot) => {
+    const reasons = snapshot.payload?.counterfactualReasons;
+    return Array.isArray(reasons) ? reasons : [];
+  });
+  const snapshotReplays = bundle.actions
+    .map((action) => action.payload?.recommendationSnapshot)
+    .filter(
+      (snapshot): snapshot is Record<string, unknown> =>
+        typeof snapshot === "object" && snapshot !== null && !Array.isArray(snapshot),
+    )
+    .map((snapshot) => ({
+      authenticated: buildSnapshotReplayView({
+        snapshot,
+        counterfactuals,
+        viewer: "authenticated",
+      }),
+      publicSafe: buildSnapshotReplayView({ snapshot, counterfactuals, viewer: "public" }),
+    }));
   return {
     id: bundle.run.id,
     source: bundle.run.surface === "github_comment" ? "github-command" : bundle.run.surface,
@@ -403,6 +428,7 @@ function mapAgentRunBundle(bundle: AgentRunBundle): AgentRun {
     created_at: bundle.run.createdAt ?? bundle.run.updatedAt ?? new Date().toISOString(),
     summary: bundle.summary,
     recommendations: bundle.actions.map((action) => action.recommendation).filter(isString),
+    snapshotReplays,
   };
 }
 
@@ -778,6 +804,24 @@ function DrawerSurface({
             ))}
           </ul>
         </div>
+
+        {run.snapshotReplays.length > 0 && (
+          <div className="space-y-2">
+            <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+              Snapshot replay
+            </div>
+            {run.snapshotReplays.map((replay) => (
+              <SnapshotReplayCard
+                key={
+                  replay.authenticated.snapshotId ??
+                  `${replay.authenticated.actionType}-${replay.authenticated.generatedAt}`
+                }
+                authenticated={replay.authenticated}
+                publicSafe={replay.publicSafe}
+              />
+            ))}
+          </div>
+        )}
       </motion.div>
 
       <footer className="border-t border-border p-4">

--- a/test/unit/snapshot-replay-ui.test.ts
+++ b/test/unit/snapshot-replay-ui.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSnapshotReplayView } from "../../apps/gittensory-ui/src/lib/snapshot-replay";
+
+describe("buildSnapshotReplayView", () => {
+  it("renders a populated replay from fresh, complete provenance", () => {
+    const view = buildSnapshotReplayView({ snapshot: snapshot(), viewer: "authenticated" });
+    expect(view.status).toBe("populated");
+    expect(view.notice).toBe("All replayed evidence is fresh and complete.");
+    expect(view.snapshotId).toBe("recommendation:context-1:run-1:00:choose_next_work");
+    expect(view.actionType).toBe("choose_next_work");
+    expect(view.confidence).toBe("high");
+    expect(view.freshness).toBe("fresh");
+    expect(view.scoringModelId).toBe("scoring-1");
+    expect(view.target).toEqual({ repoFullName: "JSONbored/gittensory", pullNumber: 12, issueNumber: null });
+    expect(view.sources).toEqual([
+      { name: "contributor_decision_pack", freshness: "fresh", generatedAt: "2026-06-08T00:00:00.000Z" },
+    ]);
+    expect(view.evidenceComplete).toBe(true);
+    expect(view.staleReasons).toEqual([]);
+  });
+
+  it("marks stale freshness, incomplete evidence, and gaps as explicit caveats", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot({
+        provenance: provenance({
+          freshness: "stale",
+          evidenceComplete: false,
+          evidenceGaps: ["official_contributor_stats: missing"],
+          sources: [{ name: "official_contributor_stats", freshness: "missing", generatedAt: null }],
+        }),
+      }),
+      viewer: "authenticated",
+    });
+    expect(view.status).toBe("stale");
+    expect(view.staleReasons).toEqual([
+      "Snapshot freshness is stale.",
+      "Evidence is incomplete.",
+      "Evidence gap — official_contributor_stats: missing.",
+    ]);
+    expect(view.notice).toBe("Replaying with 3 evidence caveats.");
+  });
+
+  it("returns a missing view when the snapshot is absent or malformed", () => {
+    for (const bad of [null, undefined, "nope", 42, []] as unknown[]) {
+      const view = buildSnapshotReplayView({ snapshot: bad, viewer: "authenticated" });
+      expect(view.status).toBe("missing");
+      expect(view.notice).toBe("No decision snapshot is available to replay.");
+    }
+  });
+
+  it("returns a missing view but preserves identity when provenance is absent", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot({ provenance: undefined }),
+      viewer: "authenticated",
+    });
+    expect(view.status).toBe("missing");
+    expect(view.notice).toBe("This snapshot has no provenance to replay.");
+    expect(view.snapshotId).toBe("recommendation:context-1:run-1:00:choose_next_work");
+    expect(view.actionType).toBe("choose_next_work");
+    expect(view.target.repoFullName).toBe("JSONbored/gittensory");
+  });
+
+  it("shows private counterfactual detail for authenticated viewers", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot(),
+      counterfactuals: counterfactuals(),
+      viewer: "authenticated",
+    });
+    expect(view.counterfactuals).toEqual([
+      {
+        repoFullName: "JSONbored/gittensory",
+        recommendation: "contribute_now",
+        alternatives: [
+          {
+            alternative: "cleanup_existing",
+            group: "cleanup",
+            publicSummary: "Cleanup was lower priority than new work.",
+            reason: "Open PR pressure is below the spam threshold.",
+            facts: ["2 open PRs"],
+            assumptions: ["threshold is 5"],
+          },
+        ],
+      },
+    ]);
+    expect(view.withheldPrivateFields).toEqual([]);
+  });
+
+  it("withholds private counterfactual detail for public viewers", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot(),
+      counterfactuals: counterfactuals(),
+      viewer: "public",
+    });
+    const alt = view.counterfactuals[0]?.alternatives[0];
+    expect(alt?.publicSummary).toBe("Cleanup was lower priority than new work.");
+    expect(alt?.reason).toBeNull();
+    expect(alt?.facts).toEqual([]);
+    expect(alt?.assumptions).toEqual([]);
+    expect(view.withheldPrivateFields).toEqual(["counterfactual_detail"]);
+    expect(JSON.stringify(view)).not.toMatch(/Open PR pressure is below|2 open PRs|threshold is 5/);
+  });
+
+  it("only includes counterfactuals for the snapshot's target repo", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot(),
+      counterfactuals: [
+        ...counterfactuals(),
+        { repoFullName: "other/repo", recommendation: "skip", rejectedAlternatives: [{ publicSummary: "Other repo alt." }] },
+      ],
+      viewer: "authenticated",
+    });
+    expect(view.counterfactuals).toHaveLength(1);
+    expect(view.counterfactuals[0]?.repoFullName).toBe("JSONbored/gittensory");
+  });
+
+  it("narrows unknown confidence/freshness and skips malformed sources and alternatives", () => {
+    const view = buildSnapshotReplayView({
+      snapshot: snapshot({
+        provenance: provenance({
+          confidence: "stellar",
+          freshness: "ancient",
+          sources: ["nope", {}, { name: "" }, { name: "repo_decision", freshness: "weird" }] as unknown[],
+        }),
+      }),
+      counterfactuals: [
+        { repoFullName: "JSONbored/gittensory", recommendation: "contribute_now", rejectedAlternatives: ["x", {}, { facts: [] }] },
+      ],
+      viewer: "authenticated",
+    });
+    expect(view.confidence).toBe("unknown");
+    expect(view.freshness).toBe("unknown");
+    expect(view.sources).toEqual([{ name: "repo_decision", freshness: "unknown", generatedAt: null }]);
+    expect(view.counterfactuals).toEqual([]);
+  });
+});
+
+function provenance(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    confidence: "high",
+    freshness: "fresh",
+    generatedAt: "2026-06-08T00:00:00.000Z",
+    scoringModelId: "scoring-1",
+    repoSignalSnapshotIds: [],
+    sources: [{ name: "contributor_decision_pack", freshness: "fresh", generatedAt: "2026-06-08T00:00:00.000Z" }],
+    evidenceGaps: [],
+    evidenceComplete: true,
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    kind: "recommendation_snapshot",
+    version: 1,
+    snapshotId: "recommendation:context-1:run-1:00:choose_next_work",
+    contextSnapshotId: "context-1",
+    actionId: "run-1:00:choose_next_work",
+    runId: "run-1",
+    actionType: "choose_next_work",
+    generatedAt: "2026-06-08T00:00:00.000Z",
+    publicSafe: true,
+    target: { repoFullName: "JSONbored/gittensory", pullNumber: 12 },
+    provenance: provenance(),
+  };
+  const merged = { ...base, ...overrides };
+  if ("provenance" in overrides && overrides.provenance === undefined) delete merged.provenance;
+  return merged;
+}
+
+function counterfactuals(): Array<Record<string, unknown>> {
+  return [
+    {
+      repoFullName: "JSONbored/gittensory",
+      recommendation: "contribute_now",
+      rejectedAlternatives: [
+        {
+          alternative: "cleanup_existing",
+          group: "cleanup",
+          rank: 1,
+          reason: "Open PR pressure is below the spam threshold.",
+          facts: ["2 open PRs"],
+          assumptions: ["threshold is 5"],
+          publicSummary: "Cleanup was lower priority than new work.",
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Add an inspection-only decision snapshot replay view in the control panel (Agent runs → run detail) that surfaces a snapshot's public-safe provenance: confidence, freshness, evidence sources, scoring model, repo-signal snapshot ids, and explicit evidence gaps.
- Render counterfactuals ("why not the alternatives") behind an **Authenticated ⇄ Public-safe** audience toggle — private `reason`/`facts`/`assumptions` are shown only to authenticated viewers and withheld (with an explicit notice) in the public-safe view.
- Represent missing, stale, and incomplete evidence explicitly (status pill + caveats) instead of silently omitting it; fail closed on malformed snapshots.
- Add a pure, standalone view-model builder (`buildSnapshotReplayView`) with focused unit tests for populated / stale / missing / private states. No schema, API/OpenAPI, or migration changes.

Closes #285

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

`npm run test:ci` passes end to end. Coverage (`src/**` scope): statements **99.07%**, branches **97.05%**, functions **98.52%**, lines **99.71%** (all ≥ 97%). `npm audit` reports 0 vulnerabilities. The new view-model is unit-tested by `test/unit/snapshot-replay-ui.test.ts` (8 tests: populated, stale, missing, missing-provenance, authenticated counterfactuals, public-safe withholding with a leakage assertion, target filtering, and defensive parsing). Note: `apps/**` is outside the `src/**` coverage scope, so these UI additions do not affect the global coverage gate.

If any required check was skipped, explain why:

- None. The full `npm run test:ci` gate was run locally and passed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. The public-safe view withholds private counterfactual `reason`/`facts`/`assumptions`; provenance exposes only structured identifiers, enums, and timestamps. A unit test asserts the serialized public view excludes the private detail.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A — no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. N/A — read-only UI that consumes the existing freeform agent-run action payload (snapshot provenance from #282, counterfactuals from #361); no contract change (`ui:openapi:check` clean).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. The panel builds replays from live `/v1/agent/runs` data; missing/stale states are derived from real evidence, with no mock/demo fallback.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. N/A — no docs/changelog changes.

## UI Evidence

Agent runs → run detail → **Snapshot replay**. The audience toggle switches between the authenticated and public-safe views; private counterfactual detail is shown only when authenticated and withheld for the public-safe view.

| State / title | JPG/PNG evidence |
| --- | --- |
| Authenticated (loaded) — full provenance + private counterfactuals, with toggle | <img width="1416" height="1112" alt="snapshot-replay-card" src="https://github.com/user-attachments/assets/dfb793b8-2972-4d75-a9d9-1d5b76e5a4a2" /> |
| Public-safe — private counterfactual detail withheld | <img width="1416" height="1010" alt="snapshot-replay-public" src="https://github.com/user-attachments/assets/b0a781c1-36e1-4d62-b48f-39b27b427941" /> |
| Stale evidence — explicit caveats | <img width="1416" height="1234" alt="snapshot-replay-stale" src="https://github.com/user-attachments/assets/96be3f6a-1276-41c4-b300-2e577c216a15" /> |
| Missing evidence | <img width="1416" height="242" alt="snapshot-replay-missing" src="https://github.com/user-attachments/assets/28f4ef59-9c5e-4aec-93be-264b2d78cefd" /> |

## Notes

- No DB migration and no schema/OpenAPI change: provenance comes from the recommendation snapshot envelope (added in #282) and counterfactuals from the existing context-snapshot payload (#361); the view derives everything client-side and renders inline in the existing Agent runs detail.
- Inspection-only by design — no issue filing, PR creation, comments, labels, closure, or merge actions are added (per the issue's scope).
- Public/private separation is structural: the raw private evidence stays in the action payload and is never copied into the public-safe view; the audience toggle switches between two precomputed views and never re-derives withheld fields.
- Files changed (4, +737): `apps/gittensory-ui/src/lib/snapshot-replay.ts` (view-model + tests target), `apps/gittensory-ui/src/components/site/snapshot-replay.tsx` (`SnapshotReplay` + `SnapshotReplayCard` toggle), `apps/gittensory-ui/src/routes/app.runs.tsx` (wires it into run detail), `test/unit/snapshot-replay-ui.test.ts`.
