### PR TITLE
fix(review): fail auto-maintain guardrail safe on unknown changed paths

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -99,7 +99,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const passing = input.conclusion === "success";
   // A changed path matching a hard guardrail forces manual review: suppress the irreversible dispositions
   // (merge / close) AND the auto-approve that could later satisfy a merge. label + request_changes still run.
-  const guardrailHit = changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0;
+  // Fail SAFE on UNKNOWN paths: when guardrails are configured but the changed-file set is empty (cache not
+  // yet/no-longer populated), we cannot prove the PR doesn't touch a guarded path, so treat it as a hit —
+  // never auto-merge/close a PR whose diff we don't know. Repos with no guardrails stay permissive.
+  const guardrailHit =
+    input.hardGuardrailGlobs.length > 0 &&
+    (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
 
   // 1) label — reflect the verdict bucket. After the neutral/skipped return above, a non-blocking verdict is
   // necessarily `success`. Idempotent: skip if the PR already carries the label.

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -145,6 +145,23 @@ describe("planAgentMaintenanceActions (#778)", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, changedPaths: ["docs/readme.md", "src/ui/button.tsx"], hardGuardrailGlobs: ["src/scoring/**", "scripts/**"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
       expect(plan).toContain("merge");
     });
+
+    it("fails SAFE on UNKNOWN paths: with guardrails configured but no changed-file set, suppress merge/close/approve", () => {
+      // The changed-file cache can be empty (fresh PR before backfill) or stale; we cannot prove the PR
+      // doesn't touch a guarded path, so it must fall through to a human (label/request_changes still run).
+      const merge = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", label: "auto" }, changedPaths: [], hardGuardrailGlobs: ["src/scoring/**", "scripts/**"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(merge).not.toContain("merge");
+      expect(merge).toContain("label");
+      const close = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], changedPaths: [], hardGuardrailGlobs: ["src/scoring/**"], pr: { labels: [], slopRisk: 95 } })));
+      expect(close).not.toContain("close");
+      const approve = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" }, changedPaths: [], hardGuardrailGlobs: ["src/scoring/**"], pr: { labels: [] } })));
+      expect(approve).not.toContain("approve");
+    });
+
+    it("stays permissive on empty paths when the repo has NO guardrails configured (opted out)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, changedPaths: [], hardGuardrailGlobs: [], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(plan).toContain("merge");
+    });
   });
 
   describe("owner-PR guard: never auto-close the repo owner's own PRs", () => {


### PR DESCRIPTION
## Summary

The autonomous auto-maintain planner (#1050, the "rollout-blocker for autonomy" guardrail) suppresses the irreversible dispositions (auto-merge / auto-close / auto-approve) **only** when a PR's changed path hits a hard-guardrail glob (`.github/workflows/**`, `scripts/**`, scoring/auth). But the changed paths are read from the `pull_request_files` **DB cache** with no freshness guarantee, and `maybeRunAgentMaintenance` never refreshes them:

```ts
// src/queue/processors.ts:488 — reads the cache, never refreshes
const [changedFiles] = await Promise.all([listPullRequestFiles(env, repoFullName, pr.number), ...]);
const changedPaths = changedFiles.map((f) => f.path).filter((p) => p.length > 0); // can be []
```

The file refresh runs only under the slop/manifest gate condition (`processors.ts:1010`), which is **off by default** and independent of auto-maintain. So when the cache is empty (a fresh PR processed before the async backfill) or stale (a `synchronize` added a guarded file after the cache was populated), `changedPaths = []` → `changedPathsHittingGuardrail([], globs)` returns `[]` → `guardrailHit = false` → the automation may auto-merge or auto-close a PR that actually touches a guarded path. The guardrail fails **open** — exactly the irreversible mis-action on a CI/policy/auth PR that #1050 exists to block.

## Fix

The guardrail's real contract is "never auto-merge/close a PR that touches a guarded path." If the changed paths are **unknown** (empty) while guardrails are configured, the automation cannot prove the PR is safe, so it must fall through to a human. Make the planner fail SAFE:

```ts
// src/settings/agent-actions.ts
const guardrailHit =
  input.hardGuardrailGlobs.length > 0 &&
  (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
```

Repos with no guardrails configured stay permissive (unchanged); an empty-diff PR is not a real merge/close target, so suppressing it is harmless. (A complementary refresh-before-read in `maybeRunAgentMaintenance` would avoid merely *delaying* a legitimate auto-merge on the fresh-PR race; the planner fail-safe alone closes the hole.)

## Tests

There was **no** test exercising the empty-paths guardrail case (the existing planner tests pass `changedPaths` explicitly and default it to `[]`, which silently blessed the fail-open). Added regression tests: with guardrails configured and `changedPaths: []`, the planner emits no `merge`/`close`/`approve` (label still runs); and with **no** guardrails configured, empty paths stay permissive. Planner suite 27/27; broader unit suite green (3363 passed); `tsc` clean.

Closes #1061
