### PR TITLE
Fix lockfile entry: align @lovable.dev/vite-tanstack-config to 2.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,21 +127,22 @@
       }
     },
     "apps/gittensory-ui/node_modules/@lovable.dev/vite-tanstack-config": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lovable.dev/vite-tanstack-config/-/vite-tanstack-config-2.1.1.tgz",
-      "integrity": "sha512-tAQWfpdBzCEK7Yxugu2QuLowdbqNkaHeqNkUc2AvhGawXwYwkJggJG4i05Rnl0FHu2qn9w9mUoHp5GZYIv8fww==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lovable.dev/vite-tanstack-config/-/vite-tanstack-config-2.5.3.tgz",
+      "integrity": "sha512-MI1DqcZVbMg6bfZaYX/Jfep4sxAY2ngXA9lRCAkV4sJBKPBXvToRXe6hQNIAKz3Blv47FDWBCe6rbh4tz9eqnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lovable.dev/vite-plugin-dev-server-bridge": "^1.0.0",
-        "@lovable.dev/vite-plugin-hmr-gate": "^1.0.0",
+        "@lovable.dev/vite-plugin-dev-server-bridge": "^1.0.2",
+        "@lovable.dev/vite-plugin-hmr-gate": "^1.1.0",
+        "lightningcss": "^1.30.0",
         "lovable-tagger": "1.2.0"
       },
       "peerDependencies": {
         "@tailwindcss/vite": ">=4.0.0",
         "@tanstack/react-start": ">=1.100.0",
         "@vitejs/plugin-react": ">=4.0.0",
-        "nitro": ">=3.0.260429-beta",
+        "nitro": ">=3.0.260603-beta",
         "vite": ">=5.0.0 <9.0.0",
         "vite-tsconfig-paths": ">=6.0.0"
       },


### PR DESCRIPTION
### Motivation
- The UI workspace declares `@lovable.dev/vite-tanstack-config` at `2.5.3` but `package-lock.json` still contained a locked record for `2.1.1`, which breaks deterministic installs (`npm ci`) and CI/build validation.

### Description
- Updated the `package-lock.json` record for `apps/gittensory-ui/node_modules/@lovable.dev/vite-tanstack-config` to `version: "2.5.3"` and adjusted the `resolved` tarball URL and `integrity` to match the v2.5.3 package metadata.
- Aligned the locked package's `dependencies`, `peerDependencies`, and `peerDependenciesMeta` to the published v2.5.3 metadata (updated Lovable plugin ranges and added `lightningcss`/peer range tweaks).
- No application source files were modified and the change preserves existing functionality while restoring lockfile consistency.

### Testing
- Ran `npm ls @lovable.dev/vite-tanstack-config --workspace apps/gittensory-ui --package-lock-only --json` and it reported the dependency resolved to `2.5.3` (success).
- Ran `npm ci --workspace apps/gittensory-ui --ignore-scripts --dry-run --prefer-offline` and the dry-run completed without the prior lock mismatch error (success).
- Ran `git diff --check` to ensure no whitespace/merge issues were introduced (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3902ec130c832ca1dfdba4d64715ae)