### PR TITLE
ci(coverage): upload vitest results to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,13 @@ jobs:
           done
           echo "::error::npm ci failed after 3 attempts"
           exit 1
+      - name: Prepare test reports dir
+        run: mkdir -p reports/junit
       - name: Test with coverage (shard ${{ matrix.shard }}/2)
         id: coverage
         env:
           COVERAGE_NO_THRESHOLDS: "1"
+          VITEST_JUNIT_PATH: reports/junit/vitest-shard-${{ matrix.shard }}.xml
         run: npm run test:coverage -- --shard=${{ matrix.shard }}/2
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
@@ -153,6 +156,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
+          fail_ci_if_error: false
+      - name: Upload Vitest results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./reports/junit/vitest-shard-${{ matrix.shard }}.xml
+          report_type: test_results
           fail_ci_if_error: false
 
   # Worker-pool runtime tests (separate vitest config); split out of `test` so it

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -455,5 +455,5 @@ describe("MCP output schemas validate on real tool calls (#550)", () => {
     const fetched = await client.callTool({ name: "gittensory_agent_get_run", arguments: { runId } });
     expect(fetched.isError, `agent_get_run errored: ${JSON.stringify(fetched.content)}`).toBeFalsy();
     expect(fetched.structuredContent).toBeDefined();
-  });
+  }, 30_000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+const junitPath = process.env.VITEST_JUNIT_PATH;
+
 export default defineConfig({
   ssr: {
     noExternal: ["agents", "partyserver"],
@@ -16,6 +18,8 @@ export default defineConfig({
     testTimeout: 15000,
     include: ["test/**/*.test.ts"],
     exclude: ["test/workers/**/*.test.ts"],
+    reporters: junitPath ? ["default", "junit"] : ["default"],
+    ...(junitPath ? { outputFile: { junit: junitPath } } : {}),
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Upload Vitest JUnit results to Codecov from the existing sharded coverage job.
- Keep the current sharded coverage run and Codecov lcov upload unchanged.
- Give the existing MCP output-schema smoke test a local timeout because it calls a large set of MCP tools in one test.

## What changed
- Add opt-in JUnit reporter output when `VITEST_JUNIT_PATH` is set.
- Write one JUnit file per coverage shard.
- Upload the shard JUnit report with `report_type: test_results`.
- Set the long MCP output-schema validation test timeout to 30s instead of relying on the repo-wide 15s default.

## Why
- Codecov evaluates reports; CI still produces the test and coverage artifacts.
- This adds Codecov Test Analytics without adding another test pass or changing the coverage gate.
- The timeout override keeps the existing integration-style schema smoke stable under full-shard CI load.

## Validation
- `npm run actionlint`
- `actionlint .github/workflows/ci.yml`
- `VITEST_JUNIT_PATH=reports/junit/vitest-smoke.xml npx vitest run test/unit/slop.test.ts`
- `VITEST_JUNIT_PATH=reports/junit/mcp-output-schemas.xml npx vitest run test/unit/mcp-output-schemas.test.ts`
- `git diff --check`

## Notes
- The commit is unsigned because the configured SSH signing private key was not available in the local worktree environment.