### PR TITLE
feat(mcp): gittensory_lint_pr_text (commit/PR-body rubric linter)

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -139,6 +139,12 @@ const checkBeforeStartShape = {
   plannedPaths: z.array(z.string()).optional(),
 };
 
+const lintPrTextShape = {
+  commitMessages: z.array(z.string()).max(50).optional(),
+  prBody: z.string().optional(),
+  linkedIssue: z.number().int().positive().optional(),
+};
+
 const preflightShape = {
   repoFullName: z.string().min(3),
   contributorLogin: z.string().min(1).optional(),
@@ -312,6 +318,16 @@ server.registerTool(
     };
     return toolResult("Gittensory pre-start check.", await apiPost(`${prefix}/check-before-start`, body));
   },
+);
+
+server.registerTool(
+  "gittensory_lint_pr_text",
+  {
+    description:
+      "Lint a commit message + PR body against the gittensor traceability/no-issue-rationale and Conventional Commit rubric before submitting. Returns a deterministic verdict (strong/adequate/weak) plus specific public-safe fixes. No source upload.",
+    inputSchema: lintPrTextShape,
+  },
+  async (input) => toolResult("Gittensory PR-text lint.", await apiPost("/v1/lint/pr-text", input)),
 );
 
 server.registerTool(

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -181,6 +181,7 @@ import {
   buildLaneAdvice,
   buildLinkedIssueValidation,
   buildLocalDiffPreflightResult,
+  buildPrTextLint,
   buildMaintainerCutReadiness,
   buildMaintainerLaneReport,
   buildPullRequestMaintainerPacket,
@@ -350,6 +351,12 @@ const checkBeforeStartSchema = z.object({
   issueNumber: z.number().int().positive().optional(),
   title: z.string().min(1).max(PREFLIGHT_LIMITS.titleChars).optional(),
   plannedPaths: z.array(z.string().max(PREFLIGHT_LIMITS.changedFileChars)).max(PREFLIGHT_LIMITS.changedFiles).optional(),
+});
+
+const lintPrTextSchema = z.object({
+  commitMessages: z.array(z.string().max(PREFLIGHT_LIMITS.bodyChars)).max(50).optional(),
+  prBody: z.string().max(PREFLIGHT_LIMITS.bodyChars).optional(),
+  linkedIssue: z.number().int().positive().optional(),
 });
 
 const skippedPrAuditQuerySchema = z
@@ -2057,6 +2064,13 @@ export function createApp() {
       decision,
       dataQuality: pack.dataQuality,
     });
+  });
+
+  app.post("/v1/lint/pr-text", async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsed = lintPrTextSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_lint_pr_text_request", issues: parsed.error.issues }, 400);
+    return c.json(buildPrTextLint(parsed.data));
   });
 
   app.post("/v1/preflight/pr", async (c) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -75,6 +75,7 @@ import {
   buildLocalDiffPreflightResult,
   buildPreflightResult,
   buildPreStartCheck,
+  buildPrTextLint,
   buildQueueHealth,
   buildRegistryChangeReport,
   buildRoleContext,
@@ -140,6 +141,12 @@ const checkBeforeStartShape = {
   issueNumber: z.number().int().positive().optional(),
   title: z.string().min(1).max(PREFLIGHT_LIMITS.titleChars).optional(),
   plannedPaths: z.array(z.string().max(PREFLIGHT_LIMITS.changedFileChars)).max(PREFLIGHT_LIMITS.changedFiles).optional(),
+};
+
+const lintPrTextShape = {
+  commitMessages: z.array(z.string().max(PREFLIGHT_LIMITS.bodyChars)).max(50).optional(),
+  prBody: z.string().max(PREFLIGHT_LIMITS.bodyChars).optional(),
+  linkedIssue: z.number().int().positive().optional(),
 };
 
 const preflightShape = {
@@ -507,6 +514,15 @@ const checkBeforeStartOutputSchema = {
   report: z.unknown().optional(),
 };
 
+const lintPrTextOutputSchema = {
+  verdict: z.string().optional(),
+  score: z.number().optional(),
+  components: z.unknown().optional(),
+  fixes: z.unknown().optional(),
+  summary: z.string().optional(),
+  generatedAt: z.string().optional(),
+};
+
 export async function handleMcpRequest(c: AppContext): Promise<Response> {
   if (c.req.method === "OPTIONS") return new Response(null, { status: 204 });
   const identity = await authenticateMcpRequest(c);
@@ -783,6 +799,17 @@ export class GittensoryMcp {
         outputSchema: checkBeforeStartOutputSchema,
       },
       async (input) => this.toolResult(await this.checkBeforeStart(input)),
+    );
+
+    server.registerTool(
+      "gittensory_lint_pr_text",
+      {
+        description:
+          "Lint a commit message + PR body against the gittensor traceability/no-issue-rationale and Conventional Commit rubric, before submitting. Returns a deterministic quality verdict (strong/adequate/weak) and specific public-safe fixes. Metadata only; no source upload, no GitHub writes.",
+        inputSchema: lintPrTextShape,
+        outputSchema: lintPrTextOutputSchema,
+      },
+      async (input) => this.toolResult(this.lintPrText(input)),
     );
 
     server.registerTool(
@@ -1197,6 +1224,14 @@ export class GittensoryMcp {
         blockers: report.blockers,
         report: report as unknown as Record<string, unknown>,
       },
+    };
+  }
+
+  private lintPrText(input: { commitMessages?: string[] | undefined; prBody?: string | undefined; linkedIssue?: number | undefined }): ToolPayload {
+    const report = buildPrTextLint(input);
+    return {
+      summary: `Gittensory PR-text lint verdict: ${report.verdict}.`,
+      data: report as unknown as Record<string, unknown>,
     };
   }
 

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4293,7 +4293,156 @@ function queuePressureOpenPullRequestScore(openPullRequests: number): number {
   return 3;
 }
 
-function hasClearNoIssueRationale(pr: PullRequestRecord): boolean {
+export type PrTextLintInput = {
+  commitMessages?: string[] | undefined;
+  prBody?: string | undefined;
+  linkedIssue?: number | undefined;
+};
+
+export type PrTextLintComponent = {
+  key: "traceability" | "commit_message" | "pr_body";
+  label: string;
+  status: "ok" | "weak";
+  evidence: string;
+  fix?: string | undefined;
+};
+
+export type PrTextLintReport = {
+  generatedAt: string;
+  verdict: "strong" | "adequate" | "weak";
+  /**
+   * 0-100 PR-text quality score from the deterministic rubric (sum of per-component weights; weak
+   * components score 25% of their weight). Advisory sub-signal only — `verdict` is authoritative.
+   * Because traceability is a hard gate for the verdict but only one weighted component of the score,
+   * the two can rank-disagree (e.g. a strong commit + body with no linked issue scores ~78 yet the
+   * verdict is "weak"). Rank by `verdict`, not `score`. Not a Gittensor reward/trust score.
+   */
+  score: number;
+  components: PrTextLintComponent[];
+  fixes: string[];
+  summary: string;
+};
+
+const GENERIC_COMMIT_PATTERN = /^(?:wip|fix(?:es|ed|ing)?|updat(?:e|es|ed|ing)|change[sd]?|edit[sd]?|patch|minor|tweak[sd]?|misc|cleanup|chore|stuff|temp|tmp|test|final|done|commit|asdf+|\.+)\b[\s.!]*$/i;
+// Conventional Commit subject: one of CONTRIBUTING's allowed types, optional `(scope)`, optional `!`,
+// then `: ` and a non-empty summary (e.g. `feat(api): add cursor pagination`). Single source of truth
+// with CONTRIBUTING.md "Commit And PR Titles".
+const CONVENTIONAL_COMMIT_PATTERN = /^(?:feat|fix|test|docs|refactor|build|ci|chore|revert)(?:\([^()\r\n]+\))?!?:\s+\S/i;
+const PR_TEXT_LINT_WEIGHTS = { traceability: 30, commit_message: 35, pr_body: 35 } as const;
+
+function stripPrBodyScaffolding(body: string): string {
+  return body
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/^#{1,6}\s.*$/gm, " ")
+    .replace(/^\s*[-*]\s*\[[ xX]\]/gm, " ")
+    .replace(/[#>*_`[\]()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Deterministic commit-message + PR-body rubric linter. Catches generic/empty AI-slop text before
+ * submit and returns a quality verdict plus specific, public-safe fixes. Reuses the gittensor
+ * traceability/no-issue-rationale rubric ({@link hasClearNoIssueRationale}, {@link tokenize},
+ * {@link STOPWORDS}) shared with the public readiness score. All output is routed through
+ * {@link sanitizePublicComment}; no private scoring is exposed.
+ */
+export function buildPrTextLint(input: PrTextLintInput): PrTextLintReport {
+  const commitMessages = (input.commitMessages ?? []).map((message) => message.trim()).filter((message) => message.length > 0);
+  const prBody = (input.prBody ?? "").trim();
+  const linkedIssue = typeof input.linkedIssue === "number" && input.linkedIssue > 0 ? input.linkedIssue : undefined;
+
+  const hasRationale = hasClearNoIssueRationale({ title: "", body: prBody });
+  const traceabilityOk = linkedIssue !== undefined || hasRationale;
+  const traceability: PrTextLintComponent = traceabilityOk
+    ? {
+        key: "traceability",
+        label: "Traceability",
+        status: "ok",
+        evidence: linkedIssue !== undefined ? `Linked issue #${linkedIssue}.` : "PR body includes a no-issue rationale.",
+      }
+    : {
+        key: "traceability",
+        label: "Traceability",
+        status: "weak",
+        evidence: "No linked issue and no no-issue rationale in the PR body.",
+        fix: 'Link the issue this PR resolves (e.g. "Fixes #123"), or explain in the body why no issue applies.',
+      };
+
+  const primaryCommit = commitMessages[0] ?? "";
+  const commitTokens = tokenize(commitMessages.join(" "));
+  const commitGeneric = primaryCommit.length > 0 && GENERIC_COMMIT_PATTERN.test(primaryCommit);
+  // The `^`-anchored pattern matches against the subject line at the start of the message.
+  const commitConventional = CONVENTIONAL_COMMIT_PATTERN.test(primaryCommit);
+  const commitOk = commitConventional && primaryCommit.length >= 15 && commitTokens.length >= 2 && !commitGeneric;
+  const commitMessage: PrTextLintComponent = commitOk
+    ? { key: "commit_message", label: "Commit message", status: "ok", evidence: "Commit message is specific and follows Conventional Commit format." }
+    : {
+        key: "commit_message",
+        label: "Commit message",
+        status: "weak",
+        evidence:
+          commitMessages.length === 0
+            ? "No commit message was provided."
+            : commitGeneric
+              ? "Commit message is generic (e.g. update/fix/wip)."
+              : !commitConventional
+                ? "Commit message does not follow Conventional Commit format (type(scope): summary)."
+                : "Commit message is too short or lacks specific detail.",
+        fix: "Use a Conventional Commit subject (type(scope): summary, e.g. feat(api): add cursor pagination) that names what changed and why; avoid generic words like update, fix, or wip on their own.",
+      };
+
+  const strippedBody = stripPrBodyScaffolding(prBody);
+  const bodyTokens = tokenize(strippedBody);
+  const bodyLooksTemplated = prBody.length > 0 && /\[[ xX]\]|<!--/.test(prBody);
+  // tokenize() only counts ASCII word tokens, so a fully non-Latin (CJK/Cyrillic/…) body yields 0
+  // tokens and would be mislabelled "thin". Fall back to a Unicode-aware letter density check so
+  // substantive non-Latin prose is recognised before we flag a body as low-effort.
+  const bodyNonWhitespace = strippedBody.replace(/\s+/g, "");
+  const bodyLetterCount = (bodyNonWhitespace.match(/\p{L}/gu) ?? []).length;
+  const bodyLetterDense = bodyNonWhitespace.length >= 24 && bodyLetterCount / bodyNonWhitespace.length >= 0.6;
+  const bodyOk = strippedBody.length >= 40 && (bodyTokens.length >= 5 || bodyLetterDense);
+  const prBodyComponent: PrTextLintComponent = bodyOk
+    ? {
+        key: "pr_body",
+        label: "PR body",
+        status: "ok",
+        evidence: hasValidationNote(prBody) ? "PR body describes the change and includes validation notes." : "PR body describes the change with specific detail.",
+      }
+    : {
+        key: "pr_body",
+        label: "PR body",
+        status: "weak",
+        evidence: prBody.length === 0 ? "PR body is empty." : bodyLooksTemplated ? "PR body looks like an unfilled template." : "PR body is thin and lacks specific detail about the change.",
+        fix: "Describe what changed, why, and how it was validated; fill in or remove unused template sections.",
+      };
+
+  const components = [traceability, commitMessage, prBodyComponent];
+  const score = components.reduce((sum, component) => sum + (component.status === "ok" ? PR_TEXT_LINT_WEIGHTS[component.key] : Math.round(PR_TEXT_LINT_WEIGHTS[component.key] * 0.25)), 0);
+  const weakCount = components.filter((component) => component.status === "weak").length;
+  const verdict: PrTextLintReport["verdict"] = weakCount === 0 ? "strong" : traceabilityOk && weakCount === 1 ? "adequate" : "weak";
+  const summary =
+    verdict === "strong"
+      ? "PR text is traceable, specific, and ready to submit."
+      : verdict === "adequate"
+        ? "PR text is acceptable but has one area to tighten before submitting."
+        : "PR text reads as low-effort; address the flagged items before submitting.";
+
+  return {
+    generatedAt: nowIso(),
+    verdict,
+    score,
+    components: components.map((component) => ({
+      ...component,
+      evidence: sanitizePublicComment(component.evidence),
+      ...(component.fix === undefined ? {} : { fix: sanitizePublicComment(component.fix) }),
+    })),
+    fixes: components.flatMap((component) => (component.fix === undefined ? [] : [sanitizePublicComment(component.fix)])),
+    summary: sanitizePublicComment(summary),
+  };
+}
+
+function hasClearNoIssueRationale(pr: Pick<PullRequestRecord, "title" | "body">): boolean {
   return /\b(no issue\s*(?:because|:)|no linked issue\s*(?:because|:)|no ticket\s*(?:because|:)|maintenance|docs? only|typo|chore|cleanup)\b/i.test([pr.title, pr.body ?? ""].join(" "));
 }
 

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -932,6 +932,19 @@ describe("api routes", () => {
     const invalidLocalDiff = await app.request("/v1/preflight/local-diff", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({}) }, env);
     expect(invalidLocalDiff.status).toBe(400);
 
+    const lintPrText = await app.request(
+      "/v1/lint/pr-text",
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ commitMessages: ["wip"], prBody: "" }) },
+      env,
+    );
+    expect(lintPrText.status).toBe(200);
+    const lintPrTextBody = await lintPrText.json();
+    expect(lintPrTextBody).toMatchObject({ verdict: "weak", fixes: expect.any(Array) });
+    expect(JSON.stringify(lintPrTextBody)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+
+    const invalidLintPrText = await app.request("/v1/lint/pr-text", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ linkedIssue: -1 }) }, env);
+    expect(invalidLintPrText.status).toBe(400);
+
     const queueIntelligence = await app.request(
       "/v1/internal/queue-intelligence",
       {

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -20,6 +20,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_get_issue_quality",
   "gittensory_validate_linked_issue",
   "gittensory_check_before_start",
+  "gittensory_lint_pr_text",
   "gittensory_get_registry_changes",
   "gittensory_get_upstream_drift",
   "gittensory_local_status",
@@ -173,6 +174,26 @@ describe("MCP tool calls return schema-valid structured content", () => {
     expect(["go", "raise", "avoid"]).toContain(data.recommendation);
     expect(data.found).toBe(false);
     expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+  });
+
+  it("gittensory_lint_pr_text returns a deterministic verdict and fixes", async () => {
+    const { client } = await connectTestClient();
+    const weak = await client.callTool({ name: "gittensory_lint_pr_text", arguments: { commitMessages: ["wip"], prBody: "" } });
+    expect(weak.isError).toBeFalsy();
+    const weakData = weak.structuredContent as Record<string, unknown>;
+    expect(weakData.verdict).toBe("weak");
+    expect(Array.isArray(weakData.fixes)).toBe(true);
+    expect(JSON.stringify(weakData)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+
+    const strong = await client.callTool({
+      name: "gittensory_lint_pr_text",
+      arguments: {
+        commitMessages: ["feat(api): add cursor pagination to the labels endpoint for large repositories"],
+        prBody: "Adds cursor-based pagination to the labels endpoint so labels beyond the first cached page are returned. Tested with vitest.",
+        linkedIssue: 160,
+      },
+    });
+    expect((strong.structuredContent as Record<string, unknown>).verdict).toBe("strong");
   });
 
   it("gittensory_get_repo_outcome_patterns reports not-found, computed, and cached outcomes", async () => {

--- a/test/unit/pr-text-lint.test.ts
+++ b/test/unit/pr-text-lint.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { buildPrTextLint, type PrTextLintReport } from "../../src/signals/engine";
+
+const FORBIDDEN_PUBLIC_TERMS = /wallet|hotkey|coldkey|mnemonic|payout|reward|farming|raw trust|trust score|scoreability|reviewability/i;
+const GOOD_COMMIT = "feat(api): add cursor pagination to the labels endpoint for large repositories";
+const GOOD_BODY =
+  "This pull request adds cursor-based pagination to the repository labels endpoint so labels beyond the first cached page are returned. Tested with vitest covering the new pagination path.";
+
+function component(report: PrTextLintReport, key: string) {
+  return report.components.find((c) => c.key === key)!;
+}
+
+function assertPublicSafe(report: PrTextLintReport): void {
+  for (const line of [report.summary, ...report.fixes, ...report.components.flatMap((c) => [c.evidence, c.fix ?? ""])]) {
+    expect(line).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  }
+}
+
+describe("buildPrTextLint", () => {
+  it("returns strong for linked, descriptive, validated text", () => {
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: GOOD_BODY, linkedIssue: 160 });
+    expect(report.verdict).toBe("strong");
+    expect(report.score).toBe(100);
+    expect(report.fixes).toHaveLength(0);
+    expect(component(report, "traceability").evidence).toMatch(/#160/);
+    expect(component(report, "pr_body").evidence).toMatch(/validation notes/i);
+    assertPublicSafe(report);
+  });
+
+  it("accepts a no-issue rationale in place of a linked issue", () => {
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: "Docs only change to clarify the README setup steps; no issue needed for this maintenance edit." });
+    expect(component(report, "traceability").status).toBe("ok");
+    expect(component(report, "traceability").evidence).toMatch(/no-issue rationale/i);
+    assertPublicSafe(report);
+  });
+
+  it("describes the change without flagging a missing validation note", () => {
+    const body = "This change refactors the pagination helper so the labels endpoint returns every page of results for large repositories without duplicate calls.";
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: body, linkedIssue: 1 });
+    expect(component(report, "pr_body").status).toBe("ok");
+    expect(component(report, "pr_body").evidence).toMatch(/specific detail/i);
+    assertPublicSafe(report);
+  });
+
+  it("is adequate when only the commit message is generic", () => {
+    const report = buildPrTextLint({ commitMessages: ["wip"], prBody: GOOD_BODY, linkedIssue: 160 });
+    expect(component(report, "commit_message").status).toBe("weak");
+    expect(component(report, "commit_message").evidence).toMatch(/generic/i);
+    expect(report.verdict).toBe("adequate");
+    expect(report.fixes.some((f) => /conventional commit subject/i.test(f))).toBe(true);
+    assertPublicSafe(report);
+  });
+
+  it("flags an empty commit message", () => {
+    const report = buildPrTextLint({ commitMessages: [], prBody: GOOD_BODY, linkedIssue: 160 });
+    expect(component(report, "commit_message").evidence).toMatch(/No commit message/i);
+    expect(report.verdict).toBe("adequate");
+    assertPublicSafe(report);
+  });
+
+  it("flags a too-short commit message", () => {
+    const report = buildPrTextLint({ commitMessages: ["fix(ui): typo"], prBody: GOOD_BODY, linkedIssue: 160 });
+    expect(component(report, "commit_message").status).toBe("weak");
+    expect(component(report, "commit_message").evidence).toMatch(/too short|specific detail/i);
+    assertPublicSafe(report);
+  });
+
+  it("flags a descriptive commit that is not Conventional-Commit format", () => {
+    const report = buildPrTextLint({ commitMessages: ["Add cursor pagination to the labels endpoint"], prBody: GOOD_BODY, linkedIssue: 160 });
+    expect(component(report, "commit_message").status).toBe("weak");
+    expect(component(report, "commit_message").evidence).toMatch(/conventional commit/i);
+    expect(report.fixes.some((f) => /conventional commit/i.test(f))).toBe(true);
+    assertPublicSafe(report);
+  });
+
+  it("is weak when traceability is missing even if the rest is good", () => {
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: GOOD_BODY });
+    expect(component(report, "traceability").status).toBe("weak");
+    expect(report.verdict).toBe("weak");
+    expect(report.fixes.some((f) => /Fixes #123|no issue applies/i.test(f))).toBe(true);
+    assertPublicSafe(report);
+  });
+
+  it("flags an empty PR body", () => {
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: "", linkedIssue: 160 });
+    expect(component(report, "pr_body").evidence).toMatch(/empty/i);
+    assertPublicSafe(report);
+  });
+
+  it("flags an unfilled template PR body", () => {
+    const templated = "## Summary\n\n<!-- Describe your change -->\n\n## Checklist\n- [ ] Tests\n- [ ] Docs";
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: templated, linkedIssue: 160 });
+    expect(component(report, "pr_body").status).toBe("weak");
+    expect(component(report, "pr_body").evidence).toMatch(/unfilled template/i);
+    assertPublicSafe(report);
+  });
+
+  it("flags a thin PR body", () => {
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: "fixes stuff", linkedIssue: 160 });
+    expect(component(report, "pr_body").evidence).toMatch(/thin/i);
+    assertPublicSafe(report);
+  });
+
+  it("does not flag a substantive non-Latin PR body as thin", () => {
+    const cyrillic =
+      "Этот запрос добавляет курсорную пагинацию к конечной точке меток репозитория, чтобы возвращались все страницы результатов для больших репозиториев.";
+    const cjk = "この変更は、リポジトリのラベルエンドポイントにカーソルベースのページネーションを追加し、最初のページ以降のラベルも返されるようにします。";
+    for (const prBody of [cyrillic, cjk]) {
+      const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody, linkedIssue: 160 });
+      expect(component(report, "pr_body").status).toBe("ok");
+      assertPublicSafe(report);
+    }
+  });
+
+  it("returns weak with all fixes when every dimension is low-effort", () => {
+    const report = buildPrTextLint({ commitMessages: ["update"], prBody: "" });
+    expect(report.verdict).toBe("weak");
+    expect(report.fixes).toHaveLength(3);
+    expect(report.score).toBeLessThan(50);
+    expect(report.summary).toMatch(/low-effort/i);
+    assertPublicSafe(report);
+  });
+
+  it("handles entirely empty input deterministically", () => {
+    const report = buildPrTextLint({});
+    expect(report.verdict).toBe("weak");
+    expect(report.components).toHaveLength(3);
+    assertPublicSafe(report);
+  });
+});


### PR DESCRIPTION
Fixes #549

## What

Adds `gittensory_lint_pr_text`, a deterministic MCP tool that lints a **commit message + PR body** against the gittensor traceability / no-issue-rationale rubric *before* submitting. It returns a quality verdict (`strong` / `adequate` / `weak`) plus specific, public-safe fixes — catching generic/empty AI-slop text pre-submit. Metadata only; no source upload, no GitHub writes.

## How

- **`src/signals/engine.ts`** — `buildPrTextLint` scores three rubric components (traceability, commit message, PR body), **reusing the existing rubric helpers**: `hasClearNoIssueRationale`, `tokenize` + `STOPWORDS`, and `hasValidationNote`. Every reason/fix is routed through `sanitizePublicComment` (public-safe, fail-closed).
- **`src/mcp/server.ts`** — registers the tool with an `inputSchema` and `outputSchema`.
- **`src/api/routes.ts`** — `POST /v1/lint/pr-text` backing the local CLI tool.
- **`packages/gittensory-mcp/bin/gittensory-mcp.js`** — exposes the tool, proxying to the API route.

**Input:** `{ commitMessages?, prBody?, linkedIssue? }`. **Output:** `{ verdict, score, components[], fixes[], summary }`.

## Output boundaries

Public-safe verdict + fixes only; no source contents leave the process.

## Tests

- `test/unit/pr-text-lint.test.ts` — verdict cases (strong/adequate/weak), each rubric component's weak paths (generic/empty/short commit, empty/template/thin body, missing traceability), and forbidden-term assertions on all output.
- `test/unit/mcp-output-schemas.test.ts` — output-schema discovery + structured-content call.
- `test/integration/api.test.ts` — route success + invalid-body (400).

`npm run validate` (typecheck + coverage) is green at the 97%+ branch threshold; `build:mcp`, `test:mcp-pack`, `test:workers`, and `ui:openapi:check` also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)