### PR TITLE
test: preview-screenshot check (transient — will close)

### DIFF
--- a/apps/gittensory-ui/src/routes/index.tsx
+++ b/apps/gittensory-ui/src/routes/index.tsx
@@ -68,7 +68,7 @@ function Hero() {
           </div>
           <h1 className="mt-5 text-token-3xl font-medium leading-token-tight tracking-tight text-foreground">
             Mine Gittensor like an engineer.
-            <span className="block text-muted-foreground">Not like a bot.</span>
+            <span className="block text-muted-foreground">Not like a bot. (preview check)</span>
           </h1>
           <p className="mt-5 max-w-lg text-token-md leading-token-normal text-muted-foreground">
             Gittensory is the deterministic base-agent layer for Gittensor OSS contribution mining.


### PR DESCRIPTION
Verifying the **before/after preview screenshots** work end-to-end after the CI fixes (#653/#654/#658). Changes the homepage hero (`Not like a bot.` → `Not like a bot. (preview check)`) so the **after** screenshot should differ from **before**. Transient; will close.