### PR TITLE
fix(release): keep UI known-latest at 0.5.0 until mcp-v0.6.0 publishes

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -6,7 +6,9 @@ export const MCP_PACKAGE_NAME = "@jsonbored/gittensory-mcp";
 export const MCP_PACKAGE_ENCODED_NAME = "@jsonbored%2fgittensory-mcp";
 export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAGE_ENCODED_NAME}`;
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.6.0";
+// Lags one release behind by design: ui:version-audit requires this to equal npm dist-tags.latest, so it is
+// bumped to the new version only AFTER that version publishes (npm latest is still 0.5.0 until mcp-v0.6.0 ships).
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.5.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
## Why

The `mcp-v0.6.0` publish workflow failed at the **MCP release validation gate** (`test:release:mcp` → `test:ci` → `ui:version-audit`). `ui:version-audit` requires `MCP_PACKAGE_KNOWN_LATEST_VERSION` to equal npm's `dist-tags.latest`, which is **still 0.5.0** until 0.6.0 publishes. The release commit (#745) bumped this fallback pin to 0.6.0 ahead of publish.

The `mcp-v0.5.0` tag's tree confirms the pattern: it carried UI known-latest **`"0.4.0"`** (the previously-published version). This pin **lags one release** and is bumped only *after* the new version ships.

## Change

Revert just that one line: `MCP_PACKAGE_KNOWN_LATEST_VERSION` 0.6.0 → **0.5.0** (with a comment explaining the lag). `package.json` (0.6.0) + backend `LATEST_RECOMMENDED_MCP_VERSION` (0.6.0) are unchanged — those correctly lead the release.

After this merges, the `mcp-v0.6.0` tag is moved here and the publish re-runs; once 0.6.0 is on npm, a follow-up bumps this pin to 0.6.0.

**No publish occurred** — the gate failed before the publish step.

## Verify

- `ui:version-audit` ✅ (UI 0.5.0 == npm 0.5.0) · `typecheck` ✅ · UI tests ✅