### PR TITLE
fix(api): allow session pre-start checks

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3723,6 +3723,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoSettingsPreviewPath(path)) return true;
   if (isRepoOnboardingPackPreviewPath(path)) return true;
   if (isRepoFocusManifestPath(path)) return true;
+  if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
   return false;
@@ -3738,6 +3739,10 @@ function isRepoOnboardingPackPreviewPath(path: string): boolean {
 
 function isRepoContributorIssueDraftGeneratePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/contributor-issue-drafts\/generate$/.test(path);
+}
+
+function isRepoCheckBeforeStartPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/check-before-start$/.test(path);
 }
 
 function isIssueQualityPath(path: string): boolean {

--- a/test/unit/routes-check-before-start.test.ts
+++ b/test/unit/routes-check-before-start.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/check-before-start";
+
+async function seedRegisteredInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
+    .bind(`${owner}/${name}`)
+    .run();
+}
+
+describe("check-before-start route auth", () => {
+  it("allows same-repo owner sessions to reach the route-specific repository guard", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ issueNumber: 1 }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      recommendation: expect.any(String),
+    });
+  });
+
+  it("rejects cross-repo owner sessions with forbidden_repo", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { token } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ issueNumber: 1 }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+});


### PR DESCRIPTION
### Motivation
- A new `/v1/repos/:owner/:repo/check-before-start` REST endpoint was added but normal session-authenticated callers were blocked by the global session allowlist before route-specific `requireSessionRepoAccess` could run, causing an availability regression for non-admin sessions.

### Description
- Permit the pre-start endpoint through the global session path gate by adding `isRepoCheckBeforeStartPath` to `canSessionAccessPath` in `src/api/routes.ts`.
- Add the `isRepoCheckBeforeStartPath` helper that matches `^/v1/repos/[^/]+/[^/]+/check-before-start$` to centralize the allowlist logic.
- Add a regression unit test `test/unit/routes-check-before-start.test.ts` that verifies same-repo owner sessions reach the route and cross-repo owner sessions receive `forbidden_repo`.

### Testing
- Ran the new unit test with `npm test -- --run test/unit/routes-check-before-start.test.ts` and it passed (2 tests, 2 assertions).
- Ran a focused integration test pattern with `npm test -- --run test/integration/api.test.ts --testNamePattern "authorized operator session to run pre-start checks|normal users receive scoped repo access"` and the relevant pre-start checks passed (1 test passed, remaining tests skipped by pattern).
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cf79ba280832aae07438fa073c253)