### PR TITLE
fix(auth): scope issue-quality reports to repo access

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1504,6 +1504,14 @@ export function createApp() {
 
   app.get("/v1/repos/:owner/:repo/issue-quality", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- Protected middleware rejects unauthenticated private routes before route-specific repo guards. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const repo = identity.kind === "session" ? await getRepository(c.env, fullName) : null;
+    if (identity.kind === "session") {
+      const forbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (forbidden) return forbidden;
+    }
     const response = await buildIssueQualityResponse(c.env, fullName);
     if (!response) return c.json({ error: "issue_quality_not_found", repoFullName: fullName }, 404);
     return c.json(response);
@@ -3487,6 +3495,7 @@ function isExtensionScopedSession(identity: AuthIdentity): boolean {
 function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: "session" }>, path: string): boolean {
   if (isAuthorizedGitHubSessionLogin(env, identity.actor)) return true;
   if (path.startsWith("/v1/app/")) return true;
+  if (isIssueQualityPath(path)) return true;
   if (isRepoOnboardingPackPreviewPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
@@ -3499,6 +3508,10 @@ function isRepoOnboardingPackPreviewPath(path: string): boolean {
 
 function isRepoContributorIssueDraftGeneratePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/contributor-issue-drafts\/generate$/.test(path);
+}
+
+function isIssueQualityPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-quality$/.test(path);
 }
 
 async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,7 +5,7 @@ import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/proto
 import { ElicitResultSchema, type ServerNotification, type ServerRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { authenticatePrivateToken, extractBearerToken, type AuthIdentity } from "../auth/security";
-import { loadControlPanelRoleSummary } from "../services/control-panel-roles";
+import { loadControlPanelAccessScope, loadControlPanelRoleSummary } from "../services/control-panel-roles";
 import {
   countOpenIssues,
   countOpenPullRequests,
@@ -862,6 +862,12 @@ export class GittensoryMcp {
 
   private async getIssueQuality(input: { owner: string; repo: string }): Promise<ToolPayload> {
     const fullName = `${input.owner}/${input.repo}`;
+    if (!(await this.canAccessRepo(fullName))) {
+      return {
+        summary: `Forbidden: session cannot access issue quality for ${fullName}.`,
+        data: { status: "forbidden", repoFullName: fullName },
+      };
+    }
     const response = await loadOrComputeIssueQualityResponse(this.env, fullName);
     if (!response) {
       return {
@@ -876,6 +882,16 @@ export class GittensoryMcp {
           : `Gittensory issue quality for ${fullName} (computed from cached metadata).`,
       data: response as unknown as Record<string, unknown>,
     };
+  }
+
+  private async canAccessRepo(fullName: string): Promise<boolean> {
+    if (this.identity.kind !== "session") return true;
+    const [summary, repo] = await Promise.all([loadControlPanelRoleSummary(this.env, this.identity.actor), getRepository(this.env, fullName)]);
+    if (summary.roles.includes("operator")) return true;
+    const scope = await loadControlPanelAccessScope(this.env, this.identity.actor);
+    const requestedRepo = fullName.toLowerCase();
+    if (scope.repositoryFullNames.some((name) => name.toLowerCase() === requestedRepo)) return true;
+    return Boolean(repo && scope.accountLogins.some((login) => login.toLowerCase() === repo.owner.toLowerCase()));
   }
 
   private async getRepoOutcomePatterns(input: { owner: string; repo: string }): Promise<ToolPayload> {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1352,6 +1352,11 @@ describe("api routes", () => {
       report: { repoFullName: "entrius/allways-ui", issues: expect.any(Array) },
     });
 
+    const { token: unrelatedIssueQualityToken } = await createSessionForGitHubUser(env, { login: "unrelated-user", id: 404 });
+    const forbiddenIssueQuality = await app.request("/v1/repos/entrius/allways-ui/issue-quality", { headers: { authorization: `Bearer ${unrelatedIssueQualityToken}` } }, env);
+    expect(forbiddenIssueQuality.status).toBe(403);
+    await expect(forbiddenIssueQuality.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
     await upsertRepositoryFromGitHub(env, { name: "uncached", full_name: "entrius/uncached", private: false, owner: { login: "entrius" }, default_branch: "main" });
     const computedIssueQuality = await app.request("/v1/repos/entrius/uncached/issue-quality", { headers: apiHeaders(env) }, env);
     expect(computedIssueQuality.status).toBe(200);

--- a/test/unit/mcp-upstream.test.ts
+++ b/test/unit/mcp-upstream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { authenticatePrivateToken, createSessionForGitHubUser } from "../../src/auth/security";
-import { persistUpstreamRulesetSnapshot, upsertUpstreamDriftReport } from "../../src/db/repositories";
+import { persistSignalSnapshot, persistUpstreamRulesetSnapshot, upsertRepositoryFromGitHub, upsertUpstreamDriftReport } from "../../src/db/repositories";
 import { GittensoryMcp } from "../../src/mcp/server";
 import type { UpstreamDriftReportRecord, UpstreamRulesetSnapshotRecord } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
@@ -15,6 +15,33 @@ describe("MCP contributor access", () => {
     await expect((mcp as unknown as { monitorOpenPullRequests(login: string): Promise<unknown> }).monitorOpenPullRequests("victim")).rejects.toThrow(
       /Forbidden: session can only access the authenticated GitHub login/,
     );
+  });
+
+  it("blocks session actors from issue-quality reports for inaccessible repos", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "private-repo", full_name: "victim/private-repo", private: true, owner: { login: "victim" }, default_branch: "main" });
+    await persistSignalSnapshot(env, {
+      id: "private-issue-quality",
+      signalType: "issue-quality",
+      targetKey: "victim/private-repo",
+      repoFullName: "victim/private-repo",
+      payload: {
+        repoFullName: "victim/private-repo",
+        generatedAt: "2026-05-25T00:00:00.000Z",
+        lane: { lane: "issue_discovery" },
+        issues: [{ number: 1, title: "SECRET private issue", status: "ready", score: 90, reasons: [], warnings: [] }],
+        summary: "fixture",
+      },
+      generatedAt: "2026-05-25T00:00:00.000Z",
+    });
+    const { token } = await createSessionForGitHubUser(env, { login: "attacker", id: 7 });
+    const identity = await authenticatePrivateToken(env, token);
+    if (!identity || identity.kind !== "session") throw new Error("expected session identity");
+
+    const payload = await (new GittensoryMcp(env, identity) as unknown as { getIssueQuality(input: { owner: string; repo: string }): Promise<{ data: Record<string, unknown> }> }).getIssueQuality({ owner: "victim", repo: "private-repo" });
+
+    expect(payload.data).toEqual({ status: "forbidden", repoFullName: "victim/private-repo" });
+    expect(JSON.stringify(payload)).not.toContain("SECRET private issue");
   });
 });
 


### PR DESCRIPTION
### Motivation
- Issue-quality reports (REST and MCP) could be retrieved by any bearer-authenticated identity because `authenticatePrivateToken` accepts session tokens and the loader returned cached snapshots without caller-scoped authorization, exposing private issue titles and triage signals. 
- The goal is to enforce repository-scoped access checks before loading or returning sensitive `issue-quality` payloads so sessions cannot enumerate private repo metadata.

### Description
- Require an authenticated identity and apply `requireSessionRepoAccess` before returning `/v1/repos/:owner/:repo/issue-quality` in `src/api/routes.ts` so session callers must have repo access before the report is loaded. 
- Add an `isIssueQualityPath` matcher and allow the route to be considered by session path-scoping helpers so the global protected-route middleware and route-specific guard work together. 
- Add `canAccessRepo` to the MCP server and gate `gittensory_get_issue_quality` in `src/mcp/server.ts` to return a non-leaking forbidden payload when the caller lacks access. 
- Add regression tests that assert unrelated session tokens receive `403` on the REST endpoint and that the MCP tool returns a forbidden payload without leaking snapshot contents (`test/integration/api.test.ts` and `test/unit/mcp-upstream.test.ts`).

### Testing
- Ran the focused test subset with `npm exec vitest run test/unit/mcp-upstream.test.ts test/integration/api.test.ts -- --reporter=verbose` and the tests passed. 
- Ran static type checks with `npm run typecheck` and the TypeScript check completed successfully. 
- New assertions verify REST returns `403` with `{ error: "forbidden_repo" }` for unrelated sessions and MCP returns a `{ status: "forbidden", repoFullName }` payload without exposing sensitive report fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27188b5cbc832a8443531094a48310)