### PR TITLE
fix(public-safety): redact score numbers in 'estimated score N -> M' wording

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1484,13 +1484,16 @@ export function sanitizePublicComment(value: string): string {
     .replace(/\bopen pr count\s+\d+\s+exceeds threshold\s+\d+\b\.?/gi, "private context")
     .replace(/\bopen pr count is at or below\s+\d+\b/gi, "private context")
     .replace(/\bcredibility\s+[-+]?\d+(?:\.\d+)?\s+is below floor\s+[-+]?\d+(?:\.\d+)?\b\.?/gi, "private context")
-    .replace(/\b(?:effective|projected) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
+    .replace(/\b(?:effective|projected|estimated) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\b(raw trust score|trust score|wallet|hotkey|coldkey|seed phrase|mnemonic)\b/gi, "private context")
     .replace(/\b(public score estimate|estimated score|score estimate|estimated rewards?|rewards?|reward estimates?|payout|farming|scoreability|score preview|projected score changes?)\b/gi, "private context")
     .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
     .replace(/\b(private rankings?|rankings?)\b/gi, "private context")
     .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only)\b/gi, "private context")
     .replace(/\b(?:credibility(?: updates?)?|closed pr credibility|low credibility|open pr pressure)\b/gi, "private context")
+    // Catch-all: a phrase replacement above (e.g. "score estimate"/"score preview") can leave a bare
+    // numeric score transition behind ("private context 32.5 -> 41.2"); redact those residual numbers too.
+    .replace(/\bprivate context\b\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");
   return sanitizeReviewabilityTerm(sanitized).replace(/private context(?:,\s*private context)+/gi, "private context");
 }

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -156,6 +156,11 @@ describe("GitHub mention commands", () => {
     expect(sanitizePublicComment("public score estimate private scoreability context score preview")).not.toMatch(/public score estimate|scoreability|score preview/i);
     expect(sanitizePublicComment("projected score changes 12.3 -> 45.6")).not.toMatch(/projected score changes|12\.3|45\.6/i);
     expect(sanitizePublicComment("effective score 0 -> 42")).not.toMatch(/effective score|0|42/i);
+    // The score engine (buildGateDeltas) emits the "estimated score N -> M" wording — the raw numbers must
+    // be redacted too, not just the words (the catch-all also clears residual numbers from other phrases).
+    expect(sanitizePublicComment("Open PR pressure changes estimated score 32.5 -> 41.2.")).not.toMatch(/estimated score|32\.5|41\.2/i);
+    expect(sanitizePublicComment("Linked issue/no-issue context changes estimated score 18 -> 27.")).not.toMatch(/estimated score|18|27/i);
+    expect(sanitizePublicComment("score estimate 5 → 9")).not.toMatch(/score estimate|\b5\b|\b9\b/i);
     expect(sanitizePublicComment("Open PR count 7 exceeds threshold 3.")).not.toMatch(/open PR count|7|threshold|3/i);
     expect(sanitizePublicComment("Credibility 0.12 is below floor 0.4.")).not.toMatch(/credibility|0\.12|floor|0\.4/i);
     expect(sanitizePublicComment("open_pr_pressure closed_pr_credibility low_credibility credibility updates")).not.toMatch(/open_pr_pressure|closed_pr_credibility|low_credibility|credibility/i);


### PR DESCRIPTION
## Summary

`sanitizePublicComment` (the shared public-safety sanitizer) redacts the raw score-transition numbers (`N -> M`) **only** for the `effective`/`projected` prefixes — but **not** for the `estimated score` prefix, which is the exact wording the score engine (`buildGateDeltas`) actually emits. So a gate-delta explanation is only half-sanitized: the words `estimated score` become `private context`, but the raw internal scores survive.

```ts
// src/scoring/preview.ts — buildGateDeltas emits the "estimated score N -> M" wording
explanation: `Open PR pressure changes estimated score ${current...} -> ${best...}.`,
```

Running the real sanitizer on the real engine wording:
```
"Open PR pressure changes estimated score 32.5 -> 41.2."
  => "Open PR pressure changes private context 32.5 -> 41.2."   ← raw 32.5 -> 41.2 LEAKS
```

These strings flow into every `gittensory_explain_score_breakdown` / `POST /v1/scoring/explain-breakdown` response, which runs each one through this sanitizer precisely to be public-safe (`src/services/score-breakdown.ts` `gateHighlightsFor` → `sanitizePublicComment(delta.explanation)`). The estimated score is a product-defined private "scoreability" value (`estimated score`/`score estimate`/`scoreability` are forbidden public terms), so leaking the raw number is a scoreability leak by the project's own definition.

The sanitizer's contract — `test/unit/github-commands.test.ts` — asserts the score-transition **numbers** are redacted, but only for `projected`/`effective`; it never covered the `estimated score` prefix the engine uses, so the gap shipped green.

## Fix

- Add `estimated` to the number-stripping pattern, so `estimated score N -> M` is fully redacted (matches the engine's wording).
- Add a catch-all that clears any **residual** numeric transition left behind after a phrase replacement (e.g. `score estimate`/`score preview` followed by `N -> M`), so the same class of half-redaction can't recur for sibling phrases.

## Tests

Added regression assertions for the `buildGateDeltas` wording (`estimated score 32.5 -> 41.2`, `... 18 -> 27`) and the residual catch-all (`score estimate 5 → 9`) — all asserting the numbers are gone, not just the words. Full unit suite green locally (2218 passed; only the known local-only CRLF `gittensory-focus-manifest` test fails locally, passes in CI).

Closes #929
