### PR TITLE
fix(mcp): report package version 0.6.0

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -11,7 +11,7 @@ import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadat
 const defaultApiUrl = "https://gittensory-api.aethereal.dev";
 const legacyDefaultApiUrls = new Set(["https://gittensory-api.zeronode.workers.dev"]);
 const packageName = "@jsonbored/gittensory-mcp";
-const packageVersion = "0.5.0";
+const packageVersion = "0.6.0";
 const npmRegistryUrl = (process.env.GITTENSORY_NPM_REGISTRY_URL ?? "https://registry.npmjs.org").replace(/\/+$/, "");
 const upgradeCommand = `npm install -g ${packageName}@latest`;
 const npxFallbackCommand = `npx ${packageName}@latest <command>`;

--- a/test/unit/mcp-cli.test.ts
+++ b/test/unit/mcp-cli.test.ts
@@ -212,7 +212,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("reports a current install without upgrade guidance", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer({ latestVersion: "0.5.0", minMcpVersion: "0.5.0" });
+    const url = await startFixtureServer({ latestVersion: "0.6.0", minMcpVersion: "0.5.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -232,7 +232,7 @@ describe("gittensory-mcp CLI", () => {
       status: "compatible",
       source: "compatibility_endpoint",
       minVersion: "0.5.0",
-      latestRecommendedVersion: "0.5.0",
+      latestRecommendedVersion: "0.6.0",
       apiVersion: "0.1.0",
     });
   });
@@ -252,8 +252,8 @@ describe("gittensory-mcp CLI", () => {
     expect(ahead.package).toMatchObject({ state: "ahead", updateAvailable: false });
     await new Promise<void>((resolve) => server?.close(() => resolve()));
 
-    // Local 0.5.0 vs a higher-core prerelease 0.6.0-rc.1 -> stale.
-    const staleUrl = await startFixtureServer({ latestVersion: "0.6.0-rc.1" });
+    // Local 0.6.0 vs a higher-core prerelease 0.7.0-rc.1 -> stale.
+    const staleUrl = await startFixtureServer({ latestVersion: "0.7.0-rc.1" });
     const stale = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: staleUrl,
@@ -348,7 +348,7 @@ describe("gittensory-mcp CLI", () => {
 
   it("uses API recommended package metadata when the npm registry is unavailable", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: "0.6.0" });
+    const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: "0.7.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
         GITTENSORY_API_URL: url,
@@ -360,7 +360,7 @@ describe("gittensory-mcp CLI", () => {
     expect(payload.package).toMatchObject({
       state: "stale",
       latestStatus: "api",
-      latestVersion: "0.6.0",
+      latestVersion: "0.7.0",
       upgradeCommand: "npm install -g @jsonbored/gittensory-mcp@latest",
     });
   });
@@ -620,12 +620,12 @@ describe("gittensory-mcp CLI", () => {
       }),
     ) as { package: { name: string; version: string; latestStatus: string }; api: { status: string }; auth: { login: string } };
 
-    expect(status.package).toMatchObject({ name: "@jsonbored/gittensory-mcp", version: "0.5.0", latestStatus: "skipped" });
+    expect(status.package).toMatchObject({ name: "@jsonbored/gittensory-mcp", version: "0.6.0", latestStatus: "skipped" });
     expect(status.api.status).toBe("ok");
     expect(status.auth.login).toBe("JSONbored");
 
     const changelog = JSON.parse(run(["changelog", "--json"])) as { package: { version: string }; changelog: string };
-    expect(changelog.package.version).toBe("0.5.0");
+    expect(changelog.package.version).toBe("0.6.0");
     expect(changelog.changelog).toContain("# Changelog");
   });
 
@@ -643,7 +643,7 @@ describe("gittensory-mcp CLI", () => {
 
     const sessionRequest = requests.find((request) => request.url === "/v1/auth/session");
     expect(sessionRequest?.headers["x-gittensory-mcp-package"]).toBe("@jsonbored/gittensory-mcp");
-    expect(sessionRequest?.headers["x-gittensory-mcp-version"]).toBe("0.5.0");
+    expect(sessionRequest?.headers["x-gittensory-mcp-version"]).toBe("0.6.0");
     expect(sessionRequest?.headers["x-gittensory-mcp-client"]).toBe("gittensory-mcp-cli");
     const telemetryHeaders = JSON.stringify({
       package: sessionRequest?.headers["x-gittensory-mcp-package"],
@@ -1124,7 +1124,7 @@ describe("gittensory-mcp CLI", () => {
   });
 
   it("reports the package version via version, --version, and -v", () => {
-    const expected = "@jsonbored/gittensory-mcp/0.5.0";
+    const expected = "@jsonbored/gittensory-mcp/0.6.0";
     for (const flag of ["version", "--version", "-v"]) {
       const plain = run([flag]).trim();
       expect(plain).toContain(expected);
@@ -1137,7 +1137,7 @@ describe("gittensory-mcp CLI", () => {
   it("emits machine-readable version output with --json", () => {
     const payload = JSON.parse(run(["version", "--json"])) as { name: string; version: string; apiVersion: string; node: string };
     expect(payload.name).toBe("@jsonbored/gittensory-mcp");
-    expect(payload.version).toBe("0.5.0");
+    expect(payload.version).toBe("0.6.0");
     expect(payload.apiVersion).toBe("0.1.0");
     expect(payload.node).toBe(process.version);
   });


### PR DESCRIPTION
### Motivation
- The MCP CLI binary still hardcoded `packageVersion` as `0.5.0` while `packages/gittensory-mcp/package.json` and API compatibility metadata were bumped to `0.6.0`, causing CLI output, `x-gittensory-mcp-version` telemetry, and compatibility/status checks to report a stale version.

### Description
- Update the `packageVersion` constant in `packages/gittensory-mcp/bin/gittensory-mcp.js` from `"0.5.0"` to `"0.6.0"` so CLI output, server metadata, compatibility checks, and telemetry headers match `package.json`.

### Testing
- Ran `node --check packages/gittensory-mcp/bin/gittensory-mcp.js`, `node packages/gittensory-mcp/bin/gittensory-mcp.js --version` (now prints `@jsonbored/gittensory-mcp/0.6.0`), `npm run build:mcp`, and `npm run test:mcp-pack`, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f3de537e8832aaff226cfdd4d1188)