### PR TITLE
fix: bound grounding file fetches

### DIFF
--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -111,28 +111,58 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
   token = token ?? env.GITHUB_PUBLIC_TOKEN;
   const { owner, name } = repoParts(repoFullName);
   return {
-    async getFileContent(path: string, ref: string): Promise<string | null> {
+    async getFileContent(path: string, ref: string, maxChars = 24_001): Promise<string | null> {
       try {
         const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/contents/${path
           .split("/")
           .map(encodeURIComponent)
           .join("/")}?ref=${encodeURIComponent(ref)}`;
-        const response = await fetch(url, {
-          headers: {
-            // raw media type returns the file body directly (no base64 envelope to decode).
-            accept: "application/vnd.github.raw+json",
-            "user-agent": "gittensory/0.1",
-            "x-github-api-version": "2022-11-28",
-            ...(token ? { authorization: `Bearer ${token}` } : {}),
-          },
-        });
-        if (!response.ok) return null;
-        return await response.text();
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        try {
+          const response = await fetch(url, {
+            signal: controller.signal,
+            headers: {
+              // raw media type returns the file body directly (no base64 envelope to decode).
+              accept: "application/vnd.github.raw+json",
+              "user-agent": "gittensory/0.1",
+              "x-github-api-version": "2022-11-28",
+              ...(token ? { authorization: `Bearer ${token}` } : {}),
+            },
+          });
+          if (!response.ok) return null;
+          const contentLength = response.headers.get("content-length");
+          if (contentLength && Number(contentLength) > maxChars) return " ".repeat(maxChars + 1);
+          return await readTextWithLimit(response, maxChars);
+        } finally {
+          clearTimeout(timeout);
+        }
       } catch {
         return null; // network / decode failure → skip this file (fail-safe)
       }
     },
   };
+}
+
+async function readTextWithLimit(response: Response, maxChars: number): Promise<string | null> {
+  if (!response.body) {
+    const text = await response.text();
+    return text.length > maxChars ? text.slice(0, maxChars + 1) : text;
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+    if (text.length > maxChars) {
+      await reader.cancel().catch(() => undefined);
+      return text.slice(0, maxChars + 1);
+    }
+  }
+  text += decoder.decode();
+  return text.length > maxChars ? text.slice(0, maxChars + 1) : text;
 }
 
 /** The grounding text spliced into the reviewer prompts. Both fields are "" when grounding is OFF or empty,

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -117,7 +117,7 @@ export function diffFilePriority(path: string): number {
  *  post-change text of one file at a ref, returning null when unreadable (binary / vanished / perms). The
  *  host adapts reviewbot's getRepositoryFileContent (or any backend) to this shape at the call site. */
 export interface FileFetcher {
-  getFileContent(path: string, ref: string): Promise<string | null>;
+  getFileContent(path: string, ref: string, maxChars?: number): Promise<string | null>;
 }
 
 /** Centrally fetch the FULL post-change content of changed files (the one grounding input no lane fetches
@@ -143,13 +143,14 @@ export async function fetchFullFileContents(
     }
     let text: string | null = null;
     try {
-      text = await fetcher.getFileContent(file.filename, ref);
+      text = await fetcher.getFileContent(file.filename, ref, Math.min(MAX_SINGLE_FILE, FILE_CONTENT_BUDGET - used) + 1);
     } catch {
       text = null;
     }
     if (text == null) continue; // unreadable (binary / vanished / perms) — skip silently
     if (text.length > MAX_SINGLE_FILE || used + text.length > FILE_CONTENT_BUDGET) {
       out.push({ path: file.filename, text: "", truncated: true });
+      used = FILE_CONTENT_BUDGET;
       continue;
     }
     out.push({ path: file.filename, text });

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -363,6 +363,119 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
     fetchSpy.mockRestore();
   });
 
+  it("streams the body and truncates once the running text exceeds the per-file cap", async () => {
+    const env = createTestEnv();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            // Left open (not closed) so getFileContent must cancel() the reader on truncation. The
+            // throwing cancel() forces reader.cancel() to reject, exercising the .catch fail-safe.
+            controller.enqueue(new TextEncoder().encode("x".repeat(50)));
+          },
+          cancel() {
+            throw new Error("cancel boom");
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    const out = await fetcher.getFileContent("big.ts", "sha7", 10);
+    // The reader loop sees the running text exceed the cap and returns maxChars + 1 chars.
+    expect(out).toBe("x".repeat(11));
+    fetchSpy.mockRestore();
+  });
+
+  it("streams an under-cap body to completion and returns the full text", async () => {
+    const env = createTestEnv();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("small"));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    expect(await fetcher.getFileContent("small.ts", "sha7", 10)).toBe("small");
+    fetchSpy.mockRestore();
+  });
+
+  it("over-counts a trailing partial multibyte sequence on the final flush and truncates", async () => {
+    const env = createTestEnv();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            // "abc" keeps the running length at the cap; the lone 0xE2 byte is an incomplete UTF-8
+            // 3-byte lead, so the final decoder flush emits U+FFFD and pushes the total over the cap.
+            controller.enqueue(new TextEncoder().encode("abc"));
+            controller.enqueue(new Uint8Array([0xe2]));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    const out = await fetcher.getFileContent("multibyte.ts", "sha7", 3);
+    expect(out).toHaveLength(4);
+    expect(out?.startsWith("abc")).toBe(true);
+    fetchSpy.mockRestore();
+  });
+
+  it("falls back to text() when the response has no streamable body, truncating over-cap content", async () => {
+    const env = createTestEnv();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      headers: new Headers(), // no content-length → skips the early Content-Length guard
+      body: null,
+      text: async () => "y".repeat(50),
+    } as unknown as Response);
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    expect(await fetcher.getFileContent("nobody.ts", "sha7", 10)).toBe("y".repeat(11));
+    fetchSpy.mockRestore();
+  });
+
+  it("falls back to text() and returns the full body when no streamable body and under cap", async () => {
+    const env = createTestEnv();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      body: null,
+      text: async () => "tiny",
+    } as unknown as Response);
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    expect(await fetcher.getFileContent("nobody-small.ts", "sha7", 10)).toBe("tiny");
+    fetchSpy.mockRestore();
+  });
+
+  it("aborts the fetch via the 10s timeout and resolves to null (fail-safe)", async () => {
+    vi.useFakeTimers();
+    try {
+      const env = createTestEnv();
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = (init as RequestInit | undefined)?.signal;
+            signal?.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      );
+      const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+      const pending = fetcher.getFileContent("slow.ts", "sha7");
+      // Fire the abort timer; the rejected fetch is swallowed by the outer fail-safe catch.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(await pending).toBeNull();
+      fetchSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("attempts an installation token when given an installationId, falling back to the public token on failure", async () => {
     // No GitHub App key is configured in the test env, so createInstallationToken rejects; the wire
     // swallows it (.catch -> undefined) and the fetcher then authenticates with the public token.

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -347,6 +347,22 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
     fetchSpy.mockRestore();
   });
 
+  it("does not read bodies whose Content-Length exceeds the per-file cap", async () => {
+    const env = createTestEnv();
+    const text = vi.fn(async () => "too large");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-length": "100" }),
+      text,
+      body: null,
+    } as unknown as Response);
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    const out = await fetcher.getFileContent("big.ts", "sha7", 10);
+    expect(out?.length).toBeGreaterThan(10);
+    expect(text).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it("attempts an installation token when given an installationId, falling back to the public token on failure", async () => {
     // No GitHub App key is configured in the test env, so createInstallationToken rejects; the wire
     // swallows it (.catch -> undefined) and the fetcher then authenticates with the public token.

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -147,6 +147,27 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
     expect(out).toEqual([{ path: "src/big.ts", text: "", truncated: true }]);
   });
 
+  it("passes a per-read cap and stops fetching after an oversized file exhausts the budget", async () => {
+    const reads: Array<{ path: string; maxChars: number | undefined }> = [];
+    const fetcher: FileFetcher = {
+      getFileContent: async (path, _ref, maxChars) => {
+        reads.push({ path, maxChars });
+        return path === "src/big.ts" ? "x".repeat((maxChars ?? 0) + 1) : "ok";
+      },
+    };
+    const out = await fetchFullFileContents(
+      { ciGrounding: false, fullFileContext: true },
+      "sha",
+      files(["src/big.ts"], ["src/after.ts"]),
+      fetcher,
+    );
+    expect(out).toEqual([
+      { path: "src/big.ts", text: "", truncated: true },
+      { path: "src/after.ts", text: "", truncated: true },
+    ]);
+    expect(reads).toEqual([{ path: "src/big.ts", maxChars: 24_001 }]);
+  });
+
   it("returns undefined when nothing readable was inlined", async () => {
     const out = await fetchFullFileContents({ ciGrounding: false, fullFileContext: true }, "sha", files(["gone.ts"]), fetcherFrom({}));
     expect(out).toBeUndefined();


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory/time/network use when grounding fetches full PR files by stopping oversized downloads before the whole response is read. 
- Ensure the grounding budget is respected so repeated large files cannot be fetched sequentially and exhaust Worker resources.

### Description
- Add a `maxChars` parameter to the `FileFetcher.getFileContent` contract and have `fetchFullFileContents` pass a per-read cap computed as `Math.min(MAX_SINGLE_FILE, FILE_CONTENT_BUDGET - used) + 1` to the fetcher. 
- Implement `makeGithubFileFetcher` to accept `maxChars`, add a 10s `AbortController` timeout, check `Content-Length` and short-circuit when it exceeds `maxChars`, and stream-read the body with a `readTextWithLimit` helper that cancels the reader when the cap is exceeded. 
- When a fetched text is oversized, mark the file `truncated` and set `used = FILE_CONTENT_BUDGET` to exhaust the remaining budget so later files are not repeatedly fetched. 
- Add unit tests covering Content-Length short-circuiting and propagation of the per-read cap + budget exhaustion, and update affected test assertions.

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/review-grounding.test.ts test/unit/grounding-wiring.test.ts` and both test files passed. 
- Type-checking with `npm run typecheck` succeeded. 
- Verified local lint/checks via `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3987049190832ca6725f2fd3608b1c)