### PR TITLE
chore(changelog): regenerate v0.6.0 CHANGELOG to match merged history

### DIFF
--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Gittensory_lint_pr_text commit/PR-body rubric linter (#634)
 - Per-repo time-decay hyperparameters + go live (#703) (#733)
 - Active issue-watch monitor — gittensory_watch_issues (#699 path B) (#735)
-- Slop-risk + issue-slop self-check tools in the npm package
+- Slop self-check tools + release @jsonbored/gittensory-mcp v0.6.0 (#745)
 
 ### Fixes
 - Bound local branch scenario inputs (#614)


### PR DESCRIPTION
## Why

The `mcp-v0.6.0` publish gate (`changelog:check:mcp`) failed: **"CHANGELOG.md is stale."** The 0.6.0 changelog was generated on the feature branch, but the squash-merges (#745, #748) rewrote the commit subjects/SHAs since the `mcp-v0.5.0` tag, so regeneration no longer matched the committed file (one line: the #745 entry's subject).

## Change

Regenerated `packages/gittensory-mcp/CHANGELOG.md` on current `main` via `npm run changelog:mcp` (one-line subject update). Committed under scope **`changelog`**, which `mcp-release-core.mjs`'s `RELEASE_SCOPES` excludes from regeneration — so this commit doesn't itself re-introduce staleness (verified: `changelog:check:mcp` reports "current" from HEAD).

After merge, the `mcp-v0.6.0` tag moves here and the publish re-runs. Both prior gate blockers are now resolved (`ui:version-audit` via #748, `changelog:check:mcp` here).

## Verify

- `changelog:check:mcp` ✅ ("current") · changelog content unchanged except the #745 subject line