### PR TITLE
fix(commands): redact private score projection deltas

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1337,8 +1337,9 @@ function sanitizeFeedbackAnswerId(answerId: string): string {
 
 export function sanitizePublicComment(value: string): string {
   const sanitized = value
+    .replace(/\bprojected score changes?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\b(raw trust score|trust score|wallet|hotkey|coldkey|seed phrase|mnemonic)\b/gi, "private context")
-    .replace(/\b(public score estimate|estimated score|score estimate|reward estimates?|payout|farming|scoreability|score preview)\b/gi, "private context")
+    .replace(/\b(public score estimate|estimated score|score estimate|reward estimates?|payout|farming|scoreability|score preview|projected score changes?)\b/gi, "private context")
     .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
     .replace(/\b(private ranking|private rankings)\b/gi, "private context")
     .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -147,8 +147,40 @@ describe("GitHub mention commands", () => {
     );
     expect(sanitizePublicComment("public score estimate and scoreability should stay private")).not.toMatch(/public score estimate|scoreability/i);
     expect(sanitizePublicComment("public score estimate private scoreability context score preview")).not.toMatch(/public score estimate|scoreability|score preview/i);
+    expect(sanitizePublicComment("projected score changes 12.3 -> 45.6")).not.toMatch(/projected score changes|12\.3|45\.6/i);
     expect(sanitizePublicComment("Command: @gittensory reviewability")).toContain("@gittensory reviewability");
     expect(sanitizePublicComment("private ranking, wallet, payout")).toBe("private context");
+  });
+
+  it("redacts private score projection deltas from public command rerun guidance", () => {
+    const baseBundle = sampleBundle();
+    const bundle = {
+      ...baseBundle,
+      actions: [
+        {
+          ...baseBundle.actions[0]!,
+          actionType: "prepare_pr_packet" as const,
+          publicSafeSummary: "Prepare public PR packet after validation completes.",
+          rerunWhen:
+            "Rerun after pending PRs merge/close or after open PR count is at or below 3; projected score changes 12.3 -> 45.6.",
+        },
+      ],
+    };
+
+    for (const mention of ["@gittensory preflight", "@gittensory reviewability", "@gittensory packet"]) {
+      const body = buildPublicAgentCommandComment({
+        command: parseGittensoryMentionCommand(mention)!,
+        repo: { fullName: "owner/repo" } as any,
+        issue: { number: 12, title: "PR", state: "open", pull_request: {} },
+        pullRequest: null,
+        actorKind: "author",
+        bundle,
+      });
+
+      expect(body).toContain("Rerun when:");
+      expect(body).toContain("private context");
+      expect(body).not.toMatch(/projected score changes|12\.3|45\.6/i);
+    }
   });
 
   it("adds parseable aggregate-only feedback context without public leak terms", () => {


### PR DESCRIPTION
### Motivation
- Prevent accidental public disclosure of private score-preview values that can appear in agent rerun guidance phrases such as "projected score changes X -> Y" which were reachable from public GitHub mention commands.

### Description
- Update `sanitizePublicComment` in `src/github/commands.ts` to explicitly redact the full `projected score changes` phrase including numeric deltas via a new regex match. 
- Also add the plain phrase `projected score changes` to the general forbidden-phrase replacement so isolated mentions are handled.
- Add regression coverage in `test/unit/github-commands.test.ts` that asserts the sanitizer removes both the phrase and numeric score deltas and that public command outputs for `@gittensory preflight`, `@gittensory reviewability`, and `@gittensory packet` do not leak the numeric projections.

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/github-commands.test.ts`, and the test file passed (all tests succeeded). 
- Ran TypeScript typecheck with `npm run typecheck`, and it completed successfully with no errors. 
- Verified repository formatting/lint/diff checks (`git diff --check`) produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283a5f75d8832a85524ffcc33f056f)