### PR TITLE
test(footer): cover maintainer customText CTA preservation

### DIFF
--- a/test/unit/footer.test.ts
+++ b/test/unit/footer.test.ts
@@ -26,4 +26,14 @@ describe("gittensory public-comment footer", () => {
       expect(footer).not.toContain(word.toLowerCase());
     }
   });
+
+  it("preserves maintainer custom lead text while appending the Gittensor CTA", () => {
+    const earnUrl = gittensorRepoEarnUrl("JSONbored/gittensory");
+    const footer = gittensoryFooter({ customText: "Thanks for contributing to Gittensory!", earnUrl });
+    expect(footer.startsWith("Thanks for contributing to Gittensory!")).toBe(true);
+    expect(footer).toContain("register to start earning");
+    expect(footer).toContain(earnUrl);
+    expect(footer).toContain(GITTENSORY_SITE_URL);
+    expect(footer.toLowerCase()).not.toMatch(/reward|payout|score/);
+  });
 });


### PR DESCRIPTION
## Summary
- Add unit coverage for `gittensoryFooter({ customText, earnUrl })`
- Ensures maintainer-provided footer lead is preserved while the Gittensor register CTA and Gittensory attribution are still appended
- Asserts forbidden reward/payout/score wording stays out of customized footers

## Test plan
- [x] `npm test -- test/unit/footer.test.ts`