### PR TITLE
test: dotted + authed route preview check (transient — will close)

### DIFF
--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -131,7 +131,7 @@ function ProductAnalytics() {
                 Analytics
               </div>
               <h1 className="mt-1 font-display text-token-2xl font-semibold tracking-tight">
-                Usage & value analytics
+                Usage & value analytics (preview check)
               </h1>
               <p className="mt-1 max-w-2xl text-token-sm text-muted-foreground">
                 Operator-facing adoption, activation, retention, and ecosystem value from product

--- a/apps/gittensory-ui/src/routes/docs.quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.quickstart.tsx
@@ -32,7 +32,7 @@ function Quickstart() {
       title="Quickstart"
       description="Install the MCP, sign in, and run your first analysis. About two minutes."
     >
-      <h2>1. Install</h2>
+      <h2>1. Install (preview check)</h2>
       <p>
         The MCP is published as <code>@jsonbored/gittensory-mcp</code>. You can run it with{" "}
         <code>npx</code>, or install it globally.


### PR DESCRIPTION
Two route shapes in one PR: a **dotted/nested** route `docs.quickstart.tsx` → `/docs/quickstart` (visible diff expected) and an **authed** route `app.analytics.tsx` → `/app/analytics` (expected: before/after show the *anonymous* view, likely identical since the previewer isn't signed in). Transient; will close.