### PR TITLE
feat(agent): autoMaintain config block + dashboard (#774)

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -8090,6 +8090,26 @@
                 ]
               }
             }
+          },
+          "autoMaintain": {
+            "type": "object",
+            "properties": {
+              "requireApprovals": {
+                "type": "integer"
+              },
+              "mergeMethod": {
+                "type": "string",
+                "enum": [
+                  "merge",
+                  "squash",
+                  "rebase"
+                ]
+              }
+            },
+            "required": [
+              "requireApprovals",
+              "mergeMethod"
+            ]
           }
         },
         "required": [

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -40,7 +40,29 @@ type MaintainerSettings = {
   requireLinkedIssue: boolean;
   badgeEnabled: boolean;
   commandAuthorization: CommandAuthorization;
+  autonomy: Partial<Record<AgentActionClass, AutonomyLevel>>;
+  autoMaintain: { requireApprovals: number; mergeMethod: AutoMergeMethod };
 };
+
+type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_approval" | "auto";
+type AgentActionClass = "review" | "request_changes" | "approve" | "merge" | "close" | "label";
+type AutoMergeMethod = "merge" | "squash" | "rebase";
+
+const AUTONOMY_LEVELS: AutonomyLevel[] = [
+  "observe",
+  "suggest",
+  "propose",
+  "auto_with_approval",
+  "auto",
+];
+const AGENT_ACTION_CLASSES: AgentActionClass[] = [
+  "review",
+  "request_changes",
+  "approve",
+  "merge",
+  "close",
+  "label",
+];
 
 type Message = { kind: "ok" | "err"; text: string };
 
@@ -84,6 +106,8 @@ const EDITABLE_KEYS: Array<keyof MaintainerSettings> = [
   "requireLinkedIssue",
   "badgeEnabled",
   "commandAuthorization",
+  "autonomy",
+  "autoMaintain",
 ];
 
 type SelectFieldDef = {
@@ -277,7 +301,19 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
       credentials: "include",
       silentStatus: true,
     });
-    setSettings(result.ok ? result.data : null);
+    // Default the agent-layer fields defensively so the editor renders even against an older response shape.
+    setSettings(
+      result.ok
+        ? {
+            ...result.data,
+            autonomy: result.data.autonomy ?? {},
+            autoMaintain: result.data.autoMaintain ?? {
+              requireApprovals: 1,
+              mergeMethod: "squash",
+            },
+          }
+        : null,
+    );
     setLoading(false);
   }, [repoFullName]);
 
@@ -441,6 +477,76 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
                 ))}
               </dl>
             ) : null}
+          </div>
+
+          <div>
+            <h3 className={LABEL_CLASS}>Auto-maintain (agent layer)</h3>
+            <p className="mt-1 text-token-2xs text-muted-foreground">
+              Per-action autonomy: <code className="font-mono">observe</code> (watch only) →{" "}
+              <code className="font-mono">suggest</code> →{" "}
+              <code className="font-mono">propose</code> →{" "}
+              <code className="font-mono">auto_with_approval</code> →{" "}
+              <code className="font-mono">auto</code>. Deny-by-default — anything left at{" "}
+              <code className="font-mono">observe</code> never acts.
+            </p>
+            <div className="mt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {AGENT_ACTION_CLASSES.map((actionClass) => (
+                <label key={actionClass} className="block">
+                  <span className={LABEL_CLASS}>{actionClass.replace(/_/g, " ")}</span>
+                  <select
+                    value={settings.autonomy[actionClass] ?? "observe"}
+                    onChange={(event) =>
+                      setField("autonomy", {
+                        ...settings.autonomy,
+                        [actionClass]: event.target.value as AutonomyLevel,
+                      })
+                    }
+                    className={FIELD_CLASS}
+                  >
+                    {AUTONOMY_LEVELS.map((level) => (
+                      <option key={level} value={level}>
+                        {level}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+            </div>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <label className="block">
+                <span className={LABEL_CLASS}>Approvals before auto-merge</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={settings.autoMaintain.requireApprovals}
+                  onChange={(event) =>
+                    setField("autoMaintain", {
+                      ...settings.autoMaintain,
+                      requireApprovals: Math.max(0, Math.min(10, Number(event.target.value) || 0)),
+                    })
+                  }
+                  className={FIELD_CLASS}
+                />
+              </label>
+              <label className="block">
+                <span className={LABEL_CLASS}>Merge method</span>
+                <select
+                  value={settings.autoMaintain.mergeMethod}
+                  onChange={(event) =>
+                    setField("autoMaintain", {
+                      ...settings.autoMaintain,
+                      mergeMethod: event.target.value as AutoMergeMethod,
+                    })
+                  }
+                  className={FIELD_CLASS}
+                >
+                  <option value="merge">merge</option>
+                  <option value="squash">squash</option>
+                  <option value="rebase">rebase</option>
+                </select>
+              </label>
+            </div>
           </div>
 
           <div className="flex flex-wrap items-center gap-3">

--- a/migrations/0043_agent_auto_maintain.sql
+++ b/migrations/0043_agent_auto_maintain.sql
@@ -1,0 +1,4 @@
+-- Auto-maintain policy (#774, Wave 2 Phase 0). Per-repo merge method + approval count for the agent action
+-- layer, stored as JSON ({ requireApprovals, mergeMethod }). Default '{}' resolves to the conservative
+-- defaults (squash / 1 approval) via normalizeAutoMaintainPolicy. Additive; existing repos are unaffected.
+ALTER TABLE repository_settings ADD COLUMN auto_maintain_json TEXT NOT NULL DEFAULT '{}';

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -626,6 +626,10 @@ const maintainerSettingsSchema = z
       default: z.array(z.enum(["maintainer", "collaborator", "pr_author", "confirmed_miner"])).max(4).optional(),
       commands: z.record(z.string().trim().min(1).max(64), z.array(z.enum(["maintainer", "collaborator", "pr_author", "confirmed_miner"])).max(4)).optional(),
     }),
+    // Agent-layer config (#773/#774). The DB layer normalizes both (autonomy: deny-by-default; autoMaintain:
+    // defaults filled), so a loose record/object here is safe — invalid entries are dropped on persist.
+    autonomy: z.record(z.string().trim().min(1).max(32), z.enum(["observe", "suggest", "propose", "auto_with_approval", "auto"])),
+    autoMaintain: z.object({ requireApprovals: z.number().int().min(0).max(10).optional(), mergeMethod: z.enum(["merge", "squash", "rebase"]).optional() }),
   })
   .partial();
 

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -62,6 +62,7 @@ import type {
   AgentActionStatus,
   AgentActionType,
   AutonomyPolicy,
+  AutoMaintainPolicy,
   AgentCommandAnswerRecord,
   AgentCommandFeedbackRecord,
   AgentContextSnapshotRecord,
@@ -151,7 +152,7 @@ import type {
 import type { GittensorContributorSnapshot, OfficialGittensorMinerDetection } from "../gittensor/api";
 import { classifyMcpClientVersion, LATEST_RECOMMENDED_MCP_VERSION, MINIMUM_SUPPORTED_MCP_VERSION } from "../services/mcp-compatibility";
 import { DEFAULT_COMMAND_AUTHORIZATION_POLICY, normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
-import { normalizeAutonomyPolicy } from "../settings/autonomy";
+import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy, DEFAULT_AUTO_MAINTAIN_POLICY } from "../settings/autonomy";
 import { decryptSecret, encryptSecret, sha256Hex } from "../utils/crypto";
 import { jsonString, nowIso, parseJson, repoParts } from "../utils/json";
 
@@ -425,6 +426,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
       badgeEnabled: false,
       commandAuthorization: normalizeCommandAuthorizationPolicy(DEFAULT_COMMAND_AUTHORIZATION_POLICY).policy,
       autonomy: {},
+      autoMaintain: { ...DEFAULT_AUTO_MAINTAIN_POLICY },
     };
   }
   return {
@@ -461,6 +463,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     badgeEnabled: row.badgeEnabled,
     commandAuthorization: parseCommandAuthorizationPolicy(row.commandAuthorizationJson),
     autonomy: parseAutonomyPolicy(row.autonomyJson),
+    autoMaintain: parseAutoMaintainPolicy(row.autoMaintainJson),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -501,6 +504,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     badgeEnabled: settings.badgeEnabled ?? false,
     commandAuthorization: normalizeCommandAuthorizationPolicy(settings.commandAuthorization).policy,
     autonomy: normalizeAutonomyPolicy(settings.autonomy),
+    autoMaintain: normalizeAutoMaintainPolicy(settings.autoMaintain),
   };
   const db = getDb(env.DB);
   await db
@@ -539,6 +543,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
       badgeEnabled: resolved.badgeEnabled,
       commandAuthorizationJson: jsonString(resolved.commandAuthorization),
       autonomyJson: jsonString(resolved.autonomy),
+      autoMaintainJson: jsonString(resolved.autoMaintain),
       updatedAt: nowIso(),
     })
     .onConflictDoUpdate({
@@ -578,6 +583,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
         badgeEnabled: resolved.badgeEnabled,
         commandAuthorizationJson: jsonString(resolved.commandAuthorization),
         autonomyJson: jsonString(resolved.autonomy),
+        autoMaintainJson: jsonString(resolved.autoMaintain),
         updatedAt: nowIso(),
       },
     });
@@ -4970,6 +4976,10 @@ function parseCommandAuthorizationPolicy(value: string): RepositorySettings["com
 
 function parseAutonomyPolicy(value: string): AutonomyPolicy {
   return normalizeAutonomyPolicy(parseJson<unknown>(value, null));
+}
+
+function parseAutoMaintainPolicy(value: string): AutoMaintainPolicy {
+  return normalizeAutoMaintainPolicy(parseJson<unknown>(value, null));
 }
 
 function parseSyncStatus(value: string): RepoSyncStateRecord["status"] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,6 +72,7 @@ export const repositorySettings = sqliteTable("repository_settings", {
   badgeEnabled: integer("badge_enabled", { mode: "boolean" }).notNull().default(false),
   commandAuthorizationJson: text("command_authorization_json").notNull().default("{}"),
   autonomyJson: text("autonomy_json").notNull().default("{}"),
+  autoMaintainJson: text("auto_maintain_json").notNull().default("{}"),
   createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
   updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
 });

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -584,6 +584,7 @@ export const RepositorySettingsSchema = z
     autonomy: z
       .record(z.enum(["review", "request_changes", "approve", "merge", "close", "label"]), z.enum(["observe", "suggest", "propose", "auto_with_approval", "auto"]))
       .optional(),
+    autoMaintain: z.object({ requireApprovals: z.number().int(), mergeMethod: z.enum(["merge", "squash", "rebase"]) }).optional(),
     createdAt: z.string().nullable().optional(),
     updatedAt: z.string().nullable().optional(),
   })

--- a/src/settings/autonomy.ts
+++ b/src/settings/autonomy.ts
@@ -1,4 +1,4 @@
-import type { AgentActionClass, AutonomyLevel, AutonomyPolicy } from "../types";
+import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyLevel, AutonomyPolicy } from "../types";
 
 // The graduated autonomy dial (#773), ordered least → most autonomous. Every later agent-layer phase reads
 // this BEFORE acting. `observe` is the deny-by-default floor — gittensory watches but never takes an action.
@@ -47,4 +47,31 @@ export function normalizeAutonomyPolicy(input: unknown): AutonomyPolicy {
     }
   }
   return policy;
+}
+
+// Auto-maintain policy (#774): how an action behaves once its autonomy level permits acting.
+export const AUTO_MERGE_METHODS = ["merge", "squash", "rebase"] as const;
+const AUTO_MERGE_METHOD_SET = new Set<string>(AUTO_MERGE_METHODS);
+
+// Conservative defaults: squash (the tidiest history) + a single human approval before any auto-merge.
+export const DEFAULT_AUTO_MAINTAIN_POLICY: AutoMaintainPolicy = { requireApprovals: 1, mergeMethod: "squash" };
+
+// Approvals are clamped to a sane band so a malformed config can't disable the gate (negative) or stall it.
+const MAX_REQUIRE_APPROVALS = 10;
+
+/**
+ * Parse/validate an arbitrary value into an AutoMaintainPolicy, filling the conservative defaults for any
+ * missing/invalid field. `requireApprovals` is clamped to [0, 10]. Pure.
+ */
+export function normalizeAutoMaintainPolicy(input: unknown): AutoMaintainPolicy {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return { ...DEFAULT_AUTO_MAINTAIN_POLICY };
+  const record = input as Record<string, unknown>;
+  const rawApprovals = record.requireApprovals;
+  const requireApprovals =
+    typeof rawApprovals === "number" && Number.isFinite(rawApprovals)
+      ? Math.min(MAX_REQUIRE_APPROVALS, Math.max(0, Math.trunc(rawApprovals)))
+      : DEFAULT_AUTO_MAINTAIN_POLICY.requireApprovals;
+  const rawMethod = record.mergeMethod;
+  const mergeMethod = typeof rawMethod === "string" && AUTO_MERGE_METHOD_SET.has(rawMethod) ? (rawMethod as AutoMergeMethod) : DEFAULT_AUTO_MAINTAIN_POLICY.mergeMethod;
+  return { requireApprovals, mergeMethod };
 }

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1,6 +1,6 @@
 import { parse as parseYaml } from "yaml";
 import type { GatePolicyPack, GateRuleMode, JsonValue, RepositorySettings } from "../types";
-import { normalizeAutonomyPolicy } from "../settings/autonomy";
+import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../settings/autonomy";
 
 export type FocusManifestSource = "repo_file" | "api_record" | "none";
 export type FocusManifestLinkedIssuePolicy = "required" | "preferred" | "optional";
@@ -68,6 +68,7 @@ export type FocusManifestSettings = Partial<
     | "backfillEnabled"
     | "privateTrustEnabled"
     | "autonomy"
+    | "autoMaintain"
   >
 >;
 
@@ -433,6 +434,11 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   if (r.autonomy !== undefined) {
     const autonomy = normalizeAutonomyPolicy(r.autonomy);
     if (Object.keys(autonomy).length > 0) out.autonomy = autonomy;
+  }
+  // Auto-maintain policy (#774): `settings.autoMaintain` declares the full policy (defaults fill any unset
+  // field) and overlays the DB value via the resolver. Only a mapping is honoured; anything else is ignored.
+  if (typeof r.autoMaintain === "object" && r.autoMaintain !== null && !Array.isArray(r.autoMaintain)) {
+    out.autoMaintain = normalizeAutoMaintainPolicy(r.autoMaintain);
   }
   return out;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -462,6 +462,9 @@ export type RepositorySettings = {
    *  `{}` = deny-by-default = "observe" for every class); optional so existing settings fixtures/callers
    *  need not be touched. The single source the action layer (#778) reads via `resolveAutonomy`. */
   autonomy?: AutonomyPolicy | undefined;
+  /** Auto-maintain policy (#774): merge method + approval count. Always populated by the DB layer with
+   *  defaults (squash / 1 approval); optional so existing settings fixtures/callers need not be touched. */
+  autoMaintain?: AutoMaintainPolicy | undefined;
   createdAt?: string | null | undefined;
   updatedAt?: string | null | undefined;
 };
@@ -483,6 +486,17 @@ export type AgentActionClass = "review" | "request_changes" | "approve" | "merge
 
 /** Per-action-class autonomy. An unset class resolves to `observe` (deny-by-default). */
 export type AutonomyPolicy = Partial<Record<AgentActionClass, AutonomyLevel>>;
+
+/** How the agent merges when it auto-merges (#774). */
+export type AutoMergeMethod = "merge" | "squash" | "rebase";
+
+/** Auto-maintain policy (#774): the "how" once an action is at an acting autonomy level. `requireApprovals`
+ *  is the human approval count an `auto_with_approval` action waits for (#779); `mergeMethod` is how an
+ *  auto-merge merges. Always populated by the DB layer with defaults. */
+export type AutoMaintainPolicy = {
+  requireApprovals: number;
+  mergeMethod: AutoMergeMethod;
+};
 
 export type RepoSyncStateRecord = {
   repoFullName: string;

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2212,11 +2212,29 @@ describe("api routes", () => {
     // override; unrelated groups are preserved by the load-merge in the handler.
     const settingsUpdate = await app.request(
       "/v1/repos/repo-owner/owned-repo/settings",
-      { method: "PUT", headers: ownerHeaders, body: JSON.stringify({ gateCheckMode: "enabled", slopGateMode: "block", slopGateMinScore: 55 }) },
+      {
+        method: "PUT",
+        headers: ownerHeaders,
+        // #773/#774: the agent-layer config is settable here; the DB layer drops an unknown action class.
+        body: JSON.stringify({ gateCheckMode: "enabled", slopGateMode: "block", slopGateMinScore: 55, autonomy: { merge: "auto_with_approval", deploy: "auto" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" } }),
+      },
       ownerEnv,
     );
     expect(settingsUpdate.status).toBe(200);
-    await expect(settingsUpdate.json()).resolves.toMatchObject({ gateCheckMode: "enabled", slopGateMode: "block", slopGateMinScore: 55 });
+    await expect(settingsUpdate.json()).resolves.toMatchObject({
+      gateCheckMode: "enabled",
+      slopGateMode: "block",
+      slopGateMinScore: 55,
+      autonomy: { merge: "auto_with_approval" }, // unknown action class dropped by the DB normalizer
+      autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" },
+    });
+    // requireApprovals is bounded at the API boundary — an out-of-range value is rejected, not silently clamped.
+    const settingsBadApprovals = await app.request(
+      "/v1/repos/repo-owner/owned-repo/settings",
+      { method: "PUT", headers: ownerHeaders, body: JSON.stringify({ autoMaintain: { requireApprovals: 99 } }) },
+      ownerEnv,
+    );
+    expect(settingsBadApprovals.status).toBe(400);
     const settingsInvalid = await app.request(
       "/v1/repos/repo-owner/owned-repo/settings",
       { method: "PUT", headers: ownerHeaders, body: JSON.stringify({ gateCheckMode: "nonsense" }) },

--- a/test/unit/autonomy.test.ts
+++ b/test/unit/autonomy.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   AGENT_ACTION_CLASSES,
   AUTONOMY_LEVELS,
+  AUTO_MERGE_METHODS,
   DEFAULT_AUTONOMY_LEVEL,
+  DEFAULT_AUTO_MAINTAIN_POLICY,
   autonomyRequiresApproval,
   isActingAutonomyLevel,
+  normalizeAutoMaintainPolicy,
   normalizeAutonomyPolicy,
   resolveAutonomy,
 } from "../../src/settings/autonomy";
@@ -78,5 +81,29 @@ describe("normalizeAutonomyPolicy", () => {
   it("round-trips a valid policy through normalization", () => {
     const policy: AutonomyPolicy = { review: "propose", request_changes: "auto_with_approval", merge: "observe" };
     expect(normalizeAutonomyPolicy(policy)).toEqual(policy);
+  });
+});
+
+describe("normalizeAutoMaintainPolicy (#774)", () => {
+  it("fills conservative defaults (squash / 1 approval) for missing or non-object input", () => {
+    expect(normalizeAutoMaintainPolicy({})).toEqual({ requireApprovals: 1, mergeMethod: "squash" });
+    expect(normalizeAutoMaintainPolicy(null)).toEqual(DEFAULT_AUTO_MAINTAIN_POLICY);
+    expect(normalizeAutoMaintainPolicy("nope")).toEqual(DEFAULT_AUTO_MAINTAIN_POLICY);
+    expect(normalizeAutoMaintainPolicy([1])).toEqual(DEFAULT_AUTO_MAINTAIN_POLICY);
+  });
+
+  it("keeps valid fields and round-trips a full policy", () => {
+    expect(normalizeAutoMaintainPolicy({ requireApprovals: 2, mergeMethod: "rebase" })).toEqual({ requireApprovals: 2, mergeMethod: "rebase" });
+  });
+
+  it("clamps requireApprovals to [0,10] and truncates, and rejects an invalid merge method", () => {
+    expect(normalizeAutoMaintainPolicy({ requireApprovals: -3, mergeMethod: "foo" })).toEqual({ requireApprovals: 0, mergeMethod: "squash" });
+    expect(normalizeAutoMaintainPolicy({ requireApprovals: 99 }).requireApprovals).toBe(10);
+    expect(normalizeAutoMaintainPolicy({ requireApprovals: 2.9 }).requireApprovals).toBe(2);
+    expect(normalizeAutoMaintainPolicy({ requireApprovals: "two" }).requireApprovals).toBe(1); // non-number → default
+  });
+
+  it("AUTO_MERGE_METHODS is the closed set merge/squash/rebase", () => {
+    expect(AUTO_MERGE_METHODS).toEqual(["merge", "squash", "rebase"]);
   });
 });

--- a/test/unit/data-spine.test.ts
+++ b/test/unit/data-spine.test.ts
@@ -267,6 +267,12 @@ describe("data spine repositories", () => {
     await upsertRepositorySettings(env, { repoFullName: "owner/autonomyrepo", autonomy: { merge: "observe" } });
     expect((await getRepositorySettings(env, "owner/autonomyrepo")).autonomy).toEqual({ merge: "observe" }); // update persists
     expect((await getRepositorySettings(env, "owner/defaultpack")).autonomy).toEqual({}); // deny-by-default
+    // #774 autoMaintain round-trips, clamps requireApprovals, and defaults to squash/1.
+    await upsertRepositorySettings(env, { repoFullName: "owner/automaintainrepo", autoMaintain: { requireApprovals: 99, mergeMethod: "rebase" } });
+    expect((await getRepositorySettings(env, "owner/automaintainrepo")).autoMaintain).toEqual({ requireApprovals: 10, mergeMethod: "rebase" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/automaintainrepo", autoMaintain: { requireApprovals: 0, mergeMethod: "merge" } });
+    expect((await getRepositorySettings(env, "owner/automaintainrepo")).autoMaintain).toEqual({ requireApprovals: 0, mergeMethod: "merge" }); // update persists
+    expect((await getRepositorySettings(env, "owner/defaultpack")).autoMaintain).toEqual({ requireApprovals: 1, mergeMethod: "squash" }); // defaults
     expect(updated.slopAiAdvisory).toBe(false);
     expect(await getRepoSyncState(env, "missing/repo")).toBeNull();
     expect(await getPullRequest(env, "owner/repo", 404)).toBeNull();

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -919,6 +919,16 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(noOverride.autonomy).toEqual({ merge: "auto" });
   });
 
+  it("parses + resolves autoMaintain from the settings: block, filling defaults (#774)", () => {
+    const manifest = parseFocusManifest({ settings: { autoMaintain: { mergeMethod: "rebase", requireApprovals: 99 } } });
+    expect(manifest.settings.autoMaintain).toEqual({ mergeMethod: "rebase", requireApprovals: 10 }); // clamped
+    const eff = resolveEffectiveSettings({ autoMaintain: { requireApprovals: 1, mergeMethod: "squash" } } as unknown as RepositorySettings, manifest);
+    expect(eff.autoMaintain).toEqual({ mergeMethod: "rebase", requireApprovals: 10 }); // yml overlays DB
+    // A non-mapping autoMaintain is ignored, leaving the DB policy intact.
+    const ignored = resolveEffectiveSettings({ autoMaintain: { requireApprovals: 2, mergeMethod: "merge" } } as unknown as RepositorySettings, parseFocusManifest({ settings: { autoMaintain: "nope" } }));
+    expect(ignored.autoMaintain).toEqual({ requireApprovals: 2, mergeMethod: "merge" });
+  });
+
   it("resolveEffectiveSettings overlays settings: over DB and lets gate: win for gate fields", () => {
     const db = { commentMode: "off", gateCheckMode: "off", linkedIssueGateMode: "off", duplicatePrGateMode: "off", autoLabelEnabled: true } as unknown as RepositorySettings;
     const eff = resolveEffectiveSettings(


### PR DESCRIPTION
Closes #774. Builds on #773 (autonomy framework) — the per-repo auto-maintain **policy** + a **dashboard** surface.

## What
- **`AutoMaintainPolicy`** `{ requireApprovals, mergeMethod }` + `normalizeAutoMaintainPolicy` (conservative defaults **squash / 1 approval**; `requireApprovals` clamped to `[0,10]`; invalid merge method → `squash`). Pure + **100% covered**.
- **Persisted** on `repository_settings` as JSON (**migration 0043**, default `'{}'` → defaults), mirroring `autonomy`/`commandAuthorization`.
- **Config-as-code:** `.gittensory.yml` `settings.autoMaintain` (+ `settings.autonomy` from #773) resolved through the existing **yml > DB > defaults** resolver; a non-mapping block is ignored, never blanking the DB policy.
- **Dashboard:** a new **"Auto-maintain (agent layer)"** section in the maintainer settings editor (#130) — per-action autonomy selectors for all six action classes + approvals-before-auto-merge + merge method.
- **Maintainer `PUT /settings`** now accepts `autonomy` + `autoMaintain` (bounded: `requireApprovals` 0–10 rejected out of range; unknown autonomy action classes dropped by the DB normalizer).

```yaml
# .gittensory.yml
settings:
  autonomy:
    merge: auto_with_approval
  autoMaintain:
    requireApprovals: 1
    mergeMethod: squash
```

## Scope
This is config + dashboard only — nothing acts. The action layer that *consults* `resolveAutonomy` + this policy is **#778**.

## Verification
typecheck clean · migration guard (0001..0043, no dup) · full suite **2014 passed, 1 skipped** (pre-existing pngjs skip) · OpenAPI regenerated + drift-clean · UI lint/typecheck/build clean · the new policy module is 100% covered and every changed line is covered.

> Note: migration 0043 follows #773's 0042 — both ahead of the open #833; whichever merges into a 0042/0043 collision rebases + renumbers.

Relates #768 (Phase 0), #773 (autonomy framework), #778 (write-actions consume this).