### PR TITLE
chore: remove accidental self-referential node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shadowbook/Documents/gittensory/node_modules


### PR DESCRIPTION
## Problem

A `node_modules` symlink pointing at its own absolute path (`/Users/.../gittensory/node_modules`) was accidentally committed in #680 (mode `120000`). It shadows the real install with a circular link, so `node_modules/.bin/*` resolution fails on a fresh checkout with `too many levels of symbolic links` — breaking local `tsc`/`vitest` until the symlink is cleared by hand.

CI is unaffected because `npm ci` removes `node_modules` before installing, which masked the issue.

## Fix

`git rm --cached node_modules` — untrack the symlink blob. The directory is already covered by `.gitignore` (`node_modules/`), so the real install stays ignored. No source, runtime, or deploy impact.

## Verification

- `git ls-tree HEAD node_modules` → empty (no longer tracked)
- Real `node_modules/.bin/tsc` present and functional; `npm run typecheck` clean