### PR TITLE
fix: avoid scenario summary crashes on public identifiers

### DIFF
--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -332,7 +332,11 @@ function sanitizeScenarioEntryPublic(entry: ScenarioSignalEntry): ScenarioSignal
 }
 
 function assertPublicScenarioSnapshotSafe(snapshot: PublicScenarioInputSnapshot): void {
-  const serialized = JSON.stringify(snapshot);
+  // Scan only sanitized narrative signal entries. Repo names, branch refs, and issue/PR state are
+  // structural identifiers that callers may legitimately name with protocol words such as
+  // "wallet" or "hotkey"; those identifiers must not make public rendering fail closed.
+  const { facts, assumptions, estimates, unavailableSignals } = snapshot;
+  const serialized = JSON.stringify({ facts, assumptions, estimates, unavailableSignals });
   /* v8 ignore start -- Public entries are sanitized before this guard; defensive check for future fields. */
   if (FORBIDDEN_PUBLIC_LANGUAGE.test(serialized)) {
     throw new Error("Public scenario serialization still contains forbidden language.");

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1571,6 +1571,29 @@ describe("local MCP git metadata collection", () => {
     );
   });
 
+  it("does not throw when branch analysis identifiers contain protocol terms", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: "wallet-tools/api",
+        branchName: "feature/wallet-ui",
+        baseRef: "hotkey-fix",
+        changedFiles: [{ path: "src/util.ts", additions: 20, deletions: 1, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 35, totalTokenScore: 55, sourceLines: 30 },
+      },
+      repo: { ...repo, fullName: "wallet-tools/api", owner: "wallet-tools", name: "api" },
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.scenarioSummary.repoFullName).toBe("wallet-tools/api");
+    expect(analysis.scenarioSummary.dataClassification.facts).toEqual(expect.arrayContaining(["Contributor", "Repository", "Branch"]));
+  });
+
   it("populates scenarioSummary.dataClassification with contributor and repo facts from branch metadata", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {

--- a/test/unit/scenario-input-model.test.ts
+++ b/test/unit/scenario-input-model.test.ts
@@ -175,6 +175,29 @@ describe("public vs private serialization", () => {
     expect(snapshot.branchState?.branchName).toBe("feat/x");
   });
 
+  it("allows public repo and branch identifiers that contain protocol terms", () => {
+    const snapshot = serializeScenarioInputPublic(
+      buildScenarioInput({
+        scenarioType: "branch_preflight",
+        repoFullName: "wallet-tools/api",
+        branchState: { branchName: "feature/wallet-ui", baseRef: "hotkey-fix" },
+        facts: [
+          createScenarioSignalEntry({
+            id: "branch",
+            kind: "fact",
+            label: "Branch",
+            detail: "Active branch feature/wallet-ui against hotkey-fix.",
+            source: "local_metadata",
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.repo.repoFullName).toBe("wallet-tools/api");
+    expect(snapshot.branchState).toMatchObject({ branchName: "feature/wallet-ui", baseRef: "hotkey-fix" });
+    expect(JSON.stringify(snapshot.facts)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  });
+
   it("keeps advisory-only flags in both serializations", () => {
     const input = completeInput();
     expect(serializeScenarioInputPublic(input)).toMatchObject({


### PR DESCRIPTION
### Motivation
- Fix an availability bug where defensive forbidden-language guards scanned entire serialized scenario snapshots and threw on benign public identifiers (e.g. repo or branch names containing protocol terms like "wallet" or "hotkey").
- The prior behavior caused `renderPublicScenarioSummary()` / `buildLocalBranchAnalysis()` to fail for caller-controlled metadata rather than return a normal advisory summary.

### Description
- Restrict `assertPublicScenarioSnapshotSafe()` to serialize only the sanitized narrative signal buckets (`facts`, `assumptions`, `estimates`, `unavailableSignals`) instead of the full snapshot, so structural identifiers (repo names, branch refs, PR/issue state) do not trigger the forbidden-language check. 
- Add a unit test in `test/unit/scenario-input-model.test.ts` that verifies `serializeScenarioInputPublic()` preserves public repo/branch identifiers containing protocol terms while sanitized narrative fields remain free of forbidden language. 
- Add a regression test in `test/unit/local-branch.test.ts` that exercises `buildLocalBranchAnalysis()` with `repoFullName`/`branchName`/`baseRef` values such as `wallet-tools/api`, `feature/wallet-ui`, and `hotkey-fix` to confirm summaries no longer throw.

### Testing
- Ran `npm test -- test/unit/scenario-input-model.test.ts test/unit/scenario-summary.test.ts test/unit/local-branch.test.ts` and all tests passed (test run: 3 files, 66 tests). 
- Ran the TypeScript checker with `npm run typecheck` (tsc --noEmit) and it completed successfully. 
- Verified there are no serialization/format check errors with `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ade9c832c9653c8527d304930)