### PR TITLE
perf(signals): count empty-description code files in a single pass

### DIFF
--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -163,12 +163,17 @@ function buildPaddingFinding(changedLineCount: number, paddingLineCount: number)
 // Fires only when a real code change ships with an empty / whitespace-only description — a high-precision
 // weak-effort signal. A non-empty description (even a terse one) never trips it, to avoid false positives.
 export function buildEmptyDescriptionFinding(input: SlopAssessmentInput): SignalFinding | null {
-  const codePaths = (input.changedFiles ?? []).map((file) => file.path).filter(Boolean).filter(isCodeFile);
-  if (codePaths.length === 0) return null;
+  // Single pass over changedFiles instead of map().filter(Boolean).filter(isCodeFile) building three
+  // intermediate arrays: count changed code-file paths directly.
+  let codeFileCount = 0;
+  for (const file of input.changedFiles ?? []) {
+    if (file.path && isCodeFile(file.path)) codeFileCount += 1;
+  }
+  if (codeFileCount === 0) return null;
   if ((input.description ?? "").trim().length > 0) return null;
 
   const detail = ensurePublicSafeText(
-    `${codePaths.length} code file(s) changed with an empty pull request description.`,
+    `${codeFileCount} code file(s) changed with an empty pull request description.`,
     "Code changed with an empty pull request description.",
   );
   return {

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDuplicateClusterFinding,
+  buildEmptyDescriptionFinding,
   buildEmptyIssueBodyFinding,
   buildIssueSlopAssessment,
   buildLowQualityCommitMessageFinding,
@@ -244,6 +245,27 @@ describe("buildSlopAssessment", () => {
     });
     expect(high.slopRisk).toBeGreaterThanOrEqual(60);
     expect(high.band).toBe("high");
+  });
+});
+
+describe("buildEmptyDescriptionFinding — single-pass code-file detection", () => {
+  it("ignores empty-path entries and non-code files when counting changed code files", () => {
+    // blank path and docs/markdown files must not count toward the code-file total
+    expect(buildEmptyDescriptionFinding({ changedFiles: [{ path: "" }, { path: "README.md" }, { path: "docs/guide.mdx" }], description: "" })).toBeNull();
+  });
+
+  it("fires for a real code change with an empty description and reports the code-file count", () => {
+    const finding = buildEmptyDescriptionFinding({
+      changedFiles: [{ path: "" }, { path: "src/a.ts" }, { path: "README.md" }, { path: "src/b.ts" }],
+      description: "   ",
+    });
+    expect(finding).toMatchObject({ code: "empty_pr_description", severity: "warning" });
+    expect(finding?.detail).toContain("2 code file(s)");
+    expect(JSON.stringify(finding)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("does not fire when the code change has a non-empty description", () => {
+    expect(buildEmptyDescriptionFinding({ changedFiles: [{ path: "src/a.ts" }], description: "Real change." })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
`buildEmptyDescriptionFinding` ran `map().filter(Boolean).filter(isCodeFile)` over `changedFiles` — three passes allocating three intermediate arrays — only to read a length. Replace with a single `for`-loop counter: behavior-identical (the reported code-file count is unchanged), fewer allocations on the hot slop-assessment path.

## Tests
Adds focused branch tests for `buildEmptyDescriptionFinding`: empty-path entries and non-code files are excluded from the count; the finding fires only for a real code change with an empty description; a non-empty description suppresses it. `npx vitest run test/unit/slop.test.ts` → 45 passed · `npx tsc --noEmit` → clean · `git diff --check` → clean.