### PR TITLE
fix(api): require write access for settings updates

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2000,7 +2000,7 @@ export function createApp() {
   // aiReview key + the operator-only scoring internals are deliberately not settable here.
   app.put("/v1/repos/:owner/:repo/settings", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const gate = await requireRepoMaintainer(c, fullName);
+    const gate = await requireRepoWriteAccess(c, fullName);
     if (gate instanceof Response) return gate;
     const body = await c.req.json().catch(() => null);
     const parsed = maintainerSettingsSchema.safeParse(body);

--- a/test/unit/routes-ai-byok.test.ts
+++ b/test/unit/routes-ai-byok.test.ts
@@ -175,6 +175,42 @@ describe("maintainer route authz (session-scoped)", () => {
     expect((await app.request(`${OWNED}/ai-key`, { headers: { cookie: `gittensory_session=${token}` } }, env)).status).toBe(200);
   });
 
+  it("forbids a read-only collaborator from writing repo-visible settings", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, ADMIN_GITHUB_LOGINS: "" });
+    await seedRepo(env, "repo-owner", "owned-repo", 201);
+    // "reader" is in the broader maintainer data scope via PR author association, but only has read permission.
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", { number: 6, title: "docs", state: "open", user: { login: "reader" }, author_association: "COLLABORATOR", head: { sha: "b2", ref: "docs" }, base: { ref: "main" }, labels: [] });
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+    const res = await app.request(`${OWNED}/settings`, {
+      method: "PUT",
+      headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ gateCheckMode: "enabled", commandAuthorization: { default: ["pr_author"], commands: { "gate-override": ["pr_author"] } } }),
+    }, env);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "insufficient_repo_permission" });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "reader");
+  });
+
+  it("allows a repo owner with write permission to update repo-visible settings", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, ADMIN_GITHUB_LOGINS: "" });
+    await seedRepo(env, "repo-owner", "owned-repo", 201);
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("write");
+    const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const res = await app.request(`${OWNED}/settings`, {
+      method: "PUT",
+      headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ gateCheckMode: "enabled", publicSurface: "comment_only" }),
+    }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ gateCheckMode: "enabled", publicSurface: "comment_only" });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "repo-owner");
+  });
+
   it("allows an operator to set the BYOK key without a per-repo push check", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, ADMIN_GITHUB_LOGINS: "ops-admin" });


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass where maintainer-scoped sessions (derived from PR author_association) could mutate repo-visible automation settings without proving live GitHub write/maintain/admin permission.

### Description
- Replace the weaker `requireRepoMaintainer` guard with `requireRepoWriteAccess` for the `PUT /v1/repos/:owner/:repo/settings` handler and add regression tests in `test/unit/routes-ai-byok.test.ts` that assert a read-only collaborator is rejected and a repo owner with write permission can update settings.

### Testing
- Ran `npx vitest run test/unit/routes-ai-byok.test.ts --reporter=verbose` and the file's test suite passed (18 tests, all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ace13318832c876f33f9b589bc9a)