### PR TITLE
fix(scoring): apply penalty label multipliers instead of flooring to 1

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -735,10 +735,10 @@ function deltaExplanationFor(core: ScoreCore, blockedBy: ScoreGateBlocker[]): st
 
 function selectLabelMultiplier(labels: string[], multipliers: Record<string, number>, fallback: number): number {
   const normalized = new Set(labels.map((label) => label.toLowerCase()));
-  return Math.max(
-    fallback || 1,
-    ...Object.entries(multipliers).flatMap(([label, multiplier]) => (normalized.has(label.toLowerCase()) ? [multiplier] : [])),
+  const matched = Object.entries(multipliers).flatMap(([label, multiplier]) =>
+    normalized.has(label.toLowerCase()) ? [multiplier] : [],
   );
+  return matched.length > 0 ? Math.max(...matched) : fallback || 1;
 }
 
 function decideLinkedIssueMultiplier(

--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -138,19 +138,23 @@ function reviewPenaltyBreakdown(preview: ScorePreviewResult): ScoreMultiplierBre
 
 function labelMultiplierBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { labelMultiplier } = preview.scoreEstimate;
-  const band = labelMultiplier > 1 ? "full" : "neutral";
+  const band: ScoreMultiplierBand = labelMultiplier > 1 ? "full" : labelMultiplier < 1 ? "reduced" : "neutral";
   return {
     component: "labelMultiplier",
     band,
     summary:
       labelMultiplier > 1
         ? "A configured trusted label multiplier is applied."
-        : "No trusted label multiplier is applied beyond the default.",
+        : labelMultiplier < 1
+          ? "A configured penalty label multiplier is reducing the preview."
+          : "No trusted label multiplier is applied beyond the default.",
     lever:
       labelMultiplier > 1
         ? "Ensure the label match is legitimate and documented for maintainers."
-        : "Check whether the change legitimately matches a configured trusted label before submission.",
-    leverageScore: labelMultiplier > 1 ? 12 : 25,
+        : labelMultiplier < 1
+          ? "Confirm the penalty label is accurate; substantive changes may warrant a different label."
+          : "Check whether the change legitimately matches a configured trusted label before submission.",
+    leverageScore: labelMultiplier > 1 ? 12 : labelMultiplier < 1 ? 40 : 25,
   };
 }
 

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -165,6 +165,33 @@ describe("explainScoreBreakdown", () => {
     expect(breakdown.components.find((entry) => entry.component === "reviewPenaltyMultiplier")).toMatchObject({ band: "full" });
   });
 
+  it("marks penalty label multipliers as reduced strength (#994)", () => {
+    const penaltyRepo: RepositoryRecord = {
+      ...repo,
+      registryConfig: { ...repo.registryConfig!, labelMultipliers: { refactor: 0.5, bug: 1.2 } },
+    };
+    const preview = buildScorePreview({
+      repo: penaltyRepo,
+      snapshot,
+      input: {
+        repoFullName: penaltyRepo.fullName,
+        sourceTokenScore: 80,
+        totalTokenScore: 120,
+        sourceLines: 60,
+        openPrCount: 0,
+        credibility: 1,
+        labels: ["refactor"],
+        linkedIssueMode: "none",
+      },
+    });
+
+    const breakdown = explainScoreBreakdown(preview);
+    expect(breakdown.components.find((entry) => entry.component === "labelMultiplier")).toMatchObject({
+      band: "reduced",
+      summary: expect.stringMatching(/penalty label multiplier/i),
+    });
+  });
+
   it("explains failed base-token and invalid linked-issue branches", () => {
     const preview = buildScorePreview({
       repo,

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -371,6 +371,38 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     expect(preview.scoreEstimate.labelMultiplier).toBe(1);
   });
 
+  it("applies penalty label multipliers instead of flooring them to 1 (#994)", () => {
+    const baseInput: ScorePreviewInput = {
+      repoFullName: repo.fullName,
+      sourceTokenScore: 60,
+      totalTokenScore: 90,
+      sourceLines: 50,
+      openPrCount: 0,
+      credibility: 1,
+      linkedIssueMode: "none",
+    };
+    const penaltyOnly = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["refactor"] } });
+    const unmatched = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["unmatched"] } });
+    const bonusAndPenalty = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["bug", "refactor"] } });
+    const bonusOnly = buildScorePreview({ repo, snapshot, input: { ...baseInput, labels: ["bug"] } });
+    const customFallback = buildScorePreview({
+      repo: { ...repo, registryConfig: { ...repo.registryConfig!, defaultLabelMultiplier: 1.05, labelMultipliers: { bug: 1.2 } } },
+      snapshot,
+      input: { ...baseInput, labels: ["unmatched"] },
+    });
+
+    expect(penaltyOnly.scoreEstimate.labelMultiplier).toBe(0.5);
+    expect(unmatched.scoreEstimate.labelMultiplier).toBe(1);
+    expect(bonusAndPenalty.scoreEstimate.labelMultiplier).toBe(1.2);
+    expect(bonusOnly.scoreEstimate.labelMultiplier).toBe(1.2);
+    expect(customFallback.scoreEstimate.labelMultiplier).toBe(1.05);
+    expect(penaltyOnly.scoreEstimate.estimatedMergedScore).toBeLessThan(bonusOnly.scoreEstimate.estimatedMergedScore);
+    expect(penaltyOnly.scoreEstimate.estimatedMergedScore).toBeCloseTo(
+      bonusOnly.scoreEstimate.estimatedMergedScore * (0.5 / 1.2),
+      5,
+    );
+  });
+
   it("gates linked-issue assumptions with branch eligibility evidence", () => {
     const baseInput = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
Closes #994

## Summary

`selectLabelMultiplier` computed the per-PR label multiplier as `Math.max(fallback || 1, ...matchedMultipliers)`. Because the neutral fallback is always `>= 1`, any configured **penalty** label multiplier below 1 (e.g. `refactor: 0.5`, `docs: 0.3`) was clamped back up to 1 and never applied. Only **bonus** multipliers (`>= 1`) took effect, so `estimatedMergedScore` was inflated for exactly the low-value-label PRs penalty multipliers exist to dampen.

This PR applies matched multipliers directly and falls back to the neutral default only when no configured label matches. The existing "highest matched multiplier wins" tie-break is preserved (bonus + penalty on the same PR is unchanged).

## Root cause

```ts
// src/scoring/preview.ts — before
return Math.max(
  fallback || 1, // floor is always >= 1
  ...Object.entries(multipliers).flatMap(([label, m]) => (normalized.has(label.toLowerCase()) ? [m] : [])),
);
```

Verified against the repo fixture `{ bug: 1.2, refactor: 0.5 }`, fallback `1`:

| Labels | Intended multiplier | Before (bug) | After (fix) |
| --- | --- | --- | --- |
| `["refactor"]` | 0.5 | **1** (2× over-reward) | 0.5 |
| `["docs"]` (0.3 config) | 0.3 | **1** (~3.3× over-reward) | 0.3 |
| `["bug", "refactor"]` | highest match wins | 1.2 (0.5 dropped) | 1.2 |
| `["bug"]` | 1.2 | 1.2 | 1.2 |
| `["feature"]` (no match) | 1 | 1 | 1 |

## Changes

- **`src/scoring/preview.ts`** — fix `selectLabelMultiplier` so sub-1 matched multipliers are not floored against the `>= 1` fallback.
- **`src/services/score-breakdown.ts`** — surface penalty label multipliers as a `"reduced"` band with an accurate summary/lever in score breakdown explanations.
- **`test/unit/scoring.test.ts`** — regression coverage for penalty-only, unmatched, bonus+penalty, custom `defaultLabelMultiplier`, and merged-score scaling.
- **`test/unit/score-breakdown.test.ts`** — assert penalty labels render as `band: "reduced"`.

Behavior changes **only** when matched labels are all `< 1` (previously wrongly floored to 1). Unmatched labels and bonus multipliers are unchanged.

## Reachability

`labelMultipliers` is synced from the upstream registry per repo and `input.labels` is caller-supplied to `buildScorePreview` via MCP `score_preview` and score-preview / explain-breakdown routes. Any repo with a penalty label configured was affected on every preview for PRs carrying that label.

## API / OpenAPI / MCP contract

No schema changes. Score preview output semantics change for penalty-labeled PRs: `scoreEstimate.labelMultiplier` and `estimatedMergedScore` now reflect configured sub-1 multipliers instead of silently flooring to 1.

## Migration / deploy / secrets

None.

## Security / privacy

None. Scoring math only; no auth, cookie, CORS, GitHub App output, or contributor evidence changes.

## Validation

Run from repo root (Node `>= 22`):

```sh
git diff --check
npm run actionlint
npm run typecheck
npm run test:coverage
npm run test:workers
npm run build:mcp
npm run test:mcp-pack
npm run ui:openapi:check
npm run ui:version-audit
npm run ui:lint
npm run ui:typecheck
npm run ui:test
npm run ui:build
```

Equivalent combined gate:

```sh
npm run test:ci
```

All gates passed locally on branch `fix/apply-penalty-label-multipliers`.

