### PR TITLE
fix(gate): run anti-slop blocking AI review for any author

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1100,9 +1100,11 @@ export function buildAiReviewDiff(files: Awaited<ReturnType<typeof listPullReque
 /**
  * Run the opt-in AI maintainer review and fold it into the gate + panel. Mutates `advisory.findings`
  * with a dual-model consensus defect (when `aiReviewMode: block` and the free Workers-AI pair agrees with
- * high confidence) so it can become a gate blocker BEFORE evaluateGateCheck runs — still confirmed-
- * contributor gated. Returns the advisory notes for the public panel. Fully fail-safe: disabled / not a
- * confirmed contributor / no head SHA / non-ok AI / any thrown error → no finding and no notes.
+ * high confidence) so it can become a gate blocker BEFORE evaluateGateCheck runs. The default `gittensor`
+ * pack keeps AI spend confirmed-contributor gated; `oss-anti-slop` may run the blocking review for any
+ * author because that pack is explicitly author-agnostic. Returns the advisory notes for the public panel.
+ * Fully fail-safe: disabled / ineligible author / no head SHA / non-ok AI / any thrown error → no finding
+ * and no notes.
  */
 export async function runAiReviewForAdvisory(
   env: Env,
@@ -1115,7 +1117,8 @@ export async function runAiReviewForAdvisory(
     confirmedContributor: boolean;
   },
 ): Promise<{ notes: string } | undefined> {
-  if (args.settings.aiReviewMode === "off" || !args.confirmedContributor || !args.advisory.headSha) return undefined;
+  const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
+  if (args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha) return undefined;
   try {
     // BYOK: decrypt the maintainer's provider key only when opted in. Falls back to free Workers AI when
     // no key is configured or the encryption secret is unavailable (getDecryptedRepositoryAiKey → null).

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -78,13 +78,27 @@ describe("runAiReviewForAdvisory", () => {
     expect(adv.findings).toEqual([]);
   });
 
-  it("no-ops for a non-confirmed contributor and when there is no head SHA", async () => {
+  it("no-ops for a non-confirmed contributor under the gittensor pack and when there is no head SHA", async () => {
     const env = aiEnv(async () => ({ response: defectJson() }));
-    const base = { settings: { aiReviewMode: "block" } as RepositorySettings, repoFullName: "acme/widgets", pr, author: "alice" };
+    const base = { settings: { aiReviewMode: "block", gatePack: "gittensor" } as RepositorySettings, repoFullName: "acme/widgets", pr, author: "alice" };
     expect(await runAiReviewForAdvisory(env, { ...base, advisory: advisory(), confirmedContributor: false })).toBeUndefined();
     const noSha = advisory();
     delete (noSha as Partial<Advisory>).headSha;
     expect(await runAiReviewForAdvisory(env, { ...base, advisory: noSha, confirmedContributor: true })).toBeUndefined();
+  });
+
+  it("runs a blocking AI review for a non-confirmed contributor under oss-anti-slop", async () => {
+    const adv = advisory();
+    const result = await runAiReviewForAdvisory(aiEnv(async () => ({ response: defectJson() })), {
+      settings: { aiReviewMode: "block", gatePack: "oss-anti-slop" } as RepositorySettings,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      confirmedContributor: false,
+    });
+    expect(adv.findings.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
+    expect(result?.notes).toContain("Likely crash.");
   });
 
   it("appends an ai_consensus_defect finding in block mode when the models agree", async () => {


### PR DESCRIPTION
### Motivation

- The `oss-anti-slop` policy pack is author-agnostic and should allow `aiReviewMode: "block"` to produce `ai_consensus_defect` findings for any author, but the AI review runner remained gated on the raw Gittensor `confirmedContributor` flag.

### Description

- Update `runAiReviewForAdvisory` in `src/queue/processors.ts` to allow the blocking AI review to run for non-confirmed authors when `settings.gatePack === "oss-anti-slop"` and `settings.aiReviewMode === "block"` by introducing `packAllowsAnyAuthorBlockingReview` and adjusting the early-return eligibility check.
- Clarify the function comment to document that `gittensor` keeps confirmed-contributor gating while `oss-anti-slop` may run blocking reviews for any author.
- Add a unit test in `test/unit/ai-review-advisory.test.ts` to assert that non-confirmed authors are skipped under the default `gittensor` pack and that non-confirmed authors receive a blocking `ai_consensus_defect` under `oss-anti-slop`.

### Testing

- Ran unit tests: `npm test -- test/unit/ai-review-advisory.test.ts test/unit/gate-check-policy.test.ts`, all tests passed (`2 files, 59 tests` passed).
- Ran static typecheck: `npm run typecheck` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703bbe90832cbb175826d78a465a)