### PR TITLE
feat(ai-review): route free Workers-AI review calls through Cloudflare AI Gateway

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -11,6 +11,9 @@ declare global {
     WORKERS_AI_SUMMARY_MODEL?: string;
     AI_DAILY_NEURON_BUDGET?: string;
     AI_MAX_OUTPUT_TOKENS?: string;
+    /** Optional Cloudflare AI Gateway id. When set, free Workers-AI review calls route through the gateway
+     *  for caching, rate-limiting, request logging, and fallback. Unset = direct binding calls (unchanged). */
+    AI_GATEWAY_ID?: string;
     ADMIN_GITHUB_LOGINS?: string;
     GITHUB_WEBHOOK_SECRET: string;
     GITHUB_WEBHOOK_MAX_BODY_BYTES?: string;

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -83,7 +83,8 @@ type ModelReview = {
   criticalDefect: { present: boolean; confidence: number; title: string; detail: string };
 };
 
-type AiRunner = { run?: (model: string, options: Record<string, unknown>) => Promise<unknown> };
+type AiGatewayOptions = { gateway?: { id: string } };
+type AiRunner = { run?: (model: string, options: Record<string, unknown>, extra?: AiGatewayOptions) => Promise<unknown> };
 
 function isEnabled(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/i.test(value ?? "");
@@ -186,17 +187,26 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
 async function runWorkersOpinion(env: Env, primary: string, fallback: string, system: string, user: string, maxTokens: number): Promise<ModelReview | null> {
   const ai = env.AI as unknown as AiRunner | undefined;
   if (!ai || typeof ai.run !== "function") return null;
+  // Route through Cloudflare AI Gateway when configured (caching, rate-limiting, logging, fallback). The
+  // diff/prompt is the cache key input, scoped per model + content, so distinct PRs never share a cached
+  // review. Unset → direct binding call (unchanged behavior).
+  const gatewayId = env.AI_GATEWAY_ID?.trim();
+  const extra: AiGatewayOptions | undefined = gatewayId ? { gateway: { id: gatewayId } } : undefined;
   for (const model of fallback && fallback !== primary ? [primary, fallback] : [primary]) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        const result = await ai.run(model, {
-          max_tokens: maxTokens,
-          temperature: 0,
-          messages: [
-            { role: "system", content: system },
-            { role: "user", content: user },
-          ],
-        });
+        const result = await ai.run(
+          model,
+          {
+            max_tokens: maxTokens,
+            temperature: 0,
+            messages: [
+              { role: "system", content: system },
+              { role: "user", content: user },
+            ],
+          },
+          extra,
+        );
         const parsed = parseModelReview(coerceAiText(result));
         if (parsed) return parsed;
       } catch {

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -75,6 +75,23 @@ describe("runGittensoryAiReview gating", () => {
   });
 });
 
+describe("AI Gateway routing for free Workers-AI calls", () => {
+  it("routes through the gateway when AI_GATEWAY_ID is set", async () => {
+    const run = vi.fn(async () => ({ response: reviewJson() }));
+    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000", AI_GATEWAY_ID: "gtsy-gw" });
+    await runGittensoryAiReview(env, baseInput);
+    expect(run).toHaveBeenCalled();
+    expect((run.mock.calls[0] as unknown[] | undefined)?.[2]).toEqual({ gateway: { id: "gtsy-gw" } });
+  });
+
+  it("calls the binding directly (no gateway arg) when AI_GATEWAY_ID is unset", async () => {
+    const run = vi.fn(async () => ({ response: reviewJson() }));
+    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    await runGittensoryAiReview(env, baseInput);
+    expect((run.mock.calls[0] as unknown[] | undefined)?.[2]).toBeUndefined();
+  });
+});
+
 describe("runGittensoryAiReview advisory mode", () => {
   it("produces public-safe advisory notes from one Workers-AI opinion and no defect", async () => {
     const run = vi.fn(async (_model: string) => ({ response: reviewJson() }));

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,6 +39,7 @@
     "WORKERS_AI_SUMMARY_MODEL": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
     "AI_DAILY_NEURON_BUDGET": "10000",
     "AI_MAX_OUTPUT_TOKENS": "256",
+    "AI_GATEWAY_ID": "",
     "ADMIN_GITHUB_LOGINS": "JSONbored",
   },
   "routes": [


### PR DESCRIPTION
Adds an optional **Cloudflare AI Gateway** in front of the free Workers-AI review/consensus calls (`runWorkersOpinion`). Platform-native, no new dependency.

When `AI_GATEWAY_ID` is set, `env.AI.run` routes through the gateway for **response caching, per-key rate-limiting, request logging/observability, and provider fallback** — the multi-tenant AI-budget + observability answer the analysis called the single highest-ROI AI move. Unset (the default) → direct binding calls, **behavior unchanged**.

- `src/env.d.ts`: optional `AI_GATEWAY_ID`.
- `ai-review.ts`: `AiRunner` gains the gateway option; `runWorkersOpinion` passes `{ gateway: { id } }` **only** when configured. The diff/prompt is the cache-key input (scoped per model + content), so distinct PRs never share a cached review.
- `wrangler.jsonc`: `AI_GATEWAY_ID` var (empty by default; the operator sets the real gateway id).

## Verification
`typecheck` ✅ · `test:coverage` ✅ (**97.01% branch**, 1694 tests; gateway option asserted present-when-set / absent-when-unset) · `test:workers` ✅ · `git diff --check` ✅

Part of #525.

**Scoped down from the original "AI Gateway + provider registry":** the provider-adapter registry (collapsing the ~12 `anthropic|openai` sites, fixing the `normalizeAiKeyProvider` footgun) and provider expansion (OpenRouter/Gemini) are deferred to a follow-up — they're additive and lower-risk once a provider is actually being added, and AI Gateway is a complete, high-value unit on its own.