### PR TITLE
fix(github): paginate PR file/review/check-run fetches so large PRs aren't truncated

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1778,6 +1778,25 @@ async function fetchAndStorePullRequestDetails(
   }
 }
 
+// GitHub caps list endpoints at 100 items/page, so a single `per_page=100` fetch silently truncates a
+// large PR's files/reviews/checks — which then undercounts churn/size and the slop padding detector.
+// Walk the `Link` header instead, bounded so a pathological PR can't spin. A page-1 failure returns
+// undefined (the caller can fall back to GraphQL); a later-page failure keeps the pages already fetched
+// rather than dropping a successful first page.
+const PR_DETAIL_MAX_PAGES = 10;
+
+async function githubPaginatedList<T>(env: Env, repoFullName: string, path: string, token: string | undefined): Promise<T[] | undefined> {
+  const items: T[] = [];
+  for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
+    // Callers pass query-less resource paths (/pulls/N/files, /pulls/N/reviews), so the page params start the query.
+    const result = await githubJsonWithHeaders<T[]>(env, repoFullName, `${path}?per_page=100&page=${page}`, token).catch(() => undefined);
+    if (!result) return page === 1 ? undefined : items;
+    items.push(...result.data);
+    if (!hasNextPage(result.link)) break;
+  }
+  return items;
+}
+
 async function fetchPullRequestFiles(
   env: Env,
   repoFullName: string,
@@ -1785,7 +1804,7 @@ async function fetchPullRequestFiles(
   token: string | undefined,
   warnings: string[],
 ): Promise<GitHubFilePayload[]> {
-  const files = await githubJson<GitHubFilePayload[]>(env, repoFullName, `/pulls/${pullNumber}/files?per_page=100`, token).catch(() => undefined);
+  const files = await githubPaginatedList<GitHubFilePayload>(env, repoFullName, `/pulls/${pullNumber}/files`, token);
   if (files) return files;
   const fallback = token ? await fetchPullRequestDetailsFromGraphQl(env, repoFullName, pullNumber, token).catch(() => undefined) : undefined;
   if (fallback) return fallback.files;
@@ -1800,7 +1819,7 @@ async function fetchPullRequestReviews(
   token: string | undefined,
   warnings: string[],
 ): Promise<GitHubReviewPayload[]> {
-  const reviews = await githubJson<GitHubReviewPayload[]>(env, repoFullName, `/pulls/${pullNumber}/reviews?per_page=100`, token).catch(() => undefined);
+  const reviews = await githubPaginatedList<GitHubReviewPayload>(env, repoFullName, `/pulls/${pullNumber}/reviews`, token);
   if (reviews) return reviews;
   const fallback = token ? await fetchPullRequestDetailsFromGraphQl(env, repoFullName, pullNumber, token).catch(() => undefined) : undefined;
   if (fallback) return fallback.reviews;
@@ -1816,10 +1835,26 @@ async function fetchPullRequestChecks(
   warnings: string[],
 ): Promise<{ check_runs?: GitHubCheckRunPayload[] }> {
   if (!pr.headSha) return { check_runs: [] };
-  const checks = await githubJson<{ check_runs?: GitHubCheckRunPayload[] }>(env, repoFullName, `/commits/${pr.headSha}/check-runs?per_page=100`, token).catch(() => undefined);
-  if (checks) return checks;
-  warnings.push(`Check sync failed for #${pr.number}: GitHub REST check-run fetch failed.`);
-  return { check_runs: [] };
+  // Same pagination as files/reviews, but the check-runs endpoint wraps the list in { check_runs }.
+  const checkRuns: GitHubCheckRunPayload[] = [];
+  for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
+    const result = await githubJsonWithHeaders<{ check_runs?: GitHubCheckRunPayload[] }>(
+      env,
+      repoFullName,
+      `/commits/${pr.headSha}/check-runs?per_page=100&page=${page}`,
+      token,
+    ).catch(() => undefined);
+    if (!result) {
+      if (page === 1) {
+        warnings.push(`Check sync failed for #${pr.number}: GitHub REST check-run fetch failed.`);
+        return { check_runs: [] };
+      }
+      break;
+    }
+    checkRuns.push(...(result.data.check_runs ?? []));
+    if (!hasNextPage(result.link)) break;
+  }
+  return { check_runs: checkRuns };
 }
 
 async function fetchPullRequestDetailsFromGraphQl(

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1794,7 +1794,6 @@ describe("GitHub backfill", () => {
     );
   });
 
-
   it("refreshes one pull request's files before gate evaluation and drops stale cached paths", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);
@@ -1870,6 +1869,87 @@ describe("GitHub backfill", () => {
     expect(result).toMatchObject({ status: "partial", pullNumber: 12 });
     expect(result.warnings).toEqual([expect.stringContaining("File sync failed for #12")]);
     expect(await listPullRequestFiles(env, "JSONbored/gittensory", 12)).toEqual([expect.objectContaining({ path: "src/cached.ts", changes: 1 })]);
+  });
+
+  it("paginates PR files, reviews, and check-runs across Link-header pages so large PRs are not truncated", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 20,
+      title: "Large PR",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "bigsha" },
+      labels: [],
+      body: "",
+    });
+    const nextLink = (resource: string) => ({ headers: { link: `<https://api.github.com/repositories/1/${resource}?page=2>; rel="next"` } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/pulls/20/files")) {
+        return url.includes("page=2")
+          ? Response.json([{ filename: "src/b.ts", status: "modified", additions: 2, deletions: 0, changes: 2 }])
+          : Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1 }], nextLink("files"));
+      }
+      if (url.includes("/pulls/20/reviews")) {
+        return url.includes("page=2")
+          ? Response.json([{ id: 91, user: { login: "rev2" }, state: "COMMENTED", submitted_at: "2026-05-25T00:00:00Z" }])
+          : Response.json([{ id: 90, user: { login: "rev1" }, state: "APPROVED", submitted_at: "2026-05-24T00:00:00Z" }], nextLink("reviews"));
+      }
+      if (url.includes("/commits/bigsha/check-runs")) {
+        return url.includes("page=2")
+          ? Response.json({ check_runs: [{ id: 71, name: "lint", status: "completed", conclusion: "success" }] })
+          : Response.json({ check_runs: [{ id: 70, name: "test", status: "completed", conclusion: "success" }] }, nextLink("commits/bigsha/check-runs"));
+      }
+      return Response.json([]);
+    });
+
+    const result = await backfillOpenPullRequestDetails(env, { repoFullName: "JSONbored/gittensory", mode: "full", cursor: 0 });
+    expect(result).toMatchObject({ status: "complete", processed: 1, warnings: [] });
+
+    // Both pages of each list must be persisted — page 1 alone would silently drop the second page.
+    expect((await listPullRequestFiles(env, "JSONbored/gittensory", 20)).map((file) => file.path).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+    expect((await listPullRequestReviews(env, "JSONbored/gittensory", 20)).map((review) => review.reviewerLogin).sort()).toEqual(["rev1", "rev2"]);
+    expect((await listCheckSummaries(env, "JSONbored/gittensory", 20)).map((check) => check.name).sort()).toEqual(["lint", "test"]);
+  });
+
+  it("keeps the pages already fetched when a later PR-files page fails", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 21,
+      title: "Partial pages",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "psha" },
+      labels: [],
+      body: "",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/pulls/21/files")) {
+        return url.includes("page=2")
+          ? new Response("rate limited", { status: 503 })
+          : Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1 }], {
+              headers: { link: '<https://api.github.com/repositories/1/files?page=2>; rel="next"' },
+            });
+      }
+      if (url.includes("/pulls/21/reviews")) return Response.json([]);
+      if (url.includes("/commits/psha/check-runs")) {
+        // Same partial-page behavior for the check-runs envelope: page 1 ok, page 2 fails.
+        return url.includes("page=2")
+          ? new Response("rate limited", { status: 503 })
+          : Response.json({ check_runs: [{ id: 80, name: "build", status: "completed", conclusion: "success" }] }, {
+              headers: { link: '<https://api.github.com/repositories/1/commits/psha/check-runs?page=2>; rel="next"' },
+            });
+      }
+      return Response.json([]);
+    });
+
+    await backfillOpenPullRequestDetails(env, { repoFullName: "JSONbored/gittensory", mode: "full", cursor: 0 });
+    // Page 1 succeeded; a page-2 failure must keep it rather than dropping a good first page (files and checks).
+    expect((await listPullRequestFiles(env, "JSONbored/gittensory", 21)).map((file) => file.path)).toEqual(["src/a.ts"]);
+    expect((await listCheckSummaries(env, "JSONbored/gittensory", 21)).map((check) => check.name)).toEqual(["build"]);
   });
 
   it("records partial PR detail state and check summary segment when check-run fetches fail", async () => {


### PR DESCRIPTION
## The bug

`fetchPullRequestFiles`, `fetchPullRequestReviews`, and `fetchPullRequestChecks` in `src/github/backfill.ts` each fetched a **single `per_page=100` page with no pagination**. GitHub caps list endpoints at 100 items/page, so a PR with more than 100 changed files / reviews / check-runs was **silently truncated**.

For files this is the one that bites: the truncated list feeds the churn/size signals and the slop **non-substantive-padding** detector (which sums changed lines across files), so a large PR's churn was undercounted. (The GraphQL fallback also caps `files(first: 100)`, so it didn't compensate.)

## The fix

Add a small bounded `githubPaginatedList` helper that walks the GitHub `Link` header — reusing the existing `githubJsonWithHeaders` + `hasNextPage` already used elsewhere in this file — and apply it to all three fetchers (check-runs keeps its `{ check_runs }` envelope). Bounded to 10 pages (1,000 items) so a pathological PR can't spin.

Behavior is preserved:
- a **page-1 failure** returns `undefined`, so files/reviews still fall back to GraphQL and check-runs still records the same partial-sync warning;
- a **later-page failure** keeps the pages already fetched rather than dropping a good first page.

## Tests

`test/unit/backfill.test.ts` adds:
- files/reviews/check-runs each paginating across two `Link`-header pages (asserts both pages persist),
- a later-page failure preserving page 1.

Full `npm run test:coverage` stays green (branches 97.08%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)