### PR TITLE
fix(ci): resolve fork PRs when recording the preview deployment

### DIFF
--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -24,6 +24,7 @@ permissions:
   contents: read
   actions: read # download the build artifact from the triggering run
   deployments: write # record the preview Deployment Reviewbot reads
+  pull-requests: read # resolve the (often fork) PR for this build by matching head SHA
 
 concurrency:
   group: ui-preview-deploy-${{ github.event.workflow_run.head_sha }}
@@ -187,16 +188,31 @@ jobs:
             const url = ${{ toJSON(steps.upload.outputs.preview_url) }};
             // Trust only the GitHub-set head_sha — never fork-supplied data.
             const sha = context.payload.workflow_run.head_sha;
-            // Resolve the PR from the head commit. workflow_run.pull_requests is EMPTY for fork PRs,
-            // so look it up from the commit (the base repo holds the fork head as refs/pull/N/head).
-            const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: sha,
-            });
             const slug = `${context.repo.owner}/${context.repo.repo}`;
-            const open = assoc.data.find((p) => p.state === "open" && p.base.repo.full_name === slug);
-            const prNumber = open?.number ?? context.payload.workflow_run.pull_requests?.[0]?.number;
+            // Resolve the PR for this build. Both signals below are EMPTY for fork PRs (the common case
+            // here): workflow_run.pull_requests is empty for cross-repo runs, and the commit→PR
+            // association API doesn't index a fork-head commit from the base repo. So we ALSO match the
+            // open PR whose head points at this exact build SHA — head.sha is GitHub-set (the base repo
+            // tracks the fork head as refs/pull/N/head), so it's safe to trust even for forks.
+            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+              prNumber = assoc.data.find((p) => p.state === "open" && p.base.repo.full_name === slug)?.number;
+            }
+            if (!prNumber) {
+              // Fork-safe fallback: scan open PRs for the one whose head is this build's commit.
+              const openPrs = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              });
+              prNumber = openPrs.find((p) => p.head.sha === sha)?.number;
+            }
             if (!prNumber) {
               core.setFailed(`Could not resolve an open PR for ${sha} — skipping deployment record.`);
               return;


### PR DESCRIPTION
## Why

Second half of the stuck-preview fix. After [#653](https://github.com/JSONbored/gittensory/pull/653) (allow `.zip`), the preview deploy now runs all the way to a live URL — verified on a re-run of PR #635's build:

```
Validate downloaded artifact -> success
Upload preview version       -> success   (Preview: https://1ddd2740-gittensory-ui.zeronode.workers.dev)
Record deployment for Reviewbot -> FAILURE
##[error]Could not resolve an open PR for d60b5cc9… — skipping deployment record.
```

The **"Record deployment for Reviewbot"** step resolves the PR via `listPullRequestsAssociatedWithCommit`, with `workflow_run.pull_requests` as a fallback. **Both are empty for fork PRs** — and most open gittensory PRs originate from forks (635, 651, 650, 649, 637, 634 are all cross-repo). So the step fails and **no Deployment / `environment_url` is ever recorded**, leaving Reviewbot's *after* cell stuck on "Rendering preview…" even though the preview deployed fine.

## What

Add a fork-safe resolution fallback: scan open PRs for the one whose `head.sha` equals this build's GitHub-set `head_sha`. The base repo tracks the fork head as `refs/pull/N/head`, so `head.sha` is trustworthy even for forks (confirmed: `pulls.list` returns `head.sha = d60b5cc9` for fork PR #635). Also adds `pull-requests: read` for the `pulls.list` call.

Resolution order now: `workflow_run.pull_requests` → commit association → **open-PR head-SHA match** (fork-safe).

## Verification

Will re-run a fresh build→deploy for #635 after merge and confirm a `preview/pr-635` Deployment with an `environment_url` is recorded (which then re-triggers Reviewbot to fill in the "after" screenshot).