### PR TITLE
fix(mcp): include config command in shell completions

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -28,6 +28,7 @@ const CLI_COMMAND_SPEC = {
   login: [],
   logout: [],
   whoami: [],
+  config: [],
   status: [],
   changelog: [],
   completion: [],

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -1141,18 +1141,19 @@ describe("gittensory-mcp CLI", () => {
     expect(bash).toContain("_gittensory_mcp()");
     expect(bash).toContain("complete -F _gittensory_mcp gittensory-mcp");
     expect(bash).toContain("analyze-branch");
-    expect(bash).toContain("local commands=\"login logout whoami status changelog completion version doctor");
+    expect(bash).toContain("local commands=\"login logout whoami config status changelog completion version doctor");
     expect(bash).toContain("version");
     expect(bash).toContain("plan status explain packet");
 
     const zsh = run(["completion", "zsh"]);
     expect(zsh).toContain("#compdef gittensory-mcp");
     expect(zsh).toContain("_describe 'command' commands");
-    expect(zsh).toContain("commands=(login logout whoami status changelog completion version doctor");
+    expect(zsh).toContain("commands=(login logout whoami config status changelog completion version doctor");
     expect(zsh).toContain("list create switch remove");
 
     const fish = run(["completion", "fish"]);
     expect(fish).toContain("complete -c gittensory-mcp");
+    expect(fish).toContain("complete -c gittensory-mcp -n __fish_use_subcommand -a config");
     expect(fish).toContain("complete -c gittensory-mcp -n __fish_use_subcommand -a completion");
     expect(fish).toContain("__fish_seen_subcommand_from agent");
   });


### PR DESCRIPTION
### Motivation
- The `config` CLI command was added to the dispatcher and help text but was omitted from the `CLI_COMMAND_SPEC` used to generate shell completions, causing tab-completion for bash, zsh, and fish to not suggest the command.

### Description
- Add `config` to `CLI_COMMAND_SPEC` in `packages/gittensory-mcp/bin/gittensory-mcp.js` so completion generation includes the command.
- Update `test/unit/mcp-cli.test.ts` expectations to assert the generated bash, zsh, and fish completion scripts include `config`.

### Testing
- Ran the CLI unit tests with `npm test -- test/unit/mcp-cli.test.ts` and all tests passed (52 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283a5eb47c832aa52089ab9deb685b)