### PR TITLE
fix(github-app): ignore edited/deleted gate-override comments and use webhook sender for actor

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1701,8 +1701,12 @@ async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, pay
   const repoFullName = payload.repository?.full_name;
   const issue = payload.issue;
   const installationId = getInstallationId(payload);
-  const actor = comment?.user?.login ?? payload.sender?.login ?? null;
+  const actor = payload.sender?.login ?? comment?.user?.login ?? null;
   const targetKey = repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
+  if (payload.action !== "created") {
+    await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "unsupported_comment_action");
+    return true;
+  }
   if (comment?.user?.type === "Bot" || payload.sender?.type === "Bot" || /\[bot\]$/i.test(actor ?? "")) {
     await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "bot_author");
     return true;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -4491,6 +4491,73 @@ describe("queue processors", () => {
     expect(overrideAdvisory ?? null).toBeNull();
   });
 
+  it("ignores gate-override commands on edited comments", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 92,
+      title: "Edited override",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "edited-override" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { token: 0, permission: 0, checkRuns: 0, comments: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        calls.token += 1;
+        return Response.json({ token: "installation-token" });
+      }
+      if (url.includes("/collaborators/")) {
+        calls.permission += 1;
+        return Response.json({ permission: "admin" });
+      }
+      if (url.includes("/check-runs")) {
+        calls.checkRuns += 1;
+        return Response.json({ total_count: 1, check_runs: [{ id: 556, name: "Gittensory Gate" }] });
+      }
+      if (url.includes("/comments")) {
+        calls.comments += 1;
+        return Response.json([]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-override-edited",
+      eventName: "issue_comment",
+      payload: {
+        action: "edited",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 92, title: "Edited override", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 802, body: "@gittensory gate-override edited by moderator", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
+        sender: { login: "moderator", type: "User" },
+      },
+    });
+
+    expect(calls.permission).toBe(0);
+    expect(calls.checkRuns).toBe(0);
+    expect(calls.comments).toBe(0);
+    const overridden = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.gate_overridden").first<{ id: string }>();
+    expect(overridden ?? null).toBeNull();
+    const skipped = await env.DB.prepare("select actor, detail from audit_events where event_type = ?").bind("github_app.gate_override_skipped").first<{ actor: string; detail: string }>();
+    expect(skipped).toMatchObject({ actor: "moderator", detail: "unsupported_comment_action" });
+  });
+
   it("denies gate-override from an org member without real repository write/admin (ignores author_association)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);


### PR DESCRIPTION
### Motivation
- Close a security gap where edited or deleted `issue_comment` payloads could authorize a privileged `@gittensory gate-override` under the original comment author rather than the actual webhook sender. 
- Ensure gate-override processing only runs for newly created comments and that authorization is based on the real webhook actor.

### Description
- Prefer the webhook `sender` for the command `actor` (`payload.sender?.login ?? comment?.user?.login`) so authorization checks reflect who performed the webhook action. 
- Short-circuit non-`created` `issue_comment` actions with an audit/usage record by returning early and calling `recordGateOverrideSkip(..., "unsupported_comment_action")`. 
- Add a unit test (`ignores gate-override commands on edited comments`) that asserts edited comments do not trigger collaborator-permission lookups, check-run patches, or confirmation comments and that a skipped audit event is recorded attributed to the sender.

### Testing
- Ran typecheck with `npm run typecheck` and it completed successfully. 
- Ran the unit tests matching gate-override with `npm run test:unit -- test/unit/queue.test.ts -t "gate-override"` and the modified tests passed. 
- Ran a quick repository lint/check (`git diff --check`) and no whitespace issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b0c7bf40832ca83db1f8d86ae73f)