### PR TITLE
fix(review): align RAG index keys with retrieval

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -437,7 +437,7 @@ async function runRagIndexJob(
   const repo = await getRepository(env, repoFullName);
   /* v8 ignore next -- defensive: a fanned-out repo is always present; the null is belt-and-suspenders. */
   if (!repo) return;
-  const project = repoFullName;
+  const [project] = splitRepoForRag(repoFullName);
   if (paths && paths.length > 0) {
     await reindexChangedPaths(env, project, repo, paths);
     return;
@@ -3113,4 +3113,10 @@ function authoritativeContributorRepoStats(
 ) {
   const officialRepoStats = contributorRepoStatsFromGittensor(gittensorSnapshot);
   return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
+}
+
+/** Split `owner/name` into the project/repo key shape shared by RAG indexing and retrieval. */
+function splitRepoForRag(repoFullName: string): [string, string] {
+  const slash = repoFullName.indexOf("/");
+  return slash === -1 ? ["", repoFullName] : [repoFullName.slice(0, slash), repoFullName.slice(slash + 1)];
 }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3116,7 +3116,7 @@ function authoritativeContributorRepoStats(
 }
 
 /** Split `owner/name` into the project/repo key shape shared by RAG indexing and retrieval. */
-function splitRepoForRag(repoFullName: string): [string, string] {
+export function splitRepoForRag(repoFullName: string): [string, string] {
   const slash = repoFullName.indexOf("/");
   return slash === -1 ? ["", repoFullName] : [repoFullName.slice(0, slash), repoFullName.slice(slash + 1)];
 }

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { indexRepo, reindexChangedPaths } from "../../src/review/rag-index";
 import { MAX_CHUNKS_PER_REPO, RAG_DIMENSIONS, ragNamespace } from "../../src/review/rag";
-import { processJob } from "../../src/queue/processors";
+import { processJob, splitRepoForRag } from "../../src/queue/processors";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv, TestD1Database } from "../helpers/d1";
 
@@ -408,5 +408,16 @@ describe("merged-PR incremental re-index trigger (webhook)", () => {
 
   it("a non-allowlisted repo enqueues nothing", async () => {
     expect(await runMergedPrWebhook({ repos: "" })).toEqual([]);
+  });
+});
+
+describe("splitRepoForRag", () => {
+  it("splits owner/name into the shared project/repo key shape", () => {
+    expect(splitRepoForRag("JSONbored/gittensory")).toEqual(["JSONbored", "gittensory"]);
+  });
+
+  it("falls back to an empty project for a bare repo name (no slash)", () => {
+    // The slash === -1 arm — indexing and retrieval must agree on this shape for a name without an owner.
+    expect(splitRepoForRag("bareRepoName")).toEqual(["", "bareRepoName"]);
   });
 });

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -51,6 +51,7 @@ function indexEnv(over: { vec?: ReturnType<typeof vectorizeStub>; ai?: ReturnTyp
 
 const REPO = { fullName: "JSONbored/gittensory", installationId: null, defaultBranch: "main" };
 const PROJECT = "JSONbored/gittensory";
+const QUEUE_PROJECT = "JSONbored";
 
 /** Stub global fetch for the git-tree + raw-contents calls the populator makes. */
 function stubGithub(opts: {
@@ -306,7 +307,7 @@ describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
     await registerRepo(env, "JSONbored/gittensory");
     stubGithub({ tree: [{ path: "src/a.ts", size: 30 }], files: { "src/a.ts": "export const a = 1;\n" } });
     await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
-    expect(await countChunks(env, PROJECT, "gittensory")).toBe(1);
+    expect(await countChunks(env, QUEUE_PROJECT, "gittensory")).toBe(1);
   });
 
   it("per-repo dispatch SKIPS a non-allowlisted repo (no indexing)", async () => {
@@ -321,7 +322,7 @@ describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
     vi.stubGlobal("fetch", fetchSpy);
     await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+    expect(await countChunks(env, QUEUE_PROJECT, "gittensory")).toBe(0);
   });
 
   it("per-repo INCREMENTAL dispatch (with paths) runs reindexChangedPaths", async () => {
@@ -329,7 +330,7 @@ describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
     await registerRepo(env, "JSONbored/gittensory");
     stubGithub({ files: { "src/a.ts": "export const a = 1;\n" } });
     await processJob(env, { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts"] });
-    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["src/a.ts"]);
+    expect(await pathsFor(env, QUEUE_PROJECT, "gittensory")).toEqual(["src/a.ts"]);
   });
 
   it("FLAG-OFF per-repo dispatch is a no-op", async () => {
@@ -343,7 +344,7 @@ describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
     vi.stubGlobal("fetch", fetchSpy);
     await processJob(env, { type: "rag-index-repo", requestedBy: "schedule", repoFullName: "JSONbored/gittensory" });
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+    expect(await countChunks(env, QUEUE_PROJECT, "gittensory")).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The RAG feature was activated but the indexing dispatcher stored chunks under `project = repoFullName` while retrieval used `project = owner`, causing the cold-index guard to treat indexed repos as empty and return no context.
- The change aims to make indexing and retrieval use the same `project/repo` key shape so retrieval sees the populated index and avoids wasted background work.

### Description
- Change `src/queue/processors.ts` so the RAG job dispatcher derives the `project` by splitting `repoFullName` and using the owner component before calling `indexRepo` / `reindexChangedPaths` (uses `splitRepoForRag`).
- Add a small `splitRepoForRag` helper in `src/queue/processors.ts` that documents the shared key convention for RAG indexing and retrieval.
- Update `test/unit/rag-index.test.ts` assertions to expect rows written under the retriever-compatible `owner`/`repo` key shape.
- The fix is minimal and preserves existing indexing logic and fail-safes while aligning the stored keys with retrieval lookup.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check errors (passed).
- Ran `npx vitest run test/unit/rag-index.test.ts` which could not complete due to a missing environment dependency: `Cannot find package '@cloudflare/puppeteer'` (blocked/failing in this environment).
- Ran `npm run typecheck` which failed for the same missing module/type declarations (`@cloudflare/puppeteer`) in the current test environment (blocked/failing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39aa78adac832cb4a677b32ee38821)