### PR TITLE
perf(focus-manifest): compile each path pattern once when matching changed paths

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -614,24 +614,41 @@ function normalizePathForMatch(path: string): string {
 }
 
 /**
+ * Compile a manifest path pattern into a predicate over an ALREADY-normalized path. Supports exact paths,
+ * directory prefixes (`src/` or `src`), and `*` wildcards (`**` collapses to `*`). Compiling once (the
+ * wildcard regex in particular) lets a caller test many paths against one pattern without recompiling per
+ * path — see {@link matchedPatterns}. An empty/blank pattern never matches.
+ */
+function compileManifestPathMatcher(pattern: string): (normalizedPath: string) => boolean {
+  const normalizedPattern = normalizePathForMatch(pattern);
+  if (!normalizedPattern) return () => false;
+  if (normalizedPattern.includes("*")) {
+    const escaped = normalizedPattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*+/g, ".*");
+    const regex = new RegExp(`^${escaped}$`);
+    return (normalizedPath) => regex.test(normalizedPath);
+  }
+  const dirPattern = normalizedPattern.endsWith("/") ? normalizedPattern : `${normalizedPattern}/`;
+  return (normalizedPath) => normalizedPath === normalizedPattern || normalizedPath.startsWith(dirPattern);
+}
+
+/**
  * Match a changed path against a manifest path pattern. Supports exact paths, directory
  * prefixes (`src/` or `src`), and `*` wildcards (`**` collapses to `*`).
  */
 export function matchesManifestPath(path: string, pattern: string): boolean {
   const normalizedPath = normalizePathForMatch(path);
-  const normalizedPattern = normalizePathForMatch(pattern);
-  if (!normalizedPath || !normalizedPattern) return false;
-  if (normalizedPattern.includes("*")) {
-    const escaped = normalizedPattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*+/g, ".*");
-    return new RegExp(`^${escaped}$`).test(normalizedPath);
-  }
-  if (normalizedPath === normalizedPattern) return true;
-  const dirPattern = normalizedPattern.endsWith("/") ? normalizedPattern : `${normalizedPattern}/`;
-  return normalizedPath.startsWith(dirPattern);
+  if (!normalizedPath) return false;
+  return compileManifestPathMatcher(pattern)(normalizedPath);
 }
 
 function matchedPatterns(paths: string[], patterns: string[]): string[] {
-  return patterns.filter((pattern) => paths.some((path) => matchesManifestPath(path, pattern)));
+  // Normalize each path once and compile each pattern once, instead of redoing both for every (path,
+  // pattern) pair — the wildcard regex was previously recompiled per path.
+  const normalizedPaths = paths.map(normalizePathForMatch).filter(Boolean);
+  return patterns.filter((pattern) => {
+    const matches = compileManifestPathMatcher(pattern);
+    return normalizedPaths.some((normalizedPath) => matches(normalizedPath));
+  });
 }
 
 /**

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -183,6 +183,32 @@ describe("matchesManifestPath", () => {
   });
 });
 
+// Regression tests for the three compileManifestPathMatcher branches: exact,
+// directory-prefix, and wildcard. Each test exercises one branch in isolation.
+describe("matchesManifestPath — compileManifestPathMatcher branches", () => {
+  it("exact branch: returns true only when normalised path equals normalised pattern", () => {
+    expect(matchesManifestPath("src/index.ts", "src/index.ts")).toBe(true);
+    expect(matchesManifestPath("./src/Index.ts", "src/index.ts")).toBe(true); // normalisation
+    expect(matchesManifestPath("src/other.ts", "src/index.ts")).toBe(false);
+  });
+
+  it("directory-prefix branch: matches descendants but not siblings with shared prefix", () => {
+    expect(matchesManifestPath("src/utils/foo.ts", "src/utils")).toBe(true);
+    expect(matchesManifestPath("src/utils/foo.ts", "src/utils/")).toBe(true);
+    // "src/utilsX" shares the prefix string but must not match "src/utils"
+    expect(matchesManifestPath("src/utilsX/foo.ts", "src/utils")).toBe(false);
+    expect(matchesManifestPath("docs/readme.md", "src/")).toBe(false);
+  });
+
+  it("wildcard branch: * and ** expand to any characters in regex", () => {
+    expect(matchesManifestPath("packages/mcp/lib/x.ts", "packages/*/lib/*.ts")).toBe(true);
+    expect(matchesManifestPath("src/foo.ts", "src/*.ts")).toBe(true);
+    expect(matchesManifestPath("src/foo.go", "src/*.ts")).toBe(false);
+    expect(matchesManifestPath("a/b/c.ts", "**/*.ts")).toBe(true);
+    expect(matchesManifestPath("src/a.ts", "**/*.go")).toBe(false);
+  });
+});
+
 describe("buildFocusManifestGuidance", () => {
   const wanted = parseFocusManifest(FULL_MANIFEST);
 


### PR DESCRIPTION
## Summary

- Refactors \`matchesManifestPath\` and \`matchedPatterns\` to compile each glob pattern into a reusable matcher function exactly once via a new internal helper \`compileManifestPathMatcher\`.
- Eliminates repeated regex compilation and string normalisation per path/pattern pair on every call to \`matchedPatterns\`.
- Adds explicit regression tests for each of the three matcher branches (exact, directory-prefix, wildcard) to confirm behaviour is unchanged after the refactor.

## Test plan

- [x] All 2299 existing tests pass (\`npx vitest run test/unit test/integration --coverage\`).
- [x] 98 tests in \`focus-manifest.test.ts\` pass, including new describe blocks for each branch of \`compileManifestPathMatcher\`.
- [x] Branch coverage ≥ 97%.
- [x] \`npx tsc --noEmit\` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)