### PR TITLE
fix(agent): reuse canonical gate for auto-maintain

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -418,8 +418,8 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
 
 /**
  * #778 maintainer auto-maintain trigger. After the gate runs on a PR webhook, if the repo opted the agent in
- * (an acting autonomy level), recompute the CANONICAL verdict (same inputs the gate published — confirmed-
- * contributor status + the persisted slop score), plan the GitHub state actions, and run them through the
+ * (an acting autonomy level), reuse the CANONICAL verdict produced by the full gate evaluation, plan the
+ * GitHub state actions, and run them through the
  * executor's deny-toward-safety gate stack (pause → approval → write-permission → mode). Decoupled and
  * best-effort: a failure here never affects the gate or the public surface. gittensory never acts on a
  * non-confirmed contributor's PR — the same rule the gate uses to never block one.
@@ -434,23 +434,17 @@ async function maybeRunAgentMaintenance(
     settings: RepositorySettings;
     otherOpenPullRequests: PullRequestRecord[];
     deliveryId: string;
+    gate: ReturnType<typeof evaluateGateCheck> | undefined;
   },
 ): Promise<void> {
-  const { installationId, repoFullName, repo, settings, otherOpenPullRequests, deliveryId } = args;
+  const { installationId, repoFullName, settings, otherOpenPullRequests, gate } = args;
   if (!isAgentConfigured(settings.autonomy)) return;
   // Re-read the stored PR so we act on the persisted slop score the gate just wrote, not the pre-gate payload.
   const pr = await getPullRequest(env, repoFullName, args.pr.number);
   /* v8 ignore next -- defensive: the PR was upserted earlier in this same webhook, so it is always present. */
   if (!pr) return;
   if (pr.state !== "open") return;
-  // gittensory never acts on a non-confirmed contributor's PR — the same rule the gate uses to never block one.
-  const confirmedContributor = pr.authorLogin
-    ? (await getCachedOfficialMinerDetection(env, pr.authorLogin, { targetKey: `${repoFullName}#${pr.number}`, deliveryId })).status === "confirmed"
-    : false;
-
-  const requireLinkedIssue = settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off";
-  const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests, requireLinkedIssue });
-  const gate = evaluateGateCheck(advisory, gateCheckPolicy(settings, null, confirmedContributor, pr.slopRisk));
+  if (!gate) return;
 
   const planned = planAgentMaintenanceActions({
     conclusion: gate.conclusion,
@@ -928,7 +922,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       });
       await persistAdvisory(env, advisory);
       if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
-        await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
+        const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
           deliveryId,
           authorType: payload.pull_request.user?.type,
           action: payload.action,
@@ -943,11 +937,12 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
               error: errorMessage(error),
             }),
           );
+          return undefined;
         });
         // #778 maintainer auto-maintain: act on the PR's state (label/review/merge/close) per the repo's
         // autonomy config, after the gate has run. The function self-guards on agent config; best-effort here
         // so it never blocks the gate or public surface.
-        await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId }).catch((error) => {
+        await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
           /* v8 ignore next -- best-effort: auto-maintain failures are logged, never surfaced to the gate. */
           console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
         });
@@ -1262,7 +1257,7 @@ async function maybePublishPrPublicSurface(
   settings: Awaited<ReturnType<typeof getRepositorySettings>>,
   advisory: Awaited<ReturnType<typeof buildPullRequestAdvisory>>,
   webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined },
-): Promise<void> {
+): Promise<ReturnType<typeof evaluateGateCheck> | undefined> {
   const author = pr.authorLogin ?? null;
   // `settings` is the EFFECTIVE config (`.gittensory.yml` > DB > defaults), resolved by the caller via
   // resolveRepositorySettings — so gate on/off and every blocker mode already reflect the repo's config
@@ -1285,8 +1280,8 @@ async function maybePublishPrPublicSurface(
     !publicSurfaceSkipped &&
     settings.commentMode === "detected_contributors_only" &&
     (settings.publicSurface === "comment_and_label" || settings.publicSurface === "comment_only");
-  if (!gateEnabled && (publicSurfaceSkipped || (prelim.actions.length === 1 && prelim.actions[0] === "none" && !needsMinerCheckForDetectedComment))) return;
-  if (!author && !gateEnabled) return;
+  if (!gateEnabled && (publicSurfaceSkipped || (prelim.actions.length === 1 && prelim.actions[0] === "none" && !needsMinerCheckForDetectedComment))) return undefined;
+  if (!author && !gateEnabled) return undefined;
 
   if (gateEnabled && (pr.state !== "open" || webhook.action === "closed")) {
     const gateCheckResult = await createOrUpdateSkippedGateCheckRun(env, installationId, repoFullName, advisory, "PR closed before full evaluation.");
@@ -1301,7 +1296,7 @@ async function maybePublishPrPublicSurface(
       buildClosedPrPanelUpdate(repoFullName, pr.number),
       { createIfMissing: false },
     ).catch(() => undefined);
-    return;
+    return undefined;
   }
   const prelimHasPublicOutput =
     !publicSurfaceSkipped && (needsMinerCheckForDetectedComment || prelim.actions.some((action) => action === "comment" || action === "label" || action === "check_run"));
@@ -1315,12 +1310,12 @@ async function maybePublishPrPublicSurface(
     });
     if (requireOfficialMiner && official.status === "unavailable") {
       await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
-      if (!gateEnabled) return;
+      if (!gateEnabled) return undefined;
       publicSurfaceSkipped = true;
     }
     if (requireOfficialMiner && official.status !== "confirmed") {
       await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
-      if (!gateEnabled) return;
+      if (!gateEnabled) return undefined;
       publicSurfaceSkipped = true;
     }
     decision = decidePublicSurface({
@@ -1331,7 +1326,7 @@ async function maybePublishPrPublicSurface(
       minerStatus: official.status,
     });
 
-    if (!gateEnabled && decision.actions.length === 1 && decision.actions[0] === "none") return;
+    if (!gateEnabled && decision.actions.length === 1 && decision.actions[0] === "none") return undefined;
   }
 
   let pendingGateCheckRunId: number | undefined;
@@ -1525,8 +1520,8 @@ async function maybePublishPrPublicSurface(
     throw error;
   }
 
-  if (!prelimHasPublicOutput) return;
-  if (publicSurfaceSkipped || !official || !author) return;
+  if (!prelimHasPublicOutput) return gateEvaluation;
+  if (publicSurfaceSkipped || !official || !author) return gateEvaluation;
 
   const [github] = await Promise.all([fetchPublicContributorProfile(author, env)]);
   const contributorPullRequests: Awaited<ReturnType<typeof listContributorPullRequests>> = [];
@@ -1607,7 +1602,7 @@ async function maybePublishPrPublicSurface(
         metadata: { deliveryId: webhook.deliveryId, repoFullName, failedOutputs },
       });
     }
-    return;
+    return gateEvaluation;
   }
   await recordAuditEvent(env, {
     eventType: "github_app.pr_public_surface_published",
@@ -1640,6 +1635,7 @@ async function maybePublishPrPublicSurface(
       failedOutputs,
     },
   });
+  return gateEvaluation;
 }
 
 async function recordPublicSurfaceOutputFailure(

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -24,6 +24,7 @@ import {
   upsertRepoSyncSegment,
   upsertInstallation,
   upsertOfficialMinerDetection,
+  upsertPullRequestFile,
   upsertPullRequestFromGitHub,
   upsertIssueWatchSubscription,
   upsertRepositorySettings,
@@ -917,6 +918,84 @@ describe("queue processors", () => {
     const labelAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.label").first<{ outcome: string; metadata_json: string }>();
     expect(labelAudit?.outcome).toBe("completed");
     expect(JSON.parse(labelAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run", actionClass: "label" });
+    const rcAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string; metadata_json: string }>();
+    expect(rcAudit?.outcome).toBe("completed");
+    expect(JSON.parse(rcAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });
+  });
+
+  it("auto-maintain (#778): uses the full gate verdict so manifest-policy blockers cannot be merged", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      manifestPolicyGateMode: "block",
+      autonomy: { merge: "auto", request_changes: "auto" },
+      agentDryRun: true,
+    });
+    await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { manifestPolicy: "block" }, blockedPaths: ["migrations/**"] });
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 48,
+      path: "migrations/0099_attacker.sql",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "auto-maintain-manifest-block",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 48,
+          title: "Blocked migration",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "gate123" },
+          labels: [],
+          body: "Closes #1",
+          mergeable_state: "clean",
+          reviewDecision: "APPROVED",
+        },
+      },
+    });
+
+    const mergeCount = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.action.merge").first<{ n: number }>();
+    expect(mergeCount?.n).toBe(0);
     const rcAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string; metadata_json: string }>();
     expect(rcAudit?.outcome).toBe("completed");
     expect(JSON.parse(rcAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });


### PR DESCRIPTION
### Motivation
- The auto-maintain path recomputed a reduced gate verdict and could omit file-dependent blockers (manifest, AI review, readiness), allowing auto-merge/approve actions to be planned incorrectly.
- The goal is to ensure maintainer-facing write actions are driven by the canonical gate evaluation produced by the full public-surface path so configured blockers are respected.

### Description
- Stop recomputing a reduced gate inside `maybeRunAgentMaintenance`; accept and reuse the canonical `gate` produced by the full PR path instead. (update `maybeRunAgentMaintenance` signature and call site in `src/queue/processors.ts`).
- Make `maybePublishPrPublicSurface` return the evaluated gate (`gateEvaluation`) so the follow-up maintenance step can consume the canonical verdict instead of re-evaluating with incomplete inputs.
- Guard `maybeRunAgentMaintenance` to no-op when the canonical `gate` is unavailable rather than recomputing a reduced advisory.
- Add a regression test in `test/unit/queue.test.ts` that seeds a focus-manifest blocker on `migrations/**`, marks the PR as clean/approved, and asserts auto-maintain does not schedule a merge but still records a request-changes action (dry-run).

### Testing
- Ran `git diff --check` with no issues.
- Ran typecheck via `npm run typecheck` which succeeded.
- Ran the unit regression: `npx vitest run test/unit/queue.test.ts -t "auto-maintain" --reporter=verbose` and the targeted auto-maintain tests passed (regression verified blocking manifest prevents auto-merge).
- The change was committed and a PR body prepared describing the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33aa87fd94832cad2999919d8e278d)