### PR TITLE
perf(notifications): build feed in a single pass instead of filter + filter + map

### DIFF
--- a/src/notifications/service.ts
+++ b/src/notifications/service.ts
@@ -167,11 +167,12 @@ export type NotificationFeed = {
 // Shapes the recipient's badge feed: the unread count (the badge number) plus recent items. Only rows that
 // reached `delivered` (or already `read`) are shown — `pending`/`suppressed` never surface to the user.
 export function buildNotificationFeed(login: string, deliveries: NotificationDeliveryRecord[]): NotificationFeed {
-  const visible = deliveries.filter((delivery) => delivery.status === "delivered" || delivery.status === "read");
-  return {
-    login: login.toLowerCase(),
-    unreadCount: visible.filter((delivery) => delivery.status === "delivered").length,
-    notifications: visible.map((delivery) => ({
+  const notifications: NotificationFeedItem[] = [];
+  let unreadCount = 0;
+  for (const delivery of deliveries) {
+    if (delivery.status !== "delivered" && delivery.status !== "read") continue;
+    if (delivery.status === "delivered") unreadCount += 1;
+    notifications.push({
       id: delivery.id,
       eventType: delivery.eventType,
       repoFullName: delivery.repoFullName,
@@ -181,8 +182,9 @@ export function buildNotificationFeed(login: string, deliveries: NotificationDel
       deeplink: delivery.deeplink,
       status: delivery.status,
       createdAt: delivery.createdAt,
-    })),
-  };
+    });
+  }
+  return { login: login.toLowerCase(), unreadCount, notifications };
 }
 
 // Badge delivery is pull-based: "delivering" just makes the row visible to the recipient's feed (status


### PR DESCRIPTION
> **No linked issue:** Proactive optimization found during code review — no issue was filed for this pattern.

## Problem

\`buildNotificationFeed\` made **three passes** over the delivery list:

1. \`.filter()\` → allocates a \`visible[]\` intermediate array (only delivered/read rows)
2. \`.filter().length\` → scans \`visible[]\` again to count unread (\`delivered\`) rows
3. \`.map()\` → scans \`visible[]\` a third time to shape rows into \`NotificationFeedItem\`

The intermediate array is allocated and then discarded after the two downstream passes. For a miner with 50 recent notifications this is 150 iterations and two heap allocations where one pass and one allocation suffice.

## Fix

Replace the three-pass chain with a single \`for-of\` loop that:
- Skips rows whose status is neither \`delivered\` nor \`read\` (early \`continue\`)
- Increments \`unreadCount\` for \`delivered\` rows in the same pass
- Pushes the shaped \`NotificationFeedItem\` in the same iteration

```
Before: 3 array passes + 1 intermediate allocation
After:  1 pass, 0 intermediate allocations
```

No behaviour change — output shape and item ordering are identical.

## Tests

The existing test _"shows only delivered/read rows in the feed and counts only delivered as unread"_ covers all four status variants (\`delivered\`, \`read\`, \`pending\`, \`suppressed\`) and asserts both \`unreadCount\` and the notification order — no new tests needed.