### PR TITLE
Fix extension pull-context audit attribution

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1501,7 +1501,7 @@ export function createApp() {
     const privateBlockers = buildExtensionPrivateBlockers(reviewability);
     await recordAuditEvent(c.env, {
       eventType: "extension.pull_context_view",
-      actor: contributor ?? "unknown",
+      actor: identity.actor,
       route: c.req.path,
       outcome: "success",
       metadata: {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -3431,6 +3431,13 @@ describe("api routes", () => {
     });
     expect(JSON.stringify(extensionPayload)).not.toMatch(/wallet|hotkey|coldkey|raw trust|private ranking|github_pat|ghp_|payout|reward estimate|farming/i);
 
+    const pullContextAudit = await env.DB.prepare(
+      "select actor from audit_events where event_type = ? and route = ? order by created_at desc limit 1",
+    )
+      .bind("extension.pull_context_view", "/v1/extension/pull-context")
+      .first<{ actor: string }>();
+    expect(pullContextAudit?.actor).toBe("oktofeesh1");
+
     const nonMinerExtensionContext = await app.request(
       "/v1/extension/pull-context?owner=entrius&repo=allways-ui&pullNumber=13",
       { headers: { authorization: `Bearer ${extensionSessionBody.token}` } },


### PR DESCRIPTION
### Motivation
- The `extension.pull_context_view` audit event was attributing `actor` to the PR contributor (derived from `pullRequest.authorLogin`) which allows an authenticated extension session holder to generate audit entries attributed to arbitrary PR authors and undermines audit-log integrity.
- The authenticated requester identity is already available as `identity` in the route and should be used as the audit actor to correctly reflect who viewed the private extension context.

### Description
- Update `src/api/routes.ts` to record the audit event with `actor: identity.actor` instead of `contributor ?? "unknown"` for `extension.pull_context_view`.
- Add an integration assertion in `test/integration/api.test.ts` that queries `audit_events` and expects the latest `extension.pull_context_view` row for the route `/v1/extension/pull-context` to have `actor` equal to the extension session holder login (`oktofeesh1`).
- Changes touch `src/api/routes.ts` and `test/integration/api.test.ts` to enforce and validate the correct audit attribution.

### Testing
- Ran the integration tests with `npm test -- test/integration/api.test.ts` and the suite passed (`1 file, 37 tests`), confirming the new assertion and related behavior succeeded.
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it succeeded with no errors.
- An attempt to run the test with `--runInBand` (`npm test -- test/integration/api.test.ts --runInBand`) failed due to the Vitest CLI not supporting that option, but the direct test invocation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703bbd10832c84056efecbf2085b)