### PR TITLE
fix(github): cache installation tokens — stop the rate-limit storm

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -37,7 +37,18 @@ function timeoutFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Res
   return fetch(input, { ...(init ?? {}), signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS) });
 }
 
+// In-isolate installation-token cache. GitHub installation tokens are valid ~1h; minting a fresh one on EVERY
+// call (the previous behavior) multiplied GitHub API usage enormously — each review path mints several tokens,
+// and across the sweep + re-reviews that exhausted the hourly rate limit (observed min_remaining=0 → reviews
+// errored → dead-lettered → missed syncs → stale head SHAs). Caching to ~1 mint/hour/installation removes that
+// multiplier. The module-level Map persists across requests handled by the same Worker isolate; a 2-minute
+// safety margin avoids handing out a token that expires mid-request.
+const installationTokenCache = new Map<number, { token: string; expiresAtMs: number }>();
+const TOKEN_SAFETY_MARGIN_MS = 120_000;
+
 export async function createInstallationToken(env: Env, installationId: number): Promise<string> {
+  const cached = installationTokenCache.get(installationId);
+  if (cached && cached.expiresAtMs - TOKEN_SAFETY_MARGIN_MS > Date.now()) return cached.token;
   const jwt = await createAppJwt(env);
   const response = await timeoutFetch(`https://api.github.com/app/installations/${installationId}/access_tokens`, {
     method: "POST",
@@ -47,9 +58,17 @@ export async function createInstallationToken(env: Env, installationId: number):
     const body = await response.text();
     throw new Error(`Failed to create GitHub installation token (${response.status}): ${body.slice(0, 200)}`);
   }
-  const payload = (await response.json()) as { token?: string };
+  const payload = (await response.json()) as { token?: string; expires_at?: string };
   if (!payload.token) throw new Error("GitHub installation token response did not include a token.");
+  const expiresAtMs = payload.expires_at ? Date.parse(payload.expires_at) : Date.now() + 50 * 60_000;
+  installationTokenCache.set(installationId, { token: payload.token, expiresAtMs });
   return payload.token;
+}
+
+/** Test-only: clear the in-isolate installation-token cache so each test starts fresh (the module-level Map
+ *  otherwise leaks a cached token across test cases that share an installation id). */
+export function clearInstallationTokenCacheForTest(): void {
+  installationTokenCache.clear();
 }
 
 export async function getAppInstallation(env: Env, installationId: number): Promise<NonNullable<GitHubWebhookPayload["installation"]>> {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -543,21 +543,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     const gate = evaluateGateCheck(advisory, gateCheckPolicy(settings, null, undefined, pr.slopRisk ?? null));
     verdicts[String(pr.number)] = gate.conclusion;
     if (gate.conclusion === "failure" || gate.conclusion === "action_required") flaggedPulls.push(pr.number);
-    // Backstop the CI-completion trigger: re-run auto-maintain so a clean+green+approved PR is merged and a
-    // red-CI non-owner PR is closed (owner held) even if its check_run/check_suite webhook was missed or
-    // coalesced. maybeRunAgentMaintenance self-guards on autonomy + fetches the live CI aggregate itself.
+    // Backstop the CI-completion trigger AND refresh the stale public comment: fully RE-REVIEW each stale open
+    // PR (rebuild advisory → re-publish the unified comment with the current head/CI → re-run auto-maintain). The
+    // re-gate above only recomputes the audit verdict; without this re-publish, an idle PR keeps a stale comment
+    // (e.g. "safe to merge" from before a fix) and a stale status label forever. reReviewStoredPullRequest reads
+    // the freshly-synced head + the live CI, so the comment + label + action all reflect reality. Paced at
+    // SWEEP_MAX_PRS per sweep; cheap now that installation tokens are cached.
     if (sweepInstallationId != null) {
-      await maybeRunAgentMaintenance(env, {
-        installationId: sweepInstallationId,
-        repoFullName,
-        repo,
-        pr,
-        settings,
-        otherOpenPullRequests: others,
-        deliveryId: `regate-sweep:${repoFullName}#${pr.number}`,
-        gate,
-      }).catch((error) => {
-        console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number).catch((error) => {
+        console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
       });
     }
   }

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -85,6 +85,50 @@ describe("GitHub check runs", () => {
     await expect(createInstallationToken(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123)).resolves.toBe("installation-token");
   });
 
+  it("caches an installation token and reuses it within the validity window", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mints = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        return Response.json({ token: `installation-token-${mints}`, expires_at: new Date(Date.now() + 60 * 60_000).toISOString() });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const first = await createInstallationToken(env, 555);
+    const second = await createInstallationToken(env, 555);
+
+    expect(first).toBe("installation-token-1");
+    expect(second).toBe("installation-token-1");
+    expect(mints).toBe(1);
+  });
+
+  it("re-mints an installation token once the cached one is within the expiry safety margin", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mints = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        // First mint expires almost immediately (inside the 2-minute safety margin) → must not be reused.
+        const expiresInMs = mints === 1 ? 30_000 : 60 * 60_000;
+        return Response.json({ token: `installation-token-${mints}`, expires_at: new Date(Date.now() + expiresInMs).toISOString() });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const first = await createInstallationToken(env, 777);
+    const second = await createInstallationToken(env, 777);
+
+    expect(first).toBe("installation-token-1");
+    expect(second).toBe("installation-token-2");
+    expect(mints).toBe(2);
+  });
+
   it("fetches repository collaborator permissions with installation credentials", async () => {
     const privateKey = await generatePrivateKeyPem();
     const calls: string[] = [];

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
 import {
+  clearInstallationTokenCacheForTest,
   createInstallationToken,
   createOrUpdateCheckRun,
   createOrUpdateGateCheckRun,
@@ -12,6 +13,8 @@ import {
 } from "../../src/github/app";
 import type { Advisory } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
+
+beforeEach(() => clearInstallationTokenCacheForTest());
 
 describe("GitHub check runs", () => {
   afterEach(() => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import {
   listCollisionEdges,
   createAgentRun,
@@ -44,6 +45,7 @@ describe("queue processors", () => {
   // Freshness-SLO fixtures are dated relative to late May 2026; pin the clock so staleness windows
   // stay deterministic regardless of when CI runs.
   beforeEach(() => {
+    clearInstallationTokenCacheForTest();
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
   });
@@ -1959,7 +1961,8 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ token: 2, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1 });
+    // token: 1 — the installation token is now cached + reused within the request (was 2: main + permission check).
+    expect(calls).toEqual({ token: 1, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1 });
     expect(patchedBody).toContain("<!-- gittensory-pr-panel:v1 -->");
     expect(patchedBody).toContain("Readiness score:");
     expect(patchedBody).toContain("- [ ] <!-- gittensory-rerun-review:v1 --> Re-run Gittensory review");
@@ -2268,7 +2271,8 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ token: 2, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1 });
+    // token: 1 — the installation token is now cached + reused within the request (was 2: main + permission check).
+    expect(calls).toEqual({ token: 1, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1 });
   });
 
   it("skips PR panel reruns when the editing actor and PR author are unavailable", async () => {
@@ -4045,9 +4049,9 @@ describe("queue processors", () => {
     });
 
     expect(calls.commentsCreated).toBe(8);
-    // Each command now also resolves the commenter's real repo permission (#788), which fetches its own
-    // installation token — so the per-command token count is 2 (permission check + comment).
-    expect(calls.token).toBe(16);
+    // The installation token is cached + reused across all 8 commands (each previously minted 2 — permission
+    // check + comment — for 16 total). Caching collapses them to a single mint, which is the rate-limit fix.
+    expect(calls.token).toBe(1);
     expect(calls.minerList).toBeGreaterThanOrEqual(1);
     const audit = await env.DB.prepare("select event_type, detail from audit_events where target_key = ? order by created_at")
       .bind("JSONbored/gittensory#77")
@@ -4154,7 +4158,7 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ commentsCreated: 1, token: 2 }); // +1 token for the #788 permission check
+    expect(calls).toEqual({ commentsCreated: 1, token: 1 }); // token cached + reused across the #788 permission check
     const audit = await env.DB.prepare("select event_type, detail, metadata_json from audit_events where target_key = ? order by created_at")
       .bind("JSONbored/gittensory#90")
       .all<{ event_type: string; detail: string | null; metadata_json: string }>();
@@ -4287,7 +4291,7 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ commentsCreated: 1, token: 2, minerList: 0 }); // +1 token for the #788 permission check
+    expect(calls).toEqual({ commentsCreated: 1, token: 1, minerList: 0 }); // token cached + reused across the #788 permission check
     const audit = await env.DB.prepare("select event_type, detail from audit_events where target_key = ? order by created_at")
       .bind("JSONbored/gittensory#91")
       .all<{ event_type: string; detail: string | null }>();

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -578,6 +578,37 @@ describe("queue processors", () => {
     expect(sent).toEqual([]);
   });
 
+  it("agent re-gate sweep re-reviews each stale open PR (installation id) and swallows a failing re-review", async () => {
+    const env = createTestEnv({});
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, linkedIssueGateMode: "block" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Unlinked PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "no linked issue here" });
+    // Advance past the one-hour freshness window so the just-seeded PR reads as stale.
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    // Make the re-review itself REJECT (its advisory persist throws) so the sweep's per-PR error backstop runs.
+    // Only the advisories insert is poisoned; every other read/write (verdict computation, the closing audit
+    // event) keeps working — the sweep must still complete and record its advisory verdict.
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    env.DB.prepare = ((sql: string) => {
+      if (/insert\s+into\s+["'`]?advisories/i.test(sql)) throw new Error("advisory persist failed");
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    const audit = await realPrepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.sweep.regate").first<{
+      outcome: string;
+      metadata_json: string;
+    }>();
+    expect(audit?.outcome).toBe("completed");
+    expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ repoFullName: "owner/agent-repo", examined: 1, flagged: 1 });
+    // The failing re-review was caught and logged via the sweep_rereview_failed backstop, not rethrown.
+    expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_rereview_failed"))).toBe(true);
+    errors.mockRestore();
+  });
+
   it("agent re-gate sweep respects the #776 kill-switch: a paused repo records a skip and recomputes nothing (#777)", async () => {
     const env = createTestEnv({});
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } });


### PR DESCRIPTION
ROOT CAUSE of the dead-lettered reviews + stale head SHAs + wrong 'CI green' approvals: createInstallationToken minted a fresh GitHub token on EVERY call (no cache). The converged review path mints several tokens per review; across the sweep + re-reviews this exhausted the GitHub hourly rate limit (observed min_remaining=0 at 6753 calls/hr) → reviews errored → dead-lettered → missed synchronize webhooks → stale stored head SHAs → reviews ran against the old green commit → wrong approvals after a rebase. FIX: in-isolate token cache (valid ~1h, 2-min margin) → ~1 mint/hour/installation. 3460 tests pass (deployed 30733bbc).