### PR TITLE
feat(pmf): newcomer advisory, conversion hook, and no-account MCP mode

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3636,6 +3636,7 @@ async function authenticateRequestIdentity(c: ProtectedRouteContext): Promise<Au
 
 async function getRoleSummaryForIdentity(env: Env, identity: AuthIdentity) {
   if (identity.kind === "session") return loadControlPanelRoleSummary(env, identity.actor);
+  if (identity.kind === "public") return buildStaticControlPanelRoleSummary("mcp");
   return buildStaticControlPanelRoleSummary(identity.actor);
 }
 

--- a/src/auth/security.ts
+++ b/src/auth/security.ts
@@ -10,7 +10,8 @@ import { nowIso } from "../utils/json";
 
 export type AuthIdentity =
   | { kind: "static"; actor: "api" | "mcp" | "internal" }
-  | { kind: "session"; actor: string; session: AuthSessionRecord };
+  | { kind: "session"; actor: string; session: AuthSessionRecord }
+  | { kind: "public"; actor: "anonymous" };
 
 export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 export const BROWSER_SESSION_COOKIE = "gittensory_session";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -370,7 +370,6 @@ const localStatusOutputSchema = {
 export async function handleMcpRequest(c: AppContext): Promise<Response> {
   if (c.req.method === "OPTIONS") return new Response(null, { status: 204 });
   const identity = await authenticateMcpRequest(c);
-  if (!identity) return c.json({ error: "unauthorized" }, 401);
 
   const telemetry = buildMcpClientTelemetry(c.req.raw.headers, { defaultClientName: "mcp" })!;
   const usageMetadata = await describeMcpUsageRequest(c.req.raw, telemetry.metadata);
@@ -815,8 +814,17 @@ export class GittensoryMcp {
   }
 
   private requireContributorAccess(login: string): void {
+    if (this.identity.kind === "public") {
+      throw new Error("Register on Gittensory to access contributor-specific insights. Run anti-slop and preflight checks without an account; unlock contributor context after signing in.");
+    }
     if (this.identity.kind === "session" && this.identity.actor.toLowerCase() !== login.toLowerCase()) {
       throw new Error("Forbidden: session can only access the authenticated GitHub login.");
+    }
+  }
+
+  private requireAuthenticated(): void {
+    if (this.identity.kind === "public") {
+      throw new Error("Register on Gittensory to unlock gittensor-specific features like score preview, credibility, and decision context. Anti-slop preflight is available without an account.");
     }
   }
 
@@ -902,7 +910,7 @@ export class GittensoryMcp {
   }
 
   private async canAccessRepo(fullName: string): Promise<boolean> {
-    if (this.identity.kind !== "session") return true;
+    if (this.identity.kind !== "session") return true; // static and public modes access any repo
     const [scope, repo] = await Promise.all([this.loadSessionAccessScope(), getRepository(this.env, fullName)]);
     if (scope.operator) return true;
     const requestedRepo = fullName.toLowerCase();
@@ -1065,6 +1073,7 @@ export class GittensoryMcp {
   }
 
   private async previewScore(input: z.infer<z.ZodObject<typeof scorePreviewShape>>): Promise<ToolPayload> {
+    this.requireAuthenticated();
     if (input.contributorLogin) this.requireContributorAccess(input.contributorLogin);
     await this.requireRepoAccess(input.repoFullName);
     const [repo, snapshot, evidence] = await Promise.all([
@@ -1404,11 +1413,14 @@ function authoritativeContributorRepoStats(
   return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
-async function authenticateMcpRequest(c: AppContext): Promise<AuthIdentity | null> {
-  const identity = await authenticatePrivateToken(c.env, extractBearerToken(c.req.header("authorization")));
-  if (!identity || identity.kind !== "session") return identity;
+async function authenticateMcpRequest(c: AppContext): Promise<AuthIdentity> {
+  const token = extractBearerToken(c.req.header("authorization"));
+  if (!token) return { kind: "public", actor: "anonymous" };
+  const identity = await authenticatePrivateToken(c.env, token);
+  if (!identity) return { kind: "public", actor: "anonymous" };
+  if (identity.kind !== "session") return identity;
   const summary = await loadControlPanelRoleSummary(c.env, identity.actor);
-  return summary.roles.length > 0 ? identity : null;
+  return summary.roles.length > 0 ? identity : { kind: "public", actor: "anonymous" };
 }
 
 function getExecutionContext(c: AppContext): ExecutionContext<unknown> {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1053,6 +1053,35 @@ async function maybePublishPrPublicSurface(
       failedOutputs,
     },
   });
+  if (publishedOutputs.includes("comment")) {
+    if (
+      official.status !== "confirmed" &&
+      settings.publicAudienceMode === "oss_maintainer" &&
+      repo?.isRegistered === true &&
+      readiness.total >= 60
+    ) {
+      await recordProductUsageEvent(env, {
+        surface: "github_app",
+        eventName: "pmf_funnel.conversion_hook_shown",
+        actor: author,
+        repoFullName,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        metadata: { deliveryId: webhook.deliveryId, readinessTotal: readiness.total, authorAssociation: pr.authorAssociation },
+      }).catch(() => undefined);
+    }
+    if (pr.authorAssociation === "FIRST_TIME_CONTRIBUTOR" || pr.authorAssociation === "FIRST_TIMER") {
+      await recordProductUsageEvent(env, {
+        surface: "github_app",
+        eventName: "pmf_funnel.newcomer_advisory_posted",
+        actor: author,
+        repoFullName,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        metadata: { deliveryId: webhook.deliveryId, authorAssociation: pr.authorAssociation },
+      }).catch(() => undefined);
+    }
+  }
 }
 
 async function recordPublicSurfaceOutputFailure(

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3653,9 +3653,19 @@ export function buildPublicPrIntelligenceComment(args: {
     publicFindings.length > 0
       ? publicFindings.map((finding) => `- ${sanitizePanelText(finding.title)}: ${sanitizePanelText(finding.publicText ?? finding.detail)}`)
       : ["- No public-safe advisory findings were generated from cached metadata."];
+  const isFirstTimeContributor =
+    args.pr.authorAssociation === "FIRST_TIME_CONTRIBUTOR" ||
+    args.pr.authorAssociation === "FIRST_TIMER";
+  const showConversionHook =
+    !confirmedMiner &&
+    genericOssMode &&
+    args.repo?.isRegistered === true &&
+    readiness.total >= 60;
   const footer = confirmedMiner || args.settings.publicAudienceMode === "gittensor_only"
     ? "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers. Learn more about [Gittensor](https://gittensor.io) contribution workflows."
-    : "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers.";
+    : showConversionHook
+      ? "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers. This repo is registered on [Gittensor](https://gittensor.io), a contribution-tracking network for OSS — [register in 60 seconds](https://gittensor.io) to link your work and get recognized."
+      : "Checked by [Gittensory](https://github.com/JSONbored/gittensory), a quiet PR intelligence layer for OSS maintainers.";
   return [
     "<!-- gittensory-pr-panel:v1 -->",
     "",
@@ -3708,6 +3718,22 @@ export function buildPublicPrIntelligenceComment(args: {
     "",
     "</details>",
     "",
+    ...(isFirstTimeContributor
+      ? [
+          "<details>",
+          "<summary>Welcome — first contribution guide</summary>",
+          "",
+          "A few things that help a PR land in this repo:",
+          "",
+          "- Keep the change focused: one logical change per PR.",
+          "- Link an open issue or explain why no linked issue is needed.",
+          "- Include tests or a note covering the behavior change.",
+          "- Check for open duplicate PRs before submitting.",
+          "",
+          "</details>",
+          "",
+        ]
+      : []),
     `- [ ] ${PR_PANEL_RETRIGGER_MARKER} Re-run Gittensory review`,
     "",
     "---",

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -4175,6 +4175,8 @@ describe("api routes", () => {
     );
     expect(decisionBuild.status).toBe(200);
 
+    // No-account mode: unauthenticated MCP requests proceed as public identity (no 401).
+    // Missing content-type causes the MCP transport to reject with a non-auth error.
     const unauthorized = await app.request(
       "/mcp",
       {
@@ -4183,7 +4185,8 @@ describe("api routes", () => {
       },
       env,
     );
-    expect(unauthorized.status).toBe(401);
+    expect(unauthorized.status).not.toBe(401);
+    // Sessions with no roles are downgraded to public identity and allowed through.
     const { token: noRoleMcpToken } = await createSessionForGitHubUser(env, { login: "new-user", id: 222 });
     const noRoleMcp = await app.request(
       "/mcp",
@@ -4194,7 +4197,7 @@ describe("api routes", () => {
       },
       env,
     );
-    expect(noRoleMcp.status).toBe(401);
+    expect(noRoleMcp.status).not.toBe(401);
 
     const { token: operatorMcpToken } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 12345 });
     const forbiddenContributorMcp = await app.request(
@@ -4212,6 +4215,51 @@ describe("api routes", () => {
         isError: true,
         content: [expect.objectContaining({ text: expect.stringContaining("authenticated GitHub login") })],
       },
+    });
+
+    // Public identity (no auth token) calling gittensor-native tools: requireAuthenticated() fires.
+    const publicMcpHeaders = { ...mcpHeaders(env) };
+    delete (publicMcpHeaders as Record<string, string>)["authorization"];
+    const publicPreviewScore = await app.request(
+      "/mcp",
+      {
+        method: "POST",
+        headers: publicMcpHeaders,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "public-preview-score",
+          method: "tools/call",
+          params: {
+            name: "gittensory_preview_local_pr_score",
+            arguments: { repoFullName: "owner/stable", targetKey: "anon-pr", sourceTokenScore: 30, totalTokenScore: 50, sourceLines: 10 },
+          },
+        }),
+      },
+      env,
+    );
+    expect(publicPreviewScore.status).toBe(200);
+    await expect(mcpJson(publicPreviewScore)).resolves.toMatchObject({
+      result: { isError: true, content: [expect.objectContaining({ text: expect.stringContaining("Register on Gittensory") })] },
+    });
+
+    // Public identity calling contributor-scoped tools: requireContributorAccess() fires.
+    const publicDecisionPack = await app.request(
+      "/mcp",
+      {
+        method: "POST",
+        headers: publicMcpHeaders,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "public-decision-pack",
+          method: "tools/call",
+          params: { name: "gittensory_get_decision_pack", arguments: { login: "oktofeesh1" } },
+        }),
+      },
+      env,
+    );
+    expect(publicDecisionPack.status).toBe(200);
+    await expect(mcpJson(publicDecisionPack)).resolves.toMatchObject({
+      result: { isError: true, content: [expect.objectContaining({ text: expect.stringContaining("Register on Gittensory") })] },
     });
 
     const malformedMcp = await app.request(

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -979,6 +979,7 @@ describe("api route guards and error branches", () => {
         },
       } as never),
     ).rejects.toThrow("static raw request unavailable");
+    // No-account mode: invalid tokens fall back to public identity and proceed (no 401).
     expect(
       (
         await app.request(
@@ -987,7 +988,7 @@ describe("api route guards and error branches", () => {
           env,
         )
       ).status,
-    ).toBe(401);
+    ).not.toBe(401);
 
     const snapshot = await app.request("/v1/registry/snapshot", { headers: apiHeaders(env) }, env);
     expect(snapshot.status).toBe(200);

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -147,4 +147,40 @@ describe("MCP server telemetry", () => {
       }),
     ]);
   });
+
+  it("allows unauthenticated (no-account) MCP requests through as public identity", async () => {
+    vi.resetModules();
+    vi.doMock("agents/mcp", () => ({
+      createMcpHandler: () => () => Response.json({ ok: true }),
+    }));
+    const { handleMcpRequest } = await import("../../src/mcp/server");
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "mcp-public-test-salt" });
+    const request = new Request("https://api.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "anon-ping", method: "ping" }),
+    });
+
+    const response = await handleMcpRequest({
+      env,
+      executionCtx: { waitUntil() {}, passThroughOnException() {} },
+      req: {
+        method: "POST",
+        raw: request,
+        header: (name: string) => request.headers.get(name) ?? undefined,
+      },
+      json: (body: unknown, status?: number) => Response.json(body, status === undefined ? undefined : { status }),
+    } as never);
+
+    // Public identity is allowed through — no 401.
+    expect(response.status).toBe(200);
+    // Telemetry is recorded for anonymous sessions too.
+    await expect(listProductUsageEvents(env, { limit: 5 })).resolves.toEqual([
+      expect.objectContaining({
+        surface: "mcp",
+        eventName: "mcp_request",
+        outcome: "success",
+      }),
+    ]);
+  });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3461,6 +3461,67 @@ describe("queue processors", () => {
       .first<{ outcome: string; detail: string }>();
     expect(event).toMatchObject({ outcome: "error", detail: "miner_detection_unavailable" });
   });
+
+  it("records PMF funnel events when a comment is published for an eligible first-time contributor on a registered repo", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicAudienceMode: "oss_maintainer",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      // No miners — author is non-confirmed.
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.endsWith("/users/first-timer")) return Response.json({ login: "first-timer", public_repos: 2, followers: 1 });
+      if (url.includes("/users/first-timer/repos")) return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/99/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/99/comments") && method === "POST") return Response.json({ id: 99 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pmf-first-timer",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 99,
+          title: "First contribution",
+          state: "open",
+          user: { login: "first-timer" },
+          author_association: "FIRST_TIME_CONTRIBUTOR",
+          labels: [],
+          body: "Fixes #1\n\nValidation: npm test",
+        },
+      },
+    });
+
+    const events = await listProductUsageEvents(env, { limit: 20 });
+    const funnelEvents = events.filter((e) => e.eventName.startsWith("pmf_funnel."));
+    const hookEvent = funnelEvents.find((e) => e.eventName === "pmf_funnel.conversion_hook_shown");
+    const advisoryEvent = funnelEvents.find((e) => e.eventName === "pmf_funnel.newcomer_advisory_posted");
+    expect(hookEvent).toBeDefined();
+    expect(advisoryEvent).toBeDefined();
+    expect(hookEvent?.repoFullName).toBe("JSONbored/gittensory");
+    expect(advisoryEvent?.repoFullName).toBe("JSONbored/gittensory");
+  });
 });
 
 function completeSegment(repoFullName: string, segment: "labels" | "open_issues" | "open_pull_requests") {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -723,7 +723,9 @@ describe("signal coverage edge cases", () => {
     expect(collisionComment).not.toContain("possible overlaps");
     expect(collisionComment).not.toContain("Cached OSS contributor activity");
     expect(collisionComment).not.toContain("Cached prior PRs/issues");
-    expect(collisionComment).not.toContain("gittensor.io");
+    // Conversion hook is shown: non-confirmed contributor, oss_maintainer mode, registered repo, readiness >= 60.
+    expect(collisionComment).toContain("gittensor.io");
+    expect(collisionComment).toContain("register in 60 seconds");
 
     const repoBlockedComment = buildPublicPrIntelligenceComment({
       repo: null,

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -1104,6 +1104,103 @@ describe("world-class backend signals", () => {
     expect(changeReport).toMatchObject({ addedRepos: ["owner/added"], removedRepos: ["owner/removed"] });
     expect(changeReport.changedRepos[0]?.changes).toEqual(expect.arrayContaining(["label_multipliers changed", "trusted_label_pipeline false -> true"]));
   });
+
+  it("shows newcomer advisory section for first-time contributors and omits it for regular authors", () => {
+    const baseSettings: RepositorySettings = {
+      repoFullName: repo.fullName,
+      commentMode: "all_prs",
+      publicAudienceMode: "oss_maintainer",
+      publicSignalLevel: "standard",
+      checkRunMode: "off",
+      checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
+      linkedIssueGateMode: "advisory",
+      duplicatePrGateMode: "advisory",
+      qualityGateMode: "advisory",
+      qualityGateMinScore: null,
+      autoLabelEnabled: false,
+      gittensorLabel: "gittensor",
+      createMissingLabel: false,
+      publicSurface: "comment_and_label",
+      includeMaintainerAuthors: false,
+      requireLinkedIssue: false,
+      backfillEnabled: true,
+      privateTrustEnabled: true,
+    };
+    const baseArgs = {
+      repo,
+      detection: detectGittensorContributor("newcomer", pullRequests[0]!, [], []),
+      queueHealth: buildQueueHealth(repo, issues, pullRequests, buildCollisionReport(repo.fullName, issues, pullRequests)),
+      collisions: buildCollisionReport(repo.fullName, issues, pullRequests),
+      preflight: buildPreflightResult({ repoFullName: repo.fullName, title: "Fix cache", linkedIssues: [7] }, repo, issues, pullRequests),
+      profile: buildContributorProfile("newcomer", { login: "newcomer", topLanguages: [], source: "github" }, [], []),
+      settings: baseSettings,
+    };
+
+    const firstTimePr: PullRequestRecord = { ...pullRequests[0]!, authorLogin: "newcomer", authorAssociation: "FIRST_TIME_CONTRIBUTOR" };
+    const firstTimerPr: PullRequestRecord = { ...pullRequests[0]!, authorLogin: "newcomer", authorAssociation: "FIRST_TIMER" };
+    const regularPr: PullRequestRecord = { ...pullRequests[0]!, authorLogin: "newcomer", authorAssociation: "NONE" };
+
+    const firstTimeComment = buildPublicPrIntelligenceComment({ ...baseArgs, pr: firstTimePr });
+    const firstTimerComment = buildPublicPrIntelligenceComment({ ...baseArgs, pr: firstTimerPr });
+    const regularComment = buildPublicPrIntelligenceComment({ ...baseArgs, pr: regularPr });
+
+    expect(firstTimeComment).toContain("Welcome — first contribution guide");
+    expect(firstTimeComment).toContain("Keep the change focused: one logical change per PR.");
+    expect(firstTimerComment).toContain("Welcome — first contribution guide");
+    expect(regularComment).not.toContain("Welcome — first contribution guide");
+    // Advisory content must be public-safe.
+    expect(firstTimeComment).not.toMatch(/reward|wallet|hotkey|payout|farming/i);
+  });
+
+  it("shows conversion hook for non-confirmed contributors on registered repos with good readiness, and suppresses it otherwise", () => {
+    const ossSettings: RepositorySettings = {
+      repoFullName: repo.fullName,
+      commentMode: "all_prs",
+      publicAudienceMode: "oss_maintainer",
+      publicSignalLevel: "standard",
+      checkRunMode: "off",
+      checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
+      linkedIssueGateMode: "advisory",
+      duplicatePrGateMode: "advisory",
+      qualityGateMode: "advisory",
+      qualityGateMinScore: null,
+      autoLabelEnabled: false,
+      gittensorLabel: "gittensor",
+      createMissingLabel: false,
+      publicSurface: "comment_and_label",
+      includeMaintainerAuthors: false,
+      requireLinkedIssue: false,
+      backfillEnabled: true,
+      privateTrustEnabled: true,
+    };
+    const qualityPr: PullRequestRecord = { ...pullRequests[0]!, authorLogin: "outsider", authorAssociation: "NONE", linkedIssues: [7] };
+    const unregisteredRepo: RepositoryRecord = { ...repo, isRegistered: false };
+    const confirmedDetection = { ...detectGittensorContributor("outsider", qualityPr, [], []), source: "official_gittensor_api" as const };
+    const unconfirmedDetection = detectGittensorContributor("outsider", qualityPr, [], []);
+    const profile = buildContributorProfile("outsider", { login: "outsider", topLanguages: [], source: "github" }, [], []);
+    const collisions = buildCollisionReport(repo.fullName, issues, [qualityPr]);
+    const queueHealth = buildQueueHealth(repo, issues, [qualityPr], collisions);
+    const preflight = buildPreflightResult({ repoFullName: repo.fullName, title: qualityPr.title, linkedIssues: [7] }, repo, issues, [qualityPr]);
+
+    const hookShown = buildPublicPrIntelligenceComment({ repo, pr: qualityPr, profile, detection: unconfirmedDetection, queueHealth, collisions, preflight, settings: ossSettings });
+    const confirmedMinerNoHook = buildPublicPrIntelligenceComment({ repo, pr: qualityPr, profile, detection: confirmedDetection, queueHealth, collisions, preflight, settings: ossSettings });
+    const unregisteredNoHook = buildPublicPrIntelligenceComment({ repo: unregisteredRepo, pr: qualityPr, profile, detection: unconfirmedDetection, queueHealth, collisions, preflight, settings: ossSettings });
+    const gittensorOnlyNoHook = buildPublicPrIntelligenceComment({ repo, pr: qualityPr, profile, detection: unconfirmedDetection, queueHealth, collisions, preflight, settings: { ...ossSettings, publicAudienceMode: "gittensor_only" } });
+
+    // Conversion hook appears for non-confirmed contributor on registered repo with sufficient readiness.
+    expect(hookShown).toContain("register in 60 seconds");
+    expect(hookShown).toContain("gittensor.io");
+    // Confirmed miners already belong to Gittensor — no conversion hook.
+    expect(confirmedMinerNoHook).not.toContain("register in 60 seconds");
+    // Unregistered repos cannot offer Gittensor contribution tracking.
+    expect(unregisteredNoHook).not.toContain("register in 60 seconds");
+    // gittensor_only mode already filters to confirmed miners — no conversion hook needed.
+    expect(gittensorOnlyNoHook).not.toContain("register in 60 seconds");
+    // Conversion hook text must be public-safe.
+    expect(hookShown).not.toMatch(/reward|wallet|hotkey|payout|farming|estimated score/i);
+  });
 });
 
 function scoringModelSnapshot(): ScoringModelSnapshotRecord {


### PR DESCRIPTION
## Summary

Closes #805
- Adds no-account MCP mode (#799): unauthenticated MCP requests now proceed as a `public` identity instead of returning 401. Universal tools (anti-slop, preflight) work freely; gittensor-native tools (`preview_score`, `get_decision_pack`, `monitor_open_prs`) throw a registration prompt that explains what to unlock.
- Adds a conversion hook to public PR comments (#800): non-confirmed contributors on registered repos with readiness ≥ 60 see a single footer CTA — "register in 60 seconds to link your work and get recognized" — written to pass `containsPrivatePublicTerm` and `isFocusManifestPublicSafe` sanitizers.
- Adds a first-time contributor advisory (#803): PRs from authors with `authorAssociation === FIRST_TIME_CONTRIBUTOR` or `FIRST_TIMER` get a collapsed `<details>` guide covering focused changes, linked issues, tests, and duplicate checks.
- Records PMF funnel events (#802): `pmf_funnel.conversion_hook_shown` and `pmf_funnel.newcomer_advisory_posted` are written to `product_usage_events` after a successful comment publish.
- Extends `AuthIdentity` with a `public` kind (#799): `security.ts`, `routes.ts`, and `server.ts` are updated to handle anonymous callers without breaking static or session identity paths.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Closes #799, #800, #802, #803 (child issues of #805).

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Coverage after this PR: **97.04% branches** (11747/12105), up from 96.99% before new branch tests were added.

If any required check was skipped, explain why:

- MCP pack, workers, and UI checks are environment-specific and expected to run in CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No UI changes in this PR. Public comment text was validated against `containsPrivatePublicTerm` and `isFocusManifestPublicSafe` — blocked words (reward, hotkey, wallet, payout, farming, trust score, scoreability) do not appear.

## UI Evidence

No UI changes.

## Notes

- `public` identity is treated as a zero-privilege caller: `canAccessRepo` returns `true` (same as static), but `requireAuthenticated()` and `requireContributorAccess()` both throw a registration prompt. This mirrors the "tools work, insights are gated" model described in #799.
- The conversion hook threshold (readiness ≥ 60) is the same signal used by `gateCheckPolicy` to determine PR maturity; no new threshold was introduced.
- Issues #801 (extension anonymous path) and #804 (dogfood experiment) from the epic were scoped out — #801 requires extension changes outside this service, and #804 is operational.
