### PR TITLE
ci(ui-preview): drop prod custom-domain route from the preview deploy config

### DIFF
--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -110,7 +110,11 @@ jobs:
           echo "Artifact validated: no symlinks, expected SSR structure, allowlisted file types only."
 
       # The Wrangler config is written HERE (trusted) — never taken from the PR — so a fork cannot
-      # control bindings, routes, or vars. It points at the downloaded built bundle.
+      # control bindings, routes, or vars. It points at the downloaded built bundle. It deliberately
+      # OMITS the production custom-domain route: `wrangler versions upload` creates a 0%-traffic
+      # preview version (a workers.dev URL) and applies no routes, so the route is unused here — and
+      # omitting it guarantees that even a future switch to `wrangler deploy` could never point
+      # fork-built code at the production domain. Do not add a `routes` block to this preview config.
       - name: Write trusted preview Wrangler config
         if: steps.cfg.outputs.ready == 'true'
         run: |
@@ -138,12 +142,6 @@ jobs:
             "vars": {
               "VITE_GITTENSORY_API_ORIGIN": "https://gittensory-api.aethereal.dev"
             },
-            "routes": [
-              {
-                "pattern": "gittensory.aethereal.dev",
-                "custom_domain": true
-              }
-            ],
             "main": "index.mjs",
             "assets": {
               "binding": "ASSETS",


### PR DESCRIPTION
## What

Removes the production custom-domain `routes` block from the **preview** Wrangler config written in `ui-preview-deploy.yml`:

```diff
   "vars": {
     "VITE_GITTENSORY_API_ORIGIN": "https://gittensory-api.aethereal.dev"
   },
-  "routes": [
-    { "pattern": "gittensory.aethereal.dev", "custom_domain": true }
-  ],
   "main": "index.mjs",
```

## Why (defense-in-depth)

Follow-up to the fork-safe preview pipeline ([#643](https://github.com/JSONbored/gittensory/pull/643)), flagged by an adversarial security audit of that pipeline.

The preview deploy uses `wrangler versions upload`, which creates a **0%-traffic preview version** (a `workers.dev` URL) and **applies no routes** — so the production custom domain in the config was already inert. But it was a **latent footgun**: if anyone ever changed that command to `wrangler deploy` (or added `wrangler triggers deploy`), the fork-built bundle would immediately seize `gittensory.aethereal.dev` at 100% traffic, since custom domains are single-owner/account-scoped.

Removing the route from the preview config eliminates that path entirely (a workers.dev preview neither needs nor uses it), and a comment now warns against re-adding it. No behavior change to the preview pipeline.

## Validation
- `npm run actionlint` — clean
- Preview Wrangler JSON remains valid (`vars` → `main`); no other keys touched.

## Notes
- Not a fix for an *exploitable* issue today — purely reduces future blast radius. The audit otherwise found the pipeline clean (no secret exposure, correct trust boundary, fail-closed artifact validation).