### PR TITLE
fix(scoring): surface snapshot warnings in previews

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -206,7 +206,7 @@ export function buildScorePreview(args: {
   const effectiveEstimatedScore = current.scoreEstimate.estimatedMergedScore;
   const underlyingPotentialScore = current.scoreEstimate.pendingSaturationScore;
   const scoreabilityStatus = statusFor(args.repo, blockedBy, effectiveEstimatedScore, scenarioPreviews);
-  const warnings = warningsFor(args.input, args.repo, current, branchEligibility);
+  const warnings = [...args.snapshot.warnings, ...warningsFor(args.input, args.repo, current, branchEligibility)];
   const actions = [
     ...(!current.gates.baseTokenGatePassed ? ["Increase meaningful source change size or scope clarity before relying on this preview."] : []),
     ...(current.scoreEstimate.openPrMultiplier === 0 ? ["Land or close existing open PRs before opening more concurrent work."] : []),

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -114,6 +114,17 @@ OSS_EMISSION_SHARE = 0.90
     expect(served.warnings.some((warning) => /stale/i.test(warning))).toBe(false);
   });
 
+  it("surfaces snapshot warnings in score previews (#810)", () => {
+    const warning = "Scoring constants snapshot is stale; preview scores may use old constants.";
+    const preview = buildScorePreview({
+      repo,
+      input: { repoFullName: repo.fullName, sourceTokenScore: 10 },
+      snapshot: { ...snapshot, warnings: [warning] },
+    });
+
+    expect(preview.warnings).toContain(warning);
+  });
+
   it("prefers exponential saturation when mixed upstream constants are present", () => {
     const parsed = parsePythonNumberConstants(`
 MERGED_PR_BASE_SCORE = 25


### PR DESCRIPTION
### Motivation
- A staleness warning was appended to served scoring snapshots but preview responses did not include snapshot-level warnings because `buildScorePreview` constructed warnings only from `warningsFor(...)`.

### Description
- Merge `args.snapshot.warnings` into the preview `warnings` array inside `buildScorePreview` so snapshot warnings propagate to preview callers.
- Add a unit test `surfaces snapshot warnings in score previews (#810)` to verify snapshot warnings appear in preview results.
- Files changed: `src/scoring/preview.ts`, `test/unit/scoring.test.ts`.

### Testing
- Ran the targeted unit tests with `npm exec vitest run test/unit/scoring.test.ts` and the scoring test suite passed (43 tests passed).
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded.
- An initial broad `npm run test:unit` run hit unrelated failures in `test/unit/queue.test.ts`, so I re-ran the targeted scoring tests to validate the change which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37bc5d3980832cba6c311327bc73b2)