### PR TITLE
Activate gittensory CI review on JSONbored/gittensory

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,21 +48,21 @@
     "ADMIN_GITHUB_LOGINS": "JSONbored",
     // Convergence (Stage D): render the public PR comment via the unified-comment bridge. Default OFF —
     // flag-OFF keeps the legacy buildPublicPrIntelligenceComment panel byte-identical.
-    "GITTENSORY_REVIEW_UNIFIED_COMMENT": "false",
+    "GITTENSORY_REVIEW_UNIFIED_COMMENT": "true",
     // Convergence (safety): run the ported safety scan in the review path — defang untrusted PR
     // title/body/diff before the AI reviewer sees it, and surface a secret-leak blocker from the diff.
     // Default OFF — flag-OFF keeps the review path byte-identical.
-    "GITTENSORY_REVIEW_SAFETY": "false",
+    "GITTENSORY_REVIEW_SAFETY": "true",
     // Convergence (grounding): ground the AI reviewer prompt with the PR's finished CI status + the full
     // post-change content of the changed files, so a non-frontier model verifies claims instead of guessing.
     // Default OFF — flag-OFF keeps the reviewer prompt byte-identical and makes no extra GitHub fetch.
-    "GITTENSORY_REVIEW_GROUNDING": "false",
+    "GITTENSORY_REVIEW_GROUNDING": "true",
     // Convergence (reputation): factor the INTERNAL-only ported submitter-reputation signal into the AI-spend
     // gate — a new / burst / low-reputation submitter is downgraded to a deterministic-only review (AI neurons
     // skipped), and the per-(project, submitter) outcome is recorded after the gate decides. The reputation is
     // NEVER surfaced publicly. Default OFF — flag-OFF reads nothing, records nothing, and leaves the AI-spend
     // gate byte-identical.
-    "GITTENSORY_REVIEW_REPUTATION": "false",
+    "GITTENSORY_REVIEW_REPUTATION": "true",
     // Convergence (ops / observability): drive two OPERATOR surfaces off gittensory's own review-outcome data
     // — (1) a cron-tick anomaly scan over the gate-block ledger + recommendation/slop calibration that emits a
     // structured `ops_anomaly` log on drift, and (2) a bearer-gated GET /v1/internal/ops/stats outcome
@@ -100,7 +100,7 @@
     // rolls forward one repo at a time (e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). Default "" →
     // NO repos converged → the per-PR converged path stays dormant for every repo regardless of the global
     // flags (byte-identical to today). The cron/endpoint flags (ops/selftune/parity/draft) stay global.
-    "GITTENSORY_REVIEW_REPOS": "",
+    "GITTENSORY_REVIEW_REPOS": "JSONbored/gittensory",
   },
   "routes": [
     {


### PR DESCRIPTION
Activates gittensory's CI review on `JSONbored/gittensory` only.

Turns on the per-PR review features — unified review comment, safety scan, CI + full-file grounding, and submitter-reputation gating — and sets `GITTENSORY_REVIEW_REPOS` to `JSONbored/gittensory`. The per-repo allowlist keeps every other repository dormant, so this is a single-repo rollout.

Config-only change (wrangler vars). RAG, self-tune, draft, and ops stay off for now.
