### PR TITLE
perf(db): replace N+1 query loop with single batched fetch in listLatestRepoGithubTotalsSnapshots

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -951,15 +951,15 @@ export async function listLatestRepoGithubTotalsSnapshots(env: Env): Promise<Rep
     })
     .from(repoGithubTotalsSnapshots)
     .groupBy(repoGithubTotalsSnapshots.repoFullName);
-  const rows = [];
-  for (const latest of latestRows) {
-    const [row] = await db
-      .select()
-      .from(repoGithubTotalsSnapshots)
-      .where(and(eq(repoGithubTotalsSnapshots.repoFullName, latest.repoFullName), eq(repoGithubTotalsSnapshots.fetchedAt, latest.fetchedAt)))
-      .limit(1);
-    if (row) rows.push(row);
-  }
+  if (latestRows.length === 0) return [];
+  // Fetch all latest rows in one query instead of one per repo (avoids the previous N+1 loop).
+  const conditions = latestRows.map((latest) =>
+    and(eq(repoGithubTotalsSnapshots.repoFullName, latest.repoFullName), eq(repoGithubTotalsSnapshots.fetchedAt, latest.fetchedAt)),
+  );
+  const rows = await db
+    .select()
+    .from(repoGithubTotalsSnapshots)
+    .where(or(...conditions));
   return rows.map(toRepoGithubTotalsSnapshotRecord).sort((left, right) => left.repoFullName.localeCompare(right.repoFullName));
 }
 

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -952,7 +952,6 @@ export async function listLatestRepoGithubTotalsSnapshots(env: Env): Promise<Rep
     .from(repoGithubTotalsSnapshots)
     .groupBy(repoGithubTotalsSnapshots.repoFullName);
   if (latestRows.length === 0) return [];
-  // Fetch all latest rows in one query instead of one per repo (avoids the previous N+1 loop).
   const conditions = latestRows.map((latest) =>
     and(eq(repoGithubTotalsSnapshots.repoFullName, latest.repoFullName), eq(repoGithubTotalsSnapshots.fetchedAt, latest.fetchedAt)),
   );

--- a/test/unit/db-persistence.test.ts
+++ b/test/unit/db-persistence.test.ts
@@ -97,6 +97,11 @@ describe("database persistence helpers", () => {
     await expect(env.DB.prepare("select count(*) as count from bounty_lifecycle_events").first<{ count: number }>()).resolves.toMatchObject({ count: 1 });
   });
 
+  it("returns an empty array when no totals snapshots exist", async () => {
+    const env = createTestEnv();
+    expect(await listLatestRepoGithubTotalsSnapshots(env)).toEqual([]);
+  });
+
   it("returns latest totals per repo and merges duplicate contributor stats case-insensitively", async () => {
     const env = createTestEnv();
     await persistRepoGithubTotalsSnapshot(env, totalsSnapshot("totals-old", "owner/b", "2026-05-29T00:00:00.000Z", 1));


### PR DESCRIPTION
> **No linked issue:** This is a proactive performance optimization discovered during code review — no issue was filed for the N+1 query pattern.

## Problem

`listLatestRepoGithubTotalsSnapshots` issued **1 + N D1 round-trips** for N distinct repos:

1. A `GROUP BY` query to get each repo's max `fetched_at` timestamp.
2. A separate `SELECT … WHERE repo_full_name = ? AND fetched_at = ?` for **each** repo in a loop.

With 20 registered repos that's 21 queries; this function runs on every admin dashboard load and decision-pack generation.

## Fix

After the GROUP BY query, build a single `OR`-batched `SELECT` that fetches all latest rows in **one** additional round-trip — 2 total queries regardless of repo count. An early-return guard handles the empty-table case (no repos → skip the second query entirely).

```
Before: 1 + N queries
After:  2 queries
```

No behaviour change: results are still sorted alphabetically by `repoFullName` and still exclude older snapshots for any repo that has more than one.

## Tests

- Existing test: seeds two repos (one with an old + new snapshot), asserts only the newest per repo is returned — still passes.
- New test: empty table returns `[]` (covers the early-return guard added for the no-repos case).