### PR TITLE
feat(scoring): surface upstream scoring constants gittensory does not model (staleness visibility)

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -57,8 +57,15 @@ export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringMode
     const parsed = parsePythonNumberConstants(constantsResult.value);
     constants = { ...constants, ...parsed };
     activeModelConstants = parsed;
-    constantsPayload = { parsedConstantCount: Object.keys(parsed).length, sourceBytes: constantsResult.value.length };
+    const unmodeled = findUnmodeledUpstreamConstants(constantsResult.value);
+    constantsPayload = { parsedConstantCount: Object.keys(parsed).length, sourceBytes: constantsResult.value.length, unmodeledUpstreamConstants: unmodeled };
     warnings.push(...activeModelWarnings(parsed));
+    // Make staleness visible: upstream defines scoring constants gittensory does not yet model.
+    if (unmodeled.length > 0) {
+      warnings.push(
+        `Upstream gittensor defines ${unmodeled.length} scoring constant(s) gittensory does not yet model: ${unmodeled.slice(0, 12).join(", ")}${unmodeled.length > 12 ? ", …" : ""}. Scoring may be behind upstream.`,
+      );
+    }
   } else {
     sourceKind = "fallback";
     warnings.push(`Scoring constants fetch failed: ${constantsResult.error}`);
@@ -102,6 +109,20 @@ export function parsePythonNumberConstants(source: string, options: { knownOnly?
     constants[name] = Number(raw);
   }
   return constants;
+}
+
+/**
+ * Numeric constant names upstream gittensor defines that gittensory's scoring engine does NOT model.
+ * The normal parse is `knownOnly` (it keeps only constants we already encode), which silently hides
+ * upstream ADDITIONS — e.g. a newly-introduced time-decay constant. Surfacing these makes scoring
+ * staleness visible: if upstream adds a scoring dimension, an operator sees it instead of the gate
+ * silently drifting behind. Detection only — it does not change any score.
+ */
+export function findUnmodeledUpstreamConstants(source: string): string[] {
+  const all = parsePythonNumberConstants(source, { knownOnly: false });
+  return Object.keys(all)
+    .filter((name) => !SCORING_CONSTANT_NAMES.has(name))
+    .sort();
 }
 
 export function detectActiveModel(constants: Record<string, number>): ScoringModelSnapshotRecord["activeModel"] {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLatestScoringModelSnapshot } from "../../src/db/repositories";
-import { detectActiveModel, parsePythonNumberConstants, refreshScoringModelSnapshot } from "../../src/scoring/model";
+import { detectActiveModel, findUnmodeledUpstreamConstants, parsePythonNumberConstants, refreshScoringModelSnapshot } from "../../src/scoring/model";
 import { buildScorePreview, makeScorePreviewRecord } from "../../src/scoring/preview";
 import type { ScorePreviewInput } from "../../src/scoring/preview";
 import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
@@ -116,6 +116,30 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
 
     expect(refreshed.activeModel).toBe("unknown");
     expect(refreshed.warnings.join(" ")).toMatch(/recognized active-model indicator/i);
+  });
+
+  it("flags upstream scoring constants gittensory does not model (staleness visibility)", () => {
+    // SRC_TOK_SATURATION_SCALE is modeled; the TIME_DECAY_* constants are NOT — so they surface as unmodeled.
+    const unmodeled = findUnmodeledUpstreamConstants(
+      "SRC_TOK_SATURATION_SCALE = 58.0\nTIME_DECAY_GRACE_PERIOD_HOURS = 12\nTIME_DECAY_SIGMOID_MIDPOINT = 10\n",
+    );
+    expect(unmodeled).toEqual(["TIME_DECAY_GRACE_PERIOD_HOURS", "TIME_DECAY_SIGMOID_MIDPOINT"]);
+    expect(unmodeled).not.toContain("SRC_TOK_SATURATION_SCALE");
+  });
+
+  it("warns on the snapshot when upstream defines an unmodeled scoring dimension", async () => {
+    const env = createTestEnv();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response("SRC_TOK_SATURATION_SCALE = 58.0\nTIME_DECAY_GRACE_PERIOD_HOURS = 12\n");
+      if (url.includes("programming_languages.json")) return Response.json({ TypeScript: 1 });
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    expect(refreshed.warnings.join(" ")).toMatch(/does not yet model.*TIME_DECAY_GRACE_PERIOD_HOURS/);
+    expect(refreshed.payload.constants).toMatchObject({ unmodeledUpstreamConstants: ["TIME_DECAY_GRACE_PERIOD_HOURS"] });
   });
 
   it("uses saturation math as the active private preview model", () => {


### PR DESCRIPTION
The **safe half** of the scoring-currency work — makes drift *visible* without changing any score. (The ranking-changing time-decay implementation is deferred for your review with a before/after ranking diff, per your decision.)

## The gap
The upstream `constants.py` parse is `knownOnly` — it keeps only constants gittensory already encodes, which **silently hid upstream ADDITIONS**. So when gittensor introduced new scoring dimensions (e.g. the `TIME_DECAY_*` constants the audit found), gittensory drifted behind with **no signal at all**.

## Fix (detection only — no score changes)
- New `findUnmodeledUpstreamConstants()` detects numeric constants upstream defines that gittensory doesn't model.
- `refreshScoringModelSnapshot` now records them on the snapshot payload (`unmodeledUpstreamConstants`) **and** raises a warning — *"Upstream gittensor defines N scoring constant(s) gittensory does not yet model: … . Scoring may be behind upstream."* — which surfaces on `/v1/scoring/model`, `/v1/upstream/status`, and the operator dashboard. So "are we out of date?" is now answered automatically.

The live upstream-contract test already runs on a schedule via the existing `upstream-contract.yml` workflow (the audit was wrong that it's CI-skipped), so that half was already covered.

## Tests
`findUnmodeledUpstreamConstants` flags `TIME_DECAY_*` (unmodeled) and not `SRC_TOK_SATURATION_SCALE` (modeled); refresh raises the staleness warning + records the payload field.

## Verification
`typecheck` ✅ · `test:coverage` ✅ (**97.01% branch**, 1696 tests) · `test:workers` ✅ · `git diff --check` ✅

Part of #525. **Follow-up (your review):** implement the `TIME_DECAY_*` scoring dimension to match upstream — changes live rankings, so I'll bring a before/after diff before merging.