### PR TITLE
feat(ui): render the authenticated /app/* UI in PR previews (preview-session escape hatch) (#authed-route-preview)

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Build UI
         env:
           VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
+          # Preview-only: enables the synthetic demo session (useSession().signInPreview) so reviewbot can
+          # screenshot the authenticated /app/* dashboard via ?preview=1 instead of the sign-in wall. The
+          # production build (ui-deploy.yml) does NOT set this, so the escape hatch is dead-code-eliminated
+          # from prod. (#authed-route-preview)
+          VITE_PREVIEW: "1"
         run: npm run ui:build
 
       # The trusted deploy workflow downloads this by name + run-id. It contains only the built bundle

--- a/apps/gittensory-ui/src/components/site/app-shell.tsx
+++ b/apps/gittensory-ui/src/components/site/app-shell.tsx
@@ -14,7 +14,7 @@ import {
 import type { ComponentType } from "react";
 import { useEffect, useState } from "react";
 
-import { useSession } from "@/lib/api/session";
+import { PREVIEW_SESSION_ALLOWED, useSession } from "@/lib/api/session";
 import { describeApiStatus, pingHealth, useApiStatus } from "@/lib/api/status";
 import {
   Sidebar,
@@ -85,7 +85,7 @@ const GROUPS: NavGroup[] = [
 ];
 
 export function AppShell() {
-  const { session, hydrated, signOut } = useSession();
+  const { session, hydrated, signOut, signInPreview } = useSession();
   const loc = useLocation();
   const navigate = useNavigate();
   const routerState = useRouterState();
@@ -95,6 +95,16 @@ export function AppShell() {
     const m = document.cookie.match(/(?:^|; )sidebar_state=([^;]+)/);
     setSidebarOpen(m ? m[1] === "true" : true);
   }, []);
+
+  // Preview deploys: when this is a preview build (VITE_PREVIEW) and the URL carries `?preview=1`, start
+  // the synthetic demo session automatically once hydration confirms there's no real session. This lets the
+  // reviewbot screenshot pipeline capture the authenticated /app/* UI instead of the sign-in wall. The
+  // effect depends on `session`, so it self-heals if a later refresh clears the synthetic session. Inert in
+  // production (PREVIEW_SESSION_ALLOWED is compiled to false) and without the param. (#authed-route-preview)
+  useEffect(() => {
+    if (!PREVIEW_SESSION_ALLOWED || session || !hydrated) return;
+    if (new URLSearchParams(window.location.search).get("preview") === "1") signInPreview();
+  }, [session, hydrated, signInPreview]);
 
   // Keyboard shortcuts: g+o overview, g+w workbench, g+r runs, g+p repos, g+a analytics.
   useEffect(() => {

--- a/apps/gittensory-ui/src/lib/api/session.ts
+++ b/apps/gittensory-ui/src/lib/api/session.ts
@@ -64,6 +64,13 @@ function emitSessionChanged() {
   if (typeof window !== "undefined") window.dispatchEvent(new Event(SESSION_CHANGED_EVENT));
 }
 
+// The synthetic local-preview session is available in `vite dev` (DEV) AND on dedicated preview deploys
+// built with VITE_PREVIEW=1 (the per-PR `ui-preview.yml` build sets it; production builds never do, so this
+// escape hatch is dead-code-eliminated from prod). It writes no real token and grants only a client-side
+// demo session — it lets the reviewbot screenshot pipeline render the authenticated /app/* UI instead of a
+// screenshot of the sign-in wall. (#authed-route-preview)
+export const PREVIEW_SESSION_ALLOWED = import.meta.env.DEV || import.meta.env.VITE_PREVIEW === "1";
+
 export function useSession() {
   const [session, setSession] = useState<AppSession | null>(null);
   const [hydrated, setHydrated] = useState(false);
@@ -96,7 +103,7 @@ export function useSession() {
   };
 
   const signInPreview = () => {
-    if (!import.meta.env.DEV) return;
+    if (!PREVIEW_SESSION_ALLOWED) return;
     setSession({
       login: "local-preview",
       roles: ["miner", "maintainer", "owner", "operator"],
@@ -104,8 +111,8 @@ export function useSession() {
     });
     setHydrated(true);
     setAuth({ status: "idle" });
-    toast.success("Local preview session started", {
-      description: "This exists only in dev mode and never writes a production token.",
+    toast.success("Preview session started", {
+      description: "A demo session for dev + preview deploys — it never writes a production token.",
     });
   };
 


### PR DESCRIPTION
## Problem
Per-PR preview screenshots (reviewbot) of the `/app/*` dashboard captured the **sign-in wall**, not the page — `/app/*` is guarded client-side in `AppShell` and the headless browser has no session (real GitHub OAuth Device Flow can't be scripted). e.g. PR #831's `/app/audit` preview was stuck at sign-in.

## Fix
`useSession().signInPreview()` already mints a **client-only synthetic demo session** (`login: 'local-preview'`, all roles, no real token) — but it was gated to `vite dev` only, so it no-op'd on deployed previews.

- **session.ts** — gate `signInPreview` on `PREVIEW_SESSION_ALLOWED = DEV || VITE_PREVIEW==='1'`.
- **app-shell.tsx** — when allowed + URL has `?preview=1`, auto-start the synthetic session after hydration confirms no real session (self-heals via the `session` dep). Inert in prod / without the param.
- **ui-preview.yml** — set `VITE_PREVIEW=1` on the preview *Build UI* step. The production build (`ui-deploy.yml`) does **not** set it, so the escape hatch is **dead-code-eliminated from prod**.

## Safety
- Client-only synthetic session — no real token, **no real API access**. The prod API still enforces auth server-side; a preview visitor sees the dashboard shell, not anyone's data.
- Compiled out of production entirely (flag only set in the preview build).
- reviewbot appends `?preview=1` to `/app/*` routes ([reviewbot#234](https://github.com/JSONbored/reviewbot/pull/234)); each side is inert without the other.

## Scope note
This renders the **authenticated shell + layout** for visual review. Data panels that need a real token still show their empty/unauthenticated state — populating them with demo data is a separate, per-panel follow-up.

## Verify
ui:typecheck ✓ · ui:lint ✓ · preview build (`VITE_PREVIEW=1`) ✓ · UI tests 7/7 ✓