### PR TITLE
fix(scoring): apply penalty label multipliers instead of flooring to 1

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -735,10 +735,12 @@ function deltaExplanationFor(core: ScoreCore, blockedBy: ScoreGateBlocker[]): st
 
 function selectLabelMultiplier(labels: string[], multipliers: Record<string, number>, fallback: number): number {
   const normalized = new Set(labels.map((label) => label.toLowerCase()));
-  return Math.max(
-    fallback || 1,
-    ...Object.entries(multipliers).flatMap(([label, multiplier]) => (normalized.has(label.toLowerCase()) ? [multiplier] : [])),
-  );
+  const matched = Object.entries(multipliers).flatMap(([label, multiplier]) => (normalized.has(label.toLowerCase()) ? [multiplier] : []));
+  // Honour matched label multipliers even when < 1 (penalty labels like refactor/docs). The matched set must
+  // NOT be maxed against the neutral (>=1) fallback, or a sub-1 penalty would be floored to 1 and never bite;
+  // the highest matched multiplier still wins when a PR carries both a bonus and a penalty label. Only an
+  // unmatched PR falls back to the neutral default.
+  return matched.length > 0 ? Math.max(...matched) : fallback || 1;
 }
 
 function decideLinkedIssueMultiplier(

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -343,6 +343,27 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     expect(preview.privateOnly).toBe(true);
   });
 
+  it("applies penalty label multipliers (< 1) instead of flooring them to the neutral default", () => {
+    const baseInput = {
+      repoFullName: repo.fullName,
+      sourceTokenScore: 60,
+      totalTokenScore: 90,
+      sourceLines: 50,
+      openPrCount: 0,
+      credibility: 1,
+    } as const;
+    // repo fixture: labelMultipliers { bug: 1.2, refactor: 0.5 }.
+    const penalty = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["refactor"] } });
+    const neutral = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["unmatched"] } });
+    const mixed = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["bug", "refactor"] } });
+
+    expect(penalty.scoreEstimate.labelMultiplier).toBe(0.5); // was floored to 1 before the fix
+    expect(neutral.scoreEstimate.labelMultiplier).toBe(1);
+    expect(mixed.scoreEstimate.labelMultiplier).toBe(1.2); // highest matched still wins for a bonus+penalty PR
+    // The penalty actually bites: the merged-score estimate is half the neutral one.
+    expect(penalty.scoreEstimate.estimatedMergedScore).toBeCloseTo(neutral.scoreEstimate.estimatedMergedScore * 0.5, 5);
+  });
+
   it("falls back to a neutral label multiplier when repo defaults are zeroed", () => {
     const preview = buildScorePreview({
       repo: { ...repo, registryConfig: { ...repo.registryConfig!, defaultLabelMultiplier: 0, labelMultipliers: {} } },


### PR DESCRIPTION
## Summary

`selectLabelMultiplier` computes the per-PR label multiplier as `Math.max(fallback || 1, ...matchedMultipliers)`. Because the neutral fallback is always `>= 1`, any configured **penalty** label multiplier below 1 (e.g. `refactor: 0.5`, `docs: 0.3`) is clamped back up to 1 and never applied. Only **bonus** multipliers (`>= 1`) ever take effect, so the merged-score estimate is inflated — over-rewarding exactly the low-value-label PRs a penalty multiplier exists to dampen.

```ts
// src/scoring/preview.ts:736 — before
return Math.max(
  fallback || 1,                                                // floor is always >= 1
  ...Object.entries(multipliers).flatMap(([label, m]) => (normalized.has(label.toLowerCase()) ? [m] : [])),
);
```

The result multiplies the base score (`baseScore * labelMultiplier * ...`, preview.ts:353). Verified against the config the codebase itself ships (`{ bug: 1.2, refactor: 0.5 }`):

| Labels | Intended | Actual |
| --- | --- | --- |
| `["refactor"]` | 0.5 | **1** (2× over-reward) |
| `["docs"]` (0.3) | 0.3 | **1** (~3.3× over-reward) |
| `["bug","refactor"]` | (penalty present) | **1.2** (0.5 dropped) |
| `["bug"]` | 1.2 | 1.2 ✓ |

Sub-1 multipliers are first-class config: the OpenAPI/registry schema is `z.record(z.string(), z.number())` (no lower bound), the upstream registry sync parses `label_multipliers` verbatim, and the ruleset treats `labelMultipliers` as scoreability config. Reachable via the MCP `score_preview` tool and the score-preview/explain-breakdown routes for any repo with a penalty label configured.

## Fix

Apply the matched multiplier(s) directly instead of maxing the matched set against the `>= 1` fallback floor. "Highest matched wins" is preserved (so a bonus+penalty PR is unchanged); only an unmatched PR falls back to the neutral default:

```ts
const matched = Object.entries(multipliers).flatMap(([label, m]) => (normalized.has(label.toLowerCase()) ? [m] : []));
return matched.length > 0 ? Math.max(...matched) : (fallback || 1);
```

This changes behavior **only** for the previously-broken case (a PR whose matched labels are all < 1, which was wrongly floored to 1).

## Tests

Added a regression test: a PR labeled `["refactor"]` now yields `labelMultiplier 0.5` (was 1), `["unmatched"]` → 1, `["bug","refactor"]` → 1.2, and the merged-score estimate is correspondingly halved. The existing fixture defined `refactor: 0.5` but no test ever fed the `refactor` label, so the flooring shipped green. Scoring suite green locally (43 passed); `tsc` clean.

Closes #994
