### PR TITLE
perf(db): replace SELECT + DELETE with DELETE … RETURNING in deleteIssueWatchSubscription

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1394,10 +1394,8 @@ export async function listIssueWatchSubscriptionsForLogin(env: Env, login: strin
 export async function deleteIssueWatchSubscription(env: Env, login: string, repoFullName: string): Promise<boolean> {
   const db = getDb(env.DB);
   const where = and(eq(issueWatchSubscriptions.login, login.toLowerCase()), eq(issueWatchSubscriptions.repoFullName, repoFullName.toLowerCase()));
-  const existing = await db.select({ id: issueWatchSubscriptions.id }).from(issueWatchSubscriptions).where(where);
-  if (existing.length === 0) return false;
-  await db.delete(issueWatchSubscriptions).where(where);
-  return true;
+  const deleted = await db.delete(issueWatchSubscriptions).where(where).returning({ id: issueWatchSubscriptions.id });
+  return deleted.length > 0;
 }
 
 /** All miners watching a repo — the candidate recipients when a new grabbable issue opens there. */


### PR DESCRIPTION
## Problem

`deleteIssueWatchSubscription` used two D1 round-trips to accomplish one logical operation:

1. `SELECT id` to check whether the row exists.
2. `DELETE` if it did.

There is also a TOCTOU window between the check and the delete — a concurrent unsubscribe could race with the SELECT in between.

## Fix

D1 supports `RETURNING` (Drizzle already uses it in `insertNotificationDeliveryIfAbsent`). Collapse the two queries into a single `DELETE … RETURNING { id }` and derive the `boolean` return value from whether any rows were affected — 1 round-trip, no race window.

```ts
// Before (2 queries)
const existing = await db.select({ id }).from(...).where(where);
if (existing.length === 0) return false;
await db.delete(...).where(where);
return true;

// After (1 query)
const deleted = await db.delete(...).where(where).returning({ id });
return deleted.length > 0;
```

## Tests

No new tests needed — existing tests in `issue-watch.test.ts` already cover:
- `true` when a subscription exists and is removed (line 49, 71)
- `false` when the subscription is already gone (line 50)