### PR TITLE
fix(decision-pack): include rejected recommendation feedback

### DIFF
--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -230,6 +230,7 @@ export type RepoRecommendationOutcomeFeedback = {
   positive: number;
   negative: number;
   merged: number;
+  rejected: number;
   closed: number;
   stale: number;
   ignored: number;
@@ -1027,6 +1028,7 @@ function summarizeRecommendationOutcomeFeedback(feedback: AgentRecommendationOut
     positive: feedback.positive,
     negative: feedback.negative,
     merged: feedback.merged,
+    rejected: feedback.rejected,
     closed: feedback.closed,
     stale: feedback.stale,
     ignored: feedback.ignored,
@@ -1043,7 +1045,7 @@ function recommendationFeedbackWhyThisHelps(feedback: RepoRecommendationOutcomeF
 
 function recommendationFeedbackRiskReasons(feedback: RepoRecommendationOutcomeFeedback | undefined): string[] {
   if (!feedback || feedback.negative === 0) return [];
-  return [`Private recommendation feedback has ${feedback.negative} unresolved or negative contributor-lane outcome(s) for this repo (${feedback.closed} closed, ${feedback.stale} stale, ${feedback.ignored} ignored).`];
+  return [`Private recommendation feedback has ${feedback.negative} unresolved or negative contributor-lane outcome(s) for this repo (${feedback.rejected} rejected, ${feedback.closed} closed, ${feedback.stale} stale, ${feedback.ignored} ignored).`];
 }
 
 function recommendationOutcomePriorityAdjustment(feedback: RepoRecommendationOutcomeFeedback | undefined): number {

--- a/test/unit/decision-pack.test.ts
+++ b/test/unit/decision-pack.test.ts
@@ -223,7 +223,7 @@ describe("decision-pack service", () => {
       },
     });
 
-    expect(decision.recommendationOutcomeFeedback).toMatchObject({ signal: "positive", positive: 3, negative: 1, maintainerLaneTotal: 2 });
+    expect(decision.recommendationOutcomeFeedback).toMatchObject({ signal: "positive", positive: 3, rejected: 0, negative: 1, maintainerLaneTotal: 2 });
     expect(decision.priorityScore).toBeGreaterThan(baseline.priorityScore);
     expect(decision.whyThisHelps.some((line) => line.includes("Private recommendation feedback"))).toBe(true);
     expect(decision.riskReasons.some((line) => line.includes("Private recommendation feedback"))).toBe(true);
@@ -244,11 +244,11 @@ describe("decision-pack service", () => {
         repoFullName: "owner/direct",
         total: 6,
         accepted: 0,
-        rejected: 0,
+        rejected: 2,
         ignored: 2,
-        stale: 2,
+        stale: 1,
         merged: 0,
-        closed: 2,
+        closed: 1,
         improved: 0,
         positive: 0,
         negative: 6,
@@ -280,7 +280,9 @@ describe("decision-pack service", () => {
     });
 
     expect(negative.priorityScore).toBeLessThan(baseline.priorityScore);
+    expect(negative.recommendationOutcomeFeedback).toMatchObject({ negative: 6, rejected: 2, closed: 1, stale: 1, ignored: 2 });
     expect(negative.riskReasons.join(" ")).toMatch(/6 unresolved or negative/);
+    expect(negative.riskReasons.join(" ")).toContain("2 rejected, 1 closed, 1 stale, 2 ignored");
     expect(negative.whyThisHelps.some((line) => line.includes("Private recommendation feedback"))).toBe(false);
     expect(mixed.priorityScore).toBeLessThan(baseline.priorityScore);
     expect(mixed.riskReasons.join(" ")).toMatch(/2 unresolved or negative/);


### PR DESCRIPTION
### Motivation
- The repo-level outcome summaries began counting a new `rejected` outcome but the decision-pack projection omitted it, causing negative totals to list counts without the rejected breakdown and producing misleading private guidance.

### Description
- Add a `rejected: number` field to the `RepoRecommendationOutcomeFeedback` projection so consumers receive the rejected count.
- Thread `feedback.rejected` through `summarizeRecommendationOutcomeFeedback` so repo summaries preserve the rejected value.
- Include `rejected` in the private negative feedback explanation text so the risk message lists rejected along with closed/stale/ignored counts.
- Update unit tests in `test/unit/decision-pack.test.ts` to assert the rejected count is preserved and appears in the risk explanation.

### Testing
- Ran `git diff --check` to verify no whitespace/errors were introduced and it succeeded.
- Ran `npx vitest run test/unit/decision-pack.test.ts test/unit/recommendation-outcomes.test.ts --reporter=dot` and all tests passed (`Test Files 2 passed`, `Tests 56 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34703b6fc8832c8159cdeb63e5383b)