### PR TITLE
fix(backfill): paginate label fetch in monolithic backfill path

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1989,8 +1989,13 @@ async function syncLabels(
 ): Promise<{ items: GitHubLabelPayload[]; warnings: string[]; segment: RepoSyncSegmentRecord }> {
   const startedAt = nowIso();
   await markSegmentRunning(env, repo, "labels", sourceKind, mode, startedAt);
+  const items: GitHubLabelPayload[] = [];
   try {
-    const items = await githubJson<GitHubLabelPayload[]>(env, repo.fullName, "/labels?per_page=100", token);
+    for (let page = 1; ; page += 1) {
+      const result = await githubJsonWithHeaders<GitHubLabelPayload[]>(env, repo.fullName, `/labels?per_page=100&page=${page}`, token);
+      items.push(...result.data);
+      if (!hasNextPage(result.link)) break;
+    }
     const segment = await completeSegment(env, repo, "labels", sourceKind, mode, startedAt, {
       status: "complete",
       fetchedCount: items.length,
@@ -2002,12 +2007,12 @@ async function syncLabels(
     const warning = `Label sync failed: ${errorMessage(error)}`;
     const segment = await completeSegment(env, repo, "labels", sourceKind, mode, startedAt, {
       status: error instanceof GitHubApiError && error.rateLimited ? "rate_limited" : "partial",
-      fetchedCount: 0,
+      fetchedCount: items.length,
       warnings: [warning],
       errorSummary: warning,
       rateLimitResetAt: error instanceof GitHubApiError ? error.rateLimitResetAt : undefined,
     });
-    return { items: [], warnings: [warning], segment };
+    return { items, warnings: [warning], segment };
   }
 }
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -151,6 +151,37 @@ describe("GitHub backfill", () => {
     expect(authHeaders).toContain("Bearer public-token");
   });
 
+  it("paginates past the first 100 labels in the monolithic backfill path", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.github.com/graphql") return githubTotalsResponse({ openIssues: 0, openPullRequests: 0, mergedPullRequests: 0, closedPullRequests: 0, labels: 150 });
+      if (url.endsWith("/repos/JSONbored/gittensory")) {
+        return Response.json({ name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", owner: { login: "JSONbored" } });
+      }
+      if (url.includes("/labels?")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        if (page === 1) {
+          return Response.json(
+            Array.from({ length: 100 }, (_, i) => ({ name: `label-p1-${i}`, color: "aaaaaa" })),
+            { headers: { link: '<https://api.github.com/repositories/1/labels?page=2>; rel="next"' } },
+          );
+        }
+        return Response.json(Array.from({ length: 50 }, (_, i) => ({ name: `label-p2-${i}`, color: "bbbbbb" })));
+      }
+      return Response.json([]);
+    });
+
+    await backfillRegisteredRepositories(env);
+
+    const stored = await listRepoLabels(env, "JSONbored/gittensory");
+    // 150 labels from GitHub (100 page-1 + 50 page-2) plus configured labels not present on GitHub
+    expect(stored.length).toBeGreaterThanOrEqual(150);
+    expect(stored.some((l) => l.name === "label-p1-0")).toBe(true);
+    expect(stored.some((l) => l.name === "label-p2-0")).toBe(true);
+  });
+
   it("refreshes contributor activity from GitHub search counts for registered repos", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
## Summary

- `syncLabels` (called from the monolithic `backfillRegisteredRepositories` path) fetched labels with a single `GET /labels?per_page=100` call, silently truncating any repository with more than 100 labels.
- The segment-based `backfillRepositoryLabels` path already paginates correctly via `fetchPagedSegment`. This fix brings the monolithic path into parity.
- Replace the single `githubJson` call with a `githubJsonWithHeaders` loop that follows `Link: rel=\"next\"` headers until all pages are exhausted.
- Also fixes `syncLabels` error handling to return any partially-fetched items (and the correct partial count) rather than discarding them on a mid-pagination failure.

## Test plan

- [x] New test `paginates past the first 100 labels in the monolithic backfill path` mocks a 2-page label response (100 + 50) and asserts both pages land in the DB.
- [x] All 2322 existing tests pass (`npx vitest run test/unit test/integration --coverage`).
- [x] Branch coverage ≥ 97%.
- [x] `npx tsc --noEmit` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)