### PR TITLE
chore(ui): bump known-latest MCP version to 0.5.0

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -6,7 +6,7 @@ export const MCP_PACKAGE_NAME = "@jsonbored/gittensory-mcp";
 export const MCP_PACKAGE_ENCODED_NAME = "@jsonbored%2fgittensory-mcp";
 export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAGE_ENCODED_NAME}`;
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.4.0";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.5.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.2.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
Post-publish follow-up to #618 / #321. `@jsonbored/gittensory-mcp@0.5.0` is live on npm; this aligns `MCP_PACKAGE_KNOWN_LATEST_VERSION` so `ui:version-audit` (which pins to the live npm dist-tag) stays green on main.