### PR TITLE
fix(ai-review): restrict BYOK to confirmed contributors

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1168,11 +1168,11 @@ export async function runAiReviewForAdvisory(
   const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
   if (args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha) return undefined;
   try {
-    // BYOK: decrypt the maintainer's provider key only when opted in. Falls back to free Workers AI when
+    // BYOK: decrypt the maintainer's provider key only for confirmed contributors when opted in. Falls back to free Workers AI when
     // no key is configured or the encryption secret is unavailable (getDecryptedRepositoryAiKey → null).
     // Apply config-as-code provider/model: a declared provider must match the stored key's provider (else
     // skip BYOK → Workers-AI fallback); a declared model overrides the stored/default model.
-    const storedKey = args.settings.aiReviewByok ? await getDecryptedRepositoryAiKey(env, args.repoFullName) : null;
+    const storedKey = args.confirmedContributor && args.settings.aiReviewByok ? await getDecryptedRepositoryAiKey(env, args.repoFullName) : null;
     const providerKey =
       storedKey && (!args.settings.aiReviewProvider || args.settings.aiReviewProvider === storedKey.provider)
         ? { provider: storedKey.provider, key: storedKey.key, model: args.settings.aiReviewModel ?? storedKey.model }

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -156,6 +156,35 @@ describe("runAiReviewForAdvisory", () => {
     expect(result).toBeUndefined();
   });
 
+  it("does not use the maintainer's BYOK key for non-confirmed oss-anti-slop blocking reviews", async () => {
+    const run = vi.fn(async () => ({ response: defectJson() }));
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+      TOKEN_ENCRYPTION_SECRET: "advisory-test-encryption-secret-32bytes",
+    });
+    await upsertRepositoryAiKey(env, { repoFullName: "acme/widgets", provider: "anthropic", key: "sk-ant-byok-key-9999", model: null });
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: notesOnlyJson() }] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const adv = advisory();
+
+    const result = await runAiReviewForAdvisory(env, {
+      settings: { aiReviewMode: "block", gatePack: "oss-anti-slop", aiReviewByok: true } as RepositorySettings,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      confirmedContributor: false,
+    });
+
+    expect(result?.notes).toContain("Likely crash.");
+    expect(adv.findings.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+  });
+
   it("uses the maintainer's BYOK provider key when aiReviewByok is on and a key is configured", async () => {
     const env = createTestEnv({
       AI: { run: async () => ({ response: notesOnlyJson() }) } as unknown as Ai,


### PR DESCRIPTION
### Motivation
- An oss-anti-slop/block change allowed unconfirmed PR authors to enter the AI review path while still decrypting and using the maintainer BYOK provider key, which lets untrusted contributors consume BYOK quota and provider billing.
- The intent is to keep the free blocking Workers-AI review available for any author under `oss-anti-slop` while preventing unconfirmed contributors from using maintainer-paid BYOK resources.

### Description
- Change `runAiReviewForAdvisory` in `src/queue/processors.ts` so the repository BYOK key is only decrypted/used when `args.confirmedContributor` is true and `aiReviewByok` is enabled. (Only confirmed contributors may trigger BYOK provider calls.)
- Preserve the existing `oss-anti-slop` behavior so unconfirmed authors can still run the free blocking consensus review (Workers AI) without access to maintainer BYOK keys.
- Add a regression test `does not use the maintainer's BYOK key for non-confirmed oss-anti-slop blocking reviews` in `test/unit/ai-review-advisory.test.ts` to assert that unconfirmed `oss-anti-slop` block reviews call Workers AI and do not invoke the BYOK provider.

### Testing
- Ran the focused unit tests with `npm test -- --run test/unit/ai-review-advisory.test.ts` and the test file passed (all tests in that file succeeded).
- Ran the TypeScript check with `npm run typecheck` (`tsc --noEmit`) and it completed without errors.
- Verified repository checks with `git diff --check` and there were no whitespace/check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34dd036ab0832cbd2057fdb96039b7)