### PR TITLE
fix(rag): cap incremental reindex ingestion

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -27,10 +27,12 @@ import { repoParts } from "../utils/json";
 import { createReviewAdapters } from "./adapters";
 import {
   chunkFile,
+  countRepoChunks,
   deleteChunksForPaths,
   filePriority,
   isIndexablePath,
   MAX_CHUNKS_PER_REPO,
+  MAX_FILE_BYTES,
   ragNamespace,
   type RagChunk,
   upsertChunks,
@@ -86,8 +88,49 @@ async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token:
   }
 }
 
-/** Fetch a single file's raw text at `ref`. null on any non-OK / error (fail-safe — skip that file). */
-async function fetchFileText(env: Env, repoFullName: string, path: string, ref: string, token: string | undefined): Promise<string | null> {
+/** Read a response body as UTF-8 text, aborting once the byte limit is exceeded. */
+async function readTextCapped(response: Response, maxBytes: number): Promise<string | null> {
+  const contentLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) return null;
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = await response.arrayBuffer();
+    return buffer.byteLength > maxBytes ? null : new TextDecoder().decode(buffer);
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+/** Fetch a single file's raw text at `ref`. null on any non-OK / oversized / error (fail-safe — skip that file). */
+async function fetchFileText(
+  env: Env,
+  repoFullName: string,
+  path: string,
+  ref: string,
+  token: string | undefined,
+  maxBytes = MAX_FILE_BYTES,
+): Promise<string | null> {
   try {
     const { owner, name } = repoParts(repoFullName);
     const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/contents/${path
@@ -96,7 +139,7 @@ async function fetchFileText(env: Env, repoFullName: string, path: string, ref: 
       .join("/")}?ref=${encodeURIComponent(ref)}`;
     const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github.raw+json") });
     if (!response.ok) return null;
-    return await response.text();
+    return await readTextCapped(response, maxBytes);
   } catch {
     return null;
   }
@@ -231,23 +274,30 @@ export async function reindexChangedPaths(
     if (indexable.length === 0) return { indexed: 0, files: 0, capped: false };
     const token = await resolveReadToken(env, repo.installationId);
     const ref = indexRef(repo.defaultBranch);
+    let stored = await countRepoChunks(infra.storage, project, repoName);
     let upserted = 0;
     let filesIndexed = 0;
+    let capped = false;
     for (const path of indexable) {
+      if (stored >= MAX_CHUNKS_PER_REPO) {
+        capped = true;
+        break;
+      }
       const text = await fetchFileText(env, repoFullName, path, ref, token);
-      if (text === null) continue; // file deleted at head, or unreadable — already removed above, leave it gone
+      if (text === null) continue; // file deleted at head, oversized, or unreadable — already removed above, leave it gone
       const chunks = chunkFile(path, text, namespace);
       if (chunks.length === 0) continue;
-      const n = await upsertChunks(infra, project, repoName, chunks);
+      const n = await upsertChunksCapped(env, project, repoName, chunks, stored);
       if (n > 0) {
         upserted += n;
+        stored += n;
         filesIndexed += 1;
       }
     }
     console.log(
-      JSON.stringify({ ev: "rag_reindex_paths", project, repo: repoFullName, paths: unique.length, files: filesIndexed, indexed: upserted }),
+      JSON.stringify({ ev: "rag_reindex_paths", project, repo: repoFullName, paths: unique.length, files: filesIndexed, indexed: upserted, capped }),
     );
-    return { indexed: upserted, files: filesIndexed, capped: false };
+    return { indexed: upserted, files: filesIndexed, capped };
   } catch (error) {
     console.log(JSON.stringify({ ev: "rag_reindex_paths_error", repo: repo.fullName, message: String(error).slice(0, 200) }));
     return empty;

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -82,7 +82,7 @@ const CHUNK_OVERLAP = 1500;
 export const MAX_CHUNKS_PER_REPO = 1500;
 const EMBED_BATCH = 96; // Workers AI caps embedding input at 100 items/call
 const MAX_CONTEXT_CHARS = 14000; // bound the injected block (mirrors diff/knowledge budgets)
-const MAX_FILE_BYTES = 1_000_000; // skip files larger than ~1MB
+export const MAX_FILE_BYTES = 1_000_000; // skip files larger than ~1MB
 
 export type RagKind = "code" | "doc";
 /** `boundary` records HOW the chunk was cut (informational): a whole small file, or a logical JS/TS unit. */

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -221,6 +221,86 @@ describe("reindexChangedPaths: delete + re-upsert only the changed paths", () =>
     expect(vec.upserted.length).toBe(0);
   });
 
+  it("rejects a changed file whose Content-Length header already exceeds the cap (no body read)", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+      .bind(`${ns}|src/declared-big.ts::0`, PROJECT, "gittensory", "src/declared-big.ts", 0, "code", "old")
+      .run();
+    // Header declares an oversized length → readTextCapped bails before streaming the (small) body.
+    vi.stubGlobal("fetch", async () =>
+      new Response("export const a = 1;\n", { status: 200, headers: { "content-length": String(MAX_FILE_BYTES + 1) } }),
+    );
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/declared-big.ts"]);
+
+    expect(result).toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.upserted.length).toBe(0);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+  });
+
+  it("reads a changed file delivered without a readable body via arrayBuffer (within the cap)", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    // A Response built from a Blob exposes arrayBuffer() but no streamable .body in this runtime path:
+    // force the no-reader branch with an explicit body-less object.
+    const bytes = new TextEncoder().encode("export const a = 1;\n");
+    vi.stubGlobal("fetch", async () => ({
+      ok: true,
+      headers: new Headers(),
+      body: null,
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    }));
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/a.ts"]);
+
+    expect(result.files).toBe(1);
+    expect(result.indexed).toBe(1);
+    expect(vec.upserted).toContain(`${ns}|src/a.ts::0`);
+  });
+
+  it("rejects a body-less changed file whose arrayBuffer exceeds the cap", async () => {
+    const { env, vec } = indexEnv();
+    const oversized = new Uint8Array(MAX_FILE_BYTES + 1);
+    vi.stubGlobal("fetch", async () => ({
+      ok: true,
+      headers: new Headers(),
+      body: null,
+      arrayBuffer: async () => oversized.buffer,
+    }));
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/a.ts"]);
+
+    expect(result).toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.upserted.length).toBe(0);
+  });
+
+  it("tolerates empty stream chunks and cancels a stream that overflows the cap (cancel rejection swallowed)", async () => {
+    const { env, vec } = indexEnv();
+    const reads = [
+      { done: false, value: undefined }, // empty chunk → `if (!value) continue`
+      { done: false, value: new Uint8Array(MAX_FILE_BYTES + 1) }, // overflow → cancel path
+    ];
+    let i = 0;
+    vi.stubGlobal("fetch", async () => ({
+      ok: true,
+      headers: new Headers(),
+      body: {
+        getReader: () => ({
+          read: async () => reads[i++] ?? { done: true, value: undefined },
+          cancel: async () => {
+            throw new Error("cancel failed"); // exercises `.catch(() => undefined)`
+          },
+        }),
+      },
+    }));
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/a.ts"]);
+
+    expect(result).toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.upserted.length).toBe(0);
+  });
+
   it("caps incremental reindex upserts at MAX_CHUNKS_PER_REPO", async () => {
     const { env, vec } = indexEnv();
     const overCap = MAX_CHUNKS_PER_REPO + 25;

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { indexRepo, reindexChangedPaths } from "../../src/review/rag-index";
-import { MAX_CHUNKS_PER_REPO, RAG_DIMENSIONS, ragNamespace } from "../../src/review/rag";
+import { MAX_CHUNKS_PER_REPO, MAX_FILE_BYTES, RAG_DIMENSIONS, ragNamespace } from "../../src/review/rag";
 import { processJob } from "../../src/queue/processors";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv, TestD1Database } from "../helpers/d1";
@@ -202,6 +202,66 @@ describe("reindexChangedPaths: delete + re-upsert only the changed paths", () =>
     expect(vec.upserted).toContain(`${ns}|src/a.ts::0`);
     // src/b.ts was never touched (not in the changed set).
     expect(vec.deleted).not.toContain(`${ns}|src/b.ts::0`);
+  });
+
+
+  it("skips oversized changed files before chunking/upserting", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+      .bind(`${ns}|src/huge.ts::0`, PROJECT, "gittensory", "src/huge.ts", 0, "code", "old")
+      .run();
+    stubGithub({ files: { "src/huge.ts": "x".repeat(MAX_FILE_BYTES + 1) } });
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/huge.ts"]);
+
+    expect(result).toEqual({ indexed: 0, files: 0, capped: false });
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(0);
+    expect(vec.deleted).toContain(`${ns}|src/huge.ts::0`);
+    expect(vec.upserted.length).toBe(0);
+  });
+
+  it("caps incremental reindex upserts at MAX_CHUNKS_PER_REPO", async () => {
+    const { env, vec } = indexEnv();
+    const overCap = MAX_CHUNKS_PER_REPO + 25;
+    const files: Record<string, string> = {};
+    const paths = Array.from({ length: overCap }, (_, i) => `src/f${i}.ts`);
+    for (const path of paths) files[path] = `export const ${path.replace(/\W/g, "_")} = 1;\n`;
+    stubGithub({ files });
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, paths);
+
+    expect(result.capped).toBe(true);
+    expect(result.indexed).toBe(MAX_CHUNKS_PER_REPO);
+    expect(vec.upserted.length).toBe(MAX_CHUNKS_PER_REPO);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(MAX_CHUNKS_PER_REPO);
+  });
+
+
+  it("counts existing repo chunks when capping incremental reindex", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.batch(
+      Array.from({ length: MAX_CHUNKS_PER_REPO - 1 }, (_, i) =>
+        env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)").bind(
+          `${ns}|src/existing${i}.ts::0`,
+          PROJECT,
+          "gittensory",
+          `src/existing${i}.ts`,
+          0,
+          "code",
+          "old",
+        ),
+      ),
+    );
+    stubGithub({ files: { "src/new-a.ts": "export const a = 1;\n", "src/new-b.ts": "export const b = 1;\n" } });
+
+    const result = await reindexChangedPaths(env, PROJECT, REPO, ["src/new-a.ts", "src/new-b.ts"]);
+
+    expect(result.capped).toBe(true);
+    expect(result.indexed).toBe(1);
+    expect(vec.upserted.length).toBe(1);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(MAX_CHUNKS_PER_REPO);
   });
 
   it("a deleted file (404 at head) is removed and not re-added", async () => {


### PR DESCRIPTION
### Motivation

- Prevent the merged-PR incremental RAG indexing path from downloading and indexing arbitrarily large files or exceeding the per-repo vector budget, which can exhaust worker memory/AI/vector quotas.

### Description

- Add a capped response reader (`readTextCapped`) and use it in `fetchFileText` so oversized raw file responses are rejected before allocating full strings, honoring `MAX_FILE_BYTES` exported from `src/review/rag.ts`.
- Enforce the per-repo chunk cap for incremental reindexing by counting existing stored chunks after stale-path deletion and using the existing capped upsert helper (`upsertChunksCapped`) instead of the uncapped `upsertChunks` in `reindexChangedPaths` (stop when `MAX_CHUNKS_PER_REPO` is reached and surface `capped`).
- Add regression unit tests covering oversized changed-file skipping, incremental upsert capping, and cap behavior when the repo already has stored chunks (`test/unit/rag-index.test.ts`).

### Testing

- Ran repository checks (`git diff --check`) which passed.
- Attempted to run the targeted unit tests with `npx vitest run test/unit/rag-index.test.ts`, but the test process could not import `@cloudflare/puppeteer` and failed during module resolution, so the new tests could not be executed end-to-end in this environment (import error blocked test run).
- Ran `npm run typecheck` which was also blocked by the same missing module; attempted `npm install --include=dev` to restore dependencies failed due to registry `403` preventing installation in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39aa4fbc28832cb7e99df34a0fa29a)