### PR TITLE
Fix PR draft redaction for colon-prefixed local paths

### DIFF
--- a/src/services/pr-body-draft.ts
+++ b/src/services/pr-body-draft.ts
@@ -53,7 +53,7 @@ export const EXCLUDED_PRIVATE_PR_BODY_FIELDS = [
 // (e.g. a bare "reward"/"score"/"ranking"); scrubbed to a neutral phrase as defense-in-depth.
 // The term vocabulary is the canonical PUBLIC_UNSAFE_TERMS (#542) so this surface cannot drift it.
 const RESIDUAL_PRIVATE_TERMS = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b`, "gi");
-const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![:/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
+const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
 const LOCAL_PATH_PATTERN = new RegExp(LOCAL_PATH_SOURCE, "g");
 // Final guard used to drop anything that still looks unsafe after scrubbing. Same canonical terms, plus this
 // surface's richer local-path matcher.

--- a/test/unit/pr-body-draft.test.ts
+++ b/test/unit/pr-body-draft.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildPublicPrBodyDraft, EXCLUDED_PRIVATE_PR_BODY_FIELDS, type PrBodyDraftSource } from "../../src/services/pr-body-draft";
 
-const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![:/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
+const LOCAL_PATH_SOURCE = String.raw`(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s"';)]+|\\\\[^\s"';\\]+\\[^\s"';]+|(?<![/\\A-Za-z0-9._-])/[A-Za-z0-9._-]+(?:/[^\s"';)]+)*)`;
 const FORBIDDEN_PUBLIC_LANGUAGE = new RegExp(
   String.raw`\b(wallet|hotkey|coldkey|mnemonic|raw trust score|raw[-_\s]?trust|trust score|payout|reward estimate|reward|farming|private reviewability|reviewability|public score estimate|scoreability|ranking)\b|${LOCAL_PATH_SOURCE}`,
   "i",
@@ -203,6 +203,31 @@ describe("buildPublicPrBodyDraft — source-upload guard", () => {
     expect(blob).toContain("[local path]");
     expect(blob).toContain("src/ok.ts");
     expect(draft.markdown).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  });
+
+  it("redacts colon-prefixed Unix paths from validation metadata", () => {
+    const draft = buildPublicPrBodyDraft(
+      source({
+        prPacket: {
+          ...source().prPacket,
+          validationSummary: {
+            passed: 3,
+            failed: 0,
+            notRun: 0,
+            commands: [
+              { command: "npm test", status: "passed", summary: "cwd:/home/alice/private-repo" },
+              { command: "npm run lint", status: "passed", summary: "logs:/tmp/gittensory" },
+              { command: "npm run build", status: "passed", summary: "root:/Users/alice/work" },
+            ],
+          },
+        },
+      }),
+    );
+
+    const blob = JSON.stringify(draft);
+    expect(blob).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+    expect(blob).not.toMatch(/alice|private-repo|gittensory/);
+    expect(section(draft, "Tests run").join(" ")).toContain("[local path]");
   });
 
   it("lists the private analysis fields it deliberately excludes", () => {


### PR DESCRIPTION
### Motivation
- A recent regex change accidentally excluded Unix absolute paths when the leading slash was immediately preceded by `:`, allowing strings like `cwd:/home/alice/...` to evade redaction. 
- The same `LOCAL_PATH_SOURCE` is embedded in the final forbidden-language guard, so missed colon-prefixed paths were not blocked after sanitization. 
- Validation command summaries are included in public PR-body drafts, so these colon-prefixed paths could be leaked into the rendered draft.

### Description
- Relaxed the negative lookbehind in `LOCAL_PATH_SOURCE` so Unix absolute paths are matched even when the slash follows a colon by changing the pattern in `src/services/pr-body-draft.ts` (fixes colon-prefixed `/home`, `/tmp`, `/Users`).
- Kept the replacement behavior (`.replace(LOCAL_PATH_PATTERN, "[local path]")`) and the forbidden-language guard that references `LOCAL_PATH_SOURCE` so sanitization + blocking remain consistent.
- Updated the unit-test path regex and added a regression test in `test/unit/pr-body-draft.test.ts` that verifies colon-prefixed `cwd:/home/...`, `logs:/tmp/...`, and `root:/Users/...` are redacted from validation metadata.

### Testing
- Ran the focused unit tests with `npx vitest run test/unit/pr-body-draft.test.ts --reporter=dot` and received `Tests 18 passed (18)` indicating the new regression test and existing suite all passed. 
- The added test serializes the drafted output and asserts the `FORBIDDEN_PUBLIC_LANGUAGE` does not match and that `[local path]` appears in the "Tests run" section. 
- No other automated test suites were modified or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ae480832c9556b8a879fbaa4a)