### PR TITLE
fix(preflight): redact private rerun hints from PR packet

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1136,7 +1136,10 @@ function linkedIssueHygieneLines(branchEligibility: BranchEligibilityResult): st
 }
 
 function publicSafeRerunCondition(condition: string): string {
-  return /eligibility|multiplier|scoreability|score/i.test(condition) ? "Refresh linked issue and base branch metadata before submission." : condition;
+  if (/account\/queue maturity|pending PRs merge\/close|open PR count|projected score|threshold|eligibility|multiplier|scoreability|score/i.test(condition)) {
+    return "Rerun after any branch, base, or PR state changes before opening/submitting.";
+  }
+  return condition;
 }
 
 function branchFreshnessLines(freshness: LocalBranchAnalysis["baseFreshness"]): string[] {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1259,6 +1259,15 @@ describe("local branch analysis", () => {
     expect(analysis.workspaceIntelligence.blockers.branchQuality).toEqual([]);
     expect(analysis.workspaceIntelligence.blockers.accountState.length).toBeGreaterThan(0);
     expect(analysis.recommendedRerunCondition).toBe("Rerun after account/queue maturity blockers clear.");
+    expect(analysis.prPacket.markdown).not.toMatch(/account\/queue maturity|account-state|score|credibility|Open PR count/i);
+    expect(analysis.prPacket.bodySections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: "Next Steps",
+          lines: expect.arrayContaining(["- Rerun after any branch, base, or PR state changes before opening/submitting."]),
+        }),
+      ]),
+    );
     expect(analysis.nextActions[0]?.actionKind).not.toBe("land_existing_prs");
   });
 


### PR DESCRIPTION
### Motivation
- The public PR packet markdown could expose private account/queue maturity and scoreability hints such as open PR count and credibility, which violates the public/private separation for copy-paste PR text. 
- The change aims to keep account-state blockers available in internal analysis while preventing any private-derived rerun guidance from appearing in public PR text.

### Description
- Replace the public-facing sanitizer for rerun guidance by updating `publicSafeRerunCondition` in `src/signals/local-branch.ts` to map account/queue, pending-PR, open-PR-count, projected-score, threshold, eligibility, multiplier, and score-derived phrases to a generic public-safe instruction. 
- Ensure the generic string returned is `Rerun after any branch, base, or PR state changes before opening/submitting.` so private signals do not surface in the PR packet markdown. 
- Add regression assertions in `test/unit/local-branch.test.ts` that the produced `prPacket.markdown` does not contain account/queue maturity, account-state, score, credibility, or open PR count terms and that the `Next Steps` section contains the generic rerun line. 

### Testing
- Ran unit tests with `npx vitest run test/unit/local-branch.test.ts test/unit/redaction.test.ts` and all tests passed (`2 files passed`, `45 tests passed`).
- Ran type checking with `npm run typecheck` and `tsc --noEmit` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703b9b68832c9f9fa8597cae4944)