### PR TITLE
fix(mcp): keep remediation plan score blockers public-safe

### DIFF
--- a/src/services/remediation-plan.ts
+++ b/src/services/remediation-plan.ts
@@ -1,6 +1,6 @@
 import { sanitizePublicComment } from "../github/commands";
 
-export type RemediationPlanSource = "account_state" | "branch_quality" | "score";
+export type RemediationPlanSource = "account_state" | "branch_quality" | "submission_readiness";
 
 export type RemediationPlanItem = {
   rank: number;
@@ -35,12 +35,12 @@ export type RemediationPlanInput = {
 };
 
 const FORBIDDEN_PATTERN =
-  /\b(reward\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i;
+  /\b(reward\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability|private[-_\s]?scoreability|scoreability|score\w*|token[-_\s]?gate|token[-_\s]?score|base[-_\s]?score|multiplier|eligibility)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i;
 
 const SOURCE_PRIORITY: Record<RemediationPlanSource, number> = {
   account_state: 0,
   branch_quality: 1,
-  score: 2,
+  submission_readiness: 2,
 };
 
 function publicSafeText(value: string): string {
@@ -52,9 +52,7 @@ function publicSafeText(value: string): string {
 function publicSafeRerunCondition(condition: string): string {
   const sanitized = publicSafeText(condition);
   if (!sanitized) return "Rerun after branch, base, or PR state changes before opening or submitting.";
-  return /eligibility|multiplier|scoreability|score/i.test(sanitized)
-    ? "Refresh linked issue and base branch metadata before submission."
-    : sanitized;
+  return sanitized;
 }
 
 function normalizeKey(value: string): string {
@@ -96,7 +94,7 @@ function stepFromBlocker(source: RemediationPlanSource, blocker: string, finding
   if (sanitized) return sanitized;
   if (source === "account_state") return "Clear account or queue maturity blockers before opening more work.";
   if (source === "branch_quality") return "Resolve branch-quality findings before submission.";
-  return "Resolve scoreability blockers before relying on this preview.";
+  return "Resolve submission readiness blockers before submission.";
 }
 
 function impactFor(source: RemediationPlanSource, blocker: string): "high" | "medium" {
@@ -107,19 +105,24 @@ function impactFor(source: RemediationPlanSource, blocker: string): "high" | "me
 
 function collectItems(input: RemediationPlanInput): Array<Omit<RemediationPlanItem, "rank">> {
   const seen = new Set<string>();
+  const seenSteps = new Set<string>();
   const items: Array<Omit<RemediationPlanItem, "rank">> = [];
   const push = (source: RemediationPlanSource, blocker: string) => {
     const key = normalizeKey(blocker);
     if (!key || seen.has(key)) return;
-    const step = stepFromBlocker(source, blocker, input.localFindings);
-    if (!step) return;
+    const step = source === "submission_readiness"
+      ? "Resolve submission readiness blockers before submission."
+      : stepFromBlocker(source, blocker, input.localFindings);
+    const stepKey = normalizeKey(step);
+    if (!step || seenSteps.has(stepKey)) return;
     seen.add(key);
+    seenSteps.add(stepKey);
     const rerunCondition =
       source === "account_state"
         ? rerunForAccountBlocker(blocker, input.recommendedRerunCondition)
         : source === "branch_quality"
           ? rerunForBranchBlocker(blocker, input.recommendedRerunCondition)
-          : publicSafeRerunCondition(input.recommendedRerunCondition);
+          : "Rerun after branch, base, or PR state changes before opening or submitting.";
     items.push({
       source,
       step,
@@ -130,7 +133,7 @@ function collectItems(input: RemediationPlanInput): Array<Omit<RemediationPlanIt
 
   for (const blocker of input.accountStateBlockers) push("account_state", blocker);
   for (const blocker of input.branchQualityBlockers) push("branch_quality", blocker);
-  for (const blocker of input.scoreBlockers) push("score", blocker);
+  for (const blocker of input.scoreBlockers) push("submission_readiness", blocker);
 
   items.sort(
     (left, right) =>

--- a/test/unit/remediation-plan.test.ts
+++ b/test/unit/remediation-plan.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildRemediationPlan } from "../../src/services/remediation-plan";
 
-const FORBIDDEN = /\b(wallet|hotkey|coldkey|mnemonic|farming|payout|raw[-_\s]?trust)\b/i;
+const FORBIDDEN = /\b(wallet|hotkey|coldkey|mnemonic|farming|payout|raw[-_\s]?trust|score\w*|scoreability|token[-_\s]?score|base[-_\s]?score)\b/i;
 
 describe("buildRemediationPlan", () => {
   it("returns an ordered, deduplicated checklist with rerun conditions", () => {
@@ -58,7 +58,7 @@ describe("buildRemediationPlan", () => {
 
     expect(plan.items).toHaveLength(2);
     expect(plan.items[0]?.step).toBe("Fix validation before asking maintainers to review.");
-    expect(plan.items.map((item) => item.step)).toEqual(["Fix validation before asking maintainers to review.", "GitHub checks need attention"]);
+    expect(plan.items.map((item) => item.step)).toEqual(["Fix validation before asking maintainers to review.", "Resolve submission readiness blockers before submission."]);
   });
 
   it("returns a public-safe empty-state plan when no blockers are present", () => {
@@ -87,8 +87,8 @@ describe("buildRemediationPlan", () => {
       recommendedRerunCondition: "Rerun after branch/base eligibility metadata confirms eligibility or after linked issue assumptions change.",
     });
 
-    expect(plan.recommendedRerunCondition).toMatch(/linked issue and base branch metadata/i);
-    expect(plan.recommendedRerunCondition).not.toMatch(/scoreability|multiplier/i);
+    expect(plan.recommendedRerunCondition).toMatch(/branch, base, or PR state changes/i);
+    expect(plan.recommendedRerunCondition).not.toMatch(/scoreability|multiplier|eligibility/i);
   });
 
   it("maps blocker-specific rerun conditions and fallback steps", () => {
@@ -106,7 +106,7 @@ describe("buildRemediationPlan", () => {
     expect(plan.items.find((item) => /stale/i.test(item.step))?.rerunCondition).toMatch(/git fetch origin/i);
     expect(plan.items.find((item) => /duplicate-prone/i.test(item.step))?.rerunCondition).toMatch(/linked issue and base branch metadata/i);
     expect(plan.items.find((item) => /GitHub checks/i.test(item.step))?.rerunCondition).toMatch(/validation evidence/i);
-    expect(plan.items.find((item) => item.source === "score")?.step).toBe("Resolve scoreability blockers before relying on this preview.");
+    expect(plan.items.find((item) => item.source === "submission_readiness")?.step).toBe("Resolve submission readiness blockers before submission.");
     expect(JSON.stringify(plan)).not.toMatch(/\bwallet\b|\bhotkey\b|\bpayout\b/i);
   });
 
@@ -122,7 +122,7 @@ describe("buildRemediationPlan", () => {
 
     expect(plan.items.find((item) => item.source === "account_state")?.step).toBe("Repository allocation is inactive");
     expect(plan.items.find((item) => item.source === "branch_quality")?.step).toBe("Resolve branch-quality findings before submission.");
-    expect(plan.recommendedRerunCondition).toMatch(/linked issue and base branch metadata/i);
+    expect(plan.recommendedRerunCondition).toMatch(/branch, base, or PR state changes/i);
     expect(plan.summary).toMatch(/2 remediation step/i);
   });
 
@@ -155,8 +155,8 @@ describe("buildRemediationPlan", () => {
         step: "Clear account or queue maturity blockers before opening more work.",
       }),
       expect.objectContaining({
-        source: "score",
-        step: "Resolve scoreability blockers before relying on this preview.",
+        source: "submission_readiness",
+        step: "Resolve submission readiness blockers before submission.",
       }),
     ]);
   });
@@ -201,12 +201,12 @@ describe("buildRemediationPlan", () => {
     expect(plan.items).toEqual([
       expect.objectContaining({ source: "account_state", step: "Clear account or queue maturity blockers before opening more work." }),
       expect.objectContaining({ source: "branch_quality", step: "Resolve branch-quality findings before submission." }),
-      expect.objectContaining({ source: "score", step: "Resolve scoreability blockers before relying on this preview." }),
+      expect.objectContaining({ source: "submission_readiness", step: "Resolve submission readiness blockers before submission." }),
     ]);
     expect(plan.recommendedRerunCondition).toMatch(/branch, base, or PR state changes/i);
   });
 
-  it("uses score-source rerun conditions and medium impact for generic score blockers", () => {
+  it("uses neutral submission-readiness rerun conditions and medium impact for generic score blockers", () => {
     const plan = buildRemediationPlan({
       login: "miner",
       repoFullName: "octo/demo",
@@ -218,11 +218,33 @@ describe("buildRemediationPlan", () => {
 
     expect(plan.items).toEqual([
       expect.objectContaining({
-        source: "score",
+        source: "submission_readiness",
+        step: "Resolve submission readiness blockers before submission.",
         impact: "medium",
-        rerunCondition: "Rerun after local validation passes.",
+        rerunCondition: "Rerun after branch, base, or PR state changes before opening or submitting.",
       }),
     ]);
+  });
+
+
+  it("does not expose score blocker text or score source on the public-safe surface", () => {
+    const plan = buildRemediationPlan({
+      login: "miner",
+      repoFullName: "octo/demo",
+      accountStateBlockers: [],
+      branchQualityBlockers: [],
+      scoreBlockers: ["Source token score does not pass the current base-score token gate."],
+      recommendedRerunCondition: "Rerun after scoreability multiplier eligibility score preview changes.",
+    });
+
+    expect(plan.items).toEqual([
+      expect.objectContaining({
+        source: "submission_readiness",
+        step: "Resolve submission readiness blockers before submission.",
+        rerunCondition: "Rerun after branch, base, or PR state changes before opening or submitting.",
+      }),
+    ]);
+    expect(JSON.stringify(plan)).not.toMatch(/score|scoreability|token[-_\s]?gate|token[-_\s]?score|base[-_\s]?score|multiplier|eligibility/i);
   });
 
   it("strips local filesystem paths from public remediation steps", () => {


### PR DESCRIPTION
### Motivation
- The remediation-plan public surface was leaking private scoring/scoreability terminology via `scoreBlockers` and a narrow forbidden filter, which exposes sensitive scoring signals on an output advertised as public-safe. 

### Description
- Replace the `score` source with a neutral `submission_readiness` source so score-origin metadata is not emitted to the public checklist. (`src/services/remediation-plan.ts`).
- Broaden `FORBIDDEN_PATTERN` to include `scoreability`, canonical `score*` variants, `token`/`base-score`/`multiplier`/`eligibility` terms so public sanitization blocks scoring vocabulary. (`src/services/remediation-plan.ts`).
- Always emit neutral, public-safe step and rerun copy for score-derived blockers and use a neutral rerun fallback instead of score-specific wording, and deduplicate by emitted step text to avoid leaking original blocker strings. (`src/services/remediation-plan.ts`).
- Add and update unit tests to assert the public-safe behavior and to cover the reported leak case where a blocker like "Source token score does not pass the current base-score token gate." would previously surface. (`test/unit/remediation-plan.test.ts`).

### Testing
- Ran unit tests for the remediation plan: `npx vitest run test/unit/remediation-plan.test.ts --reporter=verbose` and all tests passed.
- Ran type check: `npm run typecheck` and it passed.
- Built MCP package: `npm run build:mcp` and the build checks passed.
- Ran repository diff/check commands used in CI verification and found no outstanding formatting or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b58d696c832ca9a5d02b0a8df0e9)