### PR TITLE
fix(scoring): wire trusted open issue counts

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -744,6 +744,11 @@ const digestSubscriptionSchema = z
   })
   .strict();
 
+function contributorOpenIssueCount(issues: Array<{ repoFullName: string; state: string }>, repoFullName: string): number {
+  const targetRepo = repoFullName.toLowerCase();
+  return issues.filter((issue) => issue.repoFullName.toLowerCase() === targetRepo && issue.state === "open").length;
+}
+
 export function createApp() {
   const app = new Hono<AppBindings>();
   app.use("*", async (c, next) => {
@@ -1591,13 +1596,15 @@ export function createApp() {
       const unauthorized = await requireContributorAccess(c, parsed.data.contributorLogin);
       if (unauthorized) return unauthorized;
     }
-    const [repo, snapshot, evidence] = await Promise.all([
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
       getRepository(c.env, parsed.data.repoFullName),
       getOrCreateScoringModelSnapshot(c.env),
       parsed.data.contributorLogin ? getContributorEvidence(c.env, parsed.data.contributorLogin) : Promise.resolve(null),
+      parsed.data.contributorLogin ? listContributorIssues(c.env, parsed.data.contributorLogin) : Promise.resolve([]),
     ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, parsed.data.repoFullName);
     // Time-decay (#703) is an owner-gated global, injected server-side (not caller-controllable).
-    const input = { ...parsed.data, applyTimeDecay: isTimeDecayEnabled(c.env) };
+    const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
     const result = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
     const record = makeScorePreviewRecord(input, snapshot, result);
     await persistScorePreview(c.env, record);
@@ -1611,13 +1618,15 @@ export function createApp() {
     if (!parsed.data.contributorLogin) return c.json({ error: "contributor_login_required" }, 400);
     const unauthorized = await requireContributorAccess(c, parsed.data.contributorLogin);
     if (unauthorized) return unauthorized;
-    const [repo, snapshot, evidence] = await Promise.all([
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
       getRepository(c.env, parsed.data.repoFullName),
       getOrCreateScoringModelSnapshot(c.env),
       getContributorEvidence(c.env, parsed.data.contributorLogin),
+      listContributorIssues(c.env, parsed.data.contributorLogin),
     ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, parsed.data.repoFullName);
     // Time-decay (#703) is an owner-gated global, injected server-side (not caller-controllable).
-    const input = { ...parsed.data, applyTimeDecay: isTimeDecayEnabled(c.env) };
+    const input = { ...parsed.data, openIssueCount, applyTimeDecay: isTimeDecayEnabled(c.env) };
     const preview = buildScorePreview({ input, repo, snapshot, contributorEvidence: evidence });
     return c.json(explainScoreBreakdown(preview));
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -487,6 +487,11 @@ const agentPlanShape = {
   repoFullName: z.string().min(3).optional(),
 };
 
+function contributorOpenIssueCount(issues: Array<{ repoFullName: string; state: string }>, repoFullName: string): number {
+  const targetRepo = repoFullName.toLowerCase();
+  return issues.filter((issue) => issue.repoFullName.toLowerCase() === targetRepo && issue.state === "open").length;
+}
+
 const linkedIssueContextShape = {
   status: z.enum(["raw", "plausible", "validated", "invalid", "unavailable"]).optional(),
   source: z.enum(["user_supplied", "official_mirror", "github_cache", "issue_quality", "missing"]).optional(),
@@ -2065,13 +2070,15 @@ export class GittensoryMcp {
   private async previewScore(input: z.infer<z.ZodObject<typeof scorePreviewShape>>): Promise<ToolPayload> {
     if (input.contributorLogin) this.requireContributorAccess(input.contributorLogin);
     await this.requireRepoAccess(input.repoFullName);
-    const [repo, snapshot, evidence] = await Promise.all([
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
       getRepository(this.env, input.repoFullName),
       getOrCreateScoringModelSnapshot(this.env),
       input.contributorLogin ? getContributorEvidence(this.env, input.contributorLogin) : Promise.resolve(null),
+      input.contributorLogin ? listContributorIssues(this.env, input.contributorLogin) : Promise.resolve([]),
     ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, input.repoFullName);
     // Time-decay (#703) is an owner-gated global, injected server-side (not caller-controllable).
-    const scoreInput = { ...input, applyTimeDecay: isTimeDecayEnabled(this.env) };
+    const scoreInput = { ...input, openIssueCount, applyTimeDecay: isTimeDecayEnabled(this.env) };
     const result = buildScorePreview({ input: scoreInput, repo, snapshot, contributorEvidence: evidence });
     return {
       summary: `Private Gittensory scoring preview for ${input.repoFullName}.`,

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -472,6 +472,7 @@ function buildLocalScoreInput(args: {
     testTokenScore: scorer?.testTokenScore ?? testLineCount,
     nonCodeTokenScore: scorer?.nonCodeTokenScore ?? nonCodeLineCount,
     openPrCount: args.outcomeHistory.totals.openPullRequests,
+    openIssueCount: args.repoOutcome?.openIssues ?? args.outcomeHistory.totals.openIssues,
     credibility: args.repoOutcome?.credibility ?? args.outcomeHistory.totals.credibility,
     metadataOnly: scorer?.mode !== "gittensor_root" && scorer?.mode !== "external_command",
     pendingMergedPrCount: args.input.pendingMergedPrCount,

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -182,6 +182,7 @@ export function buildRepoRewardRisk(args: {
 
   const labels = bestFitLabels(args.repo);
   const currentOpenPrCount = nonNegative(args.outcomeHistory.totals.openPullRequests);
+  const currentOpenIssueCount = nonNegative(repoOutcome?.openIssues ?? args.outcomeHistory.totals.openIssues);
   /* v8 ignore next -- Credibility fallback order protects sparse private snapshots; behavior is covered through scoring profile tests. */
   const credibility = repoOutcome?.credibility && repoOutcome.credibility > 0 ? repoOutcome.credibility : args.scoringProfile?.evidence.credibilityAssumption ?? args.outcomeHistory.totals.credibility ?? 0.8;
   const commonPreviewInput = {
@@ -198,6 +199,7 @@ export function buildRepoRewardRisk(args: {
     credibility,
     metadataOnly: true,
     duplicateRiskCount: collisions.summary.highRiskCount,
+    openIssueCount: currentOpenIssueCount,
   };
   const currentPreview = buildScorePreview({
     input: { ...commonPreviewInput, openPrCount: currentOpenPrCount },

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -94,6 +94,34 @@ describe("local branch analysis", () => {
     expect(analysis.scorePreview.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ code: "duplicate_risk" })]));
   });
 
+  it("applies the open-issue spam gate from trusted outcome history", () => {
+    const issueHeavyHistory: ContributorOutcomeHistory = {
+      ...outcomeHistory,
+      totals: { ...outcomeHistory.totals, issues: 99, openIssues: 99 },
+      repoOutcomes: [{ ...outcomeHistory.repoOutcomes[0]!, issues: 99, openIssues: 99 }],
+    };
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        labels: ["enhancement"],
+        changedFiles: [{ path: "src/cache.ts", additions: 42, deletions: 4, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 48, totalTokenScore: 80, sourceLines: 46 },
+      },
+      repo,
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory: issueHeavyHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.scorePreview.gates.openIssueCount).toBe(99);
+    expect(analysis.scorePreview.scoreEstimate.openIssueMultiplier).toBe(0);
+    expect(analysis.scorePreview.blockedBy).toEqual(expect.arrayContaining([expect.objectContaining({ code: "open_issue_threshold" })]));
+  });
+
   it("bounds local scorer warnings before adding local findings", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
### Motivation

- A recent scoring change introduced an `openIssueCount` gate but left `openIssueCount` optional in score-preview inputs, allowing production preview paths to default it to 0 and bypass the open-issue spam gate.
- Trusted contributor/repo open-issue counts are already available in cached outcome data and should be used server-side rather than trusting caller-supplied input.

### Description

- Derive `openIssueCount` server-side for REST preview endpoints and `explain-breakdown` by fetching contributor issues and computing the repo-specific open-issue count via `contributorOpenIssueCount` and passing it into `buildScorePreview` (`src/api/routes.ts`).
- Apply the same server-side derivation to MCP preview paths and pass `openIssueCount` into the MCP score-preview pipeline (`src/mcp/server.ts`).
- Wire trusted cached counts from `ContributorOutcomeHistory` into local-branch and reward-risk preview inputs by populating `openIssueCount` from `repoOutcome?.openIssues ?? outcomeHistory.totals.openIssues` (`src/signals/local-branch.ts`, `src/signals/reward-risk.ts`).
- Add a unit regression test that constructs an issue-heavy outcome history and verifies `openIssueCount` is set, the `openIssueMultiplier` becomes 0, and the `open_issue_threshold` blocker is emitted (`test/unit/local-branch.test.ts`).

### Testing

- Ran typecheck with `npx tsc --noEmit` which succeeded without errors.
- Ran unit tests with `npx vitest run test/unit/local-branch.test.ts test/unit/scoring.test.ts --reporter=dot` and the suite passed (all tests in the invoked files passed).
- Ran repository lint/check `git diff --check` which reported no whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b2305460832c971ddff36199d561)