### PR TITLE
fix(check-runs): avoid private finding titles in check-run annotations

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -265,7 +265,7 @@ export function buildCheckRunAnnotations(
         path,
         1,
         severityToAnnotationLevel(finding.severity),
-        finding.title,
+        "Gittensory public finding",
         finding.publicText,
       );
     }

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -613,7 +613,8 @@ describe("advisory rules", () => {
     const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 14 }, "standard");
 
     expect(annotations.some((entry) => entry.annotation_level === "notice" && entry.title === "Possible duplicate overlap")).toBe(true);
-    expect(annotations.some((entry) => entry.annotation_level === "failure" && entry.title === "Issue discovery is disabled for this repo")).toBe(true);
+    expect(annotations.some((entry) => entry.annotation_level === "failure" && entry.title === "Gittensory public finding")).toBe(true);
+    expect(annotations.some((entry) => entry.title === "Issue discovery is disabled for this repo")).toBe(false);
     expect(annotations.some((entry) => entry.title === "Missing test evidence")).toBe(false);
   });
 
@@ -666,8 +667,10 @@ describe("advisory rules", () => {
     };
 
     const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 15 }, "deep");
-    expect(annotations.some((entry) => entry.annotation_level === "notice" && entry.title === "Configured lane")).toBe(true);
-    expect(annotations.some((entry) => entry.annotation_level === "warning" && entry.title === "Queue pressure")).toBe(true);
+    expect(annotations.some((entry) => entry.annotation_level === "notice" && entry.title === "Gittensory public finding")).toBe(true);
+    expect(annotations.some((entry) => entry.annotation_level === "warning" && entry.title === "Gittensory public finding")).toBe(true);
+    expect(annotations.some((entry) => entry.title === "Configured lane")).toBe(false);
+    expect(annotations.some((entry) => entry.title === "Queue pressure")).toBe(false);
     expect(annotations.some((entry) => entry.title === "   ")).toBe(false);
   });
 
@@ -750,7 +753,8 @@ describe("advisory rules", () => {
 
     expect(annotations.some((entry) => entry.title === "Missing test evidence")).toBe(false);
     expect(annotations.some((entry) => entry.title === "Possible duplicate overlap")).toBe(false);
-    expect(annotations.filter((entry) => entry.title === "Configured lane")).toHaveLength(2);
+    expect(annotations.filter((entry) => entry.title === "Gittensory public finding")).toHaveLength(2);
+    expect(annotations.some((entry) => entry.title === "Configured lane")).toBe(false);
   });
 
   it("buildCheckRunAnnotations deduplicates identical hotspot annotations", () => {


### PR DESCRIPTION
### Motivation
- Prevent leaking private/internal advisory titles into public GitHub check-run inline annotations by making annotation titles fail-closed while still showing vetted public messages.

### Description
- Replace use of the internal `finding.title` with a generic public-safe title (`"Gittensory public finding"`) when constructing inline check-run annotations in `src/rules/advisory.ts`.
- Preserve emission of the explicit `finding.publicText` as the annotation message and only emit annotations when `publicText` is present.
- Update unit tests in `test/unit/rules.test.ts` to assert the generic public title is used and that private/internal titles are not emitted.
- No changes to public output formatting beyond inline annotation titles and no type or API surface changes.

### Testing
- Ran `npx vitest run test/unit/rules.test.ts test/unit/github-app.test.ts` and all tests passed (53 tests across 2 files).
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded.
- Iterated with `npx vitest run test/unit/rules.test.ts` during development to validate the change and ensured the final full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703abf10832ca44502e34dcb3157)