### PR TITLE
fix(ui): surface uncrawled docs follow-up

### DIFF
--- a/apps/gittensory-ui/src/lib/registration-workspace.ts
+++ b/apps/gittensory-ui/src/lib/registration-workspace.ts
@@ -457,7 +457,7 @@ export function buildRegistrationOwnerWorkflow(
     docsItems.push({
       id: "docs-crawl",
       title: "Onboarding docs",
-      state: "accepted",
+      state: "needs_cleanup",
       summary: docs.note,
       remediation:
         "Manually verify CONTRIBUTING.md, README onboarding steps, and issue templates in GitHub; remote doc crawling is not enabled in this signal yet.",

--- a/test/unit/registration-workspace-ui.test.ts
+++ b/test/unit/registration-workspace-ui.test.ts
@@ -164,10 +164,12 @@ describe("registration workspace UI helpers", () => {
       "maintainer_capacity",
     ]);
     const docs = workflow.buckets.find((bucket) => bucket.id === "docs_onboarding");
-    expect(docs?.state).toBe("accepted");
+    expect(docs?.state).toBe("needs_cleanup");
     expect(docs?.items[0]?.remediationKind).toBe("manual");
-    expect(workflow.overallState).toBe("accepted");
-    expect(workflow.nextSteps).toEqual([]);
+    expect(workflow.overallState).toBe("needs_cleanup");
+    expect(workflow.nextSteps).toContain(
+      "Manually verify CONTRIBUTING.md, README onboarding steps, and issue templates in GitHub; remote doc crawling is not enabled in this signal yet.",
+    );
   });
 
   it("blocked readiness maps workflow to not ready with concrete blocker remediation", () => {


### PR DESCRIPTION
### Motivation
- The owner workflow incorrectly treated `repo_docs_not_crawled` as `accepted`, which suppresses the manual documentation verification from `nextSteps` and can mislead owners into thinking onboarding docs are complete.

### Description
- Change the docs onboarding item for `repo_docs_not_crawled` from `state: "accepted"` to `state: "needs_cleanup"` in `apps/gittensory-ui/src/lib/registration-workspace.ts` and update `test/unit/registration-workspace-ui.test.ts` to assert the docs bucket and overall workflow are `needs_cleanup` and that the manual remediation is present in `nextSteps`.

### Testing
- Ran `npx vitest run test/unit/registration-workspace-ui.test.ts` and the targeted test file passed (13 tests); `git diff --check` reported no issues.
- An invocation of `npm run test:unit -- test/unit/registration-workspace-ui.test.ts` expanded to the full unit suite and was stopped after an unrelated test timed out, but the targeted Vitest run above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29ca4cbef0832a879595c958834cc4)