### PR TITLE
feat(ui): responsive/mobile + accessibility pass (Fixes #794)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -20,6 +20,7 @@ import {
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
+import { ResponsiveDataTable } from "@/components/site/responsive-data-table";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
@@ -282,59 +283,78 @@ function MaintainerDashboardView() {
             </div>
           </section>
 
-          <section className="rounded-token border-hairline bg-card p-5">
-            <div className="flex items-center justify-between">
-              <h2 className="font-display text-token-lg font-semibold">Reviewability queue</h2>
+          <section
+            className="rounded-token border-hairline bg-card p-5"
+            aria-labelledby="reviewability-queue-title"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2
+                id="reviewability-queue-title"
+                className="font-display text-token-lg font-semibold"
+              >
+                Reviewability queue
+              </h2>
               <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
                 private
               </span>
             </div>
-            <table className="mt-4 w-full text-left text-token-sm">
-              <thead>
-                <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                  <th className="py-2 pr-3 font-normal">PR</th>
-                  <th className="py-2 pr-3 font-normal">Title</th>
-                  <th className="py-2 pr-3 font-normal">Author</th>
-                  <th className="py-2 pr-3 font-normal">Bucket</th>
-                  <th className="py-2 pr-3 font-normal">Slop</th>
-                  <th className="py-2 font-normal">Reason</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.reviewability.map((row) => (
-                  <tr
-                    key={row.pr}
-                    className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
-                  >
-                    <td className="py-2 pr-3 font-mono text-token-xs text-foreground/90">
-                      {row.pr}
-                    </td>
-                    <td className="py-2 pr-3">{row.title}</td>
-                    <td className="py-2 pr-3 text-token-xs text-muted-foreground">{row.author}</td>
-                    <td className="py-2 pr-3">
-                      <StatusPill status={BUCKET_TONE[row.bucket] ?? "info"}>
-                        {row.bucket}
+            <ResponsiveDataTable
+              className="mt-4"
+              caption="Reviewability queue"
+              rows={data.reviewability}
+              rowKey={(row) => row.pr}
+              emptyMessage="No open pull requests are queued for reviewability scoring."
+              columns={[
+                {
+                  id: "pr",
+                  header: "PR",
+                  cell: (row) => (
+                    <span className="font-mono text-token-xs text-foreground/90">{row.pr}</span>
+                  ),
+                },
+                {
+                  id: "title",
+                  header: "Title",
+                  cell: (row) => row.title,
+                },
+                {
+                  id: "author",
+                  header: "Author",
+                  cellClassName: "text-token-xs text-muted-foreground",
+                  cell: (row) => row.author,
+                },
+                {
+                  id: "bucket",
+                  header: "Bucket",
+                  cell: (row) => (
+                    <StatusPill status={BUCKET_TONE[row.bucket] ?? "info"}>{row.bucket}</StatusPill>
+                  ),
+                },
+                {
+                  id: "slop",
+                  header: "Slop",
+                  cell: (row) =>
+                    row.slop ? (
+                      <StatusPill status={SLOP_BAND_TONE[row.slop.band] ?? "info"}>
+                        {row.slop.band} {row.slop.risk}
                       </StatusPill>
-                    </td>
-                    <td className="py-2 pr-3">
-                      {row.slop ? (
-                        <StatusPill status={SLOP_BAND_TONE[row.slop.band] ?? "info"}>
-                          {row.slop.band} {row.slop.risk}
-                        </StatusPill>
-                      ) : (
-                        <span
-                          className="text-token-xs text-muted-foreground"
-                          title="Slop detection is off for this repo, or this PR has not been assessed yet."
-                        >
-                          —
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 text-token-xs text-muted-foreground">{row.reason}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    ) : (
+                      <span
+                        className="text-token-xs text-muted-foreground"
+                        title="Slop detection is off for this repo, or this PR has not been assessed yet."
+                      >
+                        —
+                      </span>
+                    ),
+                },
+                {
+                  id: "reason",
+                  header: "Reason",
+                  cellClassName: "text-token-xs text-muted-foreground",
+                  cell: (row) => row.reason,
+                },
+              ]}
+            />
           </section>
 
           <SurfacePreview reviewability={data.reviewability} />
@@ -440,7 +460,7 @@ function SurfacePreview({
             type="button"
             disabled={busy || !repoParts}
             onClick={() => void runPreview()}
-            className="inline-flex items-center gap-2 rounded-token border border-mint/40 bg-mint px-3 py-2 text-token-xs font-medium text-primary-foreground transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-token border border-mint/40 bg-mint px-3 py-2 text-token-xs font-medium text-primary-foreground transition-all hover:brightness-110 focus-ring disabled:cursor-not-allowed disabled:opacity-50"
           >
             {busy ? <RefreshCw className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
             {busy ? "Running" : "Run preview"}
@@ -637,26 +657,31 @@ function PreviewResult({
       )}
 
       {preview.installation?.permissionRemediation.length ? (
-        <div className="overflow-hidden rounded-token border-hairline">
-          <table className="w-full text-left text-token-xs">
-            <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
-              <tr>
-                <th className="px-3 py-2 font-normal">Permission</th>
-                <th className="px-3 py-2 font-normal">Current</th>
-                <th className="px-3 py-2 font-normal">Required</th>
-              </tr>
-            </thead>
-            <tbody>
-              {preview.installation.permissionRemediation.map((row) => (
-                <tr key={row.permission} className="border-b-hairline last:border-b-0">
-                  <td className="px-3 py-2 text-foreground">{row.permission}</td>
-                  <td className="px-3 py-2 text-muted-foreground">{row.currentAccess}</td>
-                  <td className="px-3 py-2 text-muted-foreground">{row.requiredAccess}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ResponsiveDataTable
+          caption="Permission remediation"
+          tableClassName="text-token-xs"
+          rows={preview.installation.permissionRemediation}
+          rowKey={(row) => row.permission}
+          columns={[
+            {
+              id: "permission",
+              header: "Permission",
+              cell: (row) => row.permission,
+            },
+            {
+              id: "current",
+              header: "Current",
+              cellClassName: "text-muted-foreground",
+              cell: (row) => row.currentAccess,
+            },
+            {
+              id: "required",
+              header: "Required",
+              cellClassName: "text-muted-foreground",
+              cell: (row) => row.requiredAccess,
+            },
+          ]}
+        />
       ) : null}
 
       <div>
@@ -666,7 +691,7 @@ function PreviewResult({
           </div>
           <StatusPill status="info">sanitized</StatusPill>
         </div>
-        <pre className="max-h-[360px] overflow-auto whitespace-pre-wrap rounded-token border border-border bg-[oklch(0.13_0.005_260)] p-3 font-mono text-token-xs leading-token-relaxed text-foreground/90">
+        <pre className="max-h-[360px] overflow-auto whitespace-pre-wrap rounded-token border border-border bg-surface-2 p-3 font-mono text-token-xs leading-token-relaxed text-foreground/90">
           {preview.previewComment ?? "No public comment would be posted for this scenario."}
         </pre>
       </div>

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -26,6 +26,8 @@ import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { useSession } from "@/lib/api/session";
+import { useDevMockMode } from "@/lib/dev-mock-mode";
+import { MAINTAINER_DASHBOARD_MOCK } from "@/lib/dev-panel-mocks";
 import {
   PREVIEW_SCENARIOS,
   buildSettingsPreviewRequest,
@@ -183,9 +185,12 @@ export function MaintainerPanel() {
 }
 
 function MaintainerDashboardView() {
+  const mockMode = useDevMockMode();
   const dashboard = useApiResource<MaintainerDashboard>(
     "/v1/app/maintainer-dashboard",
     "Maintainer dashboard",
+    undefined,
+    { mockData: mockMode ? MAINTAINER_DASHBOARD_MOCK : undefined },
   );
   const data = dashboard.status === "ready" ? dashboard.data : null;
   const isEmpty = data !== null && data.health.length === 0 && data.reviewability.length === 0;

--- a/apps/gittensory-ui/src/components/site/app-panels/miner-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/miner-panel.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { Check, Copy, Download, History, Loader2, RefreshCw } from "lucide-react";
 
 import { KeyValueGrid, StatusPill, type Status } from "@/components/site/control-primitives";
+import { ResponsiveDataTable } from "@/components/site/responsive-data-table";
 import { McpVersionBadge } from "@/components/site/mcp-version-badge";
 import { StatCard } from "@/components/site/primitives";
 import { StateBoundary } from "@/components/site/state-views";
@@ -328,47 +329,55 @@ export function MinerPanel() {
                 </div>
               </div>
 
-              <div className="rounded-token border-hairline bg-card p-5">
-                <h2 className="font-display text-token-lg font-semibold">Repo fit</h2>
+              <div
+                className="rounded-token border-hairline bg-card p-5"
+                aria-labelledby="miner-repo-fit-title"
+              >
+                <h2 id="miner-repo-fit-title" className="font-display text-token-lg font-semibold">
+                  Repo fit
+                </h2>
                 <p className="mt-1 text-token-xs text-muted-foreground">
                   Where to spend time, and where not to.
                 </p>
-                <table className="mt-4 w-full text-left text-token-sm">
-                  <thead>
-                    <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                      <th className="py-2 pr-3 font-normal">Repo</th>
-                      <th className="py-2 pr-3 font-normal">Lane</th>
-                      <th className="py-2 font-normal">Why</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.repoFit.map((repo, index) => {
-                      const lane = repo.lane ?? "pursue";
-                      return (
-                        <tr
-                          key={`${repo.repoFullName ?? index}`}
-                          className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
-                        >
-                          <td className="py-2 pr-3 align-top">
-                            <div className="break-all font-mono text-token-xs text-foreground/90">
-                              {repo.repoFullName ?? "repo pending"}
-                            </div>
-                            <RecommendationChangeInline change={repo.change} />
-                          </td>
-                          <td className="py-2 pr-3 align-top">
-                            <StatusPill status={LANE_TONE[lane] ?? "info"}>{lane}</StatusPill>
-                          </td>
-                          <td className="py-2 align-top text-token-xs text-muted-foreground">
-                            {repo.why ??
-                              repo.rationale ??
-                              repo.recommendation ??
-                              "No rationale recorded."}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                <ResponsiveDataTable
+                  className="mt-4"
+                  caption="Repo fit"
+                  rows={data.repoFit}
+                  rowKey={(repo, index) => `${repo.repoFullName ?? index}`}
+                  emptyMessage="No ranked repo fit recommendations yet."
+                  columns={[
+                    {
+                      id: "repo",
+                      header: "Repo",
+                      cell: (repo) => (
+                        <>
+                          <div className="break-all font-mono text-token-xs text-foreground/90">
+                            {repo.repoFullName ?? "repo pending"}
+                          </div>
+                          <RecommendationChangeInline change={repo.change} />
+                        </>
+                      ),
+                    },
+                    {
+                      id: "lane",
+                      header: "Lane",
+                      cell: (repo) => {
+                        const lane = repo.lane ?? "pursue";
+                        return <StatusPill status={LANE_TONE[lane] ?? "info"}>{lane}</StatusPill>;
+                      },
+                    },
+                    {
+                      id: "why",
+                      header: "Why",
+                      cellClassName: "text-token-xs text-muted-foreground",
+                      cell: (repo) =>
+                        repo.why ??
+                        repo.rationale ??
+                        repo.recommendation ??
+                        "No rationale recorded.",
+                    },
+                  ]}
+                />
               </div>
             </section>
           </div>
@@ -433,7 +442,7 @@ function MinerPanelActions({
   onChangelog: () => void;
 }) {
   const buttonClass =
-    "inline-flex items-center gap-2 rounded-token border-hairline bg-card px-3 py-2 text-token-xs font-medium text-foreground transition-colors hover:border-strong disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center gap-2 rounded-token border-hairline bg-card px-3 py-2 text-token-xs font-medium text-foreground transition-colors hover:border-strong focus-ring disabled:cursor-not-allowed disabled:opacity-50";
   return (
     <section
       className="flex flex-wrap items-center justify-between gap-3"

--- a/apps/gittensory-ui/src/components/site/app-panels/miner-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/miner-panel.tsx
@@ -18,6 +18,8 @@ import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { useSession } from "@/lib/api/session";
+import { useDevMockMode } from "@/lib/dev-mock-mode";
+import { MINER_DASHBOARD_MOCK } from "@/lib/dev-panel-mocks";
 import {
   buildMinerCommandActions,
   type MinerCommandAction,
@@ -91,12 +93,16 @@ type MinerDashboard = {
 
 export function MinerPanel() {
   const { session } = useSession();
+  const mockMode = useDevMockMode();
   const login = session?.login ?? "";
   const dashboard = useApiResource<MinerDashboard>(
     `/v1/app/miner-dashboard?login=${encodeURIComponent(login)}`,
     "Miner dashboard",
     undefined,
-    { enabled: Boolean(login) },
+    {
+      enabled: mockMode || Boolean(login),
+      mockData: mockMode ? MINER_DASHBOARD_MOCK : undefined,
+    },
   );
   const data = dashboard.status === "ready" ? dashboard.data : null;
   const blockerCount = data?.blockers.reduce((count, group) => count + group.items.length, 0) ?? 0;

--- a/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
@@ -73,23 +73,37 @@ export function OwnerPanel() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-token border-hairline bg-card p-5">
+      <section
+        className="rounded-token border-hairline bg-card p-5"
+        aria-labelledby="owner-registration-workspace-title"
+      >
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <h2 className="font-display text-token-lg font-semibold">Registration workspace</h2>
+            <h2
+              id="owner-registration-workspace-title"
+              className="font-display text-token-lg font-semibold"
+            >
+              Registration workspace
+            </h2>
             <p className="mt-1 text-token-xs text-muted-foreground">
               Readiness report with lane tradeoffs — not raw Gittensor telemetry.
             </p>
           </div>
           <div className="w-full sm:w-64">
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="owner-repo-input"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Repository
             </label>
             <Input
+              id="owner-repo-input"
               value={repo}
               onChange={(e) => setRepo(e.target.value)}
-              className="mt-1 font-mono text-token-xs"
+              className="mt-1 font-mono text-token-xs focus-ring"
               placeholder="owner/repo"
+              autoComplete="off"
+              spellCheck={false}
             />
             {invalidRepo ? (
               <p className="mt-1 text-token-2xs text-danger">Use a valid owner/repo slug.</p>

--- a/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
@@ -8,6 +8,12 @@ import {
 } from "@/components/site/control-primitives";
 import { StateBoundary } from "@/components/site/state-views";
 import { Input } from "@/components/ui/input";
+import { useDevMockMode } from "@/lib/dev-mock-mode";
+import {
+  MOCK_OWNER_REPO,
+  OWNER_CONFIG_RECOMMENDATION_MOCK,
+  OWNER_REGISTRATION_READINESS_MOCK,
+} from "@/lib/dev-panel-mocks";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import {
   buildRegistrationWorkspaceView,
@@ -40,7 +46,8 @@ const WORKFLOW_STATUS_MAP: Record<OwnerWorkflowState, Status> = {
 };
 
 export function OwnerPanel() {
-  const [repo, setRepo] = useState("entrius/gittensor");
+  const mockMode = useDevMockMode();
+  const [repo, setRepo] = useState(mockMode ? MOCK_OWNER_REPO : "entrius/gittensor");
   const parts = splitRepoFullName(repo.trim());
   const repoPath = parts
     ? `/v1/repos/${encodeURIComponent(parts.owner)}/${encodeURIComponent(parts.repo)}`
@@ -49,13 +56,19 @@ export function OwnerPanel() {
     `${repoPath ?? "/v1/repos/__invalid__/__invalid__"}/registration-readiness`,
     "Registration readiness",
     undefined,
-    { enabled: Boolean(repoPath) },
+    {
+      enabled: Boolean(repoPath),
+      mockData: mockMode ? OWNER_REGISTRATION_READINESS_MOCK : undefined,
+    },
   );
   const config = useApiResource<GittensorConfigRecommendationPayload>(
     `${repoPath ?? "/v1/repos/__invalid__/__invalid__"}/gittensor-config-recommendation`,
     "Config recommendation",
     undefined,
-    { enabled: Boolean(repoPath) },
+    {
+      enabled: Boolean(repoPath),
+      mockData: mockMode ? OWNER_CONFIG_RECOMMENDATION_MOCK : undefined,
+    },
   );
 
   const workspace = useMemo(() => {

--- a/apps/gittensory-ui/src/components/site/app-shell.tsx
+++ b/apps/gittensory-ui/src/components/site/app-shell.tsx
@@ -33,6 +33,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { GittensoryMark } from "./mark";
+import { ThemeToggle } from "./theme-toggle";
 import { StatusPill, type Status } from "./control-primitives";
 import { LoadingState } from "./state-views";
 import { cn } from "@/lib/utils";
@@ -295,11 +296,14 @@ export function AppShell() {
               </>
             )}
           </nav>
-          <div className="ml-auto hidden items-center gap-1 font-mono text-token-2xs text-muted-foreground sm:flex">
-            <kbd className="rounded border border-border bg-background/60 px-1 py-0.5">g</kbd>
-            <span>then</span>
-            <kbd className="rounded border border-border bg-background/60 px-1 py-0.5">o w r</kbd>
-            <span>to navigate</span>
+          <div className="ml-auto flex items-center gap-2">
+            <ThemeToggle />
+            <div className="hidden items-center gap-1 font-mono text-token-2xs text-muted-foreground sm:flex">
+              <kbd className="rounded border border-border bg-background/60 px-1 py-0.5">g</kbd>
+              <span>then</span>
+              <kbd className="rounded border border-border bg-background/60 px-1 py-0.5">o w r</kbd>
+              <span>to navigate</span>
+            </div>
           </div>
         </header>
         <div className="min-w-0 px-4 py-6 sm:px-6 lg:px-8">

--- a/apps/gittensory-ui/src/components/site/app-shell.tsx
+++ b/apps/gittensory-ui/src/components/site/app-shell.tsx
@@ -33,6 +33,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { GittensoryMark } from "./mark";
+import { DevMockBanner } from "./dev-mock-banner";
 import { ThemeToggle } from "./theme-toggle";
 import { StatusPill, type Status } from "./control-primitives";
 import { LoadingState } from "./state-views";
@@ -307,6 +308,7 @@ export function AppShell() {
           </div>
         </header>
         <div className="min-w-0 px-4 py-6 sm:px-6 lg:px-8">
+          <DevMockBanner />
           <Outlet />
         </div>
       </SidebarInset>

--- a/apps/gittensory-ui/src/components/site/dev-mock-banner.tsx
+++ b/apps/gittensory-ui/src/components/site/dev-mock-banner.tsx
@@ -1,0 +1,20 @@
+import { useDevMockMode } from "@/lib/dev-mock-mode";
+
+export function DevMockBanner() {
+  const mockMode = useDevMockMode();
+  if (!mockMode) return null;
+
+  return (
+    <div
+      role="status"
+      className="mb-4 rounded-token border border-mint/30 bg-mint/10 px-4 py-2 text-token-xs text-foreground"
+    >
+      <span className="font-mono uppercase tracking-wider text-mint">Dev mock data</span>
+      <span className="text-muted-foreground">
+        {" "}
+        — API responses are replaced with fixtures for screenshot capture. Remove{" "}
+        <code className="font-mono">mock=1</code> from the URL to load live data.
+      </span>
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/responsive-data-table.test.tsx
+++ b/apps/gittensory-ui/src/components/site/responsive-data-table.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ResponsiveDataTable } from "@/components/site/responsive-data-table";
+
+type Row = { id: string; name: string };
+
+describe("ResponsiveDataTable", () => {
+  it("renders desktop table headers and mobile definition lists", () => {
+    render(
+      <ResponsiveDataTable<Row>
+        caption="Sample queue"
+        rows={[{ id: "1", name: "Alpha" }]}
+        rowKey={(row) => row.id}
+        columns={[
+          { id: "id", header: "ID", cell: (row) => row.id },
+          { id: "name", header: "Name", cell: (row) => row.name },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("ID").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Alpha").length).toBeGreaterThan(0);
+    expect(screen.getByRole("region", { name: "Sample queue" })).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Sample queue" })).toBeTruthy();
+  });
+
+  it("shows an empty message when there are no rows", () => {
+    render(
+      <ResponsiveDataTable<Row>
+        caption="Empty queue"
+        rows={[]}
+        rowKey={(row) => row.id}
+        emptyMessage="Nothing queued yet."
+        columns={[{ id: "id", header: "ID", cell: (row) => row.id }]}
+      />,
+    );
+
+    expect(screen.getByText("Nothing queued yet.")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/responsive-data-table.tsx
+++ b/apps/gittensory-ui/src/components/site/responsive-data-table.tsx
@@ -1,0 +1,108 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type ResponsiveTableColumn<T> = {
+  id: string;
+  header: string;
+  headerClassName?: string;
+  cellClassName?: string;
+  cell: (row: T) => ReactNode;
+};
+
+type ResponsiveDataTableProps<T> = {
+  caption: string;
+  columns: ResponsiveTableColumn<T>[];
+  rows: T[];
+  rowKey: (row: T, index: number) => string;
+  emptyMessage?: string;
+  className?: string;
+  tableClassName?: string;
+};
+
+/** Desktop table (md+) with a stacked card list on narrow viewports (#794). */
+export function ResponsiveDataTable<T>({
+  caption,
+  columns,
+  rows,
+  rowKey,
+  emptyMessage,
+  className,
+  tableClassName,
+}: ResponsiveDataTableProps<T>) {
+  if (rows.length === 0) {
+    return emptyMessage ? (
+      <p className="text-token-xs text-muted-foreground">{emptyMessage}</p>
+    ) : null;
+  }
+
+  return (
+    <>
+      <div
+        className={cn("hidden overflow-x-auto md:block", className)}
+        role="region"
+        aria-label={caption}
+        tabIndex={0}
+      >
+        <table className={cn("min-w-[36rem] w-full text-left text-token-sm", tableClassName)}>
+          <caption className="sr-only">{caption}</caption>
+          <thead>
+            <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+              {columns.map((column) => (
+                <th
+                  key={column.id}
+                  scope="col"
+                  className={cn("py-2 pr-3 font-normal last:pr-0", column.headerClassName)}
+                >
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr
+                key={rowKey(row, index)}
+                className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
+              >
+                {columns.map((column) => (
+                  <td
+                    key={column.id}
+                    className={cn("py-2 pr-3 align-top last:pr-0", column.cellClassName)}
+                  >
+                    {column.cell(row)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ul className="space-y-3 md:hidden" aria-label={caption}>
+        {rows.map((row, index) => (
+          <li
+            key={rowKey(row, index)}
+            className="rounded-token border-hairline bg-background/40 p-3 transition-colors hover:border-strong"
+          >
+            <dl className="space-y-2">
+              {columns.map((column) => (
+                <div
+                  key={column.id}
+                  className="grid grid-cols-[minmax(5.5rem,34%)_1fr] gap-x-3 gap-y-1"
+                >
+                  <dt className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                    {column.header}
+                  </dt>
+                  <dd className={cn("min-w-0 text-token-sm", column.cellClassName)}>
+                    {column.cell(row)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/site-header.tsx
+++ b/apps/gittensory-ui/src/components/site/site-header.tsx
@@ -7,6 +7,7 @@ import { GittensoryMark } from "./mark";
 import { CommandPalette } from "./command-palette";
 import { GithubStatsChip } from "./github-stats-chip";
 import { KeyboardShortcutsDialog } from "./keyboard-shortcuts";
+import { ThemeToggle } from "./theme-toggle";
 
 const nav = [
   { to: "/miners", label: "Miners" },
@@ -153,6 +154,7 @@ export function SiteHeader() {
 
         <div className="ml-auto flex items-center gap-1.5">
           <CommandPalette />
+          <ThemeToggle />
           <McpVersionBadge className="hidden lg:block" />
           <GithubStatsChip className="hidden sm:inline-flex" />
           <KeyboardShortcutsDialog />

--- a/apps/gittensory-ui/src/components/site/theme-toggle.test.tsx
+++ b/apps/gittensory-ui/src/components/site/theme-toggle.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThemeToggle } from "@/components/site/theme-toggle";
+import { applyThemePreference } from "@/lib/theme-preference";
+
+describe("theme toggle", () => {
+  afterEach(() => {
+    document.documentElement.classList.add("dark");
+    document.documentElement.style.colorScheme = "dark";
+    window.localStorage.clear();
+  });
+
+  it("toggles between light and dark themes", () => {
+    applyThemePreference("dark");
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole("button", { name: "Switch to light theme" });
+    fireEvent.click(button);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(screen.getByRole("button", { name: "Switch to dark theme" })).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/theme-toggle.tsx
+++ b/apps/gittensory-ui/src/components/site/theme-toggle.tsx
@@ -1,9 +1,35 @@
-// Dark-mode-only build. The toggle has been removed; this file now only
-// ships the no-flash script that locks <html> into dark mode on first paint.
-export const THEME_NOFLASH_SCRIPT = `
-(function(){try{
-  var r=document.documentElement;
-  r.classList.add('dark');
-  r.style.colorScheme='dark';
-}catch(e){}})();
-`;
+import { Moon, Sun } from "lucide-react";
+
+import { useTheme } from "@/lib/theme-preference";
+import { cn } from "@/lib/utils";
+
+export {
+  THEME_NOFLASH_SCRIPT,
+  THEME_STORAGE_KEY,
+  type ThemePreference,
+} from "@/lib/theme-preference";
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { resolved, toggle, hydrated } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={resolved === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+      aria-pressed={resolved === "dark"}
+      className={cn(
+        "inline-flex h-8 w-8 items-center justify-center rounded-token text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-ring",
+        className,
+      )}
+    >
+      {!hydrated ? (
+        <span className="size-4" aria-hidden />
+      ) : resolved === "dark" ? (
+        <Sun className="size-4" aria-hidden />
+      ) : (
+        <Moon className="size-4" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/apps/gittensory-ui/src/lib/api/use-api-resource-mock.test.tsx
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource-mock.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useApiResource } from "@/lib/api/use-api-resource";
+
+type MockPayload = { ok: boolean };
+
+function Probe({ mock }: { mock?: MockPayload }) {
+  const state = useApiResource<MockPayload>("/v1/example", "Example", undefined, {
+    mockData: mock,
+  });
+  return <div>{state.status === "ready" ? "ready" : state.status}</div>;
+}
+
+describe("useApiResource dev mocks", () => {
+  it("serves mockData in dev without calling the network", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    render(<Probe mock={{ ok: true }} />);
+    await waitFor(() => {
+      expect(screen.getByText("ready")).toBeTruthy();
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.ts
@@ -8,17 +8,20 @@ type ResourceState<T> =
   | { status: "ready"; data: T; error: null }
   | { status: "error"; data: null; error: string };
 
-type UseApiResourceOptions = {
+type UseApiResourceOptions<T> = {
   enabled?: boolean;
+  /** Dev-only fixture; when set, skips the network and serves mock data immediately. */
+  mockData?: T;
 };
 
 export function useApiResource<T>(
   path: string,
   label: string,
   token?: string,
-  options: UseApiResourceOptions = {},
+  options: UseApiResourceOptions<T> = {},
 ) {
   const enabled = options.enabled ?? true;
+  const mockData = options.mockData;
   const [state, setState] = useState<ResourceState<T>>({
     status: "loading",
     data: null,
@@ -28,6 +31,10 @@ export function useApiResource<T>(
   const load = useCallback(async () => {
     if (!enabled) {
       setState({ status: "error", data: null, error: "disabled" });
+      return;
+    }
+    if (import.meta.env.DEV && mockData !== undefined) {
+      setState({ status: "ready", data: mockData, error: null });
       return;
     }
     setState({ status: "loading", data: null, error: null });
@@ -43,7 +50,7 @@ export function useApiResource<T>(
     } else {
       setState({ status: "error", data: null, error: result.message });
     }
-  }, [enabled, label, path, token]);
+  }, [enabled, label, mockData, path, token]);
 
   useEffect(() => {
     if (!enabled) {

--- a/apps/gittensory-ui/src/lib/dev-mock-mode.ts
+++ b/apps/gittensory-ui/src/lib/dev-mock-mode.ts
@@ -1,0 +1,25 @@
+import { useSearch } from "@tanstack/react-router";
+
+/** Dev-only screenshot fixtures. Enable with `?mock=1` (usually alongside `?preview=1`). */
+export function isDevMockMode(search: string | Record<string, unknown> | undefined): boolean {
+  if (!import.meta.env.DEV) return false;
+  if (typeof search === "string") {
+    return new URLSearchParams(search).get("mock") === "1";
+  }
+  if (search && typeof search === "object" && "mock" in search) {
+    return search.mock === "1" || search.mock === 1 || search.mock === true;
+  }
+  if (typeof window !== "undefined") {
+    return new URLSearchParams(window.location.search).get("mock") === "1";
+  }
+  return false;
+}
+
+export function useDevMockMode(): boolean {
+  const search = useSearch({ strict: false }) as Record<string, unknown>;
+  if (isDevMockMode(search)) return true;
+  if (typeof window !== "undefined") {
+    return new URLSearchParams(window.location.search).get("mock") === "1";
+  }
+  return false;
+}

--- a/apps/gittensory-ui/src/lib/dev-panel-mocks.ts
+++ b/apps/gittensory-ui/src/lib/dev-panel-mocks.ts
@@ -1,0 +1,321 @@
+import type {
+  GittensorConfigRecommendationPayload,
+  RegistrationReadinessPayload,
+} from "./registration-workspace";
+
+const MOCK_NOW = "2026-06-20T12:00:00.000Z";
+
+export type MaintainerDashboardMock = {
+  metrics: Array<{ label: string; value: number; spark: number[] }>;
+  health: Array<{
+    installationId: number;
+    accountLogin: string;
+    installedReposCount: number;
+    status: "healthy" | "needs_attention" | "broken";
+    missingPermissions: string[];
+    missingEvents: string[];
+    checkedAt: string;
+  }>;
+  reviewability: Array<{
+    pr: string;
+    title: string;
+    author: string;
+    bucket: string;
+    reason: string;
+    slop?: { risk: number; band: string } | null;
+  }>;
+  settingsPreview: { removed: string[]; added: string[] };
+};
+
+export type MinerDashboardMock = {
+  status: "ready" | "needs_refresh";
+  login: string;
+  nextActions: Array<Record<string, unknown>>;
+  blockers: Array<{
+    group: string;
+    items: Array<{ code: string; title: string; howToClear: string }>;
+  }>;
+  projections: Array<{ name: string; label: string; weight: number; note: string }>;
+  repoFit: Array<Record<string, unknown>>;
+  mcp?: { snapshot?: string | null; drift?: string | null; lastRun?: string | null };
+};
+
+export const MOCK_OWNER_REPO = "JSONbored/gittensory";
+
+export const MAINTAINER_DASHBOARD_MOCK: MaintainerDashboardMock = {
+  metrics: [
+    { label: "Open PRs", value: 14, spark: [4, 6, 8, 11, 14, 12, 14] },
+    { label: "Review-now", value: 3, spark: [1, 2, 2, 3, 3, 2, 3] },
+    { label: "Installations", value: 2, spark: [2, 2, 2, 2, 2, 2, 2] },
+    { label: "Repos tracked", value: 9, spark: [6, 7, 7, 8, 8, 9, 9] },
+  ],
+  health: [
+    {
+      installationId: 1001,
+      accountLogin: "JSONbored",
+      installedReposCount: 6,
+      status: "healthy",
+      missingPermissions: [],
+      missingEvents: [],
+      checkedAt: MOCK_NOW,
+    },
+    {
+      installationId: 1002,
+      accountLogin: "entrius",
+      installedReposCount: 3,
+      status: "needs_attention",
+      missingPermissions: ["pull_requests:write"],
+      missingEvents: ["pull_request"],
+      checkedAt: MOCK_NOW,
+    },
+  ],
+  reviewability: [
+    {
+      pr: "JSONbored/gittensory#142",
+      title: "feat(ui): responsive tables and theme toggle",
+      author: "kiannidev",
+      bucket: "review-now",
+      reason: "Merge-ready with linked issue and passing CI hints.",
+      slop: { risk: 12, band: "low" },
+    },
+    {
+      pr: "JSONbored/gittensory#138",
+      title: "docs: clarify maintainer install trust checklist",
+      author: "docs-bot",
+      bucket: "watch",
+      reason: "Low churn docs PR; no maintainer lane signal yet.",
+      slop: { risk: 4, band: "clean" },
+    },
+    {
+      pr: "entrius/allways-ui#57",
+      title: "fix: tighten linked-issue gate for draft PRs",
+      author: "lane-dev",
+      bucket: "needs-author",
+      reason: "Missing validation evidence in PR body.",
+      slop: null,
+    },
+    {
+      pr: "entrius/allways-ui#61",
+      title: "chore: dependency refresh (automated)",
+      author: "dependabot",
+      bucket: "redirect",
+      reason: "Bot author without maintainer lane context.",
+      slop: { risk: 68, band: "elevated" },
+    },
+    {
+      pr: "JSONbored/gittensory#130",
+      title: "refactor: split registration workspace cards",
+      author: "jsonbored",
+      bucket: "review_now",
+      reason: "Maintainer-authored follow-up with small diff.",
+      slop: { risk: 81, band: "high" },
+    },
+  ],
+  settingsPreview: {
+    removed: ["linkedIssueGateMode: off", "publicSurface: off"],
+    added: [
+      "linkedIssueGateMode: block",
+      "publicSurface: comment_and_label",
+      "slopGateMode: advisory",
+    ],
+  },
+};
+
+export const MINER_DASHBOARD_MOCK: MinerDashboardMock = {
+  status: "ready",
+  login: "local-preview",
+  nextActions: [
+    {
+      actionKind: "open_new_direct_pr",
+      repoFullName: "JSONbored/gittensory",
+      recommendation: "pursue",
+      priorityScore: 84,
+      change: {
+        status: "changed",
+        summary: "Queue pressure eased; direct-PR lane reopened.",
+        labels: [
+          { kind: "repo_state", label: "open PRs", before: "5", after: "2" },
+          { kind: "validation_state", label: "preflight", before: "missing", after: "passed" },
+        ],
+      },
+    },
+    {
+      actionKind: "cleanup_open_pr",
+      repoFullName: "entrius/allways-ui",
+      recommendation: "cleanup-first",
+      priorityScore: 61,
+      change: { status: "unchanged", summary: "Still blocked by open-PR pressure.", labels: [] },
+    },
+  ],
+  blockers: [
+    {
+      group: "scoreability",
+      items: [
+        {
+          code: "linked_issue_missing",
+          title: "Linked issue required",
+          howToClear: "Reference a repo issue in the PR body or title before opening.",
+        },
+      ],
+    },
+    {
+      group: "decision-pack",
+      items: [
+        {
+          code: "refresh_stale",
+          title: "Decision pack is stale",
+          howToClear: "Run Refresh on the miner dashboard or rebuild via MCP plan.",
+        },
+      ],
+    },
+  ],
+  projections: [
+    {
+      name: "direct_pr",
+      label: "Direct PR lane",
+      weight: 0.62,
+      note: "Best fit for code changes with tests.",
+    },
+    {
+      name: "issue_discovery",
+      label: "Issue discovery",
+      weight: 0.24,
+      note: "Use when triage-ready issues exist.",
+    },
+    {
+      name: "maintainer_lane",
+      label: "Maintainer lane",
+      weight: 0.14,
+      note: "Only when you are a listed maintainer.",
+    },
+  ],
+  repoFit: [
+    {
+      repoFullName: "JSONbored/gittensory",
+      lane: "pursue",
+      recommendation: "pursue",
+      why: "Low queue burden, trusted label pipeline, and strong preflight history.",
+      change: { status: "changed", summary: "Moved from watch to pursue.", labels: [] },
+    },
+    {
+      repoFullName: "entrius/allways-ui",
+      lane: "cleanup-first",
+      recommendation: "cleanup-first",
+      why: "Open PR count exceeds dynamic threshold until one merge lands.",
+      change: { status: "unchanged", summary: "Still cleanup-first.", labels: [] },
+    },
+    {
+      repoFullName: "entrius/gittensor",
+      lane: "maintainer-lane",
+      recommendation: "maintainer-lane",
+      why: "Maintainer association detected; use maintainer issue multiplier path.",
+      change: { status: "new", summary: "New maintainer-lane signal.", labels: [] },
+    },
+    {
+      repoFullName: "JSONbored/awesome-claude",
+      lane: "avoid",
+      recommendation: "avoid",
+      why: "Issue-discovery-only repo with saturated intake this week.",
+      change: { status: "unchanged", summary: "Avoid for now.", labels: [] },
+    },
+  ],
+  mcp: {
+    snapshot: "score-model-fixture",
+    drift: "none",
+    lastRun: MOCK_NOW,
+  },
+};
+
+export const OWNER_REGISTRATION_READINESS_MOCK: RegistrationReadinessPayload = {
+  repoFullName: MOCK_OWNER_REPO,
+  generatedAt: MOCK_NOW,
+  ready: false,
+  recommendedRegistrationMode: "split",
+  issuePolicy: "split_pr_and_issue_discovery_enabled",
+  directPrReadiness: {
+    ready: true,
+    reasons: ["Direct-PR lane is healthy with linked-issue gate enabled."],
+  },
+  issueDiscoveryReadiness: {
+    ready: true,
+    recommendation: "recommended_with_guardrails",
+    reasons: ["Issue queue is staffed and discovery share is non-zero."],
+  },
+  labelPolicy: {
+    autoLabelEnabled: true,
+    label: "gittensor",
+    trustedPipelineReady: true,
+    missingOrUnusedRegistryLabels: ["bug", "feature"],
+  },
+  maintainerCutReadiness: {
+    ready: true,
+    summary: "Maintainer cut can be reviewed without blocking intake.",
+    reasons: ["Queue burden is moderate."],
+    warnings: ["Consider documenting maintainer cut in CONTRIBUTING.md."],
+    recommendedAction: "consider_small_cut",
+  },
+  testCoverageHealth: {
+    status: "gate_ready",
+    trustedLabelPipelineReady: true,
+    checkRunMode: "enabled",
+    requiredGate: ["npm run test:ci", "npm run ui:test"],
+    note: "Use repo CI gates before widening contributor intake.",
+    warnings: [],
+  },
+  queueHealth: {
+    level: "moderate",
+    burdenScore: 0.48,
+    reviewablePullRequests: 5,
+    summary: "Five PRs are reviewable; queue burden is moderate.",
+  },
+  contributorIntakeHealth: {
+    level: "healthy",
+    summary: "Contributor intake signals are stable.",
+  },
+  githubApp: {
+    installed: true,
+    publicSurface: "comment_and_label",
+    commentMode: "detected_contributors_only",
+    checkRunMode: "enabled",
+    quietByDefault: true,
+    behavior: "Quiet-by-default GitHub App assistance with check runs enabled.",
+    warnings: [],
+  },
+  policyReadiness: {
+    summary: "Focus manifest present with one warning.",
+    publicWarnings: [
+      {
+        title: "Validation expectations missing",
+        detail: "Add explicit validation commands to CONTRIBUTING.md.",
+        action: "Document npm run test:ci as the minimum bar.",
+        severity: "warn",
+      },
+    ],
+  },
+  blockers: ["Document maintainer cut policy before enabling maintainerCut > 0."],
+  warnings: ["Registry emission share is below recommended minimum for new repos."],
+  docsCompleteness: {
+    status: "repo_docs_not_crawled",
+    requiredDocs: ["CONTRIBUTING.md", "README.md"],
+    note: "Gittensory validates public repo docs locally; remote crawl is not enabled yet.",
+  },
+  dataQuality: { status: "complete", partial: false, warnings: [] },
+};
+
+export const OWNER_CONFIG_RECOMMENDATION_MOCK: GittensorConfigRecommendationPayload = {
+  repoFullName: MOCK_OWNER_REPO,
+  generatedAt: MOCK_NOW,
+  privateOnly: true,
+  current: { participationMode: "direct_pr", maintainerCut: 0, issueDiscoveryShare: 0 },
+  recommended: { participationMode: "split", maintainerCut: 0.15, issueDiscoveryShare: 0.25 },
+  tradeoffs: [
+    "Split mode opens issue-discovery flow but increases maintainer triage load.",
+    "A 15% maintainer cut rewards upkeep while leaving most share for contributors.",
+  ],
+  reasons: [
+    "Queue health supports a small issue-discovery slice without blocking direct PRs.",
+    "Trusted label pipeline is ready for widened intake.",
+  ],
+  warnings: ["Confirm maintainer cut policy in public docs before applying."],
+  dataQuality: { status: "complete", partial: false, warnings: [] },
+};

--- a/apps/gittensory-ui/src/lib/theme-preference.ts
+++ b/apps/gittensory-ui/src/lib/theme-preference.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+import { useLocalStorage } from "@/lib/use-local-storage";
+
+export type ThemePreference = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "gittensory.theme";
+
+export const THEME_NOFLASH_SCRIPT = `
+(function(){try{
+  var t=localStorage.getItem("${THEME_STORAGE_KEY}")||"dark";
+  var d=t!=="light";
+  var r=document.documentElement;
+  r.classList.toggle("dark",d);
+  r.style.colorScheme=d?"dark":"light";
+}catch(e){}})();
+`;
+
+export function applyThemePreference(preference: ThemePreference) {
+  const dark = preference === "dark";
+  document.documentElement.classList.toggle("dark", dark);
+  document.documentElement.style.colorScheme = dark ? "dark" : "light";
+}
+
+export function useTheme() {
+  const [preference, setPreference, hydrated] = useLocalStorage<ThemePreference>(
+    THEME_STORAGE_KEY,
+    "dark",
+  );
+
+  useEffect(() => {
+    if (!hydrated) return;
+    applyThemePreference(preference);
+  }, [preference, hydrated]);
+
+  const resolved: ThemePreference = preference;
+  const toggle = () => setPreference((current) => (current === "dark" ? "light" : "dark"));
+
+  return { preference, resolved, setPreference, toggle, hydrated };
+}


### PR DESCRIPTION
## Summary
- Add `ResponsiveDataTable` so maintainer/miner tables render as stacked cards on narrow viewports and scrollable tables on `md+`.
- Restore light/dark theme toggle (persists to `localStorage`) using existing dual-theme tokens in `styles.css`.
- Improve panel a11y: section labels, associated form inputs, focus rings, and theme-aware preview surfaces.
- Add dev-only screenshot fixtures (`?preview=1&mock=1`) for maintainer, owner, and miner panels with a visible mock banner.

Fixes #794

## UI evidence
_Screenshots captured locally — maintainer, owner, and miner panels at desktop/mobile in dark and light. Will attach thumbnails in a follow-up edit._

<table>
<tr>
<td><img width="300" height="250" alt="Screenshot_58" src="https://github.com/user-attachments/assets/748d7666-4497-41c7-895a-5075e917fd94" /></td>
<td>
<img width="300" height="250" alt="Screenshot_59" src="https://github.com/user-attachments/assets/71f12956-d802-45d7-8ad1-1a0ee79394ec" />
</td>
<td>
<img width="300" height="500" alt="Screenshot_61" src="https://github.com/user-attachments/assets/84fc9f26-e1ba-4262-b380-067aeb7a9d96" />
</td>
<td>
<img width="300" height="500" alt="Screenshot_60" src="https://github.com/user-attachments/assets/7c24aace-51bb-4341-8335-0710190e1a2a" />
</td>
</tr>
<tr>
<td>
<img width="300" height="250" alt="Screenshot_62" src="https://github.com/user-attachments/assets/827e6059-98bf-4406-98b9-12c9aad44a5f" />
</td>
<td>
<img width="300" height="250" alt="Screenshot_63" src="https://github.com/user-attachments/assets/d8292f9d-d7fd-4bbd-bc1c-95c9c0f847cd" />
</td>
<td>
<img width="300" height="500" alt="Screenshot_64" src="https://github.com/user-attachments/assets/06612d90-378f-462d-87a5-a5503f63ae01" />
</td>
<td>
<img width="300" height="500" alt="Screenshot_65" src="https://github.com/user-attachments/assets/1e5d2dd1-42fc-4f14-809b-f6693ee646cd" />
</td>
</tr>
<tr>
<td>
<img width="300" height="250" alt="Screenshot_67" src="https://github.com/user-attachments/assets/37139bb8-628c-4f92-a8d3-71942c5030cc" />
</td>
<td>
<img width="300" height="250" alt="Screenshot_66" src="https://github.com/user-attachments/assets/94fe165d-185d-418b-990d-002b208ddc2b" />
</td>
<td>
<img width="300" height="250" alt="Screenshot_68" src="https://github.com/user-attachments/assets/d8dbc8fb-dff1-4356-8cf7-7603b817a3dd" />
</td>
<td>
<img width="300" height="250" alt="Screenshot_69" src="https://github.com/user-attachments/assets/d9babe4e-acba-428c-a1bb-45f19c94f389" />
</td>
</tr>
</table>

## Test plan
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm --workspace @jsonbored/gittensory-ui run test` (responsive table, theme toggle, mock hook)
- [x] Manual: `?preview=1&mock=1` on `/app/repos?tab=maintainer`, `/app/repos?tab=owner`, `/app/workbench?tab=miner`
- [ ] CI green on PR

