### PR TITLE
fix(cli): reject prototype agent profile names

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -2004,9 +2004,8 @@ function initClient(options) {
 function resolveAgentProfile(profileId) {
   if (!profileId) return null;
   const id = String(profileId).trim().toLowerCase();
-  const profile = AGENT_PROFILES[id];
-  if (!profile) throw new Error(`Unsupported agent profile: ${profileId}. Use ${AGENT_PROFILE_IDS.join(", ")}.`);
-  return profile;
+  if (!Object.hasOwn(AGENT_PROFILES, id)) throw new Error(`Unsupported agent profile: ${profileId}. Use ${AGENT_PROFILE_IDS.join(", ")}.`);
+  return AGENT_PROFILES[id];
 }
 
 function formatAgentProfile(profile) {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -1106,7 +1106,10 @@ describe("gittensory-mcp CLI", () => {
   });
 
   it("rejects unsupported agent profiles", () => {
-    expect(() => run(["init-client", "--print", "codex", "--agent-profile", "autopilot"])).toThrow(/Unsupported agent profile/);
+    for (const profile of ["autopilot", "__proto__", "constructor"]) {
+      expect(() => run(["init-client", "--print", "codex", "--agent-profile", profile])).toThrow(/Unsupported agent profile/);
+      expect(() => run(["init-client", "--print", "codex", "--agent-profile", profile, "--json"])).toThrow(/Unsupported agent profile/);
+    }
   });
 
   it("reports the package version via version, --version, and -v", () => {


### PR DESCRIPTION
### Motivation
- Fix a CLI validation bug where inherited prototype properties like `__proto__` or `constructor` could be accepted as agent profiles and lead to malformed JSON or runtime `TypeError` crashes.
- Ensure agent profile resolution only accepts explicit registry keys to avoid accidental or malicious use of prototype names.

### Description
- Replace plain bracket lookup in `resolveAgentProfile` with an own-property check using `Object.hasOwn(AGENT_PROFILES, id)` and then return `AGENT_PROFILES[id]` in `packages/gittensory-mcp/bin/gittensory-mcp.js`.
- Extend the unit test `it("rejects unsupported agent profiles")` in `test/unit/mcp-cli.test.ts` to assert that unsupported names including `__proto__` and `constructor` are rejected in both plain and `--json` output modes.
- The change preserves existing error behavior and message when an unsupported profile is supplied.

### Testing
- Ran `npm run build:mcp` which completed successfully.
- Ran targeted test `npx vitest run test/unit/mcp-cli.test.ts -t "rejects unsupported agent profiles"` which passed.
- Ran the full unit test file `npx vitest run test/unit/mcp-cli.test.ts` and all tests passed (52 passed, 0 failed for the suite run during verification).
- Manual CLI checks confirmed `node packages/gittensory-mcp/bin/gittensory-mcp.js init-client --print codex --agent-profile __proto__ --json` and `--agent-profile constructor` now exit with an error and print `Unsupported agent profile: ...` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b1ca104832aa5d6b9ae3d3f1c68)