### PR TITLE
fix(ui): strip credentials from analytics proxy

### DIFF
--- a/apps/gittensory-ui/src/lib/analytics-proxy.ts
+++ b/apps/gittensory-ui/src/lib/analytics-proxy.ts
@@ -22,9 +22,12 @@ const ROUTES: Record<string, ReadonlySet<string>> = {
   "/stats/api/send": new Set(["POST"]),
 };
 
-// Request headers we never forward upstream (hop-by-hop or our-origin specific).
+// Request headers we never forward upstream (hop-by-hop, credentials, or our-origin specific).
 const STRIP_REQUEST_HEADERS = new Set([
   "host",
+  "authorization",
+  "cookie",
+  "proxy-authorization",
   "connection",
   "keep-alive",
   "transfer-encoding",
@@ -81,14 +84,18 @@ export async function handleAnalyticsProxy(request: Request): Promise<Response |
 
   const hasBody = request.method !== "GET" && request.method !== "HEAD";
 
+  const upstreamRequest: RequestInit = {
+    method: request.method,
+    headers,
+  };
+  if (hasBody) {
+    // Buffer the (tiny) collect payload so we don't need a streaming/duplex body.
+    upstreamRequest.body = await request.arrayBuffer();
+  }
+
   let upstream: Response;
   try {
-    upstream = await fetch(upstreamUrl, {
-      method: request.method,
-      headers,
-      // Buffer the (tiny) collect payload so we don't need a streaming/duplex body.
-      body: hasBody ? await request.arrayBuffer() : undefined,
-    });
+    upstream = await fetch(upstreamUrl, upstreamRequest);
   } catch {
     // Analytics must never take the page down — fail quietly.
     return new Response(null, { status: 502 });

--- a/test/unit/analytics-proxy.test.ts
+++ b/test/unit/analytics-proxy.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleAnalyticsProxy } from "../../apps/gittensory-ui/src/lib/analytics-proxy";
+
+describe("analytics proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not forward first-party credentials to the analytics upstream", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("ok"),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleAnalyticsProxy(
+      new Request("https://gittensory.aethereal.dev/stats/api/send", {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: "Bearer ui-token",
+          cookie: "session=secret",
+          "cf-connecting-ip": "203.0.113.10",
+          "proxy-authorization": "Basic proxy-secret",
+          "x-forwarded-for": "198.51.100.25",
+        },
+        body: JSON.stringify({ type: "event" }),
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const init = call?.[1];
+    expect(init).toBeDefined();
+    const forwardedHeaders = new Headers(init?.headers);
+
+    expect(forwardedHeaders.get("accept")).toBe("application/json");
+    expect(forwardedHeaders.get("x-forwarded-for")).toBe(
+      "198.51.100.25, 203.0.113.10",
+    );
+    expect(forwardedHeaders.has("authorization")).toBe(false);
+    expect(forwardedHeaders.has("cookie")).toBe(false);
+    expect(forwardedHeaders.has("proxy-authorization")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- The first-party analytics proxy was unintentionally forwarding sensitive first-party credentials (e.g. `Cookie`, `Authorization`, `Proxy-Authorization`) to the upstream Umami host.
- That forwarding can leak HttpOnly cookies or authorization headers to the analytics service and its logs, so the proxy must fail closed for credentials while preserving telemetry.
- The change aims to remove credential forwarding with minimal impact to the proxy behaviour and site analytics.

### Description
- Add `authorization`, `cookie`, and `proxy-authorization` to the inbound header denylist in `apps/gittensory-ui/src/lib/analytics-proxy.ts` so they are not forwarded upstream.
- Build the proxied request `RequestInit` (`upstreamRequest`) and attach the buffered body only when present to avoid passing an explicit `undefined` body to `fetch` while preserving GET/HEAD behaviour.
- Add a unit test `test/unit/analytics-proxy.test.ts` that verifies analytics headers and `x-forwarded-for` are preserved while `Authorization`, `Cookie`, and `Proxy-Authorization` are not forwarded.

### Testing
- Ran the new unit test with `npx vitest run test/unit/analytics-proxy.test.ts --reporter verbose` and it passed.
- Ran the full TypeScript check with `npm run typecheck` and it completed successfully.
- Ran the UI workspace typecheck with `npm run ui:typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a7cf89e80832abeb7b3bbe8fa62d3)