### PR TITLE
fix(api): require write access for focus manifest updates

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1901,14 +1901,8 @@ export function createApp() {
 
   app.put("/v1/repos/:owner/:repo/focus-manifest", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
-    if (forbidden) return forbidden;
-    const identity = await authenticateRequestIdentity(c);
-    const repo = await getRepository(c.env, fullName);
-    if (identity?.kind === "session") {
-      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
-      if (repoForbidden) return repoForbidden;
-    }
+    const gate = await requireRepoWriteAccess(c, fullName);
+    if (gate instanceof Response) return gate;
     const body = await c.req.json().catch(() => null);
     if (body === null) return c.json({ error: "invalid_json" }, 400);
     const manifest = await upsertRepoFocusManifest(c.env, fullName, body, "api_record");

--- a/test/unit/routes-focus-manifest.test.ts
+++ b/test/unit/routes-focus-manifest.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { createSessionForGitHubUser } from "../../src/auth/security";
-import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
 import { createTestEnv } from "../helpers/d1";
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
 
 const FOCUS_MANIFEST_PATH = "/v1/repos/JSONbored/gittensory/focus-manifest";
 const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/focus-manifest";
@@ -35,6 +43,7 @@ async function seedRegisteredInstalledRepo(env: Env, installationId: number, own
 }
 
 describe("focus-manifest route auth", () => {
+  beforeEach(() => mockedPermission.mockReset());
   it("rejects unauthenticated access", async () => {
     const app = createApp();
     const env = createTestEnv();
@@ -52,10 +61,11 @@ describe("focus-manifest route auth", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "insufficient_role" });
   });
 
-  it("allows same-repo owner sessions to read and update focus manifests", async () => {
+  it("allows same-repo owner sessions with GitHub write permission to read and update focus manifests", async () => {
     const app = createApp();
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
     await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    mockedPermission.mockResolvedValue("write");
     const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
     const cookie = `gittensory_session=${token}`;
 
@@ -81,6 +91,37 @@ describe("focus-manifest route auth", () => {
       repoFullName: "repo-owner/owned-repo",
       manifest: { present: true, source: "api_record", wantedPaths: ["src/"] },
     });
+  });
+
+  it("rejects focus-manifest writes from sessions without live GitHub write permission", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 5,
+      title: "docs tweak",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "abc123", ref: "docs" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "PUT",
+        headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ settings: { autonomy: { merge: "auto", close: "auto", approve: "auto" } } }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
   });
 
   it("rejects cross-repo owner sessions with forbidden_repo", async () => {


### PR DESCRIPTION
### Motivation
- Prevent sessions that only have cached control-panel scope (e.g. PR author association MEMBER/COLLABORATOR) from persisting sensitive agent autonomy policies via the focus-manifest API. 
- The focus-manifest `settings.autonomy` overlay became effective for agent decisions, so the write path must require live GitHub write/maintain/admin permission, not just cached scope.

### Description
- Gate `PUT /v1/repos/:owner/:repo/focus-manifest` with the existing `requireRepoWriteAccess` helper that verifies live GitHub collaborator permission instead of the weaker `requireSessionRepoAccess` cached scope check. 
- Keep input validation and persistence using `upsertRepoFocusManifest` and `compileFocusManifestPolicy` unchanged. 
- Add unit test scaffolding to mock `getRepositoryCollaboratorPermission` and update the focus-manifest tests to assert that sessions with live `write` permission can update manifests while sessions with only cached scope/read-only permission are rejected. 

### Testing
- Ran `git diff --check` with no issues reported. (passed)
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors. (passed)
- Ran `npx vitest run test/unit/routes-focus-manifest.test.ts` and observed the test file's suite complete successfully (all tests passed). (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b127fbc4832c955748755a925415)