### PR TITLE
ci: don't cancel in-progress main push runs (fix startup_failure on rapid merges)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only superseded PR runs (keep the newest). NEVER cancel main-branch push CI:
+  # back-to-back merges share group `ci-refs/heads/main`, and cancel-in-progress racing during
+  # startup turns those runs into `startup_failure` instead of giving each merge a complete run.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Detect which areas a PR touches so the heavy jobs can skip when irrelevant.


### PR DESCRIPTION
## Problem
Merging two PRs within seconds left main's CI showing `startup_failure` on both push runs. Root cause: `ci.yml` uses

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

For `push` to main, `github.ref` is `refs/heads/main`, so back-to-back merges land in the same group and `cancel-in-progress` races them during startup → both end as `startup_failure` (GitHub can't cleanly cancel a run that's still starting). The workflows are valid — the PRs' `pull_request` runs passed identically.

## Fix
Scope cancellation to PR events only:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR pushes still cancel superseded runs (fast feedback), but every merge to main now gets a complete CI run. Merging this also produces the clean green push run main is currently missing.