### PR TITLE
fix(review): refresh complete guardrail paths

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2693,8 +2693,7 @@ export async function listPullRequestFiles(env: Env, fullName: string, pullNumbe
   const rows = await db
     .select()
     .from(pullRequestFiles)
-    .where(and(eq(pullRequestFiles.repoFullName, fullName), eq(pullRequestFiles.pullNumber, pullNumber)))
-    .limit(500);
+    .where(and(eq(pullRequestFiles.repoFullName, fullName), eq(pullRequestFiles.pullNumber, pullNumber)));
   return rows.map(toPullRequestFileRecord);
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -453,6 +453,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   });
 }
 
+export function changedPathsForGuardrail(files: Awaited<ReturnType<typeof listPullRequestFiles>>): string[] {
+  const paths = new Set<string>();
+  for (const file of files) {
+    if (file.path.length > 0) paths.add(file.path);
+    if (file.previousFilename && file.previousFilename.length > 0) paths.add(file.previousFilename);
+  }
+  return [...paths];
+}
+
 /**
  * #778 maintainer auto-maintain trigger. After the gate runs on a PR webhook, if the repo opted the agent in
  * (an acting autonomy level), reuse the CANONICAL verdict produced by the full gate evaluation, plan the
@@ -489,7 +498,7 @@ async function maybeRunAgentMaintenance(
     listPullRequestFiles(env, repoFullName, pr.number),
     loadHardGuardrailGlobs(env, repoFullName),
   ]);
-  const changedPaths = changedFiles.map((file) => file.path).filter((path) => path.length > 0);
+  const changedPaths = changedPathsForGuardrail(changedFiles);
   const repoOwner = repoFullName.includes("/") ? repoFullName.slice(0, repoFullName.indexOf("/")) : "";
   const authorLogin = pr.authorLogin ?? "";
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
@@ -1004,7 +1013,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       });
       await persistAdvisory(env, advisory);
       if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
-        if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
+        if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off" || isAgentConfigured(settings.autonomy)) {
           await refreshPullRequestDetails(env, repoFullName, pr.number);
         }
         const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {

--- a/test/unit/agent-guardrail-paths.test.ts
+++ b/test/unit/agent-guardrail-paths.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { changedPathsForGuardrail } from "../../src/queue/processors";
+import type { PullRequestFileRecord } from "../../src/types";
+
+function file(path: string, previousFilename?: string | null): PullRequestFileRecord {
+  return {
+    repoFullName: "JSONbored/gittensory",
+    pullNumber: 42,
+    path,
+    previousFilename,
+    status: previousFilename ? "renamed" : "modified",
+    additions: 1,
+    deletions: 0,
+    changes: 1,
+    payload: { filename: path },
+  };
+}
+
+describe("changedPathsForGuardrail", () => {
+  it("includes previous filenames so guarded renames still force manual review", () => {
+    expect(changedPathsForGuardrail([file("docs/deploy-renamed.md", "scripts/deploy.sh")])).toEqual(["docs/deploy-renamed.md", "scripts/deploy.sh"]);
+  });
+
+  it("deduplicates current and previous filenames", () => {
+    expect(changedPathsForGuardrail([file("scripts/deploy.sh", "scripts/deploy.sh")])).toEqual(["scripts/deploy.sh"]);
+  });
+});

--- a/test/unit/data-spine.test.ts
+++ b/test/unit/data-spine.test.ts
@@ -130,6 +130,29 @@ describe("data spine repositories", () => {
       payload: { name: "test" },
     });
     expect(await listPullRequestFiles(env, "JSONbored/gittensory", 5)).toMatchObject([{ path: "src/index.ts", changes: 12 }]);
+    for (let index = 0; index < 501; index += 1) {
+      await upsertPullRequestFile(env, {
+        repoFullName: "JSONbored/gittensory",
+        pullNumber: 6,
+        path: `docs/file-${index}.md`,
+        status: "modified",
+        additions: 1,
+        deletions: 0,
+        changes: 1,
+        payload: { filename: `docs/file-${index}.md` },
+      });
+    }
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 6,
+      path: "scripts/deploy.sh",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: { filename: "scripts/deploy.sh" },
+    });
+    expect(await listPullRequestFiles(env, "JSONbored/gittensory", 6)).toHaveLength(502);
     expect(await listPullRequestReviews(env, "JSONbored/gittensory", 5)).toMatchObject([{ reviewerLogin: "maintainer" }]);
     expect(await listCheckSummaries(env, "JSONbored/gittensory", 5)).toMatchObject([{ name: "test", conclusion: "success" }]);
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -34,7 +34,7 @@ import {
   upsertRepositorySettings,
   upsertRepositoryFromGitHub,
 } from "../../src/db/repositories";
-import { processJob } from "../../src/queue/processors";
+import { changedPathsForGuardrail, processJob } from "../../src/queue/processors";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -5528,3 +5528,14 @@ async function generatePrivateKeyPem(): Promise<string> {
   const base64 = Buffer.from(exported as ArrayBuffer).toString("base64").replace(/(.{64})/g, "$1\n");
   return `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----`;
 }
+
+describe("changedPathsForGuardrail", () => {
+  it("collects current + rename paths and skips empty entries", () => {
+    const files = [
+      { path: "src/a.ts", previousFilename: null },
+      { path: "src/b.ts", previousFilename: "src/old-b.ts" }, // a rename contributes both names
+      { path: "", previousFilename: "" }, // an empty path AND empty rename are both skipped (both guard branches false)
+    ] as unknown as Parameters<typeof changedPathsForGuardrail>[0];
+    expect(changedPathsForGuardrail(files)).toEqual(["src/a.ts", "src/b.ts", "src/old-b.ts"]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent auto-maintain decisions (approve/merge/close) from being made using stale or truncated PR file records so hard guardrails cannot be bypassed.
- Ensure renamed files that hit a guardrail are still detected by including `previousFilename` in the path set.

### Description
- Refresh PR details for guardrail evaluation when the agent is configured by adding `isAgentConfigured(settings.autonomy)` to the `refreshPullRequestDetails` trigger so cached file rows are up-to-date before planning. 
- Add a new helper `changedPathsForGuardrail(files)` that collects both `path` and `previousFilename` (deduplicated) and wire the planner to use it instead of mapping only `file.path`.
- Remove the hard `.limit(500)` on `listPullRequestFiles` so all cached file rows for a pull request are returned for guardrail checks.
- Add unit regression coverage: `test/unit/agent-guardrail-paths.test.ts` to validate previous-filename handling and extend `test/unit/data-spine.test.ts` to exercise large PR file lists.

### Testing
- Ran targeted unit tests with `npm test -- --run test/unit/agent-actions.test.ts test/unit/agent-guardrail-paths.test.ts test/unit/data-spine.test.ts test/unit/backfill.test.ts`, and all tests passed. 
- Ran full typecheck with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a397e8a1c3c832cb0fc8a9b773a24db)