### PR TITLE
Fix public scenario reward/ranking sanitization

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1488,9 +1488,9 @@ export function sanitizePublicComment(value: string): string {
   const sanitized = value
     .replace(/\bprojected score changes?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\b(raw trust score|trust score|wallet|hotkey|coldkey|seed phrase|mnemonic)\b/gi, "private context")
-    .replace(/\b(public score estimate|estimated score|score estimate|reward estimates?|payout|farming|scoreability|score preview|projected score changes?)\b/gi, "private context")
+    .replace(/\b(public score estimate|estimated score|score estimate|estimated rewards?|rewards?|reward estimates?|payout|farming|scoreability|score preview|projected score changes?)\b/gi, "private context")
     .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
-    .replace(/\b(private ranking|private rankings)\b/gi, "private context")
+    .replace(/\b(private rankings?|rankings?)\b/gi, "private context")
     .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only)\b/gi, "private context")
     .replace(/\b(?:credibility(?: updates?)?|closed pr credibility|low credibility|open pr pressure)\b/gi, "private context")
     .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");

--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -30,7 +30,7 @@ export const scenarioSignalSources = [
 export type ScenarioSignalSource = (typeof scenarioSignalSources)[number];
 
 const FORBIDDEN_PUBLIC_LANGUAGE =
-  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward[-\s]?estimate|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
+  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|estimated[-\s]?rewards?|rewards?|reward[-\s]?estimate|rankings?|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
 
 const FORBIDDEN_SOURCE_UPLOAD_KEYS =
   /^(?:sourceContent|sourceContents|fileContent|fileContents|rawSource|rawSourceContent|content|contents|diff|patch|rawDiff)$/i;

--- a/test/unit/scenario-input-model.test.ts
+++ b/test/unit/scenario-input-model.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../src/scenarios/input-model";
 
 const FORBIDDEN_PUBLIC_LANGUAGE =
-  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward[-\s]?estimate|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
+  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|estimated[-\s]?rewards?|rewards?|reward[-\s]?estimate|rankings?|farming|raw trust|trust[-\s]?score|scoreability|private[-\s]?reviewability|public[-\s]?score[-\s]?(?:estimate|prediction)/i;
 
 function completeInput() {
   return buildScenarioInput({
@@ -147,6 +147,26 @@ describe("public vs private serialization", () => {
 
     const privateSnapshot = serializeScenarioInputPrivate(input);
     expect(privateSnapshot.assumptions[0]?.detail).toMatch(/trust score/i);
+  });
+
+  it("sanitizes reward and ranking language in estimate snapshots", () => {
+    const input = buildScenarioInput({
+      scenarioType: "general_repo",
+      repoFullName: "octo/demo",
+      estimates: [
+        createScenarioSignalEntry({
+          id: "sensitive_estimate",
+          kind: "estimate",
+          label: "Estimated rewards ranking",
+          detail: "estimated rewards place this contributor in the top ranking and rankings table",
+          source: "gittensory_projection",
+        }),
+      ],
+    });
+
+    const serialized = JSON.stringify(serializeScenarioInputPublic(input));
+    expect(serialized).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+    expect(serialized).toMatch(/private context/i);
   });
 
   it("omits optional state sections when not provided", () => {
@@ -302,6 +322,10 @@ describe("invariants", () => {
       "public score estimate",
       "private reviewability",
       "farming loop",
+      "estimated rewards",
+      "rewards",
+      "ranking",
+      "rankings",
     ];
     for (const sample of samples) {
       const input = buildScenarioInput({


### PR DESCRIPTION
### Motivation
- The public scenario serializer could emit sensitive reward/ranking phrasing because the sanitizer and defensive forbidden-language regex omitted variants like “estimated rewards”, “rewards”, “ranking”, and “rankings”.

### Description
- Expand `sanitizePublicComment` patterns to redact generic reward and ranking language so entry `label`/`detail` are normalized to "private context" when matched. (changes in `src/github/commands.ts`)
- Extend the module-level `FORBIDDEN_PUBLIC_LANGUAGE` defensive regex to include the newly-covered reward/ranking variants so any surviving terms cause the public-serialization guard to fail closed. (changes in `src/scenarios/input-model.ts`)
- Add a regression test that exercises an `estimate` entry containing reward/ranking wording and extend the public-serialization sample list to include the new variants. (changes in `test/unit/scenario-input-model.test.ts`)

### Testing
- Ran the unit tests with `npx vitest run test/unit/scenario-input-model.test.ts`, and all tests passed (`16 passed`).
- Ran formatting and checks (`prettier --check` and project checks) and fixed style issues so checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703beb48832c8cb573bd4f9ca728)