### PR TITLE
fix(signals): account for queue burden in readiness score

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3844,7 +3844,7 @@ function queuePressureComponent(queueHealth: QueueHealth): { score: number; max:
   const cachedOpenPullRequests = Math.max(0, signals.cachedOpenPullRequests ?? signals.ageBuckets.under7Days + signals.ageBuckets.days7To30 + signals.ageBuckets.over30Days);
   const likelyReviewablePullRequests = Math.max(0, Math.min(openPullRequests, signals.likelyReviewablePullRequests));
   const sampledLikelyReviewable = signals.likelyReviewablePullRequestsSource === "sampled_cache" || (signals.likelyReviewablePullRequestsSource === undefined && cachedOpenPullRequests < openPullRequests);
-  const score = queuePressureScore(openPullRequests);
+  const score = queuePressureScore(queueHealth, openPullRequests);
   const likelyEvidence =
     openPullRequests === 0
       ? "0 likely reviewable"
@@ -3867,10 +3867,22 @@ function queuePressureComponent(queueHealth: QueueHealth): { score: number; max:
   };
 }
 
-function queuePressureScore(openPullRequests: number): number {
+function queuePressureScore(queueHealth: QueueHealth, openPullRequests: number): number {
+  if (openPullRequests === 0) return 10;
+  return Math.min(queuePressureOpenPullRequestScore(openPullRequests), queuePressureLevelScore(queueHealth.level));
+}
+
+function queuePressureOpenPullRequestScore(openPullRequests: number): number {
   if (openPullRequests <= 4) return 10;
   if (openPullRequests <= 8) return 8;
   if (openPullRequests <= 13) return 5;
+  return 3;
+}
+
+function queuePressureLevelScore(level: QueueHealth["level"]): number {
+  if (level === "low") return 10;
+  if (level === "medium") return 8;
+  if (level === "high") return 5;
   return 3;
 }
 

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1176,6 +1176,30 @@ describe("signal coverage edge cases", () => {
       action: "No action.",
     });
 
+    const staleQueuePullRequests = [44, 45, 46, 47].map((number) =>
+      pr(directRepo.fullName, number, `Stale unlinked queue item ${number}`, {
+        updatedAt: "2020-01-01T00:00:00.000Z",
+      }),
+    );
+    const criticalBurdenQueue = buildQueueHealth(
+      directRepo,
+      [],
+      staleQueuePullRequests,
+      buildCollisionReport(directRepo.fullName, [], staleQueuePullRequests),
+    );
+    expect(criticalBurdenQueue).toMatchObject({ level: "critical", burdenScore: 100 });
+
+    const criticalBurdenScore = buildPublicReadinessScore({
+      pr: currentPr,
+      preflight: { ...preflight, status: "ready", reviewBurden: "low", findings: [] },
+      queueHealth: criticalBurdenQueue,
+    });
+    expect(scoreComponent(criticalBurdenScore, "queue_pressure")).toMatchObject({
+      score: 3,
+      evidence: "4 open PR(s), 0 likely reviewable, 4 stale, 4 unlinked.",
+      action: "Expect slower review.",
+    });
+
     const sampledQueue = buildQueueHealth(
       directRepo,
       [],


### PR DESCRIPTION
### Motivation
- The queue-pressure component previously scored purely from `signals.openPullRequests`, which could produce a perfect queue score for small open-PR counts even when `QueueHealth.burdenScore`/`level` indicated critical burden from stale/unlinked/collision signals, allowing a readiness total to bypass a configured blocking quality Gate.

### Description
- Change `queuePressureScore` to accept `QueueHealth` and use the more conservative score between open-PR pressure and `QueueHealth.level`, while preserving `10/10` for genuine zero open-PR evidence by short-circuiting on `openPullRequests === 0` in `queuePressureScore`.
- Introduce `queuePressureOpenPullRequestScore` and `queuePressureLevelScore` helper functions and wire them into `queuePressureComponent` so level-derived burden cannot be ignored.
- Add a regression test in `test/unit/signals-coverage.test.ts` that constructs a small (4 PR) queue with stale/unlinked items and asserts the queue component scores low and reports the expected evidence.

### Testing
- Ran the focused test: `npm test -- test/unit/signals-coverage.test.ts`, which passed after the changes. 
- Ran type checking: `npm run typecheck`, which passed with no errors. 
- Ran the full test suite: `npm test`, with all tests passing (`1388 passed | 1 skipped`). 
- Ran `git diff --check` and code formatting/type checks with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b23a148832a942c660bd0196248)