### PR TITLE
fix(public-stats): scope ledger aggregates to review allowlist

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -21,7 +21,9 @@
 export const MINUTES_SAVED_PER_PR = 20;
 
 /** Truthy-string flag check, matching ops-wire / selftune-wire. */
-export function isPublicStatsEnabled(env: { GITTENSORY_PUBLIC_STATS?: string | undefined }): boolean {
+export function isPublicStatsEnabled(env: {
+  GITTENSORY_PUBLIC_STATS?: string | undefined;
+}): boolean {
   return /^(1|true|yes|on)$/i.test(env.GITTENSORY_PUBLIC_STATS ?? "");
 }
 
@@ -31,7 +33,11 @@ function storage(env: Env): D1Database {
 }
 
 /** Read-only helper that degrades a missing/empty table (or absent column in some envs) to []. */
-async function safeAll<T>(env: Env, sql: string, ...binds: unknown[]): Promise<T[]> {
+async function safeAll<T>(
+  env: Env,
+  sql: string,
+  ...binds: unknown[]
+): Promise<T[]> {
   try {
     const prepared = storage(env).prepare(sql);
     const stmt = binds.length > 0 ? prepared.bind(...binds) : prepared;
@@ -43,7 +49,12 @@ async function safeAll<T>(env: Env, sql: string, ...binds: unknown[]): Promise<T
 }
 
 /** reviewed = the PRs gittensory actually reviewed (excludes ignored drafts/bots + errors). */
-function reviewedOf(d: { merged: number; closed: number; commented: number; manual: number }): number {
+function reviewedOf(d: {
+  merged: number;
+  closed: number;
+  commented: number;
+  manual: number;
+}): number {
   return d.merged + d.closed + d.commented + d.manual;
 }
 
@@ -54,10 +65,29 @@ function filteredPct(reviewed: number, merged: number): number | null {
 }
 
 /** Reversal-grounded accuracy over the irreversible auto-actions (merged + closed); null until there is signal. */
-function accuracyPct(merged: number, closed: number, reversed: number): number | null {
+function accuracyPct(
+  merged: number,
+  closed: number,
+  reversed: number,
+): number | null {
   const decided = merged + closed;
   if (decided <= 0) return null;
   return Math.round((1 - reversed / decided) * 1000) / 10;
+}
+
+/** Public stats are intentionally constrained to the reviewed-repo allowlist. Empty allowlist => publish nothing. */
+function publicStatsProjects(env: {
+  GITTENSORY_REVIEW_REPOS?: string | undefined;
+}): string[] {
+  const seen = new Set<string>();
+  const projects: string[] = [];
+  for (const entry of (env.GITTENSORY_REVIEW_REPOS ?? "").split(",")) {
+    const project = entry.trim().toLowerCase();
+    if (!project || seen.has(project)) continue;
+    seen.add(project);
+    projects.push(project);
+  }
+  return projects;
 }
 
 interface DispositionRow {
@@ -91,7 +121,13 @@ export interface PublicStatsPayload {
   /** Trailing-7-day additions (by review time), for the "+N this week" hero delta. */
   weekly: { reviewed: number; merged: number };
   /** Per-repo split, busiest first. Public repo slugs only. */
-  byProject: Array<{ project: string; reviewed: number; merged: number; closed: number; accuracyPct: number | null }>;
+  byProject: Array<{
+    project: string;
+    reviewed: number;
+    merged: number;
+    closed: number;
+    accuracyPct: number | null;
+  }>;
 }
 
 const DISPOSITION_SELECT = `
@@ -103,24 +139,77 @@ const DISPOSITION_SELECT = `
   SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error`;
 
 /** Assemble the public-safe payload from the LIVE review ledger (cheap: review_targets is one row per PR). */
-export async function getPublicStats(env: Env, nowMs: number = Date.now()): Promise<PublicStatsPayload> {
-  const sinceIso = new Date(nowMs - 7 * 86_400_000).toISOString().slice(0, 19).replace("T", " ");
+export async function getPublicStats(
+  env: Env,
+  nowMs: number = Date.now(),
+): Promise<PublicStatsPayload> {
+  const sinceIso = new Date(nowMs - 7 * 86_400_000)
+    .toISOString()
+    .slice(0, 19)
+    .replace("T", " ");
+  const projects = publicStatsProjects(env);
+  const generatedAt = new Date(nowMs).toISOString();
+  const empty = (): PublicStatsPayload => ({
+    generatedAt,
+    updatedAt: generatedAt,
+    totals: {
+      handled: 0,
+      reviewed: 0,
+      merged: 0,
+      closed: 0,
+      commented: 0,
+      ignored: 0,
+      manual: 0,
+      error: 0,
+      reversed: 0,
+      filteredPct: null,
+      accuracyPct: null,
+      minutesSaved: 0,
+    },
+    weekly: { reviewed: 0, merged: 0 },
+    byProject: [],
+  });
+  if (projects.length === 0) return empty();
+
+  const projectFilter = `LOWER(project) IN (${projects.map(() => "?").join(", ")})`;
   const [dispositions, reversalRows, weekly] = await Promise.all([
-    safeAll<DispositionRow>(env, `SELECT project, COUNT(*) AS handled,${DISPOSITION_SELECT} FROM review_targets GROUP BY project`),
+    safeAll<DispositionRow>(
+      env,
+      `SELECT project, COUNT(*) AS handled,${DISPOSITION_SELECT} FROM review_targets WHERE ${projectFilter} GROUP BY project`,
+      ...projects,
+    ),
     safeAll<{ project: string; reversed: number }>(
       env,
       `SELECT project, COUNT(*) AS reversed FROM review_audit
-       WHERE event_type IN ('reversal_reverted', 'reversal_reopened') GROUP BY project`,
+       WHERE event_type IN ('reversal_reverted', 'reversal_reopened') AND ${projectFilter} GROUP BY project`,
+      ...projects,
     ),
-    safeAll<{ merged: number; closed: number; commented: number; manual: number }>(
+    safeAll<{
+      merged: number;
+      closed: number;
+      commented: number;
+      manual: number;
+    }>(
       env,
-      `SELECT${DISPOSITION_SELECT.replace(/, $/, "")} FROM review_targets WHERE created_at >= ?`,
+      `SELECT${DISPOSITION_SELECT.replace(/, $/, "")} FROM review_targets WHERE created_at >= ? AND ${projectFilter}`,
       sinceIso,
+      ...projects,
     ),
   ]);
 
-  const reversedByProject = new Map(reversalRows.map((r) => [r.project, r.reversed ?? 0]));
-  const totals = { handled: 0, merged: 0, closed: 0, commented: 0, ignored: 0, manual: 0, error: 0, reversed: 0 };
+  const reversedByProject = new Map(
+    reversalRows.map((r) => [r.project, r.reversed ?? 0]),
+  );
+  const totals = {
+    handled: 0,
+    merged: 0,
+    closed: 0,
+    commented: 0,
+    ignored: 0,
+    manual: 0,
+    error: 0,
+    reversed: 0,
+  };
   const byProject = dispositions
     .map((d) => {
       const merged = d.merged ?? 0;
@@ -139,14 +228,19 @@ export async function getPublicStats(env: Env, nowMs: number = Date.now()): Prom
       totals.error += error;
       totals.reversed += reversed;
       const reviewed = reviewedOf({ merged, closed, commented, manual });
-      return { project: d.project, reviewed, merged, closed, accuracyPct: accuracyPct(merged, closed, reversed) };
+      return {
+        project: d.project,
+        reviewed,
+        merged,
+        closed,
+        accuracyPct: accuracyPct(merged, closed, reversed),
+      };
     })
     .filter((r) => r.reviewed > 0)
     .sort((a, b) => b.reviewed - a.reviewed);
 
   const reviewed = reviewedOf(totals);
   const w = weekly[0] ?? { merged: 0, closed: 0, commented: 0, manual: 0 };
-  const generatedAt = new Date(nowMs).toISOString();
   return {
     generatedAt,
     updatedAt: generatedAt,

--- a/test/integration/public-stats-route.test.ts
+++ b/test/integration/public-stats-route.test.ts
@@ -33,7 +33,10 @@ describe("GET /v1/public/stats (#1059)", () => {
   });
 
   it("serves public-safe aggregates with no auth + a cache header when enabled", async () => {
-    const env = createTestEnv({ GITTENSORY_PUBLIC_STATS: "1" });
+    const env = createTestEnv({
+      GITTENSORY_PUBLIC_STATS: "1",
+      GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory,JSONbored/awesome-claude",
+    });
     await seed(env);
     const res = await createApp().request("/v1/public/stats", {}, env);
     expect(res.status).toBe(200);

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -13,7 +13,11 @@ function stubEnv(handler: (sql: string, args: unknown[]) => Row[]): Env {
     bind: (...a: unknown[]) => make(sql, a),
     all: async () => ({ results: handler(sql, args) }),
   });
-  return { DB: { prepare: (sql: string) => make(sql, []) } } as unknown as Env;
+  return {
+    DB: { prepare: (sql: string) => make(sql, []) },
+    GITTENSORY_REVIEW_REPOS:
+      "JSONbored/gittensory,JSONbored/awesome-claude,JSONbored/metagraphed",
+  } as unknown as Env;
 }
 
 const NOW = Date.parse("2026-06-22T00:00:00Z");
@@ -107,6 +111,101 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
       "JSONbored/gittensory",
     ]);
     expect(out.updatedAt).toBe(out.generatedAt);
+  });
+
+  it("publishes only projects from the reviewed-repo allowlist", async () => {
+    const out = await getPublicStats(
+      stubEnv((sql, args) => {
+        if (sql.includes("FROM review_audit")) {
+          return [
+            { project: "JSONbored/gittensory", reversed: 1 },
+            { project: "CustomerCo/stealth-product", reversed: 1 },
+          ].filter((row) => args.includes(String(row.project).toLowerCase()));
+        }
+        if (sql.includes("created_at >= ?")) {
+          const allowed = args.slice(1);
+          const weeklyRows = [
+            {
+              project: "JSONbored/gittensory",
+              merged: 1,
+              closed: 1,
+              commented: 0,
+              manual: 0,
+            },
+            {
+              project: "CustomerCo/stealth-product",
+              merged: 3,
+              closed: 0,
+              commented: 0,
+              manual: 0,
+            },
+          ].filter((row) =>
+            allowed.includes(String(row.project).toLowerCase()),
+          );
+          return [
+            weeklyRows.reduce(
+              (acc, row) => ({
+                merged: acc.merged + row.merged,
+                closed: acc.closed + row.closed,
+                commented: acc.commented + row.commented,
+                manual: acc.manual + row.manual,
+              }),
+              { merged: 0, closed: 0, commented: 0, manual: 0 },
+            ),
+          ];
+        }
+        if (sql.includes("GROUP BY project")) {
+          return [
+            {
+              project: "JSONbored/gittensory",
+              handled: 2,
+              merged: 1,
+              closed: 1,
+              commented: 0,
+              ignored: 0,
+              manual: 0,
+              error: 0,
+            },
+            {
+              project: "CustomerCo/stealth-product",
+              handled: 3,
+              merged: 3,
+              closed: 0,
+              commented: 0,
+              ignored: 0,
+              manual: 0,
+              error: 0,
+            },
+          ].filter((row) => args.includes(String(row.project).toLowerCase()));
+        }
+        return [];
+      }),
+      NOW,
+    );
+
+    expect(out.totals.handled).toBe(2);
+    expect(out.totals.reviewed).toBe(2);
+    expect(out.totals.reversed).toBe(1);
+    expect(out.weekly).toEqual({ reviewed: 2, merged: 1 });
+    expect(out.byProject.map((p) => p.project)).toEqual([
+      "JSONbored/gittensory",
+    ]);
+  });
+
+  it("publishes no ledger data when the reviewed-repo allowlist is empty", async () => {
+    const env = {
+      DB: {
+        prepare: () => {
+          throw new Error("public stats must not query an unscoped ledger");
+        },
+      },
+      GITTENSORY_REVIEW_REPOS: "",
+    } as unknown as Env;
+    const out = await getPublicStats(env, NOW);
+    expect(out.totals.handled).toBe(0);
+    expect(out.totals.reviewed).toBe(0);
+    expect(out.weekly).toEqual({ reviewed: 0, merged: 0 });
+    expect(out.byProject).toEqual([]);
   });
 
   it("returns zeroed totals with null derived metrics when the ledger is empty", async () => {


### PR DESCRIPTION
### Motivation
- The unauthenticated `/v1/public/stats` endpoint previously aggregated the entire review ledger and exposed per-project slugs and totals without checking repository privacy or opt-in, which can leak private or unallowlisted project metadata.
- The intent is to ensure public stats only include repositories explicitly opted into the review system so no unscoped ledger rows are published.

### Description
- Parse and normalize the `GITTENSORY_REVIEW_REPOS` allowlist via a new `publicStatsProjects` helper and treat an empty allowlist as a safe no-op that returns an empty payload. (`src/review/public-stats.ts`)
- Constrain all live ledger SQL reads (`review_targets` and `review_audit`) with a `LOWER(project) IN (...)` filter built from the allowlist so lifetime, reversal, weekly, and per-project aggregates are scoped before aggregation. (`src/review/public-stats.ts`)
- Return an explicit zeroed/empty `PublicStatsPayload` when the allowlist is empty so no unscoped DB queries are performed. (`src/review/public-stats.ts`)
- Add unit tests that assert only allowlisted projects are published and that an empty allowlist produces no ledger reads/published data, and update the integration route test to exercise the endpoint with an explicit `GITTENSORY_REVIEW_REPOS` env value. (`test/unit/public-stats.test.ts`, `test/integration/public-stats-route.test.ts`)

### Testing
- Ran `npx vitest run test/unit/public-stats.test.ts test/integration/public-stats-route.test.ts` and all tests passed. 
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a08be5c2c832c9ac9c5b42c7bad01)