### PR TITLE
fix(queue): avoid duplicate miner unavailable skip audit

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1317,8 +1317,7 @@ async function maybePublishPrPublicSurface(
       await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
       if (!gateEnabled) return;
       publicSurfaceSkipped = true;
-    }
-    if (requireOfficialMiner && official.status !== "confirmed") {
+    } else if (requireOfficialMiner && official.status !== "confirmed") {
       await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
       if (!gateEnabled) return;
       publicSurfaceSkipped = true;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1236,6 +1236,73 @@ describe("queue processors", () => {
     expect(audit?.detail).toBe("not_official_gittensor_miner");
   });
 
+  it("keeps gate checks without double-auditing unavailable miner detection as not official", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicAudienceMode: "gittensor_only",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "block",
+    });
+
+    const calls = { minerList: 0, gateChecks: 0, comments: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") {
+        calls.minerList += 1;
+        return new Response("gittensor unavailable", { status: 503 });
+      }
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gateunavailable123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/issues/55/comments")) {
+        calls.comments += 1;
+        return Response.json([]);
+      }
+      if (url.includes("/check-runs") && method === "POST") {
+        calls.gateChecks += 1;
+        return Response.json({ id: 921 }, { status: 201 });
+      }
+      if (url.includes("/check-runs/921") && method === "PATCH") {
+        calls.gateChecks += 1;
+        return Response.json({ id: 921 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { linkedIssue: "block" } });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-unavailable-miner-public-skip",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 55, title: "Unavailable miner PR", state: "open", user: { login: "newbie" }, head: { sha: "gateunavailable123" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    expect(calls).toEqual({ minerList: 1, gateChecks: 2, comments: 0 });
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = ? and target_key = ? order by id")
+      .bind("github_app.pr_visibility_skipped", "JSONbored/gittensory#55")
+      .all<{ detail: string }>();
+    expect(audit.results.map((event) => event.detail)).toEqual(["miner_detection_unavailable"]);
+  });
+
   it("hard-blocks a confirmed Gittensor contributor in a gate-only configuration when a configured blocker fires", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(


### PR DESCRIPTION
### Motivation
- Fix an audit/data-quality bug where `official.status === "unavailable"` could be recorded as both `miner_detection_unavailable` and `not_official_gittensor_miner` when gate checks were enabled, producing misleading duplicate visibility-skip records.

### Description
- Change the miner-detection branching in `maybePublishPrPublicSurface` so the `not_official_gittensor_miner` path is `else if` and does not execute when the status is `"unavailable"` in `src/queue/processors.ts`.
- Add a regression test `keeps gate checks without double-auditing unavailable miner detection as not official` to `test/unit/queue.test.ts` that stubs the Gittensor API to return 503, verifies gate checks still run, and asserts only `miner_detection_unavailable` is audited.

### Testing
- Ran the targeted unit test with `npx vitest run test/unit/queue.test.ts --reporter=verbose -t "unavailable miner detection"`, which passed (1 passed, 77 skipped).
- Ran the TypeScript typecheck with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703ae02c832cb17034fc04147fe1)