### PR TITLE
fix(ci): allow .zip in the preview-deploy artifact allowlist (unblock UI previews)

### DIFF
--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -99,8 +99,10 @@ jobs:
           test -d client || { echo "::error::artifact missing client/ assets dir"; exit 1; }
           # 3) Allowlist file extensions — fail on anything that isn't a normal web/build output (blocks
           #    smuggled scripts/binaries). A few extensionless CF asset files are explicitly permitted.
+          #    `zip` covers the served downloads (e.g. /downloads/gittensory-extension.zip) — a passive
+          #    static asset wrangler only uploads (never executes), so allowing it doesn't run fork code.
           unexpected="$(find . -regextype posix-extended -type f \
-            -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|wgsl|glb|gltf)$' \
+            -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|zip|wgsl|glb|gltf)$' \
             -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore')"
           if [ -n "$unexpected" ]; then
             echo "::error::Artifact contains unexpected file types — refusing to deploy:"


### PR DESCRIPTION
## Why

Every **UI Preview Deploy** run has been failing — all recent runs `failure` — at the **"Validate downloaded artifact"** step:

```
##[error]Artifact contains unexpected file types — refusing to deploy:
./client/downloads/gittensory-extension.zip
```

The UI build emits a legitimately-served static asset, `client/downloads/gittensory-extension.zip`:
- generated by `scripts/build-extension.mjs`
- linked from `apps/gittensory-ui/src/routes/extension.tsx` (`/downloads/gittensory-extension.zip`)
- asserted `200 application/zip` by `scripts/smoke-production.mjs`

…but `zip` was missing from the validation step's extension allowlist, so validation rejected the bundle and the deploy aborted **before** `createDeployment`. With no preview Deployment / `environment_url` ever recorded, **Reviewbot's before/after table stays stuck on "Rendering preview…" for every UI PR** (e.g. #635) — the *after* screenshot can never fill in.

## What

Add `zip` to the allowlist regex in the validate step. One line.

```diff
-            -not -iregex '.*\.(mjs|js|...|md|csv|wgsl|glb|gltf)$' \
+            -not -iregex '.*\.(mjs|js|...|md|csv|zip|wgsl|glb|gltf)$' \
```

## Security

The allowlist is the fork-PR defense (the build runs possibly-fork code; the deploy must not smuggle executables in). A `.zip` here is a **passive download asset** — `wrangler versions upload` only uploads it as a static asset; it is never executed by the worker (fork code only ever runs inside the isolated `workers.dev` preview when the URL is visited). So allowing `.zip` is the same risk class as the `.wasm` / binary fonts already permitted — no meaningful change to the boundary.

## Effect

Once merged, UI preview deploys succeed again, the `deployment_status` → Reviewbot re-review path records the `environment_url`, and the stuck "after" screenshots fill in automatically. No Reviewbot change is required for this part (a companion Reviewbot PR separately makes a *failed* deploy show a terminal card instead of an eternal spinner).