### PR TITLE
fix(review): escape angle brackets in unified PR comments

### DIFF
--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -263,14 +263,14 @@ function statusChips(input: UnifiedReviewInput, ctx: UnifiedCommentContext): str
   if (input.readiness) {
     const ci = input.readiness.ciState;
     chips.push(ci === "passed" ? "`CI green`" : ci === "failed" ? "`CI failing`" : "`CI pending`");
-    if (input.readiness.mergeStateLabel) chips.push(`\`${input.readiness.mergeStateLabel}\``);
+    if (input.readiness.mergeStateLabel) chips.push(`\`${escapePublicHtmlAngles(input.readiness.mergeStateLabel)}\``);
   }
   return chips.join(" · ");
 }
 
 function verdictLine(status: UnifiedCommentStatus, input: UnifiedReviewInput): string {
   const icon = STATUS_META[status].icon;
-  const reason = input.verdictReason ? ` — ${input.verdictReason}` : "";
+  const reason = input.verdictReason ? ` — ${escapePublicHtmlAngles(input.verdictReason)}` : "";
   switch (status) {
     case "ready":
       return input.merged
@@ -301,9 +301,15 @@ function dedupeLines(items: string[], cap = 12): string[] {
   return out;
 }
 
+/** Escape angle brackets in caller-provided public text so raw HTML, HTML comments,
+ *  or stray closing tags cannot change the GitHub comment structure. */
+function escapePublicHtmlAngles(text: string): string {
+  return text.replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"));
+}
+
 function bullets(items: string[]): string {
   return dedupeLines(items)
-    .map((i) => `- ${i}`)
+    .map((i) => `- ${escapePublicHtmlAngles(i)}`)
     .join("\n");
 }
 
@@ -317,15 +323,19 @@ function signalTable(input: UnifiedReviewInput, ctx: UnifiedCommentContext): str
   };
   const rows = [codeRow, ...(ctx.signals ?? [])];
   const lines = rows.map((r, i) => {
-    const label = i === 0 ? `**${r.label}**` : r.label;
-    const result = `${SIGNAL_ICON[r.state]}${r.result ? ` ${r.result}` : ""}`;
-    return `| ${label} | ${result} | ${r.evidence ?? ""} |`;
+    const labelText = escapePublicHtmlAngles(r.label);
+    const label = i === 0 ? `**${labelText}**` : labelText;
+    const resultText = r.result ? ` ${escapePublicHtmlAngles(r.result)}` : "";
+    const result = `${SIGNAL_ICON[r.state]}${resultText}`;
+    return `| ${label} | ${result} | ${escapePublicHtmlAngles(r.evidence ?? "")} |`;
   });
   return ["| Signal | Result | Evidence |", "|---|---|---|", ...lines].join("\n");
 }
 
 function details(title: string, body: string, sub?: string): string {
-  return `<details><summary><b>${title}</b>${sub ? ` — ${sub}` : ""}</summary>\n\n${body}\n</details>`;
+  const safeTitle = escapePublicHtmlAngles(title);
+  const safeSub = sub ? ` — ${escapePublicHtmlAngles(sub)}` : "";
+  return `<details><summary><b>${safeTitle}</b>${safeSub}</summary>\n\n${escapePublicHtmlAngles(body)}\n</details>`;
 }
 
 /** Wrap the assembled body in a GitHub alert blockquote — this is the full-comment colored sidebar. */
@@ -345,7 +355,7 @@ function asAlert(alert: string, inner: string): string {
 export function renderUnifiedReviewComment(input: UnifiedReviewInput, ctx: UnifiedCommentContext = {}): string {
   const status = deriveUnifiedStatus(input, ctx);
   const meta = STATUS_META[status];
-  const brand = ctx.brand ?? "Gittensory review";
+  const brand = escapePublicHtmlAngles(ctx.brand ?? "Gittensory review");
 
   const blocks: string[] = [
     meta.square.repeat(12),
@@ -354,7 +364,7 @@ export function renderUnifiedReviewComment(input: UnifiedReviewInput, ctx: Unifi
     verdictLine(status, input),
   ];
 
-  if (input.summary.trim()) blocks.push(`**Review summary**\n${input.summary.trim()}`);
+  if (input.summary.trim()) blocks.push(`**Review summary**\n${escapePublicHtmlAngles(input.summary.trim())}`);
 
   const blockers = dedupeLines(input.blockers ?? []);
   if (blockers.length) {

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -198,6 +198,34 @@ describe("renderUnifiedReviewComment", () => {
     const md = renderUnifiedReviewComment({ ...base, decision: "merge" }, { extraCollapsibles: [{ title: "Empty section", body: "   " }] });
     expect(md).not.toContain("Empty section");
   });
+
+  it("escapes angle brackets from public renderer fields while preserving details wrappers", () => {
+    const md = renderUnifiedReviewComment(
+      {
+        ...base,
+        decision: "manual",
+        summary: "Safe summary </details><!-- hidden -->",
+        blockers: ["Blocker <script>alert(1)</script>"],
+        nits: ["Nit closes </details>"],
+        verdictReason: "needs <maintainer> review",
+      },
+      {
+        signals: [{ label: "Gate <row>", state: "fail", result: "Bad <tag>", evidence: "Evidence </td>" }],
+        extraCollapsibles: [{ title: "Extra <title>", body: "Body <!-- comment -->" }],
+      },
+    );
+
+    expect(md).toContain("Safe summary &lt;/details&gt;&lt;!-- hidden --&gt;");
+    expect(md).toContain("- Blocker &lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(md).toContain("- Nit closes &lt;/details&gt;");
+    expect(md).toContain("needs &lt;maintainer&gt; review");
+    expect(md).toContain("| Gate &lt;row&gt; | ❌ Bad &lt;tag&gt; | Evidence &lt;/td&gt; |");
+    expect(md).toContain("<details><summary><b>Extra &lt;title&gt;</b></summary>");
+    expect(md).toContain("Body &lt;!-- comment --&gt;");
+    expect(md).toContain("<details><summary><b>Nits</b> — 1 non-blocking</summary>");
+    expect(md).not.toContain("Safe summary </details>");
+    expect(md).not.toContain("Body <!-- comment -->");
+  });
 });
 
 function reviewNote(rec: ReviewRecommendation, extra: Partial<ReviewNotes> = {}): DualReviewNote {


### PR DESCRIPTION
### Motivation
- The unified PR comment renderer inserted AI-sourced text directly into Markdown/HTML structures without escaping `<`/`>`, allowing injected tags or HTML comments to alter the published bot comment structure. 
- The legacy panel deliberately escaped angle brackets as a final guard; the converged renderer must preserve the same protection to avoid integrity issues when `UNIFIED_REVIEW_COMMENT` is enabled. 

### Description
- Add a small sanitizer `escapePublicHtmlAngles(text: string)` that replaces `<`/`>` with `&lt;`/`&gt;` and keep it narrowly scoped to public renderer fields. 
- Apply angle-bracket escaping to summary, brand, verdict reason, status-chip `mergeStateLabel`, bullets (blockers/nits), signal table label/result/evidence, and details titles/bodies while preserving the renderer-owned `<details>` wrapper. 
- Add a regression unit test that ensures injected closing tags and HTML comments are escaped and that the `<details>` wrappers the renderer controls are preserved. 

### Testing
- Ran `git diff --check` which reported no whitespace or formatting errors. 
- Performed a runtime sanity check with `node_modules/.bin/tsx -e "...renderUnifiedReviewComment(...)..."` which printed `manual renderer check passed`. 
- Attempted typecheck with `npm run typecheck` which failed due to missing local type packages (`@cloudflare/vitest-pool-workers/types` and `vitest/globals`). 
- Attempted to run the unit file via `npm run test -- --run test/unit/unified-comment.test.ts` but the local `vitest` binary was not available and full `npm install` could not complete due to a registry `403 Forbidden` for `esbuild`, so the full test-suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39168284e4832c848d297e3bd3bd75)