### PR TITLE
feat(config): expose gate.mergeReadiness + gate.firstTimeContributorGrace in .gittensory.yml (#822)

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -29,6 +29,8 @@ export type FocusManifestGateConfig = {
   aiReviewByok: boolean | null;
   aiReviewProvider: "anthropic" | "openai" | null;
   aiReviewModel: string | null;
+  mergeReadiness: GateRuleMode | null;
+  firstTimeContributorGrace: boolean | null;
 };
 
 /**
@@ -157,6 +159,8 @@ const EMPTY_GATE_CONFIG: FocusManifestGateConfig = {
   aiReviewByok: null,
   aiReviewProvider: null,
   aiReviewModel: null,
+  mergeReadiness: null,
+  firstTimeContributorGrace: null,
 };
 
 const EMPTY_MANIFEST: FocusManifest = {
@@ -297,6 +301,8 @@ function parseGateConfig(value: JsonValue | undefined, warnings: string[]): Focu
     aiReviewByok: normalizeOptionalBoolean(aiReviewRecord?.byok, "gate.aiReview.byok", warnings),
     aiReviewProvider: normalizeOptionalEnum(aiReviewRecord?.provider, "gate.aiReview.provider", ["anthropic", "openai"] as const, warnings),
     aiReviewModel: normalizeOptionalString(aiReviewRecord?.model, "gate.aiReview.model", warnings),
+    mergeReadiness: normalizeOptionalGateMode(record.mergeReadiness, "gate.mergeReadiness", warnings),
+    firstTimeContributorGrace: normalizeOptionalBoolean(record.firstTimeContributorGrace, "gate.firstTimeContributorGrace", warnings),
   };
   gate.present =
     gate.enabled !== null ||
@@ -311,7 +317,9 @@ function parseGateConfig(value: JsonValue | undefined, warnings: string[]): Focu
     gate.aiReviewMode !== null ||
     gate.aiReviewByok !== null ||
     gate.aiReviewProvider !== null ||
-    gate.aiReviewModel !== null;
+    gate.aiReviewModel !== null ||
+    gate.mergeReadiness !== null ||
+    gate.firstTimeContributorGrace !== null;
   return gate;
 }
 
@@ -347,6 +355,8 @@ export function gateConfigToJson(gate: FocusManifestGateConfig): JsonValue {
     if (gate.aiReviewModel !== null) aiReview.model = gate.aiReviewModel;
     out.aiReview = aiReview;
   }
+  if (gate.mergeReadiness !== null) out.mergeReadiness = gate.mergeReadiness;
+  if (gate.firstTimeContributorGrace !== null) out.firstTimeContributorGrace = gate.firstTimeContributorGrace;
   return out;
 }
 
@@ -492,6 +502,8 @@ export function resolveEffectiveSettings(dbSettings: RepositorySettings, manifes
   if (gate.aiReviewByok !== null) effective.aiReviewByok = gate.aiReviewByok;
   if (gate.aiReviewProvider !== null) effective.aiReviewProvider = gate.aiReviewProvider;
   if (gate.aiReviewModel !== null) effective.aiReviewModel = gate.aiReviewModel;
+  if (gate.mergeReadiness !== null) effective.mergeReadinessGateMode = gate.mergeReadiness;
+  if (gate.firstTimeContributorGrace !== null) effective.firstTimeContributorGrace = gate.firstTimeContributorGrace;
   return effective;
 }
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -400,7 +400,7 @@ describe("compileFocusManifestPolicy", () => {
       issueDiscoveryPolicy: "neutral",
       maintainerNotes: [],
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
-      gate: { present: false, enabled: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null },
+      gate: { present: false, enabled: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, mergeReadiness: null, firstTimeContributorGrace: null },
       settings: {},
       review: { present: false, footerText: null, note: null, fields: {} },
       warnings: [],
@@ -688,7 +688,19 @@ describe("parseFocusManifest gate config", () => {
   it("parses a full gate section including the readiness block", () => {
     const m = parseFocusManifest({ gate: { linkedIssue: "block", duplicates: "advisory", readiness: { mode: "block", minScore: 70 } } });
     expect(m.present).toBe(true);
-    expect(m.gate).toEqual({ present: true, enabled: null, pack: null, linkedIssue: "block", duplicates: "advisory", readinessMode: "block", readinessMinScore: 70, slopMode: null, slopMinScore: null, slopAiAdvisory: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null });
+    expect(m.gate).toEqual({ present: true, enabled: null, pack: null, linkedIssue: "block", duplicates: "advisory", readinessMode: "block", readinessMinScore: 70, slopMode: null, slopMinScore: null, slopAiAdvisory: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, mergeReadiness: null, firstTimeContributorGrace: null });
+  });
+
+  it("parses gate.mergeReadiness + gate.firstTimeContributorGrace, round-trips them, and warns on bad values (#822)", () => {
+    const m = parseFocusManifest({ gate: { mergeReadiness: "block", firstTimeContributorGrace: true } });
+    expect(m.gate.present).toBe(true);
+    expect(m.gate.mergeReadiness).toBe("block");
+    expect(m.gate.firstTimeContributorGrace).toBe(true);
+    expect(gateConfigToJson(m.gate)).toMatchObject({ mergeReadiness: "block", firstTimeContributorGrace: true });
+    const bad = parseFocusManifest({ gate: { mergeReadiness: "sometimes", firstTimeContributorGrace: "yes" } });
+    expect(bad.gate.mergeReadiness).toBeNull();
+    expect(bad.gate.firstTimeContributorGrace).toBeNull();
+    expect(bad.gate.present).toBe(false);
   });
 
   it("parses the gate.slop block, round-trips it, and warns on a non-mapping (#530/#532)", () => {

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -76,6 +76,19 @@ describe(".gittensory.yml settings override (resolveEffectiveSettings)", () => {
     expect(evaluateGateCheck(missingIssueAdvisory(), gateCheckPolicy(eff, null, true)).conclusion).toBe("success");
   });
 
+  it("end-to-end: manifest gate.mergeReadiness:block drives the composite even when the DB sub-gate is advisory (#822)", () => {
+    const eff = resolveEffectiveSettings(settings({ linkedIssueGateMode: "advisory", mergeReadinessGateMode: "off" }), parseFocusManifest({ gate: { mergeReadiness: "block" } }));
+    expect(eff.mergeReadinessGateMode).toBe("block");
+    expect(evaluateGateCheck(missingIssueAdvisory(), gateCheckPolicy(eff, null, true)).conclusion).toBe("failure");
+  });
+
+  it("end-to-end: manifest gate.firstTimeContributorGrace:true softens a newcomer's block to advisory (#822/#552)", () => {
+    const eff = resolveEffectiveSettings(settings({ linkedIssueGateMode: "block", firstTimeContributorGrace: false }), parseFocusManifest({ gate: { firstTimeContributorGrace: true } }));
+    expect(eff.firstTimeContributorGrace).toBe(true);
+    const newcomerPolicy = gateCheckPolicy(eff, null, true, null, { mergedPrCount: 0, closedUnmergedPrCount: 0 });
+    expect(evaluateGateCheck(missingIssueAdvisory(), newcomerPolicy).conclusion).toBe("neutral");
+  });
+
   it("still only blocks confirmed contributors regardless of the config", () => {
     const eff = resolveEffectiveSettings(settings({ linkedIssueGateMode: "advisory" }), parseFocusManifest({ gate: { linkedIssue: "block" } }));
     const nonConfirmed = evaluateGateCheck(missingIssueAdvisory(), gateCheckPolicy(eff, null, false));


### PR DESCRIPTION
Closes #822.

## What
The last two gate settings — `mergeReadinessGateMode` (#551) and `firstTimeContributorGrace` (#552) — shipped **DB-only**; their `.gittensory.yml` parity was deferred each time. This closes that recurring debt so the config-as-code gate surface is complete (a prerequisite for the agent layer reading/proposing full gate policy as code).

```yaml
gate:
  mergeReadiness: block          # off | advisory | block  -> mergeReadinessGateMode
  firstTimeContributorGrace: true # true | false           -> firstTimeContributorGrace
```

## How
Six surgical additions in `src/signals/focus-manifest.ts`, each mirroring the existing per-field pattern (e.g. `gate.slop.mode`):
- `FocusManifestGateConfig` type + `EMPTY_GATE_CONFIG` default
- `parseGateConfig` — `normalizeOptionalGateMode` / `normalizeOptionalBoolean` (bad values warn + null out, never block)
- the `gate.present` predicate
- `gateConfigToJson` serializer (the cache round-trip path)
- `resolveEffectiveSettings` — manifest wins over DB, identical to every other gate mode

## Tests
- `focus-manifest.test.ts`: parse + round-trip + bad-value warnings for both keys; updated the two full-gate-object equality fixtures
- `gate-check-policy.test.ts`: end-to-end — `gate.mergeReadiness: block` drives the composite to failure even when the DB sub-gate is advisory; `gate.firstTimeContributorGrace: true` softens a newcomer's block to neutral

## Verification
typecheck clean · full suite 1965 passed, 1 skipped (only the pre-existing pngjs visual-agent skip) · diff is 3 files, +40/-3 · no migration / no openapi change

Relates #551, #552, #555 (focus-manifest-as-gate).