### PR TITLE
ci: revert concurrency expression to literal (fix startup_failure / stuck validate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  # Cancel only superseded PR runs (keep the newest). NEVER cancel main-branch push CI:
-  # back-to-back merges share group `ci-refs/heads/main`, and cancel-in-progress racing during
-  # startup turns those runs into `startup_failure` instead of giving each merge a complete run.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # NB: keep this a literal boolean. An expression here (cancel-in-progress: ${{ ... }}) made GitHub
+  # fail the workflow at startup (startup_failure), so `validate` never reported. Avoid merging multiple
+  # PRs within seconds instead — racing main-push runs in this group can cancel each other on startup.
+  cancel-in-progress: true
 
 jobs:
   # Detect which areas a PR touches so the heavy jobs can skip when irrelevant.


### PR DESCRIPTION
#1006 changed `cancel-in-progress` to an expression `${{ github.event_name == 'pull_request' }}`. GitHub fails `ci.yml` at **startup** with that form on both push and pull_request — so `validate`/`test`/`lint` jobs are never created and the required `validate` check sits stuck at *waiting*, blocking #1007 and every new PR. actionlint accepts the expression; GitHub's runtime parser won't start the run.

Reverts to the known-good literal `cancel-in-progress: true` (green at `9df11d07`). **Surgical** — only that one line changes; all security hardening (checkout head-SHA pinning at the 6 checkout steps, `permissions: contents: read`) is untouched.