### PR TITLE
fix(signals): redact windows home paths in public PR packets

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1339,7 +1339,7 @@ function requirePublicSafePacketMarkdown(markdown) {
 }
 
 function isUnsafePublicPacketText(value) {
-  return /\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:\\Users\\/i.test(value);
+  return /\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i.test(value);
 }
 
 function printVersion(options) {

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1162,7 +1162,7 @@ function firstCommitTitle(messages: string[] | undefined): string | undefined {
 }
 
 function isPublicSafeText(text: string): boolean {
-  return !/\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:\\Users\\/i.test(text);
+  return !/\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i.test(text);
 }
 
 function safeRepoPath(path: string): string {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1092,6 +1092,31 @@ describe("local branch analysis", () => {
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score|\/Users\/example/i);
   });
 
+  it("removes Windows home paths from public PR packet title and validation lines", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        title: "Fix cache failure from C:\\Users\\alice\\workspace",
+        body: "Fixes #7",
+        changedFiles: [{ path: "src/cache.ts", additions: 12, deletions: 2, status: "modified" }],
+        validation: [
+          { command: "npm test C:\\Users\\alice\\workspace\\cache.log", status: "passed", summary: "log at C:\\Users\\alice\\workspace\\cache.log" },
+        ],
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Cache refresh fails", state: "open", labels: ["bug"], linkedPrs: [] }],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.prPacket.markdown).toContain("## Validation");
+    expect(analysis.prPacket.markdown).not.toMatch(/C:\\Users\\alice/i);
+  });
+
   it("removes snake_case private signals from public PR packet markdown", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -890,7 +890,18 @@ describe("gittensory-mcp CLI", () => {
     git(tempDir, "commit", "-m", "initial commit");
     git(tempDir, "checkout", "-b", "codex/public-safe-pr-packets");
 
-    for (const unsafePhrase of ["score: 1.15", "reward estimate", "wallet address", "hotkey id", "raw-trust: 0.7", "private-reviewability: ready", "raw_trust: 0.7", "private_reviewability: ready", "trust_score: 0.4"]) {
+    for (const unsafePhrase of [
+      "score: 1.15",
+      "reward estimate",
+      "wallet address",
+      "hotkey id",
+      "raw-trust: 0.7",
+      "private-reviewability: ready",
+      "raw_trust: 0.7",
+      "private_reviewability: ready",
+      "trust_score: 0.4",
+      "log path C:\\Users\\alice\\workspace\\raw.log",
+    ]) {
       if (server) await new Promise<void>((resolve) => server?.close(() => resolve()));
       server = null;
       const url = await startFixtureServer({ packetMarkdown: `# Public-safe PR packet\n\n- ${unsafePhrase}\n` });


### PR DESCRIPTION
### Motivation
- Public-safe PR packet text and the CLI safety gate were not rejecting Windows home-directory paths that use normal backslashes (e.g. `C:\Users\alice\...`), which could leak local workspace paths in copy-paste PR text.

### Description
- Strengthen the server-side public-safety check by updating `isPublicSafeText` to detect Windows home paths with either `\` or `/` separators (in `src/signals/local-branch.ts`).
- Apply the same Windows-path handling to the MCP CLI final safety gate by updating `isUnsafePublicPacketText` (in `packages/gittensory-mcp/bin/gittensory-mcp.js`).
- Add regression tests that verify Windows home paths are removed/rejected from packet titles and validation lines (in `test/unit/local-branch.test.ts`) and that server-provided packet markdown containing a normal `C:\Users\...` path is refused by the CLI test (in `test/unit/mcp-cli.test.ts`).

### Testing
- Ran unit tests: `npm test -- --run test/unit/local-branch.test.ts test/unit/mcp-cli.test.ts`, and all targeted tests passed.
- Ran type checking: `npm run typecheck` (`tsc --noEmit`) with no errors.
- Ran repository checks: `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283b0ed97c832aba18c6df56b70526)