### PR TITLE
feat(signals): slop signal — trivial/whitespace churn

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1210,7 +1210,7 @@ function safeRepoPath(path: string): string {
   return /^(\/Users\/|\/home\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
 }
 
-function isTestFile(file: string): boolean {
+export function isTestFile(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
@@ -1220,7 +1220,7 @@ function isTestFile(file: string): boolean {
   );
 }
 
-function isCodeFile(file: string): boolean {
+export function isCodeFile(file: string): boolean {
   return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
 }
 

--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -1,0 +1,125 @@
+import type { SignalFinding } from "./engine";
+import { isCodeFile, isTestFile } from "./local-branch";
+import { isFocusManifestPublicSafe } from "./focus-manifest";
+
+export type SlopBand = "clean" | "low" | "elevated" | "high";
+
+export type SlopChangedFile = {
+  path: string;
+  additions?: number | undefined;
+  deletions?: number | undefined;
+};
+
+export type SlopAssessmentInput = {
+  changedFiles?: SlopChangedFile[] | undefined;
+};
+
+export type SlopAssessment = {
+  slopRisk: number;
+  band: SlopBand;
+  findings: SignalFinding[];
+};
+
+export const SLOP_WEIGHTS = {
+  trivialWhitespaceChurn: 25,
+} as const;
+
+export const SLOP_RUBRIC_MARKDOWN = [
+  "# Gittensory slop assessment rubric",
+  "",
+  "- `clean`: 0",
+  "- `low`: 1-24",
+  "- `elevated`: 25-59",
+  "- `high`: 60-100",
+  "",
+  "Current deterministic signals:",
+  "- trivial / whitespace-only churn",
+].join("\n");
+
+const MIN_CHURN_LINES = 40;
+const MAX_SOURCE_LINE_SHARE = 0.15;
+
+export function buildSlopAssessment(input: SlopAssessmentInput): SlopAssessment {
+  const findings: SignalFinding[] = [];
+  const trivialChurnFinding = buildTrivialWhitespaceChurnFinding(input);
+  if (trivialChurnFinding) findings.push(trivialChurnFinding);
+
+  const slopRisk = clamp(trivialChurnFinding ? SLOP_WEIGHTS.trivialWhitespaceChurn : 0, 0, 100);
+
+  return {
+    slopRisk,
+    band: slopBandFor(slopRisk),
+    findings,
+  };
+}
+
+export function buildTrivialWhitespaceChurnFinding(input: SlopAssessmentInput): SignalFinding | null {
+  const changedFiles = input.changedFiles ?? [];
+  const lineTotals = summarizeChangedLines(changedFiles);
+  if (lineTotals.changedLineCount < MIN_CHURN_LINES) return null;
+  if (lineTotals.sourceLineCount === 0) {
+    return buildTrivialChurnFinding(lineTotals.changedLineCount, lineTotals.nonCodeLineCount);
+  }
+  const sourceShare = lineTotals.sourceLineCount / lineTotals.changedLineCount;
+  if (sourceShare > MAX_SOURCE_LINE_SHARE) return null;
+  return buildTrivialChurnFinding(lineTotals.changedLineCount, lineTotals.nonCodeLineCount);
+}
+
+function summarizeChangedLines(changedFiles: SlopChangedFile[]): {
+  changedLineCount: number;
+  sourceLineCount: number;
+  testLineCount: number;
+  nonCodeLineCount: number;
+} {
+  const changedLineCount = changedFiles.reduce(
+    (sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions),
+    0,
+  );
+  const sourceLineCount = changedFiles
+    .filter((file) => isCodeFile(file.path))
+    .reduce((sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions), 0);
+  const testLineCount = changedFiles
+    .filter((file) => isTestFile(file.path))
+    .reduce((sum, file) => sum + nonNegative(file.additions) + nonNegative(file.deletions), 0);
+  const nonCodeLineCount = Math.max(0, changedLineCount - sourceLineCount - testLineCount);
+  return { changedLineCount, sourceLineCount, testLineCount, nonCodeLineCount };
+}
+
+function buildTrivialChurnFinding(changedLineCount: number, nonCodeLineCount: number): SignalFinding {
+  const detail = ensurePublicSafeText(
+    `The diff churns ${changedLineCount} line(s) with only ${Math.max(0, changedLineCount - nonCodeLineCount)} substantive source line(s) touched.`,
+    "The diff shows high churn with minimal substantive source changes.",
+  );
+  const action = ensurePublicSafeText(
+    "Reduce whitespace-only or formatting-only churn and keep the diff focused on substantive changes.",
+    "Reduce formatting-only churn and keep the diff focused on substantive changes.",
+  );
+
+  return {
+    code: "trivial_whitespace_churn",
+    title: "Diff looks like trivial or whitespace-only churn",
+    severity: "warning",
+    detail,
+    action,
+    publicText: detail,
+  };
+}
+
+function nonNegative(value: number | undefined): number {
+  return Number.isFinite(value) && (value ?? 0) > 0 ? Math.trunc(value as number) : 0;
+}
+
+function ensurePublicSafeText(text: string, fallback: string): string {
+  return isFocusManifestPublicSafe(text) ? text : fallback;
+}
+
+function slopBandFor(slopRisk: number): SlopBand {
+  if (slopRisk <= 0) return "clean";
+  if (slopRisk < 25) return "low";
+  if (slopRisk < 60) return "elevated";
+  return "high";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlopAssessment,
+  buildTrivialWhitespaceChurnFinding,
+  SLOP_RUBRIC_MARKDOWN,
+  SLOP_WEIGHTS,
+} from "../../src/signals/slop";
+
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|raw trust|trust score|scoreability|private reviewability|\/Users|\/home|\/tmp/i;
+
+describe("buildSlopAssessment", () => {
+  it("exports rubric bands and a deterministic assessment shell", () => {
+    expect(SLOP_RUBRIC_MARKDOWN).toContain("trivial / whitespace-only churn");
+
+    const clean = buildSlopAssessment({});
+    expect(clean).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+    expect(buildSlopAssessment({})).toEqual(clean);
+  });
+
+  it("raises trivial-churn slop for high-churn diffs with minimal source lines", () => {
+    const result = buildSlopAssessment({
+      changedFiles: [
+        { path: "README.md", additions: 30, deletions: 20 },
+        { path: "docs/guide.md", additions: 25, deletions: 15 },
+        { path: "src/widget.ts", additions: 2, deletions: 1 },
+      ],
+    });
+
+    expect(result.slopRisk).toBe(SLOP_WEIGHTS.trivialWhitespaceChurn);
+    expect(result.band).toBe("elevated");
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        code: "trivial_whitespace_churn",
+        severity: "warning",
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("does not raise trivial-churn when substantive source edits dominate", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [
+          { path: "src/registry/sync.ts", additions: 80, deletions: 20 },
+          { path: "test/unit/registry-sync.test.ts", additions: 40, deletions: 5 },
+        ],
+      }),
+    ).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("does not raise trivial-churn for small diffs below the churn threshold", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [{ path: "README.md", additions: 10, deletions: 8 }],
+      }),
+    ).toEqual({ slopRisk: 0, band: "clean", findings: [] });
+  });
+
+  it("raises trivial-churn for non-code-only high-churn diffs", () => {
+    expect(
+      buildSlopAssessment({
+        changedFiles: [
+          { path: "README.md", additions: 25, deletions: 20 },
+          { path: "docs/guide.md", additions: 20, deletions: 15 },
+        ],
+      }).findings.map((finding) => finding.code),
+    ).toEqual(["trivial_whitespace_churn"]);
+  });
+});
+
+describe("buildTrivialWhitespaceChurnFinding", () => {
+  it("keeps public reason strings sanitized", () => {
+    const finding = buildTrivialWhitespaceChurnFinding({
+      changedFiles: [
+        { path: "README.md", additions: 30, deletions: 20 },
+        { path: "docs/guide.md", additions: 25, deletions: 15 },
+      ],
+    });
+
+    expect(finding).toMatchObject({
+      code: "trivial_whitespace_churn",
+      publicText: expect.any(String),
+    });
+    expect(JSON.stringify(finding)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+});


### PR DESCRIPTION
## Summary

- Scaffold `buildSlopAssessment` in `src/signals/slop.ts` with `SLOP_WEIGHTS`, `SLOP_RUBRIC_MARKDOWN`, and deterministic band mapping.
- Add the trivial/whitespace churn slop signal using the same source/test/non-code line split as `buildLocalScoreInput`, flagging high-churn diffs with minimal substantive source edits.
- Export `isCodeFile` / `isTestFile` from `src/signals/local-branch.ts` for shared file classification and add unit coverage in `test/unit/slop.test.ts`.

Fixes #560

## Scope

- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm run audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run validate` was run locally (covers `typecheck` + `test:coverage`); branch coverage met the 97% threshold.
- Remaining CI checks are left for CI to run.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. *(not applicable)*
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. *(internal slop scorer only)*
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. *(not applicable — backend only)*
- [ ] Visible UI changes include screenshots or a short recording. *(not applicable)*
- [ ] Public docs/changelogs are updated where needed. *(not applicable)*

## Notes

- Parent epic: #530
- Both #559 and this PR introduce `src/signals/slop.ts`; merge #559 first or rebase this branch afterward to combine the shared shell with both signals.

Made with [Cursor](https://cursor.com)