### PR TITLE
fix(scoring): parse underscores in fractional upstream constants

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -153,10 +153,10 @@ export async function getOrCreateScoringModelSnapshot(env: Env): Promise<Scoring
 export function parsePythonNumberConstants(source: string, options: { knownOnly?: boolean } = { knownOnly: true }): Record<string, number> {
   const constants: Record<string, number> = {};
   for (const line of source.split("\n")) {
-    // Match Python numeric literals including underscore separators (1_000_000), floats, and exponents
-    // (1e-9, 5.8e1). The previous /[-+]?\d+(?:\.\d+)?/ stopped at `_`/`e`, truncating 1_000_000 -> 1 and
-    // 1e-9 -> 1, which silently misparsed any such upstream constant and polluted the unmodeled list (#810).
-    const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)/);
+    // Match Python numeric literals including underscore separators in integer and fractional parts
+    // (1_000_000, 0.000_001, 3.14_15), floats, and exponents (1e-9, 5.8e1). The previous regex only
+    // allowed `_` in the integer part, truncating 0.000_001 -> 0 and 3.14_15 -> 3.14 (#992).
+    const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?[\d_]*|\.\d[\d_]*)(?:[eE][-+]?\d+)?)/);
     if (!match) continue;
     const name = match[1]!;
     const raw = match[2]!;

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -86,6 +86,22 @@ OSS_EMISSION_SHARE = 0.90
     expect(parsed.OSS_EMISSION_SHARE).toBe(0.9);
   });
 
+  it("parses underscore separators in the fractional part of upstream constants (#992)", () => {
+    const parsed = parsePythonNumberConstants(
+      `
+RATE = 0.000_001
+SCALE = 3.14_15
+VAL = 1_000.000_5
+BARE = .5_0
+`,
+      { knownOnly: false },
+    );
+    expect(parsed.RATE).toBe(0.000001);
+    expect(parsed.SCALE).toBe(3.1415);
+    expect(parsed.VAL).toBe(1000.0005);
+    expect(parsed.BARE).toBe(0.5);
+  });
+
   it("flags only scoring snapshots older than the freshness window as stale (#810)", () => {
     const now = Date.parse("2026-06-21T12:00:00.000Z");
     const justFresh = new Date(now - SCORING_SNAPSHOT_STALE_MS + 60_000).toISOString();


### PR DESCRIPTION
Closes #992

## Summary

#969 added underscore support to `parsePythonNumberConstants` for integer parts (`1_500_000`) and scientific notation (`1e-9`), but the fractional digit classes still rejected `_`. Per PEP 515, underscores are valid between digits in **any** part of a numeric literal.

A valid upstream constant like `RATE = 0.000_001` was truncated at the first fractional underscore and read as **`0`**, silently skewing score previews and breakdowns that depend on the fetched scoring snapshot.

## Root cause

```ts
// src/scoring/model.ts — before
const match = line.match(/^([A-Z][A-Z0-9_]+)\s*=\s*([-+]?(?:\d[\d_]*\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)/);
//                                                          ^ int allows _     ^ frac: no _   ^ bare decimal: no _
```

| Python literal (PEP 515) | True value | Before (bug) | After (fix) |
| --- | --- | --- | --- |
| `RATE = 0.000_001` | 0.000001 | **0** | 0.000001 |
| `SCALE = 3.14_15` | 3.1415 | **3.14** | 3.1415 |
| `VAL = 1_000.000_5` | 1000.0005 | **1000** | 1000.0005 |
| `BARE = .5_0` | 0.5 | **0.5** (unchanged) | 0.5 |

Integer grouping (`1_500_000`), plain floats (`0.90`), and exponents (`5.8e1`, `1e-9`) continue to parse as before.

## Changes

- **`src/scoring/model.ts`** — extend fractional digit classes to allow `_` in both `123.456_789` and `.5_0` forms.
- **`test/unit/scoring.test.ts`** — regression test for fractional underscore literals (`#992`).

`Number(raw.replace(/_/g, ""))` already strips underscores before parsing; no other logic changes.

## Reachability

`refreshScoringModelSnapshot` fetches upstream `gittensor/constants.py` and runs it through `parsePythonNumberConstants`, merging results into scoring constants used by `buildScorePreview`, score breakdown, and unmodeled-constant detection. Any upstream maintainer using fractional digit-grouping for readability hits this path.

## API / OpenAPI / MCP contract

No schema changes. Parsed upstream constant values may change when fractional underscores are present in `constants.py`.

## Migration / deploy / secrets

None.

## Security / privacy

None.

## Validation

Run from repo root (Node `>= 22`):

```sh
npm run test:ci
```

All gates passed locally on branch `fix/fractional-underscore-upstream-constants`.

## Distinct from #994

Unrelated to label multiplier selection (#994). This completes the fractional-underscore gap left by #969.
