### PR TITLE
Fix predicted gate public manifest loading

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -221,7 +221,7 @@ import { loadGatePrecisionReport } from "../services/gate-precision";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy } from "../signals/focus-manifest";
-import { loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
+import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
 import { buildRepoSettingsPreview, type PublicSurfaceSkipReason } from "../signals/settings-preview";
@@ -2471,7 +2471,7 @@ export function createApp() {
       listBountiesByRepo(c.env, parsed.data.repoFullName),
       getOrCreateScoringModelSnapshot(c.env),
       loadOrComputeIssueQualityResponse(c.env, parsed.data.repoFullName),
-      loadRepoFocusManifest(c.env, parsed.data.repoFullName),
+      loadPublicRepoFocusManifest(c.env, parsed.data.repoFullName),
     ]);
     const fit = buildContributorFit(context.profile, context.repositories, [], [], context.syncStates, context.repoStats);
     const scoringProfile = buildContributorScoringProfile({ login: parsed.data.login, fit, scoringSnapshot: snapshot });
@@ -2546,7 +2546,7 @@ export function createApp() {
       listBountiesByRepo(c.env, parsed.data.repoFullName),
       getOrCreateScoringModelSnapshot(c.env),
       loadOrComputeIssueQualityResponse(c.env, parsed.data.repoFullName),
-      loadRepoFocusManifest(c.env, parsed.data.repoFullName),
+      loadPublicRepoFocusManifest(c.env, parsed.data.repoFullName),
     ]);
     const fit = buildContributorFit(context.profile, context.repositories, [], [], context.syncStates, context.repoStats);
     const scoringProfile = buildContributorScoringProfile({ login: parsed.data.login, fit, scoringSnapshot: snapshot });

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -56,10 +56,32 @@ export async function loadRepoFocusManifest(
   repoFullName: string,
   options: { fetcher?: RepoFocusManifestFetcher; maxAgeMs?: number; refresh?: boolean } = {},
 ): Promise<FocusManifest> {
+  return loadRepoFocusManifestWithCachePolicy(env, repoFullName, options);
+}
+
+/**
+ * Load only the repo-published focus manifest. This intentionally ignores maintainer/API-backed
+ * records so contributor-facing previews cannot infer private gate policy while still benefiting
+ * from fresh public repo-file cache entries.
+ */
+export async function loadPublicRepoFocusManifest(
+  env: Env,
+  repoFullName: string,
+  options: { fetcher?: RepoFocusManifestFetcher; maxAgeMs?: number; refresh?: boolean } = {},
+): Promise<FocusManifest> {
+  return loadRepoFocusManifestWithCachePolicy(env, repoFullName, options, { publicOnly: true });
+}
+
+async function loadRepoFocusManifestWithCachePolicy(
+  env: Env,
+  repoFullName: string,
+  options: { fetcher?: RepoFocusManifestFetcher; maxAgeMs?: number; refresh?: boolean } = {},
+  cachePolicy: { publicOnly?: boolean } = {},
+): Promise<FocusManifest> {
   const fetcher = options.fetcher ?? fetchRepoFocusManifestFile;
   const maxAgeMs = options.maxAgeMs ?? REPO_FOCUS_MANIFEST_MAX_AGE_MS;
   if (!options.refresh) {
-    const cached = await readCachedManifest(env, repoFullName, maxAgeMs);
+    const cached = await readCachedManifest(env, repoFullName, maxAgeMs, cachePolicy);
     if (cached) return cached;
   }
   let manifest: FocusManifest;
@@ -145,7 +167,7 @@ export async function upsertRepoFocusManifest(env: Env, repoFullName: string, ra
   return manifest;
 }
 
-async function readCachedManifest(env: Env, repoFullName: string, maxAgeMs: number): Promise<FocusManifest | null> {
+async function readCachedManifest(env: Env, repoFullName: string, maxAgeMs: number, options: { publicOnly?: boolean } = {}): Promise<FocusManifest | null> {
   const [latest] = await listSignalSnapshots(env, REPO_FOCUS_MANIFEST_SIGNAL, repoFullName);
   if (!latest) return null;
   const manifest = parseFocusManifest(latest.payload);
@@ -153,6 +175,7 @@ async function readCachedManifest(env: Env, repoFullName: string, maxAgeMs: numb
     latest.payload !== null && typeof latest.payload === "object" && !Array.isArray(latest.payload)
       ? (latest.payload as Record<string, JsonValue>).source
       : undefined;
+  if (options.publicOnly && explicitSource !== "repo_file") return null;
   if (explicitSource === "api_record") return manifest;
   if (snapshotAgeMs(latest.generatedAt) > maxAgeMs) return null;
   return manifest;

--- a/test/unit/focus-manifest-loader.test.ts
+++ b/test/unit/focus-manifest-loader.test.ts
@@ -3,6 +3,7 @@ import { createTestEnv } from "../helpers/d1";
 import type { JsonValue } from "../../src/types";
 import {
   fetchRepoFocusManifestFile,
+  loadPublicRepoFocusManifest,
   loadRepoFocusManifest,
   loadRepoFocusManifests,
   upsertRepoFocusManifest,
@@ -85,6 +86,32 @@ describe("focus-manifest loader", () => {
     });
     expect(reloaded.wantedPaths).toEqual(["lib/"]);
     expect(reloaded.source).toBe("api_record");
+  });
+
+  it("ignores API-backed records when loading a public-only repo manifest", async () => {
+    const env = createTestEnv();
+    await upsertRepoFocusManifest(env, "owner/public-only", { wantedPaths: ["private/"], gate: { linkedIssue: "block", readinessMinScore: 99 } });
+
+    const manifest = await loadPublicRepoFocusManifest(env, "owner/public-only", {
+      fetcher: async () => JSON.stringify({ wantedPaths: ["src/"], gate: { linkedIssue: "advisory" } }),
+    });
+
+    expect(manifest.source).toBe("repo_file");
+    expect(manifest.wantedPaths).toEqual(["src/"]);
+    expect(manifest.gate.linkedIssue).toBe("advisory");
+    expect(manifest.gate.readinessMinScore).toBeNull();
+  });
+
+  it("falls back to safe public defaults when only an API-backed record exists", async () => {
+    const env = createTestEnv();
+    await upsertRepoFocusManifest(env, "owner/no-public-file", { gate: { linkedIssue: "block", readinessMinScore: 99 } });
+
+    const manifest = await loadPublicRepoFocusManifest(env, "owner/no-public-file", { fetcher: async () => null });
+
+    expect(manifest.present).toBe(false);
+    expect(manifest.source).toBe("none");
+    expect(manifest.gate.linkedIssue).toBeNull();
+    expect(manifest.gate.readinessMinScore).toBeNull();
   });
 
   it("bulk-loads manifests for many repos with a concurrency cap", async () => {


### PR DESCRIPTION
### Motivation
- The local pre-submission `predictedGate` used a cached focus manifest that could be an `api_record` (maintainer-supplied) snapshot, potentially exposing maintainer-only gate policy to contributors. 
- Contributor-facing routes must only use repository-published manifests (public `.gittensory.yml`) when predicting gate behavior so private overrides cannot be inferred. 
- The prediction result must still preserve parity with the real gate with respect to contributor confirmation status.

### Description
- Added `loadPublicRepoFocusManifest` and an internal `loadRepoFocusManifestWithCachePolicy` wrapper to load manifests with a cache policy that can exclude non-`repo_file` snapshots. 
- Updated `readCachedManifest` to accept a `publicOnly` option and return `null` when the cached snapshot is not `repo_file` and public-only is requested. 
- Switched contributor-facing routes (`POST /v1/local/branch-analysis` and `/v1/local/remediation-plan`) to call `loadPublicRepoFocusManifest` so `predictedGate` is computed from public repo files only, while maintainer paths keep using the original loader. 
- Preserved the confirmed-contributor parity by continuing to pass `confirmedContributor: Boolean(context.gittensorSnapshot)` into `buildPredictedGateVerdict`. 
- Added unit tests to cover ignoring API-backed manifests for public loads and falling back to safe public defaults when no public manifest exists (`test/unit/focus-manifest-loader.test.ts`).

### Testing
- Ran unit tests for the changed areas with `npx vitest run test/unit/focus-manifest-loader.test.ts test/unit/predicted-gate.test.ts`, and all tests passed. 
- Ran static type checking with `npm run typecheck` and it succeeded. 
- Verified no linter/diff issues with `git diff --check` (local verification command run as part of development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703b01a4832c99c00c4c791d1835)