### PR TITLE
fix(raycast): reject unsafe base refs

### DIFF
--- a/src/raycast/local-repo-analyzer.ts
+++ b/src/raycast/local-repo-analyzer.ts
@@ -76,7 +76,8 @@ export function collectRaycastLocalRepoMetadata(input: {
     throw new Error("Raycast branch analysis supports metadata-only mode; source upload mode is rejected.");
   }
   const git = input.git ?? gitLines;
-  const baseRef = input.baseRef ?? git(input.cwd, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])[0]?.replace(/^origin\//, "") ?? "main";
+  const rawBaseRef = input.baseRef ?? git(input.cwd, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])[0]?.replace(/^origin\//, "") ?? "main";
+  const baseRef = validateSafeBaseRef(rawBaseRef);
   const remoteUrl = git(input.cwd, ["config", "--get", "remote.origin.url"])[0] ?? "";
   const repoFullName = input.repoFullName ?? parseGitHubRemote(remoteUrl);
   if (!repoFullName) throw new Error("Could not infer repoFullName from the git remote; pass repoFullName explicitly.");
@@ -198,6 +199,13 @@ async function postJson(
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(errorFromPayload(payload, response));
   return payload;
+}
+
+function validateSafeBaseRef(baseRef: string): string {
+  if (!baseRef || baseRef.startsWith("-")) {
+    throw new Error("Unsafe git baseRef; pass a branch or ref name that does not begin with '-'.");
+  }
+  return baseRef;
 }
 
 function collectChangedFiles(cwd: string, baseRef: string, git: RaycastGitRunner): RaycastChangedFileMetadata[] {

--- a/test/unit/raycast-local-repo-analyzer.test.ts
+++ b/test/unit/raycast-local-repo-analyzer.test.ts
@@ -111,6 +111,37 @@ describe("Raycast local repo analyzer", () => {
     expect(calls.map((call) => call.split(" ")[0]).join("\n")).not.toMatch(/^(cat|show|grep|archive)$/m);
   });
 
+  it("rejects inferred base refs that could be parsed as git options", () => {
+    const { git, calls } = fakeGit({
+      "symbolic-ref --short refs/remotes/origin/HEAD": "origin/--output=/tmp/gittensory-owned\n",
+    });
+
+    expect(() =>
+      collectRaycastLocalRepoMetadata({
+        cwd: "/tmp/private-checkout",
+        login: "jsonbored",
+        repoFullName: "JSONbored/gittensory",
+        git,
+      }),
+    ).toThrow(/unsafe git baseRef/i);
+    expect(calls).toEqual(["symbolic-ref --short refs/remotes/origin/HEAD"]);
+  });
+
+  it("rejects explicit base refs that could be parsed as git options", () => {
+    const git = vi.fn<RaycastGitRunner>();
+
+    expect(() =>
+      collectRaycastLocalRepoMetadata({
+        cwd: "/tmp/private-checkout",
+        login: "jsonbored",
+        repoFullName: "JSONbored/gittensory",
+        baseRef: "--output=/tmp/gittensory-owned",
+        git,
+      }),
+    ).toThrow(/unsafe git baseRef/i);
+    expect(git).not.toHaveBeenCalled();
+  });
+
   it("rejects source upload mode before running git", () => {
     const git = vi.fn<RaycastGitRunner>();
 


### PR DESCRIPTION
### Motivation
- Prevent git option injection by validating the inferred or caller-supplied `baseRef` before it is reused in `git` invocations so values like `--output=/tmp/pwn` cannot be parsed as git options.

### Description
- Add `validateSafeBaseRef(baseRef: string)` which rejects empty or dash-prefixed refs and returns the validated ref for downstream use.
- Replace the previous `baseRef` assignment with a `rawBaseRef` and validate it via `const baseRef = validateSafeBaseRef(rawBaseRef);` before any `git` calls.
- Add regression tests to `test/unit/raycast-local-repo-analyzer.test.ts` covering both inferred remote HEAD refs and explicit `baseRef` inputs that start with `-` to ensure they are rejected early.

### Testing
- Ran `git diff --check` which produced no issues and succeeded.
- Ran `npx vitest run test/unit/raycast-local-repo-analyzer.test.ts` and all unit tests passed (`Test Files 1 passed`, `Tests 15 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b106424832abe8d4b7d6156a146)