### PR TITLE
fix(signals): flag dot-only commit subjects

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4336,7 +4336,7 @@ export type PrTextLintReport = {
 
 // Exported so the deterministic slop signal (#564) and the #549 lint tool share ONE definition of a
 // "generic" commit subject — a single low-effort word (wip / fix / update / "." …) that is the whole subject.
-export const GENERIC_COMMIT_PATTERN = /^(?:wip|fix(?:es|ed|ing)?|updat(?:e|es|ed|ing)|change[sd]?|edit[sd]?|patch|minor|tweak[sd]?|misc|cleanup|chore|stuff|temp|tmp|test|final|done|commit|asdf+|\.+)\b[\s.!]*$/i;
+export const GENERIC_COMMIT_PATTERN = /^(?:(?:wip|fix(?:es|ed|ing)?|updat(?:e|es|ed|ing)|change[sd]?|edit[sd]?|patch|minor|tweak[sd]?|misc|cleanup|chore|stuff|temp|tmp|test|final|done|commit|asdf+)\b|\.+)[\s.!]*$/i;
 // Conventional Commit subject: one of CONTRIBUTING's allowed types, optional `(scope)`, optional `!`,
 // then `: ` and a non-empty summary (e.g. `feat(api): add cursor pagination`). Single source of truth
 // with CONTRIBUTING.md "Commit And PR Titles".

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -36,6 +36,15 @@ describe("buildSlopAssessment", () => {
     expect(JSON.stringify(result)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
   });
 
+  it("raises low-quality-commit-message slop for dot-only commit subjects (#564)", () => {
+    for (const message of [".", "..", "..."]) {
+      expect(buildLowQualityCommitMessageFinding({ commitMessages: [message] })).toMatchObject({
+        code: "low_quality_commit_message",
+        severity: "warning",
+      });
+    }
+  });
+
   it("does not raise commit-message slop for a specific subject or when no commit data is supplied (#564)", () => {
     expect(buildSlopAssessment({ commitMessages: ["feat(api): add cursor pagination to labels endpoint"] }).findings).toEqual([]);
     expect(buildSlopAssessment({ commitMessages: [] }).findings).toEqual([]);


### PR DESCRIPTION
### Motivation
- The shared `GENERIC_COMMIT_PATTERN` was documented to include dot-only subjects (`.` / `..` / `...`) but the trailing `\b` prevented punctuation-only strings from matching, causing dot-only commit subjects to bypass the new low-quality commit-message slop finding.

### Description
- Change the regex in `src/signals/engine.ts` so the `\b` word-boundary only applies to the word-like generic alternatives and not to the `\.+` alternative, i.e. `GENERIC_COMMIT_PATTERN` now matches either a word-like generic subject with `\b` or a dot-only subject without it.
- Add a regression test in `test/unit/slop.test.ts` that asserts `buildLowQualityCommitMessageFinding` flags `.`, `..`, and `...` as low-quality commit messages.

### Testing
- Ran the targeted test file with `npx vitest run test/unit/slop.test.ts` and it passed (29 tests, 0 failures). 
- Ran `npm run test:unit -- test/unit/slop.test.ts` which confirmed the slop tests pass, while the expanded full-unit-suite run produced unrelated timeouts in other test files not touched by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c3666994832ca41d7a7a884ddabd)