### PR TITLE
fix(db): avoid oversized latest totals query

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -944,21 +944,16 @@ export async function listRepoGithubTotalsSnapshotHistory(
 
 export async function listLatestRepoGithubTotalsSnapshots(env: Env): Promise<RepoGithubTotalsSnapshotRecord[]> {
   const db = getDb(env.DB);
-  const latestRows = await db
-    .select({
-      repoFullName: repoGithubTotalsSnapshots.repoFullName,
-      fetchedAt: sql<string>`max(${repoGithubTotalsSnapshots.fetchedAt})`,
-    })
-    .from(repoGithubTotalsSnapshots)
-    .groupBy(repoGithubTotalsSnapshots.repoFullName);
-  if (latestRows.length === 0) return [];
-  const conditions = latestRows.map((latest) =>
-    and(eq(repoGithubTotalsSnapshots.repoFullName, latest.repoFullName), eq(repoGithubTotalsSnapshots.fetchedAt, latest.fetchedAt)),
-  );
   const rows = await db
     .select()
     .from(repoGithubTotalsSnapshots)
-    .where(or(...conditions));
+    .where(
+      sql`${repoGithubTotalsSnapshots.fetchedAt} = (
+        select max(latest.fetched_at)
+        from repo_github_totals_snapshots latest
+        where latest.repo_full_name = ${repoGithubTotalsSnapshots.repoFullName}
+      )`,
+    );
   return rows.map(toRepoGithubTotalsSnapshotRecord).sort((left, right) => left.repoFullName.localeCompare(right.repoFullName));
 }
 

--- a/test/unit/db-persistence.test.ts
+++ b/test/unit/db-persistence.test.ts
@@ -131,6 +131,22 @@ describe("database persistence helpers", () => {
     ]);
   });
 
+  it("loads latest totals for many repos without building an oversized OR predicate", async () => {
+    const env = createTestEnv();
+    const repoCount = 1200;
+    for (let index = 0; index < repoCount; index += 1) {
+      const repoFullName = `owner/repo-${String(index).padStart(4, "0")}`;
+      await persistRepoGithubTotalsSnapshot(env, totalsSnapshot(`totals-${index}-old`, repoFullName, "2026-05-29T00:00:00.000Z", 1));
+      await persistRepoGithubTotalsSnapshot(env, totalsSnapshot(`totals-${index}-new`, repoFullName, "2026-05-30T00:00:00.000Z", index));
+    }
+
+    const snapshots = await listLatestRepoGithubTotalsSnapshots(env);
+
+    expect(snapshots).toHaveLength(repoCount);
+    expect(snapshots[0]).toMatchObject({ repoFullName: "owner/repo-0000", openIssuesTotal: 0 });
+    expect(snapshots.at(-1)).toMatchObject({ repoFullName: "owner/repo-1199", openIssuesTotal: 1199 });
+  });
+
   it("caps contributor-graph file-path loading and still builds path edges from the capped set", async () => {
     const env = createTestEnv();
     const repoFullName = "owner/big-repo";


### PR DESCRIPTION
### Motivation
- The previous implementation built an unbounded `OR` predicate from every repo's latest timestamp which makes the generated SQL grow linearly with repository count and can exceed SQLite/D1 limits. 
- The helper `listLatestRepoGithubTotalsSnapshots` is used by readiness/sync endpoints and decision-pack loading, so the oversized query could cause internal endpoints and background jobs to fail.

### Description
- Replace the unbounded `OR(...conditions)` approach in `listLatestRepoGithubTotalsSnapshots` with a correlated `max(fetched_at)` subquery so the statement size no longer scales with the number of repos. 
- The change uses a single correlated `sql` predicate comparing `fetched_at` to a `select max(...) from repo_github_totals_snapshots latest where latest.repo_full_name = ...` expression. 
- Remove the intermediate map of latest rows/OR conditions and preserve output mapping and alphabetical sorting of snapshots. 
- Add a regression test that seeds 1,200 repo snapshots to verify the helper returns the latest row per repo without triggering SQLite expression-depth or parameter-count failures.

### Testing
- Ran `npx vitest run test/unit/db-persistence.test.ts` and all tests in that file passed, including the new `loads latest totals for many repos without building an oversized OR predicate` test. 
- Ran `npm run typecheck` (`tsc --noEmit`) and the TypeScript typecheck succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3788fdfc74832c9110f26932c1326f)