### PR TITLE
chore(deploy): auto-deploy gittensory-api via Workers Builds (migrate + deploy)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,8 +163,17 @@ Cloudflare/deploy:
   `https://gittensory.aethereal.dev/`.
 - Production API deploys through the `gittensory-api` Cloudflare Worker on
   `https://gittensory-api.aethereal.dev/`.
-- Cloudflare Workers Builds owns automatic UI deployments from GitHub. GitHub Actions UI deploy is
-  manual validation/fallback only.
+- Cloudflare Workers Builds owns automatic deployments from GitHub for BOTH workers (one connection
+  per worker, scoped by build-watch-paths). GitHub Actions are validation/fallback only — do not add
+  deploy workflows.
+  - `gittensory-api` deploy command: `npm run deploy:api` (applies pending D1 migrations, then
+    `wrangler deploy`). `wrangler d1 migrations apply` is non-interactive in CI and only applies
+    PENDING migrations, so schema + code stay in sync on every build. Recommended build-watch-paths —
+    include: `src/**`, `wrangler.jsonc`, `migrations/**`, `package.json`, `package-lock.json`,
+    `tsconfig*.json`, `drizzle.config.ts`; exclude: `apps/**`, `docs/**`, `**/*.md`.
+  - `gittensory-ui` build command: `npm run build:cloudflare`. Scope its watch-paths to
+    `apps/gittensory-ui/**` (note: the UI build runs `ui:openapi` off the API contract, so rebuild the
+    UI after API OpenAPI changes).
 - Do not re-add GitHub Pages or static-site deployment workflows.
 
 MCP:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "deploy:api": "wrangler deploy",
+    "deploy:api": "wrangler d1 migrations apply gittensory --remote && wrangler deploy",
     "cf-typegen": "wrangler types && perl -pi -e 's/[[:blank:]]+$//' worker-configuration.d.ts",
     "db:migrate:local": "wrangler d1 migrations apply gittensory --local",
     "db:migrate:remote": "wrangler d1 migrations apply gittensory --remote",


### PR DESCRIPTION
## What
Make `gittensory-api` (the backend worker) auto-deployable, like `gittensory-ui` already is.

- `deploy:api` now applies pending D1 migrations **then** deploys: `wrangler d1 migrations apply gittensory --remote && wrangler deploy`. `wrangler d1 migrations apply` is non-interactive in CI and only applies PENDING migrations (no-op when none), so schema + code stay in sync on every build.
- CONTRIBUTING.md documents the per-worker Workers Builds setup + recommended build-watch-paths.

## Why
`gittensory-api` had **no** automated deploy — only the UI auto-deploys via Cloudflare Workers Builds — so backend merges piled up unshipped (a 71-commit / 5-day backlog, including the earn-CTA footer #620, sat stale in prod).

## Follow-up (dashboard, not in this PR)
After merge: add a Workers Builds connection for `gittensory-api` (deploy command `npm run deploy:api`, build-watch-paths per CONTRIBUTING), and scope the existing `gittensory-ui` build's watch-paths so the two don't rebuild each other.