### PR TITLE
test: non-root route preview check (/roadmap) (transient — will close)

### DIFF
--- a/apps/gittensory-ui/src/routes/roadmap.tsx
+++ b/apps/gittensory-ui/src/routes/roadmap.tsx
@@ -119,7 +119,7 @@ function RoadmapPage() {
       <Reveal className="max-w-3xl">
         <Eyebrow>Roadmap</Eyebrow>
         <h1 className="mt-4 text-token-2xl font-medium tracking-tight text-foreground">
-          What&apos;s next for Gittensory
+          What&apos;s next for Gittensory (preview check)
         </h1>
         <p className="mt-3 text-muted-foreground">
           This reflects the live roadmap issue #127 and phase epics #233-#238. Project-board linkage


### PR DESCRIPTION
Verifying before/after previews work on a **non-root route**: changes the `/roadmap` page heading. Expecting reviewbot's table to show route **`/roadmap`** (not `/`) with before/after screenshots of that page. Transient; will close.