### PR TITLE
fix(api): allow sessions to reach focus-manifest refresh

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3638,7 +3638,7 @@ function isIssueQualityPath(path: string): boolean {
 }
 
 function isRepoFocusManifestPath(path: string): boolean {
-  return /^\/v1\/repos\/[^/]+\/[^/]+\/focus-manifest$/.test(path);
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/focus-manifest(?:\/refresh)?$/.test(path);
 }
 
 async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<AuthIdentity | null> {

--- a/test/unit/routes-focus-manifest.test.ts
+++ b/test/unit/routes-focus-manifest.test.ts
@@ -113,6 +113,25 @@ describe("focus-manifest route auth", () => {
     expect(ownRepoGet.status).toBe(200);
   });
 
+  it("allows a same-repo owner session to POST focus-manifest refresh", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const { token: otherToken } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+
+    // Same-repo owner session must reach the refresh handler (was 403'd by the blanket session gate).
+    const refreshed = await app.request(`${OWNED_REPO_PATH}/refresh`, { method: "POST", headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(refreshed.status).toBe(200);
+    await expect(refreshed.json()).resolves.toMatchObject({ repoFullName: "repo-owner/owned-repo" });
+
+    // Cross-repo owner session is still rejected -- by the route handler (forbidden_repo), not the blanket middleware.
+    const crossRepo = await app.request(`${OWNED_REPO_PATH}/refresh`, { method: "POST", headers: { cookie: `gittensory_session=${otherToken}` } }, env);
+    expect(crossRepo.status).toBe(403);
+    await expect(crossRepo.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
   it("allows operator sessions to access any repo focus manifest", async () => {
     const app = createApp();
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "jsonbored" });


### PR DESCRIPTION
Closes #600.

#523 added `POST /v1/repos/:owner/:repo/focus-manifest/refresh`, but `isRepoFocusManifestPath` (used by `canSessionAccessPath`) was anchored at `…/focus-manifest$`, so it did not match the `/refresh` sub-path. Since `requiresApiToken` treats the refresh path as protected, the blanket `*` middleware rejected a session-authenticated owner/maintainer with **403 `insufficient_role`** before the route handler ran — even though the handler's `requireAppRole` + `requireSessionRepoAccess` would have allowed them. GET/PUT worked for sessions; only the new refresh route was unreachable.

## Change
- Match the optional `/refresh` sub-path: `…/focus-manifest(?:/refresh)?$`, so the route handler (not the blanket middleware) gates the refresh route.
- Add a regression test: a same-repo owner **session** `POST`ing `…/focus-manifest/refresh` gets `200`, while a cross-repo owner session still gets `403 forbidden_repo` from `requireSessionRepoAccess`.

## Verification
- `routes-focus-manifest.test.ts` 12/12 (the new same-repo case fails on the old code with `insufficient_role`); `tsc --noEmit` clean; related auth/route suites green.

Same access-path-matcher class as #513 / #508; a new gap specific to the #523 sub-path.