### PR TITLE
verify: guarded-path PR must be held for manual review (not auto-merged)

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -1,3 +1,5 @@
+// (verification touch) This file is under a hard-guardrail glob (src/scoring/**); a change here must force
+// MANUAL review — gittensory must NOT auto-merge it, and should surface a needs-human-review hold.
 import {
   getLatestScoringModelSnapshot,
   persistScoringModelSnapshot,


### PR DESCRIPTION
Acceptance test for the hard-guardrail + manual-hold: a comment-only change in src/scoring/** (a guarded glob). Expected: gittensory reviews it but applies gittensory:needs-human-review (NOT ready-to-merge) and does NOT auto-merge — it falls to a human. Confirms the guardrail still holds after the diff-fetch (B) change to the changedPaths resolver. I will close this after confirming the hold.