### PR TITLE
fix(api): allow maintainer sessions on audit feed

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4483,7 +4483,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoAiConfigPath(path)) return true;
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoValidateLinkedIssuePath(path)) return true;
-  if (isRepoAgentAuditFeedPath(path)) return true;
+  if (isRepoAgentAuditFeedPath(path)) return true; // route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4481,6 +4481,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoAiConfigPath(path)) return true;
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoValidateLinkedIssuePath(path)) return true;
+  if (isRepoAgentAuditFeedPath(path)) return true;
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
@@ -4524,6 +4525,10 @@ function isRepoCheckBeforeStartPath(path: string): boolean {
 
 function isRepoValidateLinkedIssuePath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/validate-linked-issue$/.test(path);
+}
+
+function isRepoAgentAuditFeedPath(path: string): boolean {
+  return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/audit-feed$/.test(path);
 }
 
 function isIssueQualityPath(path: string): boolean {

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -168,6 +168,23 @@ describe("agent audit-feed route (#784)", () => {
     await expect(res.json()).resolves.toMatchObject({ repoFullName: "owner/repo", events: [{ eventType: "agent.pending_action.rejected" }, { eventType: "agent.action.merge" }] });
   });
 
+  it("forbids a contributor (non-maintainer) session even though the coarse allowlist permits the path (#943)", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read" }, events: ["pull_request"] },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedAudit(env);
+    // A plain contributor — not the repo owner/maintainer/operator. The audit-feed path now clears the
+    // coarse session allowlist (#943), so the repo is fully seeded and the ONLY thing that can block is the
+    // route's requireRepoMaintainer guard — which must still 403 them, proving the feed is never exposed.
+    const { token } = await createSessionForGitHubUser(env, { login: "contributor", id: 999 });
+
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: { authorization: `Bearer ${token}` } }, env);
+
+    expect([401, 403]).toContain(res.status);
+  });
+
   it("reports a null pullNumber for an agent event whose targetKey has no numeric PR", async () => {
     const env = createTestEnv();
     await recordAuditEvent(env, { eventType: "agent.action.label", actor: "gittensory", targetKey: "owner/repo#manual", outcome: "completed", createdAt: "2026-06-18T09:00:00.000Z" });

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../src/github/labels", () => ({
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { createSessionForGitHubUser } from "../../src/auth/security";
 import { createApp } from "../../src/api/routes";
-import { createPendingAgentActionIfAbsent, getPendingAgentAction, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createPendingAgentActionIfAbsent, getPendingAgentAction, recordAuditEvent, upsertInstallation, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 const app = createApp();
@@ -151,6 +151,21 @@ describe("agent audit-feed route (#784)", () => {
     const { token } = await createSessionForGitHubUser(env, { login: "rando", id: 555 });
     const forbidden = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: { authorization: `Bearer ${token}` } }, env);
     expect([401, 403]).toContain(forbidden.status);
+  });
+
+  it("allows a repository owner session to read the audit feed", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read" }, events: ["pull_request"] },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedAudit(env);
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 1 });
+
+    const res = await app.request("/v1/repos/owner/repo/agent/audit-feed", { headers: { authorization: `Bearer ${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ repoFullName: "owner/repo", events: [{ eventType: "agent.pending_action.rejected" }, { eventType: "agent.action.merge" }] });
   });
 
   it("reports a null pullNumber for an agent event whose targetKey has no numeric PR", async () => {


### PR DESCRIPTION
### Motivation
- The new maintainer-scoped endpoint `GET /v1/repos/:owner/:repo/agent/audit-feed` was blocked by the global session path allowlist, causing session-authenticated maintainers/owners to receive `insufficient_role` before the route-level `requireRepoMaintainer` check could run.

### Description
- Allow the audit-feed path in the coarse session allowlist by adding `isRepoAgentAuditFeedPath` and including `if (isRepoAgentAuditFeedPath(path)) return true;` inside `canSessionAccessPath` in `src/api/routes.ts`.
- Add a unit test to verify a repository owner session can read the audit feed and adjust test seeding to register the repository via `upsertRepositoryFromGitHub` in `test/unit/routes-agent-approval.test.ts`.
- Files changed: `src/api/routes.ts` and `test/unit/routes-agent-approval.test.ts`.

### Testing
- Ran the focused unit suite with `NO_COLOR=1 npx vitest run test/unit/routes-agent-approval.test.ts --reporter=verbose` and all tests passed (17/17). 
- Ran type checking with `npm run typecheck` which succeeded. 
- Ran `git diff --check` which produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c09ea01c832cb2908baaa983dfc1)