### PR TITLE
fix(github): verify contributors for gate-only checks

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -956,8 +956,16 @@ async function maybePublishPrPublicSurface(
     scopedOverlapCount: unionScopedOverlapClusters(collisions, pr, preflight.collisions).length,
   });
 
+  if (gateEnabled && author && !publicSurfaceSkipped && !official) {
+    official = await getCachedOfficialMinerDetection(env, author, {
+      targetKey: `${repoFullName}#${pr.number}`,
+      deliveryId: webhook.deliveryId,
+    });
+  }
+
   // Only CONFIRMED gittensor contributors can be hard-blocked; everyone else (or an unavailable
-  // detection) gets a neutral, non-blocking gate. `official` may be null if no public output ran.
+  // detection) gets a neutral, non-blocking gate. Gate-only runs still verify confirmation before
+  // evaluating blockers so confirmed contributors cannot bypass a required Gate check.
   const confirmedContributor = official?.status === "confirmed";
   const gateEvaluation =
     settings.gateCheckMode === "enabled" ? evaluateGateCheck(advisory, gateCheckPolicy(settings, readiness.total, confirmedContributor)) : undefined;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -748,7 +748,7 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ minerList: 0, gateChecks: 2 });
+    expect(calls).toEqual({ minerList: 1, gateChecks: 2 });
   });
 
   it("publishes an enabled gate when bot PR public output is skipped", async () => {
@@ -890,7 +890,7 @@ describe("queue processors", () => {
     expect(audit?.detail).toBe("not_official_gittensor_miner");
   });
 
-  it("hard-blocks a confirmed Gittensor contributor when a configured blocker fires", async () => {
+  it("hard-blocks a confirmed Gittensor contributor in a gate-only configuration when a configured blocker fires", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       env,
@@ -903,9 +903,9 @@ describe("queue processors", () => {
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
       repoFullName: "JSONbored/gittensory",
-      commentMode: "all_prs",
+      commentMode: "off",
       publicAudienceMode: "oss_maintainer",
-      publicSurface: "comment_only",
+      publicSurface: "off",
       autoLabelEnabled: false,
       checkRunMode: "off",
       gateCheckMode: "enabled",
@@ -927,12 +927,8 @@ describe("queue processors", () => {
       }
       if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
       if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
-      if (url.endsWith("/users/confirmed-dev")) return Response.json({ login: "confirmed-dev", public_repos: 2, followers: 1 });
-      if (url.includes("/users/confirmed-dev/repos")) return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/confirmed123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
-      if (url.includes("/issues/61/comments") && method === "GET") return Response.json([]);
-      if (url.includes("/issues/61/comments") && method === "POST") return Response.json({ id: 611 }, { status: 201 });
       if (url.includes("/check-runs/940") && method === "PATCH") {
         gatePatchBody = JSON.parse(String(init?.body ?? "{}")) as typeof gatePatchBody;
         calls.gateChecks += 1;
@@ -958,7 +954,8 @@ describe("queue processors", () => {
     });
 
     // A confirmed contributor with a configured hard blocker (linked-issue gate set to block, no issue
-    // linked) IS blocked, and the Gate names the exact blocker so the fix is obvious.
+    // linked) IS blocked even when the Gate is the only public output, and the Gate names the exact
+    // blocker so the fix is obvious.
     expect(calls.minerList).toBe(1);
     expect(calls.gateChecks).toBe(2);
     expect(gatePatchBody.conclusion).toBe("failure");


### PR DESCRIPTION
### Motivation

- Gate-only repository configurations could bypass contributor confirmation because `official` was only fetched when a non-gate public output path ran miner detection. 
- That allowed confirmed contributors to escape hard blockers when `gateCheckMode` was enabled but `publicSurface`/other outputs were disabled, weakening merge-protection integrity.

### Description

- Ensure contributor confirmation is retrieved before evaluating enabled Gate checks in gate-only flows by fetching `official` when `gateEnabled && author && !publicSurfaceSkipped && !official` in `maybePublishPrPublicSurface` (`src/queue/processors.ts`).
- Preserve existing neutral/advisory semantics for non-confirmed authors and for skipped public-surface cases while guaranteeing confirmed authors cannot bypass configured hard blockers.
- Update unit tests in `test/unit/queue.test.ts` to cover gate-only behavior and to assert that miner confirmation is requested for gate-only runs and that confirmed contributors are still hard-blocked by configured blockers.

### Testing

- Ran the targeted gate unit tests with `npm test -- test/unit/queue.test.ts -t "gate"`, which passed (test file run passed with the gate-related tests succeeding).
- Ran type checking with `npm run typecheck`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d21028bac832abf36e47a8fb0bf14)