### PR TITLE
fix(github): redact ask command citation metadata

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -335,7 +335,7 @@ function buildAskPublicAnswerCard(args: {
   ];
   const sourceEvidence = contributingSources.slice(0, 3).map((source) => {
     const observed = source.generatedAt ? ` as of ${source.generatedAt}` : "";
-    return `Connected source ${source.label} (${source.origin}): freshness ${source.freshness}${observed}.`;
+    return `Connected source ${source.label}: freshness ${source.freshness}${observed}.`;
   });
   return {
     title,
@@ -737,7 +737,7 @@ function askSourcesFromContextSnapshot(snapshot: AgentRunBundle["contextSnapshot
           origin: kind,
           generatedAt: typeof record.generatedAt === "string" ? record.generatedAt : graphGeneratedAt,
           freshness: typeof record.freshness === "string" ? record.freshness : "unknown",
-          detail: typeof record.detail === "string" ? record.detail : "Connected contributor evidence graph source.",
+          detail: publicContextSnapshotSourceDetail(kind),
         });
       }
     }
@@ -762,16 +762,6 @@ function askSourcesFromContextSnapshot(snapshot: AgentRunBundle["contextSnapshot
       generatedAt,
       freshness: branchEligibility.stale === true ? "stale" : branchEligibility.evidence === "missing" ? "missing" : "fresh",
       detail: "Branch eligibility metadata from connected local/GitHub context.",
-    });
-  }
-  if (typeof payload.scoreabilityStatus === "string") {
-    sources.push({
-      key: "scoreability_status",
-      label: "contribution readiness metadata",
-      origin: "metadata_only",
-      generatedAt,
-      freshness: snapshotFreshnessFromWarnings(snapshot),
-      detail: `Contribution readiness status: ${payload.scoreabilityStatus}.`,
     });
   }
   const dataQuality = readRecord(payload.dataQuality);
@@ -802,7 +792,7 @@ function askSourcesFromContextSnapshot(snapshot: AgentRunBundle["contextSnapshot
       origin: "contributor_decision_pack",
       generatedAt: generatedAt ?? snapshot.decisionPackVersion ?? null,
       freshness: snapshotFreshnessFromWarnings(snapshot),
-      detail: `Contributor decision pack (${payload.source}).`,
+      detail: "Contributor decision-pack metadata was available for this cached agent run.",
     });
   }
   const openPrMonitor = readRecord(payload.openPrMonitor);
@@ -819,7 +809,17 @@ function askSourcesFromContextSnapshot(snapshot: AgentRunBundle["contextSnapshot
   return sources;
 }
 
-const PRIVATE_ASK_ACTION_EVIDENCE_SOURCES = new Set(["repo_decision"]);
+function publicContextSnapshotSourceDetail(name: string): string {
+  const details: Record<string, string> = {
+    computed: "Computed contributor-signal metadata was available for this cached agent run.",
+    mirror: "Gittensor mirror registry metadata was available for this cached agent run.",
+    repo_focus_manifest: "Repo focus manifest metadata was available for this cached agent run.",
+    open_pr_monitor: "Cached open PR and issue queue metadata was available for this cached agent run.",
+  };
+  return details[name] ?? "Connected contributor evidence metadata was available for this cached agent run.";
+}
+
+const PRIVATE_ASK_ACTION_EVIDENCE_SOURCES = new Set(["repo_decision", "score_preview"]);
 
 function askSourcesFromActionEvidence(action: AgentActionRecord): AskContributingSource[] {
   const evidence = readRecord(action.payload.recommendationEvidence);
@@ -854,7 +854,7 @@ function publicActionEvidenceSourceDetail(name: string): string {
 }
 
 function formatAskCitation(source: AskContributingSource): string {
-  const header = `Source: ${source.label}; origin: ${source.origin}; freshness: ${source.freshness}`;
+  const header = `Source: ${source.label}; freshness: ${source.freshness}`;
   const observed = source.generatedAt ? ` as of ${source.generatedAt}` : "";
   const detail = source.detail ? ` — ${publicBlockerDetail(source.detail)}` : "";
   return `- ${header}${observed}${detail}.`;

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -319,12 +319,12 @@ describe("GitHub mention commands", () => {
     expect(ask).toContain("**Contribution context Q&A**");
     expect(ask).toContain("Question: what should I improve for contribution quality?");
     const askFindings = publicCardFindings(ask);
-    expect(askFindings).toContain("origin: contributor_decision_pack; freshness: fresh");
-    expect(askFindings).toContain("origin: open_pr_monitor; freshness: fresh");
-    expect(askFindings).toContain("origin: github_cache; freshness: fresh");
-    expect(askFindings).toContain("origin: official_gittensor; freshness: fresh");
-    expect(askFindings).toContain("signal data-quality status; origin: cached_signals");
-    expect(ask).toMatch(/Connected source contributor decision pack snapshot \(contributor_decision_pack\): freshness fresh/);
+    expect(askFindings).toContain("Source: contributor decision pack snapshot; freshness: fresh");
+    expect(askFindings).toContain("Source: cached GitHub open PR/issue queue; freshness: fresh");
+    expect(askFindings).toContain("Source: cached GitHub issues, PRs, reviews, and checks; freshness: fresh");
+    expect(askFindings).toContain("Source: official Gittensor API/cache; freshness: fresh");
+    expect(askFindings).toContain("signal data-quality status; freshness:");
+    expect(ask).toMatch(/Connected source contributor decision pack snapshot: freshness fresh/);
     expect(ask).toContain("README/docs context is included only when connected repo sources");
     expect(ask).not.toContain("source: action choose_next_work");
     expect(ask).not.toContain("**Source coverage**");
@@ -375,7 +375,7 @@ describe("GitHub mention commands", () => {
         ],
       }),
     });
-    expect(publicCardFindings(askWithTargets)).toContain("Source: repo focus manifest; origin: repo_focus_manifest; freshness: fresh");
+    expect(publicCardFindings(askWithTargets)).toContain("Source: repo focus manifest; freshness: fresh");
     expect(askWithTargets).toContain("owner/repo: Prepare a concise packet and verify linked context.");
   });
 
@@ -698,7 +698,7 @@ describe("GitHub mention commands", () => {
     });
     expect(askMetadata).toContain("repo sync freshness metadata");
     expect(askMetadata).toContain("branch eligibility metadata");
-    expect(askMetadata).toContain("contribution readiness metadata");
+    expect(askMetadata).not.toContain("Contribution readiness status");
     expect(publicCardFindings(askMetadata)).toContain("freshness: partial");
     expect(askMetadata).not.toContain("No concrete cached source reference is available for this response.");
 
@@ -745,7 +745,7 @@ describe("GitHub mention commands", () => {
         summary: "ask evidence only",
       },
     });
-    expect(askEvidenceOnly).toContain("origin: custom_unknown_source");
+    expect(askEvidenceOnly).toContain("Source: custom unknown source; freshness:");
     expect(askEvidenceOnly).toContain("custom unknown source");
 
     const askFallbackCitations = buildPublicAgentCommandComment({
@@ -1769,7 +1769,7 @@ describe("ask citation helpers", () => {
       actorKind: "author",
       bundle,
     });
-    expect(comment).toContain("origin: open_pr_monitor");
+    expect(comment).toContain("Source: cached GitHub open PR/issue queue; freshness: fresh");
     expect(comment).not.toMatch(/ranked|pursue_now|priority 0\.87321/i);
     expect(comment).not.toContain("owner/private-repo ranked");
   });
@@ -1814,8 +1814,9 @@ describe("ask citation helpers", () => {
       summary: "internals",
     });
     expect(sources.map((source) => source.key)).toEqual(
-      expect.arrayContaining(["scoreability_status", "score_preview", "branch_eligibility", "base_freshness", "evidence_graph_computed"]),
+      expect.arrayContaining(["branch_eligibility", "base_freshness", "evidence_graph_computed"]),
     );
+    expect(sources.some((source) => source.key === "scoreability_status" || source.key === "score_preview")).toBe(false);
     expect(sources.find((source) => source.key === "branch_eligibility")?.freshness).toBe("fresh");
     expect(
       githubCommandsInternals.snapshotFreshnessFromWarnings({
@@ -1845,7 +1846,7 @@ describe("ask citation helpers", () => {
         freshness: "unknown",
         detail: "",
       }),
-    ).toBe("- Source: metadata-only source; origin: metadata_only; freshness: unknown.");
+    ).toBe("- Source: metadata-only source; freshness: unknown.");
 
     const extended = githubCommandsInternals.collectAskContributingSources({
       run: completedRun("run-ask-internals-extended"),
@@ -1871,9 +1872,9 @@ describe("ask citation helpers", () => {
     });
     expect(extended.find((source) => source.key === "branch_eligibility")?.freshness).toBe("missing");
     expect(extended.some((source) => source.label.includes("Gittensor mirror registry snapshot"))).toBe(true);
-    expect(extended.some((source) => source.detail.includes("Connected contributor evidence graph source"))).toBe(true);
+    expect(extended.some((source) => source.detail.includes("metadata was available"))).toBe(true);
     expect(extended.some((source) => source.key === "freshness_warnings")).toBe(true);
-    expect(extended.some((source) => source.key === "contributor_decision_pack" && source.detail.includes("gittensor_api"))).toBe(true);
+    expect(extended.some((source) => source.key === "contributor_decision_pack" && source.detail.includes("Contributor decision-pack metadata"))).toBe(true);
     expect(extended.find((source) => source.key === "open_pr_monitor")?.freshness).toBe("unknown");
 
     const askOverflow = buildPublicAgentCommandComment({
@@ -1885,7 +1886,7 @@ describe("ask citation helpers", () => {
       bundle: askCitedBundle(),
     });
     expect(askOverflow).toContain("<summary>Additional safe details</summary>");
-    expect(askOverflow).toContain("origin: open_pr_monitor");
+    expect(askOverflow).toContain("Source: cached GitHub open PR/issue queue; freshness:");
 
     const askWithoutTimestamps = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory ask what is synced?")!,
@@ -1908,7 +1909,7 @@ describe("ask citation helpers", () => {
         summary: "no timestamps",
       },
     });
-    expect(askWithoutTimestamps).toContain("Connected source repo sync freshness metadata (metadata_only): freshness unknown.");
+    expect(askWithoutTimestamps).toContain("Connected source repo sync freshness metadata: freshness unknown.");
     expect(askWithoutTimestamps).not.toContain("freshness unknown as of");
 
     const askFourSources = buildPublicAgentCommandComment({


### PR DESCRIPTION
### Motivation
- The public `@gittensory ask` response was including raw agent evidence (origin identifiers, ranking/priority numbers, and scoreability text) that can leak private contribution intelligence.
- The goal is to preserve useful public-safe context (labels and freshness) while preventing disclosure of private recommendation/score metadata.

### Description
- Stop including source `origin` identifiers in rendered citation/evidence lines and remove origin from the citation header in `src/github/commands.ts` by changing the citation header to exclude `origin` and by not rendering `(source.origin)` in evidence entries.
- Replace raw context-snapshot `detail` text with canonical, public-safe descriptions via a new `publicContextSnapshotSourceDetail` helper and substitute decision-pack detail with a safe canned message.
- Prevent private action evidence sources from being published by adding `score_preview` to the `PRIVATE_ASK_ACTION_EVIDENCE_SOURCES` set (previously `repo_decision` only) and map public action-evidence details to safe labels via `publicActionEvidenceSourceDetail`.
- Update unit tests in `test/unit/github-commands.test.ts` to expect the sanitized, public-safe citation and evidence formatting (labels, freshness, and safe canned details) instead of private-origin and score text.

### Testing
- Ran unit tests: `npm test -- --run test/unit/github-commands.test.ts` and all tests passed (20/20). 
- Ran static type checks: `npm run typecheck` and `tsc --noEmit` succeeded with no errors. 
- Verified repository hygiene: `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d42b66f0832cae9dbdb5086c74de)