### PR TITLE
fix(issues): require trusted declined draft evidence

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3154,6 +3154,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     body?: string | null;
     created_at?: string | null;
     updated_at?: string | null;
+    closed_at?: string | null;
     draft?: boolean | null;
     mergeable_state?: string | null;
     reviewDecision?: string | null;
@@ -3176,6 +3177,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     body: payload.body,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at ?? row.updatedAt,
+    closedAt: payload.closed_at,
     labels: parseJson<string[]>(row.labelsJson, []),
     linkedIssues: parseJson<number[]>(row.linkedIssuesJson, []),
   };
@@ -3202,6 +3204,7 @@ function compactGitHubPayload(payload: {
   body?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  closed_at?: string | null;
   draft?: boolean | null;
   isDraft?: boolean | null;
   mergeable?: boolean | null;
@@ -3215,6 +3218,7 @@ function compactGitHubPayload(payload: {
     body: truncateBody(payload.body),
     created_at: payload.created_at ?? null,
     updated_at: payload.updated_at ?? null,
+    closed_at: payload.closed_at ?? null,
     ...(draft !== undefined ? { draft } : {}),
     ...(mergeableState !== undefined ? { mergeable_state: mergeableState } : {}),
     ...(payload.reviewDecision !== undefined ? { reviewDecision: payload.reviewDecision } : {}),
@@ -3233,7 +3237,7 @@ function truncateBody(body: string | null | undefined): string | null {
 }
 
 function toIssueRecordFromRow(row: typeof issues.$inferSelect): IssueRecord {
-  const payload = parseJson<{ body?: string | null; created_at?: string | null; updated_at?: string | null }>(row.payloadJson, {});
+  const payload = parseJson<{ body?: string | null; created_at?: string | null; updated_at?: string | null; closed_at?: string | null }>(row.payloadJson, {});
   return {
     repoFullName: row.repoFullName,
     number: row.number,
@@ -3245,6 +3249,7 @@ function toIssueRecordFromRow(row: typeof issues.$inferSelect): IssueRecord {
     body: payload.body,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at ?? row.updatedAt,
+    closedAt: payload.closed_at,
     labels: parseJson<string[]>(row.labelsJson, []),
     linkedPrs: parseJson<number[]>(row.linkedPrsJson, []),
   };

--- a/src/services/contributor-issue-draft.ts
+++ b/src/services/contributor-issue-draft.ts
@@ -14,6 +14,7 @@ import {
   recordAuditEvent,
 } from "../db/repositories";
 import type { IssueRecord, RepositoryRecord, RepositorySettings } from "../types";
+import { isMaintainerAssociation } from "../github/commands";
 import { sha256Hex } from "../utils/crypto";
 import { jsonString, nowIso, repoParts } from "../utils/json";
 import {
@@ -178,10 +179,12 @@ export const CONTRIBUTOR_ISSUE_DRAFT_DECLINED_COOLDOWN_MS = 30 * 24 * 60 * 60 * 
 const DECLINED_DRAFT_WONTFIX_LABELS = new Set(["wontfix", "wont-fix", "invalid", "duplicate", "not-planned"]);
 
 /**
- * Detect whether a draft was already declined by a maintainer closing the generated issue.
- * Matches by the stable marker fingerprint on a closed issue. A `wontfix`-style label suppresses
- * re-proposal indefinitely; otherwise the closure is honored only within the cooldown window, so a
- * genuine later regression of the underlying warning can resurface once the cooldown elapses.
+ * Detect whether a draft was already declined through trusted maintainer evidence.
+ * Matches by the stable marker fingerprint on a closed issue, but never lets an arbitrary
+ * marker-bearing issue suppress generation: a `wontfix`-style label is trusted because
+ * labels are maintainer-controlled, while cooldown suppression requires a maintainer-
+ * associated issue author. Cooldowns use GitHub's close timestamp instead of `updated_at`
+ * so comments or unrelated edits cannot refresh the suppression window.
  */
 export function findDeclinedContributorDraft(
   closedIssues: IssueRecord[],
@@ -197,7 +200,8 @@ export function findDeclinedContributorDraft(
     if (issue.labels.some((label) => DECLINED_DRAFT_WONTFIX_LABELS.has(label.trim().toLowerCase()))) {
       return { number: issue.number, title: issue.title, reason: "wontfix" };
     }
-    const closedAtMs = issue.updatedAt ? Date.parse(issue.updatedAt) : Number.NaN;
+    if (!isMaintainerAssociation(issue.authorAssociation)) continue;
+    const closedAtMs = issue.closedAt ? Date.parse(issue.closedAt) : Number.NaN;
     if (!Number.isFinite(closedAtMs) || nowMs - closedAtMs < cooldownMs) {
       return { number: issue.number, title: issue.title, reason: "cooldown" };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,7 @@ export type GitHubPullRequestPayload = {
   reviewDecision?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  closed_at?: string | null;
   user?: {
     login?: string;
     type?: string;
@@ -195,6 +196,7 @@ export type GitHubIssuePayload = {
   html_url?: string;
   created_at?: string | null;
   updated_at?: string | null;
+  closed_at?: string | null;
   user?: {
     login?: string;
   };
@@ -310,6 +312,7 @@ export type PullRequestRecord = {
   body?: string | null | undefined;
   createdAt?: string | null | undefined;
   updatedAt?: string | null | undefined;
+  closedAt?: string | null | undefined;
   labels: string[];
   linkedIssues: number[];
 };
@@ -325,6 +328,7 @@ export type IssueRecord = {
   body?: string | null | undefined;
   createdAt?: string | null | undefined;
   updatedAt?: string | null | undefined;
+  closedAt?: string | null | undefined;
   labels: string[];
   linkedPrs: number[];
 };

--- a/test/unit/contributor-issue-draft.test.ts
+++ b/test/unit/contributor-issue-draft.test.ts
@@ -236,6 +236,8 @@ describe("contributor issue drafts", () => {
     const closed = (over: Partial<IssueRecord>): IssueRecord => ({
       ...openIssue(5, "feat(issues): address focus-policy-missing policy readiness for repo", marker),
       state: "closed",
+      authorAssociation: "OWNER",
+      closedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       ...over,
     });
@@ -244,11 +246,14 @@ describe("contributor issue drafts", () => {
     // Recently closed -> suppressed within the cooldown window.
     expect(findDeclinedContributorDraft([closed({})], { fingerprint })).toMatchObject({ number: 5, reason: "cooldown" });
     // wontfix-style label -> suppressed regardless of age.
-    expect(findDeclinedContributorDraft([closed({ updatedAt: longAgo, labels: ["wontfix"] })], { fingerprint })).toMatchObject({ reason: "wontfix" });
+    expect(findDeclinedContributorDraft([closed({ closedAt: longAgo, labels: ["wontfix"] })], { fingerprint })).toMatchObject({ reason: "wontfix" });
     // Past the cooldown without a wontfix label -> may resurface (a later regression).
-    expect(findDeclinedContributorDraft([closed({ updatedAt: longAgo })], { fingerprint })).toBeNull();
-    // Missing/unparseable close timestamp -> treat as still within cooldown (suppress).
-    expect(findDeclinedContributorDraft([closed({ updatedAt: undefined })], { fingerprint })).toMatchObject({ reason: "cooldown" });
+    expect(findDeclinedContributorDraft([closed({ closedAt: longAgo, updatedAt: new Date().toISOString() })], { fingerprint })).toBeNull();
+    // Missing/unparseable close timestamp on trusted maintainer-authored issues -> treat as still within cooldown (suppress).
+    expect(findDeclinedContributorDraft([closed({ closedAt: undefined })], { fingerprint })).toMatchObject({ reason: "cooldown" });
+    // Attacker-controlled issue bodies cannot suppress drafts without maintainer authorship or maintainer-applied labels.
+    expect(findDeclinedContributorDraft([closed({ authorAssociation: "NONE" })], { fingerprint })).toBeNull();
+    expect(findDeclinedContributorDraft([closed({ authorAssociation: "NONE", closedAt: longAgo, labels: ["not-planned"] })], { fingerprint })).toMatchObject({ reason: "wontfix" });
     // Open issues, missing markers, and other fingerprints are ignored.
     expect(findDeclinedContributorDraft([{ ...closed({}), state: "open" }], { fingerprint })).toBeNull();
     expect(findDeclinedContributorDraft([closed({ body: "no marker here" })], { fingerprint })).toBeNull();
@@ -263,7 +268,13 @@ describe("contributor issue drafts", () => {
     const marker = contributorIssueDraftMarker(fingerprint);
     vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
     vi.spyOn(repositories, "listClosedContributorDraftIssues").mockResolvedValue([
-      { ...openIssue(90, "feat(issues): address focus-policy-missing policy readiness for repo", marker), state: "closed", updatedAt: new Date().toISOString() },
+      {
+        ...openIssue(90, "feat(issues): address focus-policy-missing policy readiness for repo", marker),
+        state: "closed",
+        authorAssociation: "OWNER",
+        closedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
     ]);
 
     const result = await generateContributorIssueDrafts(env, repoFullName, { dryRun: false, create: true, limit: 1 });
@@ -271,6 +282,37 @@ describe("contributor issue drafts", () => {
     expect(result.created).toBe(0);
     expect(result.drafts[0]?.status).toBe("skipped_declined");
     expect(result.drafts[0]?.declinedBy).toMatchObject({ number: 90, reason: "cooldown" });
+  });
+
+  it("does not let untrusted closed issue markers suppress draft creation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          number: 502,
+          html_url: "https://github.com/other-owner/other-repo/issues/502",
+        }),
+      ),
+    );
+    const env = createTestEnv({ GITTENSORY_CONTRIBUTOR_ISSUE_TOKEN: "token" });
+    const repoFullName = "other-owner/other-repo";
+    const fingerprint = await contributorIssueDraftFingerprint(repoFullName, "policy:focus_policy_missing", "policy:focus_policy_missing");
+    const marker = contributorIssueDraftMarker(fingerprint);
+    vi.spyOn(repositories, "listOpenIssues").mockResolvedValue([]);
+    vi.spyOn(repositories, "listClosedContributorDraftIssues").mockResolvedValue([
+      {
+        ...openIssue(91, "attacker-controlled spoof", marker),
+        state: "closed",
+        authorAssociation: "NONE",
+        closedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    const result = await generateContributorIssueDrafts(env, repoFullName, { dryRun: false, create: true, limit: 1 });
+    expect(result.skippedDeclined).toBe(0);
+    expect(result.created).toBe(1);
+    expect(result.drafts[0]?.status).toBe("created");
   });
 
   it("records skipped_create_failed when GitHub create is unavailable", async () => {


### PR DESCRIPTION
### Motivation
- A closed-issue marker used to suppress contributor-draft creation could be spoofed by an attacker because markers and fingerprints are deterministic and arbitrary closed issue bodies were trusted.  
- The previous cooldown used `updated_at`, which allowed comments or other non-close updates to refresh suppression windows.

### Description
- Require trusted maintainer evidence before treating a marker-bearing closed issue as a decline: `wontfix`-style labels still suppress indefinitely, but cooldown suppression now only applies when the closed issue is maintainer-associated (uses `isMaintainerAssociation`).
- Use GitHub `closed_at` as the authoritative close timestamp for cooldown calculations instead of `updated_at` to avoid refresh via comments/edits.
- Persist and expose `closed_at` through payload handling and record types so suppression logic can read the real close time (`src/db/repositories.ts`, `src/types.ts`).
- Add regression tests that cover maintainer-declined behavior, ensure attacker-controlled closed markers do not suppress draft creation, and validate `updated_at` refresh cannot extend the cooldown (`test/unit/contributor-issue-draft.test.ts`).

### Testing
- Ran static type checks with `npm run typecheck` and they passed.  
- Ran unit tests for contributor draft logic with `npx vitest run test/unit/contributor-issue-draft.test.ts` and all tests passed (`27 passed`).  
- Ran `git diff --check` to ensure no trailing whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a8eceddc0832a9b82f9e43c7b36b6)