### PR TITLE
feat(agent): agent audit feed — surface executed actions + approval decisions (#784)

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -14943,6 +14943,82 @@
           }
         ]
       }
+    },
+    "/v1/repos/{owner}/{repo}/agent/audit-feed": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Maintainer-scoped agent audit feed (#784): executed actions + approval-queue decisions, newest first, public-safe action posture only. Supports ?since=ISO-8601&limit=1-200.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "repoFullName": {
+                      "type": "string"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "eventType": {
+                            "type": "string"
+                          },
+                          "pullNumber": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "outcome": {
+                            "type": "string"
+                          },
+                          "actor": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "detail": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "eventType",
+                          "pullNumber",
+                          "outcome",
+                          "actor",
+                          "detail",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "repoFullName",
+                    "events"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed since (not ISO-8601) or limit (not an integer in 1-200)"
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -42,6 +42,7 @@ import {
   getRepoQueueTrendSnapshot,
   getRepositorySettings,
   getPendingAgentAction,
+  listAgentAuditEvents,
   listPendingAgentActions,
   recordAuditEvent,
   getContributorEvidence,
@@ -2062,6 +2063,31 @@ export function createApp() {
     const result = await decidePendingAgentAction(c.env, { id: pending.id, decision, decidedBy });
     if (result.status === "already_decided") return c.json({ error: "already_decided", action: result.action }, 409);
     return c.json(result);
+  });
+
+  // #784 audit feed: the agent's executed actions + approval-queue decisions for this repo. Maintainer-scoped,
+  // read-only, public-safe (action posture only — no trust/score metadata). `?since=ISO&limit=N` (max 200).
+  app.get("/v1/repos/:owner/:repo/agent/audit-feed", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoMaintainer(c, fullName);
+    /* v8 ignore next -- unauthorized requests are rejected by the auth middleware before reaching the handler. */
+    if (gate instanceof Response) return gate;
+    const since = c.req.query("since");
+    if (since !== undefined && Number.isNaN(Date.parse(since))) return c.json({ error: "invalid_since", detail: "since must be an ISO-8601 timestamp" }, 400);
+    const limitParam = c.req.query("limit");
+    let limit: number | undefined;
+    if (limitParam !== undefined) {
+      const parsed = Number(limitParam);
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > 200) return c.json({ error: "invalid_limit", detail: "limit must be an integer between 1 and 200" }, 400);
+      limit = parsed;
+    }
+    const events = await listAgentAuditEvents(c.env, {
+      repoFullName: fullName,
+      ...(since !== undefined ? { sinceIso: since } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    // Defense-in-depth: the free-form `detail` is the only unbounded string — scrub it before it leaves on a public surface.
+    return c.json({ repoFullName: fullName, events: events.map((event) => ({ ...event, detail: event.detail === null ? null : sanitizePublicComment(event.detail) })) });
   });
 
   // Maintainer activation demo (#701): a repo-specific "here's what Gittensory would have surfaced" preview

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2032,6 +2032,49 @@ export async function listPrVisibilitySkipAuditEvents(
   return { limit, hasMore: items.length > limit, items: items.slice(0, limit) };
 }
 
+// #784 audit feed: the agent's own action history for a repo — both executed actions (`agent.action.<class>`)
+// and approval-queue decisions (`agent.pending_action.accepted|rejected`). Repo-scoped via the `repo#pr`
+// targetKey prefix range (mirrors listPrVisibilitySkipAuditEvents). Read-only; private trust/score metadata
+// is never selected, only the public-safe action posture.
+export type AgentAuditEvent = {
+  eventType: string;
+  pullNumber: number | null;
+  outcome: string;
+  actor: string | null;
+  detail: string | null;
+  createdAt: string;
+};
+
+export async function listAgentAuditEvents(
+  env: Env,
+  options: { repoFullName: string; sinceIso?: string | undefined; limit?: number | undefined },
+): Promise<AgentAuditEvent[]> {
+  const limit = clampInteger(options.limit ?? 50, 1, 200);
+  // Match exactly `repo#<...>` keys: lower bound `repo#`, upper bound `repo#` + the max code point, which
+  // sorts past any value that can follow the `#` — robust against delimiter-adjacent edge cases.
+  const prefix = `${options.repoFullName.toLowerCase()}#`;
+  const upperBound = `${options.repoFullName.toLowerCase()}#\uffff`;
+  const conditions: SQL[] = [
+    sql`(${auditEvents.eventType} like 'agent.action.%' or ${auditEvents.eventType} like 'agent.pending_action.%')`,
+    sql`lower(${auditEvents.targetKey}) >= ${prefix} and lower(${auditEvents.targetKey}) < ${upperBound}`,
+  ];
+  if (options.sinceIso) conditions.push(gte(auditEvents.createdAt, options.sinceIso));
+  const rows = await getDb(env.DB)
+    .select({ eventType: auditEvents.eventType, targetKey: auditEvents.targetKey, outcome: auditEvents.outcome, actor: auditEvents.actor, detail: auditEvents.detail, createdAt: auditEvents.createdAt })
+    .from(auditEvents)
+    .where(and(...conditions))
+    .orderBy(desc(auditEvents.createdAt), desc(auditEvents.id))
+    .limit(limit);
+  return rows.map((row) => ({
+    eventType: row.eventType,
+    pullNumber: parsePullRequestTargetKey(row.targetKey)?.pullNumber ?? null,
+    outcome: row.outcome,
+    actor: row.actor,
+    detail: row.detail,
+    createdAt: row.createdAt,
+  }));
+}
+
 export async function getFreshOfficialMinerDetection(env: Env, login: string, now = nowIso()): Promise<OfficialGittensorMinerDetection | null> {
   const [row] = await getDb(env.DB).select().from(officialMinerDetections).where(and(eq(officialMinerDetections.login, login.toLowerCase()), gte(officialMinerDetections.expiresAt, now))).limit(1);
   return row ? toOfficialMinerDetection(row) : null;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,6 +21,7 @@ import {
   getRepository,
   getRepositorySettings,
   getRepoQueueTrendSnapshot,
+  listAgentAuditEvents,
   listCheckSummaries,
   listPendingAgentActions,
   listContributorRepoStats,
@@ -47,6 +48,7 @@ import { decidePendingAgentAction } from "../services/agent-approval-queue";
 import { buildNotificationFeed } from "../notifications/service";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
 import { getRepositoryCollaboratorPermission } from "../github/app";
+import { sanitizePublicComment } from "../github/commands";
 import { fetchPublicContributorProfile } from "../github/public";
 import { listLatestRegistrySnapshots } from "../registry/sync";
 import { getOrCreateScoringModelSnapshot, isTimeDecayEnabled } from "../scoring/model";
@@ -409,6 +411,30 @@ const decidePendingActionOutputSchema = {
   status: z.string().optional(),
   executionOutcome: z.string().optional(),
   action: pendingActionEntrySchema.optional(),
+};
+
+// #784 (MCP slice) — the agent audit feed: executed actions + approval decisions for a repo.
+const auditFeedShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  since: z.string().datetime({ offset: true }).optional(),
+  limit: z.number().int().positive().max(200).optional(),
+};
+
+const auditFeedOutputSchema = {
+  repoFullName: z.string().optional(),
+  events: z
+    .array(
+      z.object({
+        eventType: z.string(),
+        pullNumber: z.number().nullable(),
+        outcome: z.string(),
+        actor: z.string().nullable(),
+        detail: z.string().nullable(),
+        createdAt: z.string(),
+      }),
+    )
+    .optional(),
 };
 
 const focusManifestInputSchema = z
@@ -1317,6 +1343,17 @@ export class GittensoryMcp {
         outputSchema: decidePendingActionOutputSchema,
       },
       async (input) => this.toolResult(await this.decidePendingAction(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_agent_audit_feed",
+      {
+        description:
+          "Return a repo's agent audit feed: executed actions (agent.action.*) and approval-queue decisions (accepted/rejected), newest first. Read-only and public-safe (action posture only). Maintainer access required.",
+        inputSchema: auditFeedShape,
+        outputSchema: auditFeedOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getAgentAuditFeed(input)),
     );
 
     server.registerTool(
@@ -2247,6 +2284,23 @@ export class GittensoryMcp {
           createdAt: action.createdAt,
         },
       },
+    };
+  }
+
+  // #784 — the agent audit feed: executed actions + approval decisions for a repo, newest first.
+  // Maintainer-manage scoped; read-only and public-safe (action posture only — no trust/score metadata).
+  private async getAgentAuditFeed(input: z.infer<z.ZodObject<typeof auditFeedShape>>): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoManageAccess(fullName);
+    const events = await listAgentAuditEvents(this.env, {
+      repoFullName: fullName,
+      ...(input.since !== undefined ? { sinceIso: input.since } : {}),
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+    });
+    return {
+      summary: `${events.length} recent agent audit event(s) for ${fullName}.`,
+      // Defense-in-depth: scrub the only free-form field (`detail`) before it leaves on a public-safe tool result.
+      data: { repoFullName: fullName, events: events.map((event) => ({ ...event, detail: event.detail === null ? null : sanitizePublicComment(event.detail) })) },
     };
   }
 

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -412,6 +412,34 @@ export function buildOpenApiSpec() {
   });
   registry.registerPath({
     method: "get",
+    path: "/v1/repos/{owner}/{repo}/agent/audit-feed",
+    responses: {
+      200: {
+        description: "Maintainer-scoped agent audit feed (#784): executed actions + approval-queue decisions, newest first, public-safe action posture only. Supports ?since=ISO-8601&limit=1-200.",
+        content: {
+          "application/json": {
+            schema: z.object({
+              repoFullName: z.string(),
+              events: z.array(
+                z.object({
+                  eventType: z.string(),
+                  pullNumber: z.number().nullable(),
+                  outcome: z.string(),
+                  actor: z.string().nullable(),
+                  detail: z.string().nullable(),
+                  createdAt: z.string(),
+                }),
+              ),
+            }),
+          },
+        },
+      },
+      400: { description: "Malformed since (not ISO-8601) or limit (not an integer in 1-200)" },
+      403: { description: "Insufficient role" },
+    },
+  });
+  registry.registerPath({
+    method: "get",
     path: "/v1/app/self-dogfood/registration-pack",
     responses: {
       200: { description: "Private self-dogfood registration pack for the Gittensory repo", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },

--- a/test/unit/mcp-automation-state.test.ts
+++ b/test/unit/mcp-automation-state.test.ts
@@ -3,7 +3,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { getRepositoryCollaboratorPermission } from "../../src/github/app";
-import { createPendingAgentActionIfAbsent, getPendingAgentAction, listPendingAgentActions, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createPendingAgentActionIfAbsent, getPendingAgentAction, listPendingAgentActions, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
 import type { AuthIdentity } from "../../src/auth/security";
 import { createTestEnv } from "../helpers/d1";
 
@@ -272,5 +272,74 @@ describe("MCP gittensory_decide_pending_action (#784)", () => {
     expect(result.isError).toBe(true);
     expect(JSON.stringify(result)).toMatch(/write access/i);
     expect((await getPendingAgentAction(env, action.id))?.status).toBe("pending");
+  });
+});
+
+describe("MCP gittensory_get_agent_audit_feed (#784)", () => {
+  async function seedAudit(env: Env) {
+    await recordAuditEvent(env, { eventType: "agent.action.merge", actor: "gittensory", targetKey: "owner/repo#7", outcome: "completed", detail: "merged", createdAt: "2026-06-18T10:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "agent.pending_action.rejected", actor: "owner", targetKey: "owner/repo#8", outcome: "completed", detail: "rejected merge", createdAt: "2026-06-18T11:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "github_app.pr_visibility_skipped", actor: "x", targetKey: "owner/repo#9", outcome: "completed", createdAt: "2026-06-18T12:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "agent.action.label", actor: "gittensory", targetKey: "other/repo#1", outcome: "completed", createdAt: "2026-06-18T13:00:00.000Z" });
+  }
+
+  it("surfaces this repo's agent action + decision events newest-first, excluding non-agent and other-repo events", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedAudit(env);
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { repoFullName: string; events: Array<{ eventType: string; pullNumber: number | null; outcome: string }> };
+    expect(data.repoFullName).toBe("owner/repo");
+    expect(data.events.map((event) => event.eventType)).toEqual(["agent.pending_action.rejected", "agent.action.merge"]);
+    expect(data.events[0]).toMatchObject({ pullNumber: 8, outcome: "completed" });
+  });
+
+  it("honors the since filter and the limit", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedAudit(env);
+    const client = await connect(env);
+    const since = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo", since: "2026-06-18T10:30:00.000Z" } });
+    expect((since.structuredContent as { events: unknown[] }).events).toHaveLength(1);
+    const limited = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo", limit: 1 } });
+    expect((limited.structuredContent as { events: unknown[] }).events).toHaveLength(1);
+  });
+
+  it("forbids a session without live write access", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedAudit(env);
+    mockedPermission.mockResolvedValue("read");
+    const client = await connect(env, { kind: "session", actor: "rando" } as AuthIdentity);
+    const result = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo" } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toMatch(/write access/i);
+  });
+
+  it("rejects a malformed since (non ISO-8601) and an over-cap limit via schema validation", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    const client = await connect(env);
+    const badSince = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo", since: "not-a-date" } });
+    expect(badSince.isError).toBe(true);
+    const badLimit = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo", limit: 500 } });
+    expect(badLimit.isError).toBe(true);
+  });
+
+  it("scrubs forbidden terms from the free-form detail and preserves a null detail", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await recordAuditEvent(env, { eventType: "agent.action.merge", actor: "gittensory", targetKey: "owner/repo#7", outcome: "completed", detail: "reward estimate leaked", createdAt: "2026-06-18T10:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "agent.action.label", actor: "gittensory", targetKey: "owner/repo#8", outcome: "completed", createdAt: "2026-06-18T09:00:00.000Z" });
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_agent_audit_feed", arguments: { owner: "owner", repo: "repo" } });
+    const data = result.structuredContent as { events: Array<{ pullNumber: number | null; detail: string | null }> };
+    const merge = data.events.find((event) => event.pullNumber === 7);
+    const label = data.events.find((event) => event.pullNumber === 8);
+    expect(merge?.detail).not.toMatch(/reward/i);
+    expect(merge?.detail).toContain("private context");
+    expect(label?.detail).toBeNull();
   });
 });

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../src/github/labels", () => ({
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { createSessionForGitHubUser } from "../../src/auth/security";
 import { createApp } from "../../src/api/routes";
-import { createPendingAgentActionIfAbsent, getPendingAgentAction, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createPendingAgentActionIfAbsent, getPendingAgentAction, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 const app = createApp();
@@ -111,5 +111,78 @@ describe("agent approval-queue routes (#779)", () => {
     await app.request(`/v1/repos/owner/repo/agent/pending-actions/${action.id}/reject`, { method: "POST", headers: headers(env) }, env);
     const again = await app.request(`/v1/repos/owner/repo/agent/pending-actions/${action.id}/accept`, { method: "POST", headers: headers(env) }, env);
     expect(again.status).toBe(409);
+  });
+});
+
+describe("agent audit-feed route (#784)", () => {
+  async function seedAudit(env: Env) {
+    await recordAuditEvent(env, { eventType: "agent.action.merge", actor: "gittensory", targetKey: "owner/repo#7", outcome: "completed", detail: "merged", createdAt: "2026-06-18T10:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "agent.pending_action.rejected", actor: "owner", targetKey: "owner/repo#8", outcome: "completed", detail: "rejected merge", createdAt: "2026-06-18T11:00:00.000Z" });
+    // excluded: a non-agent event on this repo, and an agent event on a different repo.
+    await recordAuditEvent(env, { eventType: "github_app.pr_visibility_skipped", actor: "x", targetKey: "owner/repo#9", outcome: "completed", createdAt: "2026-06-18T12:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "agent.action.label", actor: "gittensory", targetKey: "other/repo#1", outcome: "completed", createdAt: "2026-06-18T13:00:00.000Z" });
+  }
+
+  it("returns this repo's agent action + decision events newest-first, excluding non-agent and other-repo events", async () => {
+    const env = createTestEnv();
+    await seedAudit(env);
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: headers(env) }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repoFullName: string; events: Array<{ eventType: string; pullNumber: number | null; outcome: string }> };
+    expect(body.repoFullName).toBe("owner/repo");
+    expect(body.events.map((event) => event.eventType)).toEqual(["agent.pending_action.rejected", "agent.action.merge"]);
+    expect(body.events[0]).toMatchObject({ pullNumber: 8, outcome: "completed" });
+  });
+
+  it("honors the since filter and the limit", async () => {
+    const env = createTestEnv();
+    await seedAudit(env);
+    const since = await app.request("/v1/repos/owner/repo/agent/audit-feed?since=2026-06-18T10:30:00.000Z", { headers: headers(env) }, env);
+    expect(((await since.json()) as { events: unknown[] }).events).toHaveLength(1); // only the 11:00 reject
+    const limited = await app.request("/v1/repos/owner/repo/agent/audit-feed?limit=1", { headers: headers(env) }, env);
+    expect(((await limited.json()) as { events: unknown[] }).events).toHaveLength(1);
+  });
+
+  it("requires authentication and forbids a non-operator session", async () => {
+    const env = createTestEnv();
+    await seedAudit(env);
+    const noauth = await app.request("/v1/repos/owner/repo/agent/audit-feed", {}, env);
+    expect([401, 403]).toContain(noauth.status);
+    const { token } = await createSessionForGitHubUser(env, { login: "rando", id: 555 });
+    const forbidden = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: { authorization: `Bearer ${token}` } }, env);
+    expect([401, 403]).toContain(forbidden.status);
+  });
+
+  it("reports a null pullNumber for an agent event whose targetKey has no numeric PR", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, { eventType: "agent.action.label", actor: "gittensory", targetKey: "owner/repo#manual", outcome: "completed", createdAt: "2026-06-18T09:00:00.000Z" });
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: headers(env) }, env);
+    const body = (await res.json()) as { events: Array<{ pullNumber: number | null }> };
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]?.pullNumber).toBeNull();
+  });
+
+  it("rejects a malformed since with 400", async () => {
+    const env = createTestEnv();
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed?since=not-a-date", { headers: headers(env) }, env);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_since" });
+  });
+
+  it("rejects an out-of-range or non-integer limit with 400", async () => {
+    const env = createTestEnv();
+    for (const bad of ["0", "201", "abc", "1.5"]) {
+      const res = await app.request(`/v1/repos/owner/repo/agent/audit-feed?limit=${bad}`, { headers: headers(env) }, env);
+      expect(res.status, `limit=${bad}`).toBe(400);
+    }
+  });
+
+  it("scrubs forbidden terms from the free-form detail before returning", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, { eventType: "agent.action.merge", actor: "gittensory", targetKey: "owner/repo#7", outcome: "completed", detail: "reward estimate leaked", createdAt: "2026-06-18T10:00:00.000Z" });
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: headers(env) }, env);
+    const body = (await res.json()) as { events: Array<{ detail: string | null }> };
+    expect(body.events[0]?.detail).not.toMatch(/reward/i);
+    expect(body.events[0]?.detail).toContain("private context");
   });
 });


### PR DESCRIPTION
Closes #784. Second of two focused PRs for Phase 3's agent automation control surface (the first, #934, added the MCP approval-queue list/decide tools and is merged). Rebased onto current main; supersedes #935/#936 (closed) with the review feedback fully addressed.

## What this adds
The agent already writes an audit trail (`agent.action.<class>`, `agent.pending_action.accepted|rejected`) but nothing could read it back. This adds the read side:
- **DB**: `listAgentAuditEvents(repoFullName, since?, limit)` — repo-scoped via the `repo#<...>` targetKey range, filtered to agent events, newest first, capped at 200.
- **HTTP**: `GET /v1/repos/:owner/:repo/agent/audit-feed` — maintainer-scoped, `?since=ISO&limit=N`. Now in the **OpenAPI spec**.
- **MCP**: `gittensory_get_agent_audit_feed {owner, repo, since?, limit?}` — maintainer-manage scoped.

## Review feedback addressed (from #936)
- **Sanitisation**: the free-form `detail` is scrubbed with `sanitizePublicComment` before it leaves the endpoint or the MCP tool (defense-in-depth on the public/private boundary). Other fields are controlled vocab (eventType/outcome) or logins (actor).
- **`since` validation**: HTTP returns **400** for a non-ISO-8601 `since`; the MCP schema validates it as `z.string().datetime()`.
- **`limit` bound**: HTTP returns **400** for a non-integer or out-of-1–200 `limit` (no longer silently clamped); the MCP schema caps at 200.
- **Robust prefix range**: upper bound is `repo#` + `U+FFFF` so no delimiter-adjacent key is wrongly excluded.
- **OpenAPI**: the endpoint + its auth/validation responses are documented; `npm run ui:openapi:check` passes.

## Scope on #784
With #934 (MCP list/decide) and the merged CLI `maintain` commands + `get_automation_state`/`propose_action` MCP tools, this completes the **CLI + MCP + HTTP** control surface. The dashboard Automation tab is owner-led *visual* work, intentionally separate.

## Tests
Repo-scoping, ordering, since/limit filters + their 400/schema rejections, detail sanitisation (+ null passthrough), the maintainer-access gate, non-numeric targetKey → null pullNumber. Full `npm run test:coverage` green (branches 97.03%); new lines fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)