### PR TITLE
fix(api): require live repo write access for AI config routes

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2102,11 +2102,11 @@ export function createApp() {
   });
 
   // Maintainer self-serve AI-review config (non-secret: mode/byok/provider/model). Session-authenticated +
-  // scoped to repos the maintainer owns/maintains. The secret provider key goes through the ai-key route.
+  // scoped to repos the maintainer has live GitHub write access to. The secret provider key goes through the ai-key route.
   // Merges onto current settings so unrelated settings are preserved.
   app.put("/v1/repos/:owner/:repo/ai-review", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const gate = await requireRepoMaintainer(c, fullName);
+    const gate = await requireRepoWriteAccess(c, fullName);
     if (gate instanceof Response) return gate;
     const parsed = repositoryAiReviewSchema.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return c.json({ error: "invalid_ai_review_config", issues: parsed.error.issues }, 400);
@@ -2127,11 +2127,11 @@ export function createApp() {
     });
   });
 
-  // Maintainer self-serve BYOK provider key. Write-only + maintainer-scoped. GET returns only
+  // Maintainer self-serve BYOK provider key. Write-only + live GitHub write-access scoped. GET returns only
   // {configured, provider, last4, model}; the key is never returned, logged, or surfaced.
   app.get("/v1/repos/:owner/:repo/ai-key", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const gate = await requireRepoMaintainer(c, fullName);
+    const gate = await requireRepoWriteAccess(c, fullName);
     if (gate instanceof Response) return gate;
     return c.json(await getRepositoryAiKeyStatus(c.env, fullName));
   });
@@ -4552,7 +4552,7 @@ async function requireRepoMaintainer(c: ProtectedRouteContext, fullName: string)
 const REPO_WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
 /**
- * Stricter gate for repo-visible settings/secret WRITES. On top of the maintainer gate, a session caller
+ * Stricter gate for repo-visible settings and secret-key status/writes. On top of the maintainer gate, a session caller
  * must have real GitHub write access to the repo — resolved via the installation, not merely inferred
  * from a PR author_association (which includes org MEMBER / read-only COLLABORATOR). Operators and
  * server-to-server tokens are exempt. Fails closed (403) if write access can't be verified.

--- a/test/unit/routes-ai-byok.test.ts
+++ b/test/unit/routes-ai-byok.test.ts
@@ -133,11 +133,12 @@ describe("maintainer route authz (session-scoped)", () => {
     expect((await app.request(`${OWNED}/ai-review`, { method: "PUT", body: "{}" }, env)).status).toBe(401);
   });
 
-  it("allows the repo owner via session to write the AI-review config", async () => {
+  it("allows the repo owner (admin permission) via session to write the AI-review config", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, ADMIN_GITHUB_LOGINS: "" });
     await seedRepo(env, "repo-owner", "owned-repo", 201);
     stubMinerFetch();
+    mockedPermission.mockResolvedValue("admin"); // real GitHub write access
     const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
     const res = await app.request(`${OWNED}/ai-review`, { method: "PUT", headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" }, body: JSON.stringify({ mode: "advisory", byok: true, provider: "anthropic" }) }, env);
     expect(res.status).toBe(200);
@@ -156,7 +157,7 @@ describe("maintainer route authz (session-scoped)", () => {
     expect(await res.json()).toMatchObject({ configured: true, provider: "anthropic", last4: "4242" });
   });
 
-  it("forbids a read-only collaborator (in scope via a PR, but no push) from writing the BYOK key", async () => {
+  it("forbids a read-only collaborator (in scope via a PR, but no push) from AI-review and BYOK key routes", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET, ADMIN_GITHUB_LOGINS: "" });
     await seedRepo(env, "repo-owner", "owned-repo", 201);
@@ -171,8 +172,11 @@ describe("maintainer route authz (session-scoped)", () => {
     expect(await post.json()).toMatchObject({ error: "insufficient_repo_permission" });
     // DELETE is gated the same way.
     expect((await app.request(`${OWNED}/ai-key`, { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } }, env)).status).toBe(403);
-    // The read-only collaborator can still READ the secret-free status (GET is not write-gated).
-    expect((await app.request(`${OWNED}/ai-key`, { headers: { cookie: `gittensory_session=${token}` } }, env)).status).toBe(200);
+    // GET key status and AI-review writes are also gated by real GitHub write access.
+    expect((await app.request(`${OWNED}/ai-key`, { headers: { cookie: `gittensory_session=${token}` } }, env)).status).toBe(403);
+    const review = await app.request(`${OWNED}/ai-review`, { method: "PUT", headers: json, body: JSON.stringify({ mode: "advisory", byok: false }) }, env);
+    expect(review.status).toBe(403);
+    expect(await review.json()).toMatchObject({ error: "insufficient_repo_permission" });
   });
 
   it("allows an operator to set the BYOK key without a per-repo push check", async () => {


### PR DESCRIPTION
### Motivation
- Fix an authorization gap where maintainer self-serve AI-review and BYOK routes relied only on cached maintainer scope derived from PR author associations instead of verifying current GitHub write/maintain/admin permission.
- Prevent low-privileged org members or stale collaborator sessions from modifying repo AI configuration or BYOK key records.

### Description
- Update the AI-review PUT route to use `requireRepoWriteAccess(fullName)` instead of `requireRepoMaintainer(fullName)` so writes require a live GitHub collaborator permission check.
- Gate the BYOK `GET`/`POST`/`DELETE` routes with `requireRepoWriteAccess(fullName)` so both key status reads and secret writes/deletes require live write access.
- Clarify the `requireRepoWriteAccess` documentation comment to state it covers repo-visible settings and secret-key status/writes and uses `getRepositoryCollaboratorPermission` resolved via the installation.
- Adjust unit tests in `test/unit/routes-ai-byok.test.ts` to mock and assert live permission checks (mocked `getRepositoryCollaboratorPermission`) and to verify that read-only collaborators are denied for AI-review updates and key status reads.

### Testing
- Ran `npm test -- --run test/unit/routes-ai-byok.test.ts` and all tests in that file passed (`16 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors.
- Ran repository checks (`git diff --check`) as part of validation with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33c1422f44832c8b45173f12c3b9f9)