### PR TITLE
fix(analytics): don't credit a pre-action merged PR as accepted

### DIFF
--- a/src/services/recommendation-outcomes.ts
+++ b/src/services/recommendation-outcomes.ts
@@ -284,7 +284,11 @@ function pullRequestOutcomeState(
     if (hasChangesRequestedReview(pr)) return "rejected";
     if (hasPositiveOpenPullRequestSignal(pr)) return "improved";
   }
-  if (createdAt >= actionAt || updatedAt > actionAt) return "accepted";
+  // A PR that already merged before the action cannot be a positive outcome of it. Without this guard a
+  // pre-action merge that merely receives a later updatedAt bump (e.g. a comment) would fall through to
+  // "accepted" -- mirror the "merged" branch's own >= actionAt discipline so it stays stale/ignored.
+  const mergedBeforeAction = Number.isFinite(mergedAt) && mergedAt < actionAt;
+  if (!mergedBeforeAction && (createdAt >= actionAt || updatedAt > actionAt)) return "accepted";
   if (actionAgeMs >= staleAfterMs) return "stale";
   return "ignored";
 }

--- a/test/unit/recommendation-outcomes.test.ts
+++ b/test/unit/recommendation-outcomes.test.ts
@@ -246,6 +246,24 @@ describe("recommendation outcome feedback", () => {
       }),
     ).toMatchObject({ outcomeState: "stale", outcomeTargetType: "pull_request" });
 
+    // A pre-action merge that merely receives a later updatedAt bump (e.g. a comment) must not be
+    // credited as the positive "accepted" outcome of the recommendation.
+    expect(
+      classifyRecommendationOutcome({
+        ...base,
+        action: action(run, 2, { targetRepoFullName: "owner/old-merged", targetPullNumber: 62 }),
+        pullRequests: [
+          prRecord(62, "owner/old-merged", {
+            state: "merged",
+            mergedAt: "2026-04-01T00:00:00.000Z",
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-05-10T00:00:00.000Z",
+          }),
+        ],
+        issues: [],
+      }),
+    ).toMatchObject({ outcomeState: "stale", outcomeTargetType: "pull_request" });
+
     expect(
       classifyRecommendationOutcome({
         ...base,


### PR DESCRIPTION
Closes #605.

`pullRequestOutcomeState`'s `"merged"` branch correctly requires `mergedAt >= actionAt`, but the `"accepted"` fallback only required a later `updatedAt`. So a PR **merged before** the recommendation (which fails the merged guard, and whose `!pr.mergedAt` short-circuit is false) fell through to `"accepted"` the moment it received any post-action update (a comment, label, base bump). `"accepted"` is a **positive** state (`POSITIVE_STATES`), so the recommendation was credited with a merge that causally predates it — inflating the operator recommendation-quality positives.

The intended semantics were already pinned: `recommendation-outcomes.test.ts` asserts the same pre-action-merged PR with **no** post-action activity is `"stale"`. A single `updatedAt` bump should not flip that to the positive `"accepted"`.

## Change
- Guard the `accepted` fallback against a merge that predates `actionAt`, mirroring the `merged` branch's own `>= actionAt` discipline.
- Add a regression case: PR merged before the action with `updatedAt` after it -> `"stale"`, not `"accepted"`.

## Verification
- `recommendation-outcomes.test.ts` 12/12 (the new case fails on the old code, which returns `"accepted"`); `tsc --noEmit` clean; full suite green; branch coverage holds (>= 97% gate).

Same function as the closed #475 (which fixed a changes-requested PR being scored `improved`); a different defect in the `accepted` fallback.