### PR TITLE
fix(scoring): exclude operational constants from unmodeled scoring drift (#809)

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -174,9 +174,26 @@ export function parsePythonNumberConstants(source: string, options: { knownOnly?
  * staleness visible: if upstream adds a scoring dimension, an operator sees it instead of the gate
  * silently drifting behind. Detection only — it does not change any score.
  */
+// Upstream operational/infrastructure constants (time-unit helpers, HTTP/parse timeouts, retry budgets,
+// byte-size limits, UID sentinels) are not scoring-model parameters the scorer consumes, so reporting them
+// as "unmodeled scoring drift" is a false positive. Excluding them keeps the drift signal accurate (#809).
+const NON_SCORING_UPSTREAM_CONSTANT_NAMES: ReadonlySet<string> = new Set([
+  "SECONDS_PER_DAY",
+  "SECONDS_PER_HOUR",
+  "GITHUB_HTTP_TIMEOUT_SECONDS",
+  "MIRROR_HTTP_TIMEOUT_SECONDS",
+  "MIRROR_MAX_ATTEMPTS",
+  "TREE_SITTER_PARSE_TIMEOUT_MICROS",
+  "SCORING_SUBPROCESS_BUDGET_S",
+  "MAX_FILE_SIZE_BYTES",
+  "RECYCLE_UID",
+  "ISSUES_TREASURY_UID",
+  "MAX_ISSUE_ID",
+]);
+
 export function findUnmodeledConstantKeys(allConstants: Record<string, number>): string[] {
   return Object.keys(allConstants)
-    .filter((name) => !SCORING_CONSTANT_NAMES.has(name))
+    .filter((name) => !SCORING_CONSTANT_NAMES.has(name) && !NON_SCORING_UPSTREAM_CONSTANT_NAMES.has(name))
     .sort();
 }
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -191,6 +191,18 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     expect(unmodeled).not.toContain("TIME_DECAY_GRACE_PERIOD_HOURS"); // modeled as of #703
   });
 
+  it("does not report upstream operational/infrastructure constants as unmodeled scoring drift (#809)", () => {
+    // These are timeouts, byte-size limits, retry budgets, time-unit helpers, and UID sentinels — not scoring
+    // parameters — so they must NOT surface as \"unmodeled scoring constant\" drift warnings.
+    expect(
+      findUnmodeledUpstreamConstants(
+        "SECONDS_PER_DAY = 86400\nGITHUB_HTTP_TIMEOUT_SECONDS = 15\nMAX_FILE_SIZE_BYTES = 1_000_000\nRECYCLE_UID = 0\nTREE_SITTER_PARSE_TIMEOUT_MICROS = 2_000_000\n",
+      ),
+    ).toEqual([]);
+    // A genuinely scoring-shaped unknown constant is still flagged alongside the ignored infra one.
+    expect(findUnmodeledUpstreamConstants("SECONDS_PER_DAY = 86400\nNOVELTY_BONUS_SCALAR = 3\n")).toEqual(["NOVELTY_BONUS_SCALAR"]);
+  });
+
   it("warns on the snapshot when upstream defines an unmodeled scoring dimension", async () => {
     const env = createTestEnv({
       GITTENSOR_UPSTREAM_REPO: "custom/upstream",


### PR DESCRIPTION
## Summary
Addresses #809 (drift-signal accuracy). `findUnmodeledConstantKeys` reported **every** upstream constant not in `SCORING_CONSTANT_NAMES` as "unmodeled scoring drift" — including pure operational/infra constants the scorer never consumes (`SECONDS_PER_DAY`, `GITHUB_HTTP_TIMEOUT_SECONDS`, `TREE_SITTER_PARSE_TIMEOUT_MICROS`, `MAX_FILE_SIZE_BYTES`, `RECYCLE_UID`, `MAX_ISSUE_ID`, `MIRROR_*`, `SCORING_SUBPROCESS_BUDGET_S`, …). Flagging those as "scoring constants gittensory does not model" is a **false positive** that inflates the drift warning.

## Fix
Add an explicit `NON_SCORING_UPSTREAM_CONSTANT_NAMES` ignore-set (time-unit helpers, HTTP/parse timeouts, retry budgets, byte-size limits, UID sentinels) so the drift signal only reports genuinely scoring-shaped unknowns. **Behavior-preserving for the scorer** — only the warning's accuracy changes.

## Tests (full coverage)
Infra constants → not reported; a scoring-shaped unknown (`NOVELTY_BONUS_SCALAR`) → still reported. `npx vitest run test/unit/scoring.test.ts` → 43 passed · `npx tsc --noEmit` → clean · `git diff --check` → clean.

Scope: the drift-noise half of #809; modeling additional genuinely-scoring upstream constants can follow as a separate change.