### PR TITLE
fix(github-app): guard AI slop advisory by slop gate

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1030,6 +1030,10 @@ export function shouldCollectSlopEvidence(settings: Pick<RepositorySettings, "sl
   return settings.slopGateMode !== "off" || mergeReadinessGateEnabled(settings);
 }
 
+export function shouldRunSlopAiAdvisory(settings: Pick<RepositorySettings, "slopAiAdvisory" | "slopGateMode">): boolean {
+  return settings.slopAiAdvisory && settings.slopGateMode !== "off";
+}
+
 function shouldProcessPullRequestPublicSurface(action: string | undefined): boolean {
   return PR_PUBLIC_SURFACE_ACTIONS.has(action ?? "") || PR_GATE_CLOSED_ACTIONS.has(action ?? "");
 }
@@ -1420,7 +1424,7 @@ async function maybePublishPrPublicSurface(
       await updatePullRequestSlopAssessment(env, repoFullName, pr.number, { slopRisk: slop.slopRisk, slopBand: slop.band }).catch(() => undefined);
       // AI-assisted slop advisory (#533, opt-in). Reuses the already-fetched files; appends at most one
       // advisory-only finding. Deliberately does NOT update slopRisk — only the deterministic core blocks.
-      if (settings.slopAiAdvisory) {
+      if (shouldRunSlopAiAdvisory(settings)) {
         await runAiSlopForAdvisory(env, { settings, advisory, repoFullName, pr, author, files: slopFiles, deterministicBand: slop.band, confirmedContributor });
       }
     }

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { gateCheckPolicy, shouldCollectLinkedIssueEvidence, shouldCollectSlopEvidence } from "../../src/queue/processors";
+import { gateCheckPolicy, shouldCollectLinkedIssueEvidence, shouldCollectSlopEvidence, shouldRunSlopAiAdvisory } from "../../src/queue/processors";
 import { evaluateGateCheck } from "../../src/rules/advisory";
 import { parseFocusManifest, resolveEffectiveSettings } from "../../src/signals/focus-manifest";
 import type { Advisory, RepositorySettings } from "../../src/types";
@@ -202,6 +202,13 @@ describe("merge-readiness evidence collection (#551)", () => {
     expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "block" }))).toBe(true);
     expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "advisory" }))).toBe(true);
     expect(shouldCollectSlopEvidence(settings({ slopGateMode: "off", mergeReadinessGateMode: "off" }))).toBe(false);
+  });
+
+  it("runs AI slop advisory only when the slop gate is explicitly enabled", () => {
+    expect(shouldRunSlopAiAdvisory(settings({ slopGateMode: "advisory", slopAiAdvisory: true }))).toBe(true);
+    expect(shouldRunSlopAiAdvisory(settings({ slopGateMode: "block", slopAiAdvisory: true }))).toBe(true);
+    expect(shouldRunSlopAiAdvisory(settings({ slopGateMode: "off", mergeReadinessGateMode: "advisory", slopAiAdvisory: true }))).toBe(false);
+    expect(shouldRunSlopAiAdvisory(settings({ slopGateMode: "advisory", slopAiAdvisory: false }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- A recent change broadened `shouldCollectSlopEvidence` to include merge-readiness, which unintentionally allowed the AI-assisted slop advisory to run even when `slopGateMode` is `off`, violating the documented consent boundary. 
- The intent is to keep deterministic slop evidence collection for aggregate merge-readiness while ensuring AI advisory runs only when the repository has explicitly opted the slop gate on and AI advisory enabled.

### Description
- Add a new helper `shouldRunSlopAiAdvisory(settings)` that returns `settings.slopAiAdvisory && settings.slopGateMode !== "off"` to express the AI consent boundary. 
- Replace the previous `if (settings.slopAiAdvisory)` guard with `if (shouldRunSlopAiAdvisory(settings))` before calling `runAiSlopForAdvisory` in `src/queue/processors.ts`. 
- Leave `shouldCollectSlopEvidence` unchanged so deterministic evidence collection remains available to merge-readiness. 
- Add a regression test `runs AI slop advisory only when the slop gate is explicitly enabled` in `test/unit/gate-check-policy.test.ts` and export the new helper for testing.

### Testing
- Ran `npm test -- --run test/unit/gate-check-policy.test.ts` and the test file completed successfully (all tests passed). 
- Ran `npm run typecheck` (`tsc --noEmit`) and the TypeScript typecheck passed without errors. 
- Also validated the targeted unit test asserts the new `shouldRunSlopAiAdvisory` behavior for combinations of `slopGateMode`, `mergeReadinessGateMode`, and `slopAiAdvisory` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3476a277bc832c883d20afe5347f38)