### PR TITLE
fix(api): guard contributor extension repo access

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2386,15 +2386,17 @@ export function createApp() {
     const issueNumber = Number(c.req.query("issueNumber") ?? "");
     if (!owner || !repoName || !Number.isInteger(issueNumber) || issueNumber <= 0) return c.json({ error: "valid_owner_repo_issue_required" }, 400);
     const repoFullName = `${owner}/${repoName}`;
-    const [context, repo, issues, pullRequests, bounties, issueQuality] = await Promise.all([
+    const repo = await getRepository(c.env, repoFullName);
+    if (!repo) return c.json({ error: "repo_not_found" }, 404);
+    const repoForbidden = await requireContributorRepoAccess(c, repoFullName, repo);
+    if (repoForbidden) return repoForbidden;
+    const [context, issues, pullRequests, bounties, issueQuality] = await Promise.all([
       loadContributorFastContext(c.env, login),
-      getRepository(c.env, repoFullName),
       listIssues(c.env, repoFullName),
       listPullRequests(c.env, repoFullName),
       listBountiesByRepo(c.env, repoFullName),
       loadOrComputeIssueQualityResponse(c.env, repoFullName),
     ]);
-    if (!repo) return c.json({ error: "repo_not_found" }, 404);
     const opportunities = buildContributorOpportunities(context.profile, [repo], issues, pullRequests, bounties, issueQualityMap(repoFullName, issueQuality?.report));
     const opportunity = opportunities.find((entry) => entry.issueNumber === issueNumber);
     if (!opportunity) return c.json({ repoFullName, issueNumber, eligible: false, reason: "Issue is not an open, unclaimed outside-contributor target right now." }, 200);
@@ -2409,15 +2411,17 @@ export function createApp() {
     const repoName = c.req.query("repo") ?? "";
     if (!owner || !repoName) return c.json({ error: "valid_owner_repo_required" }, 400);
     const repoFullName = `${owner}/${repoName}`;
-    const [context, repo, issues, pullRequests, bounties, issueQuality] = await Promise.all([
+    const repo = await getRepository(c.env, repoFullName);
+    if (!repo) return c.json({ error: "repo_not_found" }, 404);
+    const repoForbidden = await requireContributorRepoAccess(c, repoFullName, repo);
+    if (repoForbidden) return repoForbidden;
+    const [context, issues, pullRequests, bounties, issueQuality] = await Promise.all([
       loadContributorFastContext(c.env, login),
-      getRepository(c.env, repoFullName),
       listIssues(c.env, repoFullName),
       listPullRequests(c.env, repoFullName),
       listBountiesByRepo(c.env, repoFullName),
       loadOrComputeIssueQualityResponse(c.env, repoFullName),
     ]);
-    if (!repo) return c.json({ error: "repo_not_found" }, 404);
     const opportunities = buildContributorOpportunities(context.profile, [repo], issues, pullRequests, bounties, issueQualityMap(repoFullName, issueQuality?.report));
     return c.json({ repoFullName, badges: buildExtensionIssueBadges(opportunities, repoFullName) });
   });
@@ -2431,8 +2435,11 @@ export function createApp() {
     const pullNumber = Number(c.req.query("pullNumber") ?? "");
     if (!owner || !repoName || !Number.isInteger(pullNumber) || pullNumber <= 0) return c.json({ error: "valid_owner_repo_pull_required" }, 400);
     const repoFullName = `${owner}/${repoName}`;
-    const [repo, issues, pullRequests, bounties, issueQuality] = await Promise.all([
-      getRepository(c.env, repoFullName),
+    const repo = await getRepository(c.env, repoFullName);
+    if (!repo) return c.json({ error: "repo_not_found" }, 404);
+    const repoForbidden = await requireContributorRepoAccess(c, repoFullName, repo);
+    if (repoForbidden) return repoForbidden;
+    const [issues, pullRequests, bounties, issueQuality] = await Promise.all([
       listIssues(c.env, repoFullName),
       listPullRequests(c.env, repoFullName),
       listBountiesByRepo(c.env, repoFullName),
@@ -4494,6 +4501,15 @@ async function requireContributorAccess(c: ProtectedRouteContext, login: string)
   if (!identity) return c.json({ error: "unauthorized" }, 401);
   if (identity.kind === "session" && identity.actor.toLowerCase() !== login.toLowerCase()) return c.json({ error: "forbidden_contributor" }, 403);
   return null;
+}
+
+async function requireContributorRepoAccess(c: ProtectedRouteContext, repoFullName: string, repo: RepositoryRecord): Promise<Response | null> {
+  if (!repo.isPrivate) return null;
+  const identity = await authenticateRequestIdentity(c);
+  /* v8 ignore next -- Contributor route guard authenticates before repository access is checked. */
+  if (!identity) return c.json({ error: "unauthorized" }, 401);
+  if (identity.kind !== "session") return null;
+  return requireSessionRepoAccess(c, identity, repoFullName, repo);
 }
 
 async function requireCommandPreviewRepoAccess(

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -3761,6 +3761,9 @@ describe("api routes", () => {
     await upsertPullRequestFromGitHub(env, "octo/demo", { number: 14, title: "Tidy labels output", state: "open", html_url: "https://github.com/octo/demo/pull/14", user: { login: "contributor-dev" }, labels: [], head: { sha: "aaa111", ref: "tidy" }, base: { ref: "main" } });
     // A PR with no author -- exercises the authorLogin-defaulting path of the self-only PR guard (→ 403).
     await upsertPullRequestFromGitHub(env, "octo/demo", { number: 15, title: "Authorless PR", state: "open", html_url: "https://github.com/octo/demo/pull/15", labels: [], head: { sha: "bbb222", ref: "ghost" }, base: { ref: "main" } });
+    await upsertRepositoryFromGitHub(env, { name: "secret", full_name: "victim-org/secret", private: true, owner: { login: "victim-org" }, default_branch: "main" });
+    await upsertIssueFromGitHub(env, "victim-org/secret", { number: 99, title: "Private roadmap", state: "open", html_url: "https://github.com/victim-org/secret/issues/99", user: { login: "victim-org" }, labels: [{ name: "feature" }], body: "Confidential issue." });
+    await upsertPullRequestFromGitHub(env, "victim-org/secret", { number: 101, title: "Private implementation", state: "open", html_url: "https://github.com/victim-org/secret/pull/101", user: { login: "contributor-dev" }, labels: [], body: "Fixes #99", head: { sha: "ccc333", ref: "private" }, base: { ref: "main" } });
 
     // A non-maintainer mints a CONTRIBUTOR-scoped extension session.
     const { token: browserToken } = await createSessionForGitHubUser(env, { login: "contributor-dev", id: 555 });
@@ -3791,6 +3794,15 @@ describe("api routes", () => {
     const badgesBody = (await badges.json()) as { badges: unknown[] };
     expect(Array.isArray(badgesBody.badges)).toBe(true);
     expect(JSON.stringify(badgesBody)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
+
+    const privateIssueFit = await app.request("/v1/extension/contributors/contributor-dev/issue-fit?owner=victim-org&repo=secret&issueNumber=99", { headers: bearer }, env);
+    expect(privateIssueFit.status).toBe(403);
+    await expect(privateIssueFit.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+    const privateIssueBadges = await app.request("/v1/extension/contributors/contributor-dev/issue-badges?owner=victim-org&repo=secret", { headers: bearer }, env);
+    expect(privateIssueBadges.status).toBe(403);
+    await expect(privateIssueBadges.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+    expect((await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=victim-org&repo=secret&pullNumber=101", { headers: bearer }, env)).status).toBe(403);
+    expect((await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=victim-org&repo=secret&pullNumber=999", { headers: bearer }, env)).status).toBe(403);
 
     const prStatus = await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=octo&repo=demo&pullNumber=12", { headers: bearer }, env);
     expect(prStatus.status).toBe(200);


### PR DESCRIPTION
### Motivation
- Contributor-scoped extension endpoints could load and disclose private repository issue/PR metadata because they only enforced actor==login and did not check repository visibility or caller access.
- Prevent a cross-tenant information disclosure and a PR existence oracle for private installed repositories while preserving public repo behavior.

### Description
- Adds `requireContributorRepoAccess` which allows public repos but delegates private-repo authorization to the existing `requireSessionRepoAccess` gate for session identities.
- Updates the contributor extension routes (`/v1/extension/contributors/:login/issue-fit`, `/issue-badges`, and `/pr-status`) to resolve the repository first, return `404` for missing repos, call the new repo-access guard, and only then load issues/PRs/bounties/quality data.
- Preserves the existing self-only checks (actor === `:login`) and public-safe output formatting while blocking unauthorized reads of private repos.
- Adds integration coverage that seeds a private repo and asserts the contributor extension endpoints return `403` for private repo access attempts.

### Testing
- Ran typecheck with `npm run typecheck` and it completed successfully.
- Ran the modified integration test with `npx vitest run test/integration/api.test.ts --reporter=verbose`, and the suite passed (integration tests covering the contributor extension routes succeeded).
- Ran the targeted integration file as part of full integration test run; all assertions for the new private-repo denial and PR-existence-oracle prevention passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b6065798832cb3c988634b2d927a)