### PR TITLE
feat(notifications): event detection (changes-requested)

### DIFF
--- a/src/notifications/events.ts
+++ b/src/notifications/events.ts
@@ -1,0 +1,61 @@
+import type { GitHubWebhookPayload } from "../types";
+import { nowIso } from "../utils/json";
+
+export type NotificationEventType = "pull_request_changes_requested";
+
+export type DetectedNotificationEvent = {
+  eventType: NotificationEventType;
+  recipientLogin: string;
+  repoFullName: string;
+  pullNumber: number;
+  dedupKey: string;
+  deeplink: string;
+  actorLogin: string;
+  detectedAt: string;
+};
+
+function isBotUser(user: { login?: string; type?: string } | undefined): boolean {
+  return user?.type === "Bot";
+}
+
+function normalizeLogin(login: string | undefined): string | undefined {
+  return login?.trim().toLowerCase() || undefined;
+}
+
+export function detectNotificationEvents(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+  detectedAt: string = nowIso(),
+): DetectedNotificationEvent[] {
+  if (eventName !== "pull_request_review") return [];
+  if (payload.action !== "submitted" && payload.action !== "edited") return [];
+
+  const repoFullName = payload.repository?.full_name;
+  const pullRequest = payload.pull_request;
+  const pullNumber = pullRequest?.number;
+  const authorLogin = pullRequest?.user?.login;
+  if (!repoFullName || !pullNumber || !authorLogin) return [];
+
+  const reviewState = payload.review?.state?.toLowerCase();
+  if (reviewState !== "changes_requested") return [];
+
+  const reviewerLogin = payload.review?.user?.login ?? payload.sender?.login;
+  if (isBotUser(payload.review?.user) || isBotUser(payload.sender) || isBotUser(pullRequest?.user)) return [];
+  if (reviewerLogin && normalizeLogin(reviewerLogin) === normalizeLogin(authorLogin)) return [];
+
+  const submittedAt = payload.review?.submitted_at ?? detectedAt;
+  const dedupKey = `changes_requested:${repoFullName}#${pullNumber}:${normalizeLogin(reviewerLogin) ?? "unknown"}:${submittedAt}`;
+
+  return [
+    {
+      eventType: "pull_request_changes_requested",
+      recipientLogin: authorLogin,
+      repoFullName,
+      pullNumber,
+      dedupKey,
+      deeplink: payload.review?.html_url ?? pullRequest.html_url ?? `https://github.com/${repoFullName}/pull/${pullNumber}`,
+      actorLogin: reviewerLogin ?? "unknown",
+      detectedAt,
+    },
+  ];
+}

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -76,6 +76,7 @@ import { ensurePullRequestLabel } from "../github/labels";
 import { fetchPublicContributorProfile } from "../github/public";
 import { refreshRegistry } from "../registry/sync";
 import { buildIssueAdvisory, buildPullRequestAdvisory, evaluateGateCheck } from "../rules/advisory";
+import { detectNotificationEvents } from "../notifications/events";
 import { getOrCreateScoringModelSnapshot, refreshScoringModelSnapshot } from "../scoring/model";
 import { buildAndPersistContributorDecisionPack, loadDecisionPackSharedInputs } from "../services/decision-pack";
 import {
@@ -725,6 +726,25 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       const repo = await getRepository(env, payload.repository.full_name);
       const advisory = buildIssueAdvisory(repo, issue);
       await persistAdvisory(env, advisory);
+    }
+
+    for (const notificationEvent of detectNotificationEvents(eventName, payload)) {
+      await recordAuditEvent(env, {
+        eventType: "notification.event_detected",
+        actor: notificationEvent.actorLogin,
+        targetKey: notificationEvent.recipientLogin,
+        outcome: "success",
+        detail: `${notificationEvent.eventType} for ${notificationEvent.repoFullName}#${notificationEvent.pullNumber}`,
+        metadata: {
+          deliveryId,
+          eventType: notificationEvent.eventType,
+          recipientLogin: notificationEvent.recipientLogin,
+          repoFullName: notificationEvent.repoFullName,
+          pullNumber: notificationEvent.pullNumber,
+          dedupKey: notificationEvent.dedupKey,
+          deeplink: notificationEvent.deeplink,
+        },
+      });
     }
 
     await recordWebhookEvent(env, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,7 @@ export type GitHubWebhookPayload = {
   pull_request?: GitHubPullRequestPayload;
   issue?: GitHubIssuePayload;
   comment?: GitHubIssueCommentPayload;
+  review?: GitHubReviewPayload;
   reaction?: GitHubReactionPayload;
   sender?: GitHubWebhookUserPayload;
   label?: {
@@ -186,6 +187,13 @@ export type GitHubPullRequestPayload = {
   };
   labels?: Array<{ name?: string }>;
   body?: string | null;
+};
+
+export type GitHubReviewPayload = {
+  state?: string;
+  user?: GitHubWebhookUserPayload;
+  submitted_at?: string | null;
+  html_url?: string;
 };
 
 export type GitHubIssuePayload = {

--- a/test/unit/notifications-events.test.ts
+++ b/test/unit/notifications-events.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { detectNotificationEvents } from "../../src/notifications/events";
+import type { GitHubWebhookPayload } from "../../src/types";
+
+const basePayload: GitHubWebhookPayload = {
+  action: "submitted",
+  repository: { name: "gittensory", full_name: "JSONbored/gittensory", owner: { login: "JSONbored" } },
+  pull_request: {
+    number: 42,
+    title: "Add feature",
+    state: "open",
+    user: { login: "contributor", type: "User" },
+    html_url: "https://github.com/JSONbored/gittensory/pull/42",
+  },
+  review: {
+    state: "changes_requested",
+    user: { login: "maintainer", type: "User" },
+    submitted_at: "2026-05-28T12:00:00.000Z",
+    html_url: "https://github.com/JSONbored/gittensory/pull/42#pullrequestreview-1",
+  },
+  sender: { login: "maintainer", type: "User" },
+};
+
+describe("detectNotificationEvents", () => {
+  it("emits one changes-requested event for the PR author", () => {
+    const events = detectNotificationEvents("pull_request_review", basePayload, "2026-05-28T12:00:01.000Z");
+
+    expect(events).toEqual([
+      {
+        eventType: "pull_request_changes_requested",
+        recipientLogin: "contributor",
+        repoFullName: "JSONbored/gittensory",
+        pullNumber: 42,
+        dedupKey: "changes_requested:JSONbored/gittensory#42:maintainer:2026-05-28T12:00:00.000Z",
+        deeplink: "https://github.com/JSONbored/gittensory/pull/42#pullrequestreview-1",
+        actorLogin: "maintainer",
+        detectedAt: "2026-05-28T12:00:01.000Z",
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toMatch(/trust score|wallet|hotkey|reward estimate|reviewability/i);
+  });
+
+  it("accepts edited review actions and ignores non-changes-requested states", () => {
+    expect(detectNotificationEvents("pull_request_review", { ...basePayload, action: "edited" }, "2026-05-28T12:00:01.000Z")).toHaveLength(1);
+    expect(
+      detectNotificationEvents(
+        "pull_request_review",
+        { ...basePayload, review: { ...basePayload.review, state: "approved" } },
+        "2026-05-28T12:00:01.000Z",
+      ),
+    ).toEqual([]);
+    expect(detectNotificationEvents("pull_request_review", { ...basePayload, action: "dismissed" }, "2026-05-28T12:00:01.000Z")).toEqual([]);
+  });
+
+  it("ignores unrelated webhook events and incomplete payloads", () => {
+    expect(detectNotificationEvents("pull_request", basePayload)).toEqual([]);
+    expect(detectNotificationEvents("pull_request_review", { ...basePayload, pull_request: undefined as never })).toEqual([]);
+    expect(detectNotificationEvents("pull_request_review", { ...basePayload, review: undefined as never })).toEqual([]);
+  });
+
+  it("suppresses self-notifications and bot-authored reviews", () => {
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        review: { ...basePayload.review, user: { login: "contributor", type: "User" } },
+        sender: { login: "contributor", type: "User" },
+      }),
+    ).toEqual([]);
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        review: { ...basePayload.review, user: { login: "Contributor", type: "User" } },
+        sender: { login: " CONTRIBUTOR ", type: "User" },
+      }),
+    ).toEqual([]);
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        review: { ...basePayload.review, user: { login: "dependabot[bot]", type: "Bot" } },
+        sender: { login: "dependabot[bot]", type: "Bot" },
+      }),
+    ).toEqual([]);
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        pull_request: { ...basePayload.pull_request!, user: { login: "dependabot[bot]", type: "Bot" } },
+      }),
+    ).toEqual([]);
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        review: undefined as never,
+        sender: { login: "github-actions[bot]", type: "Bot" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("falls back to sender login, generated deeplink, and detectedAt when review metadata is sparse", () => {
+    const events = detectNotificationEvents(
+      "pull_request_review",
+      {
+        action: "submitted",
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 7,
+          title: "Sparse review",
+          state: "open",
+          user: { login: "contributor", type: "User" },
+        },
+        review: {
+          state: "changes_requested",
+        },
+      },
+      "2026-05-28T13:00:00.000Z",
+    );
+
+    expect(events).toEqual([
+      {
+        eventType: "pull_request_changes_requested",
+        recipientLogin: "contributor",
+        repoFullName: "JSONbored/gittensory",
+        pullNumber: 7,
+        dedupKey: "changes_requested:JSONbored/gittensory#7:unknown:2026-05-28T13:00:00.000Z",
+        deeplink: "https://github.com/JSONbored/gittensory/pull/7",
+        actorLogin: "unknown",
+        detectedAt: "2026-05-28T13:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("uses sender login when review.user is absent", () => {
+    const events = detectNotificationEvents(
+      "pull_request_review",
+      {
+        ...basePayload,
+        review: {
+          state: "changes_requested",
+          submitted_at: "2026-05-28T12:00:00.000Z",
+        },
+        sender: { login: "maintainer", type: "User" },
+      },
+      "2026-05-28T12:00:01.000Z",
+    );
+
+    expect(events[0]?.actorLogin).toBe("maintainer");
+    expect(events[0]?.dedupKey).toContain(":maintainer:");
+  });
+
+  it("returns no events when repository or author metadata is missing", () => {
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        repository: undefined as never,
+      }),
+    ).toEqual([]);
+    expect(
+      detectNotificationEvents("pull_request_review", {
+        ...basePayload,
+        pull_request: { ...basePayload.pull_request!, user: undefined as never },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3461,6 +3461,55 @@ describe("queue processors", () => {
       .first<{ outcome: string; detail: string }>();
     expect(event).toMatchObject({ outcome: "error", detail: "miner_detection_unavailable" });
   });
+
+  it("detects a changes-requested review notification for the PR author", async () => {
+    const env = createTestEnv();
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "review-changes-requested",
+      eventName: "pull_request_review",
+      payload: {
+        action: "submitted",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 42,
+          title: "Add feature",
+          state: "open",
+          user: { login: "contributor", type: "User" },
+          html_url: "https://github.com/JSONbored/gittensory/pull/42",
+        },
+        review: {
+          state: "changes_requested",
+          user: { login: "maintainer", type: "User" },
+          submitted_at: "2026-05-28T12:00:00.000Z",
+          html_url: "https://github.com/JSONbored/gittensory/pull/42#pullrequestreview-1",
+        },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    const detected = await env.DB.prepare("select actor, target_key, outcome, detail, metadata_json from audit_events where event_type = ?")
+      .bind("notification.event_detected")
+      .all<{ actor: string; target_key: string; outcome: string; detail: string; metadata_json: string }>();
+    expect(detected.results).toHaveLength(1);
+    expect(detected.results[0]).toMatchObject({
+      actor: "maintainer",
+      target_key: "contributor",
+      outcome: "success",
+      detail: "pull_request_changes_requested for JSONbored/gittensory#42",
+    });
+    expect(JSON.parse(detected.results[0]!.metadata_json)).toMatchObject({
+      deliveryId: "review-changes-requested",
+      eventType: "pull_request_changes_requested",
+      recipientLogin: "contributor",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 42,
+      dedupKey: "changes_requested:JSONbored/gittensory#42:maintainer:2026-05-28T12:00:00.000Z",
+    });
+    expect(JSON.stringify(detected.results[0])).not.toMatch(/trust score|wallet|hotkey|reward estimate|reviewability/i);
+  });
 });
 
 function completeSegment(repoFullName: string, segment: "labels" | "open_issues" | "open_pull_requests") {


### PR DESCRIPTION
## Summary

- Adds `GitHubReviewPayload` and an optional `review` field on `GitHubWebhookPayload` in `src/types.ts` so `pull_request_review` webhooks are typed end-to-end.
- Introduces `detectNotificationEvents` in `src/notifications/events.ts` to emit a single `pull_request_changes_requested` event for the PR author, with self-notification and bot suppression.
- Records detected events from `processGitHubWebhook` via audit metadata (`notification.event_detected`) for downstream notify-evaluate/deliver jobs.
- Adds unit coverage in `test/unit/notifications-events.test.ts` and a queue processor test in `test/unit/queue.test.ts` for detection, suppression rules, fallback metadata, and one audit record per changes-requested review.

Closes #566

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm run audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run validate` was run locally (covers `typecheck` + `test:coverage`); branch coverage met the 97% threshold.
- Remaining CI checks (`actionlint`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:*`, `audit`) are left for CI to run.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. *(not applicable — webhook event detection only; no auth/session changes)*
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. *(no public API/OpenAPI/MCP surface change; audit metadata is internal)*
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. *(not applicable — backend only)*
- [ ] Visible UI changes include screenshots or a short recording. *(not applicable — no UI changes)*
- [ ] Public docs/changelogs are updated where needed. *(not applicable)*

## Notes

- Parent epic: #535
- Includes the typed `review` payload prerequisite needed for changes-requested detection (see #536 / #527).
- Detection records audit metadata only; delivery channels (`notify-evaluate` / `notify-deliver`) are tracked in #568 and follow-on notification issues.
