### PR TITLE
fix(auth): enforce repo-scoped access for self-dogfood registration pack

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1530,6 +1530,13 @@ export function createApp() {
   app.get("/v1/app/self-dogfood/registration-pack", async (c) => {
     const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
     if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const fullName = resolveSelfDogfoodRepoFullName(c.env);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
     return c.json(await buildSelfDogfoodRegistrationPackResponse(c.env));
   });
 

--- a/test/unit/routes-self-dogfood-registration-pack.test.ts
+++ b/test/unit/routes-self-dogfood-registration-pack.test.ts
@@ -1,15 +1,34 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 const SELF_DOGFOOD_PATH = "/v1/repos/JSONbored/gittensory/self-dogfood-registration-pack";
+const APP_SELF_DOGFOOD_PATH = "/v1/app/self-dogfood/registration-pack";
 
 function apiHeaders(env: Env): Record<string, string> {
   return {
     authorization: `Bearer ${env.GITTENSORY_API_TOKEN}`,
     "content-type": "application/json",
   };
+}
+
+async function seedInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
 }
 
 describe("self-dogfood registration-pack route auth", () => {
@@ -41,6 +60,31 @@ describe("self-dogfood registration-pack route auth", () => {
     );
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: "self_dogfood_repo_only", repoFullName: "JSONbored/gittensory" });
+  });
+
+  it("rejects app-route sessions scoped only to an unrelated installed repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedInstalledRepo(env, 201, "JSONbored", "gittensory");
+    await seedInstalledRepo(env, 202, "unrelated-owner", "unrelated-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "unrelated-owner", id: 202 });
+    const response = await app.request(APP_SELF_DOGFOOD_PATH, { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("allows app-route sessions scoped to the configured self-dogfood repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedInstalledRepo(env, 201, "JSONbored", "gittensory");
+    const { token } = await createSessionForGitHubUser(env, { login: "JSONbored", id: 201 });
+    const response = await app.request(APP_SELF_DOGFOOD_PATH, { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      kind: "gittensory_self_dogfood_registration_pack",
+      repoFullName: "JSONbored/gittensory",
+      privateOnly: true,
+    });
   });
 
   it("allows static-token access to the configured self-dogfood repo", async () => {


### PR DESCRIPTION
### Motivation
- The app-level `/v1/app/self-dogfood/registration-pack` route performed a global role check (`requireAppRole`) but did not verify that a browser session actually had access to the configured self-dogfood repository, allowing maintainers of unrelated repos to view a private report.

### Description
- Require the resolved self-dogfood repo and its `RepositoryRecord` inside the app route and call `requireSessionRepoAccess` for `session` identities before returning the pack. 
- Preserve existing app-role guard by keeping the `requireAppRole` check and only adding a repo-scoped access check for browser sessions. 
- Add unit tests and a `seedInstalledRepo` helper to cover the new behavior, verifying that an unrelated repo-scoped session receives `forbidden_repo` and that a session scoped to the configured repo is allowed. 
- Update imports in the test to seed installations and repositories for the auth scenarios. 

### Testing
- Ran `npm run test:unit -- test/unit/routes-self-dogfood-registration-pack.test.ts` and the added tests passed. 
- Ran `tsc --noEmit` via `npm run typecheck` and typechecking succeeded. 
- The full unit test run in this environment completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2835f8a448832ab4beb7252e481d3e)