### PR TITLE
fix(api): scope app command feedback by repo access

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1086,6 +1086,11 @@ export function createApp() {
     if (!parsed.success) return c.json({ error: "invalid_command_feedback", issues: parsed.error.issues }, 400);
     const answer = await getAgentCommandAnswer(c.env, parsed.data.answerId);
     if (!answer) return c.json({ error: "command_answer_not_found" }, 404);
+    const repo = await getRepository(c.env, answer.repoFullName);
+    if (identity.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, answer.repoFullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
     const actorLogin = identity.actor;
     await recordAgentCommandFeedback(c.env, {
       answerId: answer.id,

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1803,6 +1803,53 @@ describe("api routes", () => {
     );
     expect(forbiddenVictimPreview.status).toBe(403);
     await expect(forbiddenVictimPreview.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+    await upsertAgentCommandAnswer(ownerEnv, {
+      id: "owned-app-feedback",
+      repoFullName: "repo-owner/owned-repo",
+      issueNumber: 7,
+      command: "plan-next-work",
+      requestCommentId: 700,
+      responseCommentId: 701,
+      responseUrl: "https://github.com/repo-owner/owned-repo/pull/7#issuecomment-701",
+      actorKind: "maintainer",
+      createdAt: "2026-05-28T00:00:00.000Z",
+      updatedAt: "2026-05-28T00:00:00.000Z",
+      metadata: {},
+    });
+    await upsertAgentCommandAnswer(ownerEnv, {
+      id: "victim-app-feedback",
+      repoFullName: "victim-org/secret-repo",
+      issueNumber: 42,
+      command: "plan-next-work",
+      requestCommentId: 4200,
+      responseCommentId: 4201,
+      responseUrl: "https://github.com/victim-org/secret-repo/pull/42#issuecomment-4201",
+      actorKind: "maintainer",
+      createdAt: "2026-05-28T00:00:00.000Z",
+      updatedAt: "2026-05-28T00:00:00.000Z",
+      metadata: {},
+    });
+    const ownerRepoFeedback = await app.request(
+      "/v1/app/commands/feedback",
+      {
+        method: "POST",
+        headers: ownerHeaders,
+        body: JSON.stringify({ answerId: "owned-app-feedback", vote: "useful" }),
+      },
+      ownerEnv,
+    );
+    expect(ownerRepoFeedback.status).toBe(200);
+    const forbiddenVictimFeedback = await app.request(
+      "/v1/app/commands/feedback",
+      {
+        method: "POST",
+        headers: ownerHeaders,
+        body: JSON.stringify({ answerId: "victim-app-feedback", vote: "not_useful" }),
+      },
+      ownerEnv,
+    );
+    expect(forbiddenVictimFeedback.status).toBe(403);
+    await expect(forbiddenVictimFeedback.json()).resolves.toMatchObject({ error: "forbidden_repo" });
     const { token: operatorToken } = await createSessionForGitHubUser(ownerEnv, { login: "jsonbored", id: 1 });
     const operatorVictimPreview = await app.request(
       "/v1/app/commands/preview",


### PR DESCRIPTION
### Motivation
- The app feedback endpoint accepted any authenticated identity and recorded feedback for arbitrary answer IDs, allowing non-maintainers to vote on answers and exposing repo/issue metadata for known answer IDs.
- The intent is to require repository-scoped access for session-based browser users before recording app-surface feedback or returning answer metadata, aligning the app path with the stricter GitHub reaction authorization policy.

### Description
- Add a repository lookup and session-scoped guard before recording app command feedback by calling `getRepository` and `requireSessionRepoAccess` when `identity.kind === "session"` in the `/v1/app/commands/feedback` handler in `src/api/routes.ts`.
- Preserve the existing `requireAppRole` guard for control-panel roles and only enforce repo-scoped access for session identities to avoid widening static-token behavior.
- Add integration coverage in `test/integration/api.test.ts` to verify that an in-scope repo owner can submit feedback for their repository's answer while the same user is denied when using a known answer ID from an out-of-scope private repo.

### Testing
- Ran the targeted integration suite with `npx vitest run test/integration/api.test.ts --reporter verbose`, and the integration file completed successfully (all tests passed).
- Ran static type checks with `npm run typecheck` (`tsc --noEmit`) and the typecheck completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b23296c832a9d7e88752518fd74)