### PR TITLE
fix(issues): require live write access for draft creation

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1969,6 +1969,10 @@ export function createApp() {
     if (parsed.data.create && parsed.data.dryRun !== false) {
       return c.json({ error: "explicit_create_requires_dry_run_false" }, 400);
     }
+    if (parsed.data.create && parsed.data.dryRun === false) {
+      const writeForbidden = await requireRepoWriteAccess(c, fullName);
+      if (writeForbidden instanceof Response) return writeForbidden;
+    }
     return c.json(
       await generateContributorIssueDrafts(c.env, fullName, {
         dryRun: parsed.data.dryRun,

--- a/test/unit/routes-contributor-issue-draft.test.ts
+++ b/test/unit/routes-contributor-issue-draft.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { createSessionForGitHubUser } from "../../src/auth/security";
-import { upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { getRepositoryCollaboratorPermission } from "../../src/github/app";
 import { createTestEnv } from "../helpers/d1";
 
 const DRAFTS_PATH = "/v1/repos/JSONbored/gittensory/contributor-issue-drafts/generate";
 const OWNED_REPO_PATH = "/v1/repos/repo-owner/owned-repo/contributor-issue-drafts/generate";
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  getRepositoryCollaboratorPermission: vi.fn(),
+}));
+const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
 
 function apiHeaders(env: Env): Record<string, string> {
   return {
@@ -35,6 +42,16 @@ async function seedRegisteredInstalledRepo(env: Env, installationId: number, own
 }
 
 describe("contributor-issue-drafts route auth", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  beforeEach(() => mockedPermission.mockReset());
+
+  function stubMinerFetch() {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes("gittensor.io")) return Response.json([]);
+      return new Response("not found", { status: 404 });
+    });
+  }
+
   it("rejects unauthenticated access", async () => {
     const app = createApp();
     const env = createTestEnv();
@@ -76,6 +93,39 @@ describe("contributor-issue-drafts route auth", () => {
       dryRun: true,
       drafts: expect.any(Array),
     });
+  });
+
+  it("requires live GitHub write permission before session issue creation", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "", GITTENSORY_CONTRIBUTOR_ISSUE_TOKEN: "service-token" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 5,
+      title: "cached collaborator scope",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "a1", ref: "f" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(
+      OWNED_REPO_PATH,
+      {
+        method: "POST",
+        headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ dryRun: false, create: true, limit: 1 }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
+    expect(mockedPermission).toHaveBeenCalledWith(env, 201, "repo-owner/owned-repo", "reader");
   });
 
   it("rejects cross-repo owner sessions with forbidden_repo", async () => {


### PR DESCRIPTION
### Motivation
- Prevent session callers from triggering real GitHub issue creation via a cached app role/scope check by enforcing a live repository write-permission check before any service-token-backed create operation.

### Description
- Add a live write-permission gate call to the contributor-issue-drafts generation route so that when `create: true` and `dryRun: false` the handler calls `requireRepoWriteAccess` and fails closed on insufficient permission (file: `src/api/routes.ts`).
- Add a unit test that seeds an installed repo and a cached PR-scoped collaborator, mocks the collaborator-permission check to return `read`, and asserts the POST create request is denied with `insufficient_repo_permission` (file: `test/unit/routes-contributor-issue-draft.test.ts`).
- Wire up necessary test mocks/stubs for deterministic behavior and reset them between tests; update imports in the modified test.

### Testing
- Ran the contributor-issue-draft route tests: `NO_COLOR=1 npx vitest run test/unit/routes-contributor-issue-draft.test.ts --reporter=verbose` — all tests passed.
- Ran a broader unit subset: `NO_COLOR=1 npx vitest run test/unit/contributor-issue-draft.test.ts test/unit/routes-ai-byok.test.ts test/unit/routes-focus-manifest.test.ts --reporter=verbose` — all tests passed.
- Ran project typecheck: `npm run typecheck` and a preflight diff check — no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703af270832c8abd677921fd40eb)