### PR TITLE
fix(calibration): scope outcome recommendations by repo

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3206,11 +3206,20 @@ export async function getAgentRecommendationOutcome(env: Env, actionId: string):
 
 export async function listAgentRecommendationOutcomes(
   env: Env,
-  options: { actorLogin?: string; windowDays?: number; now?: string; limit?: number } = {},
+  options: { actorLogin?: string; repoFullName?: string; windowDays?: number; now?: string; limit?: number } = {},
 ): Promise<AgentRecommendationOutcomeRecord[]> {
   const limit = clampInteger(options.limit ?? 500, 1, 5000);
   const conditions = [];
   if (options.actorLogin) conditions.push(eq(agentRecommendationOutcomes.actorLogin, options.actorLogin));
+  if (options.repoFullName) {
+    const repoFullName = options.repoFullName.toLowerCase();
+    conditions.push(
+      or(
+        sql`lower(${agentRecommendationOutcomes.outcomeRepoFullName}) = ${repoFullName}`,
+        sql`lower(${agentRecommendationOutcomes.targetRepoFullName}) = ${repoFullName}`,
+      ),
+    );
+  }
   if (options.windowDays !== undefined) {
     const windowDays = clampInteger(options.windowDays, 1, 365);
     const now = options.now ?? nowIso();

--- a/src/services/outcome-calibration.ts
+++ b/src/services/outcome-calibration.ts
@@ -134,7 +134,7 @@ function sameRepo(a: string | null | undefined, b: string): boolean {
 export async function buildRepoOutcomeCalibration(env: Env, repoFullName: string, windowDays?: number): Promise<OutcomeCalibration> {
   const [pullRequests, outcomes] = await Promise.all([
     listPullRequests(env, repoFullName),
-    listAgentRecommendationOutcomes(env, windowDays !== undefined ? { windowDays } : {}),
+    listAgentRecommendationOutcomes(env, windowDays !== undefined ? { repoFullName, windowDays } : { repoFullName }),
   ]);
   const slop = buildSlopOutcomeCalibration(pullRequests);
   const recommendations = buildRecommendationOutcomeCalibration(outcomes, repoFullName);

--- a/test/unit/outcome-calibration.test.ts
+++ b/test/unit/outcome-calibration.test.ts
@@ -5,9 +5,9 @@ import {
   buildRepoOutcomeCalibration,
   buildSlopOutcomeCalibration,
 } from "../../src/services/outcome-calibration";
-import { updatePullRequestSlopAssessment, upsertPullRequestFromGitHub } from "../../src/db/repositories";
+import { createAgentRun, replaceAgentActions, updatePullRequestSlopAssessment, upsertAgentRecommendationOutcome, upsertPullRequestFromGitHub } from "../../src/db/repositories";
 import type { SlopBand } from "../../src/signals/slop";
-import type { AgentRecommendationOutcomeRecord, AgentRecommendationOutcomeState, PullRequestRecord } from "../../src/types";
+import type { AgentActionRecord, AgentRecommendationOutcomeRecord, AgentRecommendationOutcomeState, AgentRunRecord, PullRequestRecord } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
 // A resolved PR carrying a slop assessment. `merged` → has a merge timestamp; otherwise closed-unmerged.
@@ -119,4 +119,100 @@ describe("buildRepoOutcomeCalibration (env loader)", () => {
     expect(report.signals.length).toBeGreaterThan(0);
     expect(JSON.stringify(report)).not.toMatch(/reward|payout|trust score|wallet|hotkey/i);
   });
+
+  it("queries recommendation outcomes by repo before applying the default limit", async () => {
+    const env = createTestEnv();
+    const oldBase = Date.parse("2026-06-01T00:00:00.000Z");
+    await createAgentRun(env, runRecord("r-target", "miner", new Date(oldBase).toISOString()));
+    await createAgentRun(env, runRecord("r-other", "miner", new Date(oldBase + 10_000).toISOString()));
+    await replaceAgentActions(env, "r-target", [actionRecord("target-merged", "r-target"), actionRecord("target-closed", "r-target")]);
+    await replaceAgentActions(
+      env,
+      "r-other",
+      Array.from({ length: 500 }, (_, index) => actionRecord(`other-${index}`, "r-other")),
+    );
+    await upsertAgentRecommendationOutcome(env, {
+      actionId: "target-merged",
+      runId: "r-target",
+      actorLogin: "miner",
+      actionType: "choose_next_work",
+      targetRepoFullName: "owner/repo",
+      source: "explicit",
+      outcomeState: "merged",
+      outcomeTargetType: "pull_request",
+      maintainerLane: false,
+      confidence: "high",
+      reason: "target positive",
+      metadata: {},
+      updatedAt: new Date(oldBase).toISOString(),
+    });
+    await upsertAgentRecommendationOutcome(env, {
+      actionId: "target-closed",
+      runId: "r-target",
+      actorLogin: "miner",
+      actionType: "choose_next_work",
+      outcomeRepoFullName: "owner/repo",
+      source: "explicit",
+      outcomeState: "closed",
+      outcomeTargetType: "pull_request",
+      maintainerLane: false,
+      confidence: "high",
+      reason: "target negative",
+      metadata: {},
+      updatedAt: new Date(oldBase + 1000).toISOString(),
+    });
+
+    for (let index = 0; index < 500; index += 1) {
+      await upsertAgentRecommendationOutcome(env, {
+        actionId: `other-${index}`,
+        runId: "r-other",
+        actorLogin: "miner",
+        actionType: "choose_next_work",
+        targetRepoFullName: `other/repo-${index}`,
+        source: "explicit",
+        outcomeState: "accepted",
+        outcomeTargetType: "pull_request",
+        maintainerLane: false,
+        confidence: "high",
+        reason: "other repo",
+        metadata: {},
+        updatedAt: new Date(oldBase + 10_000 + index * 1000).toISOString(),
+      });
+    }
+
+    const report = await buildRepoOutcomeCalibration(env, "owner/repo", 365);
+    expect(report.recommendations).toMatchObject({ total: 2, positive: 1, negative: 1, positiveRate: 0.5 });
+  });
 });
+
+function runRecord(id: string, actorLogin: string, createdAt: string): AgentRunRecord {
+  return {
+    id,
+    objective: "Plan the next Gittensor OSS contribution action.",
+    actorLogin,
+    surface: "api",
+    mode: "copilot",
+    status: "completed",
+    dataQualityStatus: "complete",
+    payload: { kind: "plan_next_work", login: actorLogin },
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function actionRecord(id: string, runId: string): AgentActionRecord {
+  return {
+    id,
+    runId,
+    actionType: "choose_next_work",
+    status: "recommended",
+    recommendation: "Pick narrow work and validate it.",
+    why: ["The repo has cached opportunity signals."],
+    blockedBy: [],
+    publicSafeSummary: "Use local branch preflight before posting.",
+    approvalRequired: true,
+    safetyClass: "public_safe",
+    payload: {},
+    createdAt: "2026-06-01T00:00:00.000Z",
+  };
+}


### PR DESCRIPTION
### Motivation
- The outcome-calibration loader fetched recommendation outcomes with a global default limit and then filtered by repo in memory, which could drop older outcomes for the requested repo when many newer outcomes from other repos existed.
- This caused maintainer-facing calibration reports to show incomplete or misleading recommendation totals for a repo.

### Description
- Add an optional `repoFullName` option to `listAgentRecommendationOutcomes` and apply a database-level case-insensitive filter against both `outcomeRepoFullName` and `targetRepoFullName` so the default query `limit` is applied after repo scoping. (src/db/repositories.ts)
- Pass the requested `repoFullName` into `listAgentRecommendationOutcomes` from `buildRepoOutcomeCalibration` so repo-scoped recommendation metrics are retrieved from the DB rather than filtered in memory. (src/services/outcome-calibration.ts)
- Add a regression test that seeds two older outcomes for the target repo plus 500 newer outcomes for other repos and verifies the target repo's full recommendation totals are preserved; update test setup to satisfy DB constraints. (test/unit/outcome-calibration.test.ts)

### Testing
- Ran the updated unit test file with `npx vitest run test/unit/outcome-calibration.test.ts`, which passed (12 tests passed). 
- Ran the TypeScript typecheck with `npm run typecheck`, which succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b9ac1d18832cba0166472963681f)