### PR TITLE
fix(scoring): wire duplicate risk preview input

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -437,6 +437,7 @@ const scorePreviewSchema = z.object({
   openPrCount: z.number().int().min(0).optional(),
   credibility: z.number().min(0).max(1).optional(),
   changesRequestedCount: z.number().int().min(0).optional(),
+  duplicateRiskCount: z.number().int().min(0).optional(),
   fixedBaseScore: z.number().min(0).optional(),
   metadataOnly: z.boolean().default(false),
   pendingMergedPrCount: z.number().int().min(0).optional(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -253,6 +253,7 @@ const scorePreviewShape = {
   openPrCount: z.number().int().min(0).optional(),
   credibility: z.number().min(0).max(1).optional(),
   changesRequestedCount: z.number().int().min(0).optional(),
+  duplicateRiskCount: z.number().int().min(0).optional(),
   metadataOnly: z.boolean().default(true),
   pendingMergedPrCount: z.number().int().min(0).optional(),
   pendingClosedPrCount: z.number().int().min(0).optional(),

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1345,6 +1345,7 @@ describe("api routes", () => {
           totalTokenScore: 60,
           sourceLines: 40,
           openPrCount: 1,
+          duplicateRiskCount: 2,
         }),
       },
       env,
@@ -1353,7 +1354,12 @@ describe("api routes", () => {
     await expect(scorePreview.json()).resolves.toMatchObject({
       repoFullName: "entrius/allways-ui",
       targetType: "planned_pr",
-      result: { privateOnly: true, scoringModelSnapshotId: "scoring-1" },
+      input: { duplicateRiskCount: 2 },
+      result: {
+        privateOnly: true,
+        scoringModelSnapshotId: "scoring-1",
+        blockedBy: expect.arrayContaining([expect.objectContaining({ code: "duplicate_risk", severity: "reducer" })]),
+      },
     });
     const noContributorScorePreview = await app.request(
       "/v1/scoring/preview",
@@ -4333,6 +4339,39 @@ describe("api routes", () => {
     const callPayload = (await mcpJson(call)) as { result: { structuredContent: { repoFullName: string }; content: Array<{ text: string }> } };
     expect(callPayload.result.structuredContent.repoFullName).toBe("entrius/allways-ui");
     expect(callPayload.result.content[0]?.text).not.toMatch(/reward|farming/i);
+
+    const scorePreviewCall = await app.request(
+      "/mcp",
+      {
+        method: "POST",
+        headers: mcpHeaders(env),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "score-preview-duplicate-risk",
+          method: "tools/call",
+          params: {
+            name: "gittensory_preview_local_pr_score",
+            arguments: {
+              repoFullName: "entrius/allways-ui",
+              targetKey: "mcp-duplicate-risk",
+              sourceTokenScore: 40,
+              totalTokenScore: 60,
+              sourceLines: 42,
+              duplicateRiskCount: 2,
+            },
+          },
+        }),
+      },
+      env,
+    );
+    expect(scorePreviewCall.status).toBe(200);
+    const scorePreviewPayload = (await mcpJson(scorePreviewCall)) as {
+      result: { structuredContent: { input: { duplicateRiskCount?: number }; result: { blockedBy: Array<{ code: string; severity: string }> } } };
+    };
+    expect(scorePreviewPayload.result.structuredContent.input.duplicateRiskCount).toBe(2);
+    expect(scorePreviewPayload.result.structuredContent.result.blockedBy).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "duplicate_risk", severity: "reducer" })]),
+    );
 
     const noTotalsContext = await app.request(
       "/mcp",


### PR DESCRIPTION
### Motivation
- The `duplicate_risk` reducer blocker in `buildScorePreview()` depended on `ScorePreviewInput.duplicateRiskCount`, but public API, MCP tool shapes, and some production call paths did not preserve or populate that field so the blocker was effectively unreachable in normal flows.

### Description
- Add `duplicateRiskCount` to the public scoring preview Zod schema in `src/api/routes.ts` so `/v1/scoring/preview` preserves the signal into `buildScorePreview()`.
- Add `duplicateRiskCount` to the MCP `scorePreviewShape` in `src/mcp/server.ts` so MCP tool calls (e.g. `gittensory_preview_local_pr_score`) and variant comparisons can provide the signal.
- Add integration assertions in `test/integration/api.test.ts` to verify the API and MCP tool retain `duplicateRiskCount` and that the resulting preview includes the `duplicate_risk` reducer blocker.
- Kept existing local-branch wiring that already supplies `duplicateRiskCount` from preflight collisions, so the change only exposes the value to API/MCP callers and test coverage.

### Testing
- Ran the focused test subset with `npm test -- --run test/integration/api.test.ts test/unit/local-branch.test.ts test/unit/scenario-blockers.test.ts` and all tests passed (`Test Files 3 passed (3)`, `Tests 80 passed (80)`).
- Ran typecheck with `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b10589c832aa9f5da908d9b845a)