### PR TITLE
perf(db): collect distinct product-usage values in a single pass

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4847,12 +4847,28 @@ function productUsageRoleSortValue(role: ProductUsageRole): number {
   return PRODUCT_USAGE_ROLE_ORDER.indexOf(role);
 }
 
+// Single pass: keep predicate-matching items and collect their distinct non-empty selected values,
+// instead of building the intermediate filter()/map()/filter() arrays. Exported for direct unit coverage.
+export function distinctNonEmptyValues<T>(
+  items: T[],
+  predicate: (item: T) => boolean,
+  select: (item: T) => string | null | undefined,
+): Set<string> {
+  const result = new Set<string>();
+  for (const item of items) {
+    if (!predicate(item)) continue;
+    const value = select(item);
+    if (isNonEmptyString(value)) result.add(value);
+  }
+  return result;
+}
+
 function productUsageActorSet(events: ProductUsageEventRecord[], predicate: (event: ProductUsageEventRecord) => boolean): Set<string> {
-  return new Set(events.filter(predicate).map((event) => event.actorHash).filter(isNonEmptyString));
+  return distinctNonEmptyValues(events, predicate, (event) => event.actorHash);
 }
 
 function productUsageRepoSet(events: ProductUsageEventRecord[], predicate: (event: ProductUsageEventRecord) => boolean): Set<string> {
-  return new Set(events.filter(predicate).map((event) => event.repoFullName).filter(isNonEmptyString));
+  return distinctNonEmptyValues(events, predicate, (event) => event.repoFullName);
 }
 
 function isProductUsageDoctorPassEvent(event: ProductUsageEventRecord): boolean {

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  distinctNonEmptyValues,
   getLatestScorePreview,
   getRepoAuthorPullRequestHistory,
   getLatestScoringModelSnapshot,
@@ -426,5 +427,29 @@ describe("database row parser hardening", () => {
     const raw = await env.DB.prepare("select snapshot_json from official_miner_detections where login = ?").bind("anonymous").first<{ snapshot_json: string }>();
     expect(raw?.snapshot_json).not.toMatch(/hotkey|coldkey|wallet|must-not-cache/i);
     expect(JSON.parse(raw?.snapshot_json ?? "{}")).toMatchObject({ githubId: "", githubUsername: "", issueLabels: [] });
+  });
+});
+
+describe("distinctNonEmptyValues", () => {
+  const rows: { kind: string; value: string | null }[] = [
+    { kind: "a", value: "x" },
+    { kind: "b", value: "y" },
+    { kind: "a", value: "" },
+    { kind: "a", value: "x" },
+    { kind: "a", value: null },
+    { kind: "a", value: "z" },
+  ];
+
+  it("collects distinct non-empty selected values for predicate-matching items only", () => {
+    const result = distinctNonEmptyValues(
+      rows,
+      (row) => row.kind === "a",
+      (row) => row.value,
+    );
+    expect([...result].sort()).toEqual(["x", "z"]);
+  });
+
+  it("returns an empty set when nothing matches the predicate", () => {
+    expect(distinctNonEmptyValues(rows, () => false, (row) => row.value).size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
`productUsageActorSet` / `productUsageRepoSet` each ran `filter(predicate).map(field).filter(isNonEmptyString)` into a `Set` — three passes and two intermediate arrays. Extract a single-pass `distinctNonEmptyValues<T>(items, predicate, select)` helper and have both delegate to it: one loop, no intermediate arrays, behavior-identical, and the duplicated logic now lives in one place.

## Tests
Adds direct unit tests for `distinctNonEmptyValues`: predicate filtering, empty/null value exclusion, and de-duplication. `npx vitest run test/unit/db-parsers.test.ts` → 11 passed · `npx tsc --noEmit` → clean · `git diff --check` → clean.