### PR TITLE
fix(scoring): parse underscores in the fractional part of upstream constants

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -153,10 +153,12 @@ export async function getOrCreateScoringModelSnapshot(env: Env): Promise<Scoring
 export function parsePythonNumberConstants(source: string, options: { knownOnly?: boolean } = { knownOnly: true }): Record<string, number> {
   const constants: Record<string, number> = {};
   for (const line of source.split("\n")) {
-    // Match Python numeric literals including underscore separators (1_000_000), floats, and exponents
-    // (1e-9, 5.8e1). The previous /[-+]?\d+(?:\.\d+)?/ stopped at `_`/`e`, truncating 1_000_000 -> 1 and
-    // 1e-9 -> 1, which silently misparsed any such upstream constant and polluted the unmodeled list (#810).
-    const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)/);
+    // Match Python numeric literals including underscore separators (1_000_000, 0.000_001), floats, and
+    // exponents (1e-9, 5.8e1). PEP 515 allows underscores between digits in ANY part of the literal, so the
+    // fractional digits accept `_` too — the previous frac classes (`\d*`/`\.\d+`) stopped at the first
+    // fractional underscore, truncating 0.000_001 -> 0. The earlier /[-+]?\d+(?:\.\d+)?/ also stopped at
+    // `_`/`e` (1_000_000 -> 1, 1e-9 -> 1). Both silently misparsed upstream constants (#810).
+    const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?[\d_]*|\.\d[\d_]*)(?:[eE][-+]?\d+)?)/);
     if (!match) continue;
     const name = match[1]!;
     const raw = match[2]!;

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -86,6 +86,21 @@ OSS_EMISSION_SHARE = 0.90
     expect(parsed.OSS_EMISSION_SHARE).toBe(0.9);
   });
 
+  it("parses underscores in the FRACTIONAL part (PEP 515) without truncating to zero", () => {
+    const parsed = parsePythonNumberConstants(
+      `
+SMALL_RATE = 0.000_001
+PRECISE_SCALE = 3.14_15
+MIXED_GROUPED = 1_000.000_5
+`,
+      { knownOnly: false },
+    );
+    // Frac classes were \\d*/\\.\\d+ (no `_`), so 0.000_001 stopped at "0.000" -> 0 (a divide/multiply hazard).
+    expect(parsed.SMALL_RATE).toBe(0.000001);
+    expect(parsed.PRECISE_SCALE).toBe(3.1415);
+    expect(parsed.MIXED_GROUPED).toBe(1000.0005);
+  });
+
   it("flags only scoring snapshots older than the freshness window as stale (#810)", () => {
     const now = Date.parse("2026-06-21T12:00:00.000Z");
     const justFresh = new Date(now - SCORING_SNAPSHOT_STALE_MS + 60_000).toISOString();


### PR DESCRIPTION
## Summary

#969 ("parse underscore separators and scientific notation in upstream constants") fixed the Python-numeric-literal parser for the **integer** part (`1_500_000`) and exponents (`1e-9`) — but left the **fractional** part underscore-blind. Per PEP 515, underscores are valid between digits in **any** part of a numeric literal, including after the decimal point. So a valid upstream constant like `0.000_001` matches only up to the first fractional underscore and is read as **`0`** — a silent truncation that turns a small rate/share into zero (a divide/multiply-by-zero hazard that skews every score preview/breakdown).

```ts
// src/scoring/model.ts — before
const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)/);
//                                                          int: \d[\d_]* (has _)   frac: \d* (no _)   bare: \.\d+ (no _)
```

Verified by running the exact merged regex + `Number(raw.replace(/_/g, ""))`:

| Python literal (valid PEP 515) | True value | Old parser yields |
| --- | --- | --- |
| `0.000_001` | 0.000001 | **0** |
| `3.14_15` | 3.1415 | **3.14** |
| `1_000.000_5` | 1000.0005 | **1000** |

(Integer grouping and exponents parse correctly — only fractional grouping was broken.)

**Reachable:** `refreshScoringModelSnapshot` fetches upstream `gittensor/constants.py` and runs it through this parser into the scoring `constants` that feed `buildScorePreview` / the score breakdown / unmodeled-constant detection.

## Fix

Allow `_` in the fractional digit classes too (and require a leading digit in the bare-decimal branch), mirroring the integer part. `Number(raw.replace(/_/g, ""))` already strips the underscores, so no other change is needed:

```ts
const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?[\d_]*|\.\d[\d_]*)(?:[eE][-+]?\d+)?)/);
```

Verified to parse `0.000_001`/`3.14_15`/`1_000.000_5` correctly **and** leave every previously-passing case unchanged (`1_500_000`, `5.8e1`, `1e-9`, `-2.5e-3`, `0.90`, `1.15`, `.5`, `5`).

## Tests

Added a regression test asserting the fractional-underscore literals parse to their true values (the #969 test covered only integer underscores + exponents + a plain `0.90`, so the truncation shipped green). Scoring suite green locally (43 passed); `tsc` clean.

Closes #992
