### PR TITLE
fix(signals): keep bounty lifecycle findings private

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3925,6 +3925,7 @@ export function buildPublicPrIntelligenceComment(args: {
   const publicFindings = args.preflight.findings
     .filter((finding) => finding.severity !== "critical")
     .filter((finding) => args.settings.requireLinkedIssue || args.settings.linkedIssueGateMode !== "off" || finding.code !== "missing_linked_issue")
+    .filter((finding) => !isPrivateBountyLifecycleFinding(finding.code))
     .filter((finding) => !containsPrivatePublicTerm([finding.code, finding.title, finding.detail, finding.publicText, finding.action].filter(Boolean).join(" ")))
     .slice(0, args.settings.publicSignalLevel === "minimal" ? 2 : 5);
   const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
@@ -4524,6 +4525,10 @@ function formatCollisionItemRef(item: CollisionItem): string {
 
 function formatAlertBlock(lines: string[]): string[] {
   return lines.map((line) => (line.length > 0 ? `> ${line}` : ">"));
+}
+
+function isPrivateBountyLifecycleFinding(code: string): boolean {
+  return code === "linked_issue_bounty_historical" || code === "linked_issue_bounty_unverified";
 }
 
 function containsPrivatePublicTerm(value: string): boolean {

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -758,6 +758,50 @@ describe("world-class backend signals", () => {
     const ambiguousPreflight = buildPreflightResult({ repoFullName: repo.fullName, title: "Fix cache", body: "Fixes #7" }, repo, [openIssue], [], [ambiguousStatus]);
     expect(stalePreflight.findings.map((finding) => finding.code)).toContain("linked_issue_bounty_unverified");
     expect(ambiguousPreflight.findings.map((finding) => finding.code)).toContain("linked_issue_bounty_unverified");
+
+    const currentPr: PullRequestRecord = { ...pullRequests[0]!, body: "Fixes #7", linkedIssues: [7] };
+    const publicPreflight = buildPreflightResult({ repoFullName: repo.fullName, title: currentPr.title, body: currentPr.body ?? undefined, linkedIssues: [7] }, repo, [openIssue], [], [completed]);
+    const publicComment = buildPublicPrIntelligenceComment({
+      repo,
+      pr: currentPr,
+      profile: buildContributorProfile("oktofeesh1", { login: "oktofeesh1", topLanguages: ["TypeScript"], source: "github" }, [currentPr], []),
+      detection: { ...detectGittensorContributor("oktofeesh1", currentPr, [currentPr], []), detected: true, source: "official_gittensor_api", reason: "Official Gittensor API confirms this GitHub user." },
+      queueHealth: buildQueueHealth(repo, [openIssue], [currentPr], buildCollisionReport(repo.fullName, [openIssue], [currentPr])),
+      collisions: buildCollisionReport(repo.fullName, [openIssue], [currentPr]),
+      preflight: publicPreflight,
+      settings: {
+        repoFullName: repo.fullName,
+        commentMode: "all_prs",
+        publicAudienceMode: "gittensor_only",
+        publicSignalLevel: "standard",
+        checkRunMode: "off",
+        checkRunDetailLevel: "minimal",
+        gateCheckMode: "off",
+        gatePack: "gittensor",
+        linkedIssueGateMode: "advisory",
+        duplicatePrGateMode: "advisory",
+        qualityGateMode: "advisory",
+        slopGateMode: "off",
+        mergeReadinessGateMode: "off",
+        manifestPolicyGateMode: "off",
+        firstTimeContributorGrace: false,
+        slopAiAdvisory: false,
+        qualityGateMinScore: null,
+        autoLabelEnabled: true,
+        gittensorLabel: "gittensor",
+        createMissingLabel: true,
+        publicSurface: "comment_and_label",
+        includeMaintainerAuthors: false,
+        requireLinkedIssue: false,
+        backfillEnabled: true,
+        privateTrustEnabled: true,
+        aiReviewMode: "off",
+        aiReviewByok: false,
+      },
+    });
+    expect(publicPreflight.findings.map((finding) => finding.code)).toContain("linked_issue_bounty_historical");
+    expect(publicComment).not.toContain("Linked issue bounty is historical");
+    expect(publicComment).not.toContain("Issue #7 has a completed bounty");
   });
 
   it("includes linked PR validity when PR records are available", () => {


### PR DESCRIPTION
### Motivation

- Bounty lifecycle findings such as `linked_issue_bounty_historical` and `linked_issue_bounty_unverified` were being included in the public PR comment surface, which can disclose private reward/opportunity lifecycle signals. 
- The existing public-term sanitizer did not block bounty/lifecycle terminology, so a targeted PR could cause private bounty state to be visible to all GitHub viewers.

### Description

- Add a focused helper `isPrivateBountyLifecycleFinding(code: string)` in `src/signals/engine.ts` to identify bounty-lifecycle preflight finding codes. 
- Exclude bounty-lifecycle findings from the `publicFindings` selection in `buildPublicPrIntelligenceComment` by filtering with `!isPrivateBountyLifecycleFinding(finding.code)`. 
- Add a unit regression in `test/unit/signals.test.ts` that verifies bounty findings remain present in the internal `preflight` but are not rendered into the public comment text. 
- The change is minimal and preserves internal generation and scoring of bounty advisories while preventing their disclosure in public comments.

### Testing

- Ran `git diff --check` to validate no whitespace/format issues; result: success. 
- Ran type checking with `npm run typecheck` (`tsc --noEmit`); result: success. 
- Ran unit tests for the modified spec with `npx vitest run test/unit/signals.test.ts`; result: all tests in that file passed (30 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ab988832cb7d6bfb9f7081738)