### PR TITLE
fix(commands): guard command authorization preview lookups

### DIFF
--- a/src/settings/command-authorization.ts
+++ b/src/settings/command-authorization.ts
@@ -51,7 +51,8 @@ export function normalizeCommandAuthorizationPolicy(input: unknown): { policy: R
 
 export function commandAuthorizationAllowedRoles(policy: RepositoryCommandAuthorizationPolicy | null | undefined, commandName: string): CommandAuthorizationRole[] {
   const normalized = normalizeCommandAuthorizationPolicy(policy).policy;
-  return dedupeRoles(normalized.commands[commandName] ?? normalized.default);
+  const commandRoles = Object.hasOwn(normalized.commands, commandName) ? normalized.commands[commandName] : undefined;
+  return dedupeRoles(commandRoles ?? normalized.default);
 }
 
 export function commandAuthorizationNeedsMinerDetection(args: {

--- a/test/unit/command-authorization.test.ts
+++ b/test/unit/command-authorization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  commandAuthorizationAllowedRoles,
   commandAuthorizationNeedsMinerDetection,
   evaluateCommandAuthorization,
   normalizeCommandAuthorizationPolicy,
@@ -52,6 +53,17 @@ describe("repo command authorization policy", () => {
       authorized: false,
       reason: "command_policy_denied",
     });
+  });
+
+  it("falls back to default roles for inherited object property command names", () => {
+    for (const commandName of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      expect(commandAuthorizationAllowedRoles(undefined, commandName)).toEqual(["maintainer", "collaborator", "confirmed_miner"]);
+      expect(evaluateCommandAuthorization({ commandName, commenterAssociation: "OWNER" })).toMatchObject({
+        authorized: true,
+        reason: "maintainer_invocation",
+        allowedRoles: ["maintainer", "collaborator", "confirmed_miner"],
+      });
+    }
   });
 
   it("warns on malformed policy and falls back to default command roles", () => {


### PR DESCRIPTION
### Motivation
- Prevent a crash in the settings preview when untrusted `commandName` values that are inherited object properties (for example `constructor`, `toString`, `__proto__`) are indexed on `normalized.commands` and then passed to `dedupeRoles`, which caused a `TypeError` and availability impact.

### Description
- Use `Object.hasOwn(normalized.commands, commandName)` before reading `normalized.commands[commandName]` so prototype properties do not get treated as command role arrays and instead fall back to `normalized.default`, and add unit coverage in `test/unit/command-authorization.test.ts` exercising inherited property names through `commandAuthorizationAllowedRoles` and `evaluateCommandAuthorization`.

### Testing
- Ran `npx vitest run test/unit/command-authorization.test.ts --pool=threads --reporter=default` and `npm run typecheck`, both succeeded, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b104354832ab814b6248aa70dd9)