### PR TITLE
fix(signals): recognize colon no-issue rationales

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4473,7 +4473,7 @@ export function buildPrTextLint(input: PrTextLintInput): PrTextLintReport {
 // Exported so the deterministic no-linked-issue slop signal (#562) and the public PR-panel traceability check
 // share ONE definition of a "clear no-issue rationale" (maintenance / docs-only / "no issue: …" in the PR text).
 export function hasClearNoIssueRationale(pr: Pick<PullRequestRecord, "title" | "body">): boolean {
-  return /\b(no issue\s*(?:because|:)|no linked issue\s*(?:because|:)|no ticket\s*(?:because|:)|maintenance|docs? only|typo|chore|cleanup)\b/i.test([pr.title, pr.body ?? ""].join(" "));
+  return /\b(?:no issue\s*(?:because\b|:)|no linked issue\s*(?:because\b|:)|no ticket\s*(?:because\b|:)|(?:maintenance|docs? only|typo|chore|cleanup)\b)/i.test([pr.title, pr.body ?? ""].join(" "));
 }
 
 function hasValidationNote(value: string): boolean {

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -75,6 +75,9 @@ describe("buildSlopAssessment", () => {
   it("does not raise no-linked-issue slop when an issue is linked, a rationale is present, the lane is issue-discovery, or no data is supplied (#562)", () => {
     expect(buildSlopAssessment({ hasLinkedIssue: true }).findings).toEqual([]);
     expect(buildSlopAssessment({ hasLinkedIssue: false, description: "Docs only: fix a typo in the README." }).findings).toEqual([]);
+    expect(buildSlopAssessment({ hasLinkedIssue: false, description: "No issue: refactor the parser." }).findings).toEqual([]);
+    expect(buildSlopAssessment({ hasLinkedIssue: false, description: "No linked issue: internal maintenance." }).findings).toEqual([]);
+    expect(buildSlopAssessment({ hasLinkedIssue: false, description: "No ticket: docs cleanup." }).findings).toEqual([]);
     expect(buildSlopAssessment({ hasLinkedIssue: false, issueDiscoveryLane: true }).findings).toEqual([]);
     expect(buildSlopAssessment({}).findings).toEqual([]);
   });


### PR DESCRIPTION
### Motivation
- A deterministic slop signal reported `no_linked_issue_without_rationale` even when the PR text used documented rationale forms like `No issue: …` because the shared helper regex required a trailing word-boundary that failed after a colon. 
- The intent is to ensure `hasClearNoIssueRationale` correctly recognizes colon-ended rationale prefixes so the slop signal does not produce false positives for documented forms.

### Description
- Adjusted the rationale-matching regex in `src/signals/engine.ts` so colon-ending prefixes (`No issue:`, `No linked issue:`, `No ticket:`) are recognized without relying on a trailing `\b` after the colon. 
- Added regression assertions to `test/unit/slop.test.ts` that verify `No issue: …`, `No linked issue: …`, and `No ticket: …` in the PR description suppress the `no_linked_issue_without_rationale` finding. 
- Changes are limited to `src/signals/engine.ts` and `test/unit/slop.test.ts` to preserve existing behavior elsewhere.

### Testing
- Ran unit tests with `npm test -- test/unit/slop.test.ts` and `vitest` reported all tests passed (`42` tests, `42` passed). 
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378ae4a77c832c91954688e40a4b6e)