### PR TITLE
ci(ui): include extension changes in UI path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
               - '.github/actions/**'
             ui:
               - 'apps/gittensory-ui/**'
+              - 'apps/gittensory-extension/**'
               - 'src/**'
               - 'scripts/write-ui-openapi.ts'
               - 'scripts/build-extension.mjs'


### PR DESCRIPTION
### Motivation
- Ensure extension-only changes run the UI job (which builds/packages the browser extension) because the prior `ui` path filter omitted the extension sources and allowed extension-only PRs to skip required checks.

### Description
- Add `apps/gittensory-extension/**` to the `ui` filter in `.github/workflows/ci.yml` so PRs that touch the extension will trigger the `ui` job and its `ui:build`/extension packaging steps.

### Testing
- Ran `git diff --check` and `npm run actionlint`, both completed successfully (note: `actionlint` used a WASM fallback due to network fetch issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b56774d8832c8c4c7523e54ae170)