### PR TITLE
fix(api): allow session PR text lint

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3957,6 +3957,7 @@ function contributorEvidenceFromProfile(profile: {
 
 const EXTENSION_PULL_CONTEXT_PATH = "/v1/extension/pull-context";
 const EXTENSION_PULL_CONTEXT_SCOPE = "extension:pull_context";
+const LINT_PR_TEXT_PATH = "/v1/lint/pr-text";
 
 type ProtectedRouteContext = {
   env: Env;
@@ -3996,6 +3997,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoAiConfigPath(path)) return true;
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
+  if (path === LINT_PR_TEXT_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
   return false;
 }

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -942,6 +942,19 @@ describe("api routes", () => {
     expect(lintPrTextBody).toMatchObject({ verdict: "weak", fixes: expect.any(Array) });
     expect(JSON.stringify(lintPrTextBody)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
 
+    const { token: lintSessionToken } = await createSessionForGitHubUser(env, { login: "ordinary-mcp-user", id: 4242 });
+    const sessionLintPrText = await app.request(
+      "/v1/lint/pr-text",
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${lintSessionToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ commitMessages: ["fix: handle cache reconnect"], prBody: "Fixes #7\n\nValidated with npm test." }),
+      },
+      env,
+    );
+    expect(sessionLintPrText.status).toBe(200);
+    await expect(sessionLintPrText.json()).resolves.toMatchObject({ verdict: expect.stringMatching(/strong|adequate|weak/) });
+
     const invalidLintPrText = await app.request("/v1/lint/pr-text", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ linkedIssue: -1 }) }, env);
     expect(invalidLintPrText.status).toBe(400);
 


### PR DESCRIPTION
### Motivation

- The new local MCP tool proxies to `POST /v1/lint/pr-text`, but ordinary session-authenticated users were receiving `403` because the path was not allowlisted in `canSessionAccessPath`, creating an availability regression. 

### Description

- Add a `LINT_PR_TEXT_PATH` constant for `"/v1/lint/pr-text"` and include it in the `canSessionAccessPath` allowlist so session identities can reach the route. 
- Add an integration test that creates a non-admin session via `createSessionForGitHubUser` and verifies a `POST /v1/lint/pr-text` request returns `200` with a deterministic `verdict`. 

### Testing

- Ran `npm run typecheck`, which completed successfully. 
- Ran `npx vitest run test/integration/api.test.ts --config vitest.config.ts --reporter verbose`, and the integration test file passed (1 file, 34 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee96d2ffc832a84a15db622741056)