### PR TITLE
feat(signals): slop golden-fixture + determinism coverage and documented thresholds (#565)

### DIFF
--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -436,6 +436,9 @@ function ensurePublicSafeText(text: string, fallback: string): string {
   return isFocusManifestPublicSafe(text) ? text : fallback;
 }
 
+// Documented thresholds (#565): the deterministic slopRisk (0-100) maps to fixed bands — clean = 0,
+// low = 1-24, elevated = 25-59, high = 60-100. Strong signals weigh 30 (any two reach `high`); weak/
+// traceability signals weigh 15. Identical metadata always yields an identical band (see golden fixtures).
 function slopBandFor(slopRisk: number): SlopBand {
   if (slopRisk <= 0) return "clean";
   if (slopRisk < 25) return "low";

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -10,6 +10,8 @@ import {
   buildSlopAssessment,
   buildTrivialWhitespaceChurnFinding,
   buildUnfilledIssueTemplateFinding,
+  type SlopAssessmentInput,
+  type SlopBand,
   ISSUE_SLOP_WEIGHTS,
   SLOP_RUBRIC_MARKDOWN,
   SLOP_WEIGHTS,
@@ -403,5 +405,48 @@ describe("buildNonSubstantivePaddingFinding (#561 path-matcher signal)", () => {
     expect(result.slopRisk).toBe(SLOP_WEIGHTS.nonSubstantivePadding);
     expect(result.band).toBe("elevated");
     expect(JSON.stringify(result)).not.toMatch(FORBIDDEN);
+  });
+});
+
+describe("slop golden fixtures & determinism (#565)", () => {
+  const goldenFixtures: Array<{ name: string; input: SlopAssessmentInput; slopRisk: number; band: SlopBand; codes: string[] }> = [
+    { name: "clean — no metadata", input: {}, slopRisk: 0, band: "clean", codes: [] },
+    { name: "low — generic commit subject", input: { commitMessages: ["wip"] }, slopRisk: 15, band: "low", codes: ["low_quality_commit_message"] },
+    { name: "low — no linked issue and no rationale", input: { hasLinkedIssue: false }, slopRisk: 15, band: "low", codes: ["no_linked_issue_without_rationale"] },
+    {
+      name: "elevated — code change without test evidence",
+      input: { changedFiles: [{ path: "src/svc.ts", additions: 12, deletions: 3 }], description: "Add retry logic to the sync client." },
+      slopRisk: 30,
+      band: "elevated",
+      codes: ["missing_test_evidence"],
+    },
+    {
+      name: "elevated — untested code change inside a duplicate cluster",
+      input: { changedFiles: [{ path: "src/svc.ts", additions: 12, deletions: 3 }], description: "Add retry logic to the sync client.", inDuplicateCluster: true },
+      slopRisk: 45,
+      band: "elevated",
+      codes: ["duplicate_cluster_membership", "missing_test_evidence"],
+    },
+    {
+      name: "high — whitespace churn, untested code, and empty description",
+      input: { changedFiles: [{ path: "src/x.ts", additions: 2, deletions: 1 }, { path: "src/state.snap", additions: 60, deletions: 40 }], description: "" },
+      slopRisk: 75,
+      band: "high",
+      codes: ["empty_pr_description", "missing_test_evidence", "trivial_whitespace_churn"],
+    },
+  ];
+
+  it.each(goldenFixtures)("scores the $name fixture to its documented band", (fixture) => {
+    const result = buildSlopAssessment(fixture.input);
+    expect(result.slopRisk).toBe(fixture.slopRisk);
+    expect(result.band).toBe(fixture.band);
+    expect(result.findings.map((finding) => finding.code).sort()).toEqual(fixture.codes);
+    expect(JSON.stringify(result)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("returns identical slopRisk and findings for identical metadata (determinism)", () => {
+    for (const fixture of goldenFixtures) {
+      expect(buildSlopAssessment(fixture.input)).toEqual(buildSlopAssessment(fixture.input));
+    }
   });
 });


### PR DESCRIPTION
## Summary
Addresses #565. Adds **golden-fixture** coverage of `buildSlopAssessment` across all four bands (clean / low / elevated / high) — each fixture pins the exact `slopRisk`, `band`, and sorted finding codes — plus an explicit **determinism** check (identical metadata → identical `slopRisk` + `findings`), and documents the band thresholds on `slopBandFor`.

## Acceptance
Matches the issue's acceptance: *documented thresholds; identical metadata → identical slopRisk*.

## Weights unchanged (intentional)
The golden fixtures demonstrate the current `SLOP_WEIGHTS` already separate every band cleanly (15 → low, 30 → elevated, two strong = 60 → high), so no retuning is warranted; keeping the weights stable preserves the deterministic contract both the MCP tool and CI consume.

## Tests
`npx vitest run test/unit/slop.test.ts` → 42 passed · `npx tsc --noEmit` → clean · `git diff --check` → clean.

Closes #565.