### PR TITLE
fix(signals): wire open-PR pressure scenarios into the branch scenario summary (#348)

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -4,8 +4,10 @@ import type { GittensorContributorSnapshot } from "../gittensor/api";
 import type { BountyRecord, CheckSummaryRecord, IssueRecord, PullRequestRecord, RecentMergedPullRequestRecord, RepositoryRecord, ScoringModelSnapshotRecord } from "../types";
 import { nowIso } from "../utils/json";
 import {
+  buildCollisionReport,
   buildLaneAdvice,
   buildLocalDiffPreflightResult,
+  buildQueueHealth,
   buildRepoFitRecommendation,
   buildRoleContext,
   type ContributorOutcomeHistory,
@@ -23,6 +25,7 @@ import { isPublicSafeText } from "./redaction";
 import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { scenarioInputFromLocalBranchMetadata } from "../scenarios/input-model";
 import { renderPublicScenarioSummary, type PublicScenarioSummary, type ScenarioSummaryInput } from "../scenarios/scenario-summary";
+import { simulateOpenPrPressure } from "../services/open-pr-pressure-scenarios";
 
 export type LocalBranchChangedFile = {
   path: string;
@@ -366,6 +369,18 @@ export function buildLocalBranchAnalysis(args: {
           classified: [],
         }
       : undefined;
+  // Open-PR pressure strategy options (#348): the scenario summary renderer fills its strategy
+  // `options` (open new work / wait / clean up first) and headline from this simulation. Without
+  // passing it, scenarioSummary.options was always empty and the guidance never reached the miner.
+  const queuePressureSimulation = simulateOpenPrPressure({
+    repoFullName: args.input.repoFullName,
+    generatedAt: nowIso(),
+    queueHealth: buildQueueHealth(args.repo, args.issues, args.pullRequests, buildCollisionReport(args.input.repoFullName, args.issues, args.pullRequests)),
+    roleContext,
+    contributorOpenPrCount: (args.contributorPullRequests ?? args.pullRequests).filter(
+      (pr) => pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === args.input.login.toLowerCase(),
+    ).length,
+  });
   const scenarioSummary = renderPublicScenarioSummary({
     repoFullName: args.input.repoFullName,
     generatedAt: nowIso(),
@@ -373,6 +388,7 @@ export function buildLocalBranchAnalysis(args: {
     publicBlockers: scorePreview.blockedBy,
     scenarioInput: branchScenarioInput,
     pendingDetection: pendingDetectionForSummary,
+    pressureSimulation: queuePressureSimulation,
   });
   return {
     login: args.input.login,

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1604,6 +1604,43 @@ describe("local MCP git metadata collection", () => {
     expect(analysis.scenarioSummary.dataClassification.facts).toEqual(expect.arrayContaining(["Contributor", "Repository", "Branch"]));
   });
 
+  it("wires open-PR pressure strategy options into scenarioSummary.options (#348)", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "src/util.ts", additions: 30, deletions: 2, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 38 },
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 9, title: "Improve util", state: "open", labels: [], linkedPrs: [] }],
+      pullRequests: [
+        { repoFullName: repo.fullName, number: 4, title: "WIP util", state: "open", authorLogin: "oktofeesh1", labels: [], linkedIssues: [] },
+      ],
+      // contributorPullRequests is preferred when present; the authorless PR exercises the null-author
+      // guard in the own-open-PR count and must not be miscounted as this contributor's work.
+      contributorPullRequests: [
+        { repoFullName: repo.fullName, number: 4, title: "WIP util", state: "open", authorLogin: "oktofeesh1", labels: [], linkedIssues: [] },
+        { repoFullName: repo.fullName, number: 5, title: "Authorless", state: "open", authorLogin: null, labels: [], linkedIssues: [] },
+      ],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    // Before this fix the renderer never received the pressure simulation, so options was always [].
+    const options = analysis.scenarioSummary.options;
+    expect(options.length).toBe(3);
+    expect(options.map((option) => option.rank)).toEqual([1, 2, 3]);
+    expect(options.filter((option) => option.recommended)).toHaveLength(1);
+    expect(options[0]?.recommended).toBe(true);
+    for (const option of options) {
+      expect(option.label.length).toBeGreaterThan(0);
+      expect(option.nextStep.length).toBeGreaterThan(0);
+    }
+  });
+
   it("populates scenarioSummary.dataClassification with contributor and repo facts from branch metadata", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
## The bug

The open-PR pressure strategy feature from #348 is **dark in production**. `simulateOpenPrPressure` (`src/services/open-pr-pressure-scenarios.ts`) computes a contributor strategy comparison — *open another PR now / wait / clean up existing work first* — ranked by repo queue pressure and miner-vs-maintainer lane. Its output is rendered by `renderPublicScenarioSummary` (`src/scenarios/scenario-summary.ts`), which fills the scenario `options` and headline from it.

Both halves are implemented and unit-tested — but the only production caller, `buildLocalBranchAnalysis` (`src/signals/local-branch.ts`), **never built or passed `pressureSimulation`**. So:

- `scenarioSummary.options` was **always `[]`** in `analyze-branch` / `preflight` / `local-diff`,
- the strategy headline never fired,
- and `simulateOpenPrPressure` had **zero production callers** (only its test referenced it).

## The fix

Build the simulation at the existing call site and pass it through:
- `roleContext` is already in scope (built a few lines above),
- `queueHealth` is derived with the same `buildCollisionReport` → `buildQueueHealth` pair the pr-status route uses,
- `contributorOpenPrCount` is the contributor's own open PRs.

Pure and read-only; the renderer already runs every line through `sanitizePublicComment`, so output stays public-safe.

## Test

`test/unit/local-branch.test.ts` now asserts `scenarioSummary.options` is populated — 3 ranked options, exactly one `recommended`, each with a non-empty `label` and `nextStep` — the regression that was silently empty before. Full `npm run test:coverage` stays green (branches 97.09%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)