### PR TITLE
fix(api): debounce miner dashboard refresh jobs

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -142,6 +142,7 @@ import {
   CONTRIBUTOR_DECISION_PACK_SIGNAL,
   loadContributorDecisionPackForServing,
   repoDecisionFromPack,
+  tryEnqueueDecisionPackRebuild,
 } from "../services/decision-pack";
 import {
   buildMinerDashboardNextActions,
@@ -1108,8 +1109,8 @@ export function createApp() {
     if (!login) return c.json({ error: "login_required" }, 400);
     const unauthorized = await requireContributorAccess(c, login);
     if (unauthorized) return unauthorized;
-    const message: JobMessage = { type: "build-contributor-decision-packs", requestedBy: "api", login };
-    await c.env.JOBS.send(message);
+    const queued = await tryEnqueueDecisionPackRebuild(c.env, login);
+    if (!queued) return c.json({ error: "refresh_enqueue_failed", login }, 503);
     return c.json({ status: "queued", login }, 202);
   });
 

--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -103,6 +103,7 @@ export function routeClassForPath(path: string): RateLimitClass {
     path.includes("/v1/agent/") ||
     path.includes("/scoring/preview") ||
     path.includes("/decision-pack") ||
+    path.includes("/miner-dashboard/refresh") ||
     path.includes("/open-pr-monitor") ||
     // Maintainer BYOK config: POST /ai-key runs PBKDF2 (100k iters) + an encrypted D1 upsert per request.
     /\/ai-(?:key|review)$/.test(path) ||

--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -353,7 +353,7 @@ export async function loadContributorDecisionPackForServing(
   };
 }
 
-async function tryEnqueueDecisionPackRebuild(env: Env, login: string): Promise<boolean> {
+export async function tryEnqueueDecisionPackRebuild(env: Env, login: string): Promise<boolean> {
   const pending = pendingDecisionPackRebuilds.get(login);
   if (pending) return pending;
   const sinceIso = new Date(Date.now() - DECISION_PACK_REBUILD_DEBOUNCE_MS).toISOString();

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2075,6 +2075,14 @@ describe("api routes", () => {
     const refreshQueued = await app.request("/v1/app/miner-dashboard/refresh?login=oktofeesh1", { method: "POST", headers: apiHeaders(env) }, env);
     expect(refreshQueued.status).toBe(202);
     await expect(refreshQueued.json()).resolves.toMatchObject({ status: "queued", login: "oktofeesh1" });
+    const refreshDuplicate = await app.request("/v1/app/miner-dashboard/refresh?login=oktofeesh1", { method: "POST", headers: apiHeaders(env) }, env);
+    expect(refreshDuplicate.status).toBe(202);
+    const queuedRefreshRows = (
+      (await env.DB.prepare("SELECT COUNT(*) AS count FROM audit_events WHERE event_type='decision_pack.rebuild_enqueued' AND actor='oktofeesh1'").all()) as {
+        results: Array<{ count: number }>;
+      }
+    ).results;
+    expect(queuedRefreshRows[0]?.count).toBe(1);
     // No ?login → the login resolves from the session actor (covers the session-actor fallback).
     const refreshSelf = await app.request("/v1/app/miner-dashboard/refresh", { method: "POST", headers: { cookie: `gittensory_session=${otherToken}` } }, env);
     expect(refreshSelf.status).toBe(202);

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -85,6 +85,7 @@ describe("private-beta auth and rate limiting", () => {
     expect(routeClassForPath("/v1/scoring/preview")).toBe("expensive");
     expect(routeClassForPath("/v1/upstream/status")).toBe("expensive");
     expect(routeClassForPath("/v1/contributors/jsonbored/decision-pack")).toBe("expensive");
+    expect(routeClassForPath("/v1/app/miner-dashboard/refresh")).toBe("expensive");
     expect(routeClassForPath("/v1/contributors/jsonbored/open-pr-monitor")).toBe("expensive");
     expect(routeClassForPath("/v1/installations/999/repair/refresh")).toBe("expensive");
     expect(routeClassForPath("/v1/internal/jobs/generate-signal-snapshots")).toBe("expensive");


### PR DESCRIPTION
### Motivation
- The miner dashboard refresh endpoint previously enqueued heavy `build-contributor-decision-packs` jobs unconditionally, which can be abused by authenticated sessions to flood the queue and degrade availability. 
- The endpoint bypassed the existing debounce/audit guard used elsewhere, so duplicate refresh requests could trigger repeated expensive rebuilds for the same login. 
- The refresh path was not classified as an expensive route for rate limiting, so it received the normal (higher) request budget.

### Description
- Reused the existing debounce/audit helper by exporting and calling `tryEnqueueDecisionPackRebuild(env, login)` from the `/v1/app/miner-dashboard/refresh` handler instead of calling `c.env.JOBS.send` directly, and return a `503` when enqueueing fails. 
- Marked the `/v1/app/miner-dashboard/refresh` path as an `expensive` route in `routeClassForPath` so it is subject to stricter rate limits. 
- Added regression test coverage in the integration test to assert duplicate refresh requests only record a single `decision_pack.rebuild_enqueued` audit event and updated the unit test to expect the refresh route classification.

### Testing
- Ran `npx vitest run test/unit/auth.test.ts test/integration/api.test.ts --reporter=verbose` and observed the updated tests passed. 
- Ran `npm run typecheck` (`tsc --noEmit`) and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b128430c832cbb8c5ffedeb5cf5b)