### PR TITLE
fix(public): paginate contributor repos fetch (cap 5 pages) so topLanguages isn't truncated at 100

### DIFF
--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -58,6 +58,9 @@ const repoStatsCache = new Map<string, RepoStatsCacheEntry>();
 // Bound the api.github.com round trips so a hung response can't stall the 500-login evidence loop
 // indefinitely (mirrors GITHUB_FETCH_TIMEOUT_MS in src/github/app.ts) (#790).
 const GITHUB_PUBLIC_FETCH_TIMEOUT_MS = 12_000;
+// Cap repo pagination at 500 repos (5 pages × 100) to prevent excessive API usage for users
+// with very large public repo counts.
+const MAX_REPO_PAGES = 5;
 
 export async function fetchPublicContributorProfile(login: string, env?: Pick<Env, "GITHUB_PUBLIC_TOKEN">): Promise<PublicContributorProfile> {
   const safeLogin = encodeURIComponent(login);
@@ -77,7 +80,15 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
     ]);
     if (!userResponse.ok) throw new Error(`GitHub user lookup failed (${userResponse.status})`);
     const user = (await userResponse.json()) as GitHubUserResponse;
-    const repos = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
+    const repos: GitHubRepoResponse[] = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
+    let linkHeader = reposResponse.ok ? reposResponse.headers.get("link") : null;
+    for (let page = 2; page <= MAX_REPO_PAGES && linkHeader?.includes('rel="next"'); page += 1) {
+      const nextResponse = await fetch(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated&page=${page}`, { headers, signal });
+      if (!nextResponse.ok) break;
+      const batch = (await nextResponse.json()) as GitHubRepoResponse[];
+      repos.push(...batch);
+      linkHeader = nextResponse.headers.get("link");
+    }
     const languageCounts = new Map<string, number>();
     for (const repo of repos) {
       if (!repo.language) continue;

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -124,6 +124,52 @@ describe("small adapters and normalizers", () => {
     await expect(fetchPublicContributorProfile("missing")).resolves.toMatchObject({ login: "missing", source: "unavailable", topLanguages: [] });
   });
 
+  it("paginates past 100 repos so contributors with large portfolios get accurate topLanguages", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/prolific")) return Response.json({ login: "prolific", public_repos: 150 });
+      if (url.includes("/prolific/repos?") && !url.includes("page=2")) {
+        // page 1: 100 TypeScript repos with a Link header pointing to page 2
+        return Response.json(
+          Array.from({ length: 100 }, () => ({ language: "TypeScript" })),
+          { headers: { link: '<https://api.github.com/users/prolific/repos?page=2>; rel="next"' } },
+        );
+      }
+      if (url.includes("/prolific/repos?") && url.includes("page=2")) {
+        // page 2: 50 Rust repos only reachable via pagination
+        return Response.json(Array.from({ length: 50 }, () => ({ language: "Rust" })));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("prolific");
+    expect(profile.topLanguages[0]).toBe("TypeScript");
+    expect(profile.topLanguages).toContain("Rust");
+  });
+
+  it("stops paginating repos when a subsequent page returns a non-ok response", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/partialdev")) return Response.json({ login: "partialdev", public_repos: 200 });
+      if (url.includes("/partialdev/repos?") && !url.includes("page=2")) {
+        // page 1: 100 Go repos with a Link header
+        return Response.json(
+          Array.from({ length: 100 }, () => ({ language: "Go" })),
+          { headers: { link: '<https://api.github.com/users/partialdev/repos?page=2>; rel="next"' } },
+        );
+      }
+      if (url.includes("/partialdev/repos?") && url.includes("page=2")) {
+        return new Response("rate limited", { status: 429 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("partialdev");
+    // page 1 repos are preserved despite page 2 failing
+    expect(profile.source).toBe("github");
+    expect(profile.topLanguages).toContain("Go");
+  });
+
   it("authenticates public profile requests with GITHUB_PUBLIC_TOKEN to lift the rate ceiling (#790)", async () => {
     const authHeaders: Array<string | null> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Problem

`fetchPublicContributorProfile` fetched only the first page of a contributor's public repos (`per_page=100`, no pagination). A prolific contributor with 100+ repos had `topLanguages` derived from only their most-recently-updated 100, silently dropping any primary language that lived exclusively in older repos.

Closes #957 (closed by review gate — Reviewer A requested a page cap).

## Fix

After resolving the first page in parallel with the user-info fetch, a `Link`-header-driven loop fetches subsequent pages until GitHub omits `rel="next"`. A `MAX_REPO_PAGES = 5` constant caps the loop at 500 repos maximum, preventing excessive API usage for contributors with very large repo counts. A non-ok response on any subsequent page breaks the loop early, preserving whichever repos were already collected.

The pre-existing `AbortSignal.timeout(12 s)` is shared across all pages so total wall-clock time remains bounded independently of the page cap.

## Tests

- **Happy path**: page 1 returns 100 TypeScript repos + `Link: rel="next"`; page 2 returns 50 Rust repos — asserts `"Rust"` appears in `topLanguages` (only reachable via page 2).
- **Non-ok subsequent page**: page 1 returns 100 Go repos + `Link: rel="next"`; page 2 returns 429 — asserts `source: "github"` and page-1 languages are preserved (covers the `!nextResponse.ok` break branch flagged by Codecov).

## Test plan

- [x] `npx vitest run test/unit/adapters.test.ts` — 7/7 pass
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)