### PR TITLE
refactor(signals): single-source pr-body-draft redaction vocabulary (#542 follow-up)

### DIFF
--- a/src/services/pr-body-draft.ts
+++ b/src/services/pr-body-draft.ts
@@ -1,4 +1,5 @@
 import { sanitizePublicComment } from "../github/commands";
+import { PUBLIC_UNSAFE_TERMS } from "../signals/redaction";
 import type { LocalDiffPreflightResult } from "../signals/engine";
 import type { LocalBranchAnalysis } from "../signals/local-branch";
 
@@ -50,14 +51,13 @@ export const EXCLUDED_PRIVATE_PR_BODY_FIELDS = [
 
 // Residual private/financial terms that sanitizePublicComment does not rewrite on its own
 // (e.g. a bare "reward"/"score"/"ranking"); scrubbed to a neutral phrase as defense-in-depth.
-const RESIDUAL_PRIVATE_TERMS = /\b(reward\w*|score\w*|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability|wallet|hotkey|coldkey|mnemonic)\b/gi;
+// The term vocabulary is the canonical PUBLIC_UNSAFE_TERMS (#542) so this surface cannot drift it.
+const RESIDUAL_PRIVATE_TERMS = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b`, "gi");
 const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![:/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
 const LOCAL_PATH_PATTERN = new RegExp(LOCAL_PATH_SOURCE, "g");
-// Final guard used to drop anything that still looks unsafe after scrubbing.
-const FORBIDDEN_PR_BODY_LANGUAGE = new RegExp(
-  String.raw`\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|${LOCAL_PATH_SOURCE}`,
-  "i",
-);
+// Final guard used to drop anything that still looks unsafe after scrubbing. Same canonical terms, plus this
+// surface's richer local-path matcher.
+const FORBIDDEN_PR_BODY_LANGUAGE = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|${LOCAL_PATH_SOURCE}`, "i");
 
 function sanitizeLine(line: string): string {
   return sanitizePublicComment(line)

--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -7,8 +7,19 @@
 //
 // The pattern is intentionally NON-GLOBAL so `.test()` stays stateless (no `lastIndex` carry-over between
 // calls) and the exported constant can be reused safely across call sites and modules.
-export const PUBLIC_UNSAFE_PATTERN =
-  /\b(reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i;
+//
+// `PUBLIC_UNSAFE_TERMS` is the canonical economic/identity term vocabulary (alternation source only — no
+// flags, no `\b` anchors), so a surface that redacts/gates with these terms can compose from one source
+// instead of re-typing the list and drifting. `pr-body-draft.ts` builds its scrubber + final guard from it.
+//
+// NOTE: two other public surfaces — `agent-action-explanation-card.ts` and `miner-dashboard-recommendations.ts`
+// — keep their own context-specific, phrase-tuned vocabularies (they redact whole phrases like "public score
+// estimate" and extra terms like "seed phrase"/"private key" for cleaner output, and deliberately do not
+// redact a bare "score"/"reward"). Those are curated for their surface, not drift of this core, so they are
+// intentionally NOT collapsed onto `PUBLIC_UNSAFE_TERMS`.
+export const PUBLIC_UNSAFE_TERMS = String.raw`reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
+
+export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
 
 /** True iff `text` contains nothing that must stay private — i.e. it is safe to surface on a public GitHub surface. */
 export function isPublicSafeText(text: string): boolean {


### PR DESCRIPTION
## What

Follow-up to #542. `pr-body-draft.ts` carried the core economic/identity term alternation **verbatim twice** (`RESIDUAL_PRIVATE_TERMS` scrubber + `FORBIDDEN_PR_BODY_LANGUAGE` guard) — character-identical to the copy #542 just centralized. This removes that duplication so the term vocabulary lives in exactly one place.

## How

- `src/signals/redaction.ts` now exports **`PUBLIC_UNSAFE_TERMS`** — the canonical term alternation source (no flags/anchors). `PUBLIC_UNSAFE_PATTERN` is built from it; **no behavior change** (the `redaction.test.ts` boundary + path cases still pass).
- `pr-body-draft.ts` builds its `gi` scrubber and its final `.test()` guard from `PUBLIC_UNSAFE_TERMS`, keeping its own richer local-path matcher. The term set is identical, so output is byte-for-byte the same — the existing `pr-body-draft` tests pass unchanged.

## Deliberately not consolidated

`agent-action-explanation-card.ts` and `miner-dashboard-recommendations.ts` keep their own **phrase-tuned** vocabularies — they redact whole phrases (e.g. "public score estimate", "score previews") and extra terms ("seed phrase", "private key"), and intentionally do **not** redact a bare "score"/"reward". Collapsing them onto the core would fragment their output (partial "private context" injections) for no safety gain — they're curated per-surface, not drift of the core. This is now documented in `redaction.ts`.

## Verification

- `typecheck` ✅ · `test:coverage` ✅ (1849 passed; branches 97.04%, all ≥97) · `git diff --check` ✅ · `ui:openapi:check` ✅