### PR TITLE
docs(scoreability): note scenarios recompute on every push

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.scoreability.tsx
+++ b/apps/gittensory-ui/src/routes/docs.scoreability.tsx
@@ -57,6 +57,11 @@ function Scoreability() {
         </li>
       </ul>
 
+      <p>
+        All six scenarios are recomputed on every push, so the numbers reflect the branch's latest
+        state rather than a one-time snapshot.
+      </p>
+
       <h2>Language rules</h2>
       <p>
         Use <code>scoreability</code>, <code>estimated score</code>,{" "}


### PR DESCRIPTION
Small docs clarification — also a live check of the deployed reviewbot visual/code-review changes (enriched review prompt). Safe to close after the bot reviews.