### PR TITLE
fix(access): suspended installation revokes owner-match repo scope

### DIFF
--- a/src/services/control-panel-roles.ts
+++ b/src/services/control-panel-roles.ts
@@ -74,7 +74,14 @@ export function buildControlPanelAccessScope(args: RoleSummaryInputs): ControlPa
   const installedRepos = args.repositories.filter((repo) => repo.isInstalled);
   const accountInstallations = args.installations.filter((installation) => !installation.suspendedAt && sameLogin(installation.accountLogin, args.login));
   const accountInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
-  const ownedInstalledRepos = installedRepos.filter((repo) => sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId)));
+  // Suspending the App revokes its access, so an owned repo whose installation is suspended must drop out
+  // of scope — the owner-match fallback below previously ignored suspendedAt. We still keep the permissive
+  // owner-match for repos with no/unknown installation linkage; only a *suspended* installation excludes.
+  const suspendedInstallationIds = new Set(args.installations.filter((installation) => installation.suspendedAt).map((installation) => installation.id));
+  const ownedInstalledRepos = installedRepos.filter((repo) => {
+    if (repo.installationId !== undefined && repo.installationId !== null && suspendedInstallationIds.has(repo.installationId)) return false;
+    return sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId));
+  });
   const maintainerRepos = uniqueRepoNames(
     args.pullRequests
       .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))
@@ -101,7 +108,14 @@ export function buildControlPanelRoleSummary(args: RoleSummaryInputs): ControlPa
   const installedRepos = args.repositories.filter((repo) => repo.isInstalled);
   const accountInstallations = args.installations.filter((installation) => !installation.suspendedAt && sameLogin(installation.accountLogin, args.login));
   const accountInstallationIds = new Set(accountInstallations.map((installation) => installation.id));
-  const ownedInstalledRepos = installedRepos.filter((repo) => sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId)));
+  // Suspending the App revokes its access, so an owned repo whose installation is suspended must drop out
+  // of scope — the owner-match fallback below previously ignored suspendedAt. We still keep the permissive
+  // owner-match for repos with no/unknown installation linkage; only a *suspended* installation excludes.
+  const suspendedInstallationIds = new Set(args.installations.filter((installation) => installation.suspendedAt).map((installation) => installation.id));
+  const ownedInstalledRepos = installedRepos.filter((repo) => {
+    if (repo.installationId !== undefined && repo.installationId !== null && suspendedInstallationIds.has(repo.installationId)) return false;
+    return sameLogin(repo.owner, args.login) || (repo.installationId !== undefined && repo.installationId !== null && accountInstallationIds.has(repo.installationId));
+  });
   const maintainerRepos = uniqueRepos(
     args.pullRequests
       .filter((pull) => sameLogin(pull.authorLogin, args.login) && isMaintainerAssociation(pull.authorAssociation))

--- a/test/unit/control-panel-roles.test.ts
+++ b/test/unit/control-panel-roles.test.ts
@@ -112,6 +112,30 @@ describe("control panel role summaries", () => {
     });
   });
 
+  it("drops an owner's repo from scope when their installation is suspended (suspend revokes access)", () => {
+    // Suspending the App revokes its access; the owner-match scope branch must honor that, not just the
+    // installation-id branch — otherwise a repo owner keeps reading their repo's private data post-suspend.
+    const args = {
+      login: "repo-owner",
+      generatedAt: "2026-06-01T12:00:00.000Z",
+      confirmedMiner: false,
+      operator: false,
+      repositories: [repo("repo-owner/owned-repo", "repo-owner", 21)],
+      installations: [{ ...installation(21, "repo-owner"), suspendedAt: "2026-06-02T00:00:00.000Z" }],
+      pullRequests: [],
+    } as const;
+
+    const scope = buildControlPanelAccessScope(args);
+    expect(scope.repositoryFullNames).toEqual([]);
+    expect(scope.installationIds).toEqual([]);
+    expect(scope.accountLogins).toEqual([]);
+
+    // The role summary uses the same owner-scope logic; a suspended owner must not be granted owner/maintainer.
+    const summary = buildControlPanelRoleSummary(args);
+    expect(summary.roles).not.toContain("owner");
+    expect(summary.roles).not.toContain("maintainer");
+  });
+
   it("includes installed maintainer repositories from cached PR evidence", () => {
     const scope = buildControlPanelAccessScope({
       login: "maintainer",


### PR DESCRIPTION
## Summary

`buildControlPanelAccessScope` (and the identical block in `buildControlPanelRoleSummary`) drops **suspended** installations when computing a session's repo access — except one branch. The `ownedInstalledRepos` filter granted scope via `sameLogin(repo.owner, args.login)` **without** checking `suspendedAt`, and nothing flips `repositories.isInstalled` on the `installation` `suspend` webhook (only `deleted` is special-cased). So after a user suspends the App — GitHub's "revoke access without uninstalling" control — that user still retained control-panel access to their own installed repo's private gittensory data (settings, issue-quality, audit/skipped-PR feed, issue-watch notifications).

```ts
// src/services/control-panel-roles.ts — before
const accountInstallations = args.installations.filter((i) => !i.suspendedAt && sameLogin(i.accountLogin, args.login)); // suspend-aware
const ownedInstalledRepos = installedRepos.filter((repo) =>
  sameLogin(repo.owner, args.login)                                  // ignored suspendedAt
  || (repo.installationId != null && accountInstallationIds.has(repo.installationId)));
```

`src/queue/processors.ts`: the `suspend` action falls through to `upsertInstallation` (records `suspendedAt`) and never un-installs the repos. The intent is explicit — the `!suspendedAt` filter sits two lines above the leaking branch, and the installation-id disjunct already honors it; the owner-match disjunct was the oversight.

## Scope / honest severity

Bounded to **the repo owner's own data** (the branch only matches `repo.owner === args.login`, i.e. personally-owned repos; org-owned repos use the suspend-safe `accountLogins` path, and live-verified write paths like BYOK key routes re-check GitHub permission and fail closed). So this is a **revocation-completeness / access-boundary correctness** bug, not a cross-tenant leak — but suspension is a security control the product honors everywhere else.

## Fix

Exclude an owned repo whose installation is **suspended**, while keeping the permissive owner-match fallback for repos with no/unknown installation linkage:

```ts
const suspendedInstallationIds = new Set(args.installations.filter((i) => i.suspendedAt).map((i) => i.id));
const ownedInstalledRepos = installedRepos.filter((repo) => {
  if (repo.installationId != null && suspendedInstallationIds.has(repo.installationId)) return false;
  return sameLogin(repo.owner, args.login) || (repo.installationId != null && accountInstallationIds.has(repo.installationId));
});
```

Applied identically in both `buildControlPanelAccessScope` and `buildControlPanelRoleSummary`.

## Tests

Added a regression test: a suspended installation + an owner-owned `isInstalled` repo yields empty `repositoryFullNames`/`installationIds`/`accountLogins` and no `owner`/`maintainer` role. The `control-panel-roles`, `access-boundary`, and `issue-watch` suites all pass; the changed lines + branches are fully covered. (`control-panel-roles.test.ts` previously had zero `suspend` cases.)

Closes #953
