### PR TITLE
feat(convergence): cut over review to all 3 repos + advisory aiReview

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -38,8 +38,8 @@
     "GITTENSORY_DRIFT_ISSUE_REPO": "JSONbored/gittensory",
     "PUBLIC_API_ORIGIN": "https://gittensory-api.aethereal.dev",
     "PUBLIC_SITE_ORIGIN": "https://gittensory.aethereal.dev",
-    "AI_SUMMARIES_ENABLED": "false",
-    "AI_PUBLIC_COMMENTS_ENABLED": "false",
+    "AI_SUMMARIES_ENABLED": "true",
+    "AI_PUBLIC_COMMENTS_ENABLED": "true",
     "WORKERS_AI_SUMMARY_MODEL": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
     "AI_DAILY_NEURON_BUDGET": "10000",
     "AI_BYOK_DAILY_REPO_LIMIT": "25",
@@ -100,7 +100,7 @@
     // rolls forward one repo at a time (e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). Default "" →
     // NO repos converged → the per-PR converged path stays dormant for every repo regardless of the global
     // flags (byte-identical to today). The cron/endpoint flags (ops/selftune/parity/draft) stay global.
-    "GITTENSORY_REVIEW_REPOS": "JSONbored/gittensory",
+    "GITTENSORY_REVIEW_REPOS": "JSONbored/gittensory,JSONbored/awesome-claude,JSONbored/metagraphed",
   },
   "routes": [
     {


### PR DESCRIPTION
## What

The convergence cutover. `reviewwed[bot]` is uninstalled from all repos, so gittensory becomes the sole reviewer/actor — no double-acting.

- **`GITTENSORY_REVIEW_REPOS` → all 3** (`JSONbored/gittensory,awesome-claude,metagraphed`): activates the converged review features (unified comment, safety, grounding, reputation, **hard-guardrail**) on awesome-claude + metagraphed (already live on gittensory).
- **`AI_SUMMARIES_ENABLED` + `AI_PUBLIC_COMMENTS_ENABLED` → true**: enables the dual-AI advisory review (summary + nits). Per-repo `ai_review_mode='advisory'` set in D1 for all 3.

## Already applied out-of-band (D1)

- **Autonomy** in `repository_settings` for all 3: `{merge,close,approve,label,request_changes}=auto`, `auto_maintain={requireApprovals:0, mergeMethod:squash}`, live (`agent_dry_run=0`). The owner-PR guard (never auto-close JSONbored PRs) + hard-guardrail (no auto-merge/close on guarded paths) from #1050 are deployed and protect this.
- **State migration (#1025)** complete + verified: decision-cache (review_targets 3233, byte-perfect) + reputation (submitter_stats, additive) seeded **before** this cutover, so no re-review storm / reputation reset.

Part of epic #983. After this merges/deploys, all 3 repos are fully on gittensory.