### PR TITLE
fix(review): real diff on first review + surfaced manual holds + fuller blocked/CI comment

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -48,6 +48,7 @@ import type {
   InstallationRecord,
   JsonValue,
   PullRequestDetailSyncStateRecord,
+  PullRequestFileRecord,
   PullRequestRecord,
   RecentMergedPullRequestRecord,
   RepoGithubTotalsSnapshotRecord,
@@ -1810,6 +1811,53 @@ async function fetchPullRequestFiles(
   if (fallback) return fallback.files;
   warnings.push(`File sync failed for #${pullNumber}: GitHub REST and GraphQL detail fetches failed.`);
   return [];
+}
+
+/** Map a raw GitHub file payload to the stored {@link PullRequestFileRecord} shape (the same mapping
+ *  `fetchAndStorePullRequestDetails` does when it persists a synced PR's files). */
+function toPullRequestFileRecordFromGitHub(repoFullName: string, pullNumber: number, file: GitHubFilePayload): PullRequestFileRecord {
+  return {
+    repoFullName,
+    pullNumber,
+    path: file.filename,
+    status: file.status,
+    additions: file.additions ?? 0,
+    deletions: file.deletions ?? 0,
+    changes: file.changes ?? 0,
+    previousFilename: file.previous_filename,
+    payload: file as unknown as Record<string, JsonValue>,
+  };
+}
+
+/**
+ * Inline, best-effort file fetch for the REVIEW path (convergence). The PR-opened webhook can fire the review
+ * BEFORE the async detail-sync has populated `pull_request_files`, leaving the AI review + grounding + unified
+ * comment with an EMPTY diff ("0 files / No diff provided"). When `listPullRequestFiles` is empty at review
+ * time, the caller falls back here: fetch the PR's files straight from GitHub (REST → GraphQL, same paths the
+ * detail-sync uses), persist them (so the rest of the same review run + any later read reuse them), and return
+ * them mapped to the stored record shape.
+ *
+ * Fail-safe by construction: a fetch failure returns `[]` (never throws), so the review degrades to the same
+ * empty-diff state it has today rather than breaking. The persist is best-effort and only runs when the fetch
+ * actually returned files (a failed REST+GraphQL fetch must not wipe a row another sync just wrote).
+ */
+export async function fetchAndStorePullRequestFilesForReview(
+  env: Env,
+  repoFullName: string,
+  pullNumber: number,
+  token: string | undefined,
+): Promise<PullRequestFileRecord[]> {
+  const warnings: string[] = [];
+  const files = await fetchPullRequestFiles(env, repoFullName, pullNumber, token, warnings).catch(() => [] as GitHubFilePayload[]);
+  if (files.length === 0) return [];
+  const records = files.map((file) => toPullRequestFileRecordFromGitHub(repoFullName, pullNumber, file));
+  // Persist so the AI review, grounding, gate, check-run, and unified-comment reads in THIS run (and any later
+  // read) reuse the synced files. Best-effort: a write hiccup must never sink the review — we still return the
+  // freshly-fetched records the caller needs.
+  for (const record of records) {
+    await upsertPullRequestFile(env, record).catch(() => undefined);
+  }
+  return records;
 }
 
 async function fetchPullRequestReviews(

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -63,6 +63,7 @@ import {
   backfillRegisteredRepositories,
   backfillRepositorySegment,
   enqueueRepositoryOpenDataBackfill,
+  fetchAndStorePullRequestFilesForReview,
   refreshContributorActivity,
   refreshInstallationHealth,
   refreshPullRequestDetails,
@@ -151,7 +152,7 @@ import { buildClosedUnifiedCommentBody, buildUnifiedCommentBody, isUnifiedReview
 import { screenshotsAllowed } from "../review/visual-wire";
 import { isVisualPath } from "../review/visual/paths";
 import { buildCapture, type CaptureRoute } from "../review/visual/capture";
-import type { MergeReadiness } from "../review/unified-comment";
+import type { CheckFailureDetail, MergeReadiness } from "../review/unified-comment";
 import { buildIssueSlopAssessment, buildSlopAssessment, type SlopBand } from "../signals/slop";
 import { runGittensoryAiSlopAdvisory } from "../services/ai-slop";
 import { decidePublicSurface } from "../signals/settings-preview";
@@ -161,7 +162,7 @@ import { resolveRepositorySettings } from "../settings/repository-settings";
 import type { LocalBranchAnalysisInput } from "../signals/local-branch";
 import { runGittensoryAiReview } from "../services/ai-review";
 import { isSafetyEnabled, secretLeakFinding } from "../review/safety";
-import { buildReviewGroundingText, isGroundingEnabled } from "../review/grounding-wire";
+import { buildReviewGroundingText, checkSummaryText as checkFailureSummaryText, isGroundingEnabled } from "../review/grounding-wire";
 import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
@@ -488,8 +489,11 @@ async function maybeRunAgentMaintenance(
 
   // Convergence safety: feed the planner the PR's changed paths + the repo's hard-guardrail globs so guarded
   // paths force manual review, and flag owner-authored PRs so they are never auto-closed (standing rule).
+  // FIX B: resolve files via the shared resolver so an EMPTY stored list (the maintenance ran before the
+  // detail-sync populated pull_request_files) can't silently empty changedPaths and let a guarded PR slip the
+  // guardrail into an auto-merge — it inline-fetches the real changed paths when stored is still empty.
   const [changedFiles, hardGuardrailGlobs] = await Promise.all([
-    listPullRequestFiles(env, repoFullName, pr.number),
+    resolvePullRequestFilesForReview(env, { installationId, repoFullName, pullNumber: pr.number }),
     loadHardGuardrailGlobs(env, repoFullName),
   ]);
   const changedPaths = changedFiles.map((file) => file.path).filter((path) => path.length > 0);
@@ -1180,6 +1184,38 @@ async function loadGateAuthorHistory(env: Env, repoFullName: string, author: str
   }
 }
 
+/**
+ * Resolve the PR's changed files for the review path, preferring the stored rows and, when they are empty at
+ * review time, fetching them inline from GitHub (and persisting them). This fixes diff-less first reviews:
+ * the PR-opened webhook can fire the review BEFORE the async detail-sync populated `pull_request_files`, so
+ * the AI review / grounding / gate / unified comment built their diff from an EMPTY `listPullRequestFiles`
+ * → "0 files / No diff provided", and the review never re-ran. Now the FIRST review sees the real diff.
+ *
+ * Efficient: stored rows are read once; the inline GitHub fetch happens only when stored is empty, and the
+ * result is persisted so every later read in the SAME review run reuses it. Fully fail-safe — a token-mint or
+ * fetch failure degrades to the (possibly empty) stored rows, exactly as before this fix.
+ */
+async function resolvePullRequestFilesForReview(
+  env: Env,
+  args: { installationId: number; repoFullName: string; pullNumber: number },
+): Promise<Awaited<ReturnType<typeof listPullRequestFiles>>> {
+  const stored = await listPullRequestFiles(env, args.repoFullName, args.pullNumber);
+  if (stored.length > 0) return stored;
+  // Stored files are empty (the review fired before detail-sync). Fetch + persist inline from GitHub.
+  try {
+    const token = await createInstallationToken(env, args.installationId).catch(() => undefined);
+    const fetched = await fetchAndStorePullRequestFilesForReview(env, args.repoFullName, args.pullNumber, token ?? env.GITHUB_PUBLIC_TOKEN);
+    if (fetched.length > 0) {
+      console.log(JSON.stringify({ ev: "review_files_fetched_inline", repository: args.repoFullName, pullNumber: args.pullNumber, files: fetched.length }));
+      return fetched;
+    }
+  } catch (error) {
+    /* v8 ignore next -- fail-safe: an inline fetch failure degrades to the empty stored rows (byte-identical to pre-fix). */
+    console.error(JSON.stringify({ level: "warn", event: "review_files_inline_fetch_failed", repository: args.repoFullName, pullNumber: args.pullNumber, error: errorMessage(error) }));
+  }
+  return stored;
+}
+
 /** Build a bounded unified-diff string from cached PR files for the AI reviewer. Caps total size so a
  *  huge PR cannot blow the model context or the neuron budget; each file's patch is taken from the raw
  *  GitHub file payload when present. */
@@ -1219,6 +1255,10 @@ export async function runAiReviewForAdvisory(
     pr: { number: number; title: string; body?: string | null | undefined };
     author: string | null;
     confirmedContributor: boolean;
+    // Pre-resolved PR files (the caller's resolvePullRequestFilesForReview output). When provided, the AI
+    // review + grounding + RAG use these instead of re-reading the stored rows — so a review that fired before
+    // detail-sync still sees the REAL diff (FIX B). Omitted (e.g. unit tests) → fall back to the stored read.
+    files?: Awaited<ReturnType<typeof listPullRequestFiles>> | undefined;
   },
 ): Promise<{ notes: string; reviewerCount: number } | undefined> {
   const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
@@ -1246,7 +1286,9 @@ export async function runAiReviewForAdvisory(
       storedKey && (!args.settings.aiReviewProvider || args.settings.aiReviewProvider === storedKey.provider)
         ? { provider: storedKey.provider, key: storedKey.key, model: args.settings.aiReviewModel ?? storedKey.model }
         : null;
-    const files = await listPullRequestFiles(env, args.repoFullName, args.pr.number);
+    // FIX B: prefer the caller's pre-resolved files (real diff even on a pre-sync first review); fall back to
+    // the stored read when the caller didn't pass them (e.g. unit tests calling this function directly).
+    const files = args.files ?? (await listPullRequestFiles(env, args.repoFullName, args.pr.number));
     // Grounding (convergence, flag-gated by GITTENSORY_REVIEW_GROUNDING). Build the FINISHED CI status + the full
     // content of the changed files so the reviewer verifies its claims against reality instead of guessing.
     // Flag-OFF (default) → we take no new branch at all: NO check/repo load, NO file fetch, and `grounding`
@@ -1555,6 +1597,18 @@ async function maybePublishPrPublicSurface(
   let gateEvaluation: ReturnType<typeof evaluateGateCheck> | undefined;
   let aiReview: { notes: string; reviewerCount: number } | undefined;
   let gateFinalized = false;
+  // The PR's changed files are needed by the slop/manifest gates, the AI review + grounding + RAG, the secret
+  // scan, the check-run, and the unified comment. Resolve them AT MOST ONCE per review and share across the
+  // gate phase (inside the try) AND the publish phase (check-run + comment, after the try): memoize the first
+  // resolve so a repo that needs files anywhere pays a single resolve, and a gate-only repo that never needs
+  // them pays nothing. resolvePullRequestFilesForReview prefers the stored rows and, when they are empty at
+  // review time (the webhook beat detail-sync), fetches + persists them inline — so the FIRST review sees the
+  // real diff instead of "0 files / No diff provided" (FIX B). Fail-safe by construction.
+  let reviewFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null = null;
+  const getReviewFiles = async (): Promise<Awaited<ReturnType<typeof listPullRequestFiles>>> => {
+    if (reviewFiles === null) reviewFiles = await resolvePullRequestFilesForReview(env, { installationId, repoFullName, pullNumber: pr.number });
+    return reviewFiles;
+  };
   try {
     const [repoIssues, repoPullRequests, repoBounties] = await Promise.all([
       listIssues(env, repoFullName),
@@ -1602,11 +1656,11 @@ async function maybePublishPrPublicSurface(
     // findings as advisory context, and feed the score to the gate (it only blocks under slop: block + the
     // threshold). Loads files lazily so disabled repos pay nothing.
     let slopRisk: number | null = null;
-    // Slop (#530) and focus-manifest-policy (#555) gates both need the PR's changed files. Load ONCE and
-    // share so two opted-in gates don't double-fetch; the load is lazy so a repo with both off pays nothing.
+    // Slop (#530) and focus-manifest-policy (#555) gates both need the PR's changed files; load via the shared
+    // resolver (lazy — a repo with both off pays nothing; see getReviewFiles above).
     let gateFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null = null;
     if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
-      gateFiles = await listPullRequestFiles(env, repoFullName, pr.number);
+      gateFiles = await getReviewFiles();
     }
     if (shouldCollectSlopEvidence(settings)) {
       const slopFiles = gateFiles ?? [];
@@ -1659,13 +1713,33 @@ async function maybePublishPrPublicSurface(
 
     // AI maintainer review (opt-in via aiReviewMode). Mutates `advisory` with a consensus defect (if any)
     // BEFORE the gate evaluates, and returns advisory notes for the panel. Inside the try so any AI
-    // failure is caught and the gate is still finalized (never left in_progress).
-    aiReview = await runAiReviewForAdvisory(env, { settings, advisory, repoFullName, pr, author, confirmedContributor });
+    // failure is caught and the gate is still finalized (never left in_progress). Pass the shared resolved
+    // files so the review (+ grounding + RAG) sees the REAL diff even on a pre-detail-sync first review (FIX B);
+    // resolve only when the review will actually run (aiReviewMode !== off + a head SHA) to keep gate-only
+    // repos free of an extra file resolve.
+    const aiReviewWillRun = settings.aiReviewMode !== "off" && Boolean(advisory.headSha);
+    aiReview = await runAiReviewForAdvisory(env, {
+      settings,
+      advisory,
+      repoFullName,
+      pr,
+      author,
+      confirmedContributor,
+      ...(aiReviewWillRun ? { files: await getReviewFiles() } : {}),
+    });
 
     // Safety secrets-scan (convergence, flag-gated by GITTENSORY_REVIEW_SAFETY). Scans the diff and, on a hit,
-    // appends a critical `secret_leak` blocker BEFORE the gate evaluates. Reuses the already-loaded gate
-    // files when present. Flag-OFF (default) is an immediate no-op → the advisory/gate is byte-identical.
-    await maybeAddSecretLeakFinding(env, { advisory, repoFullName, pullNumber: pr.number, files: gateFiles });
+    // appends a critical `secret_leak` blocker BEFORE the gate evaluates. When the scan will actually run
+    // (safety flag ON + repo allowlisted), pass the shared resolved files so it scans the REAL diff (FIX B);
+    // otherwise pass the already-loaded files (or null) and let the scan early-return. Flag-OFF (default) is an
+    // immediate no-op → the advisory/gate is byte-identical.
+    const safetyWillRun = isSafetyEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
+    await maybeAddSecretLeakFinding(env, {
+      advisory,
+      repoFullName,
+      pullNumber: pr.number,
+      files: safetyWillRun ? await getReviewFiles() : reviewFiles,
+    });
 
     // First-time-contributor grace (#552): compute the author's complete per-repo PR history
     // (excluding this PR) with an aggregate DB query. Do not derive policy-enforcement history from
@@ -1759,7 +1833,9 @@ async function maybePublishPrPublicSurface(
 
   if (decision.willCheckRun && advisory.headSha) {
     try {
-      const checkRunFiles = await listPullRequestFiles(env, repoFullName, pr.number);
+      // FIX B: the check-run annotations/details need the real diff too — reuse the shared resolver (one resolve
+      // per review; inline-fetches when the stored rows are still empty from a pre-detail-sync first review).
+      const checkRunFiles = await getReviewFiles();
       const checkRunResult = await createOrUpdateCheckRun(env, installationId, repoFullName, advisory, settings.checkRunDetailLevel, {
         files: checkRunFiles,
         collisions,
@@ -1811,7 +1887,9 @@ async function maybePublishPrPublicSurface(
     //      gate signal row (which renders only the conclusion-derived status text, not the defect string).
     if (unifiedCommentAllowed && gateEvaluation) {
       const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation });
-      const unifiedFiles = await listPullRequestFiles(env, repoFullName, pr.number);
+      // FIX B: the unified comment's file count + visual-capture path filter need the real diff — reuse the
+      // shared resolver (one resolve per review; inline-fetches when stored is still empty pre-detail-sync).
+      const unifiedFiles = await getReviewFiles();
       // CI + merge-state readiness — a converged enrichment the legacy panel never showed. Maps each cached
       // check's conclusion to passed/failed/unverified; any failure (failure/timed_out/cancelled/action_required)
       // flips the whole PR to 'failed'. The gate decision stays authoritative for the comment's color (always
@@ -1823,10 +1901,18 @@ async function maybePublishPrPublicSurface(
       });
       const anyPassed = checkSummaries.some((check) => (check.conclusion ?? "").toLowerCase() === "success");
       const ciState: MergeReadiness["ciState"] = failedChecks.length > 0 ? "failed" : anyPassed ? "passed" : "unverified";
+      // FIX D3: per-failed-check WHY (codecov %/test/lint reason) from each check's output.title/summary or a
+      // commit-status description — the SAME extraction the grounding path uses (checkSummaryText), capped +
+      // public-safe (check name + short reason only). The renderer lists these under the CI chip.
+      const failingDetails: CheckFailureDetail[] = failedChecks.map((check) => {
+        const summary = checkFailureSummaryText(check);
+        return { name: check.name, ...(summary ? { summary } : {}), ...(check.detailsUrl ? { detailsUrl: check.detailsUrl } : {}) };
+      });
       const mergeReadiness: MergeReadiness = {
         ciState,
         ...(pr.mergeableState ? { mergeStateLabel: pr.mergeableState } : {}),
         ...(failedChecks.length > 0 ? { failingChecks: failedChecks.map((check) => check.name) } : {}),
+        ...(failingDetails.length > 0 ? { failingDetails } : {}),
       };
       // Visual before/after capture (visual-capture port). Fires ONLY when (1) the global flag + per-repo
       // cutover gate both allow it (screenshotsAllowed) AND (2) the PR touches WEB-VISIBLE files (isVisualPath

--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -44,8 +44,10 @@ const PASSING_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
 
 /** Pull a one-line failure reason from a check-run payload (output.title/summary) or a commit-status
  *  description — the same fields the unified comment surfaces, so the reviewer sees WHY a check failed
- *  ("60% of diff hit (target 97%)") not just "codecov/patch failed". "" when none present. */
-function checkSummaryText(check: CheckSummaryRecord): string {
+ *  ("60% of diff hit (target 97%)") not just "codecov/patch failed". "" when none present. Exported so the
+ *  unified-comment call site populates MergeReadiness.failingDetails from the SAME extraction (FIX D3),
+ *  keeping the reviewer's grounding and the public comment consistent on each check's failure reason. */
+export function checkSummaryText(check: CheckSummaryRecord): string {
   const payload = check.payload as { output?: { title?: unknown; summary?: unknown }; description?: unknown } | undefined;
   const output = payload?.output;
   const candidates = [output?.title, output?.summary, payload?.description];

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -131,15 +131,32 @@ export function buildDualReviewNotes(args: {
   aiReview?: { notes: string } | undefined;
   consensusDefect?: { title: string; detail: string } | undefined;
   warnings?: AdvisoryFinding[] | undefined;
+  /** The gate's hard blockers (GateCheckEvaluation.blockers). Folded into the reviewer blockers so a NON-AI
+   *  gate failure (missing linked issue, slop, manifest, secret leak, …) renders a populated "Why this is
+   *  blocked" list — not just an empty one driven by the AI consensus defect (FIX D1). The `ai_consensus_defect`
+   *  is EXCLUDED here because it is already surfaced via `consensusDefect` (so it appears exactly once). Each is
+   *  scrubbed through the same public-safe boundary as Nits (defense-in-depth) before reaching the comment. */
+  gateBlockers?: AdvisoryFinding[] | undefined;
   recommendation: ReviewRecommendation;
   verdict: Verdict;
   reviewerModel?: string;
 }): DualReviewNote[] {
   const assessment = args.aiReview?.notes?.trim() ?? "";
-  const blockers = args.consensusDefect ? [`${args.consensusDefect.title}${args.consensusDefect.detail ? `: ${args.consensusDefect.detail}` : ""}`.trim()] : [];
+  const consensusBlocker = args.consensusDefect ? [`${args.consensusDefect.title}${args.consensusDefect.detail ? `: ${args.consensusDefect.detail}` : ""}`.trim()] : [];
+  // FIX D1: fold the gate's own hard blockers into the reviewer blockers (so a non-AI gate failure populates
+  // "Why this is blocked"). Exclude `ai_consensus_defect` (already surfaced via consensusDefect → appears once)
+  // and scrub each through the same public-safe boundary as Nits, DROPPING any that still leaks a private term.
+  const gateBlockerLines = (args.gateBlockers ?? [])
+    .filter((finding) => finding.code !== "ai_consensus_defect")
+    .map((finding) => `${finding.title}${finding.action ? ` — ${finding.action}` : ""}`.trim())
+    .filter(Boolean)
+    .map((line) => publicSafeNit(line))
+    .filter((line): line is string => line !== null);
+  const blockers = [...consensusBlocker, ...gateBlockerLines];
   // Nits are the only renderer input not already routed through an existing public-safe filter (the gate's
   // raw warning findings). Scrub each with the private-term boundary and DROP any that still leaks. See
-  // PRIVATE_FORBIDDEN_TERMS above. (Blockers come from the consensus defect, already public-safe via toPublicSafe.)
+  // PRIVATE_FORBIDDEN_TERMS above. (The consensus-defect blocker is already public-safe via toPublicSafe; the
+  // gate blockers above go through the SAME scrub as Nits.)
   const nits = (args.warnings ?? [])
     .map((warning) => `${warning.title}${warning.action ? ` — ${warning.action}` : ""}`.trim())
     .filter(Boolean)
@@ -246,13 +263,24 @@ export function buildUnifiedCommentBody(args: UnifiedCommentBridgeArgs): string 
     aiReview: args.aiReview,
     consensusDefect,
     warnings: args.gate.warnings,
+    // FIX D1: hand the gate's own hard blockers to the reviewer note so a non-AI gate failure populates the
+    // "Why this is blocked" list (the consensus defect alone left it empty for those PRs).
+    gateBlockers: args.gate.blockers,
     recommendation: verdictToRecommendation(verdict),
     verdict,
   });
+  // FIX D2: carry the gate's authoritative reason onto the held/blocked/closed verdict headline. The gate
+  // summary is the human-readable "why" (e.g. "A hard blocker was found."); fall back to the title. Public-safe
+  // by construction (gate summary/title are author-facing) and angle-escaped by the renderer's verdictLine.
+  // Only attached for a NON-merge verdict: a passing (merge → ready) PR keeps its positive "safe to merge" /
+  // "all checks passed" wording rather than being overwritten by the gate's "no blocker found" summary.
+  const gateReason = args.gate.summary?.trim() || args.gate.title?.trim() || undefined;
+  const verdictReason = verdict !== "merge" ? gateReason : undefined;
   const input = buildUnifiedReviewInput({
     changedFiles: args.changedFiles,
     reviews,
     decision: verdict,
+    ...(verdictReason !== undefined ? { verdictReason } : {}),
     ...(args.mergeReadiness !== undefined ? { readiness: args.mergeReadiness } : {}),
     ...(args.merged !== undefined ? { merged: args.merged } : {}),
   });

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -313,6 +313,29 @@ function bullets(items: string[]): string {
     .join("\n");
 }
 
+/** Render the failing CI checks as a bullet list of `name — reason` (reason only when the check carried one),
+ *  preferring failingDetails (which pairs each name with its WHY: codecov %/test/lint reason) and falling back
+ *  to the bare failingChecks names. Public-safe: only check names + their already-public short summary, both
+ *  angle-escaped. "" when there is nothing to list, so the caller omits the section entirely. */
+function failingChecksBlock(readiness: MergeReadiness | undefined): string {
+  if (!readiness || readiness.ciState !== "failed") return "";
+  const details = readiness.failingDetails ?? [];
+  if (details.length > 0) {
+    const lines = details
+      .map((detail) => {
+        const name = escapePublicHtmlAngles(detail.name.trim());
+        if (!name) return "";
+        const reason = detail.summary?.trim() ? ` — ${escapePublicHtmlAngles(detail.summary.trim())}` : "";
+        return `- ${name}${reason}`;
+      })
+      .filter((line) => line.length > 0);
+    if (lines.length) return lines.join("\n");
+  }
+  const names = (readiness.failingChecks ?? []).map((name) => name.trim()).filter((name) => name.length > 0);
+  if (names.length === 0) return "";
+  return [...new Set(names)].map((name) => `- ${escapePublicHtmlAngles(name)}`).join("\n");
+}
+
 function signalTable(input: UnifiedReviewInput, ctx: UnifiedCommentContext): string {
   const blockerCount = (input.blockers ?? []).length;
   const codeRow: UnifiedSignalRow = {
@@ -371,6 +394,12 @@ export function renderUnifiedReviewComment(input: UnifiedReviewInput, ctx: Unifi
     const heading = status === "blocked" ? "Why this is blocked" : "Concerns raised — review before merging";
     blocks.push(`**${heading}**\n${bullets(blockers)}`);
   }
+
+  // Failing CI checks — list WHICH checks failed and WHY (codecov %/test/lint reason) under the "CI failing"
+  // chip, instead of leaving the chip as the only signal. Only when CI actually failed (failingChecksBlock
+  // guards on ciState === "failed"); public-safe (names + short reasons only).
+  const failingChecks = failingChecksBlock(input.readiness);
+  if (failingChecks) blocks.push(`**CI checks failing**\n${failingChecks}`);
 
   blocks.push(signalTable(input, ctx));
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -16,6 +16,11 @@ const DEFAULT_SLOP_GATE_MIN_SCORE = 60;
 // them and they never collide with project labels.
 export const AGENT_LABEL_READY = "gittensory:ready-to-merge";
 export const AGENT_LABEL_CHANGES = "gittensory:changes-requested";
+// A PR that PASSES the gate but touches a hard-guardrail path is NOT ready to auto-merge — it is withheld
+// for a human (the merge/approve/close dispositions are suppressed below). Labeling it `ready-to-merge`
+// would be misleading (the label promises an auto-merge that never happens), so a guarded passing PR gets
+// this distinct "needs a human" label instead. Blocking verdicts keep AGENT_LABEL_CHANGES.
+export const AGENT_LABEL_NEEDS_REVIEW = "gittensory:needs-human-review";
 
 // Maintainer-managed automation accounts whose PRs are never auto-closed. A recurring accumulator (e.g.
 // github-actions[bot] opening automation/readme-refresh) or a dependency PR must not be killed by a duplicate
@@ -102,11 +107,15 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const guardrailHit = changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0;
 
   // 1) label — reflect the verdict bucket. After the neutral/skipped return above, a non-blocking verdict is
-  // necessarily `success`. Idempotent: skip if the PR already carries the label.
+  // necessarily `success`. A passing PR that hit a hard guardrail is NOT auto-merge-ready (the irreversible
+  // dispositions below are all suppressed for it) — labeling it `ready-to-merge` would promise an auto-merge
+  // that never happens, so it gets `needs-human-review` instead. Idempotent: skip if the PR already carries
+  // the chosen label.
   if (acting("label")) {
-    const label = blocking ? AGENT_LABEL_CHANGES : AGENT_LABEL_READY;
+    const label = blocking ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
+    const reason = !blocking && guardrailHit ? `verdict=${input.conclusion}; guarded path forces human review` : `verdict=${input.conclusion}`;
     if (!hasLabel(input.pr.labels, label)) {
-      actions.push({ actionClass: "label", requiresApproval: approval("label"), reason: `verdict=${input.conclusion}`, label });
+      actions.push({ actionClass: "label", requiresApproval: approval("label"), reason, label });
     }
   }
 

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LABEL_CHANGES, AGENT_LABEL_READY, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
+import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
 import type { GateCheckConclusion } from "../../src/rules/advisory";
 
 function input(overrides: Partial<AgentActionPlanInput> & { conclusion: GateCheckConclusion }): AgentActionPlanInput {
@@ -141,9 +141,32 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan).not.toContain("merge");
     });
 
+    it("labels a guarded passing PR `needs-human-review` (NOT `ready-to-merge`) and still does not merge it", () => {
+      // A guardrail-hit PR that otherwise passes is withheld from auto-merge → the `ready-to-merge` label
+      // would be misleading. It must carry the distinct `needs-human-review` label instead, and never merge.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto", merge: "auto" }, ...guarded, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const label = plan.find((a) => a.actionClass === "label");
+      expect(label?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
+      expect(label?.label).not.toBe(AGENT_LABEL_READY);
+      expect(label?.reason).toContain("guarded path");
+      expect(classes(plan)).not.toContain("merge");
+    });
+
+    it("does not re-plan the needs-human-review label when the guarded PR already carries it (idempotent)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto" }, ...guarded, pr: { labels: [AGENT_LABEL_NEEDS_REVIEW] } })));
+      expect(plan).not.toContain("label");
+    });
+
+    it("a guarded BLOCKING PR keeps the changes-requested label (not needs-human-review)", () => {
+      const label = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { label: "auto" }, blockerTitles: ["x"], ...guarded, pr: { labels: [] } })).find((a) => a.actionClass === "label");
+      expect(label?.label).toBe(AGENT_LABEL_CHANGES);
+    });
+
     it("still auto-merges when the changed paths do NOT match any guardrail glob", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, changedPaths: ["docs/readme.md", "src/ui/button.tsx"], hardGuardrailGlobs: ["src/scoring/**", "scripts/**"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
-      expect(plan).toContain("merge");
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto", merge: "auto" }, changedPaths: ["docs/readme.md", "src/ui/button.tsx"], hardGuardrailGlobs: ["src/scoring/**", "scripts/**"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      expect(classes(plan)).toContain("merge");
+      // A clean, non-guarded passing PR keeps the `ready-to-merge` label (the auto-merge it promises happens).
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_READY);
     });
   });
 

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -116,6 +116,30 @@ describe("runAiReviewForAdvisory", () => {
     expect(result?.notes).toContain("Likely crash.");
   });
 
+  it("uses the caller's pre-resolved files (FIX B) instead of the stored read, so the model sees the real diff", async () => {
+    // FIX B: the processor passes `files` (its resolvePullRequestFilesForReview output). With no rows ever
+    // written to the test DB, a stored read would yield an EMPTY diff; passing files proves the model gets the
+    // real diff anyway — the diff-less-first-review failure mode.
+    const prompts: string[] = [];
+    const env = aiEnv(async (...args: unknown[]) => {
+      prompts.push(JSON.stringify(args));
+      return { response: notesOnlyJson() };
+    });
+    const result = await runAiReviewForAdvisory(env, {
+      settings: { aiReviewMode: "advisory" } as RepositorySettings,
+      advisory: advisory(),
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      files: [fileRecord({ path: "src/resolved.ts", status: "modified", payload: { patch: "@@\n+const fixed = true;" } })],
+    });
+    expect(result?.notes).toContain("Looks fine.");
+    // The pre-resolved file's path + patch reached the model prompt (i.e. the diff was non-empty).
+    expect(prompts.join("\n")).toContain("src/resolved.ts");
+    expect(prompts.join("\n")).toContain("const fixed = true;");
+  });
+
   it("returns advisory notes without a finding in advisory mode", async () => {
     const adv = advisory();
     const result = await runAiReviewForAdvisory(aiEnv(async () => ({ response: notesOnlyJson() })), {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -31,6 +31,7 @@ import {
   buildInstallationRepairDiagnostics,
   enqueueRepositoryOpenDataBackfill,
   enrichInstallationHealth,
+  fetchAndStorePullRequestFilesForReview,
   refreshContributorActivity,
   refreshInstallationHealth,
   refreshPullRequestDetails,
@@ -2593,6 +2594,46 @@ describe("GitHub backfill", () => {
         expect.objectContaining({ segment: "open_issues", status: "capped", nextCursor: "2" }),
       ]),
     );
+  });
+
+  // FIX B: the review path uses this to fetch + persist a PR's files inline when the stored rows are still
+  // empty (the PR-opened webhook beat the async detail-sync), so the FIRST AI review/grounding/comment sees
+  // the real diff instead of "0 files".
+  describe("fetchAndStorePullRequestFilesForReview", () => {
+    it("fetches the PR's files from GitHub, persists them, and returns the records", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/pulls/42/files")) {
+          return Response.json([
+            { filename: "src/foo.ts", status: "modified", additions: 9, deletions: 2, changes: 11, patch: "@@ -1 +1 @@\n-old\n+new" },
+            { filename: "README.md", status: "added", additions: 1, deletions: 0, changes: 1 },
+          ]);
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const records = await fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 42, "public-token");
+      expect(records.map((r) => r.path)).toEqual(["src/foo.ts", "README.md"]);
+      expect(records[0]).toMatchObject({ path: "src/foo.ts", additions: 9, deletions: 2, status: "modified" });
+      // Persisted: a subsequent stored read returns them (so the rest of the review run reuses them).
+      const stored = await listPullRequestFiles(env, "JSONbored/gittensory", 42);
+      expect(stored.map((r) => r.path).sort()).toEqual(["README.md", "src/foo.ts"]);
+    });
+
+    it("returns [] (and persists nothing) when GitHub returns no files — never throws", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async () => Response.json([]));
+      const records = await fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 7, "public-token");
+      expect(records).toEqual([]);
+      expect(await listPullRequestFiles(env, "JSONbored/gittensory", 7)).toEqual([]);
+    });
+
+    it("is fail-safe: a failed REST+GraphQL fetch returns [] rather than throwing", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async () => new Response("boom", { status: 500 }));
+      await expect(fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 99, "public-token")).resolves.toEqual([]);
+    });
   });
 });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22,6 +22,7 @@ import {
   recordGateBlockOutcome,
   recordProductUsageEvent,
   upsertAgentCommandAnswer,
+  upsertCheckSummary,
   upsertIssueFromGitHub,
   upsertRepoSyncSegment,
   upsertInstallation,
@@ -2857,6 +2858,157 @@ describe("queue processors", () => {
     // …and the renderer's synthesized "Code review" signal row (bold first table label).
     expect(postedBody).toContain("**Code review**");
     // Public-safe by construction — no internal trust/economics fields leak through the unified renderer.
+    expect(postedBody).not.toMatch(/wallet|hotkey|reward|trust score/i);
+  });
+
+  // FIX B + FIX D3 at the processor call site: a unified comment for a PR whose CI has a FAILED check, with the
+  // PR's files only available from GitHub (stored rows empty) — proves (B) the inline file fetch populates the
+  // real diff/changed-file count on the first review, and (D3) the failing check name + its per-check WHY render
+  // under a "CI checks failing" section (not just a bare "CI failing" chip).
+  it("inline-fetches the PR files and renders failing CI check names + reasons in the unified comment (FIX B + D3)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_UNIFIED_COMMENT: "1" });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "detected_contributors_only",
+      publicAudienceMode: "gittensor_only",
+      publicSignalLevel: "standard",
+      publicSurface: "comment_and_label",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      checkRunDetailLevel: "minimal",
+      gateCheckMode: "enabled",
+      backfillEnabled: true,
+      privateTrustEnabled: true,
+    });
+    // Seed a FAILED check summary with a per-check WHY (codecov-style) so listCheckSummaries returns it and the
+    // unified site populates failingDetails. (The PR row + headSha must match for the check to associate.)
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 3,
+      title: "Fix webhook duplicate delivery again",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "unified123" },
+      labels: [{ name: "bug" }],
+      body: "Fixes #1\n\nValidation: npm test",
+    });
+    await upsertCheckSummary(env, {
+      id: "JSONbored/gittensory#unified123#codecov/patch",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 3,
+      headSha: "unified123",
+      name: "codecov/patch",
+      status: "completed",
+      conclusion: "failure",
+      detailsUrl: "https://codecov.io/report",
+      payload: { output: { summary: "60% of diff hit (target 97%)" } },
+    });
+    let postedBody = "";
+    let filesFetched = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([
+          {
+            uid: 7,
+            githubUsername: "oktofeesh1",
+            githubId: "123",
+            totalPrs: 4,
+            totalMergedPrs: 3,
+            totalOpenPrs: 1,
+            totalClosedPrs: 0,
+            totalOpenIssues: 0,
+            totalClosedIssues: 0,
+            totalSolvedIssues: 0,
+            totalValidSolvedIssues: 0,
+            isEligible: true,
+            credibility: 1,
+            eligibleRepoCount: 1,
+            hotkey: "must-not-leak",
+          },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") {
+        return Response.json({
+          repositories: [
+            {
+              repositoryFullName: "JSONbored/gittensory",
+              totalPrs: "4",
+              totalMergedPrs: "3",
+              totalOpenPrs: "1",
+              totalClosedPrs: "0",
+              totalOpenIssues: "0",
+              totalClosedIssues: "0",
+              isEligible: true,
+              credibility: "1.000000",
+            },
+          ],
+        });
+      }
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/oktofeesh1")) return Response.json({ login: "oktofeesh1", public_repos: 2, followers: 1 });
+      if (url.includes("/users/oktofeesh1/repos")) return Response.json([{ language: "TypeScript" }]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // FIX B: stored pull_request_files is empty, so the review path inline-fetches from GitHub here.
+      if (url.includes("/pulls/3/files")) {
+        filesFetched += 1;
+        return Response.json([{ filename: "src/cache.ts", additions: 5, deletions: 1, status: "modified", patch: "@@\n+const x = 1;" }]);
+      }
+      if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 902 }, { status: 201 });
+      if (url.includes("/check-runs/902") && method === "PATCH") return Response.json({ id: 902 });
+      if (url.includes("/issues/3/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/3/comments") && method === "POST") {
+        postedBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 1, html_url: "https://github.com/comment/1" }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pr-unified-ci-failing",
+      eventName: "pull_request",
+      payload: {
+        action: "synchronize",
+        installation: {
+          id: 123,
+          account: { login: "JSONbored", id: 1, type: "User" },
+          repository_selection: "selected",
+          permissions: { metadata: "read", pull_requests: "read", issues: "write", checks: "write" },
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+        },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 3,
+          title: "Fix webhook duplicate delivery again",
+          state: "open",
+          user: { login: "oktofeesh1" },
+          head: { sha: "unified123" },
+          labels: [{ name: "bug" }],
+          body: "Fixes #1\n\nValidation: npm test",
+        },
+      },
+    });
+
+    // FIX B: the files were fetched inline from GitHub (stored rows were empty) and the changed-file count is real.
+    expect(filesFetched).toBeGreaterThan(0);
+    expect(postedBody).toContain("`1 file`");
+    // FIX D3: the failing check name + its WHY render under a "CI checks failing" section, plus the chip.
+    expect(postedBody).toContain("`CI failing`");
+    expect(postedBody).toContain("CI checks failing");
+    expect(postedBody).toContain("codecov/patch");
+    expect(postedBody).toContain("60% of diff hit (target 97%)");
+    // Still public-safe.
     expect(postedBody).not.toMatch(/wallet|hotkey|reward|trust score/i);
   });
 

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -336,6 +336,219 @@ describe("single AI pass: the bridge RECOVERS the consensus defect, never re-der
   });
 });
 
+// ── FIX D: fuller blocked / CI-failing comment (gate blockers + verdictReason + failing-check details) ──────
+describe("gate blockers render in 'Why this is blocked' (FIX D1)", () => {
+  it("maps a NON-AI gate blocker into the reviewer blockers (populated list, not empty)", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({
+        conclusion: "failure",
+        title: "Gittensory Gate: blocked",
+        summary: "A hard blocker was found.",
+        // A non-AI gate failure (no ai_consensus_defect anywhere) — the consensus defect alone would have left
+        // "Why this is blocked" empty. The gate blocker must now render.
+        blockers: [{ code: "missing_linked_issue", severity: "critical", title: "No linked issue", detail: "Link an issue.", action: "Add `Closes #123`." }],
+      }),
+      // no aiReview, no advisoryFindings (no consensus defect) — only the gate blocker drives the list.
+      panelRows,
+      readinessTotal: 30,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Why this is blocked");
+    expect(body).toContain("No linked issue");
+    expect(body).toContain("Add `Closes #123`."); // the finding's action is appended after " — "
+  });
+
+  it("does NOT double-list the ai_consensus_defect when it is both a gate blocker and the recovered defect", () => {
+    const title = "Use-after-free in handler";
+    const body = buildUnifiedCommentBody({
+      gate: gate({
+        conclusion: "failure",
+        summary: "A hard blocker was found.",
+        // The defect is present in BOTH the gate blockers AND advisory findings (as evaluateGateCheck produces).
+        blockers: [{ code: "ai_consensus_defect", severity: "critical", title, detail: "Both models agree." }],
+      }),
+      advisoryFindings: [{ code: "ai_consensus_defect", severity: "critical", title, detail: "Both models agree." }],
+      panelRows,
+      readinessTotal: 20,
+      changedFiles: 3,
+      footerMarkdown: footer,
+    });
+    // The defect surfaces exactly once (recovered via consensusDefect; excluded from the folded gate blockers).
+    expect(body.split(title).length - 1).toBe(1);
+  });
+
+  it("renders BOTH the recovered consensus defect AND a separate non-AI gate blocker", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({
+        conclusion: "failure",
+        summary: "A hard blocker was found.",
+        blockers: [
+          { code: "ai_consensus_defect", severity: "critical", title: "Real bug", detail: "Both agree." },
+          { code: "slop_gate", severity: "critical", title: "Slop risk too high", detail: "Padding detected." },
+        ],
+      }),
+      advisoryFindings: [{ code: "ai_consensus_defect", severity: "critical", title: "Real bug", detail: "Both agree." }],
+      panelRows,
+      readinessTotal: 10,
+      changedFiles: 4,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Real bug"); // recovered consensus defect
+    expect(body).toContain("Slop risk too high"); // folded non-AI gate blocker
+  });
+
+  it("scrubs a private term out of a gate blocker before it reaches the public comment (privacy invariant)", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({
+        conclusion: "failure",
+        summary: "A hard blocker was found.",
+        // A gate blocker whose title names a private internal must be scrubbed → "[context]", never leaked.
+        blockers: [{ code: "x", severity: "critical", title: "Your trust score is too low", detail: "...", action: "n/a" }],
+      }),
+      panelRows,
+      readinessTotal: 10,
+      changedFiles: 1,
+      footerMarkdown: footer,
+    });
+    expect(body).not.toMatch(/trust score/i);
+    expect(body).toContain("[context]");
+  });
+});
+
+describe("verdictReason on a held/blocked headline (FIX D2)", () => {
+  it("appends the gate summary to a BLOCKED (close) verdict headline", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "failure", title: "Gittensory Gate: blocked", summary: "A hard blocker was found." }),
+      panelRows,
+      readinessTotal: 30,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toMatch(/Closed|Blocked/);
+    expect(body).toContain("A hard blocker was found."); // the gate's authoritative reason on the headline
+  });
+
+  it("appends the gate summary to a HELD (manual) verdict headline", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "action_required", title: "Gittensory Gate — needs review", summary: "Manual maintainer review required." }),
+      panelRows,
+      readinessTotal: 55,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Held for maintainer review");
+    expect(body).toContain("Manual maintainer review required.");
+  });
+
+  it("falls back to the gate TITLE when the summary is empty", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "failure", title: "Gittensory Gate: blocked by policy", summary: "  " }),
+      panelRows,
+      readinessTotal: 20,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Gittensory Gate: blocked by policy");
+  });
+
+  it("does NOT overwrite the positive ready wording on a passing (merge) verdict", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "success", title: "Gittensory Gate passed", summary: "No configured hard blocker was found." }),
+      panelRows,
+      readinessTotal: 90,
+      changedFiles: 2,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("Approved"); // ready headline kept its positive wording…
+    expect(body).not.toContain("No configured hard blocker was found."); // …the gate summary did NOT replace it
+  });
+});
+
+describe("failing CI checks (names + per-check WHY) render under the CI chip (FIX D3)", () => {
+  const mergeReadiness: MergeReadiness = {
+    ciState: "failed",
+    failingChecks: ["codecov/patch", "lint"],
+    failingDetails: [
+      { name: "codecov/patch", summary: "60% of diff hit (target 97%)" },
+      { name: "lint", summary: "2 errors in src/foo.ts" },
+    ],
+  };
+
+  it("lists each failing check name AND its detail", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "action_required", summary: "CI is red." }),
+      panelRows,
+      readinessTotal: 40,
+      changedFiles: 3,
+      mergeReadiness,
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("CI checks failing");
+    expect(body).toContain("codecov/patch");
+    expect(body).toContain("60% of diff hit (target 97%)");
+    expect(body).toContain("lint");
+    expect(body).toContain("2 errors in src/foo.ts");
+    expect(body).toContain("`CI failing`"); // the chip is still present too
+  });
+
+  it("falls back to bare check names when no per-check details were captured", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "action_required", summary: "CI is red." }),
+      panelRows,
+      readinessTotal: 40,
+      changedFiles: 3,
+      mergeReadiness: { ciState: "failed", failingChecks: ["build", "e2e"] },
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("CI checks failing");
+    expect(body).toContain("build");
+    expect(body).toContain("e2e");
+  });
+
+  it("omits the failing-checks section entirely when CI passed", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({ conclusion: "success" }),
+      panelRows,
+      readinessTotal: 90,
+      changedFiles: 3,
+      mergeReadiness: { ciState: "passed" },
+      footerMarkdown: footer,
+    });
+    expect(body).not.toContain("CI checks failing");
+    expect(body).toContain("`CI green`");
+  });
+});
+
+describe("privacy invariant: the private 'Maintainer notes' internals never reach the public unified comment (FIX D)", () => {
+  it("never contains 'Maintainer notes', even on a fully-populated blocked + CI-failing comment", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate({
+        conclusion: "failure",
+        title: "Gittensory Gate: blocked",
+        summary: "A hard blocker was found.",
+        blockers: [
+          { code: "ai_consensus_defect", severity: "critical", title: "Real bug", detail: "Both agree." },
+          { code: "missing_linked_issue", severity: "critical", title: "No linked issue", detail: "...", action: "Add `Closes #1`." },
+        ],
+        warnings: [{ code: "w", severity: "warning", title: "Add a test", detail: "...", action: "Cover the branch." }],
+      }),
+      aiReview: { notes: "The change is risky." },
+      advisoryFindings: [{ code: "ai_consensus_defect", severity: "critical", title: "Real bug", detail: "Both agree." }],
+      panelRows,
+      readinessTotal: 10,
+      changedFiles: 6,
+      mergeReadiness: { ciState: "failed", failingChecks: ["codecov/patch"], failingDetails: [{ name: "codecov/patch", summary: "60% of diff hit (target 97%)" }] },
+      footerMarkdown: footer,
+    });
+    expect(body).not.toContain("Maintainer notes");
+    // Sanity: the new depth IS present (so this isn't passing on an empty body).
+    expect(body).toContain("Why this is blocked");
+    expect(body).toContain("CI checks failing");
+    expect(body).toContain("A hard blocker was found.");
+  });
+});
+
 describe("PR_PANEL_COMMENT_MARKER is single-sourced from github/comments", () => {
   it("re-exports the SAME marker value the upsert reads (no drift between modules)", () => {
     // The bridge re-exports the canonical marker rather than redefining it. A divergence here would post a

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -159,6 +159,48 @@ describe("renderUnifiedReviewComment", () => {
     expect(pending).toContain("`CI pending`");
   });
 
+  it("lists failing check names + per-check details under a 'CI checks failing' section (FIX D3)", () => {
+    const md = renderUnifiedReviewComment(
+      {
+        ...base,
+        readiness: {
+          ciState: "failed",
+          failingChecks: ["codecov/patch", "lint"],
+          failingDetails: [
+            { name: "codecov/patch", summary: "60% of diff hit (target 97%)" },
+            { name: "lint", summary: "2 errors in src/foo.ts" },
+          ],
+        },
+      },
+      {},
+    );
+    expect(md).toContain("CI checks failing");
+    expect(md).toContain("- codecov/patch — 60% of diff hit (target 97%)");
+    expect(md).toContain("- lint — 2 errors in src/foo.ts");
+  });
+
+  it("falls back to bare failing check names when no per-check detail is present (FIX D3)", () => {
+    const md = renderUnifiedReviewComment({ ...base, readiness: { ciState: "failed", failingChecks: ["build", "e2e"] } }, {});
+    expect(md).toContain("CI checks failing");
+    expect(md).toContain("- build");
+    expect(md).toContain("- e2e");
+  });
+
+  it("omits the failing-checks section when CI passed or is unverified (FIX D3)", () => {
+    expect(renderUnifiedReviewComment({ ...base, readiness: { ciState: "passed" } }, {})).not.toContain("CI checks failing");
+    expect(renderUnifiedReviewComment({ ...base, readiness: { ciState: "unverified", failingChecks: ["stale"] } }, {})).not.toContain("CI checks failing");
+  });
+
+  it("angle-escapes a failing check name + detail (FIX D3 public-safety)", () => {
+    const md = renderUnifiedReviewComment(
+      { ...base, readiness: { ciState: "failed", failingDetails: [{ name: "check <x>", summary: "broke </details>" }] } },
+      {},
+    );
+    expect(md).toContain("check &lt;x&gt;");
+    expect(md).toContain("broke &lt;/details&gt;");
+    expect(md).not.toContain("broke </details>");
+  });
+
   it("appends an explicit verdict reason across ready (merged + unmerged) and advisory states", () => {
     // The verdict word is bolded (`**…**`); the reason follows outside the bold, so assert each separately.
     const merged = renderUnifiedReviewComment({ ...base, decision: "merge", merged: true, verdictReason: "all checks green" }, {});


### PR DESCRIPTION
Three review-quality defects found by live-testing the converged review on the gittensory repo.

**B — diff-less first reviews:** the review fired before the file-detail sync populated `pull_request_files`, so the AI review/grounding/gate/check-run/comment built **empty diffs** ("0 files / No diff provided") and never re-ran. Fix: `resolvePullRequestFilesForReview` prefers stored rows and, when empty, mints an installation token and inline-fetches+persists the PR files; a memoized `getReviewFiles()` feeds all 6 review call sites — **including the auto-maintain guardrail path** (an empty changedPaths there could have let a guarded PR slip into auto-merge — a real safety bug, now closed).

**C — silent/misleading holds:** a guardrail-held passing PR got `gittensory:ready-to-merge` while nothing merged. New `gittensory:needs-human-review` label is applied instead (blocking verdicts keep `changes-requested`).

**D — fuller blocked/CI comment:** non-AI `gate.blockers` now populate "Why this is blocked" (public-safe scrubbed); `verdictReason` is threaded from `gate.summary` on held/blocked/closed headlines; `MergeReadiness.failingDetails` is populated + a "CI checks failing" section lists failing checks + reasons (restores reviewbot's CI-failure detail). Privacy invariant preserved (no "Maintainer notes").

typecheck clean; test:unit 3358 + integration 58 green; biome clean. Part of epic #983.