### PR TITLE
fix(labels): drop pre-check GET and catch 422 to handle repos with >100 labels

### DIFF
--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -31,13 +31,7 @@ export async function ensurePullRequestLabel(
 
   let created = false;
   if (options.createMissingLabel) {
-    const repoLabels = await octokit.request("GET /repos/{owner}/{repo}/labels", {
-      owner,
-      repo,
-      per_page: 100,
-    });
-    const labelExists = (repoLabels.data as GitHubLabel[]).some((label) => label.name?.toLowerCase() === labelName.toLowerCase());
-    if (!labelExists) {
+    try {
       await octokit.request("POST /repos/{owner}/{repo}/labels", {
         owner,
         repo,
@@ -46,6 +40,10 @@ export async function ensurePullRequestLabel(
         description: "Gittensor contributor context",
       });
       created = true;
+    } catch (error) {
+      const e = error as { status?: number; message?: string };
+      // Only swallow the specific "already_exists" duplicate; other 422s (e.g. invalid name) must propagate.
+      if (e.status !== 422 || !e.message?.includes("already_exists")) throw error;
     }
   }
 

--- a/test/unit/github-labels.test.ts
+++ b/test/unit/github-labels.test.ts
@@ -30,7 +30,7 @@ describe("GitHub PR labels", () => {
     expect(calls.some((call) => call.includes("/repos/JSONbored/gittensory/labels"))).toBe(false);
   });
 
-  it("applies an existing repository label without creating it", async () => {
+  it("applies an existing repository label without creating it, even when the repo has more than 100 labels", async () => {
     const calls: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -38,7 +38,13 @@ describe("GitHub PR labels", () => {
       calls.push(`${method} ${url}`);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/issues/4/labels") && method === "GET") return Response.json([]);
-      if (url.includes("/repos/JSONbored/gittensory/labels") && method === "GET") return Response.json([{ name: "gittensor" }]);
+      if (url.includes("/repos/JSONbored/gittensory/labels") && method === "POST") {
+        // GitHub 422 "already_exists" — label is in the repo (possibly beyond page 100)
+        return Response.json(
+          { message: "Validation Failed", errors: [{ resource: "Label", code: "already_exists", field: "name" }] },
+          { status: 422 },
+        );
+      }
       if (url.includes("/issues/4/labels") && method === "POST") return Response.json([{ name: "gittensor" }]);
       return new Response("unexpected", { status: 500 });
     });
@@ -48,7 +54,28 @@ describe("GitHub PR labels", () => {
     });
 
     expect(result).toEqual({ applied: true, created: false });
-    expect(calls.some((call) => call.startsWith("POST ") && call.endsWith("/repos/JSONbored/gittensory/labels"))).toBe(false);
+  });
+
+  it("propagates a 422 that is not an already_exists duplicate (e.g. invalid label name)", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/4/labels") && method === "GET") return Response.json([]);
+      if (url.includes("/repos/JSONbored/gittensory/labels") && method === "POST") {
+        return Response.json(
+          { message: "Validation Failed", errors: [{ resource: "Label", code: "invalid", field: "name" }] },
+          { status: 422 },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(
+      ensurePullRequestLabel(createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }), 123, "JSONbored/gittensory", 4, "gittensor", {
+        createMissingLabel: true,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
   });
 
   it("creates a missing repository label when configured", async () => {


### PR DESCRIPTION
## Summary

- `ensurePullRequestLabel` checked whether a repo label existed with `GET /repos/.../labels?per_page=100` before deciding whether to `POST` and create it. On repos with more than 100 labels the label could be beyond page 1, causing `labelExists=false` — then the `POST /repos/.../labels` call would fail with a GitHub 422 ("already exists"), surfacing as an unhandled error and preventing the label from being applied to the PR.
- Replace the fetch-then-decide pattern with a direct `POST` that catches only the specific `already_exists` 422 error code and treats it as "label exists, proceed." Other 422 errors (e.g. invalid label name) are re-thrown so callers still see them.
- Also removes a TOCTOU window (another concurrent process could create the label between the `GET` check and the `POST`) and saves one API round-trip in the common case.

## Test plan

- [x] Updated `applies an existing repository label without creating it` to use the 422 `already_exists` path (mirrors the actual GitHub response for a duplicate).
- [x] New test `propagates a 422 that is not an already_exists duplicate` verifies that a 422 with `code: "invalid"` (e.g. invalid label name) is re-thrown and not swallowed.
- [x] All 2323 existing tests pass (`npx vitest run test/unit test/integration --coverage`).
- [x] Branch coverage ≥ 97%.
- [x] `npx tsc --noEmit` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)