### PR TITLE
fix(api): allow maintainer settings preview sessions

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1647,12 +1647,17 @@ export function createApp() {
   });
 
   app.post("/v1/repos/:owner/:repo/settings-preview", async (c) => {
+    const identity = await authenticateRequestIdentity(c);
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
     const body = (await c.req.json().catch(() => null)) ?? {};
     const parsed = settingsPreviewSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid_settings_preview_request", issues: parsed.error.issues }, 400);
-    const [repo, settings, issues, pullRequests] = await Promise.all([
-      getRepository(c.env, fullName),
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const unauthorized = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (unauthorized) return unauthorized;
+    }
+    const [settings, issues, pullRequests] = await Promise.all([
       getRepositorySettings(c.env, fullName),
       listIssues(c.env, fullName),
       listPullRequests(c.env, fullName),
@@ -3564,10 +3569,15 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isAuthorizedGitHubSessionLogin(env, identity.actor)) return true;
   if (path.startsWith("/v1/app/")) return true;
   if (isIssueQualityPath(path)) return true;
+  if (isRepoSettingsPreviewPath(path)) return true;
   if (isRepoOnboardingPackPreviewPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
   return false;
+}
+
+function isRepoSettingsPreviewPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/settings-preview$/.test(path);
 }
 
 function isRepoOnboardingPackPreviewPath(path: string): boolean {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1841,6 +1841,20 @@ describe("api routes", () => {
     expect((await app.request("/v1/app/operator-dashboard", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/daily-rollups", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/mcp-compatibility", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
+    const ownerSettingsPreview = await app.request(
+      "/v1/repos/repo-owner/owned-repo/settings-preview",
+      { method: "POST", headers: ownerHeaders, body: JSON.stringify({ sample: { authorLogin: "oktofeesh1", minerStatus: "confirmed" } }) },
+      ownerEnv,
+    );
+    expect(ownerSettingsPreview.status).toBe(200);
+    await expect(ownerSettingsPreview.json()).resolves.toMatchObject({ repoFullName: "repo-owner/owned-repo" });
+    const forbiddenVictimSettingsPreview = await app.request(
+      "/v1/repos/victim-org/secret-repo/settings-preview",
+      { method: "POST", headers: ownerHeaders, body: JSON.stringify({ sample: { authorLogin: "oktofeesh1", minerStatus: "confirmed" } }) },
+      ownerEnv,
+    );
+    expect(forbiddenVictimSettingsPreview.status).toBe(403);
+    await expect(forbiddenVictimSettingsPreview.json()).resolves.toMatchObject({ error: "forbidden_repo" });
     const ownerWeeklyReport = await app.request("/v1/app/analytics/weekly-value-report", { headers: ownerHeaders }, ownerEnv);
     expect(ownerWeeklyReport.status).toBe(200);
     const ownerWeeklyReportBody = await ownerWeeklyReport.json();


### PR DESCRIPTION
### Motivation
- The maintainer UI posts settings preview requests to `/v1/repos/:owner/:repo/settings-preview` using the browser session cookie, but the global session gate only allowed `/v1/app/*`, causing legitimate maintainer sessions to receive `403` and the feature to fail.

### Description
- The `POST /v1/repos/:owner/:repo/settings-preview` route now authenticates the request identity and enforces repository-scoped access for session identities via `requireSessionRepoAccess`, while leaving static API-token usage unchanged.
- The global session path allowlist (`canSessionAccessPath`) was extended to permit the settings preview path by adding an `isRepoSettingsPreviewPath` helper.
- An integration test was added to `test/integration/api.test.ts` to verify a maintainer/owner session can preview its owned repo and is forbidden from previewing unrelated repos.

### Testing
- Ran the integration tests with `npm test -- test/integration/api.test.ts`, which completed successfully (33 tests passed).
- Ran the TypeScript check with `npm run typecheck`, which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283a61b698832a837ee5442a3d06b1)