### PR TITLE
Per-repo review activation gate + gittensory-branded review flags

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -906,7 +906,7 @@ export function createApp() {
     }
   });
 
-  // Public OAuth draft-submission flow (REVIEWBOT_DRAFT), ported from reviewbot. When the flag is OFF
+  // Public OAuth draft-submission flow (GITTENSORY_REVIEW_DRAFT), ported from reviewbot. When the flag is OFF
   // every handler returns 404, so the endpoints are effectively absent (the router still registers them
   // but they short-circuit). The static `/auth/callback` route is registered before the `:id` param
   // route so it is not captured as a draft id. These are public (unauthenticated) by design — submission
@@ -2824,7 +2824,7 @@ export function createApp() {
 
   app.post("/v1/github/webhook", handleGitHubWebhook);
 
-  // Convergence (ops / observability, flag REVIEWBOT_OPS). Cross-repo review-OUTCOME aggregate (gate-block
+  // Convergence (ops / observability, flag GITTENSORY_REVIEW_OPS). Cross-repo review-OUTCOME aggregate (gate-block
   // ledger + recommendation/slop calibration) for an operator dashboard. Bearer-gated by the `/v1/internal/*`
   // middleware above (INTERNAL_JOB_TOKEN). Flag-OFF (default) → 404, so the endpoint does not exist and the
   // worker is byte-identical to today. Aggregate counts only — no PR content / actor logins.
@@ -2833,7 +2833,7 @@ export function createApp() {
     return c.json(await computeOpsStats(c.env));
   });
 
-  // Convergence prep (#preconv-parity, flag REVIEWBOT_PARITY_AUDIT). The pre-cutover shadow-parity READINESS
+  // Convergence prep (#preconv-parity, flag GITTENSORY_REVIEW_PARITY_AUDIT). The pre-cutover shadow-parity READINESS
   // report: runs computeGateParity / isParityCutoverReady over the recorded review_audit rows and returns the
   // per-project agreement rate + cutover-ready verdict (floor 0.98, min 30 paired samples, zero unsafe
   // disagreements — all from parity.ts). Bearer-gated by the `/v1/internal/*` middleware (INTERNAL_JOB_TOKEN).
@@ -4764,7 +4764,7 @@ function requiresApiToken(path: string): boolean {
   if (path === "/v1/public/subnet-interface") return false;
   if (path === "/openapi.json") return false;
   if (path === "/mcp") return false;
-  // Public OAuth draft-submission flow (REVIEWBOT_DRAFT): the submission entry points are unauthenticated
+  // Public OAuth draft-submission flow (GITTENSORY_REVIEW_DRAFT): the submission entry points are unauthenticated
   // by design. The handlers themselves 404 when the flag is off, so this exemption is inert flag-OFF.
   if (path === "/v1/drafts" || path.startsWith("/v1/drafts/")) return false;
   if (path.startsWith("/v1/auth/")) return false;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -63,24 +63,24 @@ declare global {
     /** Convergence (Stage D): when truthy, the public PR comment is rendered by the unified-comment bridge
      *  (ONE in-place comment in the converged shape) instead of the legacy `buildPublicPrIntelligenceComment`
      *  panel. Default OFF — unset/false keeps the legacy panel byte-identical. */
-    UNIFIED_REVIEW_COMMENT?: string;
+    GITTENSORY_REVIEW_UNIFIED_COMMENT?: string;
     /** Convergence (safety): when truthy, the ported safety scan runs in the review path — (1) untrusted PR
      *  title/body/diff is defanged (prompt-injection neutralized) before it reaches the AI reviewer, and (2)
      *  the PR diff is scanned for leaked secrets, surfacing a `secret_leak` blocker. Default OFF —
      *  unset/false keeps the review path byte-identical (no new branch is taken). */
-    REVIEWBOT_SAFETY?: string;
+    GITTENSORY_REVIEW_SAFETY?: string;
     /** Convergence (grounding): when truthy, the AI reviewer prompt is GROUNDED — the PR's finished CI status
      *  + the FULL post-change content of the changed files are appended so a non-frontier model verifies its
      *  claims against reality instead of predicting CI / flagging symbols defined just outside the hunk.
      *  Default OFF — unset/false keeps the reviewer prompt byte-identical and makes no extra GitHub fetch. */
-    REVIEWBOT_GROUNDING?: string;
+    GITTENSORY_REVIEW_GROUNDING?: string;
     /** Convergence (reputation): when truthy, the INTERNAL-only ported submitter-reputation signal extends the
      *  AI-spend gate — a new / burst / low-reputation submitter is downgraded to a deterministic-only review
      *  (the AI neurons are skipped), and the per-(project, submitter) outcome is recorded after the gate
      *  decides. STRICTLY INTERNAL: the reputation never appears in any public comment/check. Default OFF —
      *  unset/false reads NO reputation, records NOTHING, and leaves the AI-spend gate byte-identical (the new
      *  branch is unreachable when off). */
-    REVIEWBOT_REPUTATION?: string;
+    GITTENSORY_REVIEW_REPUTATION?: string;
     /** Convergence (ops / observability): when truthy, gittensory's OWN review-outcome data drives two
      *  operator surfaces — (1) on the cron tick, an anomaly scan over the gate-block ledger + recommendation /
      *  slop calibration emits a structured `ops_anomaly` log when something drifts (gate false-positive spike,
@@ -89,7 +89,7 @@ declare global {
      *  means the cron tick enqueues NO ops job (does no new work) and the endpoint 404s, so the worker is
      *  byte-identical to today. NOTE: this is read-only OBSERVABILITY only; the auto-tune / config-mutation
      *  self-improve loop (src/review/auto-apply.ts) is deliberately NOT wired here — see ops-wire.ts. */
-    REVIEWBOT_OPS?: string;
+    GITTENSORY_REVIEW_OPS?: string;
     /** Convergence (RAG retrieval): when truthy, the AI reviewer prompt gains a RELEVANT EXISTING CODE / DOCS
      *  section — at review time the codebase vector index is queried for code/docs semantically related to the
      *  PR's changed files (callers, related modules, existing conventions) and appended as additive reference
@@ -97,7 +97,7 @@ declare global {
      *  uses NO adapter, makes NO vector query, and keeps the reviewer prompt byte-identical (the new branch is
      *  unreachable when off). Even when ON, retrieval is INERT until a vector index exists for the repo (a
      *  cold/missing index degrades to no context) — the index-population job is a deploy-time follow-up. */
-    REVIEWBOT_RAG?: string;
+    GITTENSORY_REVIEW_RAG?: string;
     /** Convergence (self-improve / auto-tune): when truthy, the ported self-improvement loop
      *  (src/review/auto-tune.ts + auto-apply.ts) runs on the cron tick over gittensory's OWN review-outcome
      *  data — it computes tuning recommendations, SHADOW-SOAKS any STRICTLY-TIGHTENING recommendation in the
@@ -111,11 +111,11 @@ declare global {
      *  signal measures gate false positives, a loosening direction); the shadow-soak + audit + recommendation
      *  recording are wired, reading a promoted override into the live gate is a noted follow-up that must not
      *  risk loosening the gate. See src/review/selftune-wire.ts. */
-    REVIEWBOT_SELFTUNE?: string;
+    GITTENSORY_REVIEW_SELFTUNE?: string;
     /** Convergence (port): public OAuth draft-submission flow ported from reviewbot. When truthy, the
      *  /v1/drafts endpoints accept a contributor draft -> GitHub OAuth -> fork PR against the content repo.
      *  Default OFF — unset/false makes every draft endpoint 404 and writes nothing (byte-identical worker). */
-    REVIEWBOT_DRAFT?: string;
+    GITTENSORY_REVIEW_DRAFT?: string;
     /** owner/repo the draft fork PR targets (defaults to the awesome-claude content repo when unset). */
     DRAFT_PUBLIC_REPO?: string;
     /** Base branch the draft PR opens against (defaults to "main"). */
@@ -131,7 +131,16 @@ declare global {
      *  review path is byte-identical) and the endpoint 404s. NOTE: this records the gittensory-native side only;
      *  the actual COMPARISON vs reviewbot's authoritative decisions needs reviewbot's rows in the SAME table,
      *  written by the deploy-time dual-run shadow step (out of scope here). See src/review/parity-wire.ts. */
-    REVIEWBOT_PARITY_AUDIT?: string;
+    GITTENSORY_REVIEW_PARITY_AUDIT?: string;
+    /** Convergence (cutover): comma-separated allowlist of repo full-names ("owner/repo") that may run the
+     *  PER-PR converged review features (safety defang + secret-leak, grounding, RAG, reputation AI-skip/record,
+     *  unified comment). A feature activates for a repo ONLY IF its existing global flag is ON AND the repo is
+     *  in this allowlist — letting the cutover roll forward (or back) one repo at a time. Matching is
+     *  case-insensitive on the trimmed "owner/repo". Default "" (unset/empty/whitespace) → NO repos → every
+     *  per-PR converged feature stays OFF for ALL repos regardless of the global flags (byte-identical dormant
+     *  deploy). The cron/endpoint flags (ops / selftune / parity / content-lane / draft) are NOT scoped by
+     *  this allowlist — they stay global. See src/review/cutover-gate.ts. */
+    GITTENSORY_REVIEW_REPOS?: string;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,11 +54,11 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
     // Agent layer (#777): re-gate stale open PRs hourly. Fans out to one job per agent-configured repo;
     // webhooks don't fire when a PR's base advances, so this is what keeps those verdicts fresh.
     jobs.push({ type: "agent-regate-sweep", requestedBy: "schedule" });
-    // Convergence (ops / observability, flag REVIEWBOT_OPS). Hourly anomaly scan over gittensory's own
+    // Convergence (ops / observability, flag GITTENSORY_REVIEW_OPS). Hourly anomaly scan over gittensory's own
     // review-outcome data. Enqueued ONLY when the flag is ON — flag-OFF (default) this job is never created,
     // so the cron tick does ZERO new work and the enqueued set is byte-identical to today.
     if (isOpsEnabled(env)) jobs.push({ type: "ops-alerts", requestedBy: "schedule" });
-    // Convergence (self-improve / auto-tune, flag REVIEWBOT_SELFTUNE). Hourly self-improvement tick over
+    // Convergence (self-improve / auto-tune, flag GITTENSORY_REVIEW_SELFTUNE). Hourly self-improvement tick over
     // gittensory's own review-outcome data: compute tuning recommendations, shadow-soak any strictly-tightening
     // one, and auto-promote it to live only after the soak window passes the gate (TIGHTENING-ONLY, audited).
     // Enqueued ONLY when the flag is ON — flag-OFF (default) this job is never created, so the cron tick does

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -159,6 +159,7 @@ import { isSafetyEnabled, secretLeakFinding } from "../review/safety";
 import { buildReviewGroundingText, isGroundingEnabled } from "../review/grounding-wire";
 import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
+import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
@@ -318,13 +319,13 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       await deliverNotification(env, message.deliveryId);
       return;
     case "ops-alerts":
-      // Convergence (ops / observability, flag REVIEWBOT_OPS). Defense-in-depth: the cron only ENQUEUES this
+      // Convergence (ops / observability, flag GITTENSORY_REVIEW_OPS). Defense-in-depth: the cron only ENQUEUES this
       // when the flag is ON, but a stale in-flight job that lands after a flag-flip must still no-op, so
       // flag-OFF does zero work here too. Read-only telemetry — never throws into the queue.
       if (isOpsEnabled(env)) await runOpsAlerts(env);
       return;
     case "selftune":
-      // Convergence (self-improve / auto-tune, flag REVIEWBOT_SELFTUNE). Defense-in-depth: the cron only
+      // Convergence (self-improve / auto-tune, flag GITTENSORY_REVIEW_SELFTUNE). Defense-in-depth: the cron only
       // ENQUEUES this when the flag is ON, but a stale in-flight job that lands after a flag-flip must still
       // no-op, so flag-OFF does zero work here too. TIGHTENING-ONLY + shadow-soak + audited; never throws into
       // the queue (runSelfTune fails safe).
@@ -334,7 +335,7 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       await processGitHubWebhook(env, message.deliveryId, message.eventName, message.payload);
       return;
     case "submit-draft":
-      // Public OAuth draft-submission (REVIEWBOT_DRAFT). No-ops internally when the flag is off.
+      // Public OAuth draft-submission (GITTENSORY_REVIEW_DRAFT). No-ops internally when the flag is off.
       await processSubmitDraft(env, message.draftId);
       return;
   }
@@ -1013,12 +1014,13 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
           /* v8 ignore next -- best-effort: auto-maintain failures are logged, never surfaced to the gate. */
           console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
         });
-        // Reputation (convergence, flag-gated by REVIEWBOT_REPUTATION). After the gate decides, record this
+        // Reputation (convergence, flag-gated by GITTENSORY_REVIEW_REPUTATION). After the gate decides, record this
         // submitter's terminal outcome (merged / closed / manual) so the INTERNAL reputation stays current. The
         // outcome is derived ONLY from the PR's realized terminal state + the gate verdict (no PR content);
         // nothing is ever surfaced publicly. Flag-OFF (default) is an immediate no-op (nothing recorded), so the
         // path is byte-identical. Best-effort: a record failure must never affect the gate or the public surface.
-        const reputationOutcome = isReputationEnabled(env) ? reputationOutcomeFromTerminalState(pr, payload.pull_request, gate) : undefined;
+        const reputationOutcome =
+          isReputationEnabled(env) && isConvergenceRepoAllowed(env, repoFullName) ? reputationOutcomeFromTerminalState(pr, payload.pull_request, gate) : undefined;
         if (reputationOutcome) {
           await recordReputationOutcome(env, { project: repoFullName, submitter: pr.authorLogin ?? null, outcome: reputationOutcome }).catch((error) => {
             /* v8 ignore next -- best-effort: a reputation-record failure is logged, never surfaced to the gate. */
@@ -1199,14 +1201,19 @@ export async function runAiReviewForAdvisory(
 ): Promise<{ notes: string } | undefined> {
   const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
   if (args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha) return undefined;
-  // Reputation anti-abuse (convergence, flag-gated by REVIEWBOT_REPUTATION). Extends the AI-spend gate above:
+  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the converged review features (reputation AI-skip,
+  // grounding, RAG) activate for THIS repo only when it is allowlisted. Computed once and ANDed into each
+  // feature's global flag below. Empty/unset allowlist → false → every converged branch here is unreachable
+  // (byte-identical to today) regardless of the global flags.
+  const convergedRepoAllowed = isConvergenceRepoAllowed(env, args.repoFullName);
+  // Reputation anti-abuse (convergence, flag-gated by GITTENSORY_REVIEW_REPUTATION). Extends the AI-spend gate above:
   // an INTERNAL low-reputation / burst / new submitter is downgraded to a DETERMINISTIC-ONLY review — the
   // (paid) AI neurons are skipped here exactly as they are for an unconfirmed contributor, so a serial abuser
   // can't make the project spend AI on a flood of low-quality PRs. STRICTLY INTERNAL: the reputation is never
   // surfaced — this only routes the private AI-spend decision. Flag-OFF (default) is an immediate no-op (no DB
   // read, no new branch) → the AI-spend gate is byte-identical to today. Fail-safe (the read degrades to
   // neutral → false on any error).
-  if (isReputationEnabled(env) && (await shouldSkipAiForReputation(env, { project: args.repoFullName, submitter: args.author }))) return undefined;
+  if (isReputationEnabled(env) && convergedRepoAllowed && (await shouldSkipAiForReputation(env, { project: args.repoFullName, submitter: args.author }))) return undefined;
   try {
     // BYOK: decrypt the maintainer's provider key only for confirmed contributors when opted in. Falls back to free Workers AI when
     // no key is configured or the encryption secret is unavailable (getDecryptedRepositoryAiKey → null).
@@ -1218,11 +1225,11 @@ export async function runAiReviewForAdvisory(
         ? { provider: storedKey.provider, key: storedKey.key, model: args.settings.aiReviewModel ?? storedKey.model }
         : null;
     const files = await listPullRequestFiles(env, args.repoFullName, args.pr.number);
-    // Grounding (convergence, flag-gated by REVIEWBOT_GROUNDING). Build the FINISHED CI status + the full
+    // Grounding (convergence, flag-gated by GITTENSORY_REVIEW_GROUNDING). Build the FINISHED CI status + the full
     // content of the changed files so the reviewer verifies its claims against reality instead of guessing.
     // Flag-OFF (default) → we take no new branch at all: NO check/repo load, NO file fetch, and `grounding`
     // is left undefined so the prompt handed to the model is byte-identical to today. Fully fail-safe.
-    const grounding = isGroundingEnabled(env)
+    const grounding = isGroundingEnabled(env) && convergedRepoAllowed
       ? await buildReviewGroundingText(env, {
           repoFullName: args.repoFullName,
           headSha: args.advisory.headSha,
@@ -1231,11 +1238,11 @@ export async function runAiReviewForAdvisory(
           installationId: (await getRepository(env, args.repoFullName))?.installationId ?? null,
         })
       : undefined;
-    // RAG retrieval (convergence, flag-gated by REVIEWBOT_RAG). Query the codebase vector index for code/docs
+    // RAG retrieval (convergence, flag-gated by GITTENSORY_REVIEW_RAG). Query the codebase vector index for code/docs
     // semantically related to the changed files and append them as additive reference context — exactly like
     // grounding. Flag-OFF (default) → NO new branch: no adapter use, no vector query, and `ragContext` is left
     // undefined so the prompt is byte-identical to today. Fully fail-safe (a missing/cold index degrades to "").
-    const ragContext = isRagEnabled(env)
+    const ragContext = isRagEnabled(env) && convergedRepoAllowed
       ? await buildReviewRagContext(env, {
           repoFullName: args.repoFullName,
           files: files.map((file) => ({ path: file.path, patch: typeof file.payload?.patch === "string" ? file.payload.patch : undefined })),
@@ -1272,7 +1279,7 @@ export async function runAiReviewForAdvisory(
 }
 
 /**
- * Safety secrets-scan (convergence, flag-gated by REVIEWBOT_SAFETY). Scans the PR diff for leaked secrets and,
+ * Safety secrets-scan (convergence, flag-gated by GITTENSORY_REVIEW_SAFETY). Scans the PR diff for leaked secrets and,
  * on a hit, appends ONE critical `secret_leak` finding to the advisory BEFORE evaluateGateCheck runs — the
  * gate treats that code as a hard blocker (rules/advisory.ts), so a committed credential holds the PR. Reuses
  * the already-loaded gate files when present, else loads them lazily. Flag-OFF (default) returns immediately:
@@ -1288,7 +1295,10 @@ export async function maybeAddSecretLeakFinding(
     files: Awaited<ReturnType<typeof listPullRequestFiles>> | null;
   },
 ): Promise<void> {
-  if (!isSafetyEnabled(env)) return;
+  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the secret-leak scan activates for THIS repo only when
+  // it is allowlisted AND the global safety flag is ON. Empty/unset allowlist → no-op for every repo (the
+  // advisory is byte-identical to today) regardless of GITTENSORY_REVIEW_SAFETY.
+  if (!isSafetyEnabled(env) || !isConvergenceRepoAllowed(env, args.repoFullName)) return;
   try {
     const files = args.files ?? (await listPullRequestFiles(env, args.repoFullName, args.pullNumber));
     const finding = secretLeakFinding(buildAiReviewDiff(files));
@@ -1405,7 +1415,7 @@ function buildClosedPrPanelUpdate(repoFullName: string, pullNumber: number): str
  *   • closed without merge → "closed".
  *   • still open but the gate routed it to manual review (failure / action_required) → "manual".
  *   • still open and the gate did not flag it → undefined (no terminal outcome — nothing to record).
- * Internal-only; the result is never surfaced. Used only when REVIEWBOT_REPUTATION is ON.
+ * Internal-only; the result is never surfaced. Used only when GITTENSORY_REVIEW_REPUTATION is ON.
  */
 export function reputationOutcomeFromTerminalState(
   pr: { state: string; mergedAt?: string | null | undefined },
@@ -1429,6 +1439,11 @@ async function maybePublishPrPublicSurface(
   webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined },
 ): Promise<ReturnType<typeof evaluateGateCheck> | undefined> {
   const author = pr.authorLogin ?? null;
+  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the unified converged comment renders for THIS repo
+  // only when it is allowlisted AND the global GITTENSORY_REVIEW_UNIFIED_COMMENT flag is ON. Computed once and ANDed into
+  // both unified-comment sites below (closed/skipped + open). Empty/unset allowlist → false → both sites keep
+  // the LEGACY panel byte-identical for every repo regardless of GITTENSORY_REVIEW_UNIFIED_COMMENT.
+  const unifiedCommentAllowed = isUnifiedReviewCommentEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
   // `settings` is the EFFECTIVE config (`.gittensory.yml` > DB > defaults), resolved by the caller via
   // resolveRepositorySettings — so gate on/off and every blocker mode already reflect the repo's config
   // file. The gate only chooses what to do; confirmedContributor governs WHO can be blocked.
@@ -1462,7 +1477,7 @@ async function maybePublishPrPublicSurface(
     // unified renderer too. Otherwise an OPEN PR's unified comment would be overwritten by the legacy panel
     // under the SAME marker when it closes. Flag-OFF (default) keeps the legacy panel byte-identical. The
     // update is createIfMissing:false either way — we only refresh an existing comment for a closing PR.
-    const closedBody = isUnifiedReviewCommentEnabled(env)
+    const closedBody = unifiedCommentAllowed
       ? buildClosedUnifiedCommentBody({ repoFullName, pullNumber: pr.number, footerMarkdown: gittensoryFooter({ earnUrl: gittensorRepoEarnUrl(repoFullName) }) })
       : buildClosedPrPanelUpdate(repoFullName, pr.number);
     await createOrUpdatePrIntelligenceComment(env, installationId, repoFullName, pr.number, closedBody, { createIfMissing: false }).catch(() => undefined);
@@ -1625,7 +1640,7 @@ async function maybePublishPrPublicSurface(
     // failure is caught and the gate is still finalized (never left in_progress).
     aiReview = await runAiReviewForAdvisory(env, { settings, advisory, repoFullName, pr, author, confirmedContributor });
 
-    // Safety secrets-scan (convergence, flag-gated by REVIEWBOT_SAFETY). Scans the diff and, on a hit,
+    // Safety secrets-scan (convergence, flag-gated by GITTENSORY_REVIEW_SAFETY). Scans the diff and, on a hit,
     // appends a critical `secret_leak` blocker BEFORE the gate evaluates. Reuses the already-loaded gate
     // files when present. Flag-OFF (default) is an immediate no-op → the advisory/gate is byte-identical.
     await maybeAddSecretLeakFinding(env, { advisory, repoFullName, pullNumber: pr.number, files: gateFiles });
@@ -1653,7 +1668,7 @@ async function maybePublishPrPublicSurface(
     }
     // #preconv-parity (convergence prep): SHADOW-record the gittensory-native gate decision (source=
     // 'gittensory-native') into review_audit so the pre-cutover parity harness has data to read. RECORD-ONLY,
-    // flag-gated by REVIEWBOT_PARITY_AUDIT: flag-OFF (default) is an immediate no-op (NO D1 write) so the review
+    // flag-gated by GITTENSORY_REVIEW_PARITY_AUDIT: flag-OFF (default) is an immediate no-op (NO D1 write) so the review
     // path is BYTE-IDENTICAL to today; flag-ON it writes one row and changes NO behavior. Best-effort. The
     // authoritative 'reviewbot' rows it is later compared against are written by reviewbot's deploy-time dual-
     // run, not here (see src/review/parity-wire.ts). Only a finalized gate evaluation (not skipped) is recorded.
@@ -1772,7 +1787,7 @@ async function maybePublishPrPublicSurface(
     //      contradict the Gittensory Gate check-run conclusion.
     //   3. The `ai_consensus_defect` surfaces exactly ONCE — as the Code-review blocker — never also in the
     //      gate signal row (which renders only the conclusion-derived status text, not the defect string).
-    if (isUnifiedReviewCommentEnabled(env) && gateEvaluation) {
+    if (unifiedCommentAllowed && gateEvaluation) {
       const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation });
       const unifiedFiles = await listPullRequestFiles(env, repoFullName, pr.number);
       deterministicBody = buildUnifiedCommentBody({

--- a/src/review/content-lane/flag.ts
+++ b/src/review/content-lane/flag.ts
@@ -6,7 +6,7 @@
 // scope classification, and metagraphed's netuid grounding). The lane is ported as native,
 // self-contained gittensory modules under this directory.
 //
-// FLAG-GATED + DEFAULT-OFF: the lane only runs when REVIEWBOT_CONTENT_LANE is truthy in the Env.
+// FLAG-GATED + DEFAULT-OFF: the lane only runs when GITTENSORY_REVIEW_CONTENT_LANE is truthy in the Env.
 // Flag-off, the host never reaches these modules, so the live behavior is byte-identical. At
 // cutover the host flips the flag and routes awesome-claude + metagraphed PRs through the lane.
 
@@ -14,14 +14,14 @@
  *  testable without the whole binding (pass a plain object). */
 export interface ContentLaneEnv {
   /** When truthy ("1"/"true"/"on"/"yes"), the content lane is enabled. Default OFF. */
-  REVIEWBOT_CONTENT_LANE?: string;
+  GITTENSORY_REVIEW_CONTENT_LANE?: string;
 }
 
 const TRUTHY = new Set(["1", "true", "on", "yes"]);
 
 /** Is the content lane enabled? Default OFF — only a recognized truthy flag turns it on. */
 export function isContentLaneEnabled(env: ContentLaneEnv | undefined | null): boolean {
-  const raw = env?.REVIEWBOT_CONTENT_LANE;
+  const raw = env?.GITTENSORY_REVIEW_CONTENT_LANE;
   if (typeof raw !== "string") return false;
   return TRUTHY.has(raw.trim().toLowerCase());
 }

--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -2,11 +2,11 @@
 //
 // The native, flag-gated content-review primitives for the two CONTENT repos — awesome-claude (a
 // curated list) and metagraphed (a registry) — a different domain from gittensory's code-gate. The
-// lane only runs when REVIEWBOT_CONTENT_LANE is truthy (see ./flag); flag-off the host never reaches
+// lane only runs when GITTENSORY_REVIEW_CONTENT_LANE is truthy (see ./flag); flag-off the host never reaches
 // these modules.
 //
 // PORTED so far (the deterministic core — pure or fetch-only, no engine):
-//  - flag                 : REVIEWBOT_CONTENT_LANE gate
+//  - flag                 : GITTENSORY_REVIEW_CONTENT_LANE gate
 //  - safe-url             : SSRF-safe URL guard (shared)
 //  - scope (awesome)      : content-PR scope classification (ignore / close / deletion / review)
 //  - duplicates (awesome) : duplicate-detection + protected-edit gate

--- a/src/review/cutover-gate.ts
+++ b/src/review/cutover-gate.ts
@@ -1,0 +1,38 @@
+// Convergence (cutover) per-repo gate: an allowlist that activates the PER-PR converged review features one
+// repo at a time, so the cutover can be rolled forward (and rolled back) on a single repo without flipping the
+// global flags off for everyone. Each per-PR converged feature ALREADY has a global switch (GITTENSORY_REVIEW_SAFETY /
+// _GROUNDING / _RAG / _REPUTATION, GITTENSORY_REVIEW_UNIFIED_COMMENT); this adds a SECOND, repo-scoped gate that must
+// ALSO pass for the feature to run on a given PR's repo.
+//
+// Single env var: GITTENSORY_REVIEW_REPOS — a comma-separated allowlist of repo full-names
+// ("owner/repo", e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). A repo activates the converged
+// features ONLY IF (the feature's global flag is ON) AND (the repo is in this allowlist).
+//
+// DEFAULT IS NO REPOS: empty / unset / whitespace-only → false for EVERY repo. So even with every global flag
+// ON, the per-PR converged path stays dormant (byte-identical to today) until a repo is explicitly listed.
+// This is deliberately the OPPOSITE default of an empty=all allowlist — the safe state is "nothing converged".
+//
+// Matching is case-insensitive exact match on the trimmed "owner/repo" (GitHub repo full-names are
+// case-insensitive). Empty entries between commas are ignored, so a trailing/stray comma is harmless.
+
+/**
+ * True when `repoFullName` is in the GITTENSORY_REVIEW_REPOS allowlist (per-repo cutover gate).
+ *
+ * - Splits the allowlist on commas, trims each entry, and does a case-insensitive exact match on "owner/repo".
+ * - Empty / unset / whitespace-only allowlist → ALWAYS false (no repos converged — the dormant default).
+ * - An empty / whitespace-only `repoFullName` → false (never matches an empty allowlist entry).
+ *
+ * Callers AND this with the feature's existing global flag (e.g. `isSafetyEnabled(env) &&
+ * isConvergenceRepoAllowed(env, repo)`), so a feature runs only when BOTH the global flag is ON and the repo is
+ * allowlisted.
+ */
+export function isConvergenceRepoAllowed(env: { GITTENSORY_REVIEW_REPOS?: string | undefined }, repoFullName: string): boolean {
+  const target = repoFullName.trim().toLowerCase();
+  if (!target) return false;
+  const raw = env.GITTENSORY_REVIEW_REPOS ?? "";
+  for (const entry of raw.split(",")) {
+    const candidate = entry.trim().toLowerCase();
+    if (candidate && candidate === target) return true;
+  }
+  return false;
+}

--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -2,7 +2,7 @@
 // content of the changed files, so a non-frontier model stops hallucinating CI outcomes ("this breaks the
 // build" on a green PR) and undefined symbols (flagged because they're defined just outside the visible hunk).
 //
-// Single env switch: REVIEWBOT_GROUNDING. Default OFF (unset/"false") — when OFF this module gathers nothing,
+// Single env switch: GITTENSORY_REVIEW_GROUNDING. Default OFF (unset/"false") — when OFF this module gathers nothing,
 // the reviewer prompt is byte-identical to today, and no extra GitHub fetch is made. Truthy follows the
 // codebase convention (`/^(1|true|yes|on)$/i`, same as isSafetyEnabled / isEnabled).
 //
@@ -25,13 +25,13 @@ import {
 } from "./review-grounding";
 
 /** True when grounding is enabled. Flag-OFF (default) → no grounding is gathered and the prompt is unchanged. */
-export function isGroundingEnabled(env: { REVIEWBOT_GROUNDING?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_GROUNDING ?? "");
+export function isGroundingEnabled(env: { GITTENSORY_REVIEW_GROUNDING?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_GROUNDING ?? "");
 }
 
 /** When ON, both grounding inputs (CI + full files) are gathered; OFF gathers neither. One switch keeps the
  *  flag-OFF path provably byte-identical (no partial grounding). */
-function groundingFlags(env: { REVIEWBOT_GROUNDING?: string | undefined }): GroundingFlags {
+function groundingFlags(env: { GITTENSORY_REVIEW_GROUNDING?: string | undefined }): GroundingFlags {
   const on = isGroundingEnabled(env);
   return { ciGrounding: on, fullFileContext: on };
 }

--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -1,5 +1,5 @@
 // Convergence (ops / observability) — wires the ported alerts + stats observability into gittensory, behind
-// the default-OFF `REVIEWBOT_OPS` flag. Flag-OFF every export here is a no-op / 404, so the worker is
+// the default-OFF `GITTENSORY_REVIEW_OPS` flag. Flag-OFF every export here is a no-op / 404, so the worker is
 // byte-identical to today (the cron enqueues no ops job; the endpoint short-circuits).
 //
 // ADAPTED TO GITTENSORY'S OWN OUTCOME DATA — NOT reviewbot's `review_targets`/`review_audit` (those tables are
@@ -33,8 +33,8 @@ import { errorMessage, nowIso } from "../utils/json";
 
 /** True when the ops observability surface is enabled. Flag-OFF (default) → every export below is a no-op /
  *  404. Truthy follows the codebase convention (`/^(1|true|yes|on)$/i`, same as isSafetyEnabled). */
-export function isOpsEnabled(env: { REVIEWBOT_OPS?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_OPS ?? "");
+export function isOpsEnabled(env: { GITTENSORY_REVIEW_OPS?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_OPS ?? "");
 }
 
 // ── Anomaly thresholds (gittensory-native; conservative so a handful of samples never cries wolf) ──────────

--- a/src/review/parity-wire.ts
+++ b/src/review/parity-wire.ts
@@ -27,8 +27,8 @@ import { errorMessage, nowIso } from "../utils/json";
 /** True when the shadow-parity audit is enabled. Flag-OFF (default) → recordNativeGateDecision is a no-op and
  *  the parity endpoint 404s. Truthy follows the codebase convention (`/^(1|true|yes|on)$/i`, same as
  *  isOpsEnabled / isSelfTuneEnabled). */
-export function isParityAuditEnabled(env: { REVIEWBOT_PARITY_AUDIT?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_PARITY_AUDIT ?? "");
+export function isParityAuditEnabled(env: { GITTENSORY_REVIEW_PARITY_AUDIT?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_PARITY_AUDIT ?? "");
 }
 
 /** The `source` discriminator this writer stamps on every row — the SHADOW side computeGateParity compares
@@ -70,7 +70,7 @@ export function nativeGateActionFromConclusion(conclusion: GateCheckConclusion):
 }
 
 /** The minimal env shape the recorder needs (the D1 binding). */
-type ParityRecorderEnv = { DB: D1Database; REVIEWBOT_PARITY_AUDIT?: string | undefined };
+type ParityRecorderEnv = { DB: D1Database; GITTENSORY_REVIEW_PARITY_AUDIT?: string | undefined };
 
 /**
  * SHADOW-record one gittensory-native gate decision into `review_audit` (source='gittensory-native').

--- a/src/review/rag-wire.ts
+++ b/src/review/rag-wire.ts
@@ -3,7 +3,7 @@
 // so a non-frontier model judges the change against how the rest of the codebase actually works. This is the
 // RETRIEVAL half of codebase RAG (Layer C) — additive prompt context, exactly like `grounding-wire`.
 //
-// Single env switch: REVIEWBOT_RAG. Default OFF (unset/"false") — when OFF this module is never invoked from
+// Single env switch: GITTENSORY_REVIEW_RAG. Default OFF (unset/"false") — when OFF this module is never invoked from
 // the review path (the caller guards on the flag), gathers nothing, makes NO adapter use and NO vector query,
 // and the reviewer prompt is byte-identical to today. Truthy follows the codebase convention
 // (`/^(1|true|yes|on)$/i`, same as isGroundingEnabled / isSafetyEnabled / isEnabled).
@@ -29,8 +29,8 @@ import { type RagChunk, retrieveContext, upsertChunks } from "./rag";
 
 /** True when RAG retrieval is enabled. Flag-OFF (default) → the caller takes no new branch, so no retrieval is
  *  performed and the reviewer prompt is unchanged. */
-export function isRagEnabled(env: { REVIEWBOT_RAG?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_RAG ?? "");
+export function isRagEnabled(env: { GITTENSORY_REVIEW_RAG?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_RAG ?? "");
 }
 
 /** Cap on how many changed-file paths feed the query string — bounds the query length / embed cost. */

--- a/src/review/reputation-wire.ts
+++ b/src/review/reputation-wire.ts
@@ -4,7 +4,7 @@
 // (the AI neurons are skipped); a good-reputation submitter proceeds normally. After the gate decides, the
 // terminal outcome is recorded so the signal stays current.
 //
-// Single env switch: REVIEWBOT_REPUTATION. Default OFF (unset/"false") — when OFF every helper here is an
+// Single env switch: GITTENSORY_REVIEW_REPUTATION. Default OFF (unset/"false") — when OFF every helper here is an
 // immediate no-op: no reputation is read, nothing is recorded, and the AI-spend gate takes no new branch, so
 // the path is byte-identical to today. Truthy follows the codebase convention (`/^(1|true|yes|on)$/i`, same
 // as isSafetyEnabled / isGroundingEnabled / isEnabled).
@@ -21,8 +21,8 @@ import {
 } from "./submitter-reputation";
 
 /** True when the reputation signal is enabled. Flag-OFF (default) → every helper below is a no-op. */
-export function isReputationEnabled(env: { REVIEWBOT_REPUTATION?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_REPUTATION ?? "");
+export function isReputationEnabled(env: { GITTENSORY_REVIEW_REPUTATION?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_REPUTATION ?? "");
 }
 
 // ── Anti-abuse thresholds. GENERIC mechanism (not the gameable secret — they don't reveal any review

--- a/src/review/safety.ts
+++ b/src/review/safety.ts
@@ -1,7 +1,7 @@
 // Convergence (safety) feature flag + helpers that wire the ported safety modules
 // (`./prompt-injection` + `./secrets-scan`) into gittensory's review path.
 //
-// Single env switch: REVIEWBOT_SAFETY. Default OFF (unset/"false") — when OFF none of the helpers here
+// Single env switch: GITTENSORY_REVIEW_SAFETY. Default OFF (unset/"false") — when OFF none of the helpers here
 // alter inputs or findings, so the review path is byte-identical to today. Truthy follows the codebase
 // convention (`/^(1|true|yes|on)$/i`, same as isUnifiedReviewCommentEnabled / isEnabled).
 
@@ -10,8 +10,8 @@ import { neutralizePromptInjection, safeReviewTitle } from "./prompt-injection";
 import { scanForSecrets } from "./secrets-scan";
 
 /** True when the safety scan is enabled. Flag-OFF (default) → every helper below is a no-op pass-through. */
-export function isSafetyEnabled(env: { REVIEWBOT_SAFETY?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_SAFETY ?? "");
+export function isSafetyEnabled(env: { GITTENSORY_REVIEW_SAFETY?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_SAFETY ?? "");
 }
 
 /** The untrusted, author-controlled fields fed to the AI reviewer. */

--- a/src/review/selftune-wire.ts
+++ b/src/review/selftune-wire.ts
@@ -1,5 +1,5 @@
 // Convergence (#self-improve) — wires the ported self-improvement loop (src/review/auto-tune.ts +
-// src/review/auto-apply.ts) into gittensory's cron behind the default-OFF `REVIEWBOT_SELFTUNE` flag.
+// src/review/auto-apply.ts) into gittensory's cron behind the default-OFF `GITTENSORY_REVIEW_SELFTUNE` flag.
 //
 // SAFETY CONTRACT (must hold under every path):
 //   • flag-OFF (default) → the cron enqueues NO selftune job and this module is never reached; ZERO tuning
@@ -44,8 +44,8 @@ import { runAutoApplyRecommendations, type StorageEnv } from "./auto-apply";
 
 /** True when the self-improvement loop is enabled. Flag-OFF (default) → every export below is a no-op. Truthy
  *  follows the codebase convention (`/^(1|true|yes|on)$/i`, same as isOpsEnabled / isReputationEnabled). */
-export function isSelfTuneEnabled(env: { REVIEWBOT_SELFTUNE?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.REVIEWBOT_SELFTUNE ?? "");
+export function isSelfTuneEnabled(env: { GITTENSORY_REVIEW_SELFTUNE?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_SELFTUNE ?? "");
 }
 
 /** The project's base confidence floor the tightening direction is judged against. Gittensory has no live

--- a/src/review/stats.ts
+++ b/src/review/stats.ts
@@ -147,7 +147,7 @@ function readSecret(env: Env, name: string): string {
 
 // ── Stats config (byte-faithful from reviewbot src/core/stats.ts) ────────────────────────────────
 
-const STATS_TOKEN_SECRET = "REVIEWBOT_STATS_TOKEN";
+const STATS_TOKEN_SECRET = "GITTENSORY_REVIEW_STATS_TOKEN";
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -276,6 +276,6 @@ export function buildClosedUnifiedCommentBody(args: { repoFullName: string; pull
 }
 
 /** Truthy-env flag check, matching the codebase convention (e.g. SCORING_TIME_DECAY_ENABLED). */
-export function isUnifiedReviewCommentEnabled(env: { UNIFIED_REVIEW_COMMENT?: string | undefined }): boolean {
-  return /^(1|true|yes|on)$/i.test(env.UNIFIED_REVIEW_COMMENT ?? "");
+export function isUnifiedReviewCommentEnabled(env: { GITTENSORY_REVIEW_UNIFIED_COMMENT?: string | undefined }): boolean {
+  return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_UNIFIED_COMMENT ?? "");
 }

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -1,4 +1,4 @@
-// Unified PR review comment renderer (convergence — see docs/UNIFIED_REVIEW_COMMENT.md).
+// Unified PR review comment renderer (convergence — see docs/GITTENSORY_REVIEW_UNIFIED_COMMENT.md).
 //
 // Produces ONE in-place comment in the gittensory SHAPE (colored alert sidebar + readiness
 // signal table + collapsibles + re-run + earning footer) with reviewbot's deep review folded

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -632,7 +632,7 @@ function isConfiguredGateBlocker(code: string, policy: GateCheckPolicy): boolean
   if (code === "ai_consensus_defect") return gateMode(policy.aiReviewGateMode ?? "advisory") === "block";
   // A leaked-secret finding (`secret_leak`) ALWAYS hard-blocks: a committed credential must be removed and
   // rotated before merge, with no opt-in. This finding is produced ONLY by the flag-gated safety scan
-  // (REVIEWBOT_SAFETY); when the flag is off the finding never exists, so this branch is unreachable and the
+  // (GITTENSORY_REVIEW_SAFETY); when the flag is off the finding never exists, so this branch is unreachable and the
   // gate verdict is byte-identical to today.
   if (code === "secret_leak") return true;
   // Focus-manifest policy (#555): the three enforceable manifest findings block ONLY when the maintainer

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -19,6 +19,7 @@
 import { countByokAiEventsForRepoSince, recordAiUsageEvent, sumAiEstimatedNeuronsSince } from "../db/repositories";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { defangReviewInput, isSafetyEnabled } from "../review/safety";
+import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 
 /**
  * The best free Workers-AI model pair for review accuracy — two different families for independence,
@@ -68,7 +69,7 @@ export type GittensoryAiReviewInput = {
   /** Present only when the repo has BYOK on AND a key configured; drives the advisory write-up. */
   providerKey?: AiReviewProviderKey | null | undefined;
   /**
-   * Convergence (grounding, flag-gated by REVIEWBOT_GROUNDING). The caller builds this from the PR's
+   * Convergence (grounding, flag-gated by GITTENSORY_REVIEW_GROUNDING). The caller builds this from the PR's
    * finished CI status + the full content of the changed files (see `review/grounding-wire`). When ABSENT
    * (the default, flag-OFF), both the system and user prompts are byte-identical to today — no section is
    * appended. `systemSuffix` carries the grounding-discipline rules; `promptSection` carries the CI STATUS
@@ -76,7 +77,7 @@ export type GittensoryAiReviewInput = {
    */
   grounding?: { systemSuffix?: string | undefined; promptSection?: string | undefined } | null | undefined;
   /**
-   * Convergence (RAG retrieval, flag-gated by REVIEWBOT_RAG). The caller builds this by querying the
+   * Convergence (RAG retrieval, flag-gated by GITTENSORY_REVIEW_RAG). The caller builds this by querying the
    * codebase vector index for code/docs semantically related to the PR's changed files (see
    * `review/rag-wire`); it is the engine's pre-formatted "RELEVANT EXISTING CODE / DOCS" block, appended to
    * the USER prompt as additive reference context (callers, related modules, existing conventions) — exactly
@@ -213,18 +214,18 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
     input.diff.slice(0, 60000),
   ];
   // Convergence (grounding): append the FINISHED CI status + FULL file content when the caller supplied them
-  // (flag REVIEWBOT_GROUNDING on). Absent/empty (the default) → the prompt is byte-identical to today.
+  // (flag GITTENSORY_REVIEW_GROUNDING on). Absent/empty (the default) → the prompt is byte-identical to today.
   const groundingSection = input.grounding?.promptSection;
   if (groundingSection) lines.push("", groundingSection);
   // Convergence (RAG retrieval): append the retrieved RELEVANT EXISTING CODE / DOCS block when the caller
-  // supplied one (flag REVIEWBOT_RAG on AND an index exists). Absent/empty (the default) → byte-identical.
+  // supplied one (flag GITTENSORY_REVIEW_RAG on AND an index exists). Absent/empty (the default) → byte-identical.
   const ragSection = input.ragContext;
   if (ragSection) lines.push("", ragSection);
   return lines.join("\n");
 }
 
 /** The effective reviewer SYSTEM prompt. Appends the grounding-discipline suffix when the caller supplied one
- *  (flag REVIEWBOT_GROUNDING on); absent/empty (default) → the base prompt, byte-identical to today. */
+ *  (flag GITTENSORY_REVIEW_GROUNDING on); absent/empty (default) → the base prompt, byte-identical to today. */
 function buildSystemPrompt(input: GittensoryAiReviewInput): string {
   const suffix = input.grounding?.systemSuffix;
   return suffix ? `${REVIEW_SYSTEM_PROMPT}${suffix}` : REVIEW_SYSTEM_PROMPT;
@@ -382,7 +383,10 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   // prompt-injection payload never reaches the model verbatim. Flag-OFF (default) passes `input` through
   // unchanged → the prompt is byte-identical to today. Only the title/body/diff fed to buildUserPrompt are
   // affected; this NEVER changes the verdict (a redaction is data, not a finding).
-  const promptInput = isSafetyEnabled(env) ? { ...input, ...defangReviewInput(input) } : input;
+  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the defang activates for THIS PR's repo only when it
+  // is allowlisted AND the global safety flag is ON. Empty/unset allowlist → `input` passes through unchanged
+  // for every repo (the prompt is byte-identical to today) regardless of GITTENSORY_REVIEW_SAFETY.
+  const promptInput = isSafetyEnabled(env) && isConvergenceRepoAllowed(env, input.repoFullName) ? { ...input, ...defangReviewInput(input) } : input;
   const user = buildUserPrompt(promptInput);
   // Grounding-discipline SYSTEM suffix (convergence, flag-gated). When the caller supplied grounding, the
   // reviewers are told to verify claims against the attached CI/files; otherwise this is REVIEW_SYSTEM_PROMPT

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -1,4 +1,4 @@
-// Public OAuth draft-submission flow (REVIEWBOT_DRAFT), ported faithfully from reviewbot
+// Public OAuth draft-submission flow (GITTENSORY_REVIEW_DRAFT), ported faithfully from reviewbot
 // (src/core/draft.ts + the fork-PR / OAuth-exchange primitives from src/core/github.ts).
 //
 //   POST /v1/drafts                -> store draft + return a GitHub OAuth authorize URL
@@ -7,7 +7,7 @@
 //   queue submit-draft             -> fork the upstream repo with the user's token + open the content PR
 //
 // Single-tenant (gittensory is one worker): the per-project `slug`/`AgentConfig` partitioning from
-// reviewbot is collapsed into module constants + env vars. The flow is gated by REVIEWBOT_DRAFT; when
+// reviewbot is collapsed into module constants + env vars. The flow is gated by GITTENSORY_REVIEW_DRAFT; when
 // the flag is off the router never mounts these handlers (callers see 404).
 import { decryptDraftToken, encryptDraftToken, newDraftId, randomDraftToken, sha256Hex, timingSafeEqualHex } from "../utils/crypto";
 
@@ -37,7 +37,7 @@ const SUPPORTED_CATEGORIES = [
 // ---------------------------------------------------------------------------
 
 export function draftFlowEnabled(env: Env): boolean {
-  return /^(1|true|yes|on)$/i.test(String(env.REVIEWBOT_DRAFT ?? "").trim());
+  return /^(1|true|yes|on)$/i.test(String(env.GITTENSORY_REVIEW_DRAFT ?? "").trim());
 }
 
 function draftConfig(env: Env): { publicRepo: string; baseRef: string; categories: string[]; branchPrefix: string } {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,14 +133,14 @@ export type JobMessage =
       deliveryId: string;
     }
   | {
-      // Convergence (ops / observability, flag-gated by REVIEWBOT_OPS). Scan gittensory's review-outcome data
+      // Convergence (ops / observability, flag-gated by GITTENSORY_REVIEW_OPS). Scan gittensory's review-outcome data
       // (gate-block ledger + recommendation/slop calibration) and emit a structured `ops_anomaly` log on drift.
       // Enqueued hourly by the cron ONLY when the flag is ON (index.ts), so flag-OFF this job never exists.
       type: "ops-alerts";
       requestedBy: "schedule" | "api" | "test";
     }
   | {
-      // Convergence (self-improve / auto-tune, flag-gated by REVIEWBOT_SELFTUNE). Run the ported
+      // Convergence (self-improve / auto-tune, flag-gated by GITTENSORY_REVIEW_SELFTUNE). Run the ported
       // self-improvement loop over gittensory's review-outcome data — compute tuning recommendations,
       // SHADOW-SOAK any strictly-tightening one, and AUTO-PROMOTE it to live only after the soak window passes
       // the gate; every action is audited. TIGHTENING-ONLY. Enqueued hourly by the cron ONLY when the flag is
@@ -149,7 +149,7 @@ export type JobMessage =
       requestedBy: "schedule" | "api" | "test";
     }
   | {
-      // Public OAuth draft-submission flow (REVIEWBOT_DRAFT): fork the content repo with the
+      // Public OAuth draft-submission flow (GITTENSORY_REVIEW_DRAFT): fork the content repo with the
       // contributor's token + open the PR. Enqueued by the draft OAuth callback.
       type: "submit-draft";
       requestedBy: "api" | "test";

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -105,7 +105,7 @@ function base64Encode(bytes: Uint8Array): string {
 }
 
 // ─── Draft user-token encryption (AES-256-GCM, single-string envelope) ───────────────────────────
-// Ported from the reviewbot public draft-submission flow (REVIEWBOT_DRAFT). Distinct from
+// Ported from the reviewbot public draft-submission flow (GITTENSORY_REVIEW_DRAFT). Distinct from
 // encryptSecret/decryptSecret above: this packs salt+iv+ciphertext into ONE `.`-joined base64url
 // string so a single TEXT column (submission_user_tokens.encrypted_token) holds the full envelope,
 // and derives the AES key via HKDF (not PBKDF2). The user's short-lived GitHub OAuth token is the

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -72,6 +72,9 @@ export function createTestEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_WEBHOOK_SECRET: "test-webhook-secret",
     GITHUB_APP_PRIVATE_KEY: "test-private-key",
     ADMIN_GITHUB_LOGINS: "jsonbored",
+    // Per-repo review allowlist: default to the test repos so flag-ON wiring tests activate the
+    // gated review features. Override to "" to assert the dormant (no-repo) default.
+    GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory,acme/widgets",
     ...overrides,
   };
 }

--- a/test/unit/content-lane-flag.test.ts
+++ b/test/unit/content-lane-flag.test.ts
@@ -6,18 +6,18 @@ describe("isContentLaneEnabled", () => {
     expect(isContentLaneEnabled(undefined)).toBe(false);
     expect(isContentLaneEnabled(null)).toBe(false);
     expect(isContentLaneEnabled({})).toBe(false);
-    expect(isContentLaneEnabled({ REVIEWBOT_CONTENT_LANE: "" })).toBe(false);
+    expect(isContentLaneEnabled({ GITTENSORY_REVIEW_CONTENT_LANE: "" })).toBe(false);
   });
 
   it("is ON for recognized truthy values (case/whitespace insensitive)", () => {
     for (const v of ["1", "true", "on", "yes", "TRUE", " On ", "Yes"]) {
-      expect(isContentLaneEnabled({ REVIEWBOT_CONTENT_LANE: v })).toBe(true);
+      expect(isContentLaneEnabled({ GITTENSORY_REVIEW_CONTENT_LANE: v })).toBe(true);
     }
   });
 
   it("is OFF for non-truthy strings", () => {
     for (const v of ["0", "false", "off", "no", "enabled", "maybe"]) {
-      expect(isContentLaneEnabled({ REVIEWBOT_CONTENT_LANE: v })).toBe(false);
+      expect(isContentLaneEnabled({ GITTENSORY_REVIEW_CONTENT_LANE: v })).toBe(false);
     }
   });
 });

--- a/test/unit/cutover-gate.test.ts
+++ b/test/unit/cutover-gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isConvergenceRepoAllowed } from "../../src/review/cutover-gate";
+
+describe("isConvergenceRepoAllowed — per-repo review allowlist", () => {
+  it("empty / unset / whitespace-only allowlist → false for every repo (the dormant default)", () => {
+    expect(isConvergenceRepoAllowed({}, "JSONbored/gittensory")).toBe(false);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: undefined }, "JSONbored/gittensory")).toBe(false);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "" }, "JSONbored/gittensory")).toBe(false);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "   " }, "JSONbored/gittensory")).toBe(false);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: " , ,, " }, "JSONbored/gittensory")).toBe(false);
+  });
+
+  it("activates a listed repo (exact owner/repo match)", () => {
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" }, "JSONbored/gittensory")).toBe(true);
+  });
+
+  it("does NOT activate an unlisted repo", () => {
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" }, "JSONbored/awesome-claude")).toBe(false);
+  });
+
+  it("is case-insensitive (GitHub repo full-names are case-insensitive)", () => {
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "JSONbored/Gittensory" }, "jsonbored/gittensory")).toBe(true);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "jsonbored/gittensory" }, "JSONbored/GITTENSORY")).toBe(true);
+  });
+
+  it("handles a multi-repo list with surrounding whitespace + stray commas", () => {
+    const env = { GITTENSORY_REVIEW_REPOS: " JSONbored/gittensory , JSONbored/awesome-claude ,, " };
+    expect(isConvergenceRepoAllowed(env, "JSONbored/gittensory")).toBe(true);
+    expect(isConvergenceRepoAllowed(env, "JSONbored/awesome-claude")).toBe(true);
+    expect(isConvergenceRepoAllowed(env, "JSONbored/metagraphed")).toBe(false);
+  });
+
+  it("an empty / whitespace `repoFullName` never matches", () => {
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" }, "")).toBe(false);
+    expect(isConvergenceRepoAllowed({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" }, "   ")).toBe(false);
+  });
+
+  it("requires a FULL owner/repo match (a bare owner or partial does not match)", () => {
+    const env = { GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" };
+    expect(isConvergenceRepoAllowed(env, "JSONbored")).toBe(false);
+    expect(isConvergenceRepoAllowed(env, "gittensory")).toBe(false);
+    expect(isConvergenceRepoAllowed(env, "JSONbored/gittensory-ui")).toBe(false);
+  });
+});

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -8,7 +8,7 @@ const DRAFT_SECRET = "draft-token-encryption-secret-at-least-32b";
 
 function draftEnv(overrides: Partial<Env> = {}): Env {
   return createTestEnv({
-    REVIEWBOT_DRAFT: "true",
+    GITTENSORY_REVIEW_DRAFT: "true",
     GITHUB_OAUTH_CLIENT_ID: "Iv-test-client-id",
     GITHUB_OAUTH_CLIENT_SECRET: "test-oauth-client-secret",
     DRAFT_TOKEN_ENCRYPTION_SECRET: DRAFT_SECRET,
@@ -35,7 +35,7 @@ const SAMPLE_FIELDS = {
   privacy_notes: "No personal data collected.",
 };
 
-describe("draft flow — flag OFF (REVIEWBOT_DRAFT unset/false)", () => {
+describe("draft flow — flag OFF (GITTENSORY_REVIEW_DRAFT unset/false)", () => {
   it("POST /v1/drafts returns 404 when the flag is off", async () => {
     const app = createApp();
     const env = createTestEnv(); // flag unset
@@ -45,7 +45,7 @@ describe("draft flow — flag OFF (REVIEWBOT_DRAFT unset/false)", () => {
 
   it("GET /v1/drafts/:id returns 404 when the flag is off", async () => {
     const app = createApp();
-    const env = createTestEnv({ REVIEWBOT_DRAFT: "false" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_DRAFT: "false" });
     const res = await app.request("/v1/drafts/draft_does_not_exist", {}, env);
     expect(res.status).toBe(404);
   });
@@ -716,7 +716,7 @@ describe("buildContributorMdx — block-scalar branch + optional frontmatter", (
 describe("queue dispatch — submit-draft job", () => {
   it("processJob routes a submit-draft message to processSubmitDraft (flag-off → internal no-op, no fetch)", async () => {
     const { processJob } = await import("../../src/queue/processors");
-    const env = createTestEnv(); // REVIEWBOT_DRAFT unset → processSubmitDraft no-ops internally
+    const env = createTestEnv(); // GITTENSORY_REVIEW_DRAFT unset → processSubmitDraft no-ops internally
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     await processJob(env, { type: "submit-draft", requestedBy: "test", draftId: "draft_anything" });
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -1283,7 +1283,7 @@ describe("draftSecrets — `?? \"\"` nullish arms (env props genuinely undefined
     // createTestEnv never sets GITHUB_OAUTH_CLIENT_ID → property is genuinely undefined,
     // so `env.GITHUB_OAUTH_CLIENT_ID ?? ""` takes the nullish-coalescing fallback.
     const env = createTestEnv({
-      REVIEWBOT_DRAFT: "true",
+      GITTENSORY_REVIEW_DRAFT: "true",
       DRAFT_TOKEN_ENCRYPTION_SECRET: DRAFT_SECRET,
       // GITHUB_OAUTH_CLIENT_ID intentionally omitted (undefined)
     });
@@ -1294,7 +1294,7 @@ describe("draftSecrets — `?? \"\"` nullish arms (env props genuinely undefined
 
   it("returns 503 when DRAFT_TOKEN_ENCRYPTION_SECRET is undefined — encKey `?? \"\"` arm", async () => {
     const env = createTestEnv({
-      REVIEWBOT_DRAFT: "true",
+      GITTENSORY_REVIEW_DRAFT: "true",
       GITHUB_OAUTH_CLIENT_ID: "Iv-test-client-id",
       // DRAFT_TOKEN_ENCRYPTION_SECRET intentionally omitted (undefined)
     });
@@ -1313,7 +1313,7 @@ describe("draftSecrets — `?? \"\"` nullish arms (env props genuinely undefined
 
     // Re-point the SAME D1 instance into an env missing the client secret (undefined, not "").
     const env = createTestEnv({
-      REVIEWBOT_DRAFT: "true",
+      GITTENSORY_REVIEW_DRAFT: "true",
       GITHUB_OAUTH_CLIENT_ID: "Iv-test-client-id",
       DRAFT_TOKEN_ENCRYPTION_SECRET: DRAFT_SECRET,
       DB: fullEnv.DB,

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -36,7 +36,7 @@ function capturingAiEnv(grounding: boolean | undefined) {
     AI_SUMMARIES_ENABLED: "true",
     AI_PUBLIC_COMMENTS_ENABLED: "true",
     AI_DAILY_NEURON_BUDGET: "100000",
-    ...(grounding === undefined ? {} : { REVIEWBOT_GROUNDING: grounding ? "true" : "false" }),
+    ...(grounding === undefined ? {} : { GITTENSORY_REVIEW_GROUNDING: grounding ? "true" : "false" }),
   });
   return { env, seenUser, seenSystem, run };
 }
@@ -80,10 +80,10 @@ const prFile = (path: string, status = "modified"): PullRequestFileRecord => ({
 describe("isGroundingEnabled", () => {
   it("is OFF for unset/false and ON for the truthy convention", () => {
     expect(isGroundingEnabled({})).toBe(false);
-    expect(isGroundingEnabled({ REVIEWBOT_GROUNDING: "false" })).toBe(false);
-    expect(isGroundingEnabled({ REVIEWBOT_GROUNDING: "true" })).toBe(true);
-    expect(isGroundingEnabled({ REVIEWBOT_GROUNDING: "1" })).toBe(true);
-    expect(isGroundingEnabled({ REVIEWBOT_GROUNDING: "on" })).toBe(true);
+    expect(isGroundingEnabled({ GITTENSORY_REVIEW_GROUNDING: "false" })).toBe(false);
+    expect(isGroundingEnabled({ GITTENSORY_REVIEW_GROUNDING: "true" })).toBe(true);
+    expect(isGroundingEnabled({ GITTENSORY_REVIEW_GROUNDING: "1" })).toBe(true);
+    expect(isGroundingEnabled({ GITTENSORY_REVIEW_GROUNDING: "on" })).toBe(true);
   });
 });
 
@@ -122,7 +122,7 @@ describe("buildCheckAggregate maps gittensory check summaries → the grounding 
 
 // ── End-to-end: flag-gated prompt grounding through runGittensoryAiReview ─────────────────────────
 
-describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)", () => {
+describe("review-grounding wired into the AI reviewer (flag GITTENSORY_REVIEW_GROUNDING)", () => {
   it("FLAG-ON: the user prompt gains CI STATUS + FULL FILE CONTENT and the system prompt gains the grounding discipline", async () => {
     const { env, seenUser, seenSystem } = capturingAiEnv(true);
     // Stub the GitHub Contents API so the real FileFetcher returns deterministic file text.
@@ -159,7 +159,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
     // runs ON, including `(await getRepository(env, repo))?.installationId ?? null`.
     const run = vi.fn(async (_model: string, _opts: Record<string, unknown>) => ({ response: notesJson }));
     const env = createTestEnv({
-      REVIEWBOT_GROUNDING: "true",
+      GITTENSORY_REVIEW_GROUNDING: "true",
       AI: { run } as unknown as Ai,
       AI_SUMMARIES_ENABLED: "true",
       AI_PUBLIC_COMMENTS_ENABLED: "true",
@@ -200,7 +200,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
   it("FLAG-ON via runAiReviewForAdvisory: a repo with NO installationId grounds with installationId null (?? null)", async () => {
     const run = vi.fn(async () => ({ response: notesJson }));
     const env = createTestEnv({
-      REVIEWBOT_GROUNDING: "true",
+      GITTENSORY_REVIEW_GROUNDING: "true",
       AI: { run } as unknown as Ai,
       AI_SUMMARIES_ENABLED: "true",
       AI_PUBLIC_COMMENTS_ENABLED: "true",
@@ -249,7 +249,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
   });
 
   it("buildReviewGroundingText returns empty (no fetch) when the flag is OFF", async () => {
-    const env = createTestEnv({ REVIEWBOT_GROUNDING: "false" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_GROUNDING: "false" });
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const out = await buildReviewGroundingText(env, {
       repoFullName: "acme/widgets",
@@ -264,7 +264,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
   });
 
   it("FLAG-ON e2e: full-file content is fetched (capped/prioritized) and inlined into the prompt", async () => {
-    const env = createTestEnv({ REVIEWBOT_GROUNDING: "true", GITHUB_PUBLIC_TOKEN: "ghp_test" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_GROUNDING: "true", GITHUB_PUBLIC_TOKEN: "ghp_test" });
     // Stub the GitHub Contents API so the real FileFetcher returns deterministic file text.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       const u = String(url);
@@ -288,7 +288,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
   });
 
   it("FLAG-ON fail-safe: a throwing fetch degrades to no file section (never throws), CI still grounds", async () => {
-    const env = createTestEnv({ REVIEWBOT_GROUNDING: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_GROUNDING: "true" });
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
     const out = await buildReviewGroundingText(env, {
       repoFullName: "acme/widgets",
@@ -305,7 +305,7 @@ describe("review-grounding wired into the AI reviewer (flag REVIEWBOT_GROUNDING)
   });
 
   it("FLAG-ON: with no CI rows AND no readable files, grounding is empty (system suffix not attached)", async () => {
-    const env = createTestEnv({ REVIEWBOT_GROUNDING: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_GROUNDING: "true" });
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 404 }));
     const out = await buildReviewGroundingText(env, {
       repoFullName: "acme/widgets",
@@ -379,7 +379,7 @@ describe("buildCheckAggregate / buildReviewGroundingText edge branches", () => {
   });
 
   it("FLAG-ON outer fail-safe: a throw inside the build degrades to EMPTY_GROUNDING (never throws)", async () => {
-    const env = createTestEnv({ REVIEWBOT_GROUNDING: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_GROUNDING: "true" });
     // A file record whose path getter throws makes toGroundingFiles throw inside the try → outer catch.
     const poison = { get path(): string { throw new Error("boom"); } } as unknown as PullRequestFileRecord;
     const out = await buildReviewGroundingText(env, {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -143,11 +143,11 @@ describe("worker entrypoint", () => {
     ]);
   });
 
-  it("enqueues the ops-alerts job hourly ONLY when REVIEWBOT_OPS is ON (flag-OFF is byte-identical)", async () => {
+  it("enqueues the ops-alerts job hourly ONLY when GITTENSORY_REVIEW_OPS is ON (flag-OFF is byte-identical)", async () => {
     const sentFor = async (opsFlag?: string): Promise<Array<import("../../src/types").JobMessage>> => {
       const sent: Array<import("../../src/types").JobMessage> = [];
       const env = createTestEnv({
-        ...(opsFlag === undefined ? {} : { REVIEWBOT_OPS: opsFlag }),
+        ...(opsFlag === undefined ? {} : { GITTENSORY_REVIEW_OPS: opsFlag }),
         JOBS: {
           async send(message: import("../../src/types").JobMessage) {
             sent.push(message);
@@ -168,10 +168,10 @@ describe("worker entrypoint", () => {
     expect(on.filter((m) => m.type === "ops-alerts")).toEqual([{ type: "ops-alerts", requestedBy: "schedule" }]);
   });
 
-  it("does NOT enqueue ops-alerts outside the hourly window even when REVIEWBOT_OPS is ON", async () => {
+  it("does NOT enqueue ops-alerts outside the hourly window even when GITTENSORY_REVIEW_OPS is ON", async () => {
     const sent: Array<import("../../src/types").JobMessage> = [];
     const env = createTestEnv({
-      REVIEWBOT_OPS: "true",
+      GITTENSORY_REVIEW_OPS: "true",
       JOBS: {
         async send(message: import("../../src/types").JobMessage) {
           sent.push(message);

--- a/test/unit/ops-wire.test.ts
+++ b/test/unit/ops-wire.test.ts
@@ -44,8 +44,8 @@ const healthySnapshot: RepoOutcomeSnapshot = {
 
 describe("isOpsEnabled — default OFF, truthy convention", () => {
   it("is OFF for unset / false / empty, ON for 1/true/yes/on", () => {
-    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isOpsEnabled({ REVIEWBOT_OPS: off })).toBe(false);
-    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isOpsEnabled({ REVIEWBOT_OPS: on })).toBe(true);
+    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isOpsEnabled({ GITTENSORY_REVIEW_OPS: off })).toBe(false);
+    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isOpsEnabled({ GITTENSORY_REVIEW_OPS: on })).toBe(true);
   });
 });
 
@@ -239,12 +239,12 @@ describe("GET /v1/internal/ops/stats — bearer-gated, flag-gated endpoint", () 
 
   it("401s without the internal token (the /v1/internal/* middleware gate)", async () => {
     const app = createApp();
-    const env = createTestEnv({ REVIEWBOT_OPS: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_OPS: "true" });
     expect((await app.request("/v1/internal/ops/stats", {}, env)).status).toBe(401);
     expect((await app.request("/v1/internal/ops/stats", { headers: { authorization: "Bearer nope" } }, env)).status).toBe(401);
   });
 
-  it("404s when REVIEWBOT_OPS is OFF — the endpoint does not exist (byte-identical to today)", async () => {
+  it("404s when GITTENSORY_REVIEW_OPS is OFF — the endpoint does not exist (byte-identical to today)", async () => {
     const app = createApp();
     const env = createTestEnv(); // flag unset → OFF
     const res = await app.request("/v1/internal/ops/stats", { headers: bearer(env) }, env);
@@ -252,9 +252,9 @@ describe("GET /v1/internal/ops/stats — bearer-gated, flag-gated endpoint", () 
     expect(((await res.json()) as { error: string }).error).toBe("not_found");
   });
 
-  it("200s with the aggregate when REVIEWBOT_OPS is ON and authorized", async () => {
+  it("200s with the aggregate when GITTENSORY_REVIEW_OPS is ON and authorized", async () => {
     const app = createApp();
-    const env = createTestEnv({ REVIEWBOT_OPS: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_OPS: "true" });
     await seedRegisteredRepo(env, "owner/repo");
     await seedGateFalsePositiveAnomaly(env, "owner/repo");
     const res = await app.request("/v1/internal/ops/stats", { headers: bearer(env) }, env);

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -46,8 +46,8 @@ async function seedReviewbotDecision(env: Env, project: string, pr: number, head
 
 describe("isParityAuditEnabled — default OFF, truthy convention", () => {
   it("is OFF for unset / false / empty, ON for 1/true/yes/on", () => {
-    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isParityAuditEnabled({ REVIEWBOT_PARITY_AUDIT: off })).toBe(false);
-    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isParityAuditEnabled({ REVIEWBOT_PARITY_AUDIT: on })).toBe(true);
+    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isParityAuditEnabled({ GITTENSORY_REVIEW_PARITY_AUDIT: off })).toBe(false);
+    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isParityAuditEnabled({ GITTENSORY_REVIEW_PARITY_AUDIT: on })).toBe(true);
   });
 });
 
@@ -67,7 +67,7 @@ describe("nativeGateActionFromConclusion — gittensory gate conclusion → pari
 
 describe("recordNativeGateDecision — flag-gated SHADOW recording into review_audit (0049 round-trip)", () => {
   it("flag-ON records ONE gittensory-native gate_decision row (migration applies; round-trips via TestD1Database)", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "success", reasonCode: "all_clear" });
 
     const rows = await rawAll(env, "SELECT * FROM review_audit");
@@ -85,7 +85,7 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
   });
 
   it("a re-run at the SAME commit REPLACES the prior decision (latest finalize wins, no duplicate)", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "success", reasonCode: "all_clear" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "failure", reasonCode: "slop_risk" });
 
@@ -95,14 +95,14 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
   });
 
   it("a new commit gets its OWN row", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "sha1", conclusion: "success" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "sha2", conclusion: "failure" });
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(2);
   });
 
   it("does NOT record a non-comparable conclusion (neutral/skipped) or a decision with no head_sha", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 1, headSha: "sha", conclusion: "neutral" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 2, headSha: "sha", conclusion: "skipped" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 3, headSha: null, conclusion: "success" });
@@ -114,13 +114,13 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "success", reasonCode: "all_clear" });
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(0);
     // ...and explicitly false-valued flags are OFF too.
-    const envFalse = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "false" });
+    const envFalse = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "false" });
     await recordNativeGateDecision(envFalse, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "failure" });
     expect((await rawAll(envFalse, "SELECT * FROM review_audit")).length).toBe(0);
   });
 
   it("fails safe: a D1 write error is swallowed + logged (telemetry never breaks finalization)", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     // Poison the audit INSERT so .run() rejects → the catch logs parity_audit_record_error and resolves.
     const realPrepare = env.DB.prepare.bind(env.DB);
     env.DB.prepare = ((sql: string) => {
@@ -142,7 +142,7 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
 
 describe("computeParityReadiness — runs computeGateParity / isParityCutoverReady over review_audit", () => {
   it("with ONLY gittensory-native rows (no reviewbot dual-run) there are no PAIRS → empty, no signal", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     for (let i = 1; i <= 40; i += 1) {
       await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: i, headSha: `sha${i}`, conclusion: "success" });
     }
@@ -154,7 +154,7 @@ describe("computeParityReadiness — runs computeGateParity / isParityCutoverRea
   });
 
   it("PERFECT agreement over >= 30 paired commits → cutoverReady true, zero unsafe disagreements", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     const nowMs = Date.now();
     for (let i = 1; i <= 35; i += 1) {
       const sha = `sha${i}`;
@@ -176,7 +176,7 @@ describe("computeParityReadiness — runs computeGateParity / isParityCutoverRea
   });
 
   it("an UNSAFE disagreement (shadow merges where reviewbot holds) blocks cutover even at high agreement", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     const nowMs = Date.now();
     for (let i = 1; i <= 35; i += 1) {
       const sha = `sha${i}`;
@@ -198,12 +198,12 @@ describe("GET /v1/internal/parity — bearer-gated, flag-gated endpoint", () => 
 
   it("401s without the internal token (the /v1/internal/* middleware gate)", async () => {
     const app = createApp();
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     expect((await app.request("/v1/internal/parity", {}, env)).status).toBe(401);
     expect((await app.request("/v1/internal/parity", { headers: { authorization: "Bearer nope" } }, env)).status).toBe(401);
   });
 
-  it("404s when REVIEWBOT_PARITY_AUDIT is OFF — the endpoint does not exist (byte-identical to today)", async () => {
+  it("404s when GITTENSORY_REVIEW_PARITY_AUDIT is OFF — the endpoint does not exist (byte-identical to today)", async () => {
     const app = createApp();
     const env = createTestEnv(); // flag unset → OFF
     const res = await app.request("/v1/internal/parity", { headers: bearer(env) }, env);
@@ -213,7 +213,7 @@ describe("GET /v1/internal/parity — bearer-gated, flag-gated endpoint", () => 
 
   it("200s with the parity readiness report when ON and authorized", async () => {
     const app = createApp();
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     for (let i = 1; i <= 35; i += 1) {
       const sha = `sha${i}`;
       await seedReviewbotDecision(env, "owner/repo", i, sha, "merge", "slop_risk");
@@ -323,9 +323,9 @@ async function nativeRows(env: Env): Promise<Array<{ decision: string; summary: 
   return res.results;
 }
 
-describe("recordNativeGateDecision wired into the review FINALIZE path (REVIEWBOT_PARITY_AUDIT)", () => {
+describe("recordNativeGateDecision wired into the review FINALIZE path (GITTENSORY_REVIEW_PARITY_AUDIT)", () => {
   it("FLAG-ON, FAILING gate (confirmed author + linked-issue block): records a 'hold' native row whose reasonCode is the blocker code (failure ternary side)", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: parityMinerSnapshot("contributor") }, 60_000);
     stubFinalizeFetch("contributor");
@@ -342,7 +342,7 @@ describe("recordNativeGateDecision wired into the review FINALIZE path (REVIEWBO
   });
 
   it("FLAG-ON, NON-confirmed author → NEUTRAL gate: the call site still runs (non-failure reasonCode side) but a neutral conclusion is non-comparable → NO native row", async () => {
-    const env = createTestEnv({ REVIEWBOT_PARITY_AUDIT: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     stubFinalizeFetch(null); // miner list empty → author unconfirmed → gate cannot hard-block → neutral
     try {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2725,13 +2725,13 @@ describe("queue processors", () => {
     expect(skipped.results.map((event) => event.detail)).toEqual(expect.arrayContaining(["not_official_gittensor_miner", "missing_author"]));
   });
 
-  // #1007 convergence (Stage D): with UNIFIED_REVIEW_COMMENT on AND the gate evaluating, the public PR-panel
+  // #1007 convergence (Stage D): with GITTENSORY_REVIEW_UNIFIED_COMMENT on AND the gate evaluating, the public PR-panel
   // comment is rendered by the UNIFIED renderer (GitHub alert + synthesized "Code review" row) instead of the
   // legacy panel — while STILL leading with the same panel marker so the in-place upsert updates the same
   // comment. Mirrors the legacy panel-posting setup (confirmed miner + comment_and_label) but flips the flag
   // and enables the gate so `maybePublishPrPublicSurface` takes the flag-ON branch.
   it("renders the unified PR-review comment when the flag is on and the gate evaluates", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), UNIFIED_REVIEW_COMMENT: "1" });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_UNIFIED_COMMENT: "1" });
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -5234,7 +5234,7 @@ describe("queue processors", () => {
     expect(overridden ?? null).toBeNull();
   });
 
-  it("ops-alerts job no-ops when REVIEWBOT_OPS is OFF (does no anomaly scan)", async () => {
+  it("ops-alerts job no-ops when GITTENSORY_REVIEW_OPS is OFF (does no anomaly scan)", async () => {
     const env = createTestEnv(); // flag unset → OFF
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 1, 1)")
       .bind("owner/repo", "owner", "repo")
@@ -5250,8 +5250,8 @@ describe("queue processors", () => {
     warn.mockRestore();
   });
 
-  it("ops-alerts job runs the anomaly scan when REVIEWBOT_OPS is ON", async () => {
-    const env = createTestEnv({ REVIEWBOT_OPS: "true" });
+  it("ops-alerts job runs the anomaly scan when GITTENSORY_REVIEW_OPS is ON", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_OPS: "true" });
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 1, 1)")
       .bind("owner/repo", "owner", "repo")
       .run();

--- a/test/unit/rag-wiring.test.ts
+++ b/test/unit/rag-wiring.test.ts
@@ -73,11 +73,11 @@ const changedFiles = [{ path: "src/a.ts", patch: "@@\n+export const A = helper()
 describe("isRagEnabled", () => {
   it("is OFF for unset/false and ON for the truthy convention", () => {
     expect(isRagEnabled({})).toBe(false);
-    expect(isRagEnabled({ REVIEWBOT_RAG: "false" })).toBe(false);
-    expect(isRagEnabled({ REVIEWBOT_RAG: "true" })).toBe(true);
-    expect(isRagEnabled({ REVIEWBOT_RAG: "1" })).toBe(true);
-    expect(isRagEnabled({ REVIEWBOT_RAG: "on" })).toBe(true);
-    expect(isRagEnabled({ REVIEWBOT_RAG: "yes" })).toBe(true);
+    expect(isRagEnabled({ GITTENSORY_REVIEW_RAG: "false" })).toBe(false);
+    expect(isRagEnabled({ GITTENSORY_REVIEW_RAG: "true" })).toBe(true);
+    expect(isRagEnabled({ GITTENSORY_REVIEW_RAG: "1" })).toBe(true);
+    expect(isRagEnabled({ GITTENSORY_REVIEW_RAG: "on" })).toBe(true);
+    expect(isRagEnabled({ GITTENSORY_REVIEW_RAG: "yes" })).toBe(true);
   });
 });
 
@@ -178,7 +178,7 @@ function aiReviewEnv(over: Partial<Env> = {}) {
   });
 }
 
-describe("RAG wired into the AI reviewer (flag REVIEWBOT_RAG)", () => {
+describe("RAG wired into the AI reviewer (flag GITTENSORY_REVIEW_RAG)", () => {
   it("FLAG-ON: the user prompt gains the RELEVANT EXISTING CODE / DOCS section", async () => {
     // Retrieve the RAG block with a stubbed Vectorize/AI/DB (the retrieval seam is exercised here)…
     const retrievalEnv = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
@@ -203,7 +203,7 @@ describe("RAG wired into the AI reviewer (flag REVIEWBOT_RAG)", () => {
     // Drives the call site (processors.ts) so the `files.map(...)` that builds the RAG `files` arg runs —
     // including BOTH ternary sides of `typeof file.payload?.patch === "string" ? … : undefined`.
     const env = aiReviewEnv({
-      REVIEWBOT_RAG: "true",
+      GITTENSORY_REVIEW_RAG: "true",
       VECTORIZE: vectorizeStub() as unknown as Vectorize,
       AI: { run: capturingChatRun().run } as unknown as Ai,
     });
@@ -250,7 +250,7 @@ describe("RAG wired into the AI reviewer (flag REVIEWBOT_RAG)", () => {
     // Mirror the caller's flag gate: when isRagEnabled is false the call site never invokes
     // buildReviewRagContext, so no adapter is built and no query is issued.
     const vec = vectorizeStub();
-    const env = aiReviewEnv({ REVIEWBOT_RAG: "false", DB: ragDbStub(), VECTORIZE: vec as unknown as Vectorize, AI: aiStub() as unknown as Ai });
+    const env = aiReviewEnv({ GITTENSORY_REVIEW_RAG: "false", DB: ragDbStub(), VECTORIZE: vec as unknown as Vectorize, AI: aiStub() as unknown as Ai });
     const ragContext = isRagEnabled(env) ? await buildReviewRagContext(env, { repoFullName: "acme/rag-offgate", files: changedFiles }) : undefined;
     expect(ragContext).toBeUndefined();
     expect(vec.query).not.toHaveBeenCalled();

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -55,10 +55,10 @@ const baseArgs = { settings: { aiReviewMode: "advisory" } as RepositorySettings,
 describe("isReputationEnabled", () => {
   it("is OFF for unset/false and ON for the truthy convention", () => {
     expect(isReputationEnabled({})).toBe(false);
-    expect(isReputationEnabled({ REVIEWBOT_REPUTATION: "false" })).toBe(false);
-    expect(isReputationEnabled({ REVIEWBOT_REPUTATION: "true" })).toBe(true);
-    expect(isReputationEnabled({ REVIEWBOT_REPUTATION: "1" })).toBe(true);
-    expect(isReputationEnabled({ REVIEWBOT_REPUTATION: "on" })).toBe(true);
+    expect(isReputationEnabled({ GITTENSORY_REVIEW_REPUTATION: "false" })).toBe(false);
+    expect(isReputationEnabled({ GITTENSORY_REVIEW_REPUTATION: "true" })).toBe(true);
+    expect(isReputationEnabled({ GITTENSORY_REVIEW_REPUTATION: "1" })).toBe(true);
+    expect(isReputationEnabled({ GITTENSORY_REVIEW_REPUTATION: "on" })).toBe(true);
   });
 });
 
@@ -79,7 +79,7 @@ describe("shouldDowngradeToDeterministic (pure)", () => {
 
 describe("AI-spend gate: reputation downgrade", () => {
   it("FLAG-ON: a low-reputation / burst submitter is downgraded to deterministic-only (no AI spend)", async () => {
-    const { env, run } = aiEnv({ REVIEWBOT_REPUTATION: "true" });
+    const { env, run } = aiEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     await seedSubmitter(env, { project: "acme/widgets", submitter: "burster", submissions: 12, merged: 0, closed: 12, manual: 0 });
     const adv = advisory();
     const result = await runAiReviewForAdvisory(env, { ...baseArgs, advisory: adv });
@@ -90,7 +90,7 @@ describe("AI-spend gate: reputation downgrade", () => {
   });
 
   it("FLAG-ON: a good-reputation submitter proceeds to the normal AI review", async () => {
-    const { env, run } = aiEnv({ REVIEWBOT_REPUTATION: "true" });
+    const { env, run } = aiEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     await seedSubmitter(env, { project: "acme/widgets", submitter: "burster", submissions: 20, merged: 18, closed: 2, manual: 0 });
     const adv = advisory();
     const result = await runAiReviewForAdvisory(env, { ...baseArgs, advisory: adv });
@@ -100,7 +100,7 @@ describe("AI-spend gate: reputation downgrade", () => {
 
   it("FLAG-OFF (default): the AI-spend path is UNCHANGED even for a burst submitter — no reputation read", async () => {
     // Same burst seed as the flag-ON downgrade case, but the flag is OFF: the AI review runs exactly as today.
-    const off = aiEnv({ REVIEWBOT_REPUTATION: "false" });
+    const off = aiEnv({ GITTENSORY_REVIEW_REPUTATION: "false" });
     await seedSubmitter(off.env, { project: "acme/widgets", submitter: "burster", submissions: 12, merged: 0, closed: 12, manual: 0 });
     const offResult = await runAiReviewForAdvisory(off.env, { ...baseArgs, advisory: advisory() });
     expect(offResult?.notes).toContain("Add a test.");
@@ -117,12 +117,12 @@ describe("AI-spend gate: reputation downgrade", () => {
 
 describe("shouldSkipAiForReputation (helper)", () => {
   it("FLAG-OFF: returns false immediately without reading the DB (broken DB still yields false)", async () => {
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "false", DB: undefined as unknown as D1Database });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "false", DB: undefined as unknown as D1Database });
     expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "burster" })).toBe(false);
   });
 
   it("FLAG-ON: true for a seeded burst submitter, false for an unseen one", async () => {
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     await seedSubmitter(env, { project: "acme/widgets", submitter: "burster", submissions: 12, merged: 0, closed: 12, manual: 0 });
     expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "burster" })).toBe(true);
     expect(await shouldSkipAiForReputation(env, { project: "acme/widgets", submitter: "newcomer" })).toBe(false);
@@ -133,8 +133,8 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
   it("FLAG-ON: a closed+merged PR webhook records a 'merged' outcome for the submitter", async () => {
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
-    // UNIFIED_REVIEW_COMMENT on so the closing-PR comment path takes the unified-renderer branch.
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "true", UNIFIED_REVIEW_COMMENT: "true" });
+    // GITTENSORY_REVIEW_UNIFIED_COMMENT on so the closing-PR comment path takes the unified-renderer branch.
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "true", GITTENSORY_REVIEW_UNIFIED_COMMENT: "true" });
     // Gate enabled so the closing-PR public-surface path (skipped-gate + unified closed comment) executes.
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", gateCheckMode: "enabled" });
     // External calls (token/miner/github) are best-effort + caught; stub them so nothing throws.
@@ -176,7 +176,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
 
   it("FLAG-ON: a closed PR with no author login records against a null submitter (authorLogin ?? null)", async () => {
     const { processJob } = await import("../../src/queue/processors");
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -209,7 +209,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     // Flag unset → `isReputationEnabled(env) ? … : undefined` is undefined → the `if (reputationOutcome)`
     // body never runs → submitter_stats stays empty (byte-identical to today).
-    const env = createTestEnv(); // REVIEWBOT_REPUTATION unset → OFF
+    const env = createTestEnv(); // GITTENSORY_REVIEW_REPUTATION unset → OFF
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -239,7 +239,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
     const { processJob } = await import("../../src/queue/processors");
     const { upsertRepositorySettings } = await import("../../src/db/repositories");
     // Reputation ON, but the PR is still OPEN and the gate does not route it to manual → undefined outcome.
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     // Gate OFF for this repo so the open PR's gate is `undefined` (not failure/action_required) → no "manual".
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", gateCheckMode: "off", publicSurface: "off", commentMode: "off" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -272,7 +272,7 @@ describe("processGitHubWebhook records the reputation outcome on a terminal PR (
 
 describe("recordReputationOutcome + the 0046 submitter_stats migration", () => {
   it("FLAG-OFF (default): records NOTHING — the table stays empty", async () => {
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "false" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "false" });
     await recordReputationOutcome(env, { project: "acme/widgets", submitter: "alice", outcome: "closed" });
     // The migration applied (the table exists and is queryable) but nothing was written.
     const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM submitter_stats").first<{ n: number }>();
@@ -280,7 +280,7 @@ describe("recordReputationOutcome + the 0046 submitter_stats migration", () => {
   });
 
   it("FLAG-ON: records the outcome and a round-trip read reflects the counts (migration applied)", async () => {
-    const env = createTestEnv({ REVIEWBOT_REPUTATION: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPUTATION: "true" });
     await recordReputationOutcome(env, { project: "acme/widgets", submitter: "alice", outcome: "merged" });
     await recordReputationOutcome(env, { project: "acme/widgets", submitter: "alice", outcome: "closed" });
     const stats = await getSubmitterReputation(env, "acme/widgets", "alice");

--- a/test/unit/safety-wiring.test.ts
+++ b/test/unit/safety-wiring.test.ts
@@ -30,7 +30,7 @@ function capturingAiEnv(safety: boolean | undefined) {
     AI_SUMMARIES_ENABLED: "true",
     AI_PUBLIC_COMMENTS_ENABLED: "true",
     AI_DAILY_NEURON_BUDGET: "100000",
-    ...(safety === undefined ? {} : { REVIEWBOT_SAFETY: safety ? "true" : "false" }),
+    ...(safety === undefined ? {} : { GITTENSORY_REVIEW_SAFETY: safety ? "true" : "false" }),
   });
   return { env, seenPrompts, run };
 }
@@ -66,10 +66,10 @@ function advisory(findings: AdvisoryFinding[] = []): Advisory {
 describe("isSafetyEnabled", () => {
   it("is OFF for unset/false and ON for the truthy convention", () => {
     expect(isSafetyEnabled({})).toBe(false);
-    expect(isSafetyEnabled({ REVIEWBOT_SAFETY: "false" })).toBe(false);
-    expect(isSafetyEnabled({ REVIEWBOT_SAFETY: "true" })).toBe(true);
-    expect(isSafetyEnabled({ REVIEWBOT_SAFETY: "1" })).toBe(true);
-    expect(isSafetyEnabled({ REVIEWBOT_SAFETY: "on" })).toBe(true);
+    expect(isSafetyEnabled({ GITTENSORY_REVIEW_SAFETY: "false" })).toBe(false);
+    expect(isSafetyEnabled({ GITTENSORY_REVIEW_SAFETY: "true" })).toBe(true);
+    expect(isSafetyEnabled({ GITTENSORY_REVIEW_SAFETY: "1" })).toBe(true);
+    expect(isSafetyEnabled({ GITTENSORY_REVIEW_SAFETY: "on" })).toBe(true);
   });
 });
 
@@ -110,7 +110,7 @@ describe("defangReviewInput (helper)", () => {
 
 describe("secret-leak finding in the advisory build", () => {
   it("FLAG-ON: a leaked secret in the diff surfaces a critical secret_leak finding", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "true" });
     const adv = advisory();
     const files = [{ repoFullName: "acme/widgets", pullNumber: 7, path: "src/config.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: '@@\n+const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";' } }];
     await maybeAddSecretLeakFinding(env, { advisory: adv, repoFullName: "acme/widgets", pullNumber: 7, files });
@@ -121,7 +121,7 @@ describe("secret-leak finding in the advisory build", () => {
   });
 
   it("FLAG-OFF (default): no secret_leak finding is produced — the advisory is unchanged", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "false" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "false" });
     const adv = advisory();
     const files = [{ repoFullName: "acme/widgets", pullNumber: 7, path: "src/config.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: '@@\n+const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";' } }];
     await maybeAddSecretLeakFinding(env, { advisory: adv, repoFullName: "acme/widgets", pullNumber: 7, files });
@@ -129,7 +129,7 @@ describe("secret-leak finding in the advisory build", () => {
   });
 
   it("FLAG-ON + files=null: lazily loads the changed files from D1 and still finds the leaked secret", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "true" });
     // Seed a changed-file row so the lazy `listPullRequestFiles` load (args.files ?? …) returns a real diff.
     await env.DB.prepare(
       "INSERT INTO pull_request_files (repo_full_name, pull_number, path, status, additions, deletions, changes, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -142,7 +142,7 @@ describe("secret-leak finding in the advisory build", () => {
   });
 
   it("FLAG-ON + files=null with no changed files: lazy load yields a clean diff, no finding", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "true" });
     const adv = advisory();
     // No seeded rows → listPullRequestFiles returns [] → buildAiReviewDiff('') → secretLeakFinding null
     await maybeAddSecretLeakFinding(env, { advisory: adv, repoFullName: "acme/widgets", pullNumber: 999, files: null });

--- a/test/unit/safety.test.ts
+++ b/test/unit/safety.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
-// Drives the REVIEWBOT_SAFETY secrets-scan WIRING through the live review finalize path
+// Drives the GITTENSORY_REVIEW_SAFETY secrets-scan WIRING through the live review finalize path
 // (processGitHubWebhook → maybePublishPrPublicSurface → `await maybeAddSecretLeakFinding(...)` at the gate
 // build). The helper itself is unit-tested elsewhere; here we prove the flag-ON call site appends a critical
 // `secret_leak` blocker that FAILS the finalized gate end-to-end, and that flag-OFF is byte-identical.
@@ -113,9 +113,9 @@ function prWebhook(deliveryId: string) {
   };
 }
 
-describe("REVIEWBOT_SAFETY secrets-scan wired into the review FINALIZE path (processors.ts call site)", () => {
+describe("GITTENSORY_REVIEW_SAFETY secrets-scan wired into the review FINALIZE path (processors.ts call site)", () => {
   it("FLAG-ON: a leaked secret in the PR's changed files FAILS the finalized gate (secret_leak blocker appended before evaluateGateCheck)", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "true", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -130,7 +130,7 @@ describe("REVIEWBOT_SAFETY secrets-scan wired into the review FINALIZE path (pro
   });
 
   it("FLAG-OFF (default): the SAME leaked secret produces NO blocker — the finalized gate is byte-identical (not failed on the secret)", async () => {
-    const env = createTestEnv({ REVIEWBOT_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SAFETY: "false", GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};
@@ -145,7 +145,7 @@ describe("REVIEWBOT_SAFETY secrets-scan wired into the review FINALIZE path (pro
   });
 
   it("UNSET behaves identically to explicit-false (the flag-OFF branch is the default — no new branch taken)", async () => {
-    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // REVIEWBOT_SAFETY unset
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // GITTENSORY_REVIEW_SAFETY unset
     await seedGateEnabledRepo(env);
     await seedLeakedSecretFile(env);
     const seen: { conclusion?: string | undefined } = {};

--- a/test/unit/selftune-wiring.test.ts
+++ b/test/unit/selftune-wiring.test.ts
@@ -63,8 +63,8 @@ async function seedRecommendationOutcomes(env: Env, repoFullName: string, positi
 
 describe("isSelfTuneEnabled — default OFF, truthy convention", () => {
   it("is OFF for unset / false / empty, ON for 1/true/yes/on", () => {
-    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isSelfTuneEnabled({ REVIEWBOT_SELFTUNE: off })).toBe(false);
-    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isSelfTuneEnabled({ REVIEWBOT_SELFTUNE: on })).toBe(true);
+    for (const off of [undefined, "", "false", "no", "0", "off"]) expect(isSelfTuneEnabled({ GITTENSORY_REVIEW_SELFTUNE: off })).toBe(false);
+    for (const on of ["1", "true", "yes", "on", "TRUE", "On"]) expect(isSelfTuneEnabled({ GITTENSORY_REVIEW_SELFTUNE: on })).toBe(true);
   });
 });
 
@@ -140,7 +140,7 @@ const ACTING_AUTONOMY = JSON.stringify({ review: "auto" }); // opts the repo int
 
 describe("runSelfTune — shadow-soak over gittensory's own outcome data", () => {
   it("FLAG-ON: a low-precision repo gets a TIGHTENING override SHADOW-SOAKED (not live yet) + audited", async () => {
-    const env = createTestEnv({ REVIEWBOT_SELFTUNE: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
     await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
     // 5 positive / 10 negative = 33% precision over 15 decided → a clear tightening signal.
     await seedRecommendationOutcomes(env, "owner/repo", 5, 10);
@@ -155,7 +155,7 @@ describe("runSelfTune — shadow-soak over gittensory's own outcome data", () =>
   });
 
   it("FLAG-ON: promotes a SOAKED tightening shadow override to live on a later tick (tightening + evidence + soaked)", async () => {
-    const env = createTestEnv({ REVIEWBOT_SELFTUNE: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
     await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
     await seedRecommendationOutcomes(env, "owner/repo", 5, 10);
     // Pre-seed a shadow override whose soak deadline is already in the past → eligible to promote this tick.
@@ -174,7 +174,7 @@ describe("runSelfTune — shadow-soak over gittensory's own outcome data", () =>
   });
 
   it("a LOOSENING change is NEVER applied — only tightening auto-applies", async () => {
-    const env = createTestEnv({ REVIEWBOT_SELFTUNE: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
     await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
     await seedRecommendationOutcomes(env, "owner/repo", 5, 10);
     // Pre-seed a LIVE floor of 0.99 and a SOAKED shadow override of 0.80 (a DROP = loosening). Even though the
@@ -198,7 +198,7 @@ describe("runSelfTune — shadow-soak over gittensory's own outcome data", () =>
   });
 
   it("FLAG-OFF (default): runSelfTune does ZERO tuning work — no shadow, no override, no audit", async () => {
-    const env = createTestEnv({ REVIEWBOT_SELFTUNE: "false" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "false" });
     await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
     await seedRecommendationOutcomes(env, "owner/repo", 5, 10);
 
@@ -211,7 +211,7 @@ describe("runSelfTune — shadow-soak over gittensory's own outcome data", () =>
   });
 
   it("FLAG-ON via the processor: a stale in-flight selftune job runs the tick (defense-in-depth gate)", async () => {
-    const env = createTestEnv({ REVIEWBOT_SELFTUNE: "true" });
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
     await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
     await seedRecommendationOutcomes(env, "owner/repo", 5, 10);
 

--- a/test/unit/stats.test.ts
+++ b/test/unit/stats.test.ts
@@ -105,7 +105,7 @@ describe("handleStats — bearer-gated, CORS-open feed", () => {
     new Request("https://w.dev/stats/data?days=30&bucket=day", { method, headers });
 
   it("204s a CORS preflight with no auth", async () => {
-    const res = await handleStats(req({}, "OPTIONS"), stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }));
+    const res = await handleStats(req({}, "OPTIONS"), stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }));
     expect(res.status).toBe(204);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
@@ -116,13 +116,13 @@ describe("handleStats — bearer-gated, CORS-open feed", () => {
   });
 
   it("401s a missing/wrong token", async () => {
-    const env = stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" });
+    const env = stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" });
     expect((await handleStats(req(), env)).status).toBe(401);
     expect((await handleStats(req({ authorization: "Bearer nope" }), env)).status).toBe(401);
   });
 
   it("200s with JSON + CORS for the correct token", async () => {
-    const res = await handleStats(req({ authorization: "Bearer s3cret" }), stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }));
+    const res = await handleStats(req({ authorization: "Bearer s3cret" }), stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }));
     expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     const body = (await res.json()) as { projects: string[] };
@@ -177,20 +177,20 @@ describe("handleParity — bearer-gated, CORS-open cross-system parity feed", ()
     new Request("https://w.dev/gittensory/internal/parity?days=90&shadow=gittensory", { method, headers });
 
   it("204s a CORS preflight with no auth", async () => {
-    const res = await handleParity(req({}, "OPTIONS"), stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), "gittensory");
+    const res = await handleParity(req({}, "OPTIONS"), stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), "gittensory");
     expect(res.status).toBe(204);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
   it("401s when the token is unset or wrong", async () => {
     expect((await handleParity(req({ authorization: "Bearer anything" }), stubEnv(), "gittensory")).status).toBe(401); // unset
-    const env = stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" });
+    const env = stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" });
     expect((await handleParity(req(), env, "gittensory")).status).toBe(401); // no header
     expect((await handleParity(req({ authorization: "Bearer nope" }), env, "gittensory")).status).toBe(401); // wrong
   });
 
   it("200s with the parity report + per-row cutoverReady for the correct token", async () => {
-    const res = await handleParity(req({ authorization: "Bearer s3cret" }), stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), "gittensory", PARITY_DEPS);
+    const res = await handleParity(req({ authorization: "Bearer s3cret" }), stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), "gittensory", PARITY_DEPS);
     expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     const body = (await res.json()) as { authoritative: string; shadow: string; cutoverReady: Array<{ project: string; ready: boolean }> };
@@ -214,7 +214,7 @@ describe("handleParity — bearer-gated, CORS-open cross-system parity feed", ()
       method: "GET",
       headers: { authorization: "Bearer s3cret" },
     });
-    const res = await handleParity(r, stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), "gittensory", deps);
+    const res = await handleParity(r, stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), "gittensory", deps);
     expect(res.status).toBe(200);
     expect(seen).toEqual({ days: 14, authoritative: "reviewbot", shadow: "gittensory" });
   });
@@ -231,13 +231,13 @@ describe("handleParity — bearer-gated, CORS-open cross-system parity feed", ()
     };
     // No days / authoritative / shadow params → days defaults to 90, both spreads collapse to {}.
     const r = new Request("https://w.dev/gittensory/internal/parity", { method: "GET", headers: { authorization: "Bearer s3cret" } });
-    const res = await handleParity(r, stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), "gittensory", deps);
+    const res = await handleParity(r, stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), "gittensory", deps);
     expect(res.status).toBe(200);
     expect(seen).toEqual({ days: 90, hasAuthoritative: false, hasShadow: false });
   });
 
   it("uses the default deps (defaultStatsEvalDeps) when none are injected — empty parity, no cutoverReady rows", async () => {
-    const res = await handleParity(req({ authorization: "Bearer s3cret" }), stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), "gittensory");
+    const res = await handleParity(req({ authorization: "Bearer s3cret" }), stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), "gittensory");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { authoritative: string; cutoverReady: unknown[] };
     // default emptyParity uses the URL's shadow=gittensory and a default authoritative=reviewbot.
@@ -260,7 +260,7 @@ describe("handleStats — query-param default branches", () => {
     };
     // No days / bucket query params → days ?? 90, bucket ?? "day".
     const r = new Request("https://w.dev/stats/data", { method: "GET", headers: { authorization: "Bearer s3cret" } });
-    const res = await handleStats(r, stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }), deps);
+    const res = await handleStats(r, stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }), deps);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { window: { days: number; bucket: string } };
     expect(body.window.days).toBe(90);
@@ -351,7 +351,7 @@ describe("timingSafeEqual + readSecret — branches reached through the handlers
       // Correct token, equal lengths → the native path is taken and authorizes (200).
       const res = await handleStats(
         new Request("https://w.dev/stats/data?days=1&bucket=day", { method: "GET", headers: { authorization: "Bearer s3cret" } }),
-        stubEnv({ REVIEWBOT_STATS_TOKEN: "s3cret" }),
+        stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "s3cret" }),
       );
       expect(res.status).toBe(200);
       expect(native).toHaveBeenCalled();
@@ -370,7 +370,7 @@ describe("timingSafeEqual + readSecret — branches reached through the handlers
       // the loop XORs out-of-range indices via `?? 0`, and the compare fails → 401.
       const res = await handleStats(
         new Request("https://w.dev/stats/data", { method: "GET", headers: { authorization: "Bearer x" } }),
-        stubEnv({ REVIEWBOT_STATS_TOKEN: "averylongtokenvalue-far-longer-than-x" }),
+        stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: "averylongtokenvalue-far-longer-than-x" }),
       );
       expect(res.status).toBe(401);
     } finally {
@@ -380,8 +380,8 @@ describe("timingSafeEqual + readSecret — branches reached through the handlers
   });
 
   it("treats a non-string token secret as unset (readSecret's `: \"\"` branch → 401)", async () => {
-    // REVIEWBOT_STATS_TOKEN present but NOT a string → readSecret returns "" → !expected → 401.
-    const env = stubEnv({ REVIEWBOT_STATS_TOKEN: 12345 });
+    // GITTENSORY_REVIEW_STATS_TOKEN present but NOT a string → readSecret returns "" → !expected → 401.
+    const env = stubEnv({ GITTENSORY_REVIEW_STATS_TOKEN: 12345 });
     const res = await handleStats(
       new Request("https://w.dev/stats/data", { method: "GET", headers: { authorization: "Bearer 12345" } }),
       env,

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -429,15 +429,15 @@ describe("buildClosedUnifiedCommentBody (closed/skipped PR through the unified r
 describe("isUnifiedReviewCommentEnabled (flag-OFF selects the legacy path)", () => {
   it("is OFF (legacy buildPublicPrIntelligenceComment path) when the flag is unset or falsy", () => {
     expect(isUnifiedReviewCommentEnabled({})).toBe(false);
-    expect(isUnifiedReviewCommentEnabled({ UNIFIED_REVIEW_COMMENT: undefined })).toBe(false);
-    expect(isUnifiedReviewCommentEnabled({ UNIFIED_REVIEW_COMMENT: "false" })).toBe(false);
-    expect(isUnifiedReviewCommentEnabled({ UNIFIED_REVIEW_COMMENT: "0" })).toBe(false);
-    expect(isUnifiedReviewCommentEnabled({ UNIFIED_REVIEW_COMMENT: "" })).toBe(false);
+    expect(isUnifiedReviewCommentEnabled({ GITTENSORY_REVIEW_UNIFIED_COMMENT: undefined })).toBe(false);
+    expect(isUnifiedReviewCommentEnabled({ GITTENSORY_REVIEW_UNIFIED_COMMENT: "false" })).toBe(false);
+    expect(isUnifiedReviewCommentEnabled({ GITTENSORY_REVIEW_UNIFIED_COMMENT: "0" })).toBe(false);
+    expect(isUnifiedReviewCommentEnabled({ GITTENSORY_REVIEW_UNIFIED_COMMENT: "" })).toBe(false);
   });
 
   it("is ON only for an explicit truthy value", () => {
     for (const value of ["1", "true", "yes", "on", "TRUE", "On"]) {
-      expect(isUnifiedReviewCommentEnabled({ UNIFIED_REVIEW_COMMENT: value })).toBe(true);
+      expect(isUnifiedReviewCommentEnabled({ GITTENSORY_REVIEW_UNIFIED_COMMENT: value })).toBe(true);
     }
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,34 +48,34 @@
     "ADMIN_GITHUB_LOGINS": "JSONbored",
     // Convergence (Stage D): render the public PR comment via the unified-comment bridge. Default OFF —
     // flag-OFF keeps the legacy buildPublicPrIntelligenceComment panel byte-identical.
-    "UNIFIED_REVIEW_COMMENT": "false",
+    "GITTENSORY_REVIEW_UNIFIED_COMMENT": "false",
     // Convergence (safety): run the ported safety scan in the review path — defang untrusted PR
     // title/body/diff before the AI reviewer sees it, and surface a secret-leak blocker from the diff.
     // Default OFF — flag-OFF keeps the review path byte-identical.
-    "REVIEWBOT_SAFETY": "false",
+    "GITTENSORY_REVIEW_SAFETY": "false",
     // Convergence (grounding): ground the AI reviewer prompt with the PR's finished CI status + the full
     // post-change content of the changed files, so a non-frontier model verifies claims instead of guessing.
     // Default OFF — flag-OFF keeps the reviewer prompt byte-identical and makes no extra GitHub fetch.
-    "REVIEWBOT_GROUNDING": "false",
+    "GITTENSORY_REVIEW_GROUNDING": "false",
     // Convergence (reputation): factor the INTERNAL-only ported submitter-reputation signal into the AI-spend
     // gate — a new / burst / low-reputation submitter is downgraded to a deterministic-only review (AI neurons
     // skipped), and the per-(project, submitter) outcome is recorded after the gate decides. The reputation is
     // NEVER surfaced publicly. Default OFF — flag-OFF reads nothing, records nothing, and leaves the AI-spend
     // gate byte-identical.
-    "REVIEWBOT_REPUTATION": "false",
+    "GITTENSORY_REVIEW_REPUTATION": "false",
     // Convergence (ops / observability): drive two OPERATOR surfaces off gittensory's own review-outcome data
     // — (1) a cron-tick anomaly scan over the gate-block ledger + recommendation/slop calibration that emits a
     // structured `ops_anomaly` log on drift, and (2) a bearer-gated GET /v1/internal/ops/stats outcome
     // aggregate. Read-only observability; the auto-tune/config-mutation self-improve loop is NOT wired here.
     // Default OFF — flag-OFF the cron enqueues no ops job and the endpoint 404s, byte-identical to today.
-    "REVIEWBOT_OPS": "false",
+    "GITTENSORY_REVIEW_OPS": "false",
     // Convergence (RAG retrieval): at review time, query the codebase vector index for code/docs semantically
     // related to the PR's changed files and append a RELEVANT EXISTING CODE / DOCS section to the reviewer
     // prompt — additive reference context (callers, related modules, conventions), exactly like grounding.
     // Default OFF — flag-OFF performs no retrieval, uses no adapter, makes no vector query, and keeps the
     // reviewer prompt byte-identical. Even when ON it is inert until a repo's vector index is populated (the
     // index-population job + cron is a deploy-time follow-up; a cold/missing index degrades to no context).
-    "REVIEWBOT_RAG": "false",
+    "GITTENSORY_REVIEW_RAG": "false",
     // Convergence (self-improve / auto-tune): run the ported self-improvement loop on the cron tick over
     // gittensory's own review-outcome data — compute tuning recommendations, SHADOW-SOAK any strictly-
     // tightening one, and AUTO-PROMOTE it to live ONLY after the soak window passes the gate; every action is
@@ -83,17 +83,24 @@
     // flag-OFF the cron enqueues no selftune job, does zero tuning work, reads/writes no override, byte-
     // identical to today. Config-application (reading a promoted override into the live gate) is a deferred
     // follow-up — see src/review/selftune-wire.ts.
-    "REVIEWBOT_SELFTUNE": "false",
+    "GITTENSORY_REVIEW_SELFTUNE": "false",
     // Convergence (port): public OAuth draft-submission flow ported from reviewbot. Default OFF — every
     // /v1/drafts endpoint 404s and no draft behavior runs. Turning it on also needs the
     // DRAFT_TOKEN_ENCRYPTION_SECRET worker secret + GITHUB_OAUTH_CLIENT_SECRET to be set.
-    "REVIEWBOT_DRAFT": "false",
+    "GITTENSORY_REVIEW_DRAFT": "false",
     // Convergence prep (#preconv-parity): SHADOW-record each finalized gittensory-native gate decision
     // (source='gittensory-native') into the review_audit audit-source table (migration 0049), and serve the
     // pre-cutover parity readiness report at GET /v1/internal/parity. RECORD-ONLY — changes no review behavior.
     // Default OFF — flag-OFF records nothing (no D1 write, the review path is byte-identical) and the endpoint
     // 404s. The cross-system comparison vs reviewbot's authoritative rows is a deploy-time dual-run step.
-    "REVIEWBOT_PARITY_AUDIT": "false",
+    "GITTENSORY_REVIEW_PARITY_AUDIT": "false",
+    // Convergence (cutover): comma-separated allowlist of repo full-names ("owner/repo") that may run the
+    // PER-PR converged review features (safety, grounding, RAG, reputation, unified comment). A feature
+    // activates for a repo ONLY when its global flag above is ON AND the repo is listed here — so the cutover
+    // rolls forward one repo at a time (e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). Default "" →
+    // NO repos converged → the per-PR converged path stays dormant for every repo regardless of the global
+    // flags (byte-identical to today). The cron/endpoint flags (ops/selftune/parity/draft) stay global.
+    "GITTENSORY_REVIEW_REPOS": "",
   },
   "routes": [
     {


### PR DESCRIPTION
Adds a **per-repo activation gate** for gittensory's review features so they can be rolled out one repository at a time, and renames the review feature flags to a consistent `GITTENSORY_REVIEW_*` family.

## Per-repo activation
New `GITTENSORY_REVIEW_REPOS` env var — a comma-separated allowlist of `owner/repo` names. A repository's per-PR review features (safety scan, CI + full-file grounding, codebase RAG, submitter-reputation gate, the unified review comment) activate only when their global flag is on **and** the repo is in this allowlist. Empty/unset allowlist (the default) = no repos, so the features stay dormant even with the global flags on — making a per-repo rollout (and rollback) safe.

## Flag naming
All review feature flags now use one consistent `GITTENSORY_REVIEW_*` family — e.g. `GITTENSORY_REVIEW_SAFETY`, `GITTENSORY_REVIEW_GROUNDING`, `GITTENSORY_REVIEW_RAG`, `GITTENSORY_REVIEW_REPUTATION`, `GITTENSORY_REVIEW_UNIFIED_COMMENT`, `GITTENSORY_REVIEW_REPOS`.

Verified: typecheck clean, 3284 unit tests pass.
