### PR TITLE
fix(review): escape visual route captions

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -232,7 +232,7 @@ export type UnifiedCommentBridgeArgs = {
  */
 export function buildBeforeAfterCollapsible(routes: CaptureRoute[]): UnifiedCollapsible | null {
   const attr = (value: string): string =>
-    value.replace(/[&"<>]/g, (char) => ({ "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" })[char] ?? char);
+    value.replace(/[&"<>]/g, (char) => ({ "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" })[char] as string);
   const markdownCode = (value: string): string =>
     `\`${value
       .replace(/\\/g, "\\\\")

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -231,13 +231,19 @@ export type UnifiedCommentBridgeArgs = {
  * when nothing is renderable (no route has any shot URL), so the section is omitted rather than shown empty.
  */
 export function buildBeforeAfterCollapsible(routes: CaptureRoute[]): UnifiedCollapsible | null {
-  const attr = (value: string): string => value.replace(/"/g, "%22");
-  const alt = (value: string): string => value.replace(/"/g, "'");
+  const attr = (value: string): string =>
+    value.replace(/[&"<>]/g, (char) => ({ "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;" })[char] ?? char);
+  const markdownCode = (value: string): string =>
+    `\`${value
+      .replace(/\\/g, "\\\\")
+      .replace(/`/g, "\\`")
+      .replace(/\|/g, "\\|")
+      .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"))}\``;
   const cell = (url: string | undefined, label: string): string =>
-    url ? `<a href="${attr(url)}" target="_blank" rel="noopener"><img width="360" alt="${alt(label)}" src="${attr(url)}"></a>` : "—";
+    url ? `<a href="${attr(url)}" target="_blank" rel="noopener"><img width="360" alt="${attr(label)}" src="${attr(url)}"></a>` : "—";
   const rows: string[] = [];
   for (const route of routes) {
-    const path = `\`${route.path.replace(/\|/g, "\\|")}\``;
+    const path = markdownCode(route.path);
     if (route.beforeUrl || route.afterUrl) {
       rows.push(`| ${path} | desktop | ${cell(route.beforeUrl, `before ${route.path}`)} | ${cell(route.afterUrl, `after ${route.path}`)} |`);
     }

--- a/test/unit/visual-collapsible.test.ts
+++ b/test/unit/visual-collapsible.test.ts
@@ -59,6 +59,18 @@ describe("buildBeforeAfterCollapsible", () => {
     const c = buildBeforeAfterCollapsible([{ path: "/a|b", afterUrl: "https://api.example.dev/gittensory/shot?key=gittensory/shots/x.png" }]);
     expect(c?.body).toContain("`/a\\|b`");
   });
+
+  it("escapes route captions before embedding them in the trusted raw HTML table", () => {
+    const c = buildBeforeAfterCollapsible([
+      {
+        path: "/p`<h2>✅ FORGED APPROVAL</h2><a href=x>maintainer click here</a>",
+        afterUrl: "https://api.example.dev/gittensory/shot?key=gittensory/shots/x.png",
+      },
+    ]);
+    expect(c?.body).toContain("`/p\\`&lt;h2&gt;✅ FORGED APPROVAL&lt;/h2&gt;&lt;a href=x&gt;maintainer click here&lt;/a&gt;`");
+    expect(c?.body).not.toContain("<h2>✅ FORGED APPROVAL</h2>");
+    expect(c?.body).not.toContain("<a href=x>maintainer click here</a>");
+  });
 });
 
 describe("buildUnifiedCommentBody beforeAfter wiring", () => {


### PR DESCRIPTION
### Motivation
- The Visual preview was emitted as trusted raw HTML (`rawHtml: true`) while embedding PR-controlled `route.path` values with only pipe escaping, allowing a contributor to inject HTML/Markdown into bot-authored public comments and forge content inside the collapsible.

### Description
- Replace the naive `attr` logic with HTML-escaping for `&`, `"`, `<`, and `>` when building anchor/img attributes in `buildBeforeAfterCollapsible` (`src/review/unified-comment-bridge.ts`).
- Add `markdownCode()` to safely render `route.path` as a Markdown code span by escaping backslashes, backticks, pipes, and angle brackets and use it instead of the previous pipe-only replacement.
- Use the new `attr()` for `alt` text and `src`/`href` attributes so URLs and labels cannot break out of the generated HTML.
- Add a regression test exercising a malicious-looking route filename containing backticks and HTML markup to `test/unit/visual-collapsible.test.ts` to ensure the caption is escaped before embedding in the trusted raw HTML table.

### Testing
- Ran `npx vitest run test/unit/visual-collapsible.test.ts` and the updated test suite for that file passed (all tests green). 
- Ran `git diff --check` with no issues reported.
- Ran `npm run typecheck`; this failed in the current environment due to missing `@cloudflare/puppeteer` type declarations (`src/review/visual/shot.ts`), which is unrelated to the change but prevents a full repo-wide typecheck here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c95ac660832ca370c2aa5020c23c)