### PR TITLE
fix(visual): block unsafe screenshot redirects

### DIFF
--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -20,6 +20,15 @@ import puppeteer from "@cloudflare/puppeteer";
 import { isSafeHttpUrl } from "../content-lane/safe-url";
 
 export type Viewport = { width: number; height: number };
+export interface CaptureShotOptions {
+  isAllowedUrl?: (targetUrl: string) => boolean;
+}
+type ScreenshotRequest = {
+  url(): string;
+  isNavigationRequest(): boolean;
+  abort(): Promise<unknown>;
+  continue(): Promise<unknown>;
+};
 export const DESKTOP_VIEWPORT: Viewport = { width: 1440, height: 900 };
 export const MOBILE_VIEWPORT: Viewport = { width: 390, height: 844 }; // iPhone-class portrait
 const VIEWPORT = DESKTOP_VIEWPORT;
@@ -106,11 +115,11 @@ function isAllowedHost(targetUrl: string, env: Env, productionUrl?: string): boo
  * not — the caller then shows an honest "requires authentication" placeholder instead of a screenshot of the
  * login screen. `png` is null on any render failure (callers degrade gracefully).
  */
-export async function captureShot(env: Env, url: string, viewport: Viewport = VIEWPORT): Promise<{ png: Uint8Array | null; authWalled: boolean }> {
+export async function captureShot(env: Env, url: string, viewport: Viewport = VIEWPORT, opts: CaptureShotOptions = {}): Promise<{ png: Uint8Array | null; authWalled: boolean }> {
   // SSRF defense-in-depth: NEVER navigate the headless browser to a non-public host (loopback / link-local /
   // private / cloud-metadata 169.254.169.254 / etc.). Callers may resolve `url` from a deployment_status
   // webhook or a PR-comment preview link, so guard at this choke point regardless of how the URL was obtained.
-  if (!url || !isSafeHttpUrl(url)) {
+  if (!url || !isSafeHttpUrl(url) || (opts.isAllowedUrl && !opts.isAllowedUrl(url))) {
     console.log(JSON.stringify({ ev: "render_screenshot_blocked", url: String(url).slice(0, 120) }));
     return { png: null, authWalled: false };
   }
@@ -119,8 +128,32 @@ export async function captureShot(env: Env, url: string, viewport: Viewport = VI
   try {
     browser = await puppeteer.launch(env.BROWSER as unknown as Parameters<typeof puppeteer.launch>[0]);
     const page = await browser.newPage();
+    await page.setRequestInterception(true);
+    page.on("request", (request: ScreenshotRequest) => {
+      const requestUrl = request.url();
+      let protocol = "";
+      try {
+        protocol = new URL(requestUrl).protocol;
+      } catch {
+        request.abort().catch(() => undefined);
+        return;
+      }
+      if (protocol === "http:" || protocol === "https:") {
+        const isAllowedNavigation = !request.isNavigationRequest() || !opts.isAllowedUrl || opts.isAllowedUrl(requestUrl);
+        if (!isSafeHttpUrl(requestUrl) || !isAllowedNavigation) {
+          console.log(JSON.stringify({ ev: "render_screenshot_request_blocked", url: requestUrl.slice(0, 120) }));
+          request.abort().catch(() => undefined);
+          return;
+        }
+      }
+      request.continue().catch(() => undefined);
+    });
     await page.setViewport(viewport);
     await page.goto(url, { waitUntil: "networkidle0", timeout: 20000 });
+    if (!isSafeHttpUrl(page.url()) || (opts.isAllowedUrl && !opts.isAllowedUrl(page.url()))) {
+      console.log(JSON.stringify({ ev: "render_screenshot_redirect_blocked", url, final: page.url().slice(0, 200) }));
+      return { png: null, authWalled: false };
+    }
     // A protected route that redirected to a login page: don't return a screenshot of the sign-in screen —
     // flag it so the caller renders an honest auth placeholder. (The requested URL not itself being a login
     // page guards a PR that legitimately changes the login screen.)
@@ -142,8 +175,8 @@ export async function captureShot(env: Env, url: string, viewport: Viewport = VI
 
 /** Back-compat thin wrapper: render a page to a PNG (or null on failure / auth wall). The on-demand
  *  `/shot?url=` route uses this; the capture pipeline uses `captureShot` to also learn `authWalled`. */
-export async function renderScreenshot(env: Env, url: string, viewport: Viewport = VIEWPORT): Promise<Uint8Array | null> {
-  return (await captureShot(env, url, viewport)).png;
+export async function renderScreenshot(env: Env, url: string, viewport: Viewport = VIEWPORT, opts: CaptureShotOptions = {}): Promise<Uint8Array | null> {
+  return (await captureShot(env, url, viewport, opts)).png;
 }
 
 export async function handleShot(request: Request, env: Env, opts: ShotOptions = {}): Promise<Response> {
@@ -181,7 +214,7 @@ export async function handleShot(request: Request, env: Env, opts: ShotOptions =
   const w = Number(params.get("w"));
   const h = Number(params.get("h"));
   const viewport: Viewport = Number.isFinite(w) && w > 0 && Number.isFinite(h) && h > 0 ? { width: Math.min(w, 2560), height: Math.min(h, 2560) } : DESKTOP_VIEWPORT;
-  const png = await renderScreenshot(env, target, viewport);
+  const png = await renderScreenshot(env, target, viewport, { isAllowedUrl: (candidate) => isAllowedHost(candidate, env, opts.productionUrl) });
   if (!png) return new Response("screenshot unavailable", { status: 502 });
   return new Response(png, {
     headers: { "content-type": "image/png", "cache-control": "public, max-age=300" },

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleShot } from "../../src/review/visual/shot";
+
+const mocks = vi.hoisted(() => ({
+  finalUrl: "https://preview.pages.dev/page",
+  screenshot: vi.fn(async () => new Uint8Array([1, 2, 3])),
+  abort: vi.fn(async () => undefined),
+  continue: vi.fn(async () => undefined),
+  close: vi.fn(async () => undefined),
+  launch: vi.fn(),
+}));
+
+vi.mock("@cloudflare/puppeteer", () => ({
+  default: {
+    launch: mocks.launch,
+  },
+}));
+
+function env(): Env {
+  return { BROWSER: {} } as Env;
+}
+
+function request(url: string): Request {
+  return new Request(`https://api.example.test/gittensory/shot?url=${encodeURIComponent(url)}`);
+}
+
+function makeRequest(url: string, navigation = true) {
+  return {
+    url: () => url,
+    isNavigationRequest: () => navigation,
+    abort: mocks.abort,
+    continue: mocks.continue,
+  };
+}
+
+describe("visual screenshot on-demand SSRF guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.finalUrl = "https://preview.pages.dev/page";
+    mocks.launch.mockImplementation(async () => {
+      let onRequest: ((request: ReturnType<typeof makeRequest>) => void) | undefined;
+      return {
+        newPage: async () => ({
+          setRequestInterception: vi.fn(async () => undefined),
+          on: vi.fn((event: string, callback: (request: ReturnType<typeof makeRequest>) => void) => {
+            if (event === "request") onRequest = callback;
+          }),
+          setViewport: vi.fn(async () => undefined),
+          goto: vi.fn(async (url: string) => {
+            onRequest?.(makeRequest(url));
+            if (mocks.finalUrl !== url) onRequest?.(makeRequest(mocks.finalUrl));
+          }),
+          url: vi.fn(() => mocks.finalUrl),
+          screenshot: mocks.screenshot,
+        }),
+        close: mocks.close,
+      };
+    });
+  });
+
+  it("rejects direct unsafe screenshot targets before launching the browser", async () => {
+    const response = await handleShot(request("http://127.0.0.1/admin"), env());
+
+    expect(response.status).toBe(400);
+    expect(mocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("does not screenshot a redirect from an allowlisted host to a private endpoint", async () => {
+    mocks.finalUrl = "http://127.0.0.1/admin";
+
+    const response = await handleShot(request("https://attacker.workers.dev/redirect"), env());
+
+    expect(response.status).toBe(502);
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+    expect(mocks.close).toHaveBeenCalled();
+  });
+
+  it("does not screenshot a redirect from an allowlisted host to an unallowlisted public host", async () => {
+    mocks.finalUrl = "https://example.com/public";
+
+    const response = await handleShot(request("https://attacker.workers.dev/redirect"), env());
+
+    expect(response.status).toBe(502);
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+    expect(mocks.close).toHaveBeenCalled();
+  });
+
+  it("renders when the final navigation remains safe and allowlisted", async () => {
+    mocks.finalUrl = "https://preview.pages.dev/page";
+
+    const response = await handleShot(request("https://preview.pages.dev/page"), env());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(mocks.continue).toHaveBeenCalled();
+    expect(mocks.screenshot).toHaveBeenCalled();
+  });
+});

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { handleShot } from "../../src/review/visual/shot";
+import { captureShot, handleShot } from "../../src/review/visual/shot";
 
 const mocks = vi.hoisted(() => ({
   finalUrl: "https://preview.pages.dev/page",
@@ -96,5 +96,43 @@ describe("visual screenshot on-demand SSRF guard", () => {
     expect(response.headers.get("content-type")).toBe("image/png");
     expect(mocks.continue).toHaveBeenCalled();
     expect(mocks.screenshot).toHaveBeenCalled();
+  });
+
+  it("captureShot rejects an unsafe target before launching the browser (defense-in-depth)", async () => {
+    const result = await captureShot(env(), "http://127.0.0.1/admin");
+    expect(result).toEqual({ png: null, authWalled: false });
+    expect(mocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("aborts a sub-request whose URL fails to parse", async () => {
+    mocks.finalUrl = "::::not-a-url";
+    const response = await handleShot(request("https://preview.pages.dev/page"), env());
+    expect(response.status).toBe(502);
+    expect(mocks.abort).toHaveBeenCalled();
+    expect(mocks.screenshot).not.toHaveBeenCalled();
+  });
+
+  it("does not apply the http SSRF check to a non-http(s) sub-request protocol", async () => {
+    mocks.finalUrl = "ftp://files.example.com/x";
+    const response = await handleShot(request("https://preview.pages.dev/page"), env());
+    expect(response.status).toBe(502); // final url is non-http(s) -> redirect-blocked downstream
+    expect(mocks.continue).toHaveBeenCalled();
+  });
+
+  it("swallows continue() and abort() rejections on the allowed + unparseable sub-requests", async () => {
+    // first request (allowed) continues; the rejected continue() must be swallowed by its .catch
+    mocks.continue.mockRejectedValueOnce(new Error("continue failed"));
+    // second request (unparseable URL) aborts; the rejected abort() must be swallowed by its .catch
+    mocks.abort.mockRejectedValueOnce(new Error("abort failed"));
+    mocks.finalUrl = "::::not-a-url";
+    const response = await handleShot(request("https://preview.pages.dev/page"), env());
+    expect(response.status).toBe(502);
+  });
+
+  it("swallows an abort() rejection on an unsafe-host sub-request", async () => {
+    mocks.abort.mockRejectedValueOnce(new Error("abort failed"));
+    mocks.finalUrl = "http://127.0.0.1/admin";
+    const response = await handleShot(request("https://preview.pages.dev/page"), env());
+    expect(response.status).toBe(502);
   });
 });


### PR DESCRIPTION
### Motivation
- The public, unauthenticated `/gittensory/shot?url=` endpoint could be abused as an SSRF primitive because the browser-renderer validated only the initial URL and allowed `.workers.dev` / `.pages.dev` hosts that can redirect to private or metadata endpoints. 
- The change aims to ensure in-browser redirects and subrequests are validated so the final navigation and any network requests cannot reach loopback, link-local, private, metadata, or otherwise disallowed endpoints. 

### Description
- Add a `CaptureShotOptions` callback (`isAllowedUrl`) and thread it through `captureShot`/`renderScreenshot` so callers can provide the per-call host allowlist. 
- Enable Puppeteer request interception inside `captureShot` and abort any HTTP(S) navigation or subrequest that fails `isSafeHttpUrl` or the provided `isAllowedUrl` predicate. 
- Revalidate `page.url()` after `page.goto()` and refuse to return a screenshot when the final URL is unsafe or leaves the allowed host set. 
- Pass the existing host allowlist from the on-demand route into the renderer and add `test/unit/visual-shot.test.ts` covering direct unsafe URLs, redirects to private endpoints, redirects to unallowlisted public hosts, and allowed final navigations. 

### Testing
- Ran `npx vitest run test/unit/visual-shot.test.ts` and the new file passed (4 tests). 
- Ran `npx vitest run test/unit/visual-wire.test.ts test/unit/visual-paths.test.ts test/unit/visual-collapsible.test.ts test/unit/visual-shot.test.ts` and all included visual unit tests passed (total 23 tests across files). 
- Attempted `npm run typecheck` but it failed in this checkout due to a missing `@cloudflare/puppeteer` in `node_modules` (the dependency is declared in `package.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39a08ec168832c802f1e33d4ba9fb0)