### PR TITLE
fix(signals): isolate readiness queue pressure from burden level

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3850,7 +3850,7 @@ function queuePressureComponent(queueHealth: QueueHealth): { score: number; max:
   const cachedOpenPullRequests = Math.max(0, signals.cachedOpenPullRequests ?? signals.ageBuckets.under7Days + signals.ageBuckets.days7To30 + signals.ageBuckets.over30Days);
   const likelyReviewablePullRequests = Math.max(0, Math.min(openPullRequests, signals.likelyReviewablePullRequests));
   const sampledLikelyReviewable = signals.likelyReviewablePullRequestsSource === "sampled_cache" || (signals.likelyReviewablePullRequestsSource === undefined && cachedOpenPullRequests < openPullRequests);
-  const score = queuePressureScore(queueHealth, openPullRequests);
+  const score = queuePressureScore(openPullRequests);
   const likelyEvidence =
     openPullRequests === 0
       ? "0 likely reviewable"
@@ -3873,22 +3873,15 @@ function queuePressureComponent(queueHealth: QueueHealth): { score: number; max:
   };
 }
 
-function queuePressureScore(queueHealth: QueueHealth, openPullRequests: number): number {
+function queuePressureScore(openPullRequests: number): number {
   if (openPullRequests === 0) return 10;
-  return Math.min(queuePressureOpenPullRequestScore(openPullRequests), queuePressureLevelScore(queueHealth.level));
+  return queuePressureOpenPullRequestScore(openPullRequests);
 }
 
 function queuePressureOpenPullRequestScore(openPullRequests: number): number {
   if (openPullRequests <= 4) return 10;
   if (openPullRequests <= 8) return 8;
   if (openPullRequests <= 13) return 5;
-  return 3;
-}
-
-function queuePressureLevelScore(level: QueueHealth["level"]): number {
-  if (level === "low") return 10;
-  if (level === "medium") return 8;
-  if (level === "high") return 5;
   return 3;
 }
 

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1195,9 +1195,29 @@ describe("signal coverage edge cases", () => {
       queueHealth: criticalBurdenQueue,
     });
     expect(scoreComponent(criticalBurdenScore, "queue_pressure")).toMatchObject({
-      score: 3,
+      score: 10,
       evidence: "4 open PR(s), 0 likely reviewable, 4 stale, 4 unlinked.",
-      action: "Expect slower review.",
+      action: "No action.",
+    });
+
+    const noisyIssues = Array.from({ length: 80 }, (_, index) => issue(directRepo.fullName, index + 1000, `Unrelated issue ${index + 1}`));
+    const issueBurdenQueue = buildQueueHealth(
+      directRepo,
+      noisyIssues,
+      [currentPr],
+      buildCollisionReport(directRepo.fullName, noisyIssues, [currentPr]),
+    );
+    expect(issueBurdenQueue).toMatchObject({ level: "critical" });
+
+    const issueBurdenScore = buildPublicReadinessScore({
+      pr: currentPr,
+      preflight: { ...preflight, status: "ready", reviewBurden: "low", findings: [] },
+      queueHealth: issueBurdenQueue,
+    });
+    expect(scoreComponent(issueBurdenScore, "queue_pressure")).toMatchObject({
+      score: 10,
+      evidence: "1 open PR(s), 1 likely reviewable.",
+      action: "No action.",
     });
 
     const sampledQueue = buildQueueHealth(


### PR DESCRIPTION
### Motivation
- Prevent repository-wide, attacker-influenced burden signals (open issues / noisy PRs) from lowering a target PR's public readiness queue-pressure score used by opt-in blocking Gate policies.
- Keep the public readiness queue-pressure metric PR-scoped so unrelated issue spam cannot cause availability/integrity failures for protected branches.

### Description
- Change `queuePressureScore` to be driven solely by `openPullRequests` and remove its use of `queueHealth.level` so the per-PR readiness row no longer depends on repo-wide burden level. 
- Remove the `queuePressureLevelScore` branch and its call sites, and update `queuePressureComponent` to call the simplified `queuePressureScore(openPullRequests)`. 
- Update `test/unit/signals-coverage.test.ts` to assert that a target PR's `queue_pressure` score is unaffected by unrelated noisy issues and to add a regression case that builds an issue-heavy `QueueHealth` and verifies the PR-scoped score remains high. 

### Testing
- Ran the focused unit tests with `npm test -- --run test/unit/signals-coverage.test.ts` and all tests in that file passed (`22 passed`).
- Ran TypeScript checks with `npm run typecheck` and `tsc --noEmit` completed successfully. 
- Confirmed no lint/diff issues with the local workspace checks used during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29948467f8832a82a75f97bf228147)