### PR TITLE
test(signals): fix drifted queue-health fixture dates (unblocks main CI)

### DIFF
--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -35,6 +35,10 @@ import {
 } from "../../src/signals/reward-risk";
 import type { ContributorRepoStatRecord, IssueRecord, PullRequestRecord, RecentMergedPullRequestRecord, RegistrySnapshot, RepoLabelRecord, RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
 
+// Shared-fixture timestamps are relative to "now" so age-bucket / reviewability windows (e.g. the
+// `< 30 days` likely-reviewable cutoff) never drift past their boundary as real time advances (no time-bomb).
+const isoDaysAgo = (days: number): string => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
 const repo: RepositoryRecord = {
   fullName: "JSONbored/gittensory",
   owner: "JSONbored",
@@ -78,7 +82,7 @@ const pullRequests: PullRequestRecord[] = [
     labels: ["bug"],
     linkedIssues: [1],
     body: "Fixes #1",
-    updatedAt: "2026-05-23T00:00:00.000Z",
+    updatedAt: isoDaysAgo(20), // recent + linked → counts as likely-reviewable (< 30 days) and stale (>= 14 days)
   },
   {
     repoFullName: repo.fullName,
@@ -90,7 +94,7 @@ const pullRequests: PullRequestRecord[] = [
     labels: ["bug"],
     linkedIssues: [1],
     body: "Fixes #1",
-    updatedAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: isoDaysAgo(82), // old → counts in the over-30-days age bucket
   },
 ];
 


### PR DESCRIPTION
## Problem
`test (2)` + the `validate` aggregator are failing on **main** and on every open PR (#985, #996, #997). Root cause is a single time-bomb test:

```
test/unit/signals-v2.test.ts > v2 signal builders > adds queue age buckets and likely-reviewable counts
AssertionError: expected 0 to be greater than or equal to 1
```

The shared `pullRequests` fixture used fixed `updatedAt` dates. PR #10 (`2026-05-23`) was chosen to be "recent" but, as of 2026-06-22, it is exactly **30 days** old — crossing the `< 30 days` likely-reviewable cutoff in `buildQueueHealth`, so `likelyReviewablePullRequests` dropped to 0.

## Fix
Anchor the shared fixture's PR ages **relative to now** (`isoDaysAgo(20)` / `isoDaysAgo(82)`) so the age-bucket / reviewability windows never drift again. Test-only change; all 31 tests in the file pass.

This unblocks `test (2)` + `validate` for main and the three open PRs.