### PR TITLE
fix(api): block public badges for private repos

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -252,12 +252,13 @@ import { errorMessage, nowIso } from "../utils/json";
 type AppBindings = { Bindings: Env };
 type AppContext = Context<AppBindings>;
 
-// Resolves the public README badge metrics for a repo, enforcing the two gates in one place: the repo must
-// be installed AND have opted in via `badgeEnabled`. Returns null (→ a benign "unavailable" badge) for any
-// repo that is unknown, uninstalled, or has not opted in — so no metrics are ever served otherwise.
+// Resolves the public README badge metrics for a repo, enforcing the public-safety gates in one place:
+// the repo must be public, installed, and opted in via `badgeEnabled`. Returns null (→ a benign
+// "unavailable" badge) for any repo that is unknown, private, uninstalled, or has not opted in — so no
+// metrics are ever served otherwise.
 async function loadPublicRepoBadge(env: Env, owner: string, repo: string): Promise<PublicRepoQuality | null> {
   const repository = await getRepository(env, `${owner}/${repo}`);
-  if (!repository || !repository.isInstalled) return null;
+  if (!repository || repository.isPrivate || !repository.isInstalled) return null;
   const settings = await getRepositorySettings(env, repository.fullName);
   if (!settings.badgeEnabled) return null;
   const pullRequests = await listPullRequests(env, repository.fullName);

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -220,10 +220,22 @@ describe("api routes", () => {
     await expect(json.json()).resolves.toMatchObject({ schemaVersion: 1, label: "gittensory", message: expect.stringContaining("real") });
 
     // Installed but NOT opted in → unavailable, no metrics.
-    await upsertRepositoryFromGitHub(env, { name: "private", full_name: "acme/private", private: false, owner: { login: "acme" }, default_branch: "main" }, 556);
-    const notOptedIn = await app.request("/v1/public/repos/acme/private/badge.svg", {}, env);
+    await upsertRepositoryFromGitHub(env, { name: "not-opted-in", full_name: "acme/not-opted-in", private: false, owner: { login: "acme" }, default_branch: "main" }, 556);
+    const notOptedIn = await app.request("/v1/public/repos/acme/not-opted-in/badge.svg", {}, env);
     expect(notOptedIn.status).toBe(404);
     expect(await notOptedIn.text()).toContain("unavailable");
+
+    // Private repos stay unavailable even when installed and explicitly opted in.
+    await upsertRepositoryFromGitHub(env, { name: "private", full_name: "acme/private", private: true, owner: { login: "acme" }, default_branch: "main" }, 558);
+    await upsertRepositorySettings(env, { repoFullName: "acme/private", badgeEnabled: true });
+    await upsertPullRequestFromGitHub(env, "acme/private", { number: 1, title: "Secret", state: "merged", created_at: "2026-06-03T00:00:00Z", merged_at: "2026-06-03T02:00:00Z", labels: [] });
+    await updatePullRequestSlopAssessment(env, "acme/private", 1, { slopRisk: 0, slopBand: "clean" });
+    const privateSvg = await app.request("/v1/public/repos/acme/private/badge.svg", {}, env);
+    expect(privateSvg.status).toBe(404);
+    expect(await privateSvg.text()).toContain("unavailable");
+    const privateJson = await app.request("/v1/public/repos/acme/private/badge.json", {}, env);
+    expect(privateJson.status).toBe(404);
+    await expect(privateJson.json()).resolves.toMatchObject({ message: "unavailable" });
 
     // Opted in but NOT installed → unavailable.
     await upsertRepositoryFromGitHub(env, { name: "uninstalled", full_name: "acme/uninstalled", private: false, owner: { login: "acme" }, default_branch: "main" });


### PR DESCRIPTION
### Motivation
- The public badge endpoints returned repository-quality metrics for any installed repo with `badgeEnabled`, but omitted a check for `repository.isPrivate`, which could expose private-repo activity signals on unauthenticated routes. 
- The change reinstates a public-safety gate so only public repos can ever publish aggregated badge metrics.

### Description
- Add a private-repository guard to `loadPublicRepoBadge` so it returns `null` when `repository.isPrivate` is true, preventing PR metrics from being loaded for private repos (`src/api/routes.ts`).
- Extend the integration test to assert that an installed, explicitly opted-in private repo returns the benign "unavailable" response for both `/badge.svg` and `/badge.json`, and adjust the not-opted-in fixture (`test/integration/api.test.ts`).

### Testing
- Ran the targeted integration test with `npm test -- test/integration/api.test.ts -t "serves the public README badge"`, which passed (`1 passed | 36 skipped`).
- Ran type checking with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b127de78832c94015015c84d46f1)