### PR TITLE
fix(plan-dag): preserve terminal step results

### DIFF
--- a/src/services/plan-dag.ts
+++ b/src/services/plan-dag.ts
@@ -106,6 +106,7 @@ export function markStepRunning(plan: PlanDag, stepId: string): PlanDag {
  */
 export function applyStepResult(plan: PlanDag, stepId: string, result: { outcome: "completed" | "failed" | "skipped"; error?: string | null | undefined }): PlanDag {
   return mapStep(plan, stepId, (step) => {
+    if (isDone(step.status) || step.status === "failed") return step;
     if (result.outcome === "completed") return { ...step, status: "completed", lastError: null };
     if (result.outcome === "skipped") return { ...step, status: "skipped", lastError: null };
     const attempts = step.attempts + 1;

--- a/test/unit/mcp-plan-dag.test.ts
+++ b/test/unit/mcp-plan-dag.test.ts
@@ -68,4 +68,20 @@ describe("MCP plan DAG tools (#783)", () => {
     expect(second.plan.steps[0]).toMatchObject({ status: "failed", attempts: 2 });
     expect(second.progress.status).toBe("failed");
   });
+  it("record_step_result preserves terminal step status", async () => {
+    const client = await connect();
+    const plan = {
+      steps: [
+        { id: "a", title: "A", dependsOn: [], status: "failed", attempts: 1, maxAttempts: 1, lastError: "boom" },
+        { id: "b", title: "B", dependsOn: ["a"], status: "pending", attempts: 0, maxAttempts: 1 },
+      ],
+    };
+
+    const result = (await client.callTool({ name: "gittensory_record_step_result", arguments: { plan, stepId: "a", outcome: "completed" } })).structuredContent as PlanView;
+
+    expect(result.plan.steps[0]).toMatchObject({ status: "failed", attempts: 1 });
+    expect(result.progress.status).toBe("failed");
+    expect(result.readySteps).toEqual([]);
+  });
+
 });

--- a/test/unit/plan-dag.test.ts
+++ b/test/unit/plan-dag.test.ts
@@ -42,6 +42,16 @@ describe("plan DAG (#783)", () => {
     plan = applyStepResult(plan, "a", { outcome: "failed" });
     expect(plan.steps[0]).toMatchObject({ status: "failed", attempts: 2, lastError: "step failed" });
     expect(applyStepResult(buildPlanDag([{ id: "x", title: "X" }]), "x", { outcome: "skipped" }).steps[0]?.status).toBe("skipped");
+
+    const completed = applyStepResult(buildPlanDag([{ id: "done", title: "Done" }]), "done", { outcome: "completed" });
+    expect(applyStepResult(completed, "done", { outcome: "failed", error: "late failure" }).steps[0]).toMatchObject({ status: "completed", attempts: 0, lastError: null });
+
+    const skipped = applyStepResult(buildPlanDag([{ id: "skip", title: "Skip" }]), "skip", { outcome: "skipped" });
+    expect(applyStepResult(skipped, "skip", { outcome: "completed" }).steps[0]).toMatchObject({ status: "skipped", attempts: 0, lastError: null });
+
+    const failed = applyStepResult(buildPlanDag([{ id: "fail", title: "Fail" }]), "fail", { outcome: "failed", error: "boom" });
+    expect(applyStepResult(failed, "fail", { outcome: "completed" }).steps[0]).toMatchObject({ status: "failed", attempts: 1, lastError: "boom" });
+
     // unknown id → no-op
     expect(applyStepResult(buildPlanDag([{ id: "x", title: "X" }]), "nope", { outcome: "completed" }).steps[0]?.status).toBe("pending");
   });


### PR DESCRIPTION
### Motivation

- `applyStepResult` could overwrite terminal step states (`completed`/`skipped`) and terminal `failed`, allowing later calls (including the MCP `gittensory_record_step_result` tool) to rewrite terminal outcomes and incorrectly unblock dependent steps. 

### Description

- Add a guard in `applyStepResult` so that if a step is already `completed`, `skipped`, or `failed` it is returned unchanged (`if (isDone(step.status) || step.status === "failed") return step;`).
- Add unit tests to `test/unit/plan-dag.test.ts` asserting that `completed`, `skipped`, and terminal `failed` step statuses are immutable to later results.
- Add an MCP-level regression test to `test/unit/mcp-plan-dag.test.ts` asserting that `gittensory_record_step_result` preserves a terminal failed dependency and does not unblock dependents.

### Testing

- Ran `npx vitest run test/unit/plan-dag.test.ts test/unit/mcp-plan-dag.test.ts --no-color`, and all tests passed (`13 passed`).
- Ran `npm run typecheck` (`tsc --noEmit`) with no errors.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b58d58cc832c9da763c38bdeef83)