### PR TITLE
fix: redact score deltas from public action cards

### DIFF
--- a/src/services/agent-action-explanation-card.ts
+++ b/src/services/agent-action-explanation-card.ts
@@ -7,7 +7,8 @@ type AgentActionExplanationInput = Pick<
 
 const BLOCKER_CATEGORY_ORDER: AgentActionBlockerCategory[] = ["branch", "account", "queue", "scoreability", "risk", "maintainer", "unknown"];
 const PUBLIC_FORBIDDEN_PATTERN =
-  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw[-_\s]?trust scores?|trust scores?|private reviewability|reviewability internals?|private scoreability|scoreability|public score estimates?|estimated scores?|score estimates?|score previews?|reward estimates?|payouts?|farming|reward optimization|private rankings?)\b/gi;
+  /\b(wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|raw[-_\s]?trust scores?|trust scores?|private reviewability|reviewability internals?|private scoreability|scoreability|projected scores?|score(?:d|s|ability)?|public score estimates?|estimated scores?|score estimates?|score previews?|reward estimates?|payouts?|farming|reward optimization|private rankings?)\b/gi;
+const PUBLIC_SCORE_DELTA_PATTERN = /\b(?:projected\s+)?score\w*(?:\s+\w+){0,4}\s+[-+]?\d+(?:\.\d+)?\s*->\s*[-+]?\d+(?:\.\d+)?\b/gi;
 const TOKEN_OR_PATH_PATTERN = /\bgithub_pat_[A-Za-z0-9_]+|\bgh[pousr]_[A-Za-z0-9_]+|\/Users\/\S+|\/home\/\S+|\/tmp\/\S+|[A-Z]:\\Users\\\S+/gi;
 
 export function withAgentActionExplanationCard(action: AgentActionRecord): AgentActionRecord {
@@ -118,6 +119,7 @@ function categorizeBlocker(blocker: string): AgentActionBlockerCategory {
 function sanitizePublicCardText(value: string): string {
   return compactText(value)
     .replace(TOKEN_OR_PATH_PATTERN, "<redacted>")
+    .replace(PUBLIC_SCORE_DELTA_PATTERN, "private context")
     .replace(PUBLIC_FORBIDDEN_PATTERN, "private context")
     .replace(/private context(?:[,\s]+private context)+/gi, "private context")
     .replace(/\s+([,.])/g, "$1")

--- a/test/unit/agent-orchestrator.test.ts
+++ b/test/unit/agent-orchestrator.test.ts
@@ -733,6 +733,15 @@ describe("agent orchestrator", () => {
       publicSafeSummary: "Cleanup existing PRs before asking for another review.",
       safetyClass: "public_safe",
     });
+    const publicPacket = buildAgentActionExplanationCard({
+      actionType: "prepare_pr_packet",
+      status: "ready",
+      why: ["A concise packet keeps public context focused on linked work."],
+      blockedBy: [],
+      rerunWhen: "Rerun after pending PRs merge/close or after open PR count is at or below 1; projected score changes 0.2 -> 0.7.",
+      publicSafeSummary: "Prepare public PR packet after validation completes.",
+      safetyClass: "public_safe",
+    });
 
     expect(recommended.summary).toMatch(/Pursue now/);
     expect(recommended.whyNow).toMatch(/deterministic planning signals/);
@@ -762,6 +771,9 @@ describe("agent orchestrator", () => {
     expect(cleanup.risk).toMatch(/increase stale or duplicate review pressure/);
     expect(cleanup.maintainerFriction).toMatch(/reduces queue noise/);
     expect(cleanup.expectedImpact).toMatch(/Lower active review pressure/);
+    expect(publicPacket.rerunWhen).toContain("projected score changes 0.2 -> 0.7");
+    expect(publicPacket.publicSafe.rerunWhen).not.toMatch(/score|0\.2|0\.7/i);
+    expect(publicPacket.publicSafe.rerunWhen).toMatch(/private context/);
   });
 
   it("covers local action ready and blocker-free branches from prepared metadata", () => {


### PR DESCRIPTION
### Motivation
- Public-safe explanation cards could leak private score-estimate deltas (e.g. `projected score changes 0.2 -> 0.7`) into `explanationCard.publicSafe.rerunWhen`, violating the public/private boundary for scoring signals.
- The existing sanitizer used a bespoke denylist that omitted bare `score` and score-delta patterns, so downstream clients could paste sensitive deltas into public contexts.

### Description
- Broadened the public forbidden pattern in `src/services/agent-action-explanation-card.ts` to catch additional bare score language and related terms by updating `PUBLIC_FORBIDDEN_PATTERN`.
- Added an explicit `PUBLIC_SCORE_DELTA_PATTERN` and apply it in `sanitizePublicCardText` before the generic forbidden-term pass so score-delta phrases like `projected score changes 0.2 -> 0.7` are redacted to `private context`.
- Added a unit regression in `test/unit/agent-orchestrator.test.ts` that builds a `prepare_pr_packet` explanation card containing a score delta and asserts the private card retains the raw delta while `publicSafe.rerunWhen` is redacted and does not contain numeric deltas or `score` tokens.

### Testing
- Ran `npm test -- test/unit/agent-orchestrator.test.ts` and the test file passed (17 tests passed).
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed with no errors.
- Ran `git diff --check` and local diff checks reported no trailing issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703b3fd0832cb5e894c3f319a0b5)