### PR TITLE
chore(release): @jsonbored/gittensory-mcp 0.5.0

### DIFF
--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## mcp-v0.5.0 - 2026-06-12
+
+### Features
+- Cache last-good decision packs (#266)
+- Add risk-adjusted action portfolio (#219)
+- Summarize repo tradeoffs (#323)
+- Add multi-account profile support (#263)
+- Add agent action explanation cards (#232)
+- Add recommendation outcome feedback (#229)
+- Add duplicate and stale-work scenario blockers (#346)
+- Add structured output schemas for existing tools (#344)
+- Add miner planning prompts (#342)
+- Define focus-manifest policy schema (#339)
+- Persist recommendation outcome events (#334)
+- Persist privacy-safe role on product usage events (#355)
+- Feed aggregate outcome quality into confidence (#332)
+- Add version command and clearer unknown-command guidance (#333)
+- Add roots-aware workspace detection (#364)
+- Add safe planning elicitation (#371)
+- Add recommendation snapshot ids (#374)
+- Add counterfactual reasons (#361)
+- Add native resources, prompts, and structured output schemas (#360)
+- Add queue pressure trend windows (#368)
+- Add public-safe PR body drafting command (#382)
+- Add shell completion command for bash, zsh, and fish (#400)
+- Group doctor onboarding checks (#421)
+- Add config command reporting resolved configuration provenance (#335)
+- Derive contribution lanes from focus manifests (#337)
+- Wire policy compiler into registration readiness (#350)
+- Add contribution policy snapshot API (#369)
+- Add Gittensory repo focus manifest (#118) (#389)
+- Render public-safe scenario summaries (#416)
+- Require 0.5.0 as the current supported client
+
+### Fixes
+- Surface npm latest across ui (#258)
+- Scope decision-pack cache to auth token (#314)
+- Remove default profile session cleanly (#327)
+- Align registry changes output schema (#366)
+- Enforce workspace roots for structured local status
+- Include completion command in shell completions
+- Shell-quote doctor next commands (#439)
+- Report source upload env in config (#441)
+- Clamp lane shares to match preview math (#453)
+- Base open-PR threshold on merged history only (#455)
+- Scope issue-quality reports to repo access (#483)
+- Scope MCP repo access (#484)
+- Preserve HTTP status for non-JSON errors (#489)
+- Keep repo outcome patterns private (#493)
+- Bound duplicate detection inputs (#497)
+- Require solved-by-PR evidence for linked issues (#506)
+- Reject prototype agent profile names (#507)
+- Include config in completions (#509)
+- Wire duplicate risk preview input (#512)
+- Redact windows home paths in public PR packets (#514)
+- Subject over-long manifest entries to dedup and list cap (#524)
+
+### Security
+- Bound focus manifest ingestion (#494)
+
 ## mcp-v0.4.0 - 2026-06-02
 
 ### Features

--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -63,7 +63,7 @@ gittensory-mcp --stdio
 `gittensory-mcp version` (aliases `--version` and `-v`) prints the installed package version, the targeted API version, and the Node.js runtime version:
 
 ```text
-@jsonbored/gittensory-mcp/0.4.0 (api 0.1.0, node v22.12.0)
+@jsonbored/gittensory-mcp/0.5.0 (api 0.1.0, node v22.12.0)
 ```
 
 Add `--json` for machine-readable output:
@@ -71,7 +71,7 @@ Add `--json` for machine-readable output:
 ```json
 {
   "name": "@jsonbored/gittensory-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "apiVersion": "0.1.0",
   "node": "v22.12.0"
 }

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -11,7 +11,7 @@ import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadat
 const defaultApiUrl = "https://gittensory-api.aethereal.dev";
 const legacyDefaultApiUrls = new Set(["https://gittensory-api.zeronode.workers.dev"]);
 const packageName = "@jsonbored/gittensory-mcp";
-const packageVersion = "0.4.0";
+const packageVersion = "0.5.0";
 const npmRegistryUrl = (process.env.GITTENSORY_NPM_REGISTRY_URL ?? "https://registry.npmjs.org").replace(/\/+$/, "");
 const upgradeCommand = `npm install -g ${packageName}@latest`;
 const npxFallbackCommand = `npx ${packageName}@latest <command>`;

--- a/packages/gittensory-mcp/package.json
+++ b/packages/gittensory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/gittensory-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "description": "Local stdio MCP wrapper for the Gittensory Gittensor base-agent.",

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -31,12 +31,12 @@ async function main() {
   checks.push(checkStatus(`${siteOrigin}/sitemap.xml`, 200, "sitemap", { contentType: /application\/xml/i }));
   checks.push(checkStatus(`${siteOrigin}/CNAME`, 404, "retired GitHub Pages CNAME"));
 
-  checks.push(checkJson(`${apiOrigin}/health`, "API health", (json) => json.status === "ok" && json.minMcpVersion === "0.4.0" && json.latestRecommendedMcpVersion === "0.4.0"));
+  checks.push(checkJson(`${apiOrigin}/health`, "API health", (json) => json.status === "ok" && json.minMcpVersion === "0.5.0" && json.latestRecommendedMcpVersion === "0.5.0"));
   checks.push(
     checkJson(
       `${apiOrigin}/v1/mcp/compatibility`,
       "MCP compatibility",
-      (json) => json.status === "ok" && json.mcp?.minimumSupportedVersion === "0.4.0" && json.mcp?.latestPackageVersion === "0.4.0",
+      (json) => json.status === "ok" && json.mcp?.minimumSupportedVersion === "0.5.0" && json.mcp?.latestPackageVersion === "0.5.0",
     ),
   );
   checks.push(checkJson(`${apiOrigin}/v1/auth/session`, "signed-out session", (json) => json.status === "signed_out"));

--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -1,7 +1,7 @@
 export const GITTENSORY_API_VERSION = "0.1.0";
 export const GITTENSORY_MCP_PACKAGE_NAME = "@jsonbored/gittensory-mcp";
-export const MINIMUM_SUPPORTED_MCP_VERSION = "0.4.0";
-export const LATEST_RECOMMENDED_MCP_VERSION = "0.4.0";
+export const MINIMUM_SUPPORTED_MCP_VERSION = "0.5.0";
+export const LATEST_RECOMMENDED_MCP_VERSION = "0.5.0";
 
 export type McpCompatibilityStatus = "current" | "stale" | "incompatible" | "unknown";
 

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -77,8 +77,8 @@ describe("api routes", () => {
     await expect(health.json()).resolves.toMatchObject({
       status: "ok",
       service: "gittensory-api",
-      minMcpVersion: "0.4.0",
-      latestRecommendedMcpVersion: "0.4.0",
+      minMcpVersion: "0.5.0",
+      latestRecommendedMcpVersion: "0.5.0",
     });
 
     const compatibility = await app.request("/v1/mcp/compatibility", {}, env);
@@ -90,9 +90,9 @@ describe("api routes", () => {
       apiVersion: "0.1.0",
       mcp: {
         packageName: "@jsonbored/gittensory-mcp",
-        minimumSupportedVersion: "0.4.0",
-        latestRecommendedVersion: "0.4.0",
-        latestPackageVersion: "0.4.0",
+        minimumSupportedVersion: "0.5.0",
+        latestRecommendedVersion: "0.5.0",
+        latestPackageVersion: "0.5.0",
       },
       compatibilityWarnings: [],
       breakingChanges: [],
@@ -3235,7 +3235,7 @@ describe("api routes", () => {
         expect.objectContaining({ label: "Product events", value: String(productUsageEvents.length) }),
         expect.objectContaining({ label: "Active users" }),
         expect.objectContaining({ label: "Activation rollups", value: "partial" }),
-        expect.objectContaining({ label: "MCP stale clients", value: "2" }),
+        expect.objectContaining({ label: "MCP stale clients", value: "4" }),
       ]),
     );
     expect(usageOperatorBody.usageSummary.totalEvents).toBe(productUsageEvents.length);
@@ -3245,7 +3245,7 @@ describe("api routes", () => {
       totalEvents: 4,
       activeActors: 4,
       staleEvents: 1,
-      incompatibleEvents: 1,
+      incompatibleEvents: 3,
       byClientVersion: expect.arrayContaining([
         { key: "0.1.0", count: 1 },
         { key: "0.2.1", count: 1 },
@@ -3256,8 +3256,7 @@ describe("api routes", () => {
         { key: "2025-03-26", count: 2 },
       ]),
       byCompatibilityStatus: expect.arrayContaining([
-        { status: "current", count: 2 },
-        { status: "incompatible", count: 1 },
+        { status: "incompatible", count: 3 },
         { status: "stale", count: 1 },
       ]),
     });
@@ -3267,10 +3266,10 @@ describe("api routes", () => {
     const mcpCompatibilityBody = await mcpCompatibility.json();
     expect(mcpCompatibilityBody).toMatchObject({
       adoption: expect.objectContaining({
-        minimumSupportedVersion: "0.4.0",
-        latestRecommendedVersion: "0.4.0",
+        minimumSupportedVersion: "0.5.0",
+        latestRecommendedVersion: "0.5.0",
         staleEvents: 1,
-        incompatibleEvents: 1,
+        incompatibleEvents: 3,
         totalEvents: 4,
       }),
     });
@@ -4975,9 +4974,9 @@ describe("api routes", () => {
           metadata: expect.objectContaining({
             toolName: "gittensory_get_bounty_advisory",
             protocolVersion: "2025-03-26",
-            compatibilityStatus: "current",
-            minimumSupportedVersion: "0.4.0",
-            latestRecommendedVersion: "0.4.0",
+            compatibilityStatus: "incompatible",
+            minimumSupportedVersion: "0.5.0",
+            latestRecommendedVersion: "0.5.0",
           }),
         }),
       ]),

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -212,7 +212,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("reports a current install without upgrade guidance", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer({ latestVersion: "0.4.0" });
+    const url = await startFixtureServer({ latestVersion: "0.5.0", minMcpVersion: "0.5.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -231,16 +231,16 @@ describe("gittensory-mcp CLI", () => {
     expect(payload.apiCompatibility).toMatchObject({
       status: "compatible",
       source: "compatibility_endpoint",
-      minVersion: "0.4.0",
-      latestRecommendedVersion: "0.4.0",
+      minVersion: "0.5.0",
+      latestRecommendedVersion: "0.5.0",
       apiVersion: "0.1.0",
     });
   });
 
   it("orders prerelease npm versions correctly (release outranks prerelease of the same core)", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    // Local 0.4.0 (release) vs latest 0.4.0-rc.1 (prerelease) -> local is ahead, not stale.
-    const aheadUrl = await startFixtureServer({ latestVersion: "0.4.0-rc.1" });
+    // Local 0.5.0 (release) vs latest 0.5.0-rc.1 (prerelease) -> local is ahead, not stale.
+    const aheadUrl = await startFixtureServer({ latestVersion: "0.5.0-rc.1" });
     const ahead = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: aheadUrl,
@@ -252,8 +252,8 @@ describe("gittensory-mcp CLI", () => {
     expect(ahead.package).toMatchObject({ state: "ahead", updateAvailable: false });
     await new Promise<void>((resolve) => server?.close(() => resolve()));
 
-    // Local 0.4.0 vs a higher-core prerelease 0.5.0-rc.1 -> stale.
-    const staleUrl = await startFixtureServer({ latestVersion: "0.5.0-rc.1" });
+    // Local 0.5.0 vs a higher-core prerelease 0.6.0-rc.1 -> stale.
+    const staleUrl = await startFixtureServer({ latestVersion: "0.6.0-rc.1" });
     const stale = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: staleUrl,
@@ -348,7 +348,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("uses API recommended package metadata when the npm registry is unavailable", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: "0.5.0" });
+    const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: "0.6.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -360,7 +360,7 @@ describe("gittensory-mcp CLI", () => {
     expect(payload.package).toMatchObject({
       state: "stale",
       latestStatus: "api",
-      latestVersion: "0.5.0",
+      latestVersion: "0.6.0",
       upgradeCommand: "npm install -g @jsonbored/gittensory-mcp@latest",
     });
   });
@@ -620,12 +620,12 @@ describe("gittensory-mcp CLI", () => {
       }),
     ) as { package: { name: string; version: string; latestStatus: string }; api: { status: string }; auth: { login: string } };
 
-    expect(status.package).toMatchObject({ name: "@jsonbored/gittensory-mcp", version: "0.4.0", latestStatus: "skipped" });
+    expect(status.package).toMatchObject({ name: "@jsonbored/gittensory-mcp", version: "0.5.0", latestStatus: "skipped" });
     expect(status.api.status).toBe("ok");
     expect(status.auth.login).toBe("JSONbored");
 
     const changelog = JSON.parse(run(["changelog", "--json"])) as { package: { version: string }; changelog: string };
-    expect(changelog.package.version).toBe("0.4.0");
+    expect(changelog.package.version).toBe("0.5.0");
     expect(changelog.changelog).toContain("# Changelog");
   });
 
@@ -643,7 +643,7 @@ describe("gittensory-mcp CLI", () => {
 
     const sessionRequest = requests.find((request) => request.url === "/v1/auth/session");
     expect(sessionRequest?.headers["x-gittensory-mcp-package"]).toBe("@jsonbored/gittensory-mcp");
-    expect(sessionRequest?.headers["x-gittensory-mcp-version"]).toBe("0.4.0");
+    expect(sessionRequest?.headers["x-gittensory-mcp-version"]).toBe("0.5.0");
     expect(sessionRequest?.headers["x-gittensory-mcp-client"]).toBe("gittensory-mcp-cli");
     const telemetryHeaders = JSON.stringify({
       package: sessionRequest?.headers["x-gittensory-mcp-package"],
@@ -1124,7 +1124,7 @@ describe("gittensory-mcp CLI", () => {
   });
 
   it("reports the package version via version, --version, and -v", () => {
-    const expected = "@jsonbored/gittensory-mcp/0.4.0";
+    const expected = "@jsonbored/gittensory-mcp/0.5.0";
     for (const flag of ["version", "--version", "-v"]) {
       const plain = run([flag]).trim();
       expect(plain).toContain(expected);
@@ -1137,7 +1137,7 @@ describe("gittensory-mcp CLI", () => {
   it("emits machine-readable version output with --json", () => {
     const payload = JSON.parse(run(["version", "--json"])) as { name: string; version: string; apiVersion: string; node: string };
     expect(payload.name).toBe("@jsonbored/gittensory-mcp");
-    expect(payload.version).toBe("0.4.0");
+    expect(payload.version).toBe("0.5.0");
     expect(payload.apiVersion).toBe("0.1.0");
     expect(payload.node).toBe(process.version);
   });

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -7,7 +7,8 @@ describe("MCP compatibility telemetry", () => {
     expect(classifyMcpClientVersion("0.1.9")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.2.1")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.3.0")).toBe("incompatible");
-    expect(classifyMcpClientVersion("0.4.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.4.0")).toBe("incompatible");
+    expect(classifyMcpClientVersion("0.5.0")).toBe("current");
     expect(classifyMcpClientVersion("not-a-version")).toBe("unknown");
     expect(classifyMcpClientVersion(undefined)).toBe("unknown");
   });
@@ -39,14 +40,14 @@ describe("MCP compatibility telemetry", () => {
     const telemetry = buildMcpClientTelemetry(
       new Headers({
         "x-gittensory-mcp-package": "@example/custom-mcp",
-        "x-gittensory-mcp-version": "0.4.0",
+        "x-gittensory-mcp-version": "0.5.0",
       }),
       { requireGittensoryHeader: true },
     );
 
     expect(telemetry).toMatchObject({
       clientName: "custom-mcp",
-      clientVersion: "0.4.0",
+      clientVersion: "0.5.0",
       metadata: {
         packageName: "@example/custom-mcp",
         compatibilityStatus: "current",

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -24,7 +24,7 @@ describe("MCP server telemetry", () => {
         authorization: `Bearer ${env.GITTENSORY_MCP_TOKEN}`,
         "content-type": "application/json",
         "x-gittensory-mcp-package": "@jsonbored/gittensory-mcp",
-        "x-gittensory-mcp-version": "0.4.0",
+        "x-gittensory-mcp-version": "0.5.0",
         "x-gittensory-mcp-client": "gittensory-mcp-cli",
       },
       body: JSON.stringify({
@@ -54,7 +54,7 @@ describe("MCP server telemetry", () => {
         eventName: "mcp_tool_called",
         outcome: "error",
         clientName: "gittensory-<redacted-actor>-cli",
-        clientVersion: "0.4.0",
+        clientVersion: "0.5.0",
         metadata: expect.objectContaining({
           toolName: "gittensory_local_status",
           compatibilityStatus: "current",


### PR DESCRIPTION
Release-prep for **mcp-v0.5.0** (tracked in #321). npm `@latest` is currently the 2026-06-02 `0.4.0` build; this ships the ~50 commits since (native MCP resources/prompts/output schemas, agent profiles, shell completion, multi-account profiles, public-safe PR-body drafting, plus fixes including windows-path redaction and repo-access scoping).

### Checklist (#321)
- [x] Bump `packages/gittensory-mcp/package.json` → `0.5.0`
- [x] Bump CLI `packageVersion` constant → `0.5.0`
- [x] Raise MCP compatibility floor (min supported + latest recommended) → `0.5.0`
- [x] Regenerate `packages/gittensory-mcp/CHANGELOG.md` (`mcp-v0.5.0` section)
- [x] `build:mcp`, `test:mcp-pack`, `changelog:check:mcp`, `actionlint` green locally
- [x] Full vitest suite green (1508 passed); version-pinned tests updated for the new floor (0.4.0 clients now classify as incompatible)
- [ ] Merge → tag `mcp-v0.5.0` → npm trusted publishing + GitHub Release
- [ ] Follow-up: bump `MCP_PACKAGE_KNOWN_LATEST_VERSION` once npm shows 0.5.0

Note: the UI known-latest constant stays at `0.4.0` here because `ui:version-audit` requires it to equal the live npm dist-tag; it bumps in a post-publish follow-up.