### PR TITLE
feat(signals): slop signal — missing test evidence

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1210,7 +1210,7 @@ function safeRepoPath(path: string): string {
   return /^(\/Users\/|\/home\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
 }
 
-function isTestFile(file: string): boolean {
+export function isTestFile(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
@@ -1220,7 +1220,7 @@ function isTestFile(file: string): boolean {
   );
 }
 
-function isCodeFile(file: string): boolean {
+export function isCodeFile(file: string): boolean {
   return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
 }
 

--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -1,0 +1,99 @@
+import type { SignalFinding } from "./engine";
+import { isCodeFile, isTestFile } from "./local-branch";
+import { hasLocalTestEvidence, isTestPath } from "./test-evidence";
+import { isFocusManifestPublicSafe } from "./focus-manifest";
+
+export type SlopBand = "clean" | "low" | "elevated" | "high";
+
+export type SlopChangedFile = {
+  path: string;
+  additions?: number | undefined;
+  deletions?: number | undefined;
+};
+
+export type SlopAssessmentInput = {
+  changedFiles?: SlopChangedFile[] | undefined;
+  tests?: string[] | undefined;
+  testFiles?: string[] | undefined;
+};
+
+export type SlopAssessment = {
+  slopRisk: number;
+  band: SlopBand;
+  findings: SignalFinding[];
+};
+
+export const SLOP_WEIGHTS = {
+  missingTestEvidence: 30,
+} as const;
+
+export const SLOP_RUBRIC_MARKDOWN = [
+  "# Gittensory slop assessment rubric",
+  "",
+  "- `clean`: 0",
+  "- `low`: 1-24",
+  "- `elevated`: 25-59",
+  "- `high`: 60-100",
+  "",
+  "Current deterministic signals:",
+  "- missing test evidence",
+].join("\n");
+
+export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
+  const findings: SignalFinding[] = [];
+  const missingTestEvidenceFinding = buildMissingTestEvidenceFinding(input);
+  if (missingTestEvidenceFinding) findings.push(missingTestEvidenceFinding);
+
+  const slopRisk = clamp(missingTestEvidenceFinding ? SLOP_WEIGHTS.missingTestEvidence : 0, 0, 100);
+
+  return {
+    slopRisk,
+    band: slopBandFor(slopRisk),
+    findings,
+  };
+}
+
+export function buildMissingTestEvidenceFinding(input: SlopAssessmentInput): SignalFinding | null {
+  const changedFiles = input.changedFiles ?? [];
+  const changedPaths = changedFiles.map((file) => file.path).filter(Boolean);
+  const codePaths = changedPaths.filter(isCodeFile);
+  if (codePaths.length === 0) return null;
+
+  const hasChangedTestPaths =
+    changedPaths.some((path) => isTestFile(path) || isTestPath(path)) ||
+    hasLocalTestEvidence({ tests: input.tests, testFiles: input.testFiles });
+  if (hasChangedTestPaths) return null;
+
+  const detail = ensurePublicSafeText(
+    `Changed paths include ${codePaths.length} code file(s) without accompanying test evidence.`,
+    "Code changes were detected without accompanying test evidence.",
+  );
+  const action = ensurePublicSafeText(
+    "Add focused regression tests or explain why existing coverage is sufficient.",
+    "Add focused tests or explain why existing coverage is sufficient.",
+  );
+
+  return {
+    code: "missing_test_evidence",
+    title: "Code changes lack test evidence",
+    severity: "warning",
+    detail,
+    action,
+    publicText: detail,
+  };
+}
+
+function ensurePublicSafeText(text: string, fallback: string): string {
+  return isFocusManifestPublicSafe(text) ? text : fallback;
+}
+
+function slopBandFor(slopRisk: number): SlopBand {
+  if (slopRisk <= 0) return "clean";
+  if (slopRisk < 25) return "low";
+  if (slopRisk < 60) return "elevated";
+  return "high";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMissingTestEvidenceFinding,
+  buildSlopAssessment,
+  SLOP_RUBRIC_MARKDOWN,
+  SLOP_WEIGHTS,
+} from "../../src/signals/slop";
+
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|raw trust|trust score|scoreability|private reviewability|\/Users|\/home|\/tmp/i;
+
+describe("buildSlopAssessment", () => {
+  it("exports rubric bands and a deterministic assessment shell", () => {
+    expect(SLOP_RUBRIC_MARKDOWN).toContain("clean");
+    expect(SLOP_RUBRIC_MARKDOWN).toContain("missing test evidence");
+
+    const clean = buildSlopAssessment({});
+    expect(clean).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+    expect(buildSlopAssessment({})).toEqual(clean);
+  });
+
+  it("raises missing-test-evidence slop for code-only diffs without tests", () => {
+    const result = buildSlopAssessment({
+      changedFiles: [{ path: "src/registry/sync.ts", additions: 24, deletions: 2 }],
+    });
+
+    expect(result.slopRisk).toBe(SLOP_WEIGHTS.missingTestEvidence);
+    expect(result.band).toBe("elevated");
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        code: "missing_test_evidence",
+        severity: "warning",
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("does not raise missing-test-evidence when changed test files are present", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [
+          { path: "src/registry/sync.ts", additions: 24, deletions: 2 },
+          { path: "test/unit/registry-sync.test.ts", additions: 18, deletions: 0 },
+        ],
+      }),
+    ).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("does not raise missing-test-evidence when external test evidence is supplied", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [{ path: "src/registry/sync.ts", additions: 12, deletions: 0 }],
+        testFiles: ["internal/cache_test.go"],
+      }),
+    ).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("ignores docs-only diffs without code files", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [{ path: "README.md", additions: 40, deletions: 0 }],
+      }),
+    ).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+});
+
+describe("buildMissingTestEvidenceFinding", () => {
+  it("keeps public reason strings sanitized", () => {
+    const finding = buildMissingTestEvidenceFinding({
+      changedFiles: [{ path: "src/api/routes.ts", additions: 3, deletions: 0 }],
+    });
+
+    expect(finding).toMatchObject({
+      code: "missing_test_evidence",
+      publicText: expect.any(String),
+    });
+    expect(JSON.stringify(finding)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+});


### PR DESCRIPTION
## Summary

- Scaffold `buildSlopAssessment` in `src/signals/slop.ts` with `SLOP_WEIGHTS`, `SLOP_RUBRIC_MARKDOWN`, and deterministic band mapping.
- Add the missing-test-evidence slop signal using `hasLocalTestEvidence` / `isTestPath` from `src/signals/test-evidence.ts` and `isCodeFile` / `isTestFile` from `src/signals/local-branch.ts`.
- Add unit coverage in `test/unit/slop.test.ts` for code-only vs test-bearing diffs and public/private output boundaries.

Fixes #559

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm run audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run validate` was run locally (covers `typecheck` + `test:coverage`); branch coverage met the 97% threshold.
- Remaining CI checks are left for CI to run.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. *(not applicable)*
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. *(internal slop scorer only)*
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. *(not applicable — backend only)*
- [ ] Visible UI changes include screenshots or a short recording. *(not applicable)*
- [ ] Public docs/changelogs are updated where needed. *(not applicable)*

## Notes

- Parent epic: #530
- This PR includes the minimal slop assessment shell required for the signal; additional slop signals land in follow-on issues.

Made with [Cursor](https://cursor.com)