### PR TITLE
fix(github-app): collect aggregate gate evidence

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -924,7 +924,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       ]);
       const advisory = buildPullRequestAdvisory(repo, pr, {
         otherOpenPullRequests,
-        requireLinkedIssue: settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off",
+        requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
       });
       await persistAdvisory(env, advisory);
       if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
@@ -1017,6 +1017,18 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
 
 type PublicSurfaceOutput = "comment" | "label" | "check_run";
 type PublicSurfaceOutputFailure = { output: PublicSurfaceOutput; error: string };
+
+function mergeReadinessGateEnabled(settings: Pick<RepositorySettings, "mergeReadinessGateMode">): boolean {
+  return settings.mergeReadinessGateMode !== "off";
+}
+
+export function shouldCollectLinkedIssueEvidence(settings: Pick<RepositorySettings, "requireLinkedIssue" | "linkedIssueGateMode" | "mergeReadinessGateMode">): boolean {
+  return settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off" || mergeReadinessGateEnabled(settings);
+}
+
+export function shouldCollectSlopEvidence(settings: Pick<RepositorySettings, "slopGateMode" | "mergeReadinessGateMode">): boolean {
+  return settings.slopGateMode !== "off" || mergeReadinessGateEnabled(settings);
+}
 
 function shouldProcessPullRequestPublicSurface(action: string | undefined): boolean {
   return PR_PUBLIC_SURFACE_ACTIONS.has(action ?? "") || PR_GATE_CLOSED_ACTIONS.has(action ?? "");
@@ -1392,10 +1404,10 @@ async function maybePublishPrPublicSurface(
     // Slop (#530) and focus-manifest-policy (#555) gates both need the PR's changed files. Load ONCE and
     // share so two opted-in gates don't double-fetch; the load is lazy so a repo with both off pays nothing.
     let gateFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null = null;
-    if (settings.slopGateMode !== "off" || settings.manifestPolicyGateMode !== "off") {
+    if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
       gateFiles = await listPullRequestFiles(env, repoFullName, pr.number);
     }
-    if (settings.slopGateMode !== "off") {
+    if (shouldCollectSlopEvidence(settings)) {
       const slopFiles = gateFiles ?? [];
       const slop = buildSlopAssessment({
         changedFiles: slopFiles.map((file) => ({ path: file.path, additions: file.additions, deletions: file.deletions })),
@@ -1933,7 +1945,7 @@ async function buildAuthorizedPrActionAdvisory(
   const [repo, otherOpenPullRequests] = await Promise.all([getRepository(env, repoFullName), listOtherOpenPullRequests(env, repoFullName, pr.number)]);
   const advisory = buildPullRequestAdvisory(repo, pr, {
     otherOpenPullRequests,
-    requireLinkedIssue: settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off",
+    requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
   });
   return { repo, advisory };
 }

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { gateCheckPolicy } from "../../src/queue/processors";
+import { gateCheckPolicy, shouldCollectLinkedIssueEvidence, shouldCollectSlopEvidence } from "../../src/queue/processors";
 import { evaluateGateCheck } from "../../src/rules/advisory";
 import { parseFocusManifest, resolveEffectiveSettings } from "../../src/signals/focus-manifest";
 import type { Advisory, RepositorySettings } from "../../src/types";
@@ -188,6 +188,20 @@ describe("slop gate (#530/#532)", () => {
     const blocked = evaluateGateCheck(cleanAdvisory(), gateCheckPolicy(eff, null, true, 80));
     expect(blocked.conclusion).toBe("failure");
     expect(blocked.blockers.map((finding) => finding.code)).toContain("slop_risk_above_threshold");
+  });
+});
+
+describe("merge-readiness evidence collection (#551)", () => {
+  it("collects linked-issue evidence when the aggregate gate is enabled even if the sub-gate is off", () => {
+    expect(shouldCollectLinkedIssueEvidence(settings({ requireLinkedIssue: false, linkedIssueGateMode: "off", mergeReadinessGateMode: "block" }))).toBe(true);
+    expect(shouldCollectLinkedIssueEvidence(settings({ requireLinkedIssue: false, linkedIssueGateMode: "off", mergeReadinessGateMode: "advisory" }))).toBe(true);
+    expect(shouldCollectLinkedIssueEvidence(settings({ requireLinkedIssue: false, linkedIssueGateMode: "off", mergeReadinessGateMode: "off" }))).toBe(false);
+  });
+
+  it("collects deterministic slop evidence when the aggregate gate is enabled even if the sub-gate is off", () => {
+    expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "block" }))).toBe(true);
+    expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "advisory" }))).toBe(true);
+    expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "off" }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The merge-readiness composite gate (`mergeReadinessGateMode`) was only applied during final gate evaluation, so upstream evidence for some sub-gates (linked-issue and deterministic slop) was not collected when those sub-gates were `off`, allowing the aggregate gate to be bypassed. 
- Evidence collection decisions (e.g. whether to build `missing_linked_issue` findings or compute `slopRisk`) must reflect the effective aggregate policy, not only the raw per-subgate settings. 
- The change ensures the aggregate gate influences upstream webhook/advisory behavior so configured blockers can actually be observed and block a PR as intended.

### Description
- Add `mergeReadinessGateEnabled`, `shouldCollectLinkedIssueEvidence`, and `shouldCollectSlopEvidence` predicates to `src/queue/processors.ts` to compute whether upstream evidence should be collected based on the effective aggregate gate mode. 
- Use `shouldCollectLinkedIssueEvidence` when building PR advisories in webhook processing and in the authorized-PR-action advisory builder so linked-issue findings are generated when the composite gate requires them. 
- Use `shouldCollectSlopEvidence` to drive lazy fetching of changed files and deterministic slop assessment so `slopRisk` is computed when the composite gate needs it. 
- Add targeted unit tests in `test/unit/gate-check-policy.test.ts` covering the new evidence-collection predicates for linked-issue and slop with aggregate gate modes.

### Testing
- Ran `npm test -- --run test/unit/gate-check-policy.test.ts` which completed successfully (`47 tests passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed without errors. 
- Ran `git diff --check` to validate whitespace/check issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b1283264832c890c82702f1b8fc4)