### PR TITLE
fix(ui): gittensory-ui deploy path (nitro cloudflare preset)

### DIFF
--- a/apps/gittensory-ui/vite.config.ts
+++ b/apps/gittensory-ui/vite.config.ts
@@ -28,7 +28,26 @@ function manualChunks(id: string) {
 }
 
 export default defineConfig({
-  nitro: shouldBuildNitro,
+  // Pin the Cloudflare target + output layout explicitly.
+  //
+  // Outside a Lovable sandbox (e.g. the Cloudflare Workers Build CI), the plugin
+  // only forwards `defaultPreset`/`preset` to nitro and does NOT override the
+  // output dir. With the pinned `nitro@3.0.260429-beta` (which predates nitro's
+  // `defaultPreset` option, added in 3.0.260603-beta), the Cloudflare fallback is
+  // ignored and a zero-config build targets Node, writing to `.output/server/`
+  // with no `wrangler.json`. Deploy then fails: `Could not read file:
+  // dist/server/wrangler.json (ENOENT)`.
+  //
+  // Replicate exactly what the plugin's sandbox path does so a fresh `npm ci`
+  // build lands the Cloudflare worker (and its generated `wrangler.json`) at
+  // `dist/server/`, matching the `version:built`/`deploy:built` scripts.
+  nitro: shouldBuildNitro
+    ? {
+        preset: "cloudflare-module",
+        output: { dir: "dist", serverDir: "dist/server", publicDir: "dist/client" },
+        cloudflare: { nodeCompat: true, deployConfig: true },
+      }
+    : false,
   vite: {
     build: {
       rollupOptions: {


### PR DESCRIPTION
## Problem

The gittensory-ui Cloudflare Workers Build deploy fails on every fresh install with:

```
Could not read file: dist/server/wrangler.json (ENOENT)
```

This is a pre-existing `main` bug. CF runs `npm clean-install` (fresh, per the lock) then `npm run build:cloudflare` then `wrangler versions upload --config dist/server/wrangler.json`. The build succeeds but writes the wrong target.

## Root cause

`apps/gittensory-ui/vite.config.ts` passed `nitro: shouldBuildNitro` (a boolean) and never pinned a preset. `@lovable.dev/vite-tanstack-config@2.5.3` relies on nitro's `defaultPreset` option to fall back to `cloudflare-module`, but the app pins `nitro@3.0.260429-beta`, which **predates** that option (added in `3.0.260603-beta`). So outside a Lovable sandbox (i.e. CI), the Cloudflare fallback is ignored and a zero-config build targets **Node**, writing to `.output/server/` (a node-server preset that emits no `wrangler.json` at all). The CF build warns about exactly this.

The bug is invisible with stale/symlinked `node_modules` (which may carry an older plugin or cached `.nitro`) and only reproduces on a fresh `npm ci`.

## Fix

Pin the Cloudflare preset **and** the output layout explicitly, replicating what the plugin's own sandbox path does — so the worker and its generated `wrangler.json` land at `dist/server/`, exactly where `version:built`/`deploy:built` read them:

```ts
nitro: shouldBuildNitro
  ? {
      preset: "cloudflare-module",
      output: { dir: "dist", serverDir: "dist/server", publicDir: "dist/client" },
      cloudflare: { nodeCompat: true, deployConfig: true },
    }
  : false,
```

The explicit `preset` bypasses the `defaultPreset` mechanism, so this works on the currently-pinned nitro with **no dependency bump**. The `output` override is required because, outside the sandbox, the plugin forwards `preset` but not the output dir, so a bare `{ preset: "cloudflare-module" }` would still land in `.output/`.

## Verification (all on a fresh `npm ci`)

- Before: no `dist/server/wrangler.json`; output at `.output/server/` with `preset: node-server` and no wrangler.json anywhere.
- After: `apps/gittensory-ui/dist/server/wrangler.json` exists; `nitro.json` preset is `cloudflare-module`; `.output/` is gone; no nitro warning.
- `npx wrangler deploy --dry-run --config dist/server/wrangler.json` resolves the config and exits 0 (`--dry-run: exiting now.`, no ENOENT).
- `npm run ui:typecheck` is clean.