### PR TITLE
ci: avoid cancelling main validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # Keep pull requests in one ref-scoped group so newer commits cancel superseded PR runs.
+  # Add github.sha for push runs so distinct main commits do not cancel each other's validation.
+  group: ci-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}
   # NB: keep this a literal boolean. An expression here (cancel-in-progress: ${{ ... }}) made GitHub
-  # fail the workflow at startup (startup_failure), so `validate` never reported. Avoid merging multiple
-  # PRs within seconds instead — racing main-push runs in this group can cancel each other on startup.
+  # fail the workflow at startup (startup_failure), so `validate` never reported.
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Motivation
- Prevent pushes to `main` from cancelling concurrent validation runs by scoping the concurrency group so distinct `main` commits do not share the same group while retaining the literal `cancel-in-progress: true` setting that avoids a previous GitHub Actions startup failure.

### Description
- Update `.github/workflows/ci.yml` `concurrency` block to use `group: ci-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}` so PRs remain ref-scoped and push runs include `github.sha`, and keep `cancel-in-progress: true` as a literal boolean.

### Testing
- Ran `git diff --check` which passed, and attempted `npm run actionlint` which failed in this checkout because the `github-actionlint` module is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3902edddd4832caa93301902a178cd)