### PR TITLE
fix(signals): verify solver PR linkage

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -2812,11 +2812,13 @@ function buildIssueLinkageRecord(
   linkedPrs: PullRequestRecord[],
   linkedMergedPrs: RecentMergedPullRequestRecord[],
 ): IssueLinkageRecord {
+  const verifiedMergedPrs = linkedPrs.filter((pr) => pr.linkedIssues.includes(issue.number) && (pr.mergedAt || pr.state === "merged"));
+  const verifiedRecentMergedPrs = linkedMergedPrs.filter((pr) => pr.linkedIssues.includes(issue.number));
   const solvedByPullRequests = [
     ...new Set([
       ...(lifecycleEntry?.solvedByPullRequests ?? []),
-      ...linkedPrs.filter((pr) => pr.mergedAt || pr.state === "merged").map((pr) => pr.number),
-      ...linkedMergedPrs.map((pr) => pr.number),
+      ...verifiedMergedPrs.map((pr) => pr.number),
+      ...verifiedRecentMergedPrs.map((pr) => pr.number),
     ]),
   ].sort((left, right) => left - right);
   const linkedWorkCount = linkedPrs.length + linkedMergedPrs.length + issue.linkedPrs.length;
@@ -2865,8 +2867,8 @@ function classifyIssueDiscoveryLifecycle(
   recentMergedPullRequests: RecentMergedPullRequestRecord[],
   lane: LaneAdvice,
 ): IssueDiscoveryLifecycleReport["states"][number] {
-  const linkedOpenPrs = pullRequests.filter((pr) => pr.linkedIssues.includes(issue.number) || issue.linkedPrs.includes(pr.number));
-  const linkedMergedPrs = recentMergedPullRequests.filter((pr) => pr.linkedIssues.includes(issue.number) || issue.linkedPrs.includes(pr.number));
+  const linkedOpenPrs = pullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
+  const linkedMergedPrs = recentMergedPullRequests.filter((pr) => pr.linkedIssues.includes(issue.number));
   const solvedByPullRequests = [...new Set([...linkedOpenPrs.filter((pr) => pr.mergedAt || pr.state === "merged").map((pr) => pr.number), ...linkedMergedPrs.map((pr) => pr.number)])].sort(
     (left, right) => left - right,
   );

--- a/test/unit/issue-quality.test.ts
+++ b/test/unit/issue-quality.test.ts
@@ -171,6 +171,24 @@ describe("issue quality reports", () => {
     });
   });
 
+  it("does not treat issue-body PR mentions as solved lifecycle evidence", () => {
+    const repo = issueDiscoveryRepo("owner/untrusted-issue-pr-mention");
+    const poisoned = issue(repo.fullName, 7, "Unsolved report mentions unrelated PR", {
+      body: "Detailed report with reproduction steps, but it only says PR #123 looks related.",
+      linkedPrs: [123],
+    });
+    const unrelatedMergedPr = recentMergedPr(repo.fullName, 123, "Unrelated merged work", { linkedIssues: [] });
+
+    const lifecycle = buildIssueDiscoveryLifecycleReport(repo, [poisoned], [], repo.fullName, [unrelatedMergedPr]);
+    expect(lifecycle.states[0]).toMatchObject({ number: 7, state: "open", solvedByPullRequests: [] });
+
+    const quality = buildIssueQualityReport(repo, [poisoned], [], repo.fullName, [], undefined, [unrelatedMergedPr]);
+    expect(quality.issues[0]).toMatchObject({
+      lifecycle: "open",
+      linkage: { status: "plausible", solvedByPullRequests: [] },
+    });
+  });
+
   it("records raw, validated, and closed-not-solved linkage states separately", () => {
     const repo = issueDiscoveryRepo("owner/linkage");
     const raw = issue(repo.fullName, 1, "Raw issue", { body: "x".repeat(220) });


### PR DESCRIPTION
### Motivation
- Prevent untrusted issue-body PR mentions from being promoted to solver evidence and incorrectly marking issues as `valid_solved`/`solved`.
- The classifier previously treated `issue.linkedPrs.includes(pr.number)` as equivalent to PR-side `linkedIssues`, enabling an attacker-controlled issue body to poison lifecycle outputs.

### Description
- Require PR-side linkage when deciding solved-by-PR evidence by only considering PRs whose `linkedIssues` includes the issue number in `classifyIssueDiscoveryLifecycle` and `buildIssueLinkageRecord` (changes in `src/signals/engine.ts`).
- Filter merged PRs into `solvedByPullRequests` only when the PR itself explicitly links the issue, keeping `issue.linkedPrs` as weak, plausible context rather than validated evidence.
- Add a regression test `does not treat issue-body PR mentions as solved lifecycle evidence` to `test/unit/issue-quality.test.ts` that asserts an issue mentioning `PR #123` with an unrelated merged PR does not become `valid_solved`.

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/issue-quality.test.ts`, and the file passed: 1 test file, 19 tests passed.
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) which completed without errors.
- Verified diffs and lint-style checks (`git diff --check`) showed no whitespace or diff-check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b0fe5c8832ab196153852a679d1)