### PR TITLE
fix(agent): revalidate pending action policy on accept

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -1,7 +1,7 @@
 import { createPendingAgentActionIfAbsent, insertNotificationDeliveryIfAbsent, recordAuditEvent } from "../db/repositories";
 import { ensurePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest } from "../github/pr-actions";
-import { resolveAutonomy } from "../settings/autonomy";
+import { isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
 import type { PlannedAgentAction } from "../settings/agent-actions";
 import type { AgentActionClass, AgentPendingActionParams, AutonomyLevel, AutonomyPolicy } from "../types";
@@ -35,7 +35,7 @@ export type AgentActionOutcome = {
 /**
  * Execute (or dry-run, or stage for approval) a planned auto-maintain action set on one PR. Each action runs
  * through the SAME deny-toward-safety gate stack before any GitHub call:
- *   pause (#776 kill-switch) → approval (auto_with_approval → #779 queue) → write-permission (#775) → mode.
+ *   pause (#776 kill-switch) → current autonomy → approval (auto_with_approval → #779 queue) → write-permission (#775) → mode.
  * Only `live` mode performs a real mutation; `dry_run` records what it WOULD do. Every path writes one
  * `agent.action.<class>` audit record (#776). A failed mutation is recorded as `error`, never swallowed.
  */
@@ -60,24 +60,30 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", "agent actions paused");
       continue;
     }
-    // 2) auto_with_approval stages the action in the approval queue (#779) for a one-tap maintainer decision
+    // 2) Current per-action autonomy must still permit this action. Pending approvals are durable, so re-check
+    //    the live repo policy before staging or executing a previously planned action.
+    if (!isActingAutonomyLevel(autonomyLevel)) {
+      await audit("denied", `autonomy for ${action.actionClass} is ${autonomyLevel} — action not currently enabled`);
+      continue;
+    }
+    // 3) auto_with_approval stages the action in the approval queue (#779) for a one-tap maintainer decision
     //    instead of executing it now.
     if (action.requiresApproval) {
       await stageForApproval(env, ctx, action, autonomyLevel);
       await audit("queued", `awaiting maintainer approval — ${action.reason}`);
       continue;
     }
-    // 3) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
+    // 4) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
       await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
       continue;
     }
-    // 4) dry-run records the intent without touching GitHub.
+    // 5) dry-run records the intent without touching GitHub.
     if (mode === "dry_run") {
       await audit("dry_run", `dry-run: would ${action.actionClass} — ${action.reason}`);
       continue;
     }
-    // 5) live — perform the real mutation, recording success or the error.
+    // 6) live — perform the real mutation, recording success or the error.
     try {
       await performAction(env, ctx, action);
       await audit("completed", action.reason);

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -12,8 +12,8 @@ export type ApprovalDecisionResult = {
 };
 
 /**
- * Decide a staged approval-queue action (#779). Accept → run the action live (the maintainer's accept IS the
- * approval, so the executor's approval gate is bypassed; the kill-switch is still honored). Reject → cancel.
+ * Decide a staged approval-queue action (#779). Accept → run the action through the current executor gates
+ * (the maintainer's accept IS the approval, so only the approval queue gate is bypassed). Reject → cancel.
  * Either decision marks the row decided (idempotent: a second decision is a no-op) and records an audit event
  * that feeds the trust loop.
  */
@@ -45,7 +45,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
       headSha: pr?.headSha,
       autonomy: settings.autonomy,
       agentPaused: settings.agentPaused,
-      agentDryRun: false, // an explicit accept always runs live (the kill-switch still wins inside the executor)
+      agentDryRun: settings.agentDryRun,
       installationPermissions: installation ? installation.permissions : null,
     },
     [pendingActionToPlanned({ actionClass: pending.actionClass, params: pending.params, reason: pending.reason })],

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -82,6 +82,15 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect((await auditFor(env, "merge"))?.outcome).toBe("queued");
   });
 
+  it("denies planned actions when current per-action autonomy is no longer acting", async () => {
+    const env = createTestEnv({});
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ autonomy: { approve: "auto" } }), [label, merge]);
+    expect(outcomes.map((o) => o.outcome)).toEqual(["denied", "denied"]);
+    expect(ensurePullRequestLabel).not.toHaveBeenCalled();
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    expect(JSON.parse((await auditFor(env, "merge"))?.metadata_json ?? "{}")).toMatchObject({ autonomyLevel: "observe" });
+  });
+
   it("PR-write without pull_requests:write → denied (re-consent), but label still runs (issues:write)", async () => {
     const env = createTestEnv({});
     const outcomes = await executeAgentMaintenanceActions(env, ctx({ installationPermissions: { pull_requests: "read", issues: "write" } }), [label, merge]);

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -111,6 +111,32 @@ describe("agent approval queue (#779)", () => {
     expect(audit).toMatchObject({ outcome: "completed", actor: "owner" });
   });
 
+  it("accept honors current dry-run setting instead of forcing a live mutation", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" }, agentDryRun: true });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash" }, reason: "clean" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("dry_run");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("accept denies stale pending actions when current autonomy no longer acts for that class", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { approve: "auto" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash" }, reason: "clean" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("denied");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
   it("reject: cancels without executing, marks it rejected, and audits", async () => {
     const env = createTestEnv({});
     const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash" }, reason: "clean" });


### PR DESCRIPTION
### Motivation
- Prevent staged/pending agent actions from executing live when the repository's current autonomy or dry-run settings no longer permit that specific action class.

### Description
- Add a live per-action autonomy gate by importing `isActingAutonomyLevel` and denying planned actions when `resolveAutonomy` yields a non-acting level before staging/execution in `executeAgentMaintenanceActions` (`src/services/agent-action-executor.ts`).
- Stop forcing live execution on maintainer accept by honoring the repository `agentDryRun` setting when rebuilding and running a pending action in `decidePendingAgentAction` (`src/services/agent-approval-queue.ts`).
- Add regression tests that assert stale pending approvals are denied and that accepts respect current dry-run (`test/unit/agent-action-executor.test.ts` and `test/unit/agent-approval-queue.test.ts`).

### Testing
- Ran the targeted unit tests `npx vitest run test/unit/agent-action-executor.test.ts test/unit/agent-approval-queue.test.ts` and they passed (22 tests across the two files passed).
- Ran `npm run typecheck` and `git diff --check` which succeeded with no type or diff errors reported for the modified files.
- Ran the full test suite with `npm test`; the targeted changes passed but the full suite surfaced unrelated existing test timeouts (5 failing tests due to 15s timeouts in other test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33aadb0238832ca2414b4efbf62401)