### PR TITLE
fix(auth): ignore spoofable proxy IP headers

### DIFF
--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -147,59 +147,8 @@ async function validateBearerForRateLimit(c: Context<{ Bindings: Env }>, token: 
 }
 
 function clientIp(c: Context<{ Bindings: Env }>): string {
-  const cloudflareIp = normalizeIpAddress(c.req.header("cf-connecting-ip"));
-  if (cloudflareIp) return cloudflareIp;
-
-  if (!isTrustedProxyRequest(c)) return "unknown-ip";
-
-  const proxyCount = trustedProxyCount(c.env.RATE_LIMIT_TRUSTED_PROXY_COUNT);
-  return (
-    firstValidIp([
-      c.req.header("x-real-ip"),
-      trustedForwardedForIp(c.req.header("x-forwarded-for"), proxyCount),
-    ]) ?? "unknown-ip"
-  );
-}
-
-function isTrustedProxyRequest(c: Context<{ Bindings: Env }>): boolean {
-  const trustedProxies = parseTrustedProxyList(c.env.RATE_LIMIT_TRUSTED_PROXIES);
-  if (trustedProxies.length === 0) return false;
-  const chain = forwardedForCandidates(c.req.header("x-forwarded-for"))
-    .map((entry) => normalizeIpAddress(entry))
-    .filter((entry): entry is string => Boolean(entry));
-  const peer = chain[chain.length - 1];
-  return peer ? trustedProxies.includes(peer) : false;
-}
-
-function parseTrustedProxyList(value: string | undefined): string[] {
-  return (value ?? "")
-    .split(",")
-    .map((entry) => normalizeIpAddress(entry))
-    .filter((entry): entry is string => Boolean(entry));
-}
-
-function trustedProxyCount(value: string | undefined): number {
-  const parsed = Number(value?.trim());
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
-}
-
-function trustedForwardedForIp(header: string | undefined, trustedProxyCountValue: number): string | undefined {
-  const chain = forwardedForCandidates(header);
-  if (chain.length < trustedProxyCountValue) return undefined;
-  return chain[chain.length - trustedProxyCountValue];
-}
-
-function forwardedForCandidates(header: string | undefined): string[] {
-  if (!header?.trim()) return [];
-  return header.split(",").map((part) => part.trim()).filter(Boolean);
-}
-
-function firstValidIp(candidates: Array<string | undefined>): string | undefined {
-  for (const candidate of candidates) {
-    const valid = normalizeIpAddress(candidate);
-    if (valid) return valid;
-  }
-  return undefined;
+  // Only trust Cloudflare-populated client IPs. Proxy fallback headers can be supplied by clients in Workers.
+  return normalizeIpAddress(c.req.header("cf-connecting-ip")) ?? "unknown-ip";
 }
 
 function normalizeIpAddress(value: string | undefined): string | undefined {

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -141,7 +141,7 @@ describe("private-beta auth and rate limiting", () => {
     expect(observedKeys[0]).toMatch(/^normal:\/v1\/public\/github\/repos\/:owner\/:repo\/stats:ip:/);
   });
 
-  it("keys pre-auth routes by proxy fallback headers when cf-connecting-ip is absent", async () => {
+  it("ignores proxy fallback headers when cf-connecting-ip is absent", async () => {
     const observedKeys: string[] = [];
     const env = rateLimitTestEnv({}, observedKeys);
 
@@ -158,7 +158,7 @@ describe("private-beta auth and rate limiting", () => {
       ),
     ).resolves.toBeNull();
     expect(observedKeys).toHaveLength(2);
-    expect(observedKeys[0]).not.toBe(observedKeys[1]);
+    expect(observedKeys[0]).toBe(observedKeys[1]);
     expect(observedKeys[0]).toMatch(/^strict:\/v1\/auth\/github\/session:ip:/);
 
     observedKeys.length = 0;
@@ -170,36 +170,12 @@ describe("private-beta auth and rate limiting", () => {
     ).resolves.toBeNull();
     await expect(
       enforceRateLimit(
-        fakeContext(env, "/v1/auth/github/session", trustedProxyHeaders({ "x-real-ip": "198.51.100.3" })),
+        fakeContext(env, "/v1/auth/github/session", trustedProxyHeaders({ "x-real-ip": "203.0.113.44" })),
         "strict",
       ),
     ).resolves.toBeNull();
     expect(observedKeys).toHaveLength(2);
     expect(observedKeys[0]).toBe(observedKeys[1]);
-
-    observedKeys.length = 0;
-    await expect(
-      enforceRateLimit(
-        fakeContext(env, "/v1/auth/github/session", trustedProxyHeaders({ "x-real-ip": "203.0.113.44", "x-forwarded-for": "198.51.100.99" })),
-        "strict",
-      ),
-    ).resolves.toBeNull();
-    await expect(
-      enforceRateLimit(fakeContext(env, "/v1/auth/github/session", trustedProxyHeaders({ "x-real-ip": "203.0.113.44" })), "strict"),
-    ).resolves.toBeNull();
-    expect(observedKeys).toHaveLength(2);
-    expect(observedKeys[0]).toBe(observedKeys[1]);
-
-    observedKeys.length = 0;
-    await expect(
-      enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "x-forwarded-for": "198.51.100.1" }), "strict"),
-    ).resolves.toBeNull();
-    await expect(
-      enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "x-forwarded-for": "198.51.100.2" }), "strict"),
-    ).resolves.toBeNull();
-    expect(observedKeys).toHaveLength(2);
-    expect(observedKeys[0]).toBe(observedKeys[1]);
-    expect(observedKeys[0]).toMatch(/^strict:\/v1\/auth\/github\/session:ip:/);
   });
 
   it("does not treat spoofed cf-ray as trusted proxy proof", async () => {
@@ -226,7 +202,7 @@ describe("private-beta auth and rate limiting", () => {
     expect(observedKeys[0]).toMatch(/^strict:\/v1\/auth\/github\/session:ip:/);
   });
 
-  it("keys pre-auth routes by configured trusted proxy IPs without cf-ray", async () => {
+  it("ignores configured trusted proxy IPs without Cloudflare client IP", async () => {
     const observedKeys: string[] = [];
     const env = createTestEnv({
       RATE_LIMITER: rateLimiterNamespace({ status: 200, body: {} }, observedKeys) as unknown as DurableObjectNamespace,
@@ -246,7 +222,7 @@ describe("private-beta auth and rate limiting", () => {
     await expect(
       enforceRateLimit(
         fakeContext(env, "/v1/auth/github/session", {
-          "x-forwarded-for": "198.51.100.2, 198.51.100.99",
+          "x-forwarded-for": "198.51.100.3, 198.51.100.99",
         }),
         "strict",
       ),
@@ -422,6 +398,31 @@ describe("private-beta auth and rate limiting", () => {
       ),
     ).resolves.toBeNull();
     expect(observedKeys[0]).toBe(unknownIpKey);
+  });
+
+  it("normalizes only valid Cloudflare client IP headers", async () => {
+    const observedKeys: string[] = [];
+    const env = rateLimitTestEnv({}, observedKeys);
+
+    await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "cf-connecting-ip": " 203.0.113.9 " }), "strict")).resolves.toBeNull();
+    const ipv4Key = observedKeys[0];
+
+    observedKeys.length = 0;
+    await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "cf-connecting-ip": "[2001:db8::1]" }), "strict")).resolves.toBeNull();
+    await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "cf-connecting-ip": "2001:db8::1" }), "strict")).resolves.toBeNull();
+    expect(observedKeys).toHaveLength(2);
+    expect(observedKeys[0]).toBe(observedKeys[1]);
+    expect(observedKeys[0]).not.toBe(ipv4Key);
+
+    observedKeys.length = 0;
+    await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session"), "strict")).resolves.toBeNull();
+    const unknownIpKey = observedKeys[0];
+
+    for (const value of ["", "not-an-ip", "1.2.3", "256.0.0.1", "1::2::3", "1:2:3:4:5:6:7:8:9", "::"]) {
+      observedKeys.length = 0;
+      await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session", { "cf-connecting-ip": value }), "strict")).resolves.toBeNull();
+      expect(observedKeys[0]).toBe(unknownIpKey);
+    }
   });
 
   it("enforces route limits with session and IP keys plus retry headers", async () => {


### PR DESCRIPTION
### Motivation
- The prior change accepted `x-real-ip`/`x-forwarded-for` as fallbacks when `cf-connecting-ip` was missing, which let unauthenticated clients spoof rate-limit identities by supplying attacker-controlled XFF entries.
- The goal is to prevent unauthenticated clients from creating arbitrary pre-auth rate-limit buckets by trusting only unspoofable peer signals.

### Description
- Removed the trusted-proxy fallback logic from `clientIp()` in `src/auth/rate-limit.ts` so the function now only trusts `cf-connecting-ip` and otherwise returns `"unknown-ip"`.
- Deleted helper logic that parsed and validated `X-Forwarded-For` chains and trusted-proxy configuration so header-controlled values are no longer used for rate-limit identities.
- Updated `test/unit/auth.test.ts` to assert that proxy headers and configured trusted-proxy values do not produce distinct pre-auth rate-limit keys when `cf-connecting-ip` is absent.
- Left token-based identity behavior unchanged so authenticated requests continue to prefer token keys where applicable.

### Testing
- Ran type checking with `tsc --noEmit` via `npm run typecheck`, which completed successfully.
- Ran the focused unit tests with `vitest` via `npm test -- --run test/unit/auth.test.ts --reporter=verbose`, and all tests in that file passed (18 tests passed).
- The full `npm test` run was attempted in this environment but did not complete within the session (environmental/time constraints), so only the targeted unit tests and typecheck were verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba73097b4832aaebd4242b362dcc4)