### PR TITLE
fix: surface registry time decay drift

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -10494,7 +10494,8 @@
                 "trustedLabelPipeline",
                 "defaultLabelMultiplier",
                 "fixedBaseScore",
-                "eligibilityMode"
+                "eligibilityMode",
+                "timeDecay"
               ]
             }
           },

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1017,6 +1017,7 @@ const RegistryHyperparameterDriftFieldSchema = z.enum([
   "defaultLabelMultiplier",
   "fixedBaseScore",
   "eligibilityMode",
+  "timeDecay",
 ]);
 
 const RegistryDriftSurfaceSchema = z.enum(["allocation", "lane_fit", "scoreability_assumptions", "maintainer_economics", "issue_discovery_behavior", "label_policy"]);

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3496,7 +3496,7 @@ export function buildCollisionEdges(report: CollisionReport): CollisionEdgeRecor
 // All comparable RegistryRepoConfig fields, rendered to a stable string for diffing.
 // Mirrors REGISTRY_DRIFT_COMPARABLE_FIELDS in upstream/ruleset.ts so the live change
 // report and the drift comparator cannot diverge as config fields are added — every
-// scoring-relevant field (fixed_base_score, default_label_multiplier, eligibility_mode)
+// scoring-relevant field (fixed_base_score, default_label_multiplier, eligibility_mode, time_decay)
 // is covered, not just the emission/lane subset.
 const REGISTRY_CHANGE_FIELDS: Array<{ label: string; render: (config: RegistryRepoConfig) => string }> = [
   { label: "emission_share", render: (config) => String(config.emissionShare) },
@@ -3508,6 +3508,7 @@ const REGISTRY_CHANGE_FIELDS: Array<{ label: string; render: (config: RegistryRe
   /* v8 ignore next -- Boolean defaulting protects older registry snapshots without trusted_label_pipeline. */
   { label: "trusted_label_pipeline", render: (config) => String(config.trustedLabelPipeline ?? false) },
   { label: "label_multipliers", render: (config) => JSON.stringify(config.labelMultipliers) },
+  { label: "time_decay", render: (config) => JSON.stringify(config.timeDecay ?? null) },
 ];
 
 function registryConfigChanges(previous: RegistryRepoConfig, current: RegistryRepoConfig): string[] {
@@ -3516,7 +3517,7 @@ function registryConfigChanges(previous: RegistryRepoConfig, current: RegistryRe
     const after = field.render(current);
     if (before === after) return [];
     // labelMultipliers is an object diff; report the fact of change, not the JSON blob.
-    return [field.label === "label_multipliers" ? "label_multipliers changed" : `${field.label} ${before} -> ${after}`];
+    return [field.label === "label_multipliers" || field.label === "time_decay" ? `${field.label} changed` : `${field.label} ${before} -> ${after}`];
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -946,7 +946,8 @@ export type RegistryHyperparameterDriftField =
   | "trustedLabelPipeline"
   | "defaultLabelMultiplier"
   | "fixedBaseScore"
-  | "eligibilityMode";
+  | "eligibilityMode"
+  | "timeDecay";
 export type RegistryDriftSurface = "allocation" | "lane_fit" | "scoreability_assumptions" | "maintainer_economics" | "issue_discovery_behavior" | "label_policy";
 export type RegistryHyperparameterDriftEvent = {
   repoFullName: string;

--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -44,6 +44,8 @@ const TRACKED_SOURCES = [
 
 type TrackedSource = (typeof TRACKED_SOURCES)[number];
 
+type RulesetTimeDecay = { gracePeriodHours: number | null; sigmoidMidpointDays: number | null; sigmoidSteepness: number | null; minMultiplier: number | null };
+
 type RulesetPayload = {
   upstream: { repo: string; ref: string; commitSha?: string | null | undefined };
   registry: {
@@ -59,6 +61,7 @@ type RulesetPayload = {
       defaultLabelMultiplier: number | null;
       fixedBaseScore: number | null;
       eligibilityMode: string | null;
+      timeDecay: RulesetTimeDecay | null;
     }>;
   };
   scoring: {
@@ -563,6 +566,17 @@ function compactRegistryRepo(repo: RegistryRepoConfig): RulesetPayload["registry
     defaultLabelMultiplier: repo.defaultLabelMultiplier ?? null,
     fixedBaseScore: repo.fixedBaseScore ?? null,
     eligibilityMode: repo.eligibilityMode ?? null,
+    timeDecay: compactTimeDecay(repo.timeDecay),
+  };
+}
+
+function compactTimeDecay(timeDecay: RegistryRepoConfig["timeDecay"] | null | undefined): RulesetTimeDecay | null {
+  if (!timeDecay) return null;
+  return {
+    gracePeriodHours: timeDecay.gracePeriodHours ?? null,
+    sigmoidMidpointDays: timeDecay.sigmoidMidpointDays ?? null,
+    sigmoidSteepness: timeDecay.sigmoidSteepness ?? null,
+    minMultiplier: timeDecay.minMultiplier ?? null,
   };
 }
 
@@ -626,6 +640,7 @@ const REGISTRY_DRIFT_FIELD_ORDER: RegistryHyperparameterDriftField[] = [
   "trustedLabelPipeline",
   "defaultLabelMultiplier",
   "labelMultipliers",
+  "timeDecay",
 ];
 type RegistryComparableHyperparameterField = Exclude<RegistryHyperparameterDriftField, "repo">;
 const REGISTRY_DRIFT_COMPARABLE_FIELDS: RegistryComparableHyperparameterField[] = [
@@ -637,6 +652,7 @@ const REGISTRY_DRIFT_COMPARABLE_FIELDS: RegistryComparableHyperparameterField[] 
   "trustedLabelPipeline",
   "defaultLabelMultiplier",
   "labelMultipliers",
+  "timeDecay",
 ];
 
 const REGISTRY_DRIFT_FIELD_METADATA: Record<RegistryHyperparameterDriftField, { severity: UpstreamDriftSeverity; affectedSurfaces: RegistryDriftSurface[] }> = {
@@ -649,6 +665,7 @@ const REGISTRY_DRIFT_FIELD_METADATA: Record<RegistryHyperparameterDriftField, { 
   trustedLabelPipeline: { severity: "medium", affectedSurfaces: ["label_policy", "scoreability_assumptions"] },
   defaultLabelMultiplier: { severity: "medium", affectedSurfaces: ["label_policy", "scoreability_assumptions"] },
   labelMultipliers: { severity: "medium", affectedSurfaces: ["label_policy", "scoreability_assumptions"] },
+  timeDecay: { severity: "high", affectedSurfaces: ["scoreability_assumptions"] },
 };
 
 function buildRegistryHyperparameterDrift(previous: RulesetRegistryRepo[], current: RulesetRegistryRepo[]): RegistryHyperparameterDriftPayload {
@@ -798,6 +815,18 @@ function emptyRegistryHyperparameterDriftPayload(): RegistryHyperparameterDriftP
   };
 }
 
+function compactTimeDecayPayload(value: JsonValue | undefined): RulesetTimeDecay | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const timeDecay = value as Record<string, JsonValue>;
+  const compacted = {
+    gracePeriodHours: numberPayload(timeDecay.gracePeriodHours),
+    sigmoidMidpointDays: numberPayload(timeDecay.sigmoidMidpointDays),
+    sigmoidSteepness: numberPayload(timeDecay.sigmoidSteepness),
+    minMultiplier: numberPayload(timeDecay.minMultiplier),
+  };
+  return Object.values(compacted).some((item) => item !== null) ? compacted : null;
+}
+
 function normalizeRulesetRegistryRepos(value: JsonValue[]): RulesetRegistryRepo[] {
   return value.flatMap((entry) => {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
@@ -814,6 +843,7 @@ function normalizeRulesetRegistryRepos(value: JsonValue[]): RulesetRegistryRepo[
             defaultLabelMultiplier: numberPayload(repo.defaultLabelMultiplier),
             fixedBaseScore: numberPayload(repo.fixedBaseScore),
             eligibilityMode: stringPayload(repo.eligibilityMode),
+            timeDecay: compactTimeDecayPayload(repo.timeDecay),
           },
         ]
       : [];
@@ -838,11 +868,14 @@ function registryHyperparameterValue(repo: RulesetRegistryRepo, field: RegistryC
       return repo.fixedBaseScore;
     case "eligibilityMode":
       return repo.eligibilityMode;
+    case "timeDecay":
+      return repo.timeDecay ?? null;
   }
 }
 
 function registryHyperparameterChangeSummary(field: RegistryHyperparameterDriftField, previous: JsonValue, current: JsonValue): string {
   if (field === "labelMultipliers") return "labelMultipliers changed";
+  if (field === "timeDecay") return "timeDecay changed";
   return `${field} ${formatRegistryHyperparameterValue(previous)} -> ${formatRegistryHyperparameterValue(current)}`;
 }
 
@@ -857,6 +890,7 @@ function registryHyperparameterFieldLabel(field: RegistryHyperparameterDriftFiel
     defaultLabelMultiplier: "default label multiplier",
     fixedBaseScore: "fixed base score",
     eligibilityMode: "eligibility mode",
+    timeDecay: "time-decay curve",
   }[field];
 }
 

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -303,6 +303,12 @@ describe("v2 signal builders", () => {
     expect(modeReport.changedRepos[0]?.changes).toEqual(
       expect.arrayContaining(["eligibility_mode branch_required -> any_branch", "default_label_multiplier 1 -> 1.2"]),
     );
+
+    const beforeDecay = snapshot("old3", [{ repo: "JSONbored/gittensory", emissionShare: 0.02, issueDiscoveryShare: 0, labelMultipliers: {}, timeDecay: { gracePeriodHours: 12 } }]);
+    const afterDecay = snapshot("new3", [{ repo: "JSONbored/gittensory", emissionShare: 0.02, issueDiscoveryShare: 0, labelMultipliers: {}, timeDecay: { gracePeriodHours: 24 } }]);
+    const decayReport = buildRegistryChangeReport([afterDecay, beforeDecay]);
+    expect(decayReport.changedRepos).toHaveLength(1);
+    expect(decayReport.changedRepos[0]?.changes).toContain("time_decay changed");
   });
 
   it("builds repo-level maintainer packets with fallback actions", () => {
@@ -1648,6 +1654,7 @@ function snapshot(
     fixedBaseScore?: number | null;
     defaultLabelMultiplier?: number | null;
     eligibilityMode?: string | null;
+    timeDecay?: RegistrySnapshot["repositories"][number]["timeDecay"];
   }>,
 ): RegistrySnapshot {
   return {
@@ -1660,6 +1667,7 @@ function snapshot(
     warnings: [],
     repositories: repositories.map((repo) => ({
       ...repo,
+      timeDecay: repo.timeDecay ?? null,
       trustedLabelPipeline: false,
       maintainerCut: 0,
       raw: {},

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -290,6 +290,18 @@ describe("upstream ruleset drift tracking", () => {
     });
   });
 
+  it("compacts per-repo time-decay overrides through the raw registry source (partial fields kept, absent fields null)", async () => {
+    const env = createTestEnv();
+    vi.stubGlobal("fetch", upstreamNoCommitShaFetch(fixturesWithPartialTimeDecay("58", 0.01)));
+
+    await refreshUpstreamSourceSnapshots(env);
+    const snapshot = await buildUpstreamRulesetSnapshot(env);
+
+    const byRepo = Object.fromEntries(rulesetRegistry(snapshot).repositories.map((repo) => [repo.repo, repo.timeDecay]));
+    expect(byRepo["owner/decay-a"]).toEqual({ gracePeriodHours: 24, sigmoidMidpointDays: null, sigmoidSteepness: 0.4, minMultiplier: null });
+    expect(byRepo["owner/decay-b"]).toEqual({ gracePeriodHours: null, sigmoidMidpointDays: 5, sigmoidSteepness: null, minMultiplier: 0.05 });
+  });
+
   it("records no drift when no ruleset exists and detects drift after two snapshots exist", async () => {
     const env = createTestEnv();
 
@@ -1043,6 +1055,18 @@ function invalidJsonFixtures(scale: string): Record<string, string> {
   const payload = fixtures(scale, 0.01);
   payload["gittensor/validator/weights/master_repositories.json"] = "{not-json";
   payload["gittensor/validator/weights/programming_languages.json"] = "{not-json";
+  return payload;
+}
+
+// Two complementary repos with PARTIAL per-repo time-decay overrides: each field is present in exactly one
+// repo and absent in the other, so compaction exercises both the present and the absent (-> null) path of
+// every time-decay field.
+function fixturesWithPartialTimeDecay(scale: string, emissionShare: number): Record<string, string> {
+  const payload = fixtures(scale, emissionShare);
+  payload["gittensor/validator/weights/master_repositories.json"] = JSON.stringify({
+    "owner/decay-a": { emission_share: emissionShare, issue_discovery_share: 0, maintainer_cut: 0.3, scoring: { time_decay: { grace_period_hours: 24, sigmoid_steepness: 0.4 } } },
+    "owner/decay-b": { emission_share: emissionShare, issue_discovery_share: 0, maintainer_cut: 0.3, scoring: { time_decay: { sigmoid_midpoint_days: 5, min_multiplier: 0.05 } } },
+  });
   return payload;
 }
 

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -238,6 +238,7 @@ describe("upstream ruleset drift tracking", () => {
               defaultLabelMultiplier: 1.2,
               fixedBaseScore: 12,
               eligibilityMode: "linked_issue_required",
+              timeDecay: { gracePeriodHours: 24, sigmoidMidpointDays: 5, sigmoidSteepness: 0.4, minMultiplier: 0.05 },
             },
           ],
         },
@@ -255,6 +256,7 @@ describe("upstream ruleset drift tracking", () => {
         defaultLabelMultiplier: null,
         fixedBaseScore: null,
         eligibilityMode: null,
+        timeDecay: null,
       },
       {
         repo: "owner/policy",
@@ -266,6 +268,7 @@ describe("upstream ruleset drift tracking", () => {
         defaultLabelMultiplier: 1.2,
         fixedBaseScore: 12,
         eligibilityMode: "linked_issue_required",
+        timeDecay: { gracePeriodHours: 24, sigmoidMidpointDays: 5, sigmoidSteepness: 0.4, minMultiplier: 0.05 },
       },
     ]);
   });
@@ -455,6 +458,7 @@ describe("upstream ruleset drift tracking", () => {
               defaultLabelMultiplier: 1.2,
               fixedBaseScore: 12,
               eligibilityMode: "linked_issue_required",
+              timeDecay: { gracePeriodHours: 24, sigmoidMidpointDays: 5, sigmoidSteepness: 0.4, minMultiplier: 0.05 },
             },
           ],
         },
@@ -462,11 +466,11 @@ describe("upstream ruleset drift tracking", () => {
       base,
     );
     const allFieldsDrift = registryDriftPayload(allFields!);
-    expect(allFields).toMatchObject({ severity: "high", summary: "8 registry hyperparameter drift event(s)" });
+    expect(allFields).toMatchObject({ severity: "high", summary: "9 registry hyperparameter drift event(s)" });
     expect(allFieldsDrift).toMatchObject({
-      totalEvents: 8,
+      totalEvents: 9,
       omittedEvents: 0,
-      highImpactCount: 5,
+      highImpactCount: 6,
       affectedRepoCount: 1,
       affectedFields: [
         "emissionShare",
@@ -477,6 +481,7 @@ describe("upstream ruleset drift tracking", () => {
         "trustedLabelPipeline",
         "defaultLabelMultiplier",
         "labelMultipliers",
+        "timeDecay",
       ],
       affectedSurfaces: ["allocation", "lane_fit", "scoreability_assumptions", "maintainer_economics", "issue_discovery_behavior", "label_policy"],
     });
@@ -486,6 +491,7 @@ describe("upstream ruleset drift tracking", () => {
       "maintainerCut",
       "fixedBaseScore",
       "eligibilityMode",
+      "timeDecay",
       "trustedLabelPipeline",
       "defaultLabelMultiplier",
       "labelMultipliers",
@@ -495,8 +501,31 @@ describe("upstream ruleset drift tracking", () => {
       "Upstream registry drift is open for JSONbored/gittensory: allocation changed; affected surface(s): allocation, lane_fit.",
       "Upstream registry drift is open for JSONbored/gittensory: issue-discovery share changed; affected surface(s): issue_discovery_behavior, lane_fit.",
       "Upstream registry drift is open for JSONbored/gittensory: maintainer cut changed; affected surface(s): maintainer_economics.",
-      "2 additional high-impact upstream registry drift event(s) are open for JSONbored/gittensory.",
+      "3 additional high-impact upstream registry drift event(s) are open for JSONbored/gittensory.",
     ]);
+
+
+    const timeDecayOnly = await buildUpstreamDriftReport(
+      withPayload(base, "time-decay-only", {
+        registry: {
+          ...baseRegistry,
+          repositories: [{ ...baseRepo!, timeDecay: { gracePeriodHours: 24, sigmoidMidpointDays: 5, sigmoidSteepness: 0.4, minMultiplier: 0.05 } }],
+        },
+      }),
+      base,
+    );
+    const timeDecayDrift = registryDriftPayload(timeDecayOnly!);
+    expect(timeDecayOnly).toMatchObject({ severity: "high", affectedAreas: ["registry"], summary: "1 registry hyperparameter drift event(s)" });
+    expect(timeDecayDrift).toMatchObject({
+      totalEvents: 1,
+      highImpactCount: 1,
+      affectedFields: ["timeDecay"],
+      affectedSurfaces: ["scoreability_assumptions"],
+    });
+    expect(timeDecayDrift.events).toEqual([
+      expect.objectContaining({ field: "timeDecay", severity: "high", summary: "timeDecay changed", affectedSurfaces: ["scoreability_assumptions"] }),
+    ]);
+
     expect(registryHyperparameterDriftWarningsForRepo([allFields!], "JSONbored/gittensory").join(" ")).not.toMatch(/wallet|hotkey|raw trust score|payout|reward estimate|farming|private reviewability|public score estimate/i);
   });
 
@@ -1235,6 +1264,7 @@ function rulesetRegistry(snapshot: UpstreamRulesetSnapshotRecord): {
     defaultLabelMultiplier: number | null;
     fixedBaseScore: number | null;
     eligibilityMode: string | null;
+    timeDecay: { gracePeriodHours?: number | null; sigmoidMidpointDays?: number | null; sigmoidSteepness?: number | null; minMultiplier?: number | null } | null;
   }>;
 } {
   return rulesetPayload(snapshot).registry as ReturnType<typeof rulesetRegistry>;
@@ -1253,6 +1283,7 @@ function registryRepo(repo: string, overrides: Partial<TestRulesetRegistryRepo> 
     defaultLabelMultiplier: null,
     fixedBaseScore: null,
     eligibilityMode: null,
+    timeDecay: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
### Motivation
- Per-repo `scoring.time_decay` overrides were parsed and used for score previews but were omitted from ruleset compaction, drift comparisons, and live registry change reports, causing time-decay-only registry updates to be invisible to drift/changes surfaces.

### Description
- Include per-repo `timeDecay` in compacted upstream ruleset payloads and in the `RulesetPayload.registry.repositories` shape so stored ruleset snapshots preserve the overrides (`src/upstream/ruleset.ts`).
- Add compacting/normalization helpers for time-decay payloads and include `timeDecay` in registry normalization (`compactTimeDecay`, `compactTimeDecayPayload`, `normalizeRulesetRegistryRepos`).
- Add `timeDecay` to the registry drift field order, comparable fields, drift metadata/severity, change summaries/labels, and value extraction so time-decay-only diffs produce drift events (`src/upstream/ruleset.ts`, `src/types.ts`, `src/openapi/schemas.ts`).
- Surface `time_decay` in the live registry change report and render a concise `time_decay changed` entry for `/v1/registry/changes`-style reports (`src/signals/engine.ts`).
- Add regression tests covering time-decay parsing, time-decay-only upstream drift, and time-decay-only registry change detection (`test/unit/upstream-ruleset.test.ts`, `test/unit/signals-v2.test.ts`).

### Testing
- Ran `npm run typecheck` and it succeeded with no type errors.
- Ran the targeted tests with `npm test -- --run test/unit/upstream-ruleset.test.ts test/unit/signals-v2.test.ts` and both tests passed.
- Ran the full unit suite with `npm run test:unit` and all unit tests passed.
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eeb2ad29c832abc7ecfcfded83d8e)