### PR TITLE
fix(comments): paginate comment search so the bot comment is never missed

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -52,15 +52,21 @@ async function createOrUpdateIssueCommentWithMarker(
 
   const token = await createInstallationToken(env, installationId);
   const octokit = new Octokit({ auth: token });
-  const comments = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", {
-    owner,
-    repo,
-    issue_number: issueNumber,
-    per_page: 100,
-  });
   const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
   const markers = markerAliases(marker);
-  const existing = (comments.data as IssueComment[]).find((comment) => isGittensoryBotComment(comment, botLogin) && markers.some((candidate) => comment.body?.includes(candidate)));
+  let existing: IssueComment | undefined;
+  for (let page = 1; !existing; page += 1) {
+    const response = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+      page,
+    });
+    const batch = response.data as IssueComment[];
+    existing = batch.find((comment) => isGittensoryBotComment(comment, botLogin) && markers.some((candidate) => comment.body?.includes(candidate)));
+    if (batch.length < 100) break;
+  }
   if (existing) {
     const response = await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
       owner,

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -65,6 +65,43 @@ describe("GitHub PR intelligence comments", () => {
     expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/101"))).toBe(true);
   });
 
+  it("finds the existing bot comment on page 2 and updates it rather than creating a duplicate", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        if (page === 1) {
+          // 100 human comments — no bot comment yet
+          return Response.json(
+            Array.from({ length: 100 }, (_, i) => ({ id: i + 1, body: `human comment ${i + 1}`, user: { login: "contributor", type: "User" } })),
+          );
+        }
+        // Bot comment is on page 2
+        return Response.json([{ id: 999, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold body`, user: { login: "gittensory[bot]", type: "Bot" } }]);
+      }
+      if (url.includes("/issues/comments/999") && init?.method === "PATCH") {
+        return Response.json({ id: 999, html_url: "https://github.com/comment/999" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\nnew body`,
+    );
+
+    expect(result?.id).toBe(999);
+    expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/999"))).toBe(true);
+    expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
+  });
+
   it("updates a legacy PR intelligence comment into the unified panel", async () => {
     const privateKey = await generatePrivateKeyPem();
     const calls: string[] = [];


### PR DESCRIPTION
## Summary

- `createOrUpdateIssueCommentWithMarker` (used by both `createOrUpdatePrIntelligenceComment` and `createOrUpdateAgentCommandComment`) fetched only the first page of comments (up to 100) when searching for the Gittensory bot's existing panel comment.
- On PRs with more than 100 comments where the bot posted its panel after the 100th human comment, the function missed the existing comment and created a duplicate `POST` instead of issuing a `PATCH` update.
- Fix: replace the single request with a paginated loop that exits as soon as the bot comment is found (so the common case of 1 page still requires exactly 1 request) and stops at the first partial page to detect the list end.

## Test plan

- [x] New test `finds the existing bot comment on page 2 and updates it rather than creating a duplicate` mocks a 100-comment first page with no bot comment, a second page containing the bot comment, and asserts a PATCH is issued (not a POST).
- [x] All 2322 existing tests pass.
- [x] Branch coverage ≥ 97%.
- [x] `npx tsc --noEmit` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)