### PR TITLE
fix(mcp): align 0.5 metadata

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -7,7 +7,7 @@ export const MCP_PACKAGE_ENCODED_NAME = "@jsonbored%2fgittensory-mcp";
 export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAGE_ENCODED_NAME}`;
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.5.0";
-export const MCP_MINIMUM_SUPPORTED_VERSION = "0.2.0";
+export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {
   "dist-tags": { latest?: string };


### PR DESCRIPTION
### Motivation
- The MCP package and API compatibility floor were bumped to `0.5.0` but the UI fallback text and root lockfile still referenced older versions, causing inconsistent version displays and release-tooling mismatches.

### Description
- Update the UI copy by setting `MCP_MINIMUM_SUPPORTED_VERSION` to `"0.5.0"` in `apps/gittensory-ui/src/lib/mcp-package.ts` so visible API/UI copy matches the compatibility floor.
- Refresh the root `package-lock.json` workspace entry for `@jsonbored/gittensory-mcp` from `0.4.0` to `0.5.0` to keep lockfile metadata consistent with the bumped package.

### Testing
- Ran `GITTENSORY_MCP_LATEST_VERSION=0.5.0 npm run ui:version-audit` which reported the UI version copy as OK. (passed)
- Ran `npm run ui:typecheck` to ensure TypeScript checks for the UI workspace succeeded. (passed)
- Ran repository checks with `git diff --check` to validate no whitespace/patch issues were introduced. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c1fa91f8c832a819652735bdfa2b5)