### PR TITLE
fix(public): paginate contributor repos fetch so topLanguages isn't truncated at 100

### DIFF
--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -77,7 +77,15 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
     ]);
     if (!userResponse.ok) throw new Error(`GitHub user lookup failed (${userResponse.status})`);
     const user = (await userResponse.json()) as GitHubUserResponse;
-    const repos = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
+    const repos: GitHubRepoResponse[] = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
+    let linkHeader = reposResponse.ok ? reposResponse.headers.get("link") : null;
+    for (let page = 2; linkHeader?.includes('rel="next"'); page += 1) {
+      const nextResponse = await fetch(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated&page=${page}`, { headers, signal });
+      if (!nextResponse.ok) break;
+      const batch = (await nextResponse.json()) as GitHubRepoResponse[];
+      repos.push(...batch);
+      linkHeader = nextResponse.headers.get("link");
+    }
     const languageCounts = new Map<string, number>();
     for (const repo of repos) {
       if (!repo.language) continue;

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -124,6 +124,29 @@ describe("small adapters and normalizers", () => {
     await expect(fetchPublicContributorProfile("missing")).resolves.toMatchObject({ login: "missing", source: "unavailable", topLanguages: [] });
   });
 
+  it("paginates past 100 repos so contributors with large portfolios get accurate topLanguages", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/prolific")) return Response.json({ login: "prolific", public_repos: 150 });
+      if (url.includes("/prolific/repos?") && !url.includes("page=2")) {
+        // page 1: 100 TypeScript repos with a Link header pointing to page 2
+        return Response.json(
+          Array.from({ length: 100 }, () => ({ language: "TypeScript" })),
+          { headers: { link: '<https://api.github.com/users/prolific/repos?page=2>; rel="next"' } },
+        );
+      }
+      if (url.includes("/prolific/repos?") && url.includes("page=2")) {
+        // page 2: 50 Rust repos — language only visible with pagination
+        return Response.json(Array.from({ length: 50 }, () => ({ language: "Rust" })));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("prolific");
+    expect(profile.topLanguages).toContain("Rust");
+    expect(profile.topLanguages[0]).toBe("TypeScript");
+  });
+
   it("authenticates public profile requests with GITHUB_PUBLIC_TOKEN to lift the rate ceiling (#790)", async () => {
     const authHeaders: Array<string | null> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Problem

`fetchPublicContributorProfile` fetched only the first page of a contributor's public repos (`per_page=100`, no pagination). For a contributor with more than 100 public repos the function silently evaluated only the 100 most-recently-updated ones, meaning any primary language that lives exclusively in older repos was missing from `topLanguages`.

The same class of truncation bug has previously been fixed in `syncLabels` (#950), `createOrUpdateIssueCommentWithMarker` (#951), and `findGitHubIssueForFingerprint` (#956).

## Fix

After the initial parallel fetch resolves the first repos page, a `Link`-header-driven loop fetches subsequent pages until GitHub omits `rel="next"`. The pre-existing `AbortSignal.timeout(12 s)` is shared across all pages so total wall-clock time remains bounded regardless of repo count.

## Tests

Added: *"paginates past 100 repos so contributors with large portfolios get accurate topLanguages"*
- Page 1: 100 TypeScript repos + `Link: rel="next"` header
- Page 2: 50 Rust repos (no next-page link)
- Asserts `topLanguages` contains `"Rust"` (only reachable via page 2) and that `"TypeScript"` still leads

## Test plan

- [x] `npx vitest run test/unit/adapters.test.ts` — 6/6 pass
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)