### PR TITLE
fix(signals): scope open PR pressure count to repo

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -378,7 +378,7 @@ export function buildLocalBranchAnalysis(args: {
     queueHealth: buildQueueHealth(args.repo, args.issues, args.pullRequests, buildCollisionReport(args.input.repoFullName, args.issues, args.pullRequests)),
     roleContext,
     contributorOpenPrCount: (args.contributorPullRequests ?? args.pullRequests).filter(
-      (pr) => pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === args.input.login.toLowerCase(),
+      (pr) => pr.repoFullName === args.input.repoFullName && pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === args.input.login.toLowerCase(),
     ).length,
   });
   const scenarioSummary = renderPublicScenarioSummary({

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1604,6 +1604,32 @@ describe("local MCP git metadata collection", () => {
     expect(analysis.scenarioSummary.dataClassification.facts).toEqual(expect.arrayContaining(["Contributor", "Repository", "Branch"]));
   });
 
+  it("ignores contributor open PRs from other repos when ranking pressure options", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "src/util.ts", additions: 30, deletions: 2, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 38 },
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 9, title: "Improve util", state: "open", labels: [], linkedPrs: [] }],
+      pullRequests: [],
+      contributorPullRequests: [
+        { repoFullName: "someone-else/other-repo", number: 4, title: "Cross-repo WIP", state: "open", authorLogin: "oktofeesh1", labels: [], linkedIssues: [] },
+      ],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    const options = analysis.scenarioSummary.options;
+    expect(options[0]).toMatchObject({ label: "Open another PR now", recommended: true });
+    expect(options[0]?.rationale).toContain("Repo queue pressure is low.");
+    expect(options[0]?.obstacles).toEqual([]);
+  });
+
   it("wires open-PR pressure strategy options into scenarioSummary.options (#348)", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
### Motivation
- The open-PR pressure simulation counted contributor PRs across all repositories when `contributorPullRequests` was supplied, which could make local-branch guidance treat cross-repo PRs as if they belonged to the repository under analysis.

### Description
- Filter `contributorPullRequests` by `pr.repoFullName === args.input.repoFullName` before counting open PRs in `buildLocalBranchAnalysis` (`src/signals/local-branch.ts`).
- Add a regression test that supplies an open PR in a different repo and asserts the pressure options still recommend opening new work for the current low-pressure repo (`test/unit/local-branch.test.ts`).

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/local-branch.test.ts`; all tests passed (43/43).
- Ran type checking with `npm run typecheck`; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36af73fc10832cb72978ffae73f5ad)