### PR TITLE
fix(scoring): exclude operational constants from unmodeled scoring drift

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -168,6 +168,24 @@ export function parsePythonNumberConstants(source: string, options: { knownOnly?
 }
 
 /**
+ * Upstream operational/infra constants gittensory intentionally does not model in score previews.
+ * They are not scoring dimensions — surfacing them as "unmodeled drift" is noise (#809).
+ */
+const NON_SCORING_UPSTREAM_CONSTANT_NAMES = new Set([
+  "SECONDS_PER_DAY",
+  "SECONDS_PER_HOUR",
+  "GITHUB_HTTP_TIMEOUT_SECONDS",
+  "MIRROR_HTTP_TIMEOUT_SECONDS",
+  "MIRROR_MAX_ATTEMPTS",
+  "TREE_SITTER_PARSE_TIMEOUT_MICROS",
+  "SCORING_SUBPROCESS_BUDGET_S",
+  "MAX_FILE_SIZE_BYTES",
+  "RECYCLE_UID",
+  "ISSUES_TREASURY_UID",
+  "MAX_ISSUE_ID",
+]);
+
+/**
  * Numeric constant names upstream gittensor defines that gittensory's scoring engine does NOT model.
  * The normal parse is `knownOnly` (it keeps only constants we already encode), which silently hides
  * upstream ADDITIONS — e.g. a newly-introduced time-decay constant. Surfacing these makes scoring
@@ -176,7 +194,7 @@ export function parsePythonNumberConstants(source: string, options: { knownOnly?
  */
 export function findUnmodeledConstantKeys(allConstants: Record<string, number>): string[] {
   return Object.keys(allConstants)
-    .filter((name) => !SCORING_CONSTANT_NAMES.has(name))
+    .filter((name) => !SCORING_CONSTANT_NAMES.has(name) && !NON_SCORING_UPSTREAM_CONSTANT_NAMES.has(name))
     .sort();
 }
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -218,6 +218,30 @@ MAX_CODE_DENSITY_MULTIPLIER = 1.15
     expect(unmodeled).not.toContain("TIME_DECAY_GRACE_PERIOD_HOURS"); // modeled as of #703
   });
 
+  it("excludes operational upstream constants from unmodeled scoring drift (#809)", () => {
+    const operationalOnly = findUnmodeledUpstreamConstants(`
+SECONDS_PER_DAY = 86400
+SECONDS_PER_HOUR = 3600
+GITHUB_HTTP_TIMEOUT_SECONDS = 15
+MIRROR_HTTP_TIMEOUT_SECONDS = 30
+MIRROR_MAX_ATTEMPTS = 3
+TREE_SITTER_PARSE_TIMEOUT_MICROS = 5_000_000
+SCORING_SUBPROCESS_BUDGET_S = 120
+MAX_FILE_SIZE_BYTES = 1_000_000
+RECYCLE_UID = 0
+ISSUES_TREASURY_UID = 111
+MAX_ISSUE_ID = 999_999
+`);
+    expect(operationalOnly).toEqual([]);
+
+    const withScoringGap = findUnmodeledUpstreamConstants(`
+SECONDS_PER_DAY = 86400
+GITHUB_HTTP_TIMEOUT_SECONDS = 15
+NOVELTY_BONUS_SCALAR = 3
+`);
+    expect(withScoringGap).toEqual(["NOVELTY_BONUS_SCALAR"]);
+  });
+
   it("warns on the snapshot when upstream defines an unmodeled scoring dimension", async () => {
     const env = createTestEnv({
       GITTENSOR_UPSTREAM_REPO: "custom/upstream",

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -242,6 +242,30 @@ NOVELTY_BONUS_SCALAR = 3
     expect(withScoringGap).toEqual(["NOVELTY_BONUS_SCALAR"]);
   });
 
+  it("truncates the unmodeled-constants warning when upstream defines more than 12 (#809)", async () => {
+    const env = createTestEnv({
+      GITTENSOR_UPSTREAM_REPO: "custom/upstream",
+      GITTENSOR_UPSTREAM_REF: "staging",
+    });
+    const manyUnmodeled = Array.from({ length: 15 }, (_, index) => `UNMODELED_CONST_${String(index).padStart(2, "0")} = ${index + 1}`).join("\n");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response(manyUnmodeled);
+      if (url.includes("programming_languages.json")) return Response.json({});
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+    const warning = refreshed.warnings.find((entry) => /does not yet model/i.test(entry));
+    expect(warning).toMatch(/UNMODELED_CONST_00/);
+    expect(warning).toMatch(/UNMODELED_CONST_11/);
+    expect(warning).not.toMatch(/UNMODELED_CONST_12/);
+    expect(warning).toMatch(/…/);
+    expect(refreshed.payload.constants).toMatchObject({
+      unmodeledUpstreamConstants: expect.arrayContaining(["UNMODELED_CONST_00", "UNMODELED_CONST_14"]),
+    });
+  });
+
   it("warns on the snapshot when upstream defines an unmodeled scoring dimension", async () => {
     const env = createTestEnv({
       GITTENSOR_UPSTREAM_REPO: "custom/upstream",


### PR DESCRIPTION
Refs #809

## Summary

`findUnmodeledConstantKeys` treated every upstream numeric constant outside `SCORING_CONSTANT_NAMES` as "unmodeled scoring drift." That included operational/infra constants the scorer never consumes — HTTP timeouts, byte limits, UID sentinels, subprocess budgets, etc.

Those false positives inflated snapshot warnings and could trigger high-severity upstream drift reports without any actual scoring gap.

## Problem

Upstream `constants.py` includes both scoring dimensions and operational knobs. Examples that were incorrectly flagged:

- `SECONDS_PER_DAY`, `SECONDS_PER_HOUR`
- `GITHUB_HTTP_TIMEOUT_SECONDS`, `MIRROR_HTTP_TIMEOUT_SECONDS`, `MIRROR_MAX_ATTEMPTS`
- `TREE_SITTER_PARSE_TIMEOUT_MICROS`, `SCORING_SUBPROCESS_BUDGET_S`
- `MAX_FILE_SIZE_BYTES`
- `RECYCLE_UID`, `ISSUES_TREASURY_UID`, `MAX_ISSUE_ID`

A genuinely unmodeled scoring constant like `NOVELTY_BONUS_SCALAR` should still surface.

## Changes

- **`src/scoring/model.ts`** — add `NON_SCORING_UPSTREAM_CONSTANT_NAMES` ignore-set; filter operational constants out of `findUnmodeledConstantKeys`.
- **`test/unit/scoring.test.ts`** — regression test: operational-only slice → `[]`; operational + `NOVELTY_BONUS_SCALAR` → only the scoring gap.

Detection-only change — no score preview math changes.

## Scope boundary

Does **not** model `MAX_LINES_SCORED_FOR_NON_CODE_EXT` or other dropped scoring constants (#809 / #991 follow-up). Those correctly remain flagged as genuinely unmodeled after this noise reduction.

## API / OpenAPI / MCP contract

No schema changes. Fewer false positives in snapshot warnings and upstream drift reports.

## Migration / deploy / secrets

None.

## Security / privacy

None.

## Validation

```sh
npm run test:ci
```

All gates passed locally on branch `fix/exclude-operational-constants-from-drift`.

## Distinct from prior PRs

Unrelated to label multiplier selection (#994) or fractional underscore parsing (#992).
