### PR TITLE
fix(api): require live write access for manifest refresh

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1888,14 +1888,8 @@ export function createApp() {
 
   app.post("/v1/repos/:owner/:repo/focus-manifest/refresh", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
-    if (forbidden) return forbidden;
-    const identity = await authenticateRequestIdentity(c);
-    const repo = await getRepository(c.env, fullName);
-    if (identity?.kind === "session") {
-      const repoForbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
-      if (repoForbidden) return repoForbidden;
-    }
+    const gate = await requireRepoWriteAccess(c, fullName);
+    if (gate instanceof Response) return gate;
     const manifest = await loadRepoFocusManifest(c.env, fullName, { refresh: true });
     return c.json({ repoFullName: fullName, manifest, policy: compileFocusManifestPolicy(manifest) });
   });

--- a/test/unit/routes-focus-manifest.test.ts
+++ b/test/unit/routes-focus-manifest.test.ts
@@ -154,11 +154,12 @@ describe("focus-manifest route auth", () => {
     expect(ownRepoGet.status).toBe(200);
   });
 
-  it("allows a same-repo owner session to POST focus-manifest refresh", async () => {
+  it("allows a same-repo owner session with GitHub write permission to POST focus-manifest refresh", async () => {
     const app = createApp();
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
     await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
     await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    mockedPermission.mockResolvedValue("write");
     const { token } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
     const { token: otherToken } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
 
@@ -171,6 +172,29 @@ describe("focus-manifest route auth", () => {
     const crossRepo = await app.request(`${OWNED_REPO_PATH}/refresh`, { method: "POST", headers: { cookie: `gittensory_session=${otherToken}` } }, env);
     expect(crossRepo.status).toBe(403);
     await expect(crossRepo.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("rejects focus-manifest refresh from sessions without live GitHub write permission", async () => {
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await upsertPullRequestFromGitHub(env, "repo-owner/owned-repo", {
+      number: 6,
+      title: "manifest docs",
+      state: "open",
+      user: { login: "reader" },
+      author_association: "COLLABORATOR",
+      head: { sha: "def456", ref: "docs" },
+      base: { ref: "main" },
+      labels: [],
+    });
+    mockedPermission.mockResolvedValue("read");
+    const { token } = await createSessionForGitHubUser(env, { login: "reader", id: 777 });
+
+    const response = await app.request(`${OWNED_REPO_PATH}/refresh`, { method: "POST", headers: { cookie: `gittensory_session=${token}` } }, env);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: "insufficient_repo_permission" });
   });
 
   it("allows operator sessions to access any repo focus manifest", async () => {


### PR DESCRIPTION
### Motivation

- The focus-manifest refresh route could persist repo policy using only cached control-panel role evidence, allowing sessions without live write privileges to change stored manifests.
- State-changing refresh must require a live GitHub write-level permission (admin/maintain/write) to prevent cached MEMBER/COLLABORATOR evidence from authorizing policy mutations.

### Description

- Gate the state-changing `POST /v1/repos/:owner/:repo/focus-manifest/refresh` endpoint with the existing `requireRepoWriteAccess` helper so callers must have live repo write-level permission before a refresh persists a manifest. 
- Preserve the stricter write check on `PUT /v1/repos/:owner/:repo/focus-manifest` to keep write-paths consistent.
- Add unit tests that assert a same-repo session with live GitHub `write` permission can refresh, and that a cached `COLLABORATOR` session with only `read` permission is rejected.

### Testing

- Ran `npm test -- --run test/unit/routes-focus-manifest.test.ts` and all route tests passed.
- Ran `npm test -- --run test/unit/focus-manifest-loader.test.ts` and loader tests passed.
- Ran `npm run typecheck` (`tsc --noEmit`) and typecheck succeeded.
- Ran `git diff --check` and there were no diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ae1c0832ca2480465ef3e05a3)