### PR TITLE
fix: validate active trusted publishing config

### DIFF
--- a/scripts/mcp-release-candidate-core.mjs
+++ b/scripts/mcp-release-candidate-core.mjs
@@ -1,4 +1,5 @@
 import { normalizeNewlines } from "./mcp-release-core.mjs";
+import YAML from "yaml";
 
 /**
  * Pure, deterministic checks for the MCP release-candidate dry-run.
@@ -108,9 +109,18 @@ export function checkTarball({ files, contentsByFile }) {
 export function checkTokenlessPublish(workflowYaml) {
   const yaml = String(workflowYaml ?? "");
   const issues = [];
-  if (!/id-token:\s*write/.test(yaml)) issues.push("publish job is missing 'id-token: write' for trusted publishing");
-  if (!/--provenance\b/.test(yaml)) issues.push("publish step is missing '--provenance'");
-  if (NPM_TOKEN_PATTERN.test(yaml)) issues.push("publish workflow references an npm auth token — trusted publishing must stay tokenless");
+  const workflow = parseWorkflowYaml(yaml);
+  const publishJobs = findPublishJobs(workflow);
+  if (publishJobs.length === 0) {
+    issues.push("publish workflow is missing an active 'npm publish' step");
+  }
+  if (publishJobs.some((job) => !hasIdTokenWrite(job.job?.permissions) && !hasIdTokenWrite(workflow?.permissions))) {
+    issues.push("publish job is missing 'id-token: write' for trusted publishing");
+  }
+  if (publishJobs.some((job) => job.publishRuns.some((run) => !hasEnabledProvenanceFlag(run)))) {
+    issues.push("publish step is missing '--provenance'");
+  }
+  if (NPM_TOKEN_PATTERN.test(JSON.stringify(workflow ?? {}))) issues.push("publish workflow references an npm auth token — trusted publishing must stay tokenless");
   const ok = issues.length === 0;
   return {
     ok,
@@ -120,6 +130,38 @@ export function checkTokenlessPublish(workflowYaml) {
       ? "Publish workflow uses tokenless trusted publishing (id-token + provenance, no npm token)."
       : `Publish workflow provenance/tokenless config needs attention — ${issues.join("; ")}.`,
   };
+}
+
+function parseWorkflowYaml(yaml) {
+  try {
+    const parsed = YAML.parse(yaml);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function findPublishJobs(workflow) {
+  return Object.values(workflow?.jobs ?? {})
+    .filter((job) => job && typeof job === "object")
+    .map((job) => ({
+      job,
+      publishRuns: (Array.isArray(job.steps) ? job.steps : [])
+        .map((step) => (step && typeof step === "object" ? String(step.run ?? "") : ""))
+        .filter((run) => /\bnpm(?:@[^\s]+)?\s+publish\b/.test(run)),
+    }))
+    .filter((job) => job.publishRuns.length > 0);
+}
+
+function hasIdTokenWrite(permissions) {
+  return permissions && typeof permissions === "object" && String(permissions["id-token"] ?? "").toLowerCase() === "write";
+}
+
+function hasEnabledProvenanceFlag(run) {
+  return run
+    .split(/\r?\n/)
+    .map((line) => line.replace(/(^|\s)#.*$/, ""))
+    .some((line) => /(^|\s)--provenance(?:\s|$)/.test(line));
 }
 
 const REMEDIATION = {

--- a/test/unit/mcp-release-candidate.test.ts
+++ b/test/unit/mcp-release-candidate.test.ts
@@ -23,7 +23,12 @@ const CHANGELOG = "# Changelog\n\n## mcp-v0.4.0 - 2026-06-02\n\n### Features\n- 
 const TOKENLESS_WORKFLOW = [
   "permissions:",
   "  contents: read",
-  "  id-token: write",
+  "jobs:",
+  "  publish:",
+  "    permissions:",
+  "      contents: read",
+  "      id-token: write",
+  "    steps:",
   "      - name: Publish with npm trusted publishing",
   "        run: npx -y npm@11.15.0 publish --workspace @jsonbored/gittensory-mcp --access public --provenance",
 ].join("\n");
@@ -106,8 +111,25 @@ describe("checkTokenlessPublish", () => {
   });
 
   it("fails when id-token or provenance is missing", () => {
-    expect(checkTokenlessPublish("permissions:\n  contents: read\n  run: npm publish --provenance").issues.join(" ")).toMatch(/id-token/);
-    expect(checkTokenlessPublish("permissions:\n  id-token: write\n  run: npm publish").issues.join(" ")).toMatch(/provenance/);
+    expect(checkTokenlessPublish("jobs:\n  publish:\n    steps:\n      - run: npm publish --provenance").issues.join(" ")).toMatch(/id-token/);
+    expect(checkTokenlessPublish("permissions:\n  id-token: write\njobs:\n  publish:\n    steps:\n      - run: npm publish").issues.join(" ")).toMatch(/provenance/);
+  });
+
+  it("ignores commented tokenless signals and disabled provenance flags", () => {
+    const invalid = [
+      "permissions:",
+      "  contents: read",
+      "  # id-token: write",
+      "jobs:",
+      "  publish:",
+      "    steps:",
+      "      # npm publish --provenance",
+      "      - run: npm publish --provenance=false",
+    ].join("\n");
+    const result = checkTokenlessPublish(invalid);
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toMatch(/id-token/);
+    expect(result.issues.join(" ")).toMatch(/provenance/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Remediate a false-positive in the release-candidate trusted-publishing check which used raw text regexes and could be bypassed by commented or disabled `id-token`/`--provenance` occurrences.

### Description
- Parse the publish workflow YAML with `yaml` instead of scanning raw text and locate active `npm publish` steps. 
- Require at least one active publish job and verify effective `id-token: write` is present on the job or workflow permissions. 
- Validate that publish `run` commands include an enabled `--provenance` flag while ignoring commented lines and disabled flags like `--provenance=false`. 
- Add helper functions for YAML parsing, publish-job discovery, permission checks, and update unit tests to cover commented/disabled signal regressions.

### Testing
- Ran `npx vitest run test/unit/mcp-release-candidate.test.ts` and the targeted test file passed (19 tests). 
- Running the broader `npm run test:unit -- test/unit/mcp-release-candidate.test.ts` invocation encountered unrelated timeouts in other unit tests, while the targeted file itself passed when run directly. 
- Invoked the checker with `node` against `.github/workflows/npm-publish.yml` and observed the expected `ok: true` result for the current correct workflow. 
- Added regression assertions that commented `id-token` lines and disabled `--provenance=false` do not satisfy the validator and those assertions pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703b4810832cbafb9570f14890d5)