### PR TITLE
Restrict weekly value report to operator role

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -14146,7 +14146,7 @@
               "example": "public"
             },
             "required": false,
-            "description": "Report variant. Operator reports require the operator app role.",
+            "description": "Report variant. Requires the operator app role because reports use deployment-wide analytics.",
             "name": "variant",
             "in": "query"
           },
@@ -14199,7 +14199,7 @@
             "description": "Unauthorized"
           },
           "403": {
-            "description": "Insufficient app role for requested report variant"
+            "description": "Operator app role required"
           }
         },
         "security": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1293,11 +1293,9 @@ export function createApp() {
   });
 
   app.get("/v1/app/analytics/weekly-value-report", async (c) => {
-    const variant = c.req.query("variant") === "operator" ? "operator" : "public";
-    const allowedRoles: ControlPanelRoleName[] =
-      variant === "operator" ? ["operator"] : ["miner", "maintainer", "owner", "operator"];
-    const forbidden = await requireAppRole(c, allowedRoles);
+    const forbidden = await requireAppRole(c, ["operator"]);
     if (forbidden) return forbidden;
+    const variant = c.req.query("variant") === "operator" ? "operator" : "public";
     const days = Math.max(1, Math.min(31, Number(c.req.query("days") ?? 7) || 7));
     const report = await loadWeeklyValueReport(c.env, { variant, days });
     if (c.req.query("format") === "markdown") {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -695,7 +695,7 @@ export function buildOpenApiSpec() {
       query: z.object({
         variant: z.enum(["public", "operator"]).optional().openapi({
           param: {
-            description: "Report variant. Operator reports require the operator app role.",
+            description: "Report variant. Requires the operator app role because reports use deployment-wide analytics.",
           },
           example: "public",
         }),
@@ -724,7 +724,7 @@ export function buildOpenApiSpec() {
         },
       },
       401: { description: "Unauthorized" },
-      403: { description: "Insufficient app role for requested report variant" },
+      403: { description: "Operator app role required" },
     },
   });
   registry.registerPath({

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2261,19 +2261,8 @@ describe("api routes", () => {
       ownerEnv,
     );
     expect(settingsForbidden.status).toBe(403);
-    const ownerWeeklyReport = await app.request("/v1/app/analytics/weekly-value-report", { headers: ownerHeaders }, ownerEnv);
-    expect(ownerWeeklyReport.status).toBe(200);
-    const ownerWeeklyReportBody = await ownerWeeklyReport.json();
-    expect(ownerWeeklyReportBody).toMatchObject({ variant: "public", publicSafe: true });
-    expect(ownerWeeklyReportBody).not.toHaveProperty("operatorDetails");
-    const ownerWeeklyReportMarkdown = await app.request("/v1/app/analytics/weekly-value-report?format=markdown", { headers: ownerHeaders }, ownerEnv);
-    expect(ownerWeeklyReportMarkdown.status).toBe(200);
-    expect(ownerWeeklyReportMarkdown.headers.get("content-type")).toContain("text/markdown");
-    const ownerWeeklyReportMarkdownText = await ownerWeeklyReportMarkdown.text();
-    expect(ownerWeeklyReportMarkdownText).toContain("# Weekly Gittensory value report");
-    expect(ownerWeeklyReportMarkdownText).toContain("## Maintainer trust");
-    expect(ownerWeeklyReportMarkdownText).not.toContain("## Operator detail");
-    expect(ownerWeeklyReportMarkdownText).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
+    expect((await app.request("/v1/app/analytics/weekly-value-report", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
+    expect((await app.request("/v1/app/analytics/weekly-value-report?format=markdown", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     expect((await app.request("/v1/app/analytics/weekly-value-report?variant=operator", { headers: ownerHeaders }, ownerEnv)).status).toBe(403);
     const ownerExtensionSession = await app.request("/v1/auth/extension/session", { method: "POST", headers: ownerHeaders }, ownerEnv);
     expect(ownerExtensionSession.status).toBe(201);


### PR DESCRIPTION
### Motivation
- The `/v1/app/analytics/weekly-value-report` endpoint previously defaulted to the `public` variant while loading deployment-wide analytics, which exposed cross-tenant operational and usage aggregates to non-operator roles. 
- The change closes the authorization boundary so that only operator sessions can fetch reports built from global rollup, registry, scoring, upstream drift, and product-usage data. 

### Description
- Require the `operator` app role up-front in the route handler before loading the weekly report to prevent non-operators from receiving deployment-wide analytics (`src/api/routes.ts`).
- Update integration coverage to assert owner sessions are denied access to the weekly report in both JSON and Markdown forms and for explicit `variant=operator` requests (`test/integration/api.test.ts`).
- Clarify the OpenAPI descriptions and 403 response text to document that the weekly value report requires operator access because it uses deployment-wide analytics (`src/openapi/spec.ts` and `apps/gittensory-ui/public/openapi.json`).

### Testing
- Ran the targeted test subset with `npm test -- --run test/integration/api.test.ts test/unit/openapi.test.ts` and the tests passed. 
- Ran the UI OpenAPI check with `npm run ui:openapi:check` and it succeeded. 
- The modified integration assertions verify that non-operator roles (owner) now receive `403` for the weekly report endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703d00b0832cb635d93c30c0bcd3)