### PR TITLE
docs(wrangler): note gittensory-api auto-deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
+  // Auto-deploys to production via Cloudflare Workers Builds on push to `main`
+  // (deploy command: `npm run deploy:api` — applies pending D1 migrations, then `wrangler deploy`).
   "name": "gittensory-api",
   "main": "src/index.ts",
   "workers_dev": true,


### PR DESCRIPTION
Small inline doc on the new gittensory-api auto-deploy (Workers Builds → `npm run deploy:api`). Also an end-to-end smoke test: exercises reviewbot + the gittensory panel on open, and the gittensory-api Workers Builds deploy on merge.