### PR TITLE
perf(signals): collect changed paths in a single pass for missing-test-evidence

### DIFF
--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -240,8 +240,12 @@ export function buildNoLinkedIssueRationaleFinding(input: SlopAssessmentInput): 
 }
 
 export function buildMissingTestEvidenceFinding(input: SlopAssessmentInput): SignalFinding | null {
-  const changedFiles = input.changedFiles ?? [];
-  const changedPaths = changedFiles.map((file) => file.path).filter(Boolean);
+  // Single pass collecting non-empty changed paths instead of map().filter(Boolean) building an
+  // intermediate array; changedPaths is reused below for both the code-file and test-evidence checks.
+  const changedPaths: string[] = [];
+  for (const file of input.changedFiles ?? []) {
+    if (file.path) changedPaths.push(file.path);
+  }
   const codePaths = changedPaths.filter(isCodeFile);
   if (codePaths.length === 0) return null;
 

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -247,6 +247,20 @@ describe("buildSlopAssessment", () => {
   });
 });
 
+describe("buildMissingTestEvidenceFinding — single-pass changed-path collection", () => {
+  it("excludes empty-path entries when collecting changed code paths", () => {
+    // blank path entries must not count as code files
+    expect(buildMissingTestEvidenceFinding({ changedFiles: [{ path: "" }, { path: "" }] })).toBeNull();
+  });
+
+  it("fires for a real code change (ignoring empty-path entries) when no test evidence is present", () => {
+    const finding = buildMissingTestEvidenceFinding({ changedFiles: [{ path: "" }, { path: "src/service.ts" }] });
+    expect(finding).toMatchObject({ code: "missing_test_evidence", severity: "warning" });
+    expect(finding?.detail).toContain("1 code file(s)");
+    expect(JSON.stringify(finding)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+});
+
 describe("buildMissingTestEvidenceFinding", () => {
   it("keeps public reason strings sanitized", () => {
     const finding = buildMissingTestEvidenceFinding({


### PR DESCRIPTION
## Summary
`buildMissingTestEvidenceFinding` built `changedPaths` via `changedFiles.map((file) => file.path).filter(Boolean)`, allocating an intermediate array. Collect non-empty paths in a single `for`-loop instead — behavior-identical (`changedPaths` is still reused for both the code-file and test-evidence checks), one fewer allocation on the hot slop-assessment path.

## Tests
Adds branch tests: empty-path entries are excluded from the changed code paths; a real code change (ignoring empty-path entries) with no test evidence still fires with the correct code-file count. `npx vitest run test/unit/slop.test.ts` → 44 passed · `npx tsc --noEmit` → clean · `git diff --check` → clean.