### PR TITLE
fix: avoid public manifest cache poisoning

### DIFF
--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -94,10 +94,12 @@ async function loadRepoFocusManifestWithCachePolicy(
   } catch {
     manifest = parseFocusManifest(null);
   }
-  // Persist even an ABSENT manifest (negative cache): effective settings are resolved from
-  // `.gittensory.yml` on every webhook, so a repo without one must not re-fetch the raw file each time.
-  // The TTL still refreshes it, so a newly-added manifest is picked up on the next window.
-  await persistRepoFocusManifest(env, repoFullName, manifest);
+  if (!cachePolicy.publicOnly) {
+    // Persist even an ABSENT manifest (negative cache): effective settings are resolved from
+    // `.gittensory.yml` on every webhook, so a repo without one must not re-fetch the raw file each time.
+    // The TTL still refreshes it, so a newly-added manifest is picked up on the next window.
+    await persistRepoFocusManifest(env, repoFullName, manifest);
+  }
   return manifest;
 }
 

--- a/test/unit/focus-manifest-loader.test.ts
+++ b/test/unit/focus-manifest-loader.test.ts
@@ -114,6 +114,29 @@ describe("focus-manifest loader", () => {
     expect(manifest.gate.readinessMinScore).toBeNull();
   });
 
+  it("does not let public-only loads overwrite API-backed private manifests", async () => {
+    const env = createTestEnv();
+    await upsertRepoFocusManifest(env, "owner/private-gates", {
+      wantedPaths: ["private/"],
+      gate: { linkedIssue: "block", readinessMinScore: 99 },
+    });
+
+    const publicManifest = await loadPublicRepoFocusManifest(env, "owner/private-gates", {
+      fetcher: async () => JSON.stringify({ wantedPaths: ["public/"], gate: { linkedIssue: "advisory" } }),
+    });
+    const privateManifest = await loadRepoFocusManifest(env, "owner/private-gates", {
+      fetcher: async () => {
+        throw new Error("should keep using the API-backed private manifest");
+      },
+    });
+
+    expect(publicManifest.source).toBe("repo_file");
+    expect(publicManifest.wantedPaths).toEqual(["public/"]);
+    expect(privateManifest.source).toBe("api_record");
+    expect(privateManifest.wantedPaths).toEqual(["private/"]);
+    expect(privateManifest.gate.linkedIssue).toBe("block");
+  });
+
   it("bulk-loads manifests for many repos with a concurrency cap", async () => {
     const env = createTestEnv();
     let active = 0;


### PR DESCRIPTION
### Motivation
- Public-only contributor-facing manifest loads were using the shared snapshot path and unconditionally persisting their fetched or empty fallback manifests into the shared `repo-focus-manifest` signal cache, which could shadow existing maintainer `api_record` snapshots and weaken private gate enforcement.
- The change prevents low-privileged contributor endpoints from poisoning the shared cache and preserves private/API-backed manifest integrity for webhook and gate-resolution paths.

### Description
- Change `loadRepoFocusManifestWithCachePolicy` to skip persisting fetched or negative-cache snapshots when `cachePolicy.publicOnly` is true by wrapping `persistRepoFocusManifest` in `if (!cachePolicy.publicOnly) { ... }` in `src/signals/focus-manifest-loader.ts`.
- Add a regression test `does not let public-only loads overwrite API-backed private manifests` to `test/unit/focus-manifest-loader.test.ts` that seeds an API-backed manifest, performs a public-only load, and asserts the private loader still returns the `api_record` snapshot.
- Preserve existing behavior for normal/private loads so they continue to persist repo-file and negative-cache snapshots for performance.

### Testing
- Ran the unit tests for the focus manifest loader with `npm test -- --run test/unit/focus-manifest-loader.test.ts`, and the suite passed with all tests succeeding (`23 passed`).
- The added regression test verifies the public-only path no longer overwrites API-backed private manifests and was included in the test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34df812c2c832ca079a2fb2cdb2ec2)