### PR TITLE
fix(signals): compare local branch repo names case-insensitively

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -378,7 +378,7 @@ export function buildLocalBranchAnalysis(args: {
     queueHealth: buildQueueHealth(args.repo, args.issues, args.pullRequests, buildCollisionReport(args.input.repoFullName, args.issues, args.pullRequests)),
     roleContext,
     contributorOpenPrCount: (args.contributorPullRequests ?? args.pullRequests).filter(
-      (pr) => pr.repoFullName === args.input.repoFullName && pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === args.input.login.toLowerCase(),
+      (pr) => sameRepo(pr.repoFullName, args.input.repoFullName) && pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === args.input.login.toLowerCase(),
     ).length,
   });
   const scenarioSummary = renderPublicScenarioSummary({

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1630,6 +1630,31 @@ describe("local MCP git metadata collection", () => {
     expect(options[0]?.obstacles).toEqual([]);
   });
 
+  it("counts same-repo contributor open PRs case-insensitively when ranking pressure options", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "Oktofeesh1",
+        repoFullName: "EnTrius/AllWays-UI",
+        changedFiles: [{ path: "src/util.ts", additions: 30, deletions: 2, status: "modified" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 38 },
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 9, title: "Improve util", state: "open", labels: [], linkedPrs: [] }],
+      pullRequests: [],
+      contributorPullRequests: [
+        { repoFullName: repo.fullName, number: 4, title: "WIP util", state: "open", authorLogin: "oktofeesh1", labels: [], linkedIssues: [] },
+      ],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    const options = analysis.scenarioSummary.options;
+    expect(options[0]).toMatchObject({ label: "Clean up existing work first", recommended: true });
+    expect(options.find((option) => option.label === "Open another PR now")?.obstacles.join(" ")).toMatch(/already have open PR/i);
+  });
+
   it("wires open-PR pressure strategy options into scenarioSummary.options (#348)", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
### Motivation

- A recent change scoped open-PR pressure counting with a case-sensitive repo equality check, which causes same-repo open PRs to be missed when the caller- or git-derived `repoFullName` uses different casing.

### Description

- Replace strict `===` repoFullName comparison with the existing case-insensitive `sameRepo()` helper in `src/signals/local-branch.ts` when computing `contributorOpenPrCount`.
- Add a regression unit test in `test/unit/local-branch.test.ts` that exercises differently-cased `repoFullName` and contributor `login` values to ensure same-repo open PRs are counted and pressure guidance recommends cleanup first.

### Testing

- Ran the unit test file with `npm test -- --run test/unit/local-branch.test.ts`, and all tests passed (`44 passed`).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`), which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c72d98c4832c9a3ead3a74775551)