### PR TITLE
fix(api): move focus manifest refresh off GET

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -14687,6 +14687,36 @@
           }
         ]
       }
+    },
+    "/v1/repos/{owner}/{repo}/focus-manifest/refresh": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Refresh the persisted focus manifest cache from the repo file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1582,7 +1582,21 @@ export function createApp() {
       const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
       if (repoForbidden) return repoForbidden;
     }
-    const manifest = await loadRepoFocusManifest(c.env, fullName, { refresh: c.req.query("refresh") === "true" });
+    const manifest = await loadRepoFocusManifest(c.env, fullName);
+    return c.json({ repoFullName: fullName, manifest, policy: compileFocusManifestPolicy(manifest) });
+  });
+
+  app.post("/v1/repos/:owner/:repo/focus-manifest/refresh", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    const repo = await getRepository(c.env, fullName);
+    if (identity?.kind === "session") {
+      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
+      if (repoForbidden) return repoForbidden;
+    }
+    const manifest = await loadRepoFocusManifest(c.env, fullName, { refresh: true });
     return c.json({ repoFullName: fullName, manifest, policy: compileFocusManifestPolicy(manifest) });
   });
 

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -394,6 +394,14 @@ export function buildOpenApiSpec() {
     },
   });
   registry.registerPath({
+    method: "post",
+    path: "/v1/repos/{owner}/{repo}/focus-manifest/refresh",
+    responses: {
+      200: { description: "Refresh the persisted focus manifest cache from the repo file", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      403: { description: "Insufficient role" },
+    },
+  });
+  registry.registerPath({
     method: "put",
     path: "/v1/repos/{owner}/{repo}/focus-manifest",
     responses: {

--- a/test/unit/routes-focus-manifest.test.ts
+++ b/test/unit/routes-focus-manifest.test.ts
@@ -149,16 +149,39 @@ describe("focus-manifest route auth", () => {
     });
   });
 
-  it("bypasses cached manifest when refresh=true", async () => {
+  it("does not refresh cached manifests from GET query parameters", async () => {
     const app = createApp();
     const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "JSONbored/gittensory" });
     const headers = apiHeaders(env);
-    const first = await app.request(FOCUS_MANIFEST_PATH, { headers }, env);
-    expect(first.status).toBe(200);
-    const refreshed = await app.request(`${FOCUS_MANIFEST_PATH}?refresh=true`, { headers }, env);
+    const putResponse = await app.request(
+      FOCUS_MANIFEST_PATH,
+      { method: "PUT", headers, body: JSON.stringify({ wantedPaths: ["private-cache/"] }) },
+      env,
+    );
+    expect(putResponse.status).toBe(200);
+
+    const response = await app.request(`${FOCUS_MANIFEST_PATH}?refresh=true`, { headers }, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      manifest: { present: true, source: "api_record", wantedPaths: ["private-cache/"] },
+    });
+  });
+
+  it("refreshes cached manifests from an unsafe POST endpoint", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_DRIFT_ISSUE_REPO: "JSONbored/gittensory" });
+    const headers = apiHeaders(env);
+    const putResponse = await app.request(
+      FOCUS_MANIFEST_PATH,
+      { method: "PUT", headers, body: JSON.stringify({ wantedPaths: ["private-cache/"] }) },
+      env,
+    );
+    expect(putResponse.status).toBe(200);
+
+    const refreshed = await app.request(`${FOCUS_MANIFEST_PATH}/refresh`, { method: "POST", headers }, env);
     expect(refreshed.status).toBe(200);
     await expect(refreshed.json()).resolves.toMatchObject({
-      manifest: { present: true, wantedPaths: expect.arrayContaining(["apps/gittensory-ui/"]) },
+      manifest: { present: true, source: "repo_file", wantedPaths: expect.arrayContaining(["apps/gittensory-ui/"]) },
     });
   });
 


### PR DESCRIPTION
### Motivation
- The `GET /v1/repos/:owner/:repo/focus-manifest` route previously accepted `refresh=true` and performed a persisted refresh, which made a state-changing operation reachable from a safe GET and therefore CSRF-vulnerable given browser `SameSite=Lax` session cookies. 
- The intent is to preserve the ability for authorized maintainers/operators to refresh a repo's focus manifest while preventing cross-site GETs from mutating persisted manifest state.

### Description
- Stop honoring the `refresh=true` query parameter in the `GET /v1/repos/:owner/:repo/focus-manifest` handler so GET now only returns the cached or computed manifest via `loadRepoFocusManifest(c.env, fullName)`. 
- Add an unsafe `POST /v1/repos/:owner/:repo/focus-manifest/refresh` endpoint that performs an explicit cache refresh by calling `loadRepoFocusManifest(..., { refresh: true })` and reuses the same role and repo-access checks. 
- Update the OpenAPI spec and regenerate the UI OpenAPI JSON to document the new `POST` refresh path. 
- Update unit tests in `test/unit/routes-focus-manifest.test.ts` to assert that `GET ?refresh=true` no longer refreshes the persisted cache and that the new `POST .../refresh` endpoint does perform refreshes.

### Testing
- Ran the focused unit tests with `npx vitest run test/unit/routes-focus-manifest.test.ts test/unit/focus-manifest-loader.test.ts`, and all tests passed. 
- Ran static type checks with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29a0018cd8832aa3b856f50de9734a)