### PR TITLE
chore(renovate): document patch-coverage gate and sole-bot policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,8 +41,9 @@
   ],
   "postUpdateOptions": ["npmDedupe"],
   "prBodyNotes": [
-    "Dependency PRs must keep `npm run test:ci` passing and preserve the 97% global coverage gate.",
-    "GitHub Actions updates must remain SHA-pinned."
+    "Dependency PRs must keep `npm run test:ci` passing. The 97% coverage requirement is enforced as Codecov patch coverage on changed lines (codecov/patch), so dependency-only bumps satisfy it without new tests.",
+    "GitHub Actions updates must remain SHA-pinned.",
+    "Renovate is the sole dependency and security-update bot for this repo; GitHub Dependabot security updates are disabled to avoid duplicate PRs (e.g. the two hono advisory PRs)."
   ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Context

Follow-up to the coverage-gate change ([#763](https://github.com/JSONbored/gittensory/pull/763)) and the **duplicate hono advisory PRs** ([#760](https://github.com/JSONbored/gittensory/pull/760) from Renovate, [#761](https://github.com/JSONbored/gittensory/pull/761) from Dependabot security updates).

## Why two PRs for one advisory

The repo had **no `dependabot.yml`** (Dependabot wasn't doing version updates), but GitHub's **Dependabot *security* updates** toggle (`automated-security-fixes`) was enabled. That toggle auto-raises PRs for advisories independently of Renovate — and Renovate's own `vulnerabilityAlerts` was already covering the same feed. One hono advisory → two PRs.

## Changes

**Repo setting (already applied, not in this diff):** disabled Dependabot security updates via the API (`automated-security-fixes` is now `enabled: false`). Renovate remains the sole bot; its `vulnerabilityAlerts` still covers security advisories, so nothing is left unwatched — there's just no duplicate.

**This diff (`renovate.json`):**
- `prBodyNotes` referenced the old *"97% global coverage gate"* that #763 replaced. Updated to describe the **Codecov patch-coverage** gate, so Renovate stops stamping stale guidance on every dependency PR.
- Recorded that Renovate is the sole dependency/security bot and Dependabot security updates is disabled.

## CI note

`validate` will be red on the `npm audit` step until the hono bump (#760) lands on `main`; this branch will go green after a sync with `main`. Config-only change — no code touched.