### PR TITLE
fix(gate): compute complete author PR history for first-time-contributor grace

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2583,6 +2583,27 @@ export async function listOtherOpenPullRequests(env: Env, fullName: string, numb
   return rows.map(toPullRequestRecordFromRow);
 }
 
+export async function getRepoAuthorPullRequestHistory(env: Env, fullName: string, login: string, excludeNumber?: number): Promise<{ mergedPrCount: number; closedUnmergedPrCount: number }> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({
+      mergedPrCount: sql<number>`sum(case when ${pullRequests.mergedAt} is not null or ${pullRequests.state} = 'merged' then 1 else 0 end)`,
+      closedUnmergedPrCount: sql<number>`sum(case when ${pullRequests.state} = 'closed' and ${pullRequests.mergedAt} is null then 1 else 0 end)`,
+    })
+    .from(pullRequests)
+    .where(
+      and(
+        eq(pullRequests.repoFullName, fullName),
+        loginMatches(pullRequests.authorLogin, login),
+        excludeNumber === undefined ? undefined : not(eq(pullRequests.number, excludeNumber)),
+      ),
+    );
+  return {
+    mergedPrCount: Number(row?.mergedPrCount ?? 0),
+    closedUnmergedPrCount: Number(row?.closedUnmergedPrCount ?? 0),
+  };
+}
+
 export async function listContributorPullRequests(env: Env, login: string): Promise<PullRequestRecord[]> {
   const db = getDb(env.DB);
   const rows = await db.select().from(pullRequests).where(loginMatches(pullRequests.authorLogin, login)).limit(1000);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6,6 +6,7 @@ import {
   getLatestRepoGithubTotalsSnapshot,
   getFreshOfficialMinerDetection,
   getPullRequest,
+  getRepoAuthorPullRequestHistory,
   getRepository,
   getDecryptedRepositoryAiKey,
   getRepositorySettings,
@@ -1066,6 +1067,17 @@ export function gateCheckPolicy(
   };
 }
 
+async function loadGateAuthorHistory(env: Env, repoFullName: string, author: string | null, pullNumber: number): Promise<{ mergedPrCount: number; closedUnmergedPrCount: number }> {
+  if (!author) return { mergedPrCount: 1, closedUnmergedPrCount: 3 };
+  try {
+    return await getRepoAuthorPullRequestHistory(env, repoFullName, author, pullNumber);
+  } catch {
+    // Fail closed for firstTimeContributorGrace: if complete author history cannot be determined,
+    // make the author ineligible for grace rather than publishing a would-be blocking gate as neutral.
+    return { mergedPrCount: 1, closedUnmergedPrCount: 3 };
+  }
+}
+
 /**
  * Effective repository settings for webhook handling: the DB-backed settings overlaid with the repo's
  * `.gittensory.yml` (config-as-code). This single resolver is why EVERYTHING — gate on/off, all blocker
@@ -1457,14 +1469,10 @@ async function maybePublishPrPublicSurface(
     // failure is caught and the gate is still finalized (never left in_progress).
     aiReview = await runAiReviewForAdvisory(env, { settings, advisory, repoFullName, pr, author, confirmedContributor });
 
-    // First-time-contributor grace (#552): the author's per-repo PR history (excluding this PR). Newcomer =
-    // 0 merged here; repeat offender = >= 3 closed-unmerged here. Cheap (in-memory over the already-loaded
-    // repo PRs) and only consulted by evaluateGateCheck when firstTimeContributorGrace is on.
-    const authorPrs = author ? repoPullRequests.filter((candidate) => candidate.authorLogin === author && candidate.number !== pr.number) : [];
-    const authorHistory = {
-      mergedPrCount: authorPrs.filter((candidate) => candidate.mergedAt || candidate.state === "merged").length,
-      closedUnmergedPrCount: authorPrs.filter((candidate) => candidate.state === "closed" && !candidate.mergedAt).length,
-    };
+    // First-time-contributor grace (#552): compute the author's complete per-repo PR history
+    // (excluding this PR) with an aggregate DB query. Do not derive policy-enforcement history from
+    // the bounded repoPullRequests sample; missing or case-mismatched history could soften a block.
+    const authorHistory = await loadGateAuthorHistory(env, repoFullName, author, pr.number);
 
     const gatePolicy = gateCheckPolicy(settings, readiness.total, confirmedContributor, slopRisk, authorHistory);
     gateEvaluation = gateEnabled ? evaluateGateCheck(advisory, gatePolicy) : undefined;

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getLatestScorePreview,
+  getRepoAuthorPullRequestHistory,
   getLatestScoringModelSnapshot,
   getFreshOfficialMinerDetection,
   listPullRequests,
@@ -51,6 +52,37 @@ describe("database row parser hardening", () => {
         expect.objectContaining({ number: 2, isDraft: false, mergeableState: "mergeable", reviewDecision: "APPROVED" }),
       ]),
     );
+  });
+
+  it("computes complete case-insensitive repo author PR history for gate grace", async () => {
+    const env = createTestEnv();
+
+    for (let number = 1; number <= 503; number += 1) {
+      await upsertPullRequestFromGitHub(env, "owner/repo", {
+        number,
+        title: `PR ${number}`,
+        state: number <= 3 ? "closed" : "open",
+        user: { login: number <= 3 ? "RepeatUser" : `other-${number}` },
+        labels: [],
+      });
+    }
+    await upsertPullRequestFromGitHub(env, "owner/repo", {
+      number: 600,
+      title: "Merged work",
+      state: "closed",
+      merged_at: "2025-01-01T00:00:00.000Z",
+      user: { login: "RepeatUser" },
+      labels: [],
+    });
+
+    await expect(getRepoAuthorPullRequestHistory(env, "owner/repo", "repeatuser", 999)).resolves.toEqual({
+      mergedPrCount: 1,
+      closedUnmergedPrCount: 3,
+    });
+    await expect(getRepoAuthorPullRequestHistory(env, "owner/repo", "repeatuser", 600)).resolves.toEqual({
+      mergedPrCount: 0,
+      closedUnmergedPrCount: 3,
+    });
   });
 
   it("normalizes enum-like database values from stored sync, scoring, and preview rows", async () => {


### PR DESCRIPTION
### Motivation
- The first-time-contributor grace used a bounded in-memory PR sample and case-sensitive equality, which can misclassify repeat offenders or prior contributors as newcomers and incorrectly soften a required gate to `neutral`.
- The intent is to ensure gate decisions rely on complete, case-insensitive author history so required checks cannot be bypassed by incomplete cache samples or login-case differences.

### Description
- Add `getRepoAuthorPullRequestHistory(env, fullName, login, excludeNumber?)` to `src/db/repositories.ts`, implementing an aggregate DB query that counts merged and closed-unmerged PRs with case-insensitive login matching.
- Replace the bounded `repoPullRequests.filter(...)` in `src/queue/processors.ts` with `loadGateAuthorHistory(...)` which calls the new aggregate and returns the author history used by `gateCheckPolicy`.
- Make grace eligibility conservative: when author is missing or the history query fails, return values that make the author ineligible for grace (fail-closed) so a blocking gate is not softened on uncertain data.
- Add a regression unit test in `test/unit/db-parsers.test.ts` to validate case-insensitive login matching and correct counts when repository PRs exceed the previous 500-row sample.

### Testing
- Ran `npm test -- --run test/unit/db-parsers.test.ts test/unit/gate-check-policy.test.ts` and both test files passed.
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking succeeded.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b04a22c0832c8ed23035a6218f7a)