### PR TITLE
fix(ui): stop proxying analytics script

### DIFF
--- a/apps/gittensory-ui/src/lib/analytics-proxy.ts
+++ b/apps/gittensory-ui/src/lib/analytics-proxy.ts
@@ -1,24 +1,22 @@
-// First-party reverse proxy for the self-hosted Umami tracker.
+// First-party endpoint for forwarding cookieless analytics events.
 //
 // The browser only ever talks to our own origin (gittensory.aethereal.dev):
-//   GET  /stats/script.js -> https://tasty.aethereal.dev/script.js
-//   POST /stats/api/send  -> https://tasty.aethereal.dev/api/send
+//   POST /stats/api/send -> https://tasty.aethereal.dev/api/send
 //
-// The tracker derives its collect endpoint from its own <script src> directory,
-// so serving it at /stats/script.js makes it POST to /stats/api/send on its own
-// — no data-host-url attribute needed. Keeping the script first-party clears the
-// Subresource-Integrity finding without an SRI hash to re-pin on every Umami
-// upgrade, and it survives ad-blockers that target the analytics subdomain.
+// Do not proxy the remote Umami script through this origin. Serving mutable
+// third-party JavaScript as same-origin code lets a compromised analytics host
+// execute with the app's privileges. The UI uses a tiny local beacon instead and
+// this proxy only relays the resulting collect payload.
 //
 // The allowlist below is load-bearing: this must NOT become an open proxy onto
-// the Umami host, whose admin/auth API lives on the same origin as the tracker.
+// the Umami host, whose admin/auth API lives on the same origin as the collect
+// endpoint.
 
 const UPSTREAM = "https://tasty.aethereal.dev";
 export const ANALYTICS_PREFIX = "/stats";
 
 // First-party path -> methods we forward. Anything else under /stats 404s here.
 const ROUTES: Record<string, ReadonlySet<string>> = {
-  "/stats/script.js": new Set(["GET", "HEAD"]),
   "/stats/api/send": new Set(["POST"]),
 };
 
@@ -54,8 +52,8 @@ const STRIP_RESPONSE_HEADERS = new Set([
 ]);
 
 /**
- * Proxies the allowlisted Umami tracker paths through our own origin.
- * Returns a `Response` for `/stats/script.js` and `/stats/api/send`, or
+ * Proxies the allowlisted Umami collect path through our own origin.
+ * Returns a `Response` for `/stats/api/send`, or
  * `undefined` for any other request so the caller falls through to SSR.
  */
 export async function handleAnalyticsProxy(request: Request): Promise<Response | undefined> {

--- a/apps/gittensory-ui/src/routes/__root.tsx
+++ b/apps/gittensory-ui/src/routes/__root.tsx
@@ -81,6 +81,38 @@ function ErrorComponent({ error, reset }: { error: Error; reset: () => void }) {
   );
 }
 
+const ANALYTICS_BEACON_SCRIPT = `
+(function () {
+  var website = "2ec37da2-e519-4bd5-bc16-76e17b03a458";
+  var endpoint = "/stats/api/send";
+  function send() {
+    if (navigator.doNotTrack === "1") return;
+    var payload = JSON.stringify({
+      type: "event",
+      payload: {
+        website: website,
+        hostname: location.hostname,
+        screen: screen.width + "x" + screen.height,
+        language: navigator.language,
+        title: document.title,
+        url: location.pathname + location.search,
+        referrer: document.referrer,
+      },
+    });
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(endpoint, new Blob([payload], { type: "application/json" }));
+      return;
+    }
+    fetch(endpoint, { method: "POST", headers: { "content-type": "application/json" }, body: payload, keepalive: true });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", send, { once: true });
+  } else {
+    send();
+  }
+})();
+`;
+
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   head: () => ({
     meta: [
@@ -126,16 +158,11 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
           description: "Deterministic base-agent layer for Gittensor OSS contribution mining.",
         }),
       },
-      // Self-hosted, privacy-friendly Umami analytics (cookieless, no PII).
-      // Served first-party via the Worker proxy in src/server.ts, which forwards
-      // /stats/* to tasty.aethereal.dev. The browser only talks to our own
-      // origin, so there's no cross-origin script (no SRI to re-pin on Umami
-      // upgrades) and the tracker derives its collect endpoint (/stats/api/send)
-      // from this src on its own.
+      // Local, cookieless analytics beacon. Do not load the mutable remote
+      // Umami tracker as first-party JavaScript; only the event payload is
+      // forwarded through /stats/api/send by the Worker proxy.
       {
-        src: "/stats/script.js",
-        defer: true,
-        "data-website-id": "2ec37da2-e519-4bd5-bc16-76e17b03a458",
+        children: ANALYTICS_BEACON_SCRIPT,
       },
     ],
   }),

--- a/apps/gittensory-ui/src/server.ts
+++ b/apps/gittensory-ui/src/server.ts
@@ -40,10 +40,9 @@ async function normalizeCatastrophicSsrResponse(response: Response): Promise<Res
 
 export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
-    // First-party proxy for the self-hosted Umami tracker (/stats/*). Runs ahead
-    // of SSR and returns undefined for every other path. Only active in the
-    // deployed Worker; `vite dev` uses TanStack's default server entry, so local
-    // /stats/script.js 404s and analytics simply doesn't load in dev (intended).
+    // First-party proxy for cookieless analytics event collection (/stats/api/send).
+    // Runs ahead of SSR and returns undefined for every other path. The remote
+    // Umami tracker script is intentionally not proxied as same-origin JavaScript.
     const analytics = await handleAnalyticsProxy(request);
     if (analytics) return analytics;
 

--- a/test/unit/analytics-proxy.test.ts
+++ b/test/unit/analytics-proxy.test.ts
@@ -5,10 +5,23 @@ const UPSTREAM = "https://tasty.aethereal.dev";
 
 function captureUpstream() {
   const calls: Array<{ url: string; init: RequestInit; headers: Headers }> = [];
-  vi.stubGlobal("fetch", async (url: RequestInfo | URL, init: RequestInit = {}) => {
-    calls.push({ url: url.toString(), init, headers: new Headers(init.headers) });
-    return new Response("ok", { status: 200, headers: { "set-cookie": "umami=1", "content-type": "application/javascript" } });
-  });
+  vi.stubGlobal(
+    "fetch",
+    async (url: RequestInfo | URL, init: RequestInit = {}) => {
+      calls.push({
+        url: url.toString(),
+        init,
+        headers: new Headers(init.headers),
+      });
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          "set-cookie": "umami=1",
+          "content-type": "application/json",
+        },
+      });
+    },
+  );
   return calls;
 }
 
@@ -17,18 +30,33 @@ describe("handleAnalyticsProxy", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not proxy the mutable remote analytics script as first-party JavaScript", async () => {
+    const calls = captureUpstream();
+
+    expect(
+      await handleAnalyticsProxy(
+        new Request("https://gittensory.aethereal.dev/stats/script.js"),
+      ),
+    ).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
   it("does not forward the visitor's cookies to the analytics upstream", async () => {
     const calls = captureUpstream();
     const response = await handleAnalyticsProxy(
-      new Request("https://gittensory.aethereal.dev/stats/script.js", {
-        method: "GET",
-        headers: { cookie: "gittensory_session=secret; gh_oauth_state=abc", "cf-connecting-ip": "203.0.113.7" },
+      new Request("https://gittensory.aethereal.dev/stats/api/send", {
+        method: "POST",
+        headers: {
+          cookie: "gittensory_session=secret; gh_oauth_state=abc",
+          "cf-connecting-ip": "203.0.113.7",
+        },
+        body: "{}",
       }),
     );
 
     expect(response?.status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.url).toBe(`${UPSTREAM}/script.js`);
+    expect(calls[0]?.url).toBe(`${UPSTREAM}/api/send`);
     // The first-party cookie must never reach the analytics host.
     expect(calls[0]?.headers.has("cookie")).toBe(false);
     // The upstream set-cookie must never be relayed back to the browser.
@@ -40,7 +68,11 @@ describe("handleAnalyticsProxy", () => {
     await handleAnalyticsProxy(
       new Request("https://gittensory.aethereal.dev/stats/api/send", {
         method: "POST",
-        headers: { "x-forwarded-for": "1.2.3.4", "cf-connecting-ip": "203.0.113.7", "content-type": "application/json" },
+        headers: {
+          "x-forwarded-for": "1.2.3.4",
+          "cf-connecting-ip": "203.0.113.7",
+          "content-type": "application/json",
+        },
         body: "{}",
       }),
     );
@@ -52,9 +84,21 @@ describe("handleAnalyticsProxy", () => {
 
   it("returns undefined for non-allowlisted paths and 405 for disallowed methods", async () => {
     captureUpstream();
-    expect(await handleAnalyticsProxy(new Request("https://gittensory.aethereal.dev/stats/api/admin"))).toBeUndefined();
-    expect(await handleAnalyticsProxy(new Request("https://gittensory.aethereal.dev/about"))).toBeUndefined();
-    const notAllowed = await handleAnalyticsProxy(new Request("https://gittensory.aethereal.dev/stats/script.js", { method: "POST" }));
+    expect(
+      await handleAnalyticsProxy(
+        new Request("https://gittensory.aethereal.dev/stats/api/admin"),
+      ),
+    ).toBeUndefined();
+    expect(
+      await handleAnalyticsProxy(
+        new Request("https://gittensory.aethereal.dev/about"),
+      ),
+    ).toBeUndefined();
+    const notAllowed = await handleAnalyticsProxy(
+      new Request("https://gittensory.aethereal.dev/stats/api/send", {
+        method: "GET",
+      }),
+    );
     expect(notAllowed?.status).toBe(405);
   });
 });


### PR DESCRIPTION
### Motivation
- Avoid serving mutable third-party JavaScript as same-origin code because a compromised analytics host could execute arbitrary code in the app origin and access sensitive storage/CORS-protected APIs.
- Keep privacy-friendly, cookieless analytics while reducing supply-chain/privilege blast radius by only forwarding event payloads, not the tracker script.

### Description
- Removed `/stats/script.js` from the analytics proxy allowlist so the Worker no longer fetches and relays the upstream Umami script as first-party JavaScript (`apps/gittensory-ui/src/lib/analytics-proxy.ts`).
- Replaced the proxied tracker in the root HTML with a small local beacon that collects minimal, cookieless event payloads and POSTs them to `/stats/api/send` (`apps/gittensory-ui/src/routes/__root.tsx`).
- Adjusted server comments to document that only the collect endpoint (`/stats/api/send`) is proxied and that the remote tracker is intentionally not proxied (`apps/gittensory-ui/src/server.ts`).
- Updated unit tests to assert the script route is not proxied and preserved tests that validate collect forwarding, header stripping, trusted client IP forwarding, and method/path allowlisting (`test/unit/analytics-proxy.test.ts`).

### Testing
- Ran the analytics proxy unit tests with `npx vitest run test/unit/analytics-proxy.test.ts` and they passed (4 tests, 4 passed).
- Ran UI typecheck with `npm run ui:typecheck` and it completed successfully (TypeScript `tsc --noEmit`).
- Ran UI lint with `npm run ui:lint` and it completed successfully (`eslint .`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33c695e650832c857a6ee637c83bf7)