### PR TITLE
fix(agent): keep public-safe packets free of private evidence

### DIFF
--- a/src/services/agent-orchestrator.ts
+++ b/src/services/agent-orchestrator.ts
@@ -599,7 +599,11 @@ function actionRecord(args: {
   payload: Record<string, JsonValue>;
   evidence?: RecommendationEvidence | undefined;
 }): AgentActionRecord {
-  const evidence = args.evidence ?? defaultRecommendationEvidence(args.actionType);
+  const safetyClass = args.safetyClass ?? "private";
+  const payload = { ...args.payload };
+  if (safetyClass !== "public_safe") {
+    payload.recommendationEvidence = (args.evidence ?? defaultRecommendationEvidence(args.actionType)) as unknown as JsonValue;
+  }
   const action: AgentActionRecord = {
     id: `${args.run.id}:${String(args.index).padStart(2, "0")}:${args.actionType}`,
     runId: args.run.id,
@@ -617,11 +621,8 @@ function actionRecord(args: {
     rerunWhen: args.rerunWhen,
     publicSafeSummary: sanitizePublicSummary(args.publicSafeSummary),
     approvalRequired: args.approvalRequired ?? true,
-    safetyClass: args.safetyClass ?? "private",
-    payload: {
-      ...args.payload,
-      recommendationEvidence: evidence as unknown as JsonValue,
-    },
+    safetyClass,
+    payload,
     createdAt: nowIso(),
   };
   return withAgentActionExplanationCard(action);

--- a/test/unit/agent-orchestrator.test.ts
+++ b/test/unit/agent-orchestrator.test.ts
@@ -836,6 +836,9 @@ describe("agent orchestrator", () => {
       freshness: "fresh",
       sources: expect.arrayContaining([expect.objectContaining({ name: "local_branch_metadata", source: "metadata_only" })]),
     });
+    expect(actions[1]).toMatchObject({ actionType: "prepare_pr_packet", safetyClass: "public_safe", approvalRequired: false });
+    expect(actions[1]?.payload.recommendationEvidence).toBeUndefined();
+    expect(JSON.stringify(actions[1]?.payload)).not.toMatch(/private score preview|score_preview|linked_issue_multiplier|scoreabilityStatus/i);
     expect(blockers[0]).toMatchObject({ status: "ready", recommendation: "No hard scoreability blocker is visible from local metadata." });
     expect(blockedActions.map((entry) => entry.actionType)).toEqual(["preflight_branch", "prepare_pr_packet", "explain_score_blockers"]);
     expect(blockedActions[0]?.scoreabilityImpact).toContain("scenario projections");
@@ -1044,6 +1047,8 @@ describe("agent orchestrator", () => {
     expect(preflight.actions.map((action) => action.actionType)).toEqual(expect.arrayContaining(["preflight_branch", "prepare_pr_packet"]));
     expect(packet.actions).toHaveLength(1);
     expect(packet.actions[0]).toMatchObject({ actionType: "prepare_pr_packet", safetyClass: "public_safe", approvalRequired: false });
+    expect(packet.actions[0]?.payload.recommendationEvidence).toBeUndefined();
+    expect(JSON.stringify(packet.actions[0]?.payload)).not.toMatch(/private score preview|score_preview|linked_issue_multiplier|scoreabilityStatus/i);
     expect(blockers.actions[0]).toMatchObject({ actionType: "explain_score_blockers", targetRepoFullName: "entrius/allways-ui" });
     expect(JSON.stringify(preflight.actions)).toContain("linked_issue_bounty_historical");
     expect(JSON.stringify(preflight.actions)).toContain("Source upload disabled");


### PR DESCRIPTION
### Motivation
- Prevent leakage of private scoreability/provenance metadata from agent actions labeled `public_safe` by ensuring recommendation evidence is not serialized into public-safe action payloads.

### Description
- Change `actionRecord` in `src/services/agent-orchestrator.ts` to only attach `payload.recommendationEvidence` when the action `safetyClass` is not `public_safe` (preserving evidence for private actions).
- Preserve existing `prepare_pr_packet` behavior as `public_safe` while removing attached `localBranchEvidence` from the returned public payload by making evidence injection conditional on `safetyClass`.
- Add unit assertions in `test/unit/agent-orchestrator.test.ts` to verify that `prepare_pr_packet` actions remain `public_safe` and that their `payload` does not include `recommendationEvidence` or private score terms.

### Testing
- Ran type checking with `npm run typecheck` which completed successfully.
- Ran the updated unit tests with `npx vitest run test/unit/agent-orchestrator.test.ts`, all tests passed (1 test file, 17 tests).
- Sanity checks (e.g., `git diff --check`) were run as part of validation and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ade28832caa3d9ce4c06d0b8f)