### PR TITLE
fix(signals): subject over-long manifest entries to dedup and list cap

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -100,12 +100,15 @@ function normalizeStringList(value: JsonValue | undefined, field: string, warnin
     }
     const trimmed = entry.trim();
     if (!trimmed) continue;
-    if (trimmed.length > MAX_ITEM_LENGTH) {
+    // Truncate in place, then flow through the same de-dup and cap logic. Falling through (rather than
+    // `continue`-ing) keeps over-long entries subject to both limits, so untrusted manifests cannot
+    // bypass de-duplication or the MAX_LIST_ITEMS safety cap via pathological long entries.
+    let normalized = trimmed;
+    if (normalized.length > MAX_ITEM_LENGTH) {
       warnings.push(`Manifest field "${field}" truncated an over-long entry.`);
-      result.push(trimmed.slice(0, MAX_ITEM_LENGTH));
-      continue;
+      normalized = normalized.slice(0, MAX_ITEM_LENGTH);
     }
-    if (!result.includes(trimmed)) result.push(trimmed);
+    if (!result.includes(normalized)) result.push(normalized);
     if (result.length >= MAX_LIST_ITEMS) {
       warnings.push(`Manifest field "${field}" exceeded ${MAX_LIST_ITEMS} entries; extra entries ignored.`);
       break;

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -82,6 +82,20 @@ describe("parseFocusManifest", () => {
     expect(manifest.wantedPaths).toEqual(["src/", "lib/"]);
   });
 
+  it("de-duplicates over-long entries after truncation", () => {
+    const prefix = "a".repeat(300);
+    const manifest = parseFocusManifest({ wantedPaths: [`${prefix}X`, `${prefix}Y`] });
+    expect(manifest.wantedPaths).toEqual([prefix]);
+    expect(manifest.warnings.join(" ")).toMatch(/truncated an over-long entry/);
+  });
+
+  it("applies the list cap to over-long entries", () => {
+    const overLong = Array.from({ length: 250 }, (_, index) => `path-${index}-${"x".repeat(300)}`);
+    const manifest = parseFocusManifest({ wantedPaths: overLong });
+    expect(manifest.wantedPaths.length).toBe(200);
+    expect(manifest.warnings.join(" ")).toMatch(/exceeded 200 entries/);
+  });
+
   it("marks a manifest with no recognized fields as absent", () => {
     const manifest = parseFocusManifest({ unrelated: "value" });
     expect(manifest.present).toBe(false);


### PR DESCRIPTION
Closes #522.

`normalizeStringList` truncated an over-long entry (> `MAX_ITEM_LENGTH` 300) then `continue`d, **skipping both** the `!result.includes` de-duplication and the `MAX_LIST_ITEMS` (200) cap that the normal path enforces. Manifests are fetched from untrusted, arbitrary repos, so a crafted `.gittensory.yml`/`.json` defeated both limits:
- duplicate entries: two over-long entries sharing a 300-char prefix both pushed after truncating to the same string;
- cap bypass (reachable): a list of all over-long entries never hits the `break`; 201 × 301-char entries (~61.5 KB) fit under the 64 KB `MAX_FOCUS_MANIFEST_BYTES` gate, yielding a 201+ entry list past the 200 cap.

## Change
- Truncate over-long entries **in place**, then fall through to the same de-dup and cap logic (no `continue`).
- Add tests: over-long entries sharing a 300-char prefix de-duplicate to one entry; 250 over-long entries cap at 200 with the `exceeded 200 entries` warning. Both fail on the old code.

## Verification
- `focus-manifest.test.ts` 65/65; `tsc --noEmit` clean; changed file branch coverage 98.36% (≥ 97% gate). (The one local-only failure in `gittensory-focus-manifest.test.ts` is a pre-existing Windows CRLF artifact comparing the on-disk `.gittensory.yml`; it passes in CI on LF and is unrelated to this change.)

Same family as merged #464 (dedup-after-cap), different site/defect.