### PR TITLE
Fix draft OAuth CSRF binding

### DIFF
--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -511,8 +511,31 @@ function clientIp(request: Request): string {
   return request.headers.get("cf-connecting-ip") || request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown-ip";
 }
 
-function json(data: unknown, status: number): Response {
-  return new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
+function json(data: unknown, status: number, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json", ...headers } });
+}
+
+const DRAFT_OAUTH_COOKIE = "gittensory_draft_oauth";
+
+function parseCookieHeader(header: string | null): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  for (const part of (header || "").split(";")) {
+    const eq = part.indexOf("=");
+    if (eq <= 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (!name) continue;
+    try {
+      cookies[name] = decodeURIComponent(part.slice(eq + 1).trim());
+    } catch {
+      cookies[name] = "";
+    }
+  }
+  return cookies;
+}
+
+function draftOAuthCookie(state: string, origin: string, maxAgeSeconds: number): string {
+  const secure = new URL(origin).protocol === "https:" ? "; Secure" : "";
+  return `${DRAFT_OAUTH_COOKIE}=${encodeURIComponent(state)}; Path=/v1/drafts/auth/callback; Max-Age=${maxAgeSeconds}; HttpOnly; SameSite=Lax${secure}`;
 }
 
 export async function handleDraftCreate(request: Request, env: Env): Promise<Response> {
@@ -560,7 +583,7 @@ export async function handleDraftCreate(request: Request, env: Env): Promise<Res
   authUrl.searchParams.set("redirect_uri", `${origin}/v1/drafts/auth/callback`);
   authUrl.searchParams.set("state", `${id}.${state}`);
 
-  return json({ ok: true, draftId: id, statusUrl: `/v1/drafts/${id}`, authUrl: authUrl.toString(), target }, 201);
+  return json({ ok: true, draftId: id, statusUrl: `/v1/drafts/${id}`, authUrl: authUrl.toString(), target }, 201, { "set-cookie": draftOAuthCookie(`${id}.${state}`, origin, 10 * 60) });
 }
 
 export async function handleDraftStatus(_request: Request, env: Env, draftId: string): Promise<Response> {
@@ -597,8 +620,14 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
   const url = new URL(request.url);
   const code = url.searchParams.get("code") || "";
   const providerError = url.searchParams.get("error") || "";
-  const [draftId, stateToken] = (url.searchParams.get("state") || "").split(".");
+  const state = url.searchParams.get("state") || "";
+  const [draftId, stateToken] = state.split(".");
   if (!draftId || !stateToken) return new Response("Invalid submission state.", { status: 400 });
+
+  const cookieState = parseCookieHeader(request.headers.get("cookie"))[DRAFT_OAUTH_COOKIE] || "";
+  if (!cookieState || !timingSafeEqualHex(await sha256Hex(cookieState), await sha256Hex(state))) {
+    return new Response("Invalid or expired submission state.", { status: 400 });
+  }
 
   const row = await env.DB.prepare(`SELECT * FROM submission_drafts WHERE id = ?`).bind(draftId).first<DraftRow>();
   // Constant-time compare of the OAuth-state hash (CSRF token); both are lowercase hex SHA-256.
@@ -631,7 +660,7 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
   await env.JOBS.send({ type: "submit-draft", requestedBy: "api", draftId });
 
   return new Response(`<meta http-equiv="refresh" content="0; url=/v1/drafts/${draftId}">Submission queued.`, {
-    headers: { "content-type": "text/html" },
+    headers: { "content-type": "text/html", "set-cookie": draftOAuthCookie("", url.origin, 0) },
   });
 }
 

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -26,6 +26,10 @@ function jsonHeaders(): Record<string, string> {
   return { "content-type": "application/json", origin: ORIGIN };
 }
 
+function callbackHeaders(setCookie: string | null): Record<string, string> {
+  return setCookie ? { cookie: setCookie.split(";")[0] ?? "" } : {};
+}
+
 const SAMPLE_FIELDS = {
   category: "skills",
   name: "Example Skill",
@@ -92,6 +96,9 @@ describe("draft endpoints — flag ON, public + unauthenticated", () => {
     // path-only URL resolves the origin to http://localhost, so the redirect_uri lives under it.
     expect(authUrl.searchParams.get("redirect_uri")).toBe("http://localhost/v1/drafts/auth/callback");
     expect(authUrl.searchParams.get("state")?.startsWith(`${body.draftId}.`)).toBe(true);
+    expect(res.headers.get("set-cookie")).toContain("gittensory_draft_oauth=");
+    expect(res.headers.get("set-cookie")).toContain("HttpOnly");
+    expect(res.headers.get("set-cookie")).toContain("SameSite=Lax");
 
     const row = await env.DB.prepare("SELECT status, category, slug, target_path, branch_name, auth_state_hash FROM submission_drafts WHERE id = ?").bind(body.draftId).first<{
       status: string;
@@ -523,23 +530,35 @@ describe("processSubmitDraft — fork-PR happy path + branches", () => {
 });
 
 describe("handleDraftOAuthCallback — success + error paths", () => {
-  async function createDraftState(env: Env): Promise<{ draftId: string; state: string }> {
+  async function createDraftState(env: Env): Promise<{ draftId: string; state: string; cookie: string }> {
     const app = createApp();
-    const created = (await (await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env)).json()) as { draftId: string; authUrl: string };
+    const response = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env);
+    const created = (await response.json()) as { draftId: string; authUrl: string };
     const state = new URL(created.authUrl).searchParams.get("state") ?? "";
-    return { draftId: created.draftId, state };
+    return { draftId: created.draftId, state, cookie: response.headers.get("set-cookie") ?? "" };
   }
+
+  it("rejects a valid OAuth state when the browser-bound draft cookie is missing", async () => {
+    const env = draftEnv();
+    const { state } = await createDraftState(env);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid-code&state=${encodeURIComponent(state)}`), env);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid or expired submission state.");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
 
   it("exchanges the code, stores an encrypted token, flips the draft to queued, and returns meta-refresh HTML", async () => {
     const env = draftEnv();
-    const { draftId, state } = await createDraftState(env);
+    const { draftId, state, cookie } = await createDraftState(env);
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
       if (url.includes("github.com/login/oauth/access_token")) return ok({ access_token: "gho_exchanged_token" });
       throw new Error(`unexpected fetch ${url}`);
     });
 
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid-code&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid-code&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     fetchSpy.mockRestore();
 
     expect(res.status).toBe(200);
@@ -558,10 +577,10 @@ describe("handleDraftOAuthCallback — success + error paths", () => {
 
   it("returns 400 when the token exchange returns an error (no access_token)", async () => {
     const env = draftEnv();
-    const { draftId, state } = await createDraftState(env);
+    const { draftId, state, cookie } = await createDraftState(env);
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => ok({ error: "bad_verification_code", error_description: "The code passed is incorrect or expired." }));
 
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=stale&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=stale&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     fetchSpy.mockRestore();
 
     expect(res.status).toBe(400);
@@ -572,9 +591,9 @@ describe("handleDraftOAuthCallback — success + error paths", () => {
 
   it("returns 400 on a provider error query param without attempting an exchange", async () => {
     const env = draftEnv();
-    const { state } = await createDraftState(env);
+    const { state, cookie } = await createDraftState(env);
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?error=access_denied&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?error=access_denied&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("GitHub authorization was not completed.");
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -583,8 +602,8 @@ describe("handleDraftOAuthCallback — success + error paths", () => {
 
   it("returns 503 when OAuth secrets are not configured", async () => {
     const env = draftEnv({ GITHUB_OAUTH_CLIENT_SECRET: "" });
-    const { state } = await createDraftState(env);
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=x&state=${encodeURIComponent(state)}`), env);
+    const { state, cookie } = await createDraftState(env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=x&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     expect(res.status).toBe(503);
   });
 });
@@ -1152,11 +1171,13 @@ describe("handleDraftOAuthCallback — extra guards", () => {
   it("returns 400 when the code is empty even though the state is valid (no-code branch)", async () => {
     const app = createApp();
     const env = draftEnv();
-    const created = (await (await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env)).json()) as { authUrl: string };
+    const createdResponse = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env);
+    const created = (await createdResponse.json()) as { authUrl: string };
     const state = new URL(created.authUrl).searchParams.get("state") ?? "";
+    const cookie = createdResponse.headers.get("set-cookie") ?? "";
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     // Valid state, but no `code` and no `error` query param → "authorization was not completed".
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("GitHub authorization was not completed.");
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -1166,12 +1187,14 @@ describe("handleDraftOAuthCallback — extra guards", () => {
   it("returns 400 with the generic 'GitHub auth failed.' message when the exchange yields no error fields", async () => {
     const app = createApp();
     const env = draftEnv();
-    const created = (await (await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env)).json()) as { authUrl: string };
+    const createdResponse = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env);
+    const created = (await createdResponse.json()) as { authUrl: string };
     const state = new URL(created.authUrl).searchParams.get("state") ?? "";
+    const cookie = createdResponse.headers.get("set-cookie") ?? "";
     // 200 OK but no access_token and no error/error_description → exchangeGitHubUserCode throws the
     // bare "GitHub auth failed." fallback, which the callback catches → 400 "GitHub authorization failed."
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => ok({}));
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     fetchSpy.mockRestore();
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("GitHub authorization failed.");
@@ -1180,11 +1203,13 @@ describe("handleDraftOAuthCallback — extra guards", () => {
   it("returns 400 when the exchange responds non-OK (response.ok false branch)", async () => {
     const app = createApp();
     const env = draftEnv();
-    const created = (await (await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env)).json()) as { authUrl: string };
+    const createdResponse = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, env);
+    const created = (await createdResponse.json()) as { authUrl: string };
     const state = new URL(created.authUrl).searchParams.get("state") ?? "";
+    const cookie = createdResponse.headers.get("set-cookie") ?? "";
     // Non-OK + a non-JSON body → response.json().catch(() => ({})) → {} → throws "GitHub auth failed."
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response("Bad Gateway", { status: 502 }));
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     fetchSpy.mockRestore();
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("GitHub authorization failed.");
@@ -1308,8 +1333,10 @@ describe("draftSecrets — `?? \"\"` nullish arms (env props genuinely undefined
     // env whose CLIENT_SECRET is genuinely undefined → draftSecrets clientSecret = "" → 503.
     const fullEnv = draftEnv();
     const app = createApp();
-    const created = (await (await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, fullEnv)).json()) as { authUrl: string };
+    const createdResponse = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, fullEnv);
+    const created = (await createdResponse.json()) as { authUrl: string };
     const state = new URL(created.authUrl).searchParams.get("state") ?? "";
+    const cookie = createdResponse.headers.get("set-cookie") ?? "";
 
     // Re-point the SAME D1 instance into an env missing the client secret (undefined, not "").
     const env = createTestEnv({
@@ -1319,7 +1346,7 @@ describe("draftSecrets — `?? \"\"` nullish arms (env props genuinely undefined
       DB: fullEnv.DB,
       // GITHUB_OAUTH_CLIENT_SECRET intentionally omitted (undefined)
     });
-    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`), env);
+    const res = await handleDraftOAuthCallback(new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }), env);
     expect(res.status).toBe(503);
     expect(await res.text()).toBe("Draft flow not configured.");
   });

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -549,6 +549,26 @@ describe("handleDraftOAuthCallback — success + error paths", () => {
     fetchSpy.mockRestore();
   });
 
+  it("treats a malformed draft cookie as absent (covers the cookie-parser empty-name + decode-failure arms)", async () => {
+    const env = draftEnv();
+    const { state } = await createDraftState(env);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // One Cookie header that drives both parseCookieHeader fallbacks:
+    //  • " =lead"                  → whitespace-only name (eq > 0 but name trims to "") → `if (!name) continue`
+    //  • gittensory_draft_oauth=%  → a lone-percent value makes decodeURIComponent throw → decoded as ""
+    // The draft cookie therefore resolves to "", cannot match the URL state, and the callback rejects (no exchange).
+    const res = await handleDraftOAuthCallback(
+      new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid-code&state=${encodeURIComponent(state)}`, {
+        headers: { cookie: " =lead; gittensory_draft_oauth=%" },
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid or expired submission state.");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it("exchanges the code, stores an encrypted token, flips the draft to queued, and returns meta-refresh HTML", async () => {
     const env = draftEnv();
     const { draftId, state, cookie } = await createDraftState(env);


### PR DESCRIPTION
### Motivation
- The unauthenticated draft OAuth flow issued a valid `state` URL to any caller but did not bind that state to the browser/session, allowing an attacker to induce a victim to complete OAuth and have the victim token applied to attacker-controlled draft data.

### Description
- Issue a browser-scoped cookie named `gittensory_draft_oauth` when creating a draft and include the draft `id.state` value in it, with `HttpOnly`, `SameSite=Lax`, `Path=/v1/drafts/auth/callback`, and `Secure` on HTTPS origins (added `draftOAuthCookie` and `parseCookieHeader`).
- Require the callback handler `handleDraftOAuthCallback` to verify the request-presented cookie value matches the returned URL `state` (timing-safe compare of SHA-256) before exchanging the GitHub `code` and storing the user token, and clear the cookie on success.
- Add a small `json` helper header param so handlers can set `Set-Cookie` responses, and add robust cookie parsing with safe `decodeURIComponent` handling.
- Update unit tests in `test/unit/draft.test.ts` to assert cookie issuance, to verify the callback rejects a valid URL `state` when the browser-bound cookie is missing, and to exercise cookie-aware callback success/error paths.
- Files changed: `src/services/draft.ts`, `test/unit/draft.test.ts`.

### Testing
- `git diff --check` ran and reported no whitespace/git-diff issues (passed).
- `npm run typecheck` was attempted and failed due to missing local type packages (`@cloudflare/vitest-pool-workers/types` and `vitest/globals`), so full TypeScript typecheck could not complete in the environment (blocked).
- Unit tests were updated to cover cookie issuance and cookie-bound callback behavior, but running `npm run test` / `vitest` locally was blocked because the `vitest` binary could not be executed in this environment and `npx vitest` failed to fetch from the registry (blocked).
- Manual code inspection and targeted local test harnesses used during development validate that the callback now rejects URL-only `state` values without the matching cookie and that a matching cookie allows the normal exchange path to proceed (logical/manual validation performed; automated unit test execution was blocked by environment constraints).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a394c9aa924832c80259ca1d50597bf)