### PR TITLE
chore(release): bump UI known-latest pin to 0.6.0 (post-publish)

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -6,9 +6,9 @@ export const MCP_PACKAGE_NAME = "@jsonbored/gittensory-mcp";
 export const MCP_PACKAGE_ENCODED_NAME = "@jsonbored%2fgittensory-mcp";
 export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAGE_ENCODED_NAME}`;
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
-// Lags one release behind by design: ui:version-audit requires this to equal npm dist-tags.latest, so it is
-// bumped to the new version only AFTER that version publishes (npm latest is still 0.5.0 until mcp-v0.6.0 ships).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.5.0";
+// Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
+// bumped to a new version only AFTER that version publishes (never ahead of npm).
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.6.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
## Why

Post-publish catch-up. `@jsonbored/gittensory-mcp` **v0.6.0 is now live on npm** (`dist-tags.latest`), so the UI fallback pin can move up to match. `ui:version-audit` requires `MCP_PACKAGE_KNOWN_LATEST_VERSION` to equal npm's latest; it intentionally lagged at 0.5.0 through the release (so the publish gate passed before 0.6.0 existed) and now catches up.

## Change

`MCP_PACKAGE_KNOWN_LATEST_VERSION` 0.5.0 → **0.6.0** (+ comment clarified to "tracks the latest PUBLISHED release"). `MCP_MINIMUM_SUPPORTED_VERSION` stays 0.5.0.

This closes the release loop: package.json + backend `LATEST_RECOMMENDED` led the release; this offline fallback now tracks the published latest, keeping the next release's `ui:version-audit` clean.

## Verify

- `ui:version-audit` ✅ ("MCP UI version copy ok: npm latest 0.6.0")