### PR TITLE
docs(CI): gittensory CI review — configuration, tuning, sample configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,99 @@
+# Gittensory — sample environment file
+#
+# Copy to `.dev.vars` (local) or set as worker vars/secrets (deployed). This file
+# lists every operator-facing GITTENSORY_REVIEW_* feature flag plus the names of
+# the secrets the worker reads. It contains NO real values — fill secrets in via
+# `wrangler secret put NAME`; never commit real secret values.
+#
+# Feature flags: every flag defaults OFF. "Truthy" = one of 1 / true / yes / on
+# (case-insensitive); unset, empty, or `false` is OFF. When a flag is OFF its
+# code path is fully inert — the review behaves as if the feature did not exist.
+#
+# See docs/review-configuration.md for the full reference (flags, per-repo
+# `.gittensory.yml` settings, and secret descriptions).
+
+# =============================================================================
+# 1. Review feature flags (GITTENSORY_REVIEW_*)
+# =============================================================================
+
+# --- Scope (per-repo cutover allowlist) -------------------------------------
+
+# Comma-separated owner/repo names allowed to run the per-PR review features
+# (SAFETY, GROUNDING, RAG, REPUTATION, UNIFIED_COMMENT). A per-PR feature runs on
+# a repo only if its own flag is ON *and* the repo is listed here. Empty = no
+# repos, so every per-PR feature stays dormant regardless of the flags below.
+# Case-insensitive, trimmed; stray commas ignored.
+# Example: GITTENSORY_REVIEW_REPOS="JSONbored/gittensory,JSONbored/awesome-claude"
+GITTENSORY_REVIEW_REPOS=
+
+# --- Per-PR capabilities (also require the repo in GITTENSORY_REVIEW_REPOS) ---
+
+# Safety scan: defangs untrusted PR title/body/diff (prompt-injection
+# neutralization) and scans the diff for leaked secrets (secret_leak blocker).
+GITTENSORY_REVIEW_SAFETY=false
+
+# Grounds the AI-reviewer prompt with the PR's finished CI status + the full
+# post-change content of the changed files, so claims are verified against reality.
+GITTENSORY_REVIEW_GROUNDING=false
+
+# Retrieval-augmented context: appends semantically related code/docs from the
+# codebase vector index to the reviewer prompt. Inert until a VECTORIZE index exists.
+GITTENSORY_REVIEW_RAG=false
+
+# Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep
+# submitters to a deterministic-only review. Never surfaced publicly.
+GITTENSORY_REVIEW_REPUTATION=false
+
+# Renders the public PR comment as one in-place unified comment instead of the
+# legacy multi-panel comment. OFF keeps the legacy comment byte-identical.
+GITTENSORY_REVIEW_UNIFIED_COMMENT=false
+
+# --- Global capabilities (NOT scoped by GITTENSORY_REVIEW_REPOS) -------------
+
+# Observability (read-only): cron anomaly scan over the gate-block ledger emits
+# ops_anomaly logs, plus a bearer-gated GET /v1/internal/ops/stats aggregate.
+GITTENSORY_REVIEW_OPS=false
+
+# Self-improvement / auto-tune loop: computes tuning recommendations, shadow-soaks
+# strictly-tightening ones, and auto-promotes only after the soak passes. Tightening-only.
+GITTENSORY_REVIEW_SELFTUNE=false
+
+# Parity readiness (shadow, record-only): shadow-records each finalized gate
+# decision and serves a readiness report at GET /v1/internal/parity. Changes no behavior.
+GITTENSORY_REVIEW_PARITY_AUDIT=false
+
+# Content-review lane: routes content repos (curated lists, registries) through the
+# dedicated content lane (dedup, source-evidence, scope, registry grounding).
+GITTENSORY_REVIEW_CONTENT_LANE=false
+
+# Public draft-submission flow: enables the /v1/drafts endpoints (contributor draft
+# -> GitHub OAuth -> fork PR). OFF every draft endpoint 404s. Needs draft secrets below.
+GITTENSORY_REVIEW_DRAFT=false
+
+# =============================================================================
+# 2. Secrets (names only — set with `wrangler secret put NAME`)
+# =============================================================================
+# Do NOT put real values here. Set each via `wrangler secret put NAME` (deployed)
+# or in `.dev.vars` (local, git-ignored). Listed by name so operators know what
+# the worker reads.
+
+# --- Core (required for the worker to run) -----------------------------------
+# GITHUB_WEBHOOK_SECRET=
+# GITHUB_APP_ID=
+# GITHUB_APP_PRIVATE_KEY=
+# GITHUB_APP_SLUG=
+# GITTENSOR_REGISTRY_URL=
+# GITTENSORY_API_TOKEN=
+# GITTENSORY_MCP_TOKEN=
+# INTERNAL_JOB_TOKEN=
+
+# --- Optional (capability-gated; degrade safely when absent) -----------------
+# GITHUB_OAUTH_CLIENT_ID=            # GitHub OAuth (dashboard sign-in, draft flow)
+# GITHUB_OAUTH_CLIENT_SECRET=        # GitHub OAuth; also required by the draft flow
+# GITHUB_PUBLIC_TOKEN=               # unauthenticated public-GitHub reads (.gittensory.yml fetch)
+# TOKEN_ENCRYPTION_SECRET=           # AES-256-GCM master secret for maintainer BYOK keys at rest
+# DRAFT_TOKEN_ENCRYPTION_SECRET=     # AES-256-GCM secret for the contributor OAuth token (draft flow)
+# GITTENSORY_REVIEW_STATS_TOKEN=     # bearer token guarding the stats data endpoint
+# GITTENSORY_DRIFT_ISSUE_TOKEN=      # token for auto-filing drift issues
+# GITTENSORY_CONTRIBUTOR_ISSUE_TOKEN=  # token for contributor-issue automation
+# PRODUCT_USAGE_HASH_SALT=           # salt for hashing product-usage identifiers

--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -1,0 +1,248 @@
+# ============================================================================
+# .gittensory.yml — per-repo configuration for gittensory CI & gittensory review
+# ============================================================================
+#
+# Drop this file at the root of any repo gittensory watches to tune how the
+# review engine scores, gates, and comments on its pull requests — as
+# config-as-code, versioned alongside the project it governs.
+#
+# WHERE IT LIVES (first match wins):
+#   .gittensory.yml  →  .github/gittensory.yml  →  .gittensory.json  →  .github/gittensory.json
+#
+# PRECEDENCE (most specific wins):
+#   this file  >  per-repo dashboard/API settings  >  built-in safe defaults
+#   The typed `gate:` block below is an alias for the gate fields and wins over
+#   the generic `settings:` block for those same fields.
+#
+# SAFE BY DEFAULT: with no file and no dashboard row, a repo falls back to a
+# quiet, non-blocking profile — gate off, AI review off, slop scoring off,
+# comments only to detected contributors, no check-run published. Everything
+# here is an explicit opt-in; every value shown is the documented default
+# unless a comment says otherwise. Delete any block to inherit the default.
+#
+# WHO CAN BE BLOCKED: gate modes choose *which* deterministic checks run, never
+# *who* gets blocked. A hard block is always confirmed-contributor-gated.
+#
+# NOTE: some capabilities (safety scanning, CI/full-file grounding, RAG,
+# reputation control, the unified comment) are switched on at the deployment
+# level by the operator's GITTENSORY_REVIEW_* feature flags AND a per-repo
+# cutover allowlist. This file tunes behavior; it does not enable those
+# deployment-wide capabilities.
+# ============================================================================
+
+
+# ----------------------------------------------------------------------------
+# 1. FOCUS / GUARDRAILS (focus manifest)
+# ----------------------------------------------------------------------------
+# Declares the repo's work areas and off-limits paths. These feed deterministic
+# findings (e.g. manifest_blocked_path, manifest_missing_tests) and — when
+# `gate.manifestPolicy: block` is set below — can become enforceable blockers.
+
+# Work areas the maintainer wants. PRs touching these are preferred/encouraged.
+# Glob list. Default: [] (no preference).
+wantedPaths:
+  - "src/**"
+
+# Paths off-limits to contributors. Touching one yields a manifest_blocked_path
+# finding (enforceable when `gate.manifestPolicy: block`).
+# Glob list. Default: [] (nothing blocked).
+blockedPaths:
+  - "vendor/**"
+  - ".github/workflows/**"
+
+# Labels the maintainer prefers on incoming PRs; a missing preferred label is
+# surfaced (never blocks). String list. Default: [].
+preferredLabels:
+  - bug
+  - enhancement
+
+# How strongly a linked issue is expected on a PR.
+# Values: required | preferred | optional. Default: optional.
+linkedIssuePolicy: optional
+
+# Test paths/areas expected to change alongside code. When code changes without
+# them, a manifest_missing_tests finding fires. String list. Default: [].
+testExpectations:
+  - "tests/**"
+
+# Whether opening discovery issues is encouraged for this repo.
+# Values: encouraged | neutral | discouraged. Default: neutral.
+issueDiscoveryPolicy: neutral
+
+# PRIVATE review context — never published to any public GitHub surface.
+# Use for triage hints the engine should know but contributors should not see.
+# String list. Default: [].
+maintainerNotes:
+  - "Private triage context only — never appears on a public comment."
+
+# Notes explicitly opted into public output. Each line is public-safe filtered;
+# unsafe lines are silently dropped. String list. Default: [].
+publicNotes:
+  - "Prefer backend changes that tie to safety or release readiness."
+
+
+# ----------------------------------------------------------------------------
+# 2. GATE POLICY (`gate:`) — refines the deterministic gate
+# ----------------------------------------------------------------------------
+# Most gate dimensions are tri-state modes:
+#   off      — the dimension is not evaluated.
+#   advisory — the finding is surfaced (comment/context) but never blocks.
+#   block    — the finding can become a hard `Gittensory Gate` blocker
+#              (always confirmed-contributor-gated).
+gate:
+  # Gate master switch. Turns the whole deterministic gate on; the per-dimension
+  # modes below only refine an already-enabled gate.
+  # Bool. Default: false (gate off).
+  enabled: true
+
+  # Policy pack.
+  #   gittensor      — confirmed-contributor-gated, registry-aware.
+  #   oss-anti-slop  — runs the deterministic rules against ANY author on ANY repo.
+  # Default: gittensor.
+  pack: gittensor
+
+  # Linked-issue gate. off | advisory | block. Default: advisory.
+  # (If the dashboard "Require linked issue" toggle is on but this is `off`,
+  #  it is auto-promoted to `block`.)
+  linkedIssue: advisory
+
+  # Duplicate-PR gate — detects duplicate/superseding PRs.
+  # off | advisory | block. Default: block.
+  duplicates: block
+
+  # Quality / merge-readiness score gate (the PR-quality score).
+  readiness:
+    # off | advisory | block. Default: advisory.
+    mode: advisory
+    # At/above this score the quality dimension passes.
+    # Number 0–100, or null for the engine default band. Default: null.
+    minScore: null
+
+  # Deterministic anti-slop signal. Opt-in.
+  slop:
+    # off | advisory | block. Default: off.
+    #   advisory — surfaces the slop score + warnings.
+    #   block    — also hard-blocks at/above minScore.
+    mode: off
+    # Slop-risk threshold at/above which `block` blocks.
+    # Number 0–100, or null. Default: null (engine uses 60, the "high" band).
+    minScore: null
+    # When true AND slop is not off, a free Workers-AI pass adds an
+    # advisory-only ai_slop_advisory finding. It never feeds the slop score or
+    # the gate. Bool. Default: false.
+    aiAdvisory: false
+
+  # Composite merge-readiness gate (no min score).
+  # off | advisory | block. Default: off.
+  mergeReadiness: off
+
+  # Manifest-policy gate. When `block`, this repo's declared policy from
+  # section 1 (blockedPaths, required linked issue, testExpectations) becomes
+  # an enforceable blocker. Independent of mergeReadiness.
+  # off | advisory | block. Default: off.
+  manifestPolicy: off
+
+  # First-time-contributor grace. When true, softens a would-be block to
+  # advisory for a genuine newcomer (0 merged PRs, < 3 closed-unmerged PRs).
+  # Repeat offenders and authors with merge history are gated normally.
+  # Bool. Default: false.
+  firstTimeContributorGrace: false
+
+  # AI maintainer review. Opt-in; the AI capabilities are switched on at the
+  # deployment level.
+  aiReview:
+    # off | advisory | block. Default: off.
+    #   advisory — posts AI review notes only.
+    #   block    — a dual-model high-confidence consensus defect may become a
+    #              blocker (confirmed-contributors only).
+    mode: off
+    # Use the maintainer's frontier model for the *advisory* write-up when a
+    # provider key is configured. The consensus blocker always uses the free
+    # Workers-AI pair, so BYOK never changes who can be blocked.
+    # Bool. Default: false.
+    byok: false
+    # BYOK provider. anthropic | openai | null. Default: null (use the stored
+    # key's own provider). Must match the stored key's provider or BYOK is
+    # skipped (Workers-AI fallback). The key itself lives only in the encrypted
+    # key store — never in this file.
+    provider: null
+    # Model override for the BYOK advisory write-up (e.g. claude-3-5-sonnet-latest).
+    # String or null. Default: null (the key record's model, else a conservative
+    # per-provider default).
+    model: null
+
+
+# ----------------------------------------------------------------------------
+# 3. GENERIC SETTINGS (`settings:`) — dashboard-equivalent overrides
+# ----------------------------------------------------------------------------
+# Everything a maintainer can toggle in the dashboard can be set here as code.
+# All values shown are the safe defaults; delete any line to inherit it.
+settings:
+  # Who receives the public PR comment.
+  # off | detected_contributors_only | all_prs. Default: detected_contributors_only.
+  commentMode: detected_contributors_only
+
+  # Public audience framing. oss_maintainer | gittensor_only. Default: oss_maintainer.
+  publicAudienceMode: oss_maintainer
+
+  # How much signal the public surface shows. minimal | standard. Default: standard.
+  publicSignalLevel: standard
+
+  # Publish a GitHub check-run. off | enabled. Default: off.
+  checkRunMode: off
+
+  # Check-run detail. minimal | standard | deep. Default: minimal.
+  checkRunDetailLevel: minimal
+
+  # Which public surfaces are used.
+  # off | comment_and_label | comment_only | label_only. Default: comment_and_label.
+  publicSurface: comment_and_label
+
+  # Apply the gittensor label automatically. Bool. Default: true.
+  autoLabelEnabled: true
+
+  # The label name to apply. String. Default: gittensor.
+  gittensorLabel: gittensor
+
+  # Create the label if it does not yet exist. Bool. Default: true.
+  createMissingLabel: true
+
+  # Also review PRs authored by maintainers (not just detected contributors).
+  # Bool. Default: false.
+  includeMaintainerAuthors: false
+
+  # Require a linked issue on every PR (dashboard equivalent of the toggle that
+  # can auto-promote gate.linkedIssue to block). Bool. Default: false.
+  requireLinkedIssue: false
+
+  # Backfill review of pre-existing open PRs when first installed.
+  # Bool. Default: true.
+  backfillEnabled: true
+
+  # Use private trust signals in scoring. Bool. Default: true.
+  privateTrustEnabled: true
+
+  # Render a README status badge for the repo. Bool. Default: false.
+  badgeEnabled: false
+
+  # Per-repo kill-switch: when true, the agent does nothing on this repo.
+  # Bool. Default: false.
+  agentPaused: false
+
+  # Dry-run / shadow mode: compute everything but take no public action.
+  # Bool. Default: false.
+  agentDryRun: false
+
+  # Autonomy dial — per-action-class level (observe … auto).
+  # Map. Default: {} (= observe everywhere, deny-by-default).
+  autonomy: {}
+
+  # Auto-maintain policy for merges the agent is allowed to perform.
+  # Defaults: mergeMethod = squash, requireApprovals = 1.
+  autoMaintain:
+    mergeMethod: squash
+    requireApprovals: 1
+
+  # Command authorization role policy. Map. Default: the built-in policy.
+  # Omit to inherit the safe built-in default.
+  # commandAuthorization: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@
 
 - Detect stale installs and API compatibility in doctor and status
 
+- Add gittensory review safety scan (prompt-injection defang + secret-leak detection)
+
+- Ground the AI reviewer with finished CI status and full changed-file content
+
+- Add codebase RAG context for related callers, modules, and conventions
+
+- Add submitter-reputation spend control (internal-only deterministic downgrade)
+
+- Render the public PR feedback as one unified review comment
+
+- Gate per-PR review capabilities behind per-repo activation (GITTENSORY_REVIEW_* flags)
+
 
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Gittensory keeps sensitive context private by default.
 
 See [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-security) for the full boundary.
 
+## Review Capabilities
+
+Gittensory CI and gittensory review score, gate, and comment on pull requests. The review algorithm is open-source; operators tune behavior through per-repo settings and the `GITTENSORY_REVIEW_*` feature flags, every one of which ships **OFF** and is opt-in per repo.
+
+- **Safety scan** — defangs untrusted PR title/body/diff (prompt-injection neutralization) before the AI reviewer reads them, and scans the diff for leaked secrets, surfacing a `secret_leak` blocker.
+- **CI + full-file grounding** — grounds the AI reviewer with the PR's finished CI status and the full post-change content of the changed files, so claims are verified against reality instead of predicted.
+- **Codebase RAG** — retrieval-augmented context that queries the codebase vector index for related callers, modules, and conventions and appends them to the reviewer prompt (additive only; inert until an index exists).
+- **Submitter-reputation gating** — an internal-only spend control that downgrades new / burst / low-reputation submitters to a deterministic-only review, never surfaced on any public comment, label, or check.
+- **Unified review comment** — renders the public PR feedback as one in-place comment instead of multiple panels.
+- **Per-repo activation** — capabilities roll forward (and back) one flag and one repo at a time via the `GITTENSORY_REVIEW_REPOS` allowlist.
+
+See [Review configuration](https://gittensory.aethereal.dev/docs/review-configuration) for the full flag, setting, and `.gittensory.yml` reference.
+
 ## Start Here
 
 | Audience                  | Start                                                                    | Useful next links                                                                                                                                                                                                 |

--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -27,6 +27,7 @@ export const docsNav: DocsGroup[] = [
   {
     title: "Core concepts",
     items: [
+      { to: "/docs/how-reviews-work", label: "How reviews work" },
       { to: "/docs/branch-analysis", label: "Branch analysis" },
       { to: "/docs/scoreability", label: "Scoreability" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
@@ -35,6 +36,7 @@ export const docsNav: DocsGroup[] = [
   {
     title: "Operating",
     items: [
+      { to: "/docs/tuning", label: "Tuning your reviews" },
       { to: "/docs/privacy-security", label: "Privacy & security" },
       { to: "/docs/troubleshooting", label: "Troubleshooting" },
     ],

--- a/apps/gittensory-ui/src/routeTree.gen.ts
+++ b/apps/gittensory-ui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as DocsIndexRouteImport } from './routes/docs.index'
 import { Route as AppIndexRouteImport } from './routes/app.index'
 import { Route as ApiIndexRouteImport } from './routes/api.index'
 import { Route as DocsUpstreamDriftRouteImport } from './routes/docs.upstream-drift'
+import { Route as DocsTuningRouteImport } from './routes/docs.tuning'
 import { Route as DocsTroubleshootingRouteImport } from './routes/docs.troubleshooting'
 import { Route as DocsScoreabilityRouteImport } from './routes/docs.scoreability'
 import { Route as DocsQuickstartRouteImport } from './routes/docs.quickstart'
@@ -33,6 +34,7 @@ import { Route as DocsMinerQuickstartRouteImport } from './routes/docs.miner-qui
 import { Route as DocsMcpClientsRouteImport } from './routes/docs.mcp-clients'
 import { Route as DocsMaintainerWorkflowRouteImport } from './routes/docs.maintainer-workflow'
 import { Route as DocsMaintainerInstallTrustRouteImport } from './routes/docs.maintainer-install-trust'
+import { Route as DocsHowReviewsWorkRouteImport } from './routes/docs.how-reviews-work'
 import { Route as DocsGithubAppRouteImport } from './routes/docs.github-app'
 import { Route as DocsBranchAnalysisRouteImport } from './routes/docs.branch-analysis'
 import { Route as DocsBetaOnboardingRouteImport } from './routes/docs.beta-onboarding'
@@ -121,6 +123,11 @@ const DocsUpstreamDriftRoute = DocsUpstreamDriftRouteImport.update({
   path: '/upstream-drift',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsTuningRoute = DocsTuningRouteImport.update({
+  id: '/tuning',
+  path: '/tuning',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsTroubleshootingRoute = DocsTroubleshootingRouteImport.update({
   id: '/troubleshooting',
   path: '/troubleshooting',
@@ -172,6 +179,11 @@ const DocsMaintainerInstallTrustRoute =
     path: '/maintainer-install-trust',
     getParentRoute: () => DocsRoute,
   } as any)
+const DocsHowReviewsWorkRoute = DocsHowReviewsWorkRouteImport.update({
+  id: '/how-reviews-work',
+  path: '/how-reviews-work',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsGithubAppRoute = DocsGithubAppRouteImport.update({
   id: '/github-app',
   path: '/github-app',
@@ -286,6 +298,7 @@ export interface FileRoutesByFullPath {
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/github-app': typeof DocsGithubAppRoute
+  '/docs/how-reviews-work': typeof DocsHowReviewsWorkRoute
   '/docs/maintainer-install-trust': typeof DocsMaintainerInstallTrustRoute
   '/docs/maintainer-workflow': typeof DocsMaintainerWorkflowRoute
   '/docs/mcp-clients': typeof DocsMcpClientsRoute
@@ -296,6 +309,7 @@ export interface FileRoutesByFullPath {
   '/docs/quickstart': typeof DocsQuickstartRoute
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
+  '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
   '/api/': typeof ApiIndexRoute
   '/app/': typeof AppIndexRoute
@@ -326,6 +340,7 @@ export interface FileRoutesByTo {
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/github-app': typeof DocsGithubAppRoute
+  '/docs/how-reviews-work': typeof DocsHowReviewsWorkRoute
   '/docs/maintainer-install-trust': typeof DocsMaintainerInstallTrustRoute
   '/docs/maintainer-workflow': typeof DocsMaintainerWorkflowRoute
   '/docs/mcp-clients': typeof DocsMcpClientsRoute
@@ -336,6 +351,7 @@ export interface FileRoutesByTo {
   '/docs/quickstart': typeof DocsQuickstartRoute
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
+  '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
   '/api': typeof ApiIndexRoute
   '/app': typeof AppIndexRoute
@@ -370,6 +386,7 @@ export interface FileRoutesById {
   '/docs/beta-onboarding': typeof DocsBetaOnboardingRoute
   '/docs/branch-analysis': typeof DocsBranchAnalysisRoute
   '/docs/github-app': typeof DocsGithubAppRoute
+  '/docs/how-reviews-work': typeof DocsHowReviewsWorkRoute
   '/docs/maintainer-install-trust': typeof DocsMaintainerInstallTrustRoute
   '/docs/maintainer-workflow': typeof DocsMaintainerWorkflowRoute
   '/docs/mcp-clients': typeof DocsMcpClientsRoute
@@ -380,6 +397,7 @@ export interface FileRoutesById {
   '/docs/quickstart': typeof DocsQuickstartRoute
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/troubleshooting': typeof DocsTroubleshootingRoute
+  '/docs/tuning': typeof DocsTuningRoute
   '/docs/upstream-drift': typeof DocsUpstreamDriftRoute
   '/api/': typeof ApiIndexRoute
   '/app/': typeof AppIndexRoute
@@ -415,6 +433,7 @@ export interface FileRouteTypes {
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/github-app'
+    | '/docs/how-reviews-work'
     | '/docs/maintainer-install-trust'
     | '/docs/maintainer-workflow'
     | '/docs/mcp-clients'
@@ -425,6 +444,7 @@ export interface FileRouteTypes {
     | '/docs/quickstart'
     | '/docs/scoreability'
     | '/docs/troubleshooting'
+    | '/docs/tuning'
     | '/docs/upstream-drift'
     | '/api/'
     | '/app/'
@@ -455,6 +475,7 @@ export interface FileRouteTypes {
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/github-app'
+    | '/docs/how-reviews-work'
     | '/docs/maintainer-install-trust'
     | '/docs/maintainer-workflow'
     | '/docs/mcp-clients'
@@ -465,6 +486,7 @@ export interface FileRouteTypes {
     | '/docs/quickstart'
     | '/docs/scoreability'
     | '/docs/troubleshooting'
+    | '/docs/tuning'
     | '/docs/upstream-drift'
     | '/api'
     | '/app'
@@ -498,6 +520,7 @@ export interface FileRouteTypes {
     | '/docs/beta-onboarding'
     | '/docs/branch-analysis'
     | '/docs/github-app'
+    | '/docs/how-reviews-work'
     | '/docs/maintainer-install-trust'
     | '/docs/maintainer-workflow'
     | '/docs/mcp-clients'
@@ -508,6 +531,7 @@ export interface FileRouteTypes {
     | '/docs/quickstart'
     | '/docs/scoreability'
     | '/docs/troubleshooting'
+    | '/docs/tuning'
     | '/docs/upstream-drift'
     | '/api/'
     | '/app/'
@@ -627,6 +651,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsUpstreamDriftRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/tuning': {
+      id: '/docs/tuning'
+      path: '/tuning'
+      fullPath: '/docs/tuning'
+      preLoaderRoute: typeof DocsTuningRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/troubleshooting': {
       id: '/docs/troubleshooting'
       path: '/troubleshooting'
@@ -695,6 +726,13 @@ declare module '@tanstack/react-router' {
       path: '/maintainer-install-trust'
       fullPath: '/docs/maintainer-install-trust'
       preLoaderRoute: typeof DocsMaintainerInstallTrustRouteImport
+      parentRoute: typeof DocsRoute
+    }
+    '/docs/how-reviews-work': {
+      id: '/docs/how-reviews-work'
+      path: '/how-reviews-work'
+      fullPath: '/docs/how-reviews-work'
+      preLoaderRoute: typeof DocsHowReviewsWorkRouteImport
       parentRoute: typeof DocsRoute
     }
     '/docs/github-app': {
@@ -870,6 +908,7 @@ interface DocsRouteChildren {
   DocsBetaOnboardingRoute: typeof DocsBetaOnboardingRoute
   DocsBranchAnalysisRoute: typeof DocsBranchAnalysisRoute
   DocsGithubAppRoute: typeof DocsGithubAppRoute
+  DocsHowReviewsWorkRoute: typeof DocsHowReviewsWorkRoute
   DocsMaintainerInstallTrustRoute: typeof DocsMaintainerInstallTrustRoute
   DocsMaintainerWorkflowRoute: typeof DocsMaintainerWorkflowRoute
   DocsMcpClientsRoute: typeof DocsMcpClientsRoute
@@ -880,6 +919,7 @@ interface DocsRouteChildren {
   DocsQuickstartRoute: typeof DocsQuickstartRoute
   DocsScoreabilityRoute: typeof DocsScoreabilityRoute
   DocsTroubleshootingRoute: typeof DocsTroubleshootingRoute
+  DocsTuningRoute: typeof DocsTuningRoute
   DocsUpstreamDriftRoute: typeof DocsUpstreamDriftRoute
   DocsIndexRoute: typeof DocsIndexRoute
 }
@@ -889,6 +929,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsBetaOnboardingRoute: DocsBetaOnboardingRoute,
   DocsBranchAnalysisRoute: DocsBranchAnalysisRoute,
   DocsGithubAppRoute: DocsGithubAppRoute,
+  DocsHowReviewsWorkRoute: DocsHowReviewsWorkRoute,
   DocsMaintainerInstallTrustRoute: DocsMaintainerInstallTrustRoute,
   DocsMaintainerWorkflowRoute: DocsMaintainerWorkflowRoute,
   DocsMcpClientsRoute: DocsMcpClientsRoute,
@@ -899,6 +940,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsQuickstartRoute: DocsQuickstartRoute,
   DocsScoreabilityRoute: DocsScoreabilityRoute,
   DocsTroubleshootingRoute: DocsTroubleshootingRoute,
+  DocsTuningRoute: DocsTuningRoute,
   DocsUpstreamDriftRoute: DocsUpstreamDriftRoute,
   DocsIndexRoute: DocsIndexRoute,
 }

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -36,10 +36,10 @@ function GithubApp() {
     >
       <p>
         Once installed, the <strong>gittensory app reviews every pull request</strong> on the repos
-        you select. Each review produces two surfaces: the <strong>Gittensory Gate</strong> check run
-        (and the advisory <strong>Gittensory Context</strong> check), and a single review comment
-        posted by <code>gittensory[bot]</code> that updates in place as the PR evolves. Everything on
-        this page configures that review.
+        you select. Each review produces two surfaces: the <strong>Gittensory Gate</strong> check
+        run (and the advisory <strong>Gittensory Context</strong> check), and a single review
+        comment posted by <code>gittensory[bot]</code> that updates in place as the PR evolves.
+        Everything on this page configures that review.
       </p>
 
       <h2>Install</h2>
@@ -107,17 +107,18 @@ GET /v1/installations/:id/repair`}
       <h2>PR panel</h2>
       <p>
         The PR panel is the review comment the gittensory app posts on each pull request. It is one
-        sticky comment authored by <code>gittensory[bot]</code> that updates in place — the app edits
-        the same comment instead of adding new ones. It shows a public-safe readiness score, concrete
-        signal evidence, and short actions for linked issues, related work, review load, validation
-        evidence, open PR queue, contributor context, and Gate result.
+        sticky comment authored by <code>gittensory[bot]</code> that updates in place — the app
+        edits the same comment instead of adding new ones. It shows a public-safe readiness score,
+        concrete signal evidence, and short actions for linked issues, related work, review load,
+        validation evidence, open PR queue, contributor context, and Gate result.
       </p>
       <p>
         By default the comment is posted only to detected contributors (<code>commentMode</code> is{" "}
-        <code>detected_contributors_only</code>). Set <code>commentMode</code> to <code>all_prs</code>{" "}
-        to comment on every PR, or <code>off</code> to suppress the comment entirely. Operators who
-        have rolled the deployment onto the unified review comment (see below) get the single in-place
-        comment shape; otherwise the legacy multi-panel comment is used unchanged.
+        <code>detected_contributors_only</code>). Set <code>commentMode</code> to{" "}
+        <code>all_prs</code> to comment on every PR, or <code>off</code> to suppress the comment
+        entirely. Operators who have rolled the deployment onto the unified review comment (see
+        below) get the single in-place comment shape; otherwise the legacy multi-panel comment is
+        used unchanged.
       </p>
 
       <h2>Checks</h2>
@@ -125,8 +126,8 @@ GET /v1/installations/:id/repair`}
         The gittensory app publishes its review as check runs. <strong>Gittensory Gate</strong> is
         the gate result; <strong>Gittensory Context</strong> is the advisory companion. Both are
         controlled per repo by <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>),
-        with <code>checkRunDetailLevel</code> choosing <code>minimal</code>, <code>standard</code>, or{" "}
-        <code>deep</code> output.
+        with <code>checkRunDetailLevel</code> choosing <code>minimal</code>, <code>standard</code>,
+        or <code>deep</code> output.
       </p>
       <p>
         <strong>Gittensory Context</strong> is advisory and should not be required in branch
@@ -228,8 +229,9 @@ review:
         always remain on the footer.
       </p>
       <p>
-        The per-repo settings above choose <em>what</em> Gittensory does on each PR. The next section
-        covers the deployment-wide capability switches that turn whole review features on or off.
+        The per-repo settings above choose <em>what</em> Gittensory does on each PR. The next
+        section covers the deployment-wide capability switches that turn whole review features on or
+        off.
       </p>
 
       <h2>
@@ -238,10 +240,10 @@ review:
       <p>
         Beyond per-repo settings, operators turn whole review <em>capabilities</em> on or off with
         the <code>GITTENSORY_REVIEW_*</code> worker environment variables. Every flag defaults to{" "}
-        <strong>OFF</strong>: when a flag is off its code path is inert and the review behaves exactly
-        as if the feature did not exist. "Truthy" is one of <code>1</code>, <code>true</code>,{" "}
-        <code>yes</code>, or <code>on</code>. You roll capabilities forward — and back — one flag, and
-        one repo, at a time.
+        <strong>OFF</strong>: when a flag is off its code path is inert and the review behaves
+        exactly as if the feature did not exist. "Truthy" is one of <code>1</code>,{" "}
+        <code>true</code>, <code>yes</code>, or <code>on</code>. You roll capabilities forward — and
+        back — one flag, and one repo, at a time.
       </p>
       <Callout variant="safety">
         Per-PR features require <strong>two</strong> conditions: the capability flag is on{" "}
@@ -280,9 +282,9 @@ review:
           the legacy comment byte-identical.
         </li>
         <li>
-          <code>GITTENSORY_REVIEW_OPS</code> — read-only observability: a cron anomaly scan over your
-          own review-outcome data plus a bearer-gated stats aggregate. Global (not scoped by the repo
-          allowlist).
+          <code>GITTENSORY_REVIEW_OPS</code> — read-only observability: a cron anomaly scan over
+          your own review-outcome data plus a bearer-gated stats aggregate. Global (not scoped by
+          the repo allowlist).
         </li>
         <li>
           <code>GITTENSORY_REVIEW_SELFTUNE</code> — self-improvement loop that computes tuning
@@ -299,10 +301,10 @@ review:
         </li>
       </ul>
       <p>
-        A safe rollout for a per-PR feature is two flips: set the capability flag truthy, then add the
-        repo to <code>GITTENSORY_REVIEW_REPOS</code>. Because both must hold, a capability can stay
-        globally enabled while remaining dormant everywhere except the repos you have explicitly
-        added.
+        A safe rollout for a per-PR feature is two flips: set the capability flag truthy, then add
+        the repo to <code>GITTENSORY_REVIEW_REPOS</code>. Because both must hold, a capability can
+        stay globally enabled while remaining dormant everywhere except the repos you have
+        explicitly added.
       </p>
       <CodeBlock
         lang="bash"

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -12,13 +12,13 @@ export const Route = createFileRoute("/docs/github-app")({
       {
         name: "description",
         content:
-          "Install the Gittensory GitHub App, choose repos, and configure sticky PR panels, advisory checks, and optional Gate enforcement.",
+          "Install the Gittensory GitHub App so the gittensory app reviews your pull requests — the Gittensory Gate check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional Gate enforcement.",
       },
       { property: "og:title", content: "GitHub App setup — Gittensory docs" },
       {
         property: "og:description",
         content:
-          "Install the Gittensory GitHub App, choose repos, and configure sticky PR panels, advisory checks, and optional Gate enforcement.",
+          "Install the Gittensory GitHub App so the gittensory app reviews your pull requests — the Gittensory Gate check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional Gate enforcement.",
       },
       { property: "og:url", content: "/docs/github-app" },
     ],
@@ -32,8 +32,16 @@ function GithubApp() {
     <DocsPage
       eyebrow="Workflows"
       title="GitHub App setup"
-      description="Install Gittensory on a repo, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
+      description="Install Gittensory on a repo so the gittensory app reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
     >
+      <p>
+        Once installed, the <strong>gittensory app reviews every pull request</strong> on the repos
+        you select. Each review produces two surfaces: the <strong>Gittensory Gate</strong> check run
+        (and the advisory <strong>Gittensory Context</strong> check), and a single review comment
+        posted by <code>gittensory[bot]</code> that updates in place as the PR evolves. Everything on
+        this page configures that review.
+      </p>
+
       <h2>Install</h2>
       <p>
         The hosted deployment uses the GitHub App slug <code>gittensory</code>. Start from{" "}
@@ -98,12 +106,28 @@ GET /v1/installations/:id/repair`}
 
       <h2>PR panel</h2>
       <p>
-        The PR panel is one sticky bot comment that updates in place. It shows a public-safe
-        readiness score, concrete signal evidence, and short actions for linked issues, related
-        work, review load, validation evidence, open PR queue, contributor context, and Gate result.
+        The PR panel is the review comment the gittensory app posts on each pull request. It is one
+        sticky comment authored by <code>gittensory[bot]</code> that updates in place — the app edits
+        the same comment instead of adding new ones. It shows a public-safe readiness score, concrete
+        signal evidence, and short actions for linked issues, related work, review load, validation
+        evidence, open PR queue, contributor context, and Gate result.
+      </p>
+      <p>
+        By default the comment is posted only to detected contributors (<code>commentMode</code> is{" "}
+        <code>detected_contributors_only</code>). Set <code>commentMode</code> to <code>all_prs</code>{" "}
+        to comment on every PR, or <code>off</code> to suppress the comment entirely. Operators who
+        have rolled the deployment onto the unified review comment (see below) get the single in-place
+        comment shape; otherwise the legacy multi-panel comment is used unchanged.
       </p>
 
       <h2>Checks</h2>
+      <p>
+        The gittensory app publishes its review as check runs. <strong>Gittensory Gate</strong> is
+        the gate result; <strong>Gittensory Context</strong> is the advisory companion. Both are
+        controlled per repo by <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>),
+        with <code>checkRunDetailLevel</code> choosing <code>minimal</code>, <code>standard</code>, or{" "}
+        <code>deep</code> output.
+      </p>
       <p>
         <strong>Gittensory Context</strong> is advisory and should not be required in branch
         protection. <strong>Gittensory Gate</strong> is opt-in and can be made required after a repo
@@ -118,10 +142,52 @@ GET /v1/installations/:id/repair`}
 
       <h2>Gate modes</h2>
       <p>
-        Each Gate rule supports <code>off</code>, <code>advisory</code>, or <code>block</code>.
-        Linked issue, duplicate PR, and quality-score checks default to <code>advisory</code>. The
-        quality rule only blocks when <code>qualityGateMode</code> is <code>block</code> and a
-        <code>qualityGateMinScore</code> threshold is configured.
+        The deterministic gate is the heart of the gittensory review. Its master switch is{" "}
+        <code>gateCheckMode</code> (<code>off</code> / <code>enabled</code>); each dimension then
+        refines an already-enabled gate with a tri-state mode — <code>off</code> (not evaluated),{" "}
+        <code>advisory</code> (surfaced, never blocks), or <code>block</code> (can become a hard{" "}
+        <strong>Gittensory Gate</strong> blocker). Blocking is always confirmed-contributor-gated:
+        the mode chooses which deterministic checks are active, never <em>who</em> can be blocked.
+      </p>
+      <ul>
+        <li>
+          <code>linkedIssueGateMode</code> — linked-issue check. Default <code>advisory</code>.
+        </li>
+        <li>
+          <code>duplicatePrGateMode</code> — duplicate / superseding PR detection. Default{" "}
+          <code>block</code>.
+        </li>
+        <li>
+          <code>qualityGateMode</code> + <code>qualityGateMinScore</code> — the PR-quality score
+          gate. Default <code>advisory</code>; only blocks when set to <code>block</code> with a
+          configured min score.
+        </li>
+        <li>
+          <code>slopGateMode</code> + <code>slopGateMinScore</code> — the deterministic anti-slop
+          signal. Default <code>off</code>; <code>advisory</code> surfaces the slop score and
+          warnings, <code>block</code> also hard-blocks at or above the min score (engine default
+          band <code>60</code>).
+        </li>
+        <li>
+          <code>mergeReadinessGateMode</code> — composite merge-readiness gate. Default{" "}
+          <code>off</code>.
+        </li>
+        <li>
+          <code>manifestPolicyGateMode</code> — makes the repo manifest's declared policy (blocked
+          paths, required linked issue, test expectations) enforceable. Default <code>off</code>.
+        </li>
+        <li>
+          <code>aiReviewMode</code> — AI review. Default <code>off</code>; <code>advisory</code>{" "}
+          posts AI review notes only, <code>block</code> lets a dual-model high-confidence consensus
+          defect become a blocker (confirmed contributors only).
+        </li>
+      </ul>
+      <p>
+        The policy pack (<code>gatePack</code>) selects which rule set runs: <code>gittensor</code>{" "}
+        (confirmed-contributor-gated, registry-aware) or <code>oss-anti-slop</code> (the
+        deterministic rules against any author on any repo). Enable{" "}
+        <code>firstTimeContributorGrace</code> to soften a would-be block to advisory for a genuine
+        newcomer.
       </p>
 
       <h2>
@@ -161,6 +227,90 @@ review:
         (reward, score, wallet, hotkey, payout, etc.); the Gittensor attribution and register link
         always remain on the footer.
       </p>
+      <p>
+        The per-repo settings above choose <em>what</em> Gittensory does on each PR. The next section
+        covers the deployment-wide capability switches that turn whole review features on or off.
+      </p>
+
+      <h2>
+        Review capability flags (<code>GITTENSORY_REVIEW_*</code>)
+      </h2>
+      <p>
+        Beyond per-repo settings, operators turn whole review <em>capabilities</em> on or off with
+        the <code>GITTENSORY_REVIEW_*</code> worker environment variables. Every flag defaults to{" "}
+        <strong>OFF</strong>: when a flag is off its code path is inert and the review behaves exactly
+        as if the feature did not exist. "Truthy" is one of <code>1</code>, <code>true</code>,{" "}
+        <code>yes</code>, or <code>on</code>. You roll capabilities forward — and back — one flag, and
+        one repo, at a time.
+      </p>
+      <Callout variant="safety">
+        Per-PR features require <strong>two</strong> conditions: the capability flag is on{" "}
+        <em>and</em> the repo is listed in <code>GITTENSORY_REVIEW_REPOS</code>. With an empty repo
+        allowlist every per-PR feature stays dormant for everyone, no matter the global flags.
+      </Callout>
+      <ul>
+        <li>
+          <code>GITTENSORY_REVIEW_REPOS</code> — per-repo cutover allowlist. Comma-separated{" "}
+          <code>owner/repo</code> names that may run the per-PR features. Add repos one at a time to
+          roll forward; remove to roll back.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_SAFETY</code> — safety scan: defangs untrusted PR title/body/diff
+          (prompt-injection neutralization) before the reviewer sees it, and surfaces a{" "}
+          <code>secret_leak</code> blocker for leaked secrets in the diff. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_GROUNDING</code> — grounds the AI reviewer with the PR's finished
+          CI status and the full post-change content of the changed files, so the model verifies its
+          claims against reality. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_RAG</code> — retrieval-augmented context: appends semantically
+          related code/docs from the codebase vector index to the reviewer prompt. Per-PR; inert
+          until a <code>VECTORIZE</code> index exists for the repo.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_REPUTATION</code> — submitter-reputation spend control: downgrades
+          a new / burst / low-reputation submitter to a deterministic-only review. Internal-only,
+          never surfaced publicly. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_UNIFIED_COMMENT</code> — renders the public PR comment as one
+          in-place unified comment instead of the legacy multi-panel comment. Per-PR; flag-off keeps
+          the legacy comment byte-identical.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_OPS</code> — read-only observability: a cron anomaly scan over your
+          own review-outcome data plus a bearer-gated stats aggregate. Global (not scoped by the repo
+          allowlist).
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_SELFTUNE</code> — self-improvement loop that computes tuning
+          recommendations from review outcomes, shadow-soaks any strictly-tightening recommendation,
+          and can <em>only ever tighten</em> the gate. Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_CONTENT_LANE</code> — routes content repos (curated lists,
+          registries) through the dedicated content lane instead of the code gate. Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_DRAFT</code> — public draft-submission flow (contributor draft →
+          GitHub OAuth → fork PR). Global; also needs the draft secrets set.
+        </li>
+      </ul>
+      <p>
+        A safe rollout for a per-PR feature is two flips: set the capability flag truthy, then add the
+        repo to <code>GITTENSORY_REVIEW_REPOS</code>. Because both must hold, a capability can stay
+        globally enabled while remaining dormant everywhere except the repos you have explicitly
+        added.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`# Roll grounding + the unified comment onto one repo:
+GITTENSORY_REVIEW_GROUNDING="true"
+GITTENSORY_REVIEW_UNIFIED_COMMENT="true"
+GITTENSORY_REVIEW_REPOS="JSONbored/gittensory"`}
+      />
 
       <h2>Dogfood mode</h2>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
@@ -39,13 +39,13 @@ function HowReviewsWork() {
       </p>
       <ol>
         <li>
-          <strong>The gate</strong> — a deterministic pass that never asks an AI. It runs a fixed set
-          of rules (duplicates, linked issues, merge-readiness, anti-slop, manifest policy) and each
-          rule is <code>off</code>, <code>advisory</code>, or <code>block</code>.
+          <strong>The gate</strong> — a deterministic pass that never asks an AI. It runs a fixed
+          set of rules (duplicates, linked issues, merge-readiness, anti-slop, manifest policy) and
+          each rule is <code>off</code>, <code>advisory</code>, or <code>block</code>.
         </li>
         <li>
-          <strong>The AI review</strong> — a dual-model read of the diff that writes review notes and,
-          when you opt in, lets a high-confidence <em>consensus</em> become a blocker.
+          <strong>The AI review</strong> — a dual-model read of the diff that writes review notes
+          and, when you opt in, lets a high-confidence <em>consensus</em> become a blocker.
         </li>
       </ol>
       <p>
@@ -63,8 +63,8 @@ function HowReviewsWork() {
       <h2>1. The gate: advisory vs. block</h2>
       <p>
         The gate is deterministic — same inputs, same verdict, no model in the loop. Its master
-        switch is <code>gateCheckMode</code> (<code>off</code> / <code>enabled</code>). Once enabled,
-        each <em>dimension</em> is independently set to one of three modes:
+        switch is <code>gateCheckMode</code> (<code>off</code> / <code>enabled</code>). Once
+        enabled, each <em>dimension</em> is independently set to one of three modes:
       </p>
       <ul>
         <li>
@@ -80,8 +80,8 @@ function HowReviewsWork() {
         </li>
       </ul>
       <p>
-        A <code>block</code> outcome is always <strong>confirmed-contributor-gated</strong>: the mode
-        chooses <em>which</em> checks are active, never <em>who</em> can be blocked. A genuine
+        A <code>block</code> outcome is always <strong>confirmed-contributor-gated</strong>: the
+        mode chooses <em>which</em> checks are active, never <em>who</em> can be blocked. A genuine
         newcomer can be softened from a block to an advisory when{" "}
         <code>firstTimeContributorGrace</code> is on.
       </p>
@@ -105,9 +105,9 @@ function HowReviewsWork() {
         </li>
         <li>
           <strong>Slop gate</strong> (<code>slopGateMode</code>, default <code>off</code>) — the
-          deterministic anti-slop signal. <code>advisory</code> surfaces the slop score and warnings;{" "}
-          <code>block</code> also hard-blocks at or above <code>slopGateMinScore</code> (engine
-          default band <code>60</code>).
+          deterministic anti-slop signal. <code>advisory</code> surfaces the slop score and
+          warnings; <code>block</code> also hard-blocks at or above <code>slopGateMinScore</code>{" "}
+          (engine default band <code>60</code>).
         </li>
         <li>
           <strong>Merge-readiness gate</strong> (<code>mergeReadinessGateMode</code>, default{" "}
@@ -144,8 +144,8 @@ function HowReviewsWork() {
 
       <h2>2. The dual-AI review and consensus</h2>
       <p>
-        AI review is its own dimension (<code>aiReviewMode</code>, default <code>off</code>). It reads
-        the diff and produces review notes — concrete findings tied to the change, not a vague
+        AI review is its own dimension (<code>aiReviewMode</code>, default <code>off</code>). It
+        reads the diff and produces review notes — concrete findings tied to the change, not a vague
         verdict. Two modes:
       </p>
       <ul>
@@ -169,16 +169,16 @@ function HowReviewsWork() {
       <p>
         With <code>aiReviewByok: true</code> and a configured provider key, the <em>advisory</em>{" "}
         write-up can use a maintainer's own frontier model (<code>aiReviewProvider</code> /{" "}
-        <code>aiReviewModel</code>, e.g. <code>claude-3-5-sonnet-latest</code>). The consensus blocker
-        always stays on the free model pair, so BYOK improves the prose without ever changing{" "}
-        <em>who</em> can be blocked.
+        <code>aiReviewModel</code>, e.g. <code>claude-3-5-sonnet-latest</code>). The consensus
+        blocker always stays on the free model pair, so BYOK improves the prose without ever
+        changing <em>who</em> can be blocked.
       </p>
       <Callout variant="note" title="Grounding makes the AI check reality">
         The <code>GITTENSORY_REVIEW_GROUNDING</code> flag grounds the reviewer prompt with the PR's
         finished CI status and the full post-change content of the changed files — so the model
         verifies its claims instead of predicting CI or flagging a symbol defined just outside the
-        diff hunk. <code>GITTENSORY_REVIEW_RAG</code> adds semantically related existing code and docs
-        as extra context. Both are additive and opt-in.
+        diff hunk. <code>GITTENSORY_REVIEW_RAG</code> adds semantically related existing code and
+        docs as extra context. Both are additive and opt-in.
       </Callout>
 
       <h2>3. The unified review comment</h2>
@@ -189,14 +189,14 @@ function HowReviewsWork() {
       </p>
       <ul>
         <li>
-          <strong>The alert</strong> — a one-line headline verdict: whether the gate blocks, what the
-          single most important blocker is, or that the PR is clear. This is the line a reader scans
-          first.
+          <strong>The alert</strong> — a one-line headline verdict: whether the gate blocks, what
+          the single most important blocker is, or that the PR is clear. This is the line a reader
+          scans first.
         </li>
         <li>
           <strong>The signal table</strong> — a compact row-per-signal summary: each dimension that
-          ran, its state (pass / advisory / block), and a short reason. This is the at-a-glance map of
-          why the verdict came out the way it did.
+          ran, its state (pass / advisory / block), and a short reason. This is the at-a-glance map
+          of why the verdict came out the way it did.
         </li>
         <li>
           <strong>Collapsibles</strong> — expandable sections for the detail behind each signal: the
@@ -209,19 +209,18 @@ function HowReviewsWork() {
         <code>commentMode</code> chooses the audience (<code>off</code> /{" "}
         <code>detected_contributors_only</code> / <code>all_prs</code>), and{" "}
         <code>publicSignalLevel</code> (<code>minimal</code> / <code>standard</code>) controls how
-        much of the signal detail is published. Private review context (
-        <code>maintainerNotes</code>) is never published to a public surface.
+        much of the signal detail is published. Private review context (<code>maintainerNotes</code>
+        ) is never published to a public surface.
       </p>
       <Callout variant="safety">
         Public-facing comments are sanitized before they leave the worker. Private scoring, reward,
         and reputation language never appears in the PR thread — and reputation-based spend control
-        (<code>GITTENSORY_REVIEW_REPUTATION</code>) is never surfaced in any comment, label, or check.
+        (<code>GITTENSORY_REVIEW_REPUTATION</code>) is never surfaced in any comment, label, or
+        check.
       </Callout>
 
       <h2>4. The signals behind a verdict</h2>
-      <p>
-        Each row in the signal table comes from a named finding. The common ones you will see:
-      </p>
+      <p>Each row in the signal table comes from a named finding. The common ones you will see:</p>
       <ul>
         <li>
           <code>secret_leak</code> — the safety scan (<code>GITTENSORY_REVIEW_SAFETY</code>) found a
@@ -230,7 +229,8 @@ function HowReviewsWork() {
         </li>
         <li>
           <code>manifest_blocked_path</code> — the PR touches a path listed in the repo's{" "}
-          <code>blockedPaths</code>. Enforceable when <code>manifestPolicy</code> is <code>block</code>.
+          <code>blockedPaths</code>. Enforceable when <code>manifestPolicy</code> is{" "}
+          <code>block</code>.
         </li>
         <li>
           <code>manifest_missing_tests</code> — code changed but the expected test paths (
@@ -245,26 +245,25 @@ function HowReviewsWork() {
           <strong>Duplicate match</strong> — the other PR this one duplicates or supersedes.
         </li>
         <li>
-          <strong>AI review notes</strong> — the dual-model findings, and (in <code>block</code> mode)
-          any consensus defect.
+          <strong>AI review notes</strong> — the dual-model findings, and (in <code>block</code>{" "}
+          mode) any consensus defect.
         </li>
       </ul>
       <p>
-        The check run can carry the same signals at adjustable depth:{" "}
-        <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>) publishes the{" "}
-        <strong>Gittensory Gate</strong> check, and <code>checkRunDetailLevel</code> (
-        <code>minimal</code> / <code>standard</code> / <code>deep</code>) sets how much the check
-        summary spells out.
+        The check run can carry the same signals at adjustable depth: <code>checkRunMode</code> (
+        <code>off</code> / <code>enabled</code>) publishes the <strong>Gittensory Gate</strong>{" "}
+        check, and <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code> /{" "}
+        <code>deep</code>) sets how much the check summary spells out.
       </p>
 
       <h2>Putting it together</h2>
       <p>
-        A pull request flows through the deterministic gate, then the dual-AI review, and the union of
-        both is rendered as one alert + signal table + collapsibles comment. The gate decides{" "}
-        <em>can this merge</em> with fixed rules you can read; the AI review adds judgment as advisory
-        notes, escalating to a blocker only on two-model consensus; and the comment is the single,
-        sanitized place a contributor reads the whole verdict. Tune every mode, threshold, and surface
-        in <a href="/docs/review-configuration">Review configuration</a>.
+        A pull request flows through the deterministic gate, then the dual-AI review, and the union
+        of both is rendered as one alert + signal table + collapsibles comment. The gate decides{" "}
+        <em>can this merge</em> with fixed rules you can read; the AI review adds judgment as
+        advisory notes, escalating to a blocker only on two-model consensus; and the comment is the
+        single, sanitized place a contributor reads the whole verdict. Tune every mode, threshold,
+        and surface in <a href="/docs/review-configuration">Review configuration</a>.
       </p>
     </DocsPage>
   );

--- a/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
@@ -1,0 +1,271 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { CodeBlock, Callout } from "@/components/site/primitives";
+
+export const Route = createFileRoute("/docs/how-reviews-work")({
+  head: () => ({
+    meta: [
+      { title: "How reviews work — Gittensory docs" },
+      {
+        name: "description",
+        content:
+          "How gittensory reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
+      },
+      { property: "og:title", content: "How reviews work — Gittensory docs" },
+      {
+        property: "og:description",
+        content:
+          "How gittensory reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
+      },
+      { property: "og:url", content: "/docs/how-reviews-work" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/how-reviews-work" }],
+  }),
+  component: HowReviewsWork,
+});
+
+function HowReviewsWork() {
+  return (
+    <DocsPage
+      eyebrow="Reviews"
+      title="How reviews work"
+      description="What gittensory does when a pull request opens — the gate, the dual-AI review and consensus, and the single comment that surfaces it."
+    >
+      <h2>The shape of a review</h2>
+      <p>
+        When a pull request opens or updates, <strong>gittensory CI</strong> runs a review in two
+        layers and reports the result in one place:
+      </p>
+      <ol>
+        <li>
+          <strong>The gate</strong> — a deterministic pass that never asks an AI. It runs a fixed set
+          of rules (duplicates, linked issues, merge-readiness, anti-slop, manifest policy) and each
+          rule is <code>off</code>, <code>advisory</code>, or <code>block</code>.
+        </li>
+        <li>
+          <strong>The AI review</strong> — a dual-model read of the diff that writes review notes and,
+          when you opt in, lets a high-confidence <em>consensus</em> become a blocker.
+        </li>
+      </ol>
+      <p>
+        Everything those layers find is folded into a single <strong>gittensory review</strong>{" "}
+        comment on the PR, plus an optional <strong>Gittensory Gate</strong> check run. The review
+        algorithm is open-source; what changes between repos is the configuration you tune. See{" "}
+        <a href="/docs/review-configuration">Review configuration</a> for every option and default.
+      </p>
+      <Callout variant="safety">
+        Defaults are quiet. With no settings and no <code>.gittensory.yml</code>, the gate is{" "}
+        <code>off</code>, AI review is <code>off</code>, and the comment is posted only to detected
+        contributors. Every capability is an explicit opt-in.
+      </Callout>
+
+      <h2>1. The gate: advisory vs. block</h2>
+      <p>
+        The gate is deterministic — same inputs, same verdict, no model in the loop. Its master
+        switch is <code>gateCheckMode</code> (<code>off</code> / <code>enabled</code>). Once enabled,
+        each <em>dimension</em> is independently set to one of three modes:
+      </p>
+      <ul>
+        <li>
+          <code>off</code> — the dimension is not evaluated at all.
+        </li>
+        <li>
+          <code>advisory</code> — the finding is <strong>surfaced</strong> in the comment, but it
+          never blocks the merge.
+        </li>
+        <li>
+          <code>block</code> — the finding can become a hard <strong>Gittensory Gate</strong>{" "}
+          blocker.
+        </li>
+      </ul>
+      <p>
+        A <code>block</code> outcome is always <strong>confirmed-contributor-gated</strong>: the mode
+        chooses <em>which</em> checks are active, never <em>who</em> can be blocked. A genuine
+        newcomer can be softened from a block to an advisory when{" "}
+        <code>firstTimeContributorGrace</code> is on.
+      </p>
+
+      <h3>The gate dimensions</h3>
+      <p>These are the deterministic rules the gate runs, with their default modes:</p>
+      <ul>
+        <li>
+          <strong>Duplicate-PR gate</strong> (<code>duplicatePrGateMode</code>, default{" "}
+          <code>block</code>) — detects duplicate or superseding PRs.
+        </li>
+        <li>
+          <strong>Linked-issue gate</strong> (<code>linkedIssueGateMode</code>, default{" "}
+          <code>advisory</code>) — checks the PR references an issue, as strongly as{" "}
+          <code>linkedIssuePolicy</code> asks.
+        </li>
+        <li>
+          <strong>Quality / merge-readiness score gate</strong> (<code>qualityGateMode</code>,
+          default <code>advisory</code>) — the PR-quality score; passes at or above{" "}
+          <code>qualityGateMinScore</code>.
+        </li>
+        <li>
+          <strong>Slop gate</strong> (<code>slopGateMode</code>, default <code>off</code>) — the
+          deterministic anti-slop signal. <code>advisory</code> surfaces the slop score and warnings;{" "}
+          <code>block</code> also hard-blocks at or above <code>slopGateMinScore</code> (engine
+          default band <code>60</code>).
+        </li>
+        <li>
+          <strong>Merge-readiness gate</strong> (<code>mergeReadinessGateMode</code>, default{" "}
+          <code>off</code>) — a composite readiness check.
+        </li>
+        <li>
+          <strong>Manifest-policy gate</strong> (<code>manifestPolicyGateMode</code>, default{" "}
+          <code>off</code>) — when <code>block</code>, the repo's declared policy (blocked paths,
+          required linked issue, test expectations) becomes enforceable.
+        </li>
+      </ul>
+      <p>
+        Which deterministic rules even apply is set by the <strong>policy pack</strong> (
+        <code>gatePack</code>): <code>gittensor</code> (confirmed-contributor-gated, registry-aware)
+        or <code>oss-anti-slop</code> (runs the rules against any author on any repo).
+      </p>
+      <CodeBlock
+        filename=".gittensory.yml"
+        code={`gate:
+  enabled: true
+  pack: gittensor
+  duplicates: block
+  linkedIssue: advisory
+  readiness:
+    mode: advisory
+    minScore: 70
+  slop:
+    mode: block
+    minScore: 60
+  mergeReadiness: advisory
+  manifestPolicy: block
+  firstTimeContributorGrace: true`}
+      />
+
+      <h2>2. The dual-AI review and consensus</h2>
+      <p>
+        AI review is its own dimension (<code>aiReviewMode</code>, default <code>off</code>). It reads
+        the diff and produces review notes — concrete findings tied to the change, not a vague
+        verdict. Two modes:
+      </p>
+      <ul>
+        <li>
+          <code>advisory</code> — the AI write-up is posted as notes only. It never blocks.
+        </li>
+        <li>
+          <code>block</code> — a <strong>dual-model high-confidence consensus</strong> defect is
+          allowed to become a blocker (confirmed contributors only).
+        </li>
+      </ul>
+      <p>
+        The blocking decision always runs on a <strong>pair</strong> of free models and only blocks
+        when <em>both</em> models independently agree, with high confidence, on a real defect. Two
+        agreeing models is the bar — there is no single-model block and no tie-breaker third model.
+        That consensus requirement is what keeps a confident-but-wrong single model from blocking a
+        good PR.
+      </p>
+
+      <h3>Bring your own model (advisory only)</h3>
+      <p>
+        With <code>aiReviewByok: true</code> and a configured provider key, the <em>advisory</em>{" "}
+        write-up can use a maintainer's own frontier model (<code>aiReviewProvider</code> /{" "}
+        <code>aiReviewModel</code>, e.g. <code>claude-3-5-sonnet-latest</code>). The consensus blocker
+        always stays on the free model pair, so BYOK improves the prose without ever changing{" "}
+        <em>who</em> can be blocked.
+      </p>
+      <Callout variant="note" title="Grounding makes the AI check reality">
+        The <code>GITTENSORY_REVIEW_GROUNDING</code> flag grounds the reviewer prompt with the PR's
+        finished CI status and the full post-change content of the changed files — so the model
+        verifies its claims instead of predicting CI or flagging a symbol defined just outside the
+        diff hunk. <code>GITTENSORY_REVIEW_RAG</code> adds semantically related existing code and docs
+        as extra context. Both are additive and opt-in.
+      </Callout>
+
+      <h2>3. The unified review comment</h2>
+      <p>
+        The result is rendered as <strong>one in-place comment</strong> on the PR — updated in place
+        on each push rather than stacked — when <code>GITTENSORY_REVIEW_UNIFIED_COMMENT</code> is on
+        for the repo. It has three parts, top to bottom:
+      </p>
+      <ul>
+        <li>
+          <strong>The alert</strong> — a one-line headline verdict: whether the gate blocks, what the
+          single most important blocker is, or that the PR is clear. This is the line a reader scans
+          first.
+        </li>
+        <li>
+          <strong>The signal table</strong> — a compact row-per-signal summary: each dimension that
+          ran, its state (pass / advisory / block), and a short reason. This is the at-a-glance map of
+          why the verdict came out the way it did.
+        </li>
+        <li>
+          <strong>Collapsibles</strong> — expandable sections for the detail behind each signal: the
+          AI review notes, the slop warnings, duplicate matches, manifest findings. Folded away by
+          default so the comment stays short, opened when a reader wants the evidence.
+        </li>
+      </ul>
+      <p>
+        Who sees the comment, and how much detail it carries, is a repo setting:{" "}
+        <code>commentMode</code> chooses the audience (<code>off</code> /{" "}
+        <code>detected_contributors_only</code> / <code>all_prs</code>), and{" "}
+        <code>publicSignalLevel</code> (<code>minimal</code> / <code>standard</code>) controls how
+        much of the signal detail is published. Private review context (
+        <code>maintainerNotes</code>) is never published to a public surface.
+      </p>
+      <Callout variant="safety">
+        Public-facing comments are sanitized before they leave the worker. Private scoring, reward,
+        and reputation language never appears in the PR thread — and reputation-based spend control
+        (<code>GITTENSORY_REVIEW_REPUTATION</code>) is never surfaced in any comment, label, or check.
+      </Callout>
+
+      <h2>4. The signals behind a verdict</h2>
+      <p>
+        Each row in the signal table comes from a named finding. The common ones you will see:
+      </p>
+      <ul>
+        <li>
+          <code>secret_leak</code> — the safety scan (<code>GITTENSORY_REVIEW_SAFETY</code>) found a
+          leaked secret in the diff. The same scan also defangs untrusted PR text before the AI
+          reviewer reads it.
+        </li>
+        <li>
+          <code>manifest_blocked_path</code> — the PR touches a path listed in the repo's{" "}
+          <code>blockedPaths</code>. Enforceable when <code>manifestPolicy</code> is <code>block</code>.
+        </li>
+        <li>
+          <code>manifest_missing_tests</code> — code changed but the expected test paths (
+          <code>testExpectations</code>) did not.
+        </li>
+        <li>
+          <strong>Slop score + warnings</strong> — the deterministic anti-slop signal. With{" "}
+          <code>slopAiAdvisory: true</code>, a free advisory-only <code>ai_slop_advisory</code>{" "}
+          finding is added too — it never feeds the score or the gate.
+        </li>
+        <li>
+          <strong>Duplicate match</strong> — the other PR this one duplicates or supersedes.
+        </li>
+        <li>
+          <strong>AI review notes</strong> — the dual-model findings, and (in <code>block</code> mode)
+          any consensus defect.
+        </li>
+      </ul>
+      <p>
+        The check run can carry the same signals at adjustable depth:{" "}
+        <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>) publishes the{" "}
+        <strong>Gittensory Gate</strong> check, and <code>checkRunDetailLevel</code> (
+        <code>minimal</code> / <code>standard</code> / <code>deep</code>) sets how much the check
+        summary spells out.
+      </p>
+
+      <h2>Putting it together</h2>
+      <p>
+        A pull request flows through the deterministic gate, then the dual-AI review, and the union of
+        both is rendered as one alert + signal table + collapsibles comment. The gate decides{" "}
+        <em>can this merge</em> with fixed rules you can read; the AI review adds judgment as advisory
+        notes, escalating to a blocker only on two-model consensus; and the comment is the single,
+        sanitized place a contributor reads the whole verdict. Tune every mode, threshold, and surface
+        in <a href="/docs/review-configuration">Review configuration</a>.
+      </p>
+    </DocsPage>
+  );
+}

--- a/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
@@ -46,13 +46,13 @@ function PrivacySecurity() {
 
       <h2>Open algorithm, private tuning</h2>
       <p>
-        Gittensory's review engine is built so the <strong>logic is public but the dial settings are
-        not</strong>. The deterministic gate, the scoring signals, the slop detector, the
-        grounding/RAG context builders, and the comment renderer all live in the open source tree —
-        anyone can read exactly how a verdict is reached. What stays private is the{" "}
-        <strong>production tuning</strong>: the thresholds, guardrail paths, and gate modes an
-        operator runs in production. That separation is what keeps a review from being gameable off
-        the public code.
+        Gittensory's review engine is built so the{" "}
+        <strong>logic is public but the dial settings are not</strong>. The deterministic gate, the
+        scoring signals, the slop detector, the grounding/RAG context builders, and the comment
+        renderer all live in the open source tree — anyone can read exactly how a verdict is
+        reached. What stays private is the <strong>production tuning</strong>: the thresholds,
+        guardrail paths, and gate modes an operator runs in production. That separation is what
+        keeps a review from being gameable off the public code.
       </p>
       <p>
         Tuning lives in two private, repo-scoped places that sit on top of the open algorithm, and
@@ -61,10 +61,10 @@ function PrivacySecurity() {
       <ul>
         <li>
           <strong>Per-repo settings</strong> — gate modes, score thresholds, and guardrails, stored
-          in the operator's database (set through the dashboard/API) or declared as config-as-code in
-          a repo's <code>.gittensory.yml</code>. Choosing <code>gate.slop.minScore</code> or marking
-          a path under <code>blockedPaths</code> tightens the gate without telling a contributor how
-          to pass it.
+          in the operator's database (set through the dashboard/API) or declared as config-as-code
+          in a repo's <code>.gittensory.yml</code>. Choosing <code>gate.slop.minScore</code> or
+          marking a path under <code>blockedPaths</code> tightens the gate without telling a
+          contributor how to pass it.
         </li>
         <li>
           <strong>Operator feature flags</strong> — the <code>GITTENSORY_REVIEW_*</code> family of
@@ -74,10 +74,10 @@ function PrivacySecurity() {
         </li>
       </ul>
       <p>
-        Every feature flag ships <strong>OFF</strong>, and a per-PR capability runs only when its own
-        flag is on <em>and</em> the repo is in the <code>GITTENSORY_REVIEW_REPOS</code> allowlist —
-        so capabilities stay dormant until an operator explicitly converges a repo, one flag and one
-        repo at a time.
+        Every feature flag ships <strong>OFF</strong>, and a per-PR capability runs only when its
+        own flag is on <em>and</em> the repo is in the <code>GITTENSORY_REVIEW_REPOS</code>{" "}
+        allowlist — so capabilities stay dormant until an operator explicitly converges a repo, one
+        flag and one repo at a time.
       </p>
       <CodeBlock
         code={`# Per-PR features run only when the flag is ON and the repo is allowlisted.
@@ -90,16 +90,16 @@ GITTENSORY_REVIEW_UNIFIED_COMMENT="true"         # one in-place unified PR comme
       />
       <p>
         The internal-only controls never surface publicly. Submitter reputation, for example, can
-        downgrade a burst or low-reputation submitter to a deterministic-only review — but no comment,
-        label, or check ever shows a reputation value. Reputation thresholds are generic anti-abuse
-        defaults that reveal no review direction and are not per-repo tunable.
+        downgrade a burst or low-reputation submitter to a deterministic-only review — but no
+        comment, label, or check ever shows a reputation value. Reputation thresholds are generic
+        anti-abuse defaults that reveal no review direction and are not per-repo tunable.
       </p>
       <Callout variant="safety">
         Reading the open source tells you <strong>how</strong> a verdict is computed, never{" "}
         <strong>what</strong> an operator's production gate will decide. The deciding inputs —
-        thresholds, guardrail globs, and which <code>GITTENSORY_REVIEW_*</code> capabilities are live
-        — are private runtime settings, so reviews cannot be reverse-engineered or gamed from the
-        public code.
+        thresholds, guardrail globs, and which <code>GITTENSORY_REVIEW_*</code> capabilities are
+        live — are private runtime settings, so reviews cannot be reverse-engineered or gamed from
+        the public code.
       </Callout>
 
       <h2>Public output rules</h2>

--- a/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
-import { Callout } from "@/components/site/primitives";
+import { CodeBlock, Callout } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/docs/privacy-security")({
   head: () => ({
@@ -43,6 +43,64 @@ function PrivacySecurity() {
         <li>No public score estimates.</li>
         <li>No private reviewability details in public GitHub output.</li>
       </ul>
+
+      <h2>Open algorithm, private tuning</h2>
+      <p>
+        Gittensory's review engine is built so the <strong>logic is public but the dial settings are
+        not</strong>. The deterministic gate, the scoring signals, the slop detector, the
+        grounding/RAG context builders, and the comment renderer all live in the open source tree —
+        anyone can read exactly how a verdict is reached. What stays private is the{" "}
+        <strong>production tuning</strong>: the thresholds, guardrail paths, and gate modes an
+        operator runs in production. That separation is what keeps a review from being gameable off
+        the public code.
+      </p>
+      <p>
+        Tuning lives in two private, repo-scoped places that sit on top of the open algorithm, and
+        neither reveals review <em>direction</em>:
+      </p>
+      <ul>
+        <li>
+          <strong>Per-repo settings</strong> — gate modes, score thresholds, and guardrails, stored
+          in the operator's database (set through the dashboard/API) or declared as config-as-code in
+          a repo's <code>.gittensory.yml</code>. Choosing <code>gate.slop.minScore</code> or marking
+          a path under <code>blockedPaths</code> tightens the gate without telling a contributor how
+          to pass it.
+        </li>
+        <li>
+          <strong>Operator feature flags</strong> — the <code>GITTENSORY_REVIEW_*</code> family of
+          worker environment variables. These switch whole capabilities (safety scanning, CI and
+          full-file grounding, RAG context, reputation-based spend control, the unified comment) on
+          or off for a deployment.
+        </li>
+      </ul>
+      <p>
+        Every feature flag ships <strong>OFF</strong>, and a per-PR capability runs only when its own
+        flag is on <em>and</em> the repo is in the <code>GITTENSORY_REVIEW_REPOS</code> allowlist —
+        so capabilities stay dormant until an operator explicitly converges a repo, one flag and one
+        repo at a time.
+      </p>
+      <CodeBlock
+        code={`# Per-PR features run only when the flag is ON and the repo is allowlisted.
+GITTENSORY_REVIEW_REPOS="JSONbored/gittensory"   # per-repo cutover allowlist (default: none)
+GITTENSORY_REVIEW_SAFETY="true"                  # prompt-injection defang + secret-leak scan
+GITTENSORY_REVIEW_GROUNDING="true"               # CI status + full changed-file content
+GITTENSORY_REVIEW_RAG="true"                     # codebase vector-index context (needs index)
+GITTENSORY_REVIEW_REPUTATION="true"              # submitter-reputation spend control (never shown)
+GITTENSORY_REVIEW_UNIFIED_COMMENT="true"         # one in-place unified PR comment`}
+      />
+      <p>
+        The internal-only controls never surface publicly. Submitter reputation, for example, can
+        downgrade a burst or low-reputation submitter to a deterministic-only review — but no comment,
+        label, or check ever shows a reputation value. Reputation thresholds are generic anti-abuse
+        defaults that reveal no review direction and are not per-repo tunable.
+      </p>
+      <Callout variant="safety">
+        Reading the open source tells you <strong>how</strong> a verdict is computed, never{" "}
+        <strong>what</strong> an operator's production gate will decide. The deciding inputs —
+        thresholds, guardrail globs, and which <code>GITTENSORY_REVIEW_*</code> capabilities are live
+        — are private runtime settings, so reviews cannot be reverse-engineered or gamed from the
+        public code.
+      </Callout>
 
       <h2>Public output rules</h2>
       <ul>

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -1,0 +1,444 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { CodeBlock, Callout } from "@/components/site/primitives";
+
+export const Route = createFileRoute("/docs/tuning")({
+  head: () => ({
+    meta: [
+      { title: "Tuning your reviews — Gittensory docs" },
+      {
+        name: "description",
+        content:
+          "Configure Gittensory CI and Gittensory review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
+      },
+      { property: "og:title", content: "Tuning your reviews — Gittensory docs" },
+      {
+        property: "og:description",
+        content:
+          "Configure Gittensory CI and Gittensory review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
+      },
+      { property: "og:url", content: "/docs/tuning" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/tuning" }],
+  }),
+  component: Tuning,
+});
+
+function Tuning() {
+  return (
+    <DocsPage
+      eyebrow="Operating"
+      title="Tuning your reviews"
+      description="How to configure Gittensory CI and Gittensory review — gate modes, score thresholds, guardrails, and feature flags — through .gittensory.yml and your repo settings."
+    >
+      <h2>How configuration fits together</h2>
+      <p>
+        <strong>Gittensory review</strong> is the engine that scores, gates, and comments on your
+        pull requests. You shape its behavior in two places, and you never have to touch the review
+        algorithm itself:
+      </p>
+      <ul>
+        <li>
+          <strong>Per-repo settings</strong> — gate modes, score thresholds, guardrails, and which
+          surfaces are enabled. Set them in the dashboard, or declare them as config-as-code in a{" "}
+          <code>.gittensory.yml</code> file in the repo.
+        </li>
+        <li>
+          <strong>Feature flags</strong> — the <code>GITTENSORY_REVIEW_*</code> family of environment
+          variables on the worker. These switch whole capabilities (safety scanning, grounding, RAG
+          context, the unified comment, the content lane, observability, self-tuning, and more) on or
+          off for the deployment.
+        </li>
+      </ul>
+      <p>
+        The review algorithm — the deterministic gate, the scoring signals, the slop detector, the
+        grounding and RAG context builders, and the comment renderer — is open source. Anyone can
+        read exactly how a verdict is reached. The settings above sit <em>on top</em> of that open
+        algorithm and never reveal review <em>direction</em>, so a contributor cannot read them and
+        game the gate.
+      </p>
+
+      <Callout variant="safety" title="Defaults are safe and conservative">
+        Every feature flag ships <strong>OFF</strong>. A repo with no settings and no{" "}
+        <code>.gittensory.yml</code> falls back to a quiet, non-blocking profile: the gate is{" "}
+        <code>off</code>, AI review is <code>off</code>, slop scoring is <code>off</code>, comments
+        go only to detected contributors, and no check-run is published. Turning anything on is
+        always an explicit opt-in — you roll capabilities forward, and back, one flag and one repo at
+        a time.
+      </Callout>
+
+      <h2>Precedence</h2>
+      <p>Most specific wins:</p>
+      <ul>
+        <li>
+          <code>.gittensory.yml</code> in the repo, then
+        </li>
+        <li>per-repo database settings, then</li>
+        <li>built-in safe defaults.</li>
+      </ul>
+      <p>
+        The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for the
+        gate-related fields and wins over the generic <code>settings:</code> block for those same
+        fields. Gittensory looks for the manifest at the first match of{" "}
+        <code>.gittensory.yml</code> → <code>.github/gittensory.yml</code> →{" "}
+        <code>.gittensory.json</code> → <code>.github/gittensory.json</code>.
+      </p>
+
+      <h2>Feature flags (GITTENSORY_REVIEW_*)</h2>
+      <p>
+        These are worker environment variables, every one defaulting to <strong>OFF</strong>.
+        "Truthy" means one of <code>1</code>, <code>true</code>, <code>yes</code>, or <code>on</code>{" "}
+        (case-insensitive); anything else — including unset, empty, or <code>false</code> — is OFF.
+        When a flag is OFF its code path is inert: the review behaves exactly as if the feature did
+        not exist.
+      </p>
+      <p>
+        One flag is a <strong>scope</strong> rather than a capability:{" "}
+        <code>GITTENSORY_REVIEW_REPOS</code> is a per-repo allowlist that must <em>also</em> pass for
+        any per-PR feature to run on a given repo. So a per-PR feature activates only when{" "}
+        <strong>its own flag is ON and the repo is allowlisted</strong>.
+      </p>
+      <ul>
+        <li>
+          <code>GITTENSORY_REVIEW_REPOS</code> — the per-repo allowlist. Comma-separated{" "}
+          <code>owner/repo</code> names that may run the per-PR features (safety, grounding, RAG,
+          reputation, unified comment). Empty or unset means no repos — every per-PR feature stays
+          dormant for everyone regardless of the global flags. Case-insensitive and trimmed; stray
+          commas are ignored. The cron and endpoint flags (ops, self-tune, parity audit, content
+          lane, draft) are <strong>not</strong> scoped by this list.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_SAFETY</code> — safety scan in the review path: it neutralizes
+          prompt-injection in untrusted PR title/body/diff before the AI reviewer sees it, and scans
+          the diff for leaked secrets, surfacing a <code>secret_leak</code> blocker. Per-PR (also
+          needs the repo in the allowlist).
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_GROUNDING</code> — grounds the AI reviewer with the PR's{" "}
+          <em>finished</em> CI status plus the <em>full post-change content</em> of the changed
+          files, so the model verifies claims against reality instead of predicting CI or flagging
+          symbols defined just outside the diff hunk. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_RAG</code> — retrieval-augmented context: queries the codebase
+          vector index for related code and docs (callers, related modules, existing conventions) and
+          appends a "Relevant existing code / docs" section to the reviewer prompt. Additive only.
+          Inert until a vector index exists for the repo — a cold or missing index degrades to no
+          context. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_REPUTATION</code> — submitter-reputation spend control. A new,
+          burst, or low-reputation submitter is downgraded to a deterministic-only review; good
+          reputation proceeds normally. Never surfaced publicly — no comment, label, or check shows
+          reputation. Per-PR.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_UNIFIED_COMMENT</code> — renders the public PR comment as one
+          in-place unified comment instead of the legacy multi-panel comment. Per-PR. With the flag
+          off, the legacy comment is byte-identical.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_OPS</code> — observability, read-only. On the cron tick an anomaly
+          scan over the gate-block ledger and calibration data emits a structured{" "}
+          <code>ops_anomaly</code> log when something drifts, and a bearer-gated{" "}
+          <code>GET /v1/internal/ops/stats</code> serves an outcome aggregate. Does not mutate config.
+          Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_SELFTUNE</code> — the self-improvement loop. On the cron tick it
+          computes tuning recommendations from your own outcome data, shadow-soaks any strictly
+          tightening recommendation, and auto-promotes it only after the soak passes. It can{" "}
+          <strong>only ever tighten</strong> the gate — a loosening recommendation is never applied.
+          Global, and safe to leave on.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_PARITY_AUDIT</code> — parity readiness, shadow record-only. Records
+          each finalized gate decision and serves a readiness report at{" "}
+          <code>GET /v1/internal/parity</code>. Changes no review behavior. Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_CONTENT_LANE</code> — routes content repos (curated lists,
+          registries) through the dedicated content lane — duplicate detection, source-evidence
+          reachability, security scanning, scope classification, registry grounding — instead of the
+          code gate. Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_DRAFT</code> — the public draft-submission flow (the{" "}
+          <code>/v1/drafts</code> endpoints: contributor draft → GitHub OAuth → fork PR). With the
+          flag off every draft endpoint 404s. Requires the{" "}
+          <code>DRAFT_TOKEN_ENCRYPTION_SECRET</code> and <code>GITHUB_OAUTH_CLIENT_SECRET</code>{" "}
+          secrets. Global.
+        </li>
+        <li>
+          <code>GITTENSORY_REVIEW_STATS_TOKEN</code> — the bearer secret for the stats data endpoint.
+          Not an on/off switch; it is the token value. When set, the stats route requires this bearer
+          token.
+        </li>
+      </ul>
+
+      <Callout variant="note" title="Rolling out a per-PR feature">
+        A safe rollout is two flips: turn the capability flag <code>true</code>, then add the repo to{" "}
+        <code>GITTENSORY_REVIEW_REPOS</code>. Because both must be true, you can leave a capability
+        globally enabled while it stays dormant everywhere except the repos you have explicitly
+        allowlisted — and you roll a single repo back by removing it from the list without disturbing
+        the others.
+      </Callout>
+
+      <h2>Gate modes</h2>
+      <p>
+        Per-repo behavior is the <strong>effective settings</strong>: the database row for the repo,
+        overlaid with the repo's <code>.gittensory.yml</code>. Most gate dimensions are tri-state:
+      </p>
+      <ul>
+        <li>
+          <code>off</code> — the dimension is not evaluated.
+        </li>
+        <li>
+          <code>advisory</code> — the finding is surfaced in the comment or context but never blocks.
+        </li>
+        <li>
+          <code>block</code> — the finding can become a hard <code>Gittensory Gate</code> blocker.
+          Blocking is always confirmed-contributor-gated: the mode chooses <em>which</em>{" "}
+          deterministic checks are active, never <em>who</em> can be blocked.
+        </li>
+      </ul>
+      <p>
+        The master switch is <code>gate.enabled</code> (<code>off</code> / <code>enabled</code>). The
+        per-dimension modes refine an already-enabled gate. The main dimensions:
+      </p>
+      <ul>
+        <li>
+          <code>gate.pack</code> — the policy pack: <code>gittensor</code> (default;
+          confirmed-contributor-gated, registry-aware) or <code>oss-anti-slop</code> (runs the
+          deterministic rules against any author on any repo).
+        </li>
+        <li>
+          <code>gate.duplicates</code> — duplicate / superseding-PR detection. Default{" "}
+          <code>block</code>.
+        </li>
+        <li>
+          <code>gate.linkedIssue</code> — linked-issue gate. Default <code>advisory</code>. If the
+          dashboard "Require linked issue" toggle is on but this is <code>off</code>, it is
+          auto-promoted to <code>block</code>.
+        </li>
+        <li>
+          <code>gate.readiness.mode</code> — the PR-quality / merge-readiness score gate. Default{" "}
+          <code>advisory</code>. Pair it with <code>gate.readiness.minScore</code> (0–100; at or
+          above this score the quality dimension passes; <code>null</code> uses the engine's default
+          band).
+        </li>
+        <li>
+          <code>gate.slop.mode</code> — the deterministic anti-slop signal. Default <code>off</code>{" "}
+          (opt-in). <code>advisory</code> surfaces the slop score and warnings; <code>block</code>{" "}
+          also hard-blocks at or above <code>gate.slop.minScore</code> (0–100; <code>null</code> uses{" "}
+          <code>60</code>, the "high" band). Set <code>gate.slop.aiAdvisory: true</code> to add a
+          free advisory-only <code>ai_slop_advisory</code> finding — it never feeds the slop score or
+          the gate.
+        </li>
+        <li>
+          <code>gate.mergeReadiness</code> — composite merge-readiness gate. Default <code>off</code>,
+          no min score.
+        </li>
+        <li>
+          <code>gate.manifestPolicy</code> — when <code>block</code>, the manifest's declared policy
+          (blocked paths, required linked issue, test expectations) becomes an enforceable blocker.
+          Default <code>off</code>.
+        </li>
+        <li>
+          <code>gate.firstTimeContributorGrace</code> — when <code>true</code>, softens a would-be
+          block to advisory for a genuine newcomer (0 merged PRs, fewer than 3 closed-unmerged PRs).
+          Repeat offenders and authors with merge history are gated normally. Default{" "}
+          <code>false</code>.
+        </li>
+        <li>
+          <code>gate.aiReview.mode</code> — AI review. Default <code>off</code>.{" "}
+          <code>advisory</code> posts AI review notes only; <code>block</code> lets a dual-model
+          high-confidence consensus defect become a blocker (confirmed contributors only).
+        </li>
+      </ul>
+
+      <h3>Bring your own model (AI review)</h3>
+      <p>
+        The AI-review write-up can optionally use your own frontier model. The consensus blocker
+        always uses the free built-in model pair, so BYOK never changes who can be blocked.
+      </p>
+      <ul>
+        <li>
+          <code>gate.aiReview.byok</code> — when <code>true</code> and a provider key is configured,
+          the advisory write-up uses the maintainer's frontier model. Default <code>false</code>.
+        </li>
+        <li>
+          <code>gate.aiReview.provider</code> — <code>anthropic</code>, <code>openai</code>, or{" "}
+          <code>null</code> (use the stored key's own provider). Must match the stored key's provider
+          or BYOK is skipped and falls back to the built-in pair.
+        </li>
+        <li>
+          <code>gate.aiReview.model</code> — model override for the BYOK write-up (for example{" "}
+          <code>claude-3-5-sonnet-latest</code>); <code>null</code> uses the key record's model, else
+          a conservative per-provider default.
+        </li>
+      </ul>
+      <Callout variant="safety">
+        The provider key itself never lives in <code>.gittensory.yml</code>. It is held only in the
+        encrypted key store and unlocked by the <code>TOKEN_ENCRYPTION_SECRET</code> worker secret —
+        absent that secret, BYOK is unavailable and AI review silently falls back to the free
+        built-in model pair.
+      </Callout>
+
+      <h2>Guardrails and scope</h2>
+      <p>
+        Top-level keys in <code>.gittensory.yml</code> declare the repo's focus and guardrails. These
+        feed the deterministic findings (such as <code>manifest_blocked_path</code> and{" "}
+        <code>manifest_missing_tests</code>) and — when <code>gate.manifestPolicy: block</code> — can
+        become enforceable blockers.
+      </p>
+      <ul>
+        <li>
+          <code>wantedPaths</code> — globs for work areas you want; PRs touching these are
+          preferred. Default <code>[]</code>.
+        </li>
+        <li>
+          <code>blockedPaths</code> — globs off-limits to contributors. Touching one yields a{" "}
+          <code>manifest_blocked_path</code> finding, enforceable when{" "}
+          <code>gate.manifestPolicy: block</code>. Default <code>[]</code>.
+        </li>
+        <li>
+          <code>preferredLabels</code> — labels you prefer on incoming PRs; a missing one is
+          surfaced. Default <code>[]</code>.
+        </li>
+        <li>
+          <code>linkedIssuePolicy</code> — <code>required</code> / <code>preferred</code> /{" "}
+          <code>optional</code>. How strongly a linked issue is expected. Default{" "}
+          <code>optional</code>.
+        </li>
+        <li>
+          <code>testExpectations</code> — test paths expected to change with code; a{" "}
+          <code>manifest_missing_tests</code> finding fires when absent. Default <code>[]</code>.
+        </li>
+        <li>
+          <code>issueDiscoveryPolicy</code> — <code>encouraged</code> / <code>neutral</code> /{" "}
+          <code>discouraged</code>. Default <code>neutral</code>.
+        </li>
+        <li>
+          <code>maintainerNotes</code> — private review context, never published to any public
+          GitHub surface. Default <code>[]</code>.
+        </li>
+        <li>
+          <code>publicNotes</code> — notes explicitly opted into public output (public-safe filtered;
+          unsafe lines are dropped). Default <code>[]</code>.
+        </li>
+      </ul>
+
+      <h2>Other repo settings</h2>
+      <p>
+        Anything you can toggle in the dashboard can also be set as code under <code>settings:</code>{" "}
+        in <code>.gittensory.yml</code>. Common ones, all defaulting to the safe values shown:
+      </p>
+      <ul>
+        <li>
+          <code>commentMode</code> — comment audience: <code>off</code> /{" "}
+          <code>detected_contributors_only</code> (default) / <code>all_prs</code>.
+        </li>
+        <li>
+          <code>publicAudienceMode</code> — <code>oss_maintainer</code> (default) /{" "}
+          <code>gittensor_only</code>.
+        </li>
+        <li>
+          <code>publicSignalLevel</code> — <code>minimal</code> / <code>standard</code> (default).
+        </li>
+        <li>
+          <code>checkRunMode</code> — check-run publishing: <code>off</code> (default) /{" "}
+          <code>enabled</code>. Pair with <code>checkRunDetailLevel</code> (<code>minimal</code>{" "}
+          (default) / <code>standard</code> / <code>deep</code>).
+        </li>
+        <li>
+          <code>publicSurface</code> — <code>off</code> / <code>comment_and_label</code> (default) /{" "}
+          <code>comment_only</code> / <code>label_only</code>.
+        </li>
+        <li>
+          <code>autoLabelEnabled</code> (default <code>true</code>), <code>gittensorLabel</code>{" "}
+          (default <code>gittensor</code>), and <code>createMissingLabel</code> (default{" "}
+          <code>true</code>) — labeling.
+        </li>
+        <li>
+          <code>includeMaintainerAuthors</code> (default <code>false</code>),{" "}
+          <code>requireLinkedIssue</code> (default <code>false</code>), <code>backfillEnabled</code>{" "}
+          (default <code>true</code>), <code>privateTrustEnabled</code> (default <code>true</code>),
+          and <code>badgeEnabled</code> (README status badge, default <code>false</code>).
+        </li>
+        <li>
+          <code>agentPaused</code> (per-repo kill-switch, default <code>false</code>) and{" "}
+          <code>agentDryRun</code> (shadow mode, default <code>false</code>).
+        </li>
+        <li>
+          <code>autonomy</code> (per-action-class level; default is observe, deny-by-default),{" "}
+          <code>autoMaintain</code> (<code>{`{ mergeMethod, requireApprovals }`}</code>; default{" "}
+          <code>squash</code> / <code>1</code>), and <code>commandAuthorization</code> (role policy;
+          built-in default).
+        </li>
+      </ul>
+
+      <h2>Example .gittensory.yml</h2>
+      <p>
+        A worked manifest: focus and guardrails up top, a refined gate, BYOK AI review, and a few
+        dashboard-equivalent overrides.
+      </p>
+      <CodeBlock
+        filename=".gittensory.yml"
+        lang="yaml"
+        code={`# Focus / guardrails
+wantedPaths:
+  - "src/**"
+blockedPaths:
+  - "vendor/**"
+  - ".github/workflows/**"
+testExpectations:
+  - "tests/**"
+linkedIssuePolicy: preferred
+
+# Gate policy (refines an enabled gate)
+gate:
+  enabled: true
+  pack: gittensor
+  duplicates: block
+  linkedIssue: advisory
+  readiness:
+    mode: advisory
+    minScore: 70
+  slop:
+    mode: block
+    minScore: 60
+    aiAdvisory: true
+  mergeReadiness: advisory
+  manifestPolicy: block
+  firstTimeContributorGrace: true
+  aiReview:
+    mode: advisory
+    byok: true
+    provider: anthropic
+    model: claude-3-5-sonnet-latest
+
+# Generic dashboard-equivalent overrides
+settings:
+  commentMode: detected_contributors_only
+  checkRunMode: enabled
+  checkRunDetailLevel: standard
+  badgeEnabled: true`}
+      />
+
+      <Callout variant="warn" title="Roll forward one step at a time">
+        Start conservative: enable the gate in <code>advisory</code> before <code>block</code>, watch
+        the surfaced findings, and only then tighten. Combined with the tightening-only self-tune
+        loop, this keeps the gate from ever blocking a contributor on a setting you have not
+        validated.
+      </Callout>
+
+      <p>
+        For the privacy guarantees behind these surfaces, see{" "}
+        <a href="/docs/privacy-security">Privacy &amp; security</a>. For the maintainer install and
+        trust flow, see <a href="/docs/maintainer-install-trust">Install &amp; trust</a>.
+      </p>
+    </DocsPage>
+  );
+}

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -45,10 +45,10 @@ function Tuning() {
           <code>.gittensory.yml</code> file in the repo.
         </li>
         <li>
-          <strong>Feature flags</strong> — the <code>GITTENSORY_REVIEW_*</code> family of environment
-          variables on the worker. These switch whole capabilities (safety scanning, grounding, RAG
-          context, the unified comment, the content lane, observability, self-tuning, and more) on or
-          off for the deployment.
+          <strong>Feature flags</strong> — the <code>GITTENSORY_REVIEW_*</code> family of
+          environment variables on the worker. These switch whole capabilities (safety scanning,
+          grounding, RAG context, the unified comment, the content lane, observability, self-tuning,
+          and more) on or off for the deployment.
         </li>
       </ul>
       <p>
@@ -64,8 +64,8 @@ function Tuning() {
         <code>.gittensory.yml</code> falls back to a quiet, non-blocking profile: the gate is{" "}
         <code>off</code>, AI review is <code>off</code>, slop scoring is <code>off</code>, comments
         go only to detected contributors, and no check-run is published. Turning anything on is
-        always an explicit opt-in — you roll capabilities forward, and back, one flag and one repo at
-        a time.
+        always an explicit opt-in — you roll capabilities forward, and back, one flag and one repo
+        at a time.
       </Callout>
 
       <h2>Precedence</h2>
@@ -78,9 +78,9 @@ function Tuning() {
         <li>built-in safe defaults.</li>
       </ul>
       <p>
-        The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for the
-        gate-related fields and wins over the generic <code>settings:</code> block for those same
-        fields. Gittensory looks for the manifest at the first match of{" "}
+        The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for
+        the gate-related fields and wins over the generic <code>settings:</code> block for those
+        same fields. Gittensory looks for the manifest at the first match of{" "}
         <code>.gittensory.yml</code> → <code>.github/gittensory.yml</code> →{" "}
         <code>.gittensory.json</code> → <code>.github/gittensory.json</code>.
       </p>
@@ -88,15 +88,15 @@ function Tuning() {
       <h2>Feature flags (GITTENSORY_REVIEW_*)</h2>
       <p>
         These are worker environment variables, every one defaulting to <strong>OFF</strong>.
-        "Truthy" means one of <code>1</code>, <code>true</code>, <code>yes</code>, or <code>on</code>{" "}
-        (case-insensitive); anything else — including unset, empty, or <code>false</code> — is OFF.
-        When a flag is OFF its code path is inert: the review behaves exactly as if the feature did
-        not exist.
+        "Truthy" means one of <code>1</code>, <code>true</code>, <code>yes</code>, or{" "}
+        <code>on</code> (case-insensitive); anything else — including unset, empty, or{" "}
+        <code>false</code> — is OFF. When a flag is OFF its code path is inert: the review behaves
+        exactly as if the feature did not exist.
       </p>
       <p>
         One flag is a <strong>scope</strong> rather than a capability:{" "}
-        <code>GITTENSORY_REVIEW_REPOS</code> is a per-repo allowlist that must <em>also</em> pass for
-        any per-PR feature to run on a given repo. So a per-PR feature activates only when{" "}
+        <code>GITTENSORY_REVIEW_REPOS</code> is a per-repo allowlist that must <em>also</em> pass
+        for any per-PR feature to run on a given repo. So a per-PR feature activates only when{" "}
         <strong>its own flag is ON and the repo is allowlisted</strong>.
       </p>
       <ul>
@@ -122,10 +122,10 @@ function Tuning() {
         </li>
         <li>
           <code>GITTENSORY_REVIEW_RAG</code> — retrieval-augmented context: queries the codebase
-          vector index for related code and docs (callers, related modules, existing conventions) and
-          appends a "Relevant existing code / docs" section to the reviewer prompt. Additive only.
-          Inert until a vector index exists for the repo — a cold or missing index degrades to no
-          context. Per-PR.
+          vector index for related code and docs (callers, related modules, existing conventions)
+          and appends a "Relevant existing code / docs" section to the reviewer prompt. Additive
+          only. Inert until a vector index exists for the repo — a cold or missing index degrades to
+          no context. Per-PR.
         </li>
         <li>
           <code>GITTENSORY_REVIEW_REPUTATION</code> — submitter-reputation spend control. A new,
@@ -142,8 +142,8 @@ function Tuning() {
           <code>GITTENSORY_REVIEW_OPS</code> — observability, read-only. On the cron tick an anomaly
           scan over the gate-block ledger and calibration data emits a structured{" "}
           <code>ops_anomaly</code> log when something drifts, and a bearer-gated{" "}
-          <code>GET /v1/internal/ops/stats</code> serves an outcome aggregate. Does not mutate config.
-          Global.
+          <code>GET /v1/internal/ops/stats</code> serves an outcome aggregate. Does not mutate
+          config. Global.
         </li>
         <li>
           <code>GITTENSORY_REVIEW_SELFTUNE</code> — the self-improvement loop. On the cron tick it
@@ -153,8 +153,8 @@ function Tuning() {
           Global, and safe to leave on.
         </li>
         <li>
-          <code>GITTENSORY_REVIEW_PARITY_AUDIT</code> — parity readiness, shadow record-only. Records
-          each finalized gate decision and serves a readiness report at{" "}
+          <code>GITTENSORY_REVIEW_PARITY_AUDIT</code> — parity readiness, shadow record-only.
+          Records each finalized gate decision and serves a readiness report at{" "}
           <code>GET /v1/internal/parity</code>. Changes no review behavior. Global.
         </li>
         <li>
@@ -171,18 +171,18 @@ function Tuning() {
           secrets. Global.
         </li>
         <li>
-          <code>GITTENSORY_REVIEW_STATS_TOKEN</code> — the bearer secret for the stats data endpoint.
-          Not an on/off switch; it is the token value. When set, the stats route requires this bearer
-          token.
+          <code>GITTENSORY_REVIEW_STATS_TOKEN</code> — the bearer secret for the stats data
+          endpoint. Not an on/off switch; it is the token value. When set, the stats route requires
+          this bearer token.
         </li>
       </ul>
 
       <Callout variant="note" title="Rolling out a per-PR feature">
-        A safe rollout is two flips: turn the capability flag <code>true</code>, then add the repo to{" "}
-        <code>GITTENSORY_REVIEW_REPOS</code>. Because both must be true, you can leave a capability
-        globally enabled while it stays dormant everywhere except the repos you have explicitly
-        allowlisted — and you roll a single repo back by removing it from the list without disturbing
-        the others.
+        A safe rollout is two flips: turn the capability flag <code>true</code>, then add the repo
+        to <code>GITTENSORY_REVIEW_REPOS</code>. Because both must be true, you can leave a
+        capability globally enabled while it stays dormant everywhere except the repos you have
+        explicitly allowlisted — and you roll a single repo back by removing it from the list
+        without disturbing the others.
       </Callout>
 
       <h2>Gate modes</h2>
@@ -195,7 +195,8 @@ function Tuning() {
           <code>off</code> — the dimension is not evaluated.
         </li>
         <li>
-          <code>advisory</code> — the finding is surfaced in the comment or context but never blocks.
+          <code>advisory</code> — the finding is surfaced in the comment or context but never
+          blocks.
         </li>
         <li>
           <code>block</code> — the finding can become a hard <code>Gittensory Gate</code> blocker.
@@ -204,8 +205,8 @@ function Tuning() {
         </li>
       </ul>
       <p>
-        The master switch is <code>gate.enabled</code> (<code>off</code> / <code>enabled</code>). The
-        per-dimension modes refine an already-enabled gate. The main dimensions:
+        The master switch is <code>gate.enabled</code> (<code>off</code> / <code>enabled</code>).
+        The per-dimension modes refine an already-enabled gate. The main dimensions:
       </p>
       <ul>
         <li>
@@ -231,14 +232,14 @@ function Tuning() {
         <li>
           <code>gate.slop.mode</code> — the deterministic anti-slop signal. Default <code>off</code>{" "}
           (opt-in). <code>advisory</code> surfaces the slop score and warnings; <code>block</code>{" "}
-          also hard-blocks at or above <code>gate.slop.minScore</code> (0–100; <code>null</code> uses{" "}
-          <code>60</code>, the "high" band). Set <code>gate.slop.aiAdvisory: true</code> to add a
-          free advisory-only <code>ai_slop_advisory</code> finding — it never feeds the slop score or
-          the gate.
+          also hard-blocks at or above <code>gate.slop.minScore</code> (0–100; <code>null</code>{" "}
+          uses <code>60</code>, the "high" band). Set <code>gate.slop.aiAdvisory: true</code> to add
+          a free advisory-only <code>ai_slop_advisory</code> finding — it never feeds the slop score
+          or the gate.
         </li>
         <li>
-          <code>gate.mergeReadiness</code> — composite merge-readiness gate. Default <code>off</code>,
-          no min score.
+          <code>gate.mergeReadiness</code> — composite merge-readiness gate. Default{" "}
+          <code>off</code>, no min score.
         </li>
         <li>
           <code>gate.manifestPolicy</code> — when <code>block</code>, the manifest's declared policy
@@ -270,13 +271,13 @@ function Tuning() {
         </li>
         <li>
           <code>gate.aiReview.provider</code> — <code>anthropic</code>, <code>openai</code>, or{" "}
-          <code>null</code> (use the stored key's own provider). Must match the stored key's provider
-          or BYOK is skipped and falls back to the built-in pair.
+          <code>null</code> (use the stored key's own provider). Must match the stored key's
+          provider or BYOK is skipped and falls back to the built-in pair.
         </li>
         <li>
           <code>gate.aiReview.model</code> — model override for the BYOK write-up (for example{" "}
-          <code>claude-3-5-sonnet-latest</code>); <code>null</code> uses the key record's model, else
-          a conservative per-provider default.
+          <code>claude-3-5-sonnet-latest</code>); <code>null</code> uses the key record's model,
+          else a conservative per-provider default.
         </li>
       </ul>
       <Callout variant="safety">
@@ -288,10 +289,10 @@ function Tuning() {
 
       <h2>Guardrails and scope</h2>
       <p>
-        Top-level keys in <code>.gittensory.yml</code> declare the repo's focus and guardrails. These
-        feed the deterministic findings (such as <code>manifest_blocked_path</code> and{" "}
-        <code>manifest_missing_tests</code>) and — when <code>gate.manifestPolicy: block</code> — can
-        become enforceable blockers.
+        Top-level keys in <code>.gittensory.yml</code> declare the repo's focus and guardrails.
+        These feed the deterministic findings (such as <code>manifest_blocked_path</code> and{" "}
+        <code>manifest_missing_tests</code>) and — when <code>gate.manifestPolicy: block</code> —
+        can become enforceable blockers.
       </p>
       <ul>
         <li>
@@ -325,15 +326,16 @@ function Tuning() {
           GitHub surface. Default <code>[]</code>.
         </li>
         <li>
-          <code>publicNotes</code> — notes explicitly opted into public output (public-safe filtered;
-          unsafe lines are dropped). Default <code>[]</code>.
+          <code>publicNotes</code> — notes explicitly opted into public output (public-safe
+          filtered; unsafe lines are dropped). Default <code>[]</code>.
         </li>
       </ul>
 
       <h2>Other repo settings</h2>
       <p>
-        Anything you can toggle in the dashboard can also be set as code under <code>settings:</code>{" "}
-        in <code>.gittensory.yml</code>. Common ones, all defaulting to the safe values shown:
+        Anything you can toggle in the dashboard can also be set as code under{" "}
+        <code>settings:</code> in <code>.gittensory.yml</code>. Common ones, all defaulting to the
+        safe values shown:
       </p>
       <ul>
         <li>
@@ -428,10 +430,10 @@ settings:
       />
 
       <Callout variant="warn" title="Roll forward one step at a time">
-        Start conservative: enable the gate in <code>advisory</code> before <code>block</code>, watch
-        the surfaced findings, and only then tighten. Combined with the tightening-only self-tune
-        loop, this keeps the gate from ever blocking a contributor on a setting you have not
-        validated.
+        Start conservative: enable the gate in <code>advisory</code> before <code>block</code>,
+        watch the surfaced findings, and only then tighten. Combined with the tightening-only
+        self-tune loop, this keeps the gate from ever blocking a contributor on a setting you have
+        not validated.
       </Callout>
 
       <p>

--- a/docs/review-configuration.md
+++ b/docs/review-configuration.md
@@ -1,0 +1,234 @@
+# Gittensory Review Configuration Reference
+
+This is the operator reference for tuning **gittensory CI** and **gittensory review** — the
+PR-review engine that scores, gates, and comments on pull requests.
+
+## How configuration works
+
+Gittensory review is built in three layers, and you tune it without touching the review algorithm
+itself:
+
+1. **The review algorithm is open-source.** The deterministic gate, the scoring signals, the slop
+   detector, the grounding/RAG context builders, and the comment renderer all live in the public
+   source tree. Anyone can read exactly how a verdict is reached.
+
+2. **Operators tune via two private, repo-scoped controls** that sit *on top* of the open algorithm:
+   - **Per-repo settings** — stored in the operator's database (set through the dashboard/API), or
+     declared as config-as-code in a repo's `.gittensory.yml`. These choose gate modes, score
+     thresholds, guardrails, and which surfaces are enabled. They never reveal review *direction*,
+     so a contributor cannot read them and game the gate.
+   - **Operator feature flags** — the `GITTENSORY_REVIEW_*` family of environment variables on the
+     worker. These switch whole *capabilities* (safety scanning, CI/full-file grounding, RAG
+     context, reputation-based spend control, observability, self-tuning, the unified comment, the
+     content lane, the draft-submission flow) on or off for the whole deployment.
+
+3. **Defaults are safe and conservative.** Every feature flag ships **OFF**. A repo with no settings
+   row and no `.gittensory.yml` falls back to a quiet, non-blocking profile: the gate is `off`, AI
+   review is `off`, slop scoring is `off`, comments are posted only to detected contributors, and no
+   check-run is published. Turning anything on is always an explicit opt-in. You roll capabilities
+   forward (and back) one flag — and one repo — at a time.
+
+**Precedence (most specific wins):** `.gittensory.yml` in the repo **>** per-repo database settings
+**>** built-in safe defaults. The friendly `gate:` block in `.gittensory.yml` is a typed alias for
+the gate-related fields and wins over the generic `settings:` block for those same fields.
+
+---
+
+## 1. Feature flags (`GITTENSORY_REVIEW_*`)
+
+These are worker environment variables (declared in `wrangler.jsonc` `vars`, overridable per
+deployment). **Every flag defaults to OFF.** "Truthy" means one of `1`, `true`, `yes`, or `on`
+(case-insensitive); anything else — including unset, empty, or `false` — is OFF. When a flag is OFF,
+its code path is inert: the review behaves exactly as if the feature did not exist (no extra GitHub
+fetch, no extra DB read/write, no extra branch taken).
+
+Two flags act as **scopes** rather than capabilities: `GITTENSORY_REVIEW_REPOS` is a per-repo
+allowlist that must *also* pass for any of the per-PR features below to run on a given repo. So a
+per-PR feature activates only when **(its own flag is ON) AND (the repo is allowlisted)**.
+
+| Flag | What it does | Default | How to tune | Sample |
+| --- | --- | --- | --- | --- |
+| `GITTENSORY_REVIEW_REPOS` | **Per-repo cutover allowlist.** Comma-separated `owner/repo` names that may run the per-PR review features (`SAFETY`, `GROUNDING`, `RAG`, `REPUTATION`, `UNIFIED_COMMENT`). A per-PR feature runs on a repo only if its global flag is ON **and** the repo is listed here. Empty/unset = **no repos** → every per-PR feature stays dormant for everyone regardless of the global flags. Cron/endpoint flags (`OPS`, `SELFTUNE`, `PARITY_AUDIT`, `CONTENT_LANE`, `DRAFT`) are **not** scoped by this. | `""` (no repos) | Add repos one at a time as you roll forward; remove to roll back. Case-insensitive, trimmed; stray commas are ignored. | `"JSONbored/gittensory,JSONbored/awesome-claude"` |
+| `GITTENSORY_REVIEW_SAFETY` | **Safety scan** in the review path: (1) defangs untrusted PR title/body/diff (prompt-injection neutralization) before the AI reviewer sees it, and (2) scans the PR diff for leaked secrets, surfacing a `secret_leak` blocker. Per-PR — also requires the repo to be in `GITTENSORY_REVIEW_REPOS`. | `false` | Flip to `true`, then add the repo to `GITTENSORY_REVIEW_REPOS`. No per-repo tuning beyond that. | `"true"` |
+| `GITTENSORY_REVIEW_GROUNDING` | **Grounds** the AI-reviewer prompt with the PR's *finished* CI status + the *full post-change content* of the changed files, so a non-frontier model verifies its claims against reality instead of predicting CI or flagging symbols defined just outside the hunk. Per-PR — also gated by `GITTENSORY_REVIEW_REPOS`. | `false` | Flip to `true` + allowlist the repo. Both grounding inputs (CI + full files) are gathered together; there is no partial mode. | `"true"` |
+| `GITTENSORY_REVIEW_RAG` | **Retrieval-augmented context.** At review time, queries the codebase vector index for code/docs semantically related to the changed files (callers, related modules, existing conventions) and appends a "Relevant existing code / docs" section to the reviewer prompt — additive only, like grounding. Per-PR — also gated by `GITTENSORY_REVIEW_REPOS`. **Inert until a vector index exists** for the repo (a cold/missing index degrades to no context). | `false` | Flip to `true` + allowlist the repo **and** bind/populate the `VECTORIZE` index. Without an index it is a safe no-op. | `"true"` |
+| `GITTENSORY_REVIEW_REPUTATION` | **Submitter-reputation spend control (internal-only).** Extends the AI-spend gate: a new / burst / low-reputation submitter is downgraded to a deterministic-only review (the paid AI neurons are skipped); good-reputation submitters proceed normally. The per-(project, submitter) outcome is recorded after the gate decides. **Never surfaced publicly** — no comment, label, or check shows reputation. Per-PR — also gated by `GITTENSORY_REVIEW_REPOS`. | `false` | Flip to `true` + allowlist the repo. Thresholds are generic anti-abuse defaults (they reveal no review direction) and are not per-repo tunable. | `"true"` |
+| `GITTENSORY_REVIEW_UNIFIED_COMMENT` | Renders the public PR comment as **one in-place unified comment** (the converged comment shape) instead of the legacy multi-panel comment. Per-PR — also gated by `GITTENSORY_REVIEW_REPOS`. | `false` | Flip to `true` + allowlist the repo. Flag-OFF keeps the legacy comment byte-identical. | `"true"` |
+| `GITTENSORY_REVIEW_OPS` | **Observability (read-only).** Drives two operator surfaces off your own review-outcome data: (1) on the cron tick, an anomaly scan over the gate-block ledger + recommendation/slop calibration emits a structured `ops_anomaly` log when something drifts (gate false-positive spike, slop score inverting, recommendation negative-rate spike); and (2) a bearer-gated `GET /v1/internal/ops/stats` outcome aggregate. **Read-only** — does not mutate config. Global (not scoped by `GITTENSORY_REVIEW_REPOS`). | `false` | Flip to `true` to enable the anomaly cron + the stats endpoint. Endpoint is bearer-gated (see secrets). | `"true"` |
+| `GITTENSORY_REVIEW_SELFTUNE` | **Self-improvement / auto-tune loop.** On the cron tick, computes tuning recommendations from your own review-outcome data, **shadow-soaks** any strictly-tightening recommendation, and auto-promotes it to live **only** after the soak window passes the gate; every action is audited. It can **only ever tighten** the gate — a loosening recommendation is never applied. Global. *Note:* reading a promoted override back into the live gate is a deferred follow-up; today it records recommendations + shadow-soak + audit. | `false` | Flip to `true` to enable the self-tuning cron. Direction is enforced (tightening-only) — safe to leave on. | `"true"` |
+| `GITTENSORY_REVIEW_PARITY_AUDIT` | **Parity readiness (shadow, record-only).** Shadow-records each finalized native gate decision into the audit-source table and serves a pre-cutover parity readiness report at `GET /v1/internal/parity`. Recording changes **no** review behavior. Global. | `false` | Flip to `true` during a validation window to collect parity data; turn off when done. | `"true"` |
+| `GITTENSORY_REVIEW_CONTENT_LANE` | **Content-review lane.** Routes *content* repos (curated lists, registries) through the dedicated content lane — duplicate detection, source-evidence reachability, security scanning, scope classification, registry/netuid grounding — instead of the code gate. Global. Flag-OFF the lane is never reached. | `false` | Flip to `true` to route content repos through the lane at cutover. | `"true"` |
+| `GITTENSORY_REVIEW_DRAFT` | **Public draft-submission flow.** Enables the `/v1/drafts` endpoints: a contributor draft → GitHub OAuth → fork PR opened against the content repo. Flag-OFF every draft endpoint 404s and nothing is written. Global. | `false` | Flip to `true` **and** set the `DRAFT_TOKEN_ENCRYPTION_SECRET` and `GITHUB_OAUTH_CLIENT_SECRET` secrets (the endpoints 503 without the encryption secret). Optionally set `DRAFT_PUBLIC_REPO` / `DRAFT_BASE_REF`. | `"true"` |
+| `GITTENSORY_REVIEW_STATS_TOKEN` | **Bearer secret** for the on-demand stats dashboard/data endpoint (not an on/off switch — it is the token value). When set, the stats data route requires this bearer token. | unset | Set via `wrangler secret put GITTENSORY_REVIEW_STATS_TOKEN`; rotate by overwriting. | `wrangler secret put GITTENSORY_REVIEW_STATS_TOKEN` |
+
+### Rollout pattern
+
+A safe rollout for a per-PR feature is two flips: turn the capability flag `true`, then add the repo
+to `GITTENSORY_REVIEW_REPOS`. Because both must be true, you can leave a capability globally enabled
+while it stays dormant everywhere except the repos you have explicitly converged — and you can roll a
+single repo back by removing it from the allowlist without disturbing the others.
+
+---
+
+## 2. Per-repo configuration (`.gittensory.yml` + database settings)
+
+Per-repo behavior is the **effective settings**: the database row for the repo, overlaid with the
+repo's `.gittensory.yml`. `.gittensory.yml` wins where it sets a value; unset fields fall through to
+the database row, and an absent database row falls through to the safe defaults below.
+
+Gittensory looks for the manifest file at (first match wins):
+`.gittensory.yml` → `.github/gittensory.yml` → `.gittensory.json` → `.github/gittensory.json`.
+
+### Gate modes
+
+Most gate dimensions are tri-state **gate-rule modes**: `off` / `advisory` / `block`.
+
+- `off` — the dimension is not evaluated.
+- `advisory` — the finding is **surfaced** (in the comment/context) but never blocks.
+- `block` — the finding can become a hard `Gittensory Gate` blocker. Blocking is always
+  **confirmed-contributor-gated** — the mode chooses *which* deterministic checks are active, never
+  *who* can be blocked.
+
+The master switch is `gateCheckMode` (`off` / `enabled`). The per-dimension modes refine an
+already-enabled gate.
+
+| Setting | `.gittensory.yml` (`gate:`) | DB field | Type / values | Default | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Gate master switch | `gate.enabled` (bool) | `gateCheckMode` | `off` / `enabled` | `off` | Turns the whole deterministic gate on. Other gate modes refine it. |
+| Policy pack | `gate.pack` | `gatePack` | `gittensor` / `oss-anti-slop` | `gittensor` | `gittensor` = confirmed-contributor-gated, registry-aware. `oss-anti-slop` runs the deterministic rules against any author on any repo. |
+| Linked-issue gate | `gate.linkedIssue` | `linkedIssueGateMode` | `off`/`advisory`/`block` | `advisory` | If the dashboard "Require linked issue" toggle (`requireLinkedIssue`) is on but this is `off`, it is auto-promoted to `block`. |
+| Duplicate-PR gate | `gate.duplicates` | `duplicatePrGateMode` | `off`/`advisory`/`block` | `block` | Detects duplicate/superseding PRs. |
+| Quality / merge-readiness score gate | `gate.readiness.mode` | `qualityGateMode` | `off`/`advisory`/`block` | `advisory` | The PR-quality score gate. |
+| Quality min score | `gate.readiness.minScore` | `qualityGateMinScore` | number 0–100 (nullable) | `null` | At/above this score the quality dimension passes; `null` = engine default band. |
+| Slop gate | `gate.slop.mode` | `slopGateMode` | `off`/`advisory`/`block` | `off` | Deterministic anti-slop signal. `advisory` surfaces the slop score + warnings; `block` also hard-blocks at/above the min score. Opt-in. |
+| Slop min score | `gate.slop.minScore` | `slopGateMinScore` | number 0–100 (nullable) | `null` (engine uses `60`, the "high" band) | The slop-risk threshold at/above which `slop block` blocks. |
+| Slop AI advisory | `gate.slop.aiAdvisory` | `slopAiAdvisory` | bool | `false` | When `true` **and** slop is not `off`, a free Workers-AI pass adds an **advisory-only** `ai_slop_advisory` finding. Never feeds the slop score or the gate. |
+| Merge-readiness gate | `gate.mergeReadiness` | `mergeReadinessGateMode` | `off`/`advisory`/`block` | `off` | Composite merge-readiness gate. No min score. |
+| Manifest-policy gate | `gate.manifestPolicy` | `manifestPolicyGateMode` | `off`/`advisory`/`block` | `off` | When `block`, the manifest's declared policy (blocked paths, required-linked-issue, test expectations) becomes an enforceable blocker. Independent of merge-readiness. |
+| First-time-contributor grace | `gate.firstTimeContributorGrace` | `firstTimeContributorGrace` | bool | `false` | When `true`, softens a would-be block to advisory for a genuine newcomer (0 merged PRs, < 3 closed-unmerged PRs). Repeat offenders and authors with merge history are gated normally. |
+| AI review | `gate.aiReview.mode` | `aiReviewMode` | `off`/`advisory`/`block` | `off` | `advisory` posts AI review notes only; `block` lets a dual-model high-confidence consensus defect become a blocker (confirmed-contributors only). |
+| AI review BYOK | `gate.aiReview.byok` | `aiReviewByok` | bool | `false` | When `true` and a provider key is configured, the *advisory* write-up uses the maintainer's frontier model. The consensus blocker always uses the free Workers-AI pair, so BYOK never changes who can be blocked. |
+| AI review provider | `gate.aiReview.provider` | `aiReviewProvider` | `anthropic` / `openai` / `null` | `null` | `null` = use the stored key's own provider. Must match the stored key's provider or BYOK is skipped (Workers-AI fallback). The key itself is only in the encrypted key store. |
+| AI review model | `gate.aiReview.model` | `aiReviewModel` | string / `null` | `null` | Model override for the BYOK advisory write-up (e.g. `claude-3-5-sonnet-latest`). `null` = the key record's model, else a conservative per-provider default. |
+
+### Guardrails and scope (focus manifest)
+
+The `.gittensory.yml` top-level keys declare the repo's focus and guardrails. These feed the
+deterministic findings (e.g. `manifest_blocked_path`, `manifest_missing_tests`) and — when
+`gate.manifestPolicy: block` — can become enforceable blockers.
+
+| Key | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `wantedPaths` | string list (globs) | `[]` | Work areas the maintainer wants — PRs touching these are preferred/encouraged. |
+| `blockedPaths` | string list (globs) | `[]` | Paths off-limits to contributors. Touching one yields a `manifest_blocked_path` finding; enforceable when `gate.manifestPolicy: block`. |
+| `preferredLabels` | string list | `[]` | Labels the maintainer prefers on incoming PRs; a missing preferred label is surfaced. |
+| `linkedIssuePolicy` | `required` / `preferred` / `optional` | `optional` | How strongly a linked issue is expected. |
+| `testExpectations` | string list | `[]` | Test paths/areas expected to change with code; a `manifest_missing_tests` finding fires when absent. |
+| `issueDiscoveryPolicy` | `encouraged` / `neutral` / `discouraged` | `neutral` | Whether opening discovery issues is encouraged. |
+| `maintainerNotes` | string list | `[]` | **Private** review context — never published to a public GitHub surface. |
+| `publicNotes` | string list | `[]` | Notes explicitly opted into public output (public-safe filtered; unsafe lines are dropped). |
+
+### Generic `settings:` overrides and other repo settings
+
+Everything a maintainer can toggle in the dashboard can be set as code under `settings:` in
+`.gittensory.yml`. Common ones (all default to the safe values shown):
+
+| Setting | DB field | Values | Default |
+| --- | --- | --- | --- |
+| Comment audience | `commentMode` | `off` / `detected_contributors_only` / `all_prs` | `detected_contributors_only` |
+| Public audience mode | `publicAudienceMode` | `oss_maintainer` / `gittensor_only` | `oss_maintainer` |
+| Public signal level | `publicSignalLevel` | `minimal` / `standard` | `standard` |
+| Check-run publishing | `checkRunMode` | `off` / `enabled` | `off` |
+| Check-run detail | `checkRunDetailLevel` | `minimal` / `standard` / `deep` | `minimal` |
+| Public surface | `publicSurface` | `off` / `comment_and_label` / `comment_only` / `label_only` | `comment_and_label` |
+| Auto-label | `autoLabelEnabled` | bool | `true` |
+| Label name | `gittensorLabel` | string | `gittensor` |
+| Create missing label | `createMissingLabel` | bool | `true` |
+| Include maintainer authors | `includeMaintainerAuthors` | bool | `false` |
+| Require linked issue | `requireLinkedIssue` | bool | `false` |
+| Backfill | `backfillEnabled` | bool | `true` |
+| Private trust | `privateTrustEnabled` | bool | `true` |
+| README status badge | `badgeEnabled` | bool | `false` |
+| Agent paused (per-repo kill-switch) | `agentPaused` | bool | `false` |
+| Agent dry-run / shadow | `agentDryRun` | bool | `false` |
+| Autonomy dial | `autonomy` | per-action-class level (`observe`…`auto`) | `{}` (= `observe`, deny-by-default) |
+| Auto-maintain policy | `autoMaintain` | `{ mergeMethod, requireApprovals }` | `squash` / `1` |
+| Command authorization | `commandAuthorization` | role policy | built-in default policy |
+
+### Example `.gittensory.yml`
+
+```yaml
+# Focus / guardrails
+wantedPaths:
+  - "src/**"
+blockedPaths:
+  - "vendor/**"
+  - ".github/workflows/**"
+testExpectations:
+  - "tests/**"
+linkedIssuePolicy: preferred
+
+# Gate policy (refines an enabled gate)
+gate:
+  enabled: true
+  pack: gittensor
+  duplicates: block
+  linkedIssue: advisory
+  readiness:
+    mode: advisory
+    minScore: 70
+  slop:
+    mode: block
+    minScore: 60
+    aiAdvisory: true
+  mergeReadiness: advisory
+  manifestPolicy: block
+  firstTimeContributorGrace: true
+  aiReview:
+    mode: advisory
+    byok: true
+    provider: anthropic
+    model: claude-3-5-sonnet-latest
+
+# Generic dashboard-equivalent overrides
+settings:
+  commentMode: detected_contributors_only
+  checkRunMode: enabled
+  checkRunDetailLevel: standard
+  badgeEnabled: true
+```
+
+---
+
+## 3. Required secrets (by name)
+
+Set these as worker secrets (`wrangler secret put NAME`) — they are **not** committed to
+`wrangler.jsonc`. Required secrets must be present for the worker to run; optional secrets gate a
+specific capability and degrade safely when absent.
+
+**Core (required):**
+
+- `GITHUB_WEBHOOK_SECRET`
+- `GITHUB_APP_ID`
+- `GITHUB_APP_PRIVATE_KEY`
+- `GITHUB_APP_SLUG`
+- `GITTENSOR_REGISTRY_URL`
+- `GITTENSORY_API_TOKEN`
+- `GITTENSORY_MCP_TOKEN`
+- `INTERNAL_JOB_TOKEN`
+
+**Optional (capability-gated):**
+
+- `GITHUB_OAUTH_CLIENT_ID` — GitHub OAuth (dashboard sign-in, draft flow).
+- `GITHUB_OAUTH_CLIENT_SECRET` — GitHub OAuth; also required by the draft flow.
+- `GITHUB_PUBLIC_TOKEN` — unauthenticated public-GitHub reads (e.g. fetching a repo's `.gittensory.yml`).
+- `TOKEN_ENCRYPTION_SECRET` — AES-256-GCM master secret for maintainer BYOK provider keys at rest. Absent ⇒ BYOK unavailable; AI review silently falls back to free Workers AI.
+- `DRAFT_TOKEN_ENCRYPTION_SECRET` — AES-256-GCM secret for the contributor OAuth token in the draft flow. Absent ⇒ draft create/callback endpoints return 503.
+- `GITTENSORY_REVIEW_STATS_TOKEN` — bearer token guarding the stats data endpoint.
+- `GITTENSORY_DRIFT_ISSUE_TOKEN` — token for auto-filing drift issues.
+- `GITTENSORY_CONTRIBUTOR_ISSUE_TOKEN` — token for contributor-issue automation.
+- `PRODUCT_USAGE_HASH_SALT` — salt for hashing product-usage identifiers.
+
+**Related infrastructure bindings** (not secrets, but gate capabilities when bound): `VECTORIZE`
+(RAG index — `GITTENSORY_REVIEW_RAG` is inert without it), `REVIEW_AUDIT` (R2 audit/screenshot
+blobs), `BROWSER` (visual capture). Absent bindings degrade safely.


### PR DESCRIPTION
Documentation + sample configs for gittensory's CI review features.

## New
- **docs/review-configuration.md** — full tuning/configuration reference: every review feature flag, every `.gittensory.yml` option + repo setting, required secrets — with defaults, how-to-tune, and sample values.
- **.gittensory.yml.example** — a fully-commented sample per-repo config.
- **.env.example** — the review feature flags (default off) + the required secret names.
- **Website pages** — "How reviews work" (the gate, the dual-AI review + consensus, the unified review comment) and "Tuning your reviews", wired into the docs nav.

## Updated
- GitHub App + Privacy & security docs pages.
- README + CHANGELOG.

All presented as native gittensory CI features.
