### PR TITLE
feat(review): RAG index ingestion pipeline (migration + populator + cron/incremental, flag-OFF)

### DIFF
--- a/migrations/0051_repo_chunks.sql
+++ b/migrations/0051_repo_chunks.sql
@@ -1,0 +1,43 @@
+-- Convergence (RAG / codebase index — Layer C, flag GITTENSORY_REVIEW_RAG): the chunk-text STORE that backs
+-- vector retrieval. This is the missing storage half of RAG: src/review/rag.ts already reads/writes this table
+-- (the retrieval path was wired in the rag-wire chunk) but no migration created it, so the index was unbacked.
+-- This migration creates it so the index-population job (src/review/rag-index.ts → upsertChunks) has somewhere
+-- to write the chunk text and retrieval (retrieveContext → readChunkTexts) has somewhere to read it from.
+--
+-- WHO READS/WRITES IT — every repo_chunks SQL string in src/review/rag.ts. The columns below are derived
+-- EXACTLY from those statements (do not add/rename columns without matching the SQL):
+--   - upsertChunks:        INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (…)
+--                          ON CONFLICT(id) DO UPDATE SET text=…, kind=…, chunk_index=…, updated_at=CURRENT_TIMESTAMP
+--   - countRepoChunks:     SELECT COUNT(*) FROM repo_chunks WHERE project = ? AND repo = ?
+--   - deleteChunksForPaths:SELECT id FROM repo_chunks WHERE project=? AND repo=? AND path IN (…)
+--                          DELETE FROM repo_chunks WHERE id IN (…)
+--   - readChunkTexts:      SELECT id, text FROM repo_chunks WHERE id IN (…)
+-- So the column set is { id, project, repo, path, chunk_index, kind, text, updated_at } — `id` is the PK
+-- (ON CONFLICT(id) target; vector ids and the storage PK are GLOBAL — the chunk id already embeds the
+-- namespace, see chunkId() in rag.ts), and `updated_at` carries the conflict touch.
+--
+-- The vector EMBEDDING itself lives in Vectorize (the `gittensory-review-rag` index), NOT here — this table is
+-- only the chunk text + light addressing metadata. Vectorize is the index; repo_chunks is the source-of-truth
+-- text the retrieved vector ids resolve back to.
+--
+-- Kept raw-SQL-only (matching the 0046–0050 convergence parity-store convention); deliberately NOT added to the
+-- Drizzle schema. Additive + idempotent (IF NOT EXISTS): the table is only ever read/written when the
+-- GITTENSORY_REVIEW_RAG flag is ON AND a Vectorize/AI binding is present, so a deploy without RAG is unaffected.
+--
+-- Privacy: indexes a repo's CODE/docs for code-review context only (isIndexablePath skips the content/data
+-- corpus). Internal review infrastructure — never surfaced publicly beyond the prompt the reviewer sees.
+CREATE TABLE IF NOT EXISTS repo_chunks (
+  id TEXT PRIMARY KEY,
+  project TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  path TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  text TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- The hot reads all scope by (project, repo): countRepoChunks (the cold-index COUNT) and deleteChunksForPaths
+-- (the path lookup). Index (project, repo, path) so both the COUNT and the path-scoped delete are cheap; this
+-- composite also covers the (project, repo) prefix the COUNT uses.
+CREATE INDEX IF NOT EXISTS idx_repo_chunks_project_repo_path ON repo_chunks (project, repo, path);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { createApp } from "./api/routes";
 import { RateLimiter } from "./auth/rate-limit";
 import { processJob } from "./queue/processors";
 import { isOpsEnabled } from "./review/ops-wire";
+import { isRagEnabled } from "./review/rag-wire";
 import { isSelfTuneEnabled } from "./review/selftune-wire";
 import type { JobMessage } from "./types";
 
@@ -78,6 +79,12 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
     jobs.push({ type: "build-contributor-evidence", requestedBy: "schedule" });
     jobs.push({ type: "build-contributor-decision-packs", requestedBy: "schedule" });
     jobs.push({ type: "file-upstream-drift-issues", requestedBy: "schedule" });
+    // Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). SLOW-CADENCE full re-index: in the six-hourly
+    // full-sync window, enqueue the RAG index fan-out (the processor fans out to one per-repo job for every
+    // registered + cutover-allowlisted repo, mirroring the signal-snapshot fan-out). Enqueued ONLY when the flag
+    // is ON — flag-OFF (default) this job is never created, so the cron does ZERO new RAG work and the enqueued
+    // set is byte-identical to today.
+    if (isRagEnabled(env)) jobs.push({ type: "rag-index-repo", requestedBy: "schedule" });
   }
   await Promise.all(jobs.map((job) => env.JOBS.send(job)));
 }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -163,6 +163,7 @@ import { runGittensoryAiReview } from "../services/ai-review";
 import { isSafetyEnabled, secretLeakFinding } from "../review/safety";
 import { buildReviewGroundingText, isGroundingEnabled } from "../review/grounding-wire";
 import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
+import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
@@ -337,6 +338,12 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // the queue (runSelfTune fails safe).
       if (isSelfTuneEnabled(env)) await runSelfTune(env);
       return;
+    case "rag-index-repo":
+      // Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). Defense-in-depth: the cron + webhook only
+      // ENQUEUE this when the flag is ON, but a stale in-flight job that lands after a flag-flip must still no-op,
+      // so flag-OFF does zero work here too. indexRepo / reindexChangedPaths are fully fail-safe (never throw).
+      if (isRagEnabled(env)) await runRagIndexJob(env, message.requestedBy, message.repoFullName, message.paths);
+      return;
     case "github-webhook":
       await processGitHubWebhook(env, message.deliveryId, message.eventName, message.payload);
       return;
@@ -405,6 +412,87 @@ async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "a
     outcome: "queued",
     metadata: { repoCount: configured.length, requestedBy },
   });
+}
+
+// Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). The dispatch for the `rag-index-repo` job.
+// Caller already gated on isRagEnabled(env).
+//   - No repoFullName → cron fan-out: enqueue one FULL re-index job per registered + cutover-allowlisted repo.
+//   - repoFullName + paths → INCREMENTAL re-index of those changed paths (the push / merged-PR path).
+//   - repoFullName + no paths → FULL re-index of that one repo's code.
+// Fully fail-safe — indexRepo / reindexChangedPaths never throw; this only delegates.
+async function runRagIndexJob(
+  env: Env,
+  requestedBy: "schedule" | "api" | "webhook" | "test",
+  repoFullName: string | undefined,
+  paths: string[] | undefined,
+): Promise<void> {
+  if (!repoFullName && requestedBy !== "test") {
+    await fanOutRagIndexJobs(env, requestedBy);
+    return;
+  }
+  if (!repoFullName) return;
+  // Defensive: a repo can drop out of the allowlist between fan-out and processing. Only index converged repos.
+  if (!isConvergenceRepoAllowed(env, repoFullName)) return;
+  const repo = await getRepository(env, repoFullName);
+  /* v8 ignore next -- defensive: a fanned-out repo is always present; the null is belt-and-suspenders. */
+  if (!repo) return;
+  const project = repoFullName;
+  if (paths && paths.length > 0) {
+    await reindexChangedPaths(env, project, repo, paths);
+    return;
+  }
+  await indexRepo(env, project, repo);
+}
+
+// Enqueue one per-repo FULL re-index job for every registered + cutover-allowlisted repo (mirrors the
+// signal-snapshot / agent-regate fan-out: a delayed per-repo queue message so each repo's index runs as its own
+// bounded, retryable job rather than one giant tick). Only allowlisted repos are indexed — retrieval is gated the
+// same way, so indexing a non-converged repo would only burn the free-tier vector budget for no benefit.
+async function fanOutRagIndexJobs(env: Env, requestedBy: "schedule" | "api" | "webhook" | "test"): Promise<void> {
+  const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered && isConvergenceRepoAllowed(env, repo.fullName));
+  await Promise.all(
+    repositories.map((repo, index) => {
+      const message: JobMessage = { type: "rag-index-repo", requestedBy, repoFullName: repo.fullName };
+      const delaySeconds = Math.min(index * 30, 900);
+      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+    }),
+  );
+  await recordAuditEvent(env, {
+    eventType: "rag.index.fanout",
+    outcome: "queued",
+    metadata: { repoCount: repositories.length, requestedBy },
+  });
+}
+
+// Cap on changed paths fed to one incremental re-index job (a huge merge re-indexes its first N changed files;
+// the slow-cadence full re-index catches the long tail). Bounds the per-job GitHub fetch + embed cost.
+const RAG_REINDEX_MAX_PATHS = 100;
+
+/**
+ * Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). On a MERGED PR into an allowlisted repo, enqueue
+ * an incremental re-index of the PR's changed files so the index reflects the new default-branch state. No-op when
+ * the flag is off, the repo isn't allowlisted, the action isn't a merge-close, or there are no changed paths.
+ *
+ * INCREMENTAL TRIGGER NOTE: gittensory does not (yet) subscribe to raw `push` events — the merged-PR close is the
+ * available signal that "code landed on the default branch". If a `push` handler is added later, that is the
+ * stronger trigger (it also catches direct-to-default-branch commits); enqueue the same `rag-index-repo` job with
+ * the pushed paths there. The slow-cadence cron full re-index (index.ts) is the backstop that catches anything
+ * the incremental path misses.
+ */
+async function maybeEnqueueRagReindexForMergedPr(
+  env: Env,
+  repoFullName: string,
+  pullNumber: number,
+  action: string | undefined,
+  mergedAt: string | null | undefined,
+): Promise<void> {
+  if (!isRagEnabled(env) || !isConvergenceRepoAllowed(env, repoFullName)) return;
+  // A PR that merged: closed action + a merged_at timestamp. (A closed-unmerged PR changed nothing on the base.)
+  if (!PR_GATE_CLOSED_ACTIONS.has(action ?? "") || !mergedAt) return;
+  const files = await listPullRequestFiles(env, repoFullName, pullNumber);
+  const paths = files.map((file) => file.path).filter((path) => path.length > 0).slice(0, RAG_REINDEX_MAX_PATHS);
+  if (paths.length === 0) return;
+  await env.JOBS.send({ type: "rag-index-repo", requestedBy: "webhook", repoFullName, paths });
 }
 
 // Recompute the DETERMINISTIC gate verdict for a repo's stalest open PRs and record it as an audit event —
@@ -1049,6 +1137,15 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
             console.error(JSON.stringify({ level: "warn", event: "reputation_record_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
           });
         }
+        // RAG incremental index (convergence, flag-gated by GITTENSORY_REVIEW_RAG + the per-repo cutover allowlist).
+        // When a PR MERGES into an allowlisted repo, its changes have landed on the default branch — enqueue an
+        // incremental re-index of just the changed files (reindexChangedPaths) so the index stays fresh without a
+        // full re-crawl. Enqueued (not run inline) so the webhook stays fast + the index work is its own retryable
+        // job. Flag-OFF (default) is a no-op (the job is never enqueued AND the processor no-ops). Best-effort.
+        await maybeEnqueueRagReindexForMergedPr(env, repoFullName, pr.number, payload.action, payload.pull_request.merged_at).catch((error) => {
+          /* v8 ignore next -- best-effort: a RAG re-index enqueue failure is logged, never surfaced to the gate. */
+          console.error(JSON.stringify({ level: "warn", event: "rag_reindex_enqueue_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+        });
       }
     }
 

--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -1,0 +1,255 @@
+// Convergence (RAG / codebase index — Layer C, flag GITTENSORY_REVIEW_RAG): the INDEX-POPULATION driver. This is
+// the half that was deferred when retrieval was wired (see rag-wire.ts `INDEX_JOB_FOLLOWUP` / `populateRepoIndexStub`):
+// it fetches a repo's CODE tree, chunks + embeds it, and upserts vectors+text into the `gittensory-review-rag`
+// Vectorize index + the `repo_chunks` table (migration 0051) — so retrieval has a warm index to read from instead
+// of always seeing a cold namespace and returning "".
+//
+// It reuses the fail-safe primitives in `./rag` verbatim (chunkFile / embedTexts / upsertChunks /
+// deleteChunksForPaths / countRepoChunks / isIndexablePath / MAX_CHUNKS_PER_REPO / ragNamespace) — NO chunking or
+// embedding logic is reimplemented here. The only new I/O is fetching the repo's git tree + file contents, which
+// reuses the installation-token + raw-Contents-API pattern grounding-wire already established
+// (`makeGithubFileFetcher`); the tree fetch is the one new GitHub call.
+//
+// HARD GUARANTEES (mirroring rag.ts):
+//   1. FAIL-SAFE — every step is caught + logged; this module NEVER throws into the queue/caller. A missing
+//      Vectorize/AI binding, a GitHub error, an oversized repo, or a partial batch degrades to "indexed less /
+//      nothing" rather than failing the job. `upsertChunks` itself already no-ops to 0 when infra is absent.
+//   2. FREE-TIER — `isIndexablePath` filters the tree to CODE (not the content/data corpus), source is
+//      prioritized, and a hard MAX_CHUNKS_PER_REPO cap bounds stored vectors per repo (the same cap retrieval
+//      assumes). We stop fetching once the cap is reached.
+//
+// GATING — the caller (processors.ts) only DISPATCHES indexing when `isRagEnabled(env)` is true, and the cron
+// only ENQUEUES the fan-out under the same flag; flag-OFF (the default) this module is never invoked, makes no
+// GitHub call, and does no adapter use — the deploy is byte-identical to today.
+
+import { createInstallationToken } from "../github/app";
+import { repoParts } from "../utils/json";
+import { createReviewAdapters } from "./adapters";
+import {
+  chunkFile,
+  deleteChunksForPaths,
+  filePriority,
+  isIndexablePath,
+  MAX_CHUNKS_PER_REPO,
+  ragNamespace,
+  type RagChunk,
+  upsertChunks,
+} from "./rag";
+
+/** A single indexable entry from the repo git tree (path + size, used by isIndexablePath's size guard). */
+type TreeEntry = { path: string; size?: number | undefined };
+
+/** Cap on how many chunks we upsert per Vectorize/D1 write batch (bounds the bound-param + neuron cost per call;
+ *  embedTexts itself batches the AI calls at EMBED_BATCH internally). */
+const UPSERT_BATCH = 50;
+
+/** Resolve the read token once for a repo: installation token (private-repo read) → public token → none.
+ *  Best-effort — a token failure degrades to the next fallback, never throws. (Mirrors makeGithubFileFetcher.) */
+async function resolveReadToken(env: Env, installationId: number | null | undefined): Promise<string | undefined> {
+  let token: string | undefined;
+  if (installationId) token = await createInstallationToken(env, installationId).catch(() => undefined);
+  return token ?? env.GITHUB_PUBLIC_TOKEN;
+}
+
+/** Shared GitHub headers for the read calls (raw media type returns file bodies directly). */
+function ghHeaders(token: string | undefined, accept: string): Record<string, string> {
+  return {
+    accept,
+    "user-agent": "gittensory/0.1",
+    "x-github-api-version": "2022-11-28",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+/**
+ * Fetch the FULL recursive git tree for a repo at `ref` and return only the blob (file) entries. Uses the
+ * Git Trees API (`?recursive=1`) — one call yields the whole tree. Returns [] on any non-OK / error response
+ * (fail-safe: a tree we can't read = nothing to index). `truncated` is honored (GitHub truncates very large
+ * trees) — we index whatever it returned; the MAX_CHUNKS cap is the real bound anyway.
+ */
+async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token: string | undefined): Promise<TreeEntry[]> {
+  try {
+    const { owner, name } = repoParts(repoFullName);
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github+json") });
+    if (!response.ok) return [];
+    const body = (await response.json()) as { tree?: Array<{ path?: string; type?: string; size?: number }> } | null;
+    const entries: TreeEntry[] = [];
+    for (const node of body?.tree ?? []) {
+      if (node.type !== "blob" || typeof node.path !== "string" || node.path.length === 0) continue;
+      entries.push(typeof node.size === "number" ? { path: node.path, size: node.size } : { path: node.path });
+    }
+    return entries;
+  } catch (error) {
+    console.log(JSON.stringify({ ev: "rag_index_tree_error", repo: repoFullName, message: String(error).slice(0, 200) }));
+    return [];
+  }
+}
+
+/** Fetch a single file's raw text at `ref`. null on any non-OK / error (fail-safe — skip that file). */
+async function fetchFileText(env: Env, repoFullName: string, path: string, ref: string, token: string | undefined): Promise<string | null> {
+  try {
+    const { owner, name } = repoParts(repoFullName);
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/contents/${path
+      .split("/")
+      .map(encodeURIComponent)
+      .join("/")}?ref=${encodeURIComponent(ref)}`;
+    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github.raw+json") });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the ref to index a repo at: the repo's default branch, falling back to HEAD when unknown. */
+function indexRef(defaultBranch: string | null | undefined): string {
+  const branch = (defaultBranch ?? "").trim();
+  return branch.length > 0 ? branch : "HEAD";
+}
+
+/** Upsert a set of chunks to the index in bounded batches, honoring the per-repo cap. Returns the number
+ *  actually upserted. Each batch is independent: a failed batch (upsertChunks returns 0) doesn't abort the rest. */
+async function upsertChunksCapped(env: Env, project: string, repo: string, chunks: RagChunk[], alreadyStored: number): Promise<number> {
+  const infra = createReviewAdapters(env);
+  let stored = alreadyStored;
+  let upserted = 0;
+  for (let i = 0; i < chunks.length && stored < MAX_CHUNKS_PER_REPO; i += UPSERT_BATCH) {
+    const remaining = MAX_CHUNKS_PER_REPO - stored;
+    const batch = chunks.slice(i, i + Math.min(UPSERT_BATCH, remaining));
+    if (batch.length === 0) break;
+    const n = await upsertChunks(infra, project, repo, batch);
+    upserted += n;
+    stored += n;
+  }
+  return upserted;
+}
+
+/** Split `owner/name` into the (project, repo) pair RAG namespaces on (same convention as rag-wire's splitRepo). */
+function splitRepo(repoFullName: string): [string, string] {
+  const slash = repoFullName.indexOf("/");
+  return slash === -1 ? ["", repoFullName] : [repoFullName.slice(0, slash), repoFullName.slice(slash + 1)];
+}
+
+export type IndexRepoResult = { indexed: number; files: number; capped: boolean };
+
+/**
+ * FULL (re)index of a repo's CODE into the RAG index. Fetches the git tree at the default branch, filters to
+ * indexable code/docs (isIndexablePath), prioritizes source over docs, fetches each file's content, chunks it
+ * (chunkFile), and upserts (embed + Vectorize + repo_chunks via upsertChunks) up to MAX_CHUNKS_PER_REPO.
+ *
+ * Idempotent: chunk ids are stable (namespace|path::idx) so re-running upserts (ON CONFLICT updates) the same
+ * rows rather than duplicating. Fully FAIL-SAFE — any error (no infra, GitHub down, bad file) degrades to
+ * "indexed fewer / nothing"; this NEVER throws.
+ *
+ * @param repo the RepositoryRecord (fullName + installationId + defaultBranch). installationId/defaultBranch are
+ *             read off it so the caller doesn't re-fetch.
+ */
+export async function indexRepo(
+  env: Env,
+  project: string,
+  repo: { fullName: string; installationId?: number | null | undefined; defaultBranch?: string | null | undefined },
+): Promise<IndexRepoResult> {
+  const empty: IndexRepoResult = { indexed: 0, files: 0, capped: false };
+  try {
+    const infra = createReviewAdapters(env);
+    // No vector index or no AI binding → upsert is a guaranteed no-op; don't spend any GitHub calls.
+    if (!infra.vector || !infra.inference) return empty;
+    const repoFullName = repo.fullName;
+    const [, repoName] = splitRepo(repoFullName);
+    const namespace = ragNamespace(project, repoName);
+    const token = await resolveReadToken(env, repo.installationId);
+    const ref = indexRef(repo.defaultBranch);
+
+    // 1. Fetch the tree, filter to indexable code/docs, prioritize source before docs (so the cap keeps code).
+    const tree = (await fetchRepoTree(env, repoFullName, ref, token))
+      .filter((entry) => isIndexablePath(entry.path, entry.size))
+      .sort((a, b) => filePriority(a.path) - filePriority(b.path) || a.path.localeCompare(b.path));
+    if (tree.length === 0) return empty;
+
+    // 2. Fetch + chunk + upsert, stopping once the per-repo vector cap is reached.
+    let stored = 0;
+    let upserted = 0;
+    let filesIndexed = 0;
+    let capped = false;
+    for (const entry of tree) {
+      if (stored >= MAX_CHUNKS_PER_REPO) {
+        capped = true;
+        break;
+      }
+      const text = await fetchFileText(env, repoFullName, entry.path, ref, token);
+      if (text === null) continue;
+      const chunks = chunkFile(entry.path, text, namespace);
+      if (chunks.length === 0) continue;
+      const n = await upsertChunksCapped(env, project, repoName, chunks, stored);
+      if (n > 0) {
+        upserted += n;
+        stored += n;
+        filesIndexed += 1;
+      }
+    }
+    console.log(
+      JSON.stringify({ ev: "rag_index_repo", project, repo: repoFullName, files: filesIndexed, indexed: upserted, capped }),
+    );
+    return { indexed: upserted, files: filesIndexed, capped };
+  } catch (error) {
+    console.log(JSON.stringify({ ev: "rag_index_repo_error", repo: repo.fullName, message: String(error).slice(0, 200) }));
+    return empty;
+  }
+}
+
+/**
+ * INCREMENTAL re-index of only the CHANGED paths of a repo (push / PR-merge maintenance). For the given paths:
+ * deletes their existing chunks (deleteChunksForPaths — removes both stale vectors + text), then re-fetches +
+ * re-chunks + re-upserts the indexable ones at the default branch. A path that's no longer indexable (deleted
+ * file, or now a content/data path) is simply deleted and not re-added. Fully FAIL-SAFE — NEVER throws.
+ *
+ * @param paths the changed file paths (e.g. from a push or merged-PR file list).
+ */
+export async function reindexChangedPaths(
+  env: Env,
+  project: string,
+  repo: { fullName: string; installationId?: number | null | undefined; defaultBranch?: string | null | undefined },
+  paths: string[],
+): Promise<IndexRepoResult> {
+  const empty: IndexRepoResult = { indexed: 0, files: 0, capped: false };
+  try {
+    const unique = [...new Set(paths.filter((path) => typeof path === "string" && path.length > 0))];
+    if (unique.length === 0) return empty;
+    const infra = createReviewAdapters(env);
+    if (!infra.vector || !infra.inference) return empty;
+    const repoFullName = repo.fullName;
+    const [, repoName] = splitRepo(repoFullName);
+    const namespace = ragNamespace(project, repoName);
+
+    // 1. Drop the existing chunks for EVERY changed path (deleted/renamed/no-longer-indexable files leave nothing
+    //    stale behind). deleteChunksForPaths is fail-safe + batches the IN-lists internally.
+    await deleteChunksForPaths(infra, project, repoName, unique);
+
+    // 2. Re-index the ones that are still indexable code/docs at the default branch.
+    const indexable = unique.filter((path) => isIndexablePath(path));
+    if (indexable.length === 0) return { indexed: 0, files: 0, capped: false };
+    const token = await resolveReadToken(env, repo.installationId);
+    const ref = indexRef(repo.defaultBranch);
+    let upserted = 0;
+    let filesIndexed = 0;
+    for (const path of indexable) {
+      const text = await fetchFileText(env, repoFullName, path, ref, token);
+      if (text === null) continue; // file deleted at head, or unreadable — already removed above, leave it gone
+      const chunks = chunkFile(path, text, namespace);
+      if (chunks.length === 0) continue;
+      const n = await upsertChunks(infra, project, repoName, chunks);
+      if (n > 0) {
+        upserted += n;
+        filesIndexed += 1;
+      }
+    }
+    console.log(
+      JSON.stringify({ ev: "rag_reindex_paths", project, repo: repoFullName, paths: unique.length, files: filesIndexed, indexed: upserted }),
+    );
+    return { indexed: upserted, files: filesIndexed, capped: false };
+  } catch (error) {
+    console.log(JSON.stringify({ ev: "rag_reindex_paths_error", repo: repo.fullName, message: String(error).slice(0, 200) }));
+    return empty;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,21 @@ export type JobMessage =
       requestedBy: "schedule" | "api" | "test";
     }
   | {
+      // Convergence (RAG / codebase index — Layer C, flag-gated by GITTENSORY_REVIEW_RAG). Populate + maintain the
+      // vector index that retrieval reads.
+      //   - No `repoFullName` (the cron fan-out) → enqueue one per-repo FULL re-index job for every
+      //     registered + cutover-allowlisted repo (mirrors the agent-regate / signal-snapshot fan-out).
+      //   - `repoFullName` + no `paths` → FULL re-index of that repo's code (indexRepo).
+      //   - `repoFullName` + `paths` → INCREMENTAL re-index of only those changed paths (reindexChangedPaths),
+      //     enqueued from a push / merged-PR webhook.
+      // Enqueued + dispatched ONLY when the flag is ON; flag-OFF (default) this job is never created and the
+      // processor no-ops, so the deploy is byte-identical to today.
+      type: "rag-index-repo";
+      requestedBy: "schedule" | "api" | "webhook" | "test";
+      repoFullName?: string;
+      paths?: string[];
+    }
+  | {
       // Public OAuth draft-submission flow (GITTENSORY_REVIEW_DRAFT): fork the content repo with the
       // contributor's token + open the PR. Enqueued by the draft OAuth callback.
       type: "submit-draft";

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -184,6 +184,47 @@ describe("worker entrypoint", () => {
     expect(sent.some((m) => m.type === "ops-alerts")).toBe(false);
   });
 
+  it("enqueues the rag-index-repo fan-out in the full-sync window ONLY when GITTENSORY_REVIEW_RAG is ON (flag-OFF is byte-identical)", async () => {
+    const sentFor = async (ragFlag?: string): Promise<Array<import("../../src/types").JobMessage>> => {
+      const sent: Array<import("../../src/types").JobMessage> = [];
+      const env = createTestEnv({
+        ...(ragFlag === undefined ? {} : { GITTENSORY_REVIEW_RAG: ragFlag }),
+        JOBS: {
+          async send(message: import("../../src/types").JobMessage) {
+            sent.push(message);
+          },
+        } as unknown as Queue,
+      });
+      const waitUntil: Promise<unknown>[] = [];
+      await worker.scheduled(controllerFor("2026-05-25T06:00:00.000Z"), env, executionContext(waitUntil)); // full-sync window
+      await Promise.all(waitUntil);
+      return sent;
+    };
+
+    // Flag OFF (default) → no rag-index-repo job; the enqueued set is unchanged from today.
+    expect((await sentFor()).some((m) => m.type === "rag-index-repo")).toBe(false);
+    expect((await sentFor("false")).some((m) => m.type === "rag-index-repo")).toBe(false);
+    // Flag ON → exactly one rag-index-repo fan-out job, enqueued in the full-sync window.
+    const on = await sentFor("true");
+    expect(on.filter((m) => m.type === "rag-index-repo")).toEqual([{ type: "rag-index-repo", requestedBy: "schedule" }]);
+  });
+
+  it("does NOT enqueue rag-index-repo outside the full-sync window even when GITTENSORY_REVIEW_RAG is ON", async () => {
+    const sent: Array<import("../../src/types").JobMessage> = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: "true",
+      JOBS: {
+        async send(message: import("../../src/types").JobMessage) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    const waitUntil: Promise<unknown>[] = [];
+    await worker.scheduled(controllerFor("2026-05-25T05:00:00.000Z"), env, executionContext(waitUntil)); // hourly but NOT full-sync
+    await Promise.all(waitUntil);
+    expect(sent.some((m) => m.type === "rag-index-repo")).toBe(false);
+  });
+
   it("enqueues weekly value report generation during the Monday report window", async () => {
     const sent: Array<import("../../src/types").JobMessage> = [];
     const env = createTestEnv({

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { indexRepo, reindexChangedPaths } from "../../src/review/rag-index";
+import { MAX_CHUNKS_PER_REPO, RAG_DIMENSIONS, ragNamespace } from "../../src/review/rag";
+import { processJob } from "../../src/queue/processors";
+import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createTestEnv, TestD1Database } from "../helpers/d1";
+
+// A valid bge-m3-width (1024-d) embedding vector — embedTexts rejects any other width.
+const VEC_1024 = Array.from({ length: RAG_DIMENSIONS }, () => 0.01);
+
+/** A Workers-AI stub: the embed model returns one 1024-d vector PER input text (embedTexts validates count+dim). */
+function aiStub() {
+  return {
+    run: vi.fn(async (_model: string, opts: Record<string, unknown>) => {
+      const texts = (opts.text as string[]) ?? [];
+      return { data: texts.map(() => VEC_1024) };
+    }),
+  };
+}
+
+/** A Vectorize stub that records every upserted vector id + every deleted id. */
+function vectorizeStub() {
+  const upserted: string[] = [];
+  const deleted: string[] = [];
+  return {
+    upserted,
+    deleted,
+    upsert: vi.fn(async (vectors: Array<{ id: string }>) => {
+      for (const v of vectors) upserted.push(v.id);
+      return { mutationId: "m1" };
+    }),
+    query: vi.fn(async () => ({ matches: [] })),
+    deleteByIds: vi.fn(async (ids: string[]) => {
+      for (const id of ids) deleted.push(id);
+      return { mutationId: "m2" };
+    }),
+  };
+}
+
+/** Build an env with a REAL TestD1Database (so repo_chunks exists via migration 0051) + stubbed Vectorize/AI. */
+function indexEnv(over: { vec?: ReturnType<typeof vectorizeStub>; ai?: ReturnType<typeof aiStub>; rag?: string } = {}) {
+  const vec = over.vec ?? vectorizeStub();
+  const ai = over.ai ?? aiStub();
+  const env = createTestEnv({
+    GITTENSORY_REVIEW_RAG: over.rag ?? "true",
+    VECTORIZE: vec as unknown as Vectorize,
+    AI: ai as unknown as Ai,
+  });
+  return { env, vec, ai };
+}
+
+const REPO = { fullName: "JSONbored/gittensory", installationId: null, defaultBranch: "main" };
+const PROJECT = "JSONbored/gittensory";
+
+/** Stub global fetch for the git-tree + raw-contents calls the populator makes. */
+function stubGithub(opts: {
+  tree?: Array<{ path: string; type?: string; size?: number }>;
+  files?: Record<string, string>;
+  treeStatus?: number;
+}) {
+  const files = opts.files ?? {};
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.includes("/git/trees/")) {
+      if (opts.treeStatus && opts.treeStatus !== 200) return new Response("err", { status: opts.treeStatus });
+      return Response.json({ tree: (opts.tree ?? []).map((n) => ({ type: "blob", ...n })), truncated: false });
+    }
+    if (url.includes("/contents/")) {
+      // Decode the path back out of the URL to look up the canned file body.
+      const match = url.match(/\/contents\/([^?]+)/);
+      const path = match ? decodeURIComponent(match[1]!.split("/").map(decodeURIComponent).join("/")) : "";
+      const body = files[path];
+      if (body === undefined) return new Response("missing", { status: 404 });
+      return new Response(body, { status: 200 });
+    }
+    return new Response("missing", { status: 404 });
+  });
+}
+
+async function countChunks(env: Env, project: string, repo: string): Promise<number> {
+  const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM repo_chunks WHERE project = ? AND repo = ?").bind(project, repo).first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+async function pathsFor(env: Env, project: string, repo: string): Promise<string[]> {
+  const rows = await env.DB.prepare("SELECT path FROM repo_chunks WHERE project = ? AND repo = ? ORDER BY path").bind(project, repo).all<{ path: string }>();
+  return [...new Set((rows.results ?? []).map((r) => r.path))];
+}
+
+describe("rag-index migration: repo_chunks exists in the test D1", () => {
+  it("the 0051 migration created repo_chunks (insert + read round-trips)", async () => {
+    const db = new TestD1Database() as unknown as D1Database;
+    await db.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+      .bind("ns|src/a.ts::0", "p", "r", "src/a.ts", 0, "code", "x")
+      .run();
+    const row = await db.prepare("SELECT COUNT(*) AS n FROM repo_chunks WHERE project = ? AND repo = ?").bind("p", "r").first<{ n: number }>();
+    expect(row?.n).toBe(1);
+  });
+});
+
+describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetches the tree, chunks+embeds+upserts the indexable code, and persists rows to repo_chunks + Vectorize", async () => {
+    const { env, vec, ai } = indexEnv();
+    stubGithub({
+      tree: [
+        { path: "src/a.ts", size: 30 },
+        { path: "README.md", size: 20 },
+        { path: "node_modules/x/index.js", size: 10 }, // skipped by isIndexablePath
+        { path: "data/big.json", size: 10 }, // skipped (content/data corpus)
+        { path: "logo.png", size: 5 }, // skipped (binary)
+      ],
+      files: {
+        "src/a.ts": "export const a = 1;\n",
+        "README.md": "# Title\n",
+      },
+    });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    // Only the two indexable files were embedded + upserted.
+    expect(result.files).toBe(2);
+    expect(result.indexed).toBe(2);
+    expect(result.capped).toBe(false);
+    // The embed model was called (1024-d vectors) and Vectorize received the two chunk ids.
+    expect(ai.run).toHaveBeenCalledWith("@cf/baai/bge-m3", expect.anything());
+    expect(vec.upserted.length).toBe(2);
+    // repo_chunks (the D1 source-of-truth text) has both rows, keyed under the repo half of the full name.
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(2);
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["README.md", "src/a.ts"]);
+    // Ids embed the namespace (global vector ids — chunkId convention).
+    const ns = ragNamespace(PROJECT, "gittensory");
+    expect(vec.upserted).toContain(`${ns}|src/a.ts::0`);
+  });
+
+  it("skips a file that fails to fetch (404) and indexes the rest (fail-safe)", async () => {
+    const { env } = indexEnv();
+    stubGithub({
+      tree: [{ path: "src/a.ts" }, { path: "src/missing.ts" }],
+      files: { "src/a.ts": "export const a = 1;\n" }, // src/missing.ts → 404
+    });
+    const result = await indexRepo(env, PROJECT, REPO);
+    expect(result.files).toBe(1);
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["src/a.ts"]);
+  });
+
+  it("a tree fetch error degrades to nothing indexed (never throws)", async () => {
+    const { env, vec } = indexEnv();
+    stubGithub({ treeStatus: 500 });
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.upserted.length).toBe(0);
+  });
+});
+
+describe("indexRepo: MAX_CHUNKS_PER_REPO cap holds", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("stops upserting once the per-repo cap is reached", async () => {
+    const { env, vec } = indexEnv();
+    // More files than the cap, each producing exactly one chunk.
+    const overCap = MAX_CHUNKS_PER_REPO + 25;
+    const tree = Array.from({ length: overCap }, (_, i) => ({ path: `src/f${i}.ts`, size: 20 }));
+    const files: Record<string, string> = {};
+    for (let i = 0; i < overCap; i++) files[`src/f${i}.ts`] = `export const f${i} = ${i};\n`;
+    stubGithub({ tree, files });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    expect(result.capped).toBe(true);
+    // Never exceed the cap in either store.
+    expect(result.indexed).toBeLessThanOrEqual(MAX_CHUNKS_PER_REPO);
+    expect(vec.upserted.length).toBeLessThanOrEqual(MAX_CHUNKS_PER_REPO);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBeLessThanOrEqual(MAX_CHUNKS_PER_REPO);
+    expect(result.indexed).toBe(MAX_CHUNKS_PER_REPO);
+  });
+});
+
+describe("reindexChangedPaths: delete + re-upsert only the changed paths", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("deletes the changed paths' existing chunks and re-upserts only those files", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    // Seed an existing index: two files already stored.
+    for (const [path, idx] of [["src/a.ts", 0], ["src/b.ts", 0]] as const) {
+      await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+        .bind(`${ns}|${path}::${idx}`, PROJECT, "gittensory", path, idx, "code", "old")
+        .run();
+    }
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(2);
+
+    // Only src/a.ts changed (+ a content/data path that is NOT indexable → deleted, not re-added).
+    stubGithub({ files: { "src/a.ts": "export const a = 2;\n" } });
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/a.ts", "data/x.json"]);
+
+    expect(result.files).toBe(1); // only src/a.ts re-indexed
+    // src/b.ts (untouched) survived; src/a.ts re-upserted; data/x.json never added.
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["src/a.ts", "src/b.ts"]);
+    // The stale src/a.ts vector was deleted from Vectorize, and the fresh one re-upserted.
+    expect(vec.deleted).toContain(`${ns}|src/a.ts::0`);
+    expect(vec.upserted).toContain(`${ns}|src/a.ts::0`);
+    // src/b.ts was never touched (not in the changed set).
+    expect(vec.deleted).not.toContain(`${ns}|src/b.ts::0`);
+  });
+
+  it("a deleted file (404 at head) is removed and not re-added", async () => {
+    const { env } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+      .bind(`${ns}|src/gone.ts::0`, PROJECT, "gittensory", "src/gone.ts", 0, "code", "old")
+      .run();
+    stubGithub({ files: {} }); // src/gone.ts → 404
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/gone.ts"]);
+    expect(result.files).toBe(0);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+  });
+
+  it("no changed paths → no-op", async () => {
+    const { env, vec } = indexEnv();
+    stubGithub({ files: {} });
+    await expect(reindexChangedPaths(env, PROJECT, REPO, [])).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.deleted.length).toBe(0);
+    expect(vec.upserted.length).toBe(0);
+  });
+});
+
+describe("flag-off / missing-infra is a no-op (no GitHub fetch, no adapter use)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("indexRepo with a MISSING Vectorize binding does nothing (no tree fetch)", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_RAG: "true", AI: aiStub() as unknown as Ai }); // no VECTORIZE
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("indexRepo with a MISSING AI binding does nothing (no tree fetch)", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_RAG: "true", VECTORIZE: vectorizeStub() as unknown as Vectorize }); // no AI
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reindexChangedPaths with missing infra does nothing", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_RAG: "true" }); // no VECTORIZE / AI
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(reindexChangedPaths(env, PROJECT, REPO, ["src/a.ts"])).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    // Note: deleteChunksForPaths runs first (storage is always present) but no vector/embed work or GitHub fetch.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── Wiring: the rag-index-repo queue job (cron fan-out + per-repo dispatch) ─────────────────────────
+
+/** Register a repo (is_registered = 1) so it joins the cron fan-out's registered set. */
+async function registerRepo(env: Env, fullName: string): Promise<void> {
+  const [owner, name] = fullName.split("/") as [string, string];
+  await upsertRepositoryFromGitHub(env, { name, full_name: fullName, private: false, owner: { login: owner } }, 123);
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?").bind(fullName).run();
+}
+
+describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("FLAG-ON cron fan-out enqueues one per-repo job for every REGISTERED + ALLOWLISTED repo only", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: "true",
+      // Allowlist only JSONbored/gittensory (acme/widgets is allowlisted by default but won't be registered here).
+      GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory",
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    await registerRepo(env, "JSONbored/gittensory"); // registered + allowlisted → indexed
+    await registerRepo(env, "owner/not-allowlisted"); // registered but NOT allowlisted → skipped
+
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule" });
+
+    expect(sent).toEqual([{ type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" }]);
+    const fanout = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("rag.index.fanout").first<{
+      outcome: string;
+      metadata_json: string;
+    }>();
+    expect(fanout?.outcome).toBe("queued");
+    expect(JSON.parse(fanout?.metadata_json ?? "{}")).toMatchObject({ repoCount: 1, requestedBy: "schedule" });
+  });
+
+  it("FLAG-OFF cron fan-out is a no-op (no per-repo jobs enqueued, no fan-out audit)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: "false",
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    await registerRepo(env, "JSONbored/gittensory");
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule" });
+    expect(sent).toHaveLength(0);
+    const fanout = await env.DB.prepare("select 1 from audit_events where event_type = ?").bind("rag.index.fanout").first();
+    expect(fanout).toBeFalsy(); // no fan-out audit row (TestD1 returns undefined for no-row)
+  });
+
+  it("per-repo FULL index dispatch runs indexRepo (writes repo_chunks) for an allowlisted repo", async () => {
+    const { env } = indexEnv({ rag: "true" });
+    await registerRepo(env, "JSONbored/gittensory");
+    stubGithub({ tree: [{ path: "src/a.ts", size: 30 }], files: { "src/a.ts": "export const a = 1;\n" } });
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(1);
+  });
+
+  it("per-repo dispatch SKIPS a non-allowlisted repo (no indexing)", async () => {
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: "true",
+      GITTENSORY_REVIEW_REPOS: "", // empty allowlist → nothing converged
+      VECTORIZE: vectorizeStub() as unknown as Vectorize,
+      AI: aiStub() as unknown as Ai,
+    });
+    await registerRepo(env, "JSONbored/gittensory");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+  });
+
+  it("per-repo INCREMENTAL dispatch (with paths) runs reindexChangedPaths", async () => {
+    const { env } = indexEnv({ rag: "true" });
+    await registerRepo(env, "JSONbored/gittensory");
+    stubGithub({ files: { "src/a.ts": "export const a = 1;\n" } });
+    await processJob(env, { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts"] });
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["src/a.ts"]);
+  });
+
+  it("FLAG-OFF per-repo dispatch is a no-op", async () => {
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: "false",
+      VECTORIZE: vectorizeStub() as unknown as Vectorize,
+      AI: aiStub() as unknown as Ai,
+    });
+    await registerRepo(env, "JSONbored/gittensory");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+  });
+});
+
+// ── Wiring: the merged-PR incremental trigger (github-webhook) ──────────────────────────────────────
+
+describe("merged-PR incremental re-index trigger (webhook)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Drive a pull_request webhook for a MERGED close and capture the enqueued jobs. */
+  async function runMergedPrWebhook(over: { rag?: string; repos?: string; merged?: boolean; files?: string[] }): Promise<import("../../src/types").JobMessage[]> {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_RAG: over.rag ?? "true",
+      GITTENSORY_REVIEW_REPOS: over.repos ?? "JSONbored/gittensory",
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    await registerRepo(env, "JSONbored/gittensory");
+    // Seed the PR's changed files so listPullRequestFiles returns them.
+    for (const path of over.files ?? ["src/a.ts", "README.md"]) {
+      await env.DB.prepare(
+        "INSERT INTO pull_request_files (repo_full_name, pull_number, path, status, additions, deletions, changes, payload_json) VALUES (?,?,?,?,?,?,?,?)",
+      ).bind("JSONbored/gittensory", 42, path, "modified", 1, 0, 1, "{}").run();
+    }
+    vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "d-merge",
+      eventName: "pull_request",
+      payload: {
+        action: "closed",
+        installation: { id: 123 },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 42,
+          title: "Merge me",
+          state: "closed",
+          merged_at: over.merged === false ? null : "2026-06-22T00:00:00.000Z",
+          user: { login: "alice" },
+          head: { sha: "h42" },
+          base: { ref: "main" },
+        },
+      },
+    });
+    return sent.filter((m) => m.type === "rag-index-repo");
+  }
+
+  it("a MERGED PR into an allowlisted repo enqueues a rag-index-repo job with the changed paths", async () => {
+    const ragJobs = await runMergedPrWebhook({});
+    expect(ragJobs).toEqual([
+      { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts", "README.md"] },
+    ]);
+  });
+
+  it("a CLOSED-UNMERGED PR (merged_at null) enqueues nothing (base unchanged)", async () => {
+    expect(await runMergedPrWebhook({ merged: false })).toEqual([]);
+  });
+
+  it("FLAG-OFF enqueues nothing", async () => {
+    expect(await runMergedPrWebhook({ rag: "false" })).toEqual([]);
+  });
+
+  it("a non-allowlisted repo enqueues nothing", async () => {
+    expect(await runMergedPrWebhook({ repos: "" })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What (closes the RAG gap for hosted)

RAG retrieval was wired but inert — no `repo_chunks` storage table, no index populator, cold Vectorize index. This adds the missing write half so vector retrieval becomes real.

- **`migrations/0051_repo_chunks.sql`** — the chunk-text store rag.ts reads/writes (columns derived exactly from its SQL: id PK, project, repo, path, chunk_index, kind, text, updated_at + index).
- **`src/review/rag-index.ts`** — the populator. `indexRepo` (git tree → `isIndexablePath` filter → source-priority → fetch → `chunkFile` → `upsertChunks`, capped at `MAX_CHUNKS_PER_REPO`) + `reindexChangedPaths` (delete + re-upsert changed files). Reuses rag.ts primitives; fully fail-safe (never throws); no-op when Vectorize/AI absent.
- **Triggers:** cron full re-index (6-hourly window, fans out per registered+allowlisted repo) + incremental on merged-PR (changed paths). Both gated on `isRagEnabled(env)`; per-repo dispatch re-checks `isConvergenceRepoAllowed`.

**Inert by default:** `GITTENSORY_REVIEW_RAG` stays `"false"`. Flag-off ⇒ no enqueue, no dispatch, no GitHub fetch, no adapter use — byte-identical to today. Activation (apply migration to prod, flip flag, populate) is a separate step.

Typecheck clean; full unit suite 3357 (21 new); migrations contiguous to 0051; biome clean. Part of epic #983 (RAG / #1019).