### PR TITLE
fix(github): keep private duplicate details out of public comments

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -966,11 +966,6 @@ function duplicateCheckSections(bundle: AgentRunBundle | null | undefined): stri
     for (const code of action.blockedBy.slice(0, 3)) {
       lines.push(`- ${publicBlockerLabel(code)}`);
     }
-    const caution = [...action.why, action.riskImpact ?? ""]
-      .filter(isPublicDuplicateCautionLine)
-      .slice(0, 3)
-      .map((item) => `- ${publicBlockerDetail(item)}`);
-    lines.push(...caution);
   }
   return dedupeBulletLines(lines);
 }
@@ -1422,7 +1417,7 @@ function formatActionBullets(
 }
 
 function mentionsDuplicateRisk(action: AgentActionRecord): boolean {
-  return [action.publicSafeSummary, action.recommendation, action.riskImpact ?? "", ...action.why, ...action.blockedBy].some(isPublicDuplicateCautionLine);
+  return [action.publicSafeSummary, ...action.blockedBy].some(isPublicDuplicateCautionLine);
 }
 
 function mentionsDuplicateRiskText(value: string): boolean {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -292,7 +292,7 @@ describe("GitHub mention commands", () => {
     });
     expect(duplicateCheck).toContain("**Gittensory duplicate & WIP check**");
     expect(duplicateCheck).toContain("**Duplicate & WIP caution**");
-    expect(duplicateCheck).toContain("possible overlap with existing work");
+    expect(duplicateCheck).toContain("Possible overlap with existing work");
     expect(duplicateCheck).not.toMatch(/\blikely_duplicate\b/i);
 
     const nextAction = buildPublicAgentCommandComment({
@@ -1029,7 +1029,8 @@ describe("GitHub mention commands", () => {
       },
     });
     expect(duplicateViaRecommendation).toContain("**Duplicate & WIP caution**");
-    expect(duplicateViaRecommendation).toMatch(/overlap|WIP|Concurrent/i);
+    expect(duplicateViaRecommendation).toContain("Review linked issues before requesting detailed review.");
+    expect(duplicateViaRecommendation).not.toContain("Concurrent review pressure");
 
     const duplicateWithInjectedWhy = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory duplicate-check")!,
@@ -1059,7 +1060,7 @@ describe("GitHub mention commands", () => {
         summary: "duplicate",
       },
     });
-    expect(duplicateWithInjectedWhy).toContain("PRs touching duplicate @​octo-team/ \\[click\\]\\(https://example.test\\)");
+    expect(duplicateWithInjectedWhy).not.toContain("PRs touching duplicate");
     expect(duplicateWithInjectedWhy).not.toMatch(/\n@octo-team|@octo-team|[^\\]\[click\]\(https:\/\/example\.test\)/);
 
     const preflightWithRerun = buildPublicAgentCommandComment({


### PR DESCRIPTION
### Motivation
- The duplicate-check public rendering could surface private `action.why` and `riskImpact` text (populated from private decision data) into public GitHub comments, creating an information disclosure risk. 
- Duplicate-risk selection also considered private fields when deciding whether to include an action, increasing the chance of leaking non-public intelligence.

### Description
- Stop emitting `action.why` and `action.riskImpact` lines in the public `duplicate-check` command output by removing the caution expansion in `duplicateCheckSections` in `src/github/commands.ts`.
- Restrict duplicate-risk matching so `mentionsDuplicateRisk` only considers `publicSafeSummary` and sanitized blocker codes (no `why`, `recommendation`, or `riskImpact`) in `src/github/commands.ts`.
- Update unit expectations in `test/unit/github-commands.test.ts` to assert that public-safe summaries and labels remain while injected `why`/risk text and mentions are omitted.

### Testing
- Ran `npm test -- --run test/unit/github-commands.test.ts` and the affected test file completed successfully (all tests passed).
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking succeeded with no errors.
- Performed repository diff/check validations and found no outstanding style/check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e9b855cc832ca879097e748f1e66)