### PR TITLE
fix(gate): refresh PR files for merge readiness

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -956,7 +956,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       });
       await persistAdvisory(env, advisory);
       if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
-        if (settings.slopGateMode !== "off" || settings.manifestPolicyGateMode !== "off") {
+        if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
           await refreshPullRequestDetails(env, repoFullName, pr.number);
         }
         const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -4754,10 +4754,15 @@ describe("queue processors", () => {
     });
     expect((await getPullRequest(env, "JSONbored/gittensory", 91))?.slopRisk).toBe(80); // stale score present pre-run
 
+    const refreshedFiles: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/91/files")) {
+        refreshedFiles.push(url);
+        return Response.json([{ filename: "src/helper.ts", status: "modified", additions: 5, deletions: 0, changes: 5 }]);
+      }
       if (url.includes("/commits/slopoff123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 991 }, { status: 201 });
       return new Response("not found", { status: 404 });
@@ -4779,6 +4784,7 @@ describe("queue processors", () => {
     const cleared = await getPullRequest(env, "JSONbored/gittensory", 91);
     expect(cleared?.slopRisk).toBeNull();
     expect(cleared?.slopBand).toBeNull();
+    expect(refreshedFiles).toHaveLength(1);
   });
 
   it("overrides the Gate to neutral for THIS commit only when a real write/admin maintainer runs gate-override", async () => {


### PR DESCRIPTION
### Motivation
- The pre-gate PR-detail refresh only ran when `slopGateMode` or `manifestPolicyGateMode` were enabled, but `mergeReadinessGateMode` also consumes slop/file evidence so stale cached file lists could let a merge-readiness gate pass incorrectly.

### Description
- Replace the explicit `settings.slopGateMode !== "off"` check with `shouldCollectSlopEvidence(settings)` so PR details are refreshed whenever slop evidence is needed (including merge-readiness-only configs) while preserving manifest refresh behavior.
- Add test instrumentation in `test/unit/queue.test.ts` to assert that the PR files endpoint is hit during the slop-off + merge-readiness scenario and verify the refresh occurs.
- Files changed: `src/queue/processors.ts` and `test/unit/queue.test.ts`.

### Testing
- Ran the targeted unit test with `npm test -- --run test/unit/queue.test.ts -t "clears the persisted dashboard slop score"` and it passed.
- Ran the project's typecheck with `npm run typecheck` (TS `tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e11983c8832cafba9360ce920da6)