### PR TITLE
fix(github): redact public score gate details

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1486,7 +1486,10 @@ function sanitizeFeedbackAnswerId(answerId: string): string {
 
 export function sanitizePublicComment(value: string): string {
   const sanitized = value
-    .replace(/\bprojected score changes?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
+    .replace(/\bopen pr count\s+\d+\s+exceeds threshold\s+\d+\b\.?/gi, "private context")
+    .replace(/\bopen pr count is at or below\s+\d+\b/gi, "private context")
+    .replace(/\bcredibility\s+[-+]?\d+(?:\.\d+)?\s+is below floor\s+[-+]?\d+(?:\.\d+)?\b\.?/gi, "private context")
+    .replace(/\b(?:effective|projected) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\b(raw trust score|trust score|wallet|hotkey|coldkey|seed phrase|mnemonic)\b/gi, "private context")
     .replace(/\b(public score estimate|estimated score|score estimate|reward estimates?|payout|farming|scoreability|score preview|projected score changes?)\b/gi, "private context")
     .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -155,6 +155,9 @@ describe("GitHub mention commands", () => {
     expect(sanitizePublicComment("public score estimate and scoreability should stay private")).not.toMatch(/public score estimate|scoreability/i);
     expect(sanitizePublicComment("public score estimate private scoreability context score preview")).not.toMatch(/public score estimate|scoreability|score preview/i);
     expect(sanitizePublicComment("projected score changes 12.3 -> 45.6")).not.toMatch(/projected score changes|12\.3|45\.6/i);
+    expect(sanitizePublicComment("effective score 0 -> 42")).not.toMatch(/effective score|0|42/i);
+    expect(sanitizePublicComment("Open PR count 7 exceeds threshold 3.")).not.toMatch(/open PR count|7|threshold|3/i);
+    expect(sanitizePublicComment("Credibility 0.12 is below floor 0.4.")).not.toMatch(/credibility|0\.12|floor|0\.4/i);
     expect(sanitizePublicComment("open_pr_pressure closed_pr_credibility low_credibility credibility updates")).not.toMatch(/open_pr_pressure|closed_pr_credibility|low_credibility|credibility/i);
     expect(sanitizePublicComment("Command: @gittensory reviewability")).toContain("@gittensory reviewability");
     expect(sanitizePublicComment("private ranking, wallet, payout")).toBe("private context");


### PR DESCRIPTION
### Motivation
- Prevent leaking private scoreability/account-state gate details (open PR thresholds, credibility floors, and projected/effective score deltas) in public GitHub mention command comments.

### Description
- Extend `sanitizePublicComment` with additional regex replacements to redact phrases like `Open PR count ... exceeds threshold ...`, `open PR count is at or below ...`, credibility-floor sentences, and `effective/projected score ... -> ...` deltas; and keep existing private-term rewrites.
- Add regression expectations to `test/unit/github-commands.test.ts` that assert these specific phrases are redacted from public comments.

### Testing
- Ran `npx vitest run test/unit/github-commands.test.ts` and the targeted test file passed (20 tests passed). 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `git diff --check` to validate whitespace/checks and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e1de62b0832c9c539911f2775fc8)