### PR TITLE
fix(gate): refresh PR files on manual review rerun

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1922,6 +1922,12 @@ async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payloa
     outcome: "completed",
     metadata: { deliveryId, repoFullName, commentId: comment.id },
   });
+  // A manual re-run is a re-evaluation surface — the user clicks it AFTER the PR changed — so the slop and
+  // manifest-policy gates must see the PR's current files, not whatever is cached. Mirror the webhook path
+  // (#866/#925): refresh before publishing so the re-published Gate check reflects the latest file set.
+  if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
+    await refreshPullRequestDetails(env, repoFullName, pr.number);
+  }
   await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
     deliveryId,
     action: "manual_retrigger",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1975,6 +1975,82 @@ describe("queue processors", () => {
     expect(usageEvents).toEqual(expect.arrayContaining([expect.objectContaining({ surface: "github_app", eventName: "pr_panel_retriggered", outcome: "completed" })]));
   });
 
+  it("refreshes the PR's files on a manual rerun so the slop/manifest gate evaluates the current diff", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicAudienceMode: "oss_maintainer",
+      publicSignalLevel: "standard",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "off",
+      includeMaintainerAuthors: true,
+      // Slop gate on → the rerun must refresh the PR files before evaluating (the guard fires).
+      slopGateMode: "advisory",
+      commandAuthorization: { default: ["maintainer", "collaborator", "confirmed_miner"], commands: { "review-now": ["maintainer"] } },
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 45,
+      title: "Refresh panel",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "panel123" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const checkedPanel = ["<!-- gittensory-pr-panel:v1 -->", "", "- [x] <!-- gittensory-rerun-review:v1 --> Re-run Gittensory review"].join("\n");
+    const calls = { pullsFiles: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([{ uid: 7, githubUsername: "contributor", githubId: "123", totalPrs: 4, totalMergedPrs: 3, totalOpenPrs: 1, totalClosedPrs: 0, totalOpenIssues: 0, totalClosedIssues: 0, totalSolvedIssues: 0, totalValidSolvedIssues: 0, isEligible: true, credibility: 1, eligibleRepoCount: 1 }]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") return Response.json({ repositories: [] });
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/contributor")) return Response.json({ login: "contributor", public_repos: 2, followers: 1 });
+      if (url.includes("/users/contributor/repos")) return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "maintain" });
+      // The refresh fetches files/reviews/checks; count the files fetch to prove the refresh ran on the rerun.
+      if (url.includes("/pulls/45/files")) {
+        calls.pullsFiles += 1;
+        return Response.json([{ filename: "src/app.ts", status: "modified", additions: 5, deletions: 1, changes: 6 }]);
+      }
+      if (url.includes("/pulls/45/reviews")) return Response.json([]);
+      if (url.includes("/commits/panel123/check-runs")) return Response.json({ check_runs: [] });
+      if (url.includes("/issues/45/comments") && method === "GET") return Response.json([{ id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } }]);
+      if (url.includes("/issues/comments/777") && method === "PATCH") return Response.json({ id: 777 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "panel-retrigger-refresh",
+      eventName: "issue_comment",
+      payload: {
+        action: "edited",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 45, title: "Refresh panel", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 777, body: checkedPanel, user: { login: "gittensory[bot]", type: "Bot" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    // The rerun fetched the PR's current files before publishing the panel/gate — not the stale cache.
+    expect(calls.pullsFiles).toBeGreaterThanOrEqual(1);
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ? and target_key = ?")
+      .bind("github_app.pr_panel_retriggered", "JSONbored/gittensory#45")
+      .first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("completed");
+  });
+
   it("reruns the panel when a confirmed-miner PR author checks the rerun task (#824 miner-detection path)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);


### PR DESCRIPTION
## Summary

The webhook gate path refreshes the PR's changed files before evaluating the slop and focus-manifest-policy gates (#866/#925) — the refresh is the **caller's** job, since `maybePublishPrPublicSurface` only reads the **cached** files (`listPullRequestFiles`):

```ts
// webhook path — refreshes first (added by #866)
if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
  await refreshPullRequestDetails(env, repoFullName, pr.number);
}
const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, { ... });
```

But `maybePublishPrPublicSurface` has **two** callers. The manual **"Re-run Gittensory review"** retrigger (`maybeProcessPrPanelRetrigger`) called it with **no refresh** (and `buildAuthorizedPrActionAdvisory` doesn't refresh either):

```ts
const { repo, advisory } = await buildAuthorizedPrActionAdvisory(env, repoFullName, pr, settings);
await persistAdvisory(env, advisory);
await recordAuditEvent(env, { eventType: "github_app.pr_panel_retriggered", ... });
await maybePublishPrPublicSurface(env, ..., { deliveryId, action: "manual_retrigger" }); // gate over STALE files
```

**Impact:** the retrigger is a re-evaluation surface — a user clicks it *after* the PR changed. Without the refresh, the slop gate (file additions/paths) and manifest-policy gate (blocked paths, missing-tests over changed paths) compute against stale (or empty, if never synced) cached files, so the re-published required **Gate check reflects the wrong diff** — the exact stale-gate class #866/#925 set out to eliminate, left unaddressed on the second caller.

## Fix

Mirror the webhook guard in `maybeProcessPrPanelRetrigger`, before the publish:

```ts
if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
  await refreshPullRequestDetails(env, repoFullName, pr.number);
}
```

`refreshPullRequestDetails` is already imported and fail-safe (#866: preserves the cached files and returns `status: "partial"` on a fetch error), so it never makes the retrigger worse on an API hiccup. The slop/manifest findings are computed inside `maybePublishPrPublicSurface` *after* the refresh — identical ordering to the webhook path.

## Tests

Added a regression test: a maintainer rerun with `slopGateMode` enabled now fetches `/pulls/<n>/files` (the refresh) before publishing, and the retrigger still audits `completed`. The existing rerun test (gates off → guard not taken) is unchanged, so both arms of the new guard are exercised.

Full unit suite green locally (2219 passed; only the known local-only CRLF `gittensory-focus-manifest` test fails locally, passes in CI).

Closes #927
