### PR TITLE
fix(parser): prevent ReDoS in issue-template comment stripping

### DIFF
--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -302,8 +302,7 @@ export function buildEmptyIssueBodyFinding(input: IssueSlopAssessmentInput): Sig
 export function buildUnfilledIssueTemplateFinding(input: IssueSlopAssessmentInput): SignalFinding | null {
   const body = (input.body ?? "").trim();
   if (body.length === 0) return null;
-  const substantive = body
-    .replace(/<!--[\s\S]*?-->/g, "") // HTML comment placeholders
+  const substantive = stripHtmlComments(body) // HTML comment placeholders
     .replace(/^#{1,6}\s.*$/gm, "") // markdown heading lines
     .replace(/^\s*[-*]\s*(\[[ xX]\])?\s*$/gm, "") // empty bullets / checkboxes
     .replace(/[\s>#*_`+-]/g, "") // residual markdown punctuation + whitespace
@@ -319,6 +318,30 @@ export function buildUnfilledIssueTemplateFinding(input: IssueSlopAssessmentInpu
     action: "Fill in the template sections with the actual problem details.",
     publicText: detail,
   };
+}
+
+function stripHtmlComments(input: string): string {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const commentStart = input.indexOf("<!--", cursor);
+    if (commentStart === -1) {
+      output += input.slice(cursor);
+      break;
+    }
+
+    output += input.slice(cursor, commentStart);
+    const commentEnd = input.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) {
+      output += input.slice(commentStart);
+      break;
+    }
+
+    cursor = commentEnd + 3;
+  }
+
+  return output;
 }
 
 function nonNegative(value: number | undefined): number {

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -232,6 +232,12 @@ describe("buildIssueSlopAssessment (#533 issue-side triage)", () => {
     expect(buildUnfilledIssueTemplateFinding({ body: "Real prose explaining the bug." })).toBeNull();
     expect(buildEmptyIssueBodyFinding({ body: "has content" })).toBeNull();
   });
+
+  it("handles repeated unterminated HTML comment openers without excessive scanning", () => {
+    const maliciousBody = "<!--".repeat(30_000);
+
+    expect(buildUnfilledIssueTemplateFinding({ body: maliciousBody })).toBeNull();
+  }, 1_000);
 });
 
 describe("buildNonSubstantivePaddingFinding (#561 path-matcher signal)", () => {


### PR DESCRIPTION
### Motivation
- The issue-side slop detector used a global lazy regex to strip HTML comments which can exhibit pathological quadratic behavior on repeated unterminated `<!--` sequences, enabling CPU denial-of-service from attacker-controlled issue bodies. 
- The change aims to preserve the original closed-comment stripping behavior while removing the expensive regex scan so webhook and MCP processing cannot be tied up by crafted inputs.

### Description
- Replace the vulnerable `replace(/<!--[\s\S]*?-->/g, "")` approach with a linear scanner `stripHtmlComments(input: string): string` and call it from `buildUnfilledIssueTemplateFinding` in `src/signals/slop.ts`.
- Add a regression unit test that constructs a malicious body of repeated `"<!--"` sequences to ensure the detector completes without excessive scanning in `test/unit/slop.test.ts`.
- Keep the remaining template-stripping steps (heading/bullet/punctuation removal) unchanged so normal behavior and detection semantics are preserved.

### Testing
- Ran the unit tests for the slop signal with `npm test -- --run test/unit/slop.test.ts` and the suite passed (`1 file, 25 tests passed`).
- Ran the TypeScript typecheck via `npm run typecheck` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346e6f80ac832ca4982bbe9e7fc4bd)