### PR TITLE
perf(db): index ai_usage_events(status, created_at) for the daily-budget query

### DIFF
--- a/migrations/0028_ai_usage_status_index.sql
+++ b/migrations/0028_ai_usage_status_index.sql
@@ -1,0 +1,6 @@
+-- Covers the daily AI-neuron budget query (sumAiEstimatedNeuronsSince):
+--   SELECT sum(estimated_neurons) FROM ai_usage_events WHERE status = 'ok' AND created_at >= ?
+-- Without this index that aggregate full-scans ai_usage_events, and it runs on every AI review/summary.
+-- Numbered 0028 to avoid colliding with migrations 0026/0027 reserved by the AI-review PR (#652); the
+-- D1 migration runner applies un-applied files in order and tolerates gaps.
+CREATE INDEX IF NOT EXISTS ai_usage_events_status_created_idx ON ai_usage_events (status, created_at);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -923,5 +923,8 @@ export const aiUsageEvents = sqliteTable(
   (table) => ({
     featureCreated: index("ai_usage_events_feature_created_idx").on(table.feature, table.createdAt),
     actorCreated: index("ai_usage_events_actor_created_idx").on(table.actor, table.createdAt),
+    // Covers the daily-budget query (sumAiEstimatedNeuronsSince): WHERE status='ok' AND created_at >= ?.
+    // Without it that aggregate full-scans ai_usage_events, which runs on every AI review/summary.
+    statusCreated: index("ai_usage_events_status_created_idx").on(table.status, table.createdAt),
   }),
 );

--- a/test/unit/ai-usage-index.test.ts
+++ b/test/unit/ai-usage-index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../helpers/d1";
+
+describe("ai_usage_events budget index", () => {
+  it("creates the (status, created_at) index and the budget query uses it (SEARCH, not SCAN)", async () => {
+    const env = createTestEnv();
+
+    const idx = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+      .bind("ai_usage_events_status_created_idx")
+      .first<{ name: string }>();
+    expect(idx?.name).toBe("ai_usage_events_status_created_idx");
+
+    // sumAiEstimatedNeuronsSince: WHERE status='ok' AND created_at >= ? — must SEARCH via the new index.
+    const plan = await env.DB.prepare(
+      "EXPLAIN QUERY PLAN SELECT coalesce(sum(estimated_neurons),0) FROM ai_usage_events WHERE created_at >= ? AND status = 'ok'",
+    )
+      .bind("2026-01-01T00:00:00.000Z")
+      .all<{ detail: string }>();
+    const detail = (plan.results ?? []).map((row) => row.detail).join(" ");
+    expect(detail).toContain("ai_usage_events_status_created_idx");
+    expect(detail).not.toContain("SCAN ai_usage_events ");
+  });
+});


### PR DESCRIPTION
## Investigation: are hot-path queries doing full table scans?

Audited the prod D1 index inventory against every query the code runs. **Conclusion: the per-webhook / gate hot path is fully indexed** — `issues`/`pull_requests`/`pull_request_files`/`bounties` by `repo_full_name`, `official_miner_detections` by `login` (PK), `repositories`/`repository_settings` by PK. The recent prod D1 overload is therefore capacity / DB-size related (~2.87 GB, blob-heavy tables), **not** a missing-index problem on the hot path.

A few things I checked and ruled out:
- `webhook_events` (39,780 rows) — the app only reads it by `delivery_id` (PK). The 40k-row scans I saw earlier were my own ad-hoc diagnostic queries, not the app. No index needed.
- `audit_events` (15,876 rows) — both app reads filter by `event_type` first, covered by `audit_events_type_created_idx`. No index needed.

## The one real gap

`sumAiEstimatedNeuronsSince` (the daily AI-neuron budget check) runs:
```sql
SELECT sum(estimated_neurons) FROM ai_usage_events WHERE status = 'ok' AND created_at >= ?
```
`EXPLAIN QUERY PLAN` on prod confirms a full **`SCAN ai_usage_events`** — the existing indexes are `(feature, created_at)` and `(actor, created_at)`, neither of which covers a `status`-only filter. This query runs on **every** AI review/summary (it's the budget gate), and `ai_usage_events` grows with each AI call, so the scan cost grows unbounded once AI is enabled — which #652 (AI review) is about to do. It also serves the existing `ai-summaries` budget query on `main`.

## Fix

Add a covering index `ai_usage_events_status_created_idx (status, created_at)` (schema + migration `0028`). A test asserts via `EXPLAIN QUERY PLAN` that the budget query now **SEARCHes** via the index instead of scanning. Full suite green.

Migration numbered `0028` to avoid colliding with `0026`/`0027` reserved by #652; the D1 runner applies un-applied migrations in order and tolerates the gap.

## Out of scope (flagged separately)
The actual prod D1 overload looks like capacity/size, not query plans — worth watching D1 metrics / considering retention pruning on the large append-only + blob tables, but that's an ops decision, not a code fix.