### PR TITLE
fix(agent): exclude repo identifier from scenario-summary guard

### DIFF
--- a/src/scenarios/scenario-summary.ts
+++ b/src/scenarios/scenario-summary.ts
@@ -178,8 +178,12 @@ function extractDataClassification(scenarioInput: AgentScenarioInput | undefined
 }
 
 function assertPublicSummaryClean(summary: PublicScenarioSummary): void {
-  const serialized = JSON.stringify(summary);
-  /* v8 ignore start -- All text fields are sanitized before this guard; defensive check for future fields. */
+  // Scan only rendered free-text fields. repoFullName/generatedAt are structural identifiers (the repo
+  // the summary is about), not sanitized content -- a legitimately named repo (e.g. "owner/hotkey-vault")
+  // must not make this guard throw and fail the whole summary.
+  const { repoFullName: _repoFullName, generatedAt: _generatedAt, ...renderedContent } = summary;
+  const serialized = JSON.stringify(renderedContent);
+  /* v8 ignore start -- Defensive: every rendered field is individually sanitized; this guards a future unsanitized field. */
   if (FORBIDDEN_PUBLIC_LANGUAGE.test(serialized)) {
     throw new Error("Public scenario summary still contains forbidden language.");
   }

--- a/test/unit/scenario-summary.test.ts
+++ b/test/unit/scenario-summary.test.ts
@@ -162,6 +162,16 @@ describe("renderPublicScenarioSummary", () => {
     expect(summary.advisoryOnly).toBe(true);
   });
 
+  it("renders for a repo whose name contains a forbidden term without throwing", () => {
+    // "hotkey"/"wallet" are Bittensor protocol terms; a legitimately named repo must not fail the guard.
+    const summary = renderPublicScenarioSummary({
+      repoFullName: "octo/hotkey-wallet",
+      generatedAt: "2026-06-12T00:00:00.000Z",
+    });
+    expect(summary.repoFullName).toBe("octo/hotkey-wallet");
+    expect(summary.headline).toMatch(/Advisory scenario summary generated from available repo signals/i);
+  });
+
   it("renders pressure options, eligibility notes, blockers, and data classification", () => {
     const pressureSimulation = simulateOpenPrPressure({
       repoFullName: "octo/demo",


### PR DESCRIPTION
Closes #624.

`assertPublicSummaryClean` serialized the **entire** summary and rejected it on `FORBIDDEN_PUBLIC_LANGUAGE`, but `repoFullName` is passed through **un-sanitized** (it is the repo identifier, not rendered content). So a legitimately named repo — and `hotkey`/`coldkey`/`wallet` are literal Bittensor protocol terms — made `renderPublicScenarioSummary` **throw**, failing the public scenario summary entirely. The guard's own `/* v8 ignore … all fields are sanitized */` rationale was false for `repoFullName`.

## Change
- Scan only the rendered free-text content; destructure out `repoFullName`/`generatedAt` (structural identifiers) before the forbidden-language check.
- Add a regression test: `repoFullName: "octo/hotkey-wallet"` renders without throwing and preserves the name.

## Verification
- `scenario-summary.test.ts` 9/9 (the new case throws on the old code); `tsc --noEmit` clean; full suite green; branch coverage holds (>= 97% gate).

Same accepted class as #457 (sanitizer breaking valid repo names like `wallet-adapter`), different surface: a public-output guard that hard-threw on the un-sanitized `repoFullName`.