### PR TITLE
fix(comments): bound sticky comment lookup

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -6,6 +6,7 @@ export const PR_INTELLIGENCE_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 export const AGENT_COMMAND_COMMENT_MARKER = PR_PANEL_COMMENT_MARKER;
 const LEGACY_PR_INTELLIGENCE_COMMENT_MARKER = "<!-- gittensory-pr-intelligence -->";
 const LEGACY_AGENT_COMMAND_COMMENT_MARKER = "<!-- gittensory-agent-command -->";
+const COMMENT_SEARCH_PAGE_LIMIT = 3;
 
 type IssueComment = {
   id: number;
@@ -55,7 +56,7 @@ async function createOrUpdateIssueCommentWithMarker(
   const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
   const markers = markerAliases(marker);
   let existing: IssueComment | undefined;
-  for (let page = 1; !existing; page += 1) {
+  for (let page = 1; !existing && page <= COMMENT_SEARCH_PAGE_LIMIT; page += 1) {
     const response = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", {
       owner,
       repo,

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -102,6 +102,38 @@ describe("GitHub PR intelligence comments", () => {
     expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
   });
 
+
+  it("bounds sticky comment lookup to protect comment publication from unbounded pagination", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const commentListCalls: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        commentListCalls.push(page);
+        return Response.json(
+          Array.from({ length: 100 }, (_, i) => ({ id: page * 100 + i, body: `human comment ${page}-${i}`, user: { login: "contributor", type: "User" } })),
+        );
+      }
+      if (url.includes("/issues/12/comments") && init?.method === "POST") {
+        return Response.json({ id: 303, html_url: "https://github.com/comment/303" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\nnew body`,
+    );
+
+    expect(result?.id).toBe(303);
+    expect(commentListCalls).toEqual([1, 2, 3]);
+  });
+
   it("updates a legacy PR intelligence comment into the unified panel", async () => {
     const privateKey = await generatePrivateKeyPem();
     const calls: string[] = [];


### PR DESCRIPTION
### Motivation
- Prevent unbounded GitHub REST pagination when searching for the bot's sticky comment so an attacker-controlled comment history cannot force arbitrarily many API requests or exhaust Worker/subrequest/time budgets. 

### Description
- Add a fixed `COMMENT_SEARCH_PAGE_LIMIT` and bound the comment-list loop to `page <= COMMENT_SEARCH_PAGE_LIMIT` in `src/github/comments.ts` so the helper performs at most a small number of paged requests. 
- Preserve existing behavior of patching an existing bot comment when found and falling back to creating a new comment when none is found within the bounded search window. 
- Add a unit test in `test/unit/github-comments.test.ts` that simulates full 100-comment pages and verifies only pages `1..3` are fetched and the helper creates the sticky comment when not found.

### Testing
- Ran `git diff --check` which reported no issues. 
- Ran `npx vitest run test/unit/github-comments.test.ts` and the updated test file passed (`1 test file, 8 tests, 8 passed`). 
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Note: an initial scripted `npm run test:unit -- test/unit/github-comments.test.ts` invocation expanded to the full unit suite and hit unrelated long-running tests that timed out, so the targeted test was rerun directly as above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371dcb258c832ca74f5bbd5c2860d1)