### PR TITLE
fix(api): allow AI review CORS methods

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -629,7 +629,7 @@ export function createApp() {
       c.header("Access-Control-Allow-Origin", allowedOrigin);
       c.header("Access-Control-Allow-Credentials", "true");
       c.header("Access-Control-Allow-Headers", "authorization, content-type, mcp-session-id, mcp-protocol-version");
-      c.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+      c.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
       c.header("Access-Control-Expose-Headers", "x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-reset, retry-after");
       c.header("Access-Control-Max-Age", "600");
       c.header("Vary", "Origin", { append: true });

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -66,6 +66,23 @@ describe("api routes", () => {
     const preflight = await app.request("/v1/repos", { method: "OPTIONS", headers: { origin: "https://gittensory.aethereal.dev" } }, env);
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get("access-control-allow-origin")).toBe("https://gittensory.aethereal.dev");
+    expect(preflight.headers.get("access-control-allow-methods")).toBe("GET, POST, PUT, DELETE, OPTIONS");
+
+    const aiReviewPreflight = await app.request(
+      "/v1/repos/octo/repo/ai-review",
+      { method: "OPTIONS", headers: { origin: "https://gittensory.aethereal.dev", "access-control-request-method": "PUT" } },
+      env,
+    );
+    expect(aiReviewPreflight.status).toBe(204);
+    expect(aiReviewPreflight.headers.get("access-control-allow-methods")).toContain("PUT");
+
+    const aiKeyDeletePreflight = await app.request(
+      "/v1/repos/octo/repo/ai-key",
+      { method: "OPTIONS", headers: { origin: "https://gittensory.aethereal.dev", "access-control-request-method": "DELETE" } },
+      env,
+    );
+    expect(aiKeyDeletePreflight.status).toBe(204);
+    expect(aiKeyDeletePreflight.headers.get("access-control-allow-methods")).toContain("DELETE");
 
     const dynamicOriginEnv = createTestEnv({ PUBLIC_SITE_ORIGIN: "https://preview.gittensory.test/app", PUBLIC_API_ORIGIN: "not a url" });
     const dynamicPreflight = await app.request("/v1/repos", { method: "OPTIONS", headers: { origin: "https://preview.gittensory.test" } }, dynamicOriginEnv);


### PR DESCRIPTION
### Motivation
- The new maintainer UI issues cross-origin `PUT` and `DELETE` requests for AI review config and BYOK key removal, but the API CORS preflight only advertised `GET, POST, OPTIONS`, causing browsers to block those calls.

### Description
- Expand the CORS `Access-Control-Allow-Methods` header to include `PUT` and `DELETE` so browser preflights permit the AI review and BYOK routes by advertising `GET, POST, PUT, DELETE, OPTIONS` in `src/api/routes.ts`.
- Add integration assertions that preflight responses include the extended methods and specifically cover `PUT` for `/v1/repos/:owner/:repo/ai-review` and `DELETE` for `/v1/repos/:owner/:repo/ai-key` in `test/integration/api.test.ts`.
- Modified files: `src/api/routes.ts` and `test/integration/api.test.ts`.

### Testing
- Ran `git diff --check` which passed locally.
- Attempted to run `npm test -- test/integration/api.test.ts` but `vitest` was not available in the environment so the test run could not be executed.
- Attempted `npm install` to install test dependencies, but the install failed due to a `403 Forbidden` from the npm registry for `esbuild`, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4680ac64832a8a9c68822b7fe308)