### PR TITLE
fix(api): require live repo write access for settings updates

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1990,12 +1990,13 @@ export function createApp() {
   });
 
   // #130 maintainer settings editor: PATCH-style save of the gate / slop / label / surface / command-auth
-  // settings. Maintainer-authenticated + audited. upsertRepositorySettings defaults any absent field, so we
-  // merge the sent keys onto the current settings rather than overwriting unrelated groups. The secret
+  // settings. Write-access gated + audited because these repo-visible settings include agent autonomy
+  // controls. upsertRepositorySettings defaults any absent field, so we merge the sent keys onto the
+  // current settings rather than overwriting unrelated groups. The secret
   // aiReview key + the operator-only scoring internals are deliberately not settable here.
   app.put("/v1/repos/:owner/:repo/settings", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const gate = await requireRepoMaintainer(c, fullName);
+    const gate = await requireRepoWriteAccess(c, fullName);
     if (gate instanceof Response) return gate;
     const body = await c.req.json().catch(() => null);
     const parsed = maintainerSettingsSchema.safeParse(body);

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -36,12 +36,19 @@ import {
 } from "../../src/db/repositories";
 import { createApp } from "../../src/api/routes";
 import { clearPublicRepoStatsCacheForTests } from "../../src/github/public";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
 import { BURDEN_FORECAST_MAX_AGE_MS } from "../../src/services/burden-forecast";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
 import { createTestEnv } from "../helpers/d1";
 import type { JsonValue } from "../../src/types";
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
 
 const FORBIDDEN_PUBLIC_REPORT_TERMS =
   /wallet|hotkey|raw trust|trust[-\s]?score|payout|reward[-\s]?estimate|farming|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)|private[-\s]?scoreability|scoreability/i;
@@ -52,6 +59,7 @@ describe("api routes", () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+    mockedPermission.mockReset();
   });
 
   afterEach(() => {
@@ -2185,6 +2193,10 @@ describe("api routes", () => {
     });
     const { token: ownerToken } = await createSessionForGitHubUser(ownerEnv, { login: "repo-owner", id: 777 });
     const ownerHeaders = { cookie: `gittensory_session=${ownerToken}`, "content-type": "application/json" };
+    mockedPermission.mockImplementation(async (_env, _installationId, repoFullName, login) => {
+      if (repoFullName === "repo-owner/owned-repo" && login === "repo-owner") return "write";
+      return "read";
+    });
     const ownerRoles = await app.request("/v1/app/roles", { headers: ownerHeaders }, ownerEnv);
     expect(ownerRoles.status).toBe(200);
     await expect(ownerRoles.json()).resolves.toMatchObject({

--- a/test/integration/maintainer-activation.test.ts
+++ b/test/integration/maintainer-activation.test.ts
@@ -101,6 +101,55 @@ describe("maintainer activation routes", () => {
     expect(await response.json()).toMatchObject({ repoFullName: FULL_NAME, gateCheckMode: "enabled" });
   });
 
+  it("forbids read-only repo collaborators from writing agent settings", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRepo(env, "owner", "repo", 201);
+    await upsertPullRequestFromGitHub(env, FULL_NAME, {
+      number: 8,
+      title: "docs tweak",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "def456", ref: "docs-2" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+    const headers = { cookie: `gittensory_session=${token}`, "content-type": "application/json" };
+
+    const update = await app.request(`${PATH_ACTIVATE.replace("/activation", "/settings")}`, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ autonomy: { merge: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "merge" } }),
+    }, env);
+
+    expect(update.status).toBe(403);
+    expect(await update.json()).toMatchObject({ error: "insufficient_repo_permission" });
+    const persisted = await getRepositorySettings(env, FULL_NAME);
+    expect(persisted.autonomy).not.toMatchObject({ merge: "auto" });
+    expect(persisted.autoMaintain?.requireApprovals).toBe(1);
+  });
+
+  it("allows a session with GitHub write permission to update repository settings", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRepo(env, "owner", "repo", 201);
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("write");
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 201 });
+    const response = await app.request(`${PATH_ACTIVATE.replace("/activation", "/settings")}`, {
+      method: "PUT",
+      headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ autonomy: { merge: "auto_with_approval" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" } }),
+    }, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ autonomy: { merge: "auto_with_approval" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" } });
+  });
+
   it("forbids a non-maintainer session from the activation preview", async () => {
     const app = createApp();
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator-admin" });


### PR DESCRIPTION
### Motivation
- Prevent persisted agent-level controls (autonomy / autoMaintain) from being written by sessions that only have cached maintainer scope derived from PR author_association, which can be spoofed to grant maintainer-scoped read access without real GitHub push rights.

### Description
- Gate `PUT /v1/repos/:owner/:repo/settings` with `requireRepoWriteAccess` instead of `requireRepoMaintainer` so settings that affect agent autonomy and auto-merge require live GitHub write/maintain/admin permission.
- Update the handler comment to reflect the stronger write-access requirement.
- Add integration tests that assert a read-only collaborator (scoped via PR author_association) is rejected with `insufficient_repo_permission` when attempting to write `autonomy`/`autoMaintain` and that a session with real GitHub write permission can update the same fields.
- Fix a small test nullability assertion to satisfy the TypeScript typecheck.

### Testing
- Ran the targeted integration suite with `npx vitest run test/integration/maintainer-activation.test.ts --reporter verbose`, and all tests in that file passed.
- Ran the TypeScript typecheck with `npm run typecheck`, and it succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33acd72604832ca38043332837773e)