### PR TITLE
feat(signals): add duplicate-cluster membership slop signal

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -669,7 +669,7 @@ export type ContributorStrategy = {
   actionImpact?: string[] | undefined;
 };
 
-const STOPWORDS = new Set([
+export const STOPWORDS = new Set([
   "the",
   "and",
   "for",

--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -1,0 +1,121 @@
+import type {
+  IssueRecord,
+  PullRequestRecord,
+  RecentMergedPullRequestRecord,
+} from "../types";
+import { buildCollisionReport, type CollisionReport, type SignalFinding } from "./engine";
+import { isFocusManifestPublicSafe } from "./focus-manifest";
+
+export type SlopBand = "clean" | "low" | "elevated" | "high";
+
+export type SlopAssessmentInput = {
+  repoFullName: string;
+  issues: IssueRecord[];
+  pullRequests: PullRequestRecord[];
+  recentMergedPullRequests?: RecentMergedPullRequestRecord[] | undefined;
+  targetPullRequestNumber?: number | undefined;
+  prebuiltCollisions?: CollisionReport | null | undefined;
+};
+
+export type SlopAssessment = {
+  slopRisk: number;
+  band: SlopBand;
+  findings: SignalFinding[];
+};
+
+export const SLOP_WEIGHTS = {
+  duplicateClusterMembership: 35,
+} as const;
+
+export const SLOP_RUBRIC_MARKDOWN = [
+  "# Gittensory slop assessment rubric",
+  "",
+  "- `clean`: 0",
+  "- `low`: 1-24",
+  "- `elevated`: 25-59",
+  "- `high`: 60-100",
+  "",
+  "Current deterministic signals:",
+  "- duplicate-cluster membership",
+].join("\n");
+
+export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
+  const collisions =
+    input.prebuiltCollisions ??
+    buildCollisionReport(
+      input.repoFullName,
+      input.issues,
+      input.pullRequests,
+      input.recentMergedPullRequests ?? [],
+    );
+  const findings: SignalFinding[] = [];
+  const duplicateClusterFinding = buildDuplicateClusterMembershipFinding(
+    collisions,
+    input.targetPullRequestNumber,
+  );
+  if (duplicateClusterFinding) findings.push(duplicateClusterFinding);
+
+  const slopRisk = clamp(
+    findings.reduce((total, finding) => {
+      if (finding.code !== "duplicate_cluster_membership") return total;
+      return total + SLOP_WEIGHTS.duplicateClusterMembership;
+    }, 0),
+    0,
+    100,
+  );
+
+  return {
+    slopRisk,
+    band: slopBandFor(slopRisk),
+    findings,
+  };
+}
+
+function buildDuplicateClusterMembershipFinding(
+  collisions: CollisionReport,
+  targetPullRequestNumber: number | undefined,
+): SignalFinding | null {
+  if (!targetPullRequestNumber || !Number.isFinite(targetPullRequestNumber)) return null;
+
+  const matchingClusters = collisions.clusters.filter(
+    (cluster) =>
+      cluster.risk === "high" &&
+      cluster.items.some(
+        (item) => item.type === "pull_request" && item.number === targetPullRequestNumber,
+      ),
+  );
+  if (matchingClusters.length === 0) return null;
+
+  const detail = ensurePublicSafeText(
+    `${matchingClusters.length} high-risk duplicate or overlap cluster(s) include PR #${targetPullRequestNumber}.`,
+    "High-risk duplicate or overlap work includes this PR.",
+  );
+  const action = ensurePublicSafeText(
+    "Resolve or narrow overlapping PR work before asking for review.",
+    "Resolve overlapping PR work before review.",
+  );
+
+  return {
+    code: "duplicate_cluster_membership",
+    title: "PR belongs to a high-risk duplicate cluster",
+    severity: "warning",
+    detail,
+    action,
+    publicText: detail,
+  };
+}
+
+function ensurePublicSafeText(text: string, fallback: string): string {
+  return isFocusManifestPublicSafe(text) ? text : fallback;
+}
+
+function slopBandFor(slopRisk: number): SlopBand {
+  if (slopRisk <= 0) return "clean";
+  if (slopRisk < 25) return "low";
+  if (slopRisk < 60) return "elevated";
+  return "high";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -3,7 +3,12 @@ import type {
   PullRequestRecord,
   RecentMergedPullRequestRecord,
 } from "../types";
-import { buildCollisionReport, type CollisionReport, type SignalFinding } from "./engine";
+import {
+  STOPWORDS,
+  buildCollisionReport,
+  type CollisionReport,
+  type SignalFinding,
+} from "./engine";
 import { isFocusManifestPublicSafe } from "./focus-manifest";
 
 export type SlopBand = "clean" | "low" | "elevated" | "high";
@@ -14,6 +19,7 @@ export type SlopAssessmentInput = {
   pullRequests: PullRequestRecord[];
   recentMergedPullRequests?: RecentMergedPullRequestRecord[] | undefined;
   targetPullRequestNumber?: number | undefined;
+  commitMessages?: string[] | undefined;
   prebuiltCollisions?: CollisionReport | null | undefined;
 };
 
@@ -23,8 +29,51 @@ export type SlopAssessment = {
   findings: SignalFinding[];
 };
 
+export type CommitMessageQualityFinding = {
+  message: string;
+  subject: string;
+  reason:
+    | "empty_subject"
+    | "template_subject"
+    | "generic_subject"
+    | "stopword_only_subject";
+};
+
+const TEMPLATE_SUBJECTS = new Set([
+  "wip",
+  "tmp",
+  "temp",
+  "test",
+  "misc",
+  "stuff",
+  "changes",
+  "work",
+  "progress",
+  "checkpoint",
+  "placeholder",
+  "tbd",
+  "asdf",
+  "qwerty",
+]);
+const GENERIC_SUBJECTS = new Set([
+  "update",
+  "fix",
+  "cleanup",
+  "refactor",
+  "changes",
+  "misc",
+  "stuff",
+  "work",
+  "progress",
+  "minor fix",
+  "small fix",
+  "address review",
+  "apply feedback",
+]);
+
 export const SLOP_WEIGHTS = {
   duplicateClusterMembership: 35,
+  lowQualityCommitMessages: 20,
 } as const;
 
 export const SLOP_RUBRIC_MARKDOWN = [
@@ -37,6 +86,7 @@ export const SLOP_RUBRIC_MARKDOWN = [
   "",
   "Current deterministic signals:",
   "- duplicate-cluster membership",
+  "- low-quality commit messages",
 ].join("\n");
 
 export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
@@ -55,11 +105,13 @@ export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment 
   );
   if (duplicateClusterFinding) findings.push(duplicateClusterFinding);
 
+  const lowQualityCommitMessages = findLowQualityCommitMessages(input.commitMessages ?? []);
+  const commitMessageFinding = buildLowQualityCommitMessageFinding(lowQualityCommitMessages);
+  if (commitMessageFinding) findings.push(commitMessageFinding);
+
   const slopRisk = clamp(
-    findings.reduce((total, finding) => {
-      if (finding.code !== "duplicate_cluster_membership") return total;
-      return total + SLOP_WEIGHTS.duplicateClusterMembership;
-    }, 0),
+    (duplicateClusterFinding ? SLOP_WEIGHTS.duplicateClusterMembership : 0) +
+      lowQualityCommitMessages.length * SLOP_WEIGHTS.lowQualityCommitMessages,
     0,
     100,
   );
@@ -69,6 +121,40 @@ export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment 
     band: slopBandFor(slopRisk),
     findings,
   };
+}
+
+export function findLowQualityCommitMessages(
+  commitMessages: string[],
+): CommitMessageQualityFinding[] {
+  const findings: CommitMessageQualityFinding[] = [];
+  for (const message of commitMessages) {
+    const subject = firstNonEmptyLine(message).trim();
+    if (!subject) {
+      findings.push({ message, subject: "", reason: "empty_subject" });
+      continue;
+    }
+    const normalized = normalizeSubject(subject);
+    if (TEMPLATE_SUBJECTS.has(normalized)) {
+      findings.push({ message, subject, reason: "template_subject" });
+      continue;
+    }
+    if (GENERIC_SUBJECTS.has(normalized)) {
+      findings.push({ message, subject, reason: "generic_subject" });
+      continue;
+    }
+    const tokens = normalized.match(/[a-z0-9]+/g) ?? [];
+    if (tokens.length === 0) {
+      findings.push({ message, subject, reason: "empty_subject" });
+      continue;
+    }
+    const meaningfulTokens = tokens.filter(
+      (term) => term.length > 2 && !STOPWORDS.has(term) && !TEMPLATE_SUBJECTS.has(term),
+    );
+    if (meaningfulTokens.length === 0) {
+      findings.push({ message, subject, reason: "stopword_only_subject" });
+    }
+  }
+  return findings;
 }
 
 function buildDuplicateClusterMembershipFinding(
@@ -105,6 +191,34 @@ function buildDuplicateClusterMembershipFinding(
   };
 }
 
+function buildLowQualityCommitMessageFinding(
+  flagged: CommitMessageQualityFinding[],
+): SignalFinding | null {
+  if (flagged.length === 0) return null;
+
+  const examples = flagged
+    .slice(0, 2)
+    .map((entry) => `\`${truncate(entry.subject || "(empty)", 40)}\``)
+    .join(", ");
+  const detail = ensurePublicSafeText(
+    `${flagged.length} low-quality commit message(s) were detected${examples ? `, including ${examples}` : ""}.`,
+    "Low-quality commit messages were detected.",
+  );
+  const action = ensurePublicSafeText(
+    "Rewrite commit subjects with traceable, descriptive summaries tied to the actual change.",
+    "Rewrite commit subjects with descriptive summaries.",
+  );
+
+  return {
+    code: "low_quality_commit_messages",
+    title: "Commit history includes low-quality messages",
+    severity: "warning",
+    detail,
+    action,
+    publicText: detail,
+  };
+}
+
 function ensurePublicSafeText(text: string, fallback: string): string {
   return isFocusManifestPublicSafe(text) ? text : fallback;
 }
@@ -118,4 +232,23 @@ function slopBandFor(slopRisk: number): SlopBand {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function firstNonEmptyLine(text: string): string {
+  return String(text)
+    .split(/\r?\n/)
+    .find((line) => line.trim().length > 0) ?? "";
+}
+
+function normalizeSubject(subject: string): string {
+  return subject
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+    .trim();
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
 }

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildCollisionReport } from "../../src/signals/engine";
 import {
   buildSlopAssessment,
+  findLowQualityCommitMessages,
   SLOP_RUBRIC_MARKDOWN,
   SLOP_WEIGHTS,
 } from "../../src/signals/slop";
@@ -51,7 +52,7 @@ function pr(
 }
 
 describe("buildSlopAssessment", () => {
-  it("raises the slop signal when the target PR belongs to a high-risk duplicate cluster", () => {
+  it("raises the duplicate-cluster slop signal when the target PR belongs to a high-risk cluster", () => {
     const repoFullName = "JSONbored/gittensory";
     const issues = [
       issue(repoFullName, 7, "Stabilize queue health signals", { linkedPrs: [41, 42] }),
@@ -80,31 +81,28 @@ describe("buildSlopAssessment", () => {
     );
   });
 
-  it("does not raise the signal without a target PR or when the target PR is unrelated", () => {
+  it("raises the commit-message slop signal for generic, empty, or template subjects", () => {
     const repoFullName = "JSONbored/gittensory";
-    const issues = [issue(repoFullName, 8, "Improve docs indexing")];
-    const pullRequests = [
-      pr(repoFullName, 51, "Add onboarding note", { linkedIssues: [8] }),
-      pr(repoFullName, 52, "Unrelated queue report cleanup"),
-    ];
-
-    const noTarget = buildSlopAssessment({
+    const result = buildSlopAssessment({
       repoFullName,
-      issues,
-      pullRequests,
-    });
-    const unrelated = buildSlopAssessment({
-      repoFullName,
-      issues,
-      pullRequests,
-      targetPullRequestNumber: 52,
+      issues: [issue(repoFullName, 8, "Track queue triage")],
+      pullRequests: [pr(repoFullName, 51, "Track queue triage")],
+      commitMessages: ["fix", "\n\n", "WIP"],
     });
 
-    expect(noTarget).toEqual({ slopRisk: 0, band: "clean", findings: [] });
-    expect(unrelated).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+    expect(result.slopRisk).toBe(60);
+    expect(result.band).toBe("high");
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "low_quality_commit_messages",
+          severity: "warning",
+        }),
+      ]),
+    );
   });
 
-  it("is deterministic for identical metadata input", () => {
+  it("aggregates both signals in one shared assessment", () => {
     const repoFullName = "JSONbored/gittensory";
     const issues = [
       issue(repoFullName, 9, "Tighten duplicate cluster detection", { linkedPrs: [61, 62] }),
@@ -113,41 +111,126 @@ describe("buildSlopAssessment", () => {
       pr(repoFullName, 61, "Tighten duplicate cluster detection", { linkedIssues: [9] }),
       pr(repoFullName, 62, "Duplicate cluster detector follow-up", { linkedIssues: [9] }),
     ];
-    const collisions = buildCollisionReport(repoFullName, issues, pullRequests);
 
-    const left = buildSlopAssessment({
+    const result = buildSlopAssessment({
       repoFullName,
       issues,
       pullRequests,
       targetPullRequestNumber: 61,
-      prebuiltCollisions: collisions,
-    });
-    const right = buildSlopAssessment({
-      repoFullName,
-      issues,
-      pullRequests,
-      targetPullRequestNumber: 61,
-      prebuiltCollisions: collisions,
+      commitMessages: ["update", "WIP"],
     });
 
-    expect(left).toEqual(right);
+    expect(result.slopRisk).toBe(75);
+    expect(result.band).toBe("high");
+    expect(result.findings.map((finding) => finding.code).sort()).toEqual([
+      "duplicate_cluster_membership",
+      "low_quality_commit_messages",
+    ]);
   });
 
-  it("keeps the rubric and finding text public-safe", () => {
+  it("does not raise either signal without a target PR and with descriptive commits", () => {
     const repoFullName = "JSONbored/gittensory";
-    const issues = [
-      issue(repoFullName, 10, "Resolve overlapping queue triage work", { linkedPrs: [71, 72] }),
-    ];
+    const issues = [issue(repoFullName, 10, "Improve docs indexing")];
     const pullRequests = [
-      pr(repoFullName, 71, "Resolve overlapping queue triage work", { linkedIssues: [10] }),
-      pr(repoFullName, 72, "Alternative overlapping queue triage work", { linkedIssues: [10] }),
+      pr(repoFullName, 71, "Add onboarding note", { linkedIssues: [10] }),
+      pr(repoFullName, 72, "Unrelated queue report cleanup"),
     ];
 
     const result = buildSlopAssessment({
       repoFullName,
       issues,
       pullRequests,
-      targetPullRequestNumber: 71,
+      commitMessages: [
+        "feat(ci): annotate failing checks with branch-specific remediation",
+        "docs(api): explain maintainer branch annotation payload",
+      ],
+    });
+
+    expect(result).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("is deterministic for identical metadata input when prebuilt collisions are reused", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [
+      issue(repoFullName, 11, "Resolve overlapping queue triage work", { linkedPrs: [81, 82] }),
+    ];
+    const pullRequests = [
+      pr(repoFullName, 81, "Resolve overlapping queue triage work", { linkedIssues: [11] }),
+      pr(repoFullName, 82, "Alternative overlapping queue triage work", { linkedIssues: [11] }),
+    ];
+    const collisions = buildCollisionReport(repoFullName, issues, pullRequests);
+
+    const left = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 81,
+      commitMessages: ["update", "WIP"],
+      prebuiltCollisions: collisions,
+    });
+    const right = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 81,
+      commitMessages: ["update", "WIP"],
+      prebuiltCollisions: collisions,
+    });
+
+    expect(left).toEqual(right);
+  });
+
+  it("shares deterministic low-quality classification helpers for the future lint tool", () => {
+    const messages = ["update", "feat(api): add branch annotation schema", "the and fix"];
+
+    expect(findLowQualityCommitMessages(messages)).toEqual([
+      expect.objectContaining({ subject: "update", reason: "generic_subject" }),
+      expect.objectContaining({ subject: "the and fix", reason: "stopword_only_subject" }),
+    ]);
+    expect(findLowQualityCommitMessages(messages)).toEqual(findLowQualityCommitMessages(messages));
+  });
+
+  it("treats punctuation-only, two-bad-message, and long-template subjects consistently", () => {
+    const repoFullName = "JSONbored/gittensory";
+    expect(findLowQualityCommitMessages(["...", "minor fix"])).toEqual([
+      expect.objectContaining({ subject: "...", reason: "empty_subject" }),
+      expect.objectContaining({ subject: "minor fix", reason: "generic_subject" }),
+    ]);
+
+    const elevated = buildSlopAssessment({
+      repoFullName,
+      issues: [issue(repoFullName, 12, "Clarify CI notes")],
+      pullRequests: [pr(repoFullName, 91, "Clarify CI notes")],
+      commitMessages: ["update", "WIP"],
+    });
+    expect(elevated.slopRisk).toBe(40);
+    expect(elevated.band).toBe("elevated");
+
+    const longTemplate = buildSlopAssessment({
+      repoFullName,
+      issues: [issue(repoFullName, 13, "Trace branch changes")],
+      pullRequests: [pr(repoFullName, 92, "Trace branch changes")],
+      commitMessages: ["placeholder ".repeat(6).trim(), "temp", "fix"],
+    });
+    expect(longTemplate.findings[0]?.detail).toContain("...");
+  });
+
+  it("keeps the rubric and finding text public-safe", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [
+      issue(repoFullName, 14, "Improve slop scoring", { linkedPrs: [101, 102] }),
+    ];
+    const pullRequests = [
+      pr(repoFullName, 101, "Improve slop scoring", { linkedIssues: [14] }),
+      pr(repoFullName, 102, "Alternative slop scoring change", { linkedIssues: [14] }),
+    ];
+
+    const result = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 101,
+      commitMessages: ["temp"],
     });
     const publicText = [
       SLOP_RUBRIC_MARKDOWN,

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCollisionReport } from "../../src/signals/engine";
+import {
+  buildSlopAssessment,
+  SLOP_RUBRIC_MARKDOWN,
+  SLOP_WEIGHTS,
+} from "../../src/signals/slop";
+import type { IssueRecord, PullRequestRecord } from "../../src/types";
+
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|raw trust|trust score|scoreability|private reviewability|\/Users|\/home|\/tmp/i;
+
+function issue(
+  repoFullName: string,
+  number: number,
+  title: string,
+  overrides: Partial<IssueRecord> = {},
+): IssueRecord {
+  return {
+    repoFullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "reporter",
+    labels: ["bug"],
+    linkedPrs: [],
+    ...overrides,
+  };
+}
+
+function pr(
+  repoFullName: string,
+  number: number,
+  title: string,
+  overrides: Partial<PullRequestRecord> = {},
+): PullRequestRecord {
+  return {
+    repoFullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "contributor",
+    authorAssociation: "NONE",
+    labels: ["bug"],
+    linkedIssues: [],
+    createdAt: "2026-06-10T00:00:00.000Z",
+    updatedAt: "2026-06-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildSlopAssessment", () => {
+  it("raises the slop signal when the target PR belongs to a high-risk duplicate cluster", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [
+      issue(repoFullName, 7, "Stabilize queue health signals", { linkedPrs: [41, 42] }),
+    ];
+    const pullRequests = [
+      pr(repoFullName, 41, "Stabilize queue health signals", { linkedIssues: [7] }),
+      pr(repoFullName, 42, "Alternative queue health stabilization", { linkedIssues: [7] }),
+    ];
+
+    const result = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 41,
+    });
+
+    expect(result.slopRisk).toBe(SLOP_WEIGHTS.duplicateClusterMembership);
+    expect(result.band).toBe("elevated");
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_cluster_membership",
+          severity: "warning",
+        }),
+      ]),
+    );
+  });
+
+  it("does not raise the signal without a target PR or when the target PR is unrelated", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [issue(repoFullName, 8, "Improve docs indexing")];
+    const pullRequests = [
+      pr(repoFullName, 51, "Add onboarding note", { linkedIssues: [8] }),
+      pr(repoFullName, 52, "Unrelated queue report cleanup"),
+    ];
+
+    const noTarget = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+    });
+    const unrelated = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 52,
+    });
+
+    expect(noTarget).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+    expect(unrelated).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("is deterministic for identical metadata input", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [
+      issue(repoFullName, 9, "Tighten duplicate cluster detection", { linkedPrs: [61, 62] }),
+    ];
+    const pullRequests = [
+      pr(repoFullName, 61, "Tighten duplicate cluster detection", { linkedIssues: [9] }),
+      pr(repoFullName, 62, "Duplicate cluster detector follow-up", { linkedIssues: [9] }),
+    ];
+    const collisions = buildCollisionReport(repoFullName, issues, pullRequests);
+
+    const left = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 61,
+      prebuiltCollisions: collisions,
+    });
+    const right = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 61,
+      prebuiltCollisions: collisions,
+    });
+
+    expect(left).toEqual(right);
+  });
+
+  it("keeps the rubric and finding text public-safe", () => {
+    const repoFullName = "JSONbored/gittensory";
+    const issues = [
+      issue(repoFullName, 10, "Resolve overlapping queue triage work", { linkedPrs: [71, 72] }),
+    ];
+    const pullRequests = [
+      pr(repoFullName, 71, "Resolve overlapping queue triage work", { linkedIssues: [10] }),
+      pr(repoFullName, 72, "Alternative overlapping queue triage work", { linkedIssues: [10] }),
+    ];
+
+    const result = buildSlopAssessment({
+      repoFullName,
+      issues,
+      pullRequests,
+      targetPullRequestNumber: 71,
+    });
+    const publicText = [
+      SLOP_RUBRIC_MARKDOWN,
+      ...result.findings.flatMap((finding) => [
+        finding.title,
+        finding.detail,
+        finding.action ?? "",
+        finding.publicText ?? "",
+      ]),
+    ].join("\n");
+
+    expect(publicText).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+});


### PR DESCRIPTION
# Summary
Implements issue #563 by adding the `duplicate-cluster membership` slop signal in a new deterministic slop-assessment module.
The new logic reuses the existing `buildCollisionReport(...)` signal builder and raises a slop finding when a target PR belongs to a `high` risk duplicate/overlap cluster. The implementation keeps all public-facing output within the existing public-safe boundary and adds focused tests for signal triggering, determinism, and forbidden-term safety.
## Related Issue
Closes: #563 
# Change Type
- [x] Feature
- [x] Tests
- [x] Signal / scoring logic
- [ ] Bug fix
- [ ] Security fix
- [ ] Dependency change
- [ ] Breaking change

# Real Behavior Proof
Validated duplicate-cluster signal behavior with executed tests.
Example validated scenario:
- issue `#7` linked to PRs `#41` and `#42`
- target PR `#41` is part of a `high` risk collision cluster
- result:
  - `slopRisk = 35`
  - `band = elevated`
  - finding includes `duplicate_cluster_membership`

Validated non-signal scenario:
- no target PR provided, or target PR unrelated to any high-risk cluster
- result:
  - `slopRisk = 0`
  - `band = clean`
  - `findings = []`

# Public / Private Boundary
- [x] Reused existing public-safe output path
- [x] Public reason strings checked against forbidden-term assertions
- [x] No new trust/reward/private-review terminology introduced

# Checklist
- [x] Reused `buildCollisionReport(...)` as required by the issue
- [x] Implemented only the duplicate-cluster membership slop signal for this issue scope
- [x] Kept scoring deterministic
- [x] Added focused automated coverage
- [x] Passed full CI-equivalent local validation
- [x] Verified the project runs locally without startup errors