### PR TITLE
fix(api): scrub public subnet descriptor wording

### DIFF
--- a/src/services/subnet-interface.ts
+++ b/src/services/subnet-interface.ts
@@ -9,13 +9,13 @@ const SUBNET_INTERFACE_SCHEMA_VERSION = "1.0";
 // Curated, contribution-relevant MCP tools surfaced to agents/devs who discover gittensor via metagraphed.
 // Names mirror src/mcp/server.ts registrations; the list is intentionally a miner-facing subset (not all 33).
 const CONTRIBUTION_MCP_TOOLS: ReadonlyArray<{ name: string; summary: string }> = [
-  { name: "gittensory_get_decision_pack", summary: "Rank high-fit, low-duplicate issues to contribute to across registered repos." },
+  { name: "gittensory_get_decision_pack", summary: "Surface contribution candidates across registered repos with duplicate-risk context." },
   { name: "gittensory_check_before_start", summary: "Check whether an issue is already claimed or solved before writing code." },
-  { name: "gittensory_validate_linked_issue", summary: "Confirm that linking an issue will earn the linked-issue scoring multiplier." },
+  { name: "gittensory_validate_linked_issue", summary: "Confirm whether a planned PR has a linked issue before opening it." },
   { name: "gittensory_preflight_pr", summary: "Preflight a planned PR for lane fit, duplicate risk, and review burden." },
   { name: "gittensory_monitor_open_prs", summary: "Track your open PRs and what to clean up first." },
   { name: "gittensory_list_notifications", summary: "See review feedback (e.g. changes requested) on your PRs." },
-  { name: "gittensory_agent_plan_next_work", summary: "Deterministically rank your next gittensor contribution actions." },
+  { name: "gittensory_agent_plan_next_work", summary: "Suggest useful next gittensor contribution actions from current repo and PR context." },
 ];
 
 const ONBOARDING_STEPS: ReadonlyArray<string> = [
@@ -65,7 +65,7 @@ export function buildSubnetInterfaceDescriptor(args: { origin: string; generated
       name: "Gittensory",
       role: "contribution_interface",
       site: GITTENSORY_SITE_URL,
-      summary: "Gittensor-native contribution quality & planning layer: deterministic signals for miners and a free anti-slop + AI second-opinion gate for maintainers.",
+      summary: "Gittensor-native contribution planning layer: MCP guidance for contributors and a free anti-slop + AI second-opinion gate for maintainers.",
     },
     interfaces: {
       mcp: {

--- a/test/unit/subnet-interface.test.ts
+++ b/test/unit/subnet-interface.test.ts
@@ -28,6 +28,6 @@ describe("buildSubnetInterfaceDescriptor", () => {
   it("defaults the upstream repo when not provided and contains no private/reward wording", () => {
     const descriptor = buildSubnetInterfaceDescriptor({ origin: "https://x.dev", generatedAt: "2026-06-14T00:00:00.000Z", appSlug: "gittensory" });
     expect(descriptor.subnet.upstreamRepo).toBe("entrius/gittensor");
-    expect(JSON.stringify(descriptor)).not.toMatch(/wallet|hotkey|reward|payout|trust score|scoreability|ranking/i);
+    expect(JSON.stringify(descriptor)).not.toMatch(/wallet|hotkey|reward|payout|earn|scoring|multiplier|trust score|scoreability|rank(?:ing)?/i);
   });
 });


### PR DESCRIPTION
### Motivation
- The unauthenticated `/v1/public/subnet-interface` descriptor exposed scoring/ranking language (e.g. `rank`, `earn`, `scoring multiplier`) which violates the project's public-safety policy and can enable gaming. 
- The descriptor was returned directly without sanitization and is reachable anonymously, so sensitive contribution-mechanics wording must be removed from any public surface. 
- The change keeps the descriptor usable for discovery while removing reward/scoreability signal words from public metadata.

### Description
- Reworded curated MCP tool summaries in `src/services/subnet-interface.ts` to remove ranking/scoring/multiplier mechanics and replace them with neutral, public-safe descriptions. 
- Reworded the provider `summary` in `src/services/subnet-interface.ts` to avoid miner/deterministic-signal phrasing on the public surface. 
- Tightened the unit test in `test/unit/subnet-interface.test.ts` to assert the descriptor JSON does not match the additional scoring/ranking terms reported by the scan. 
- Changes are minimal text edits and keep the original descriptor shape and endpoints intact.

### Testing
- Ran the targeted unit and integration checks with `npm test -- --run test/unit/subnet-interface.test.ts test/integration/subnet-interface.test.ts`, and the test run completed successfully with all tests passing. 
- The updated `buildSubnetInterfaceDescriptor` unit test validates normalization and the absence of the disallowed scoring/ranking terms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703d20d8832cba19a8976e6a7903)