### PR TITLE
perf(decision-pack): hoist login-independent maps out of the per-login build

### DIFF
--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -438,6 +438,12 @@ export type DecisionPackSharedInputs = {
   allPullRequests: PullRequestRecord[];
   bounties: BountyRecord[];
   scoringSnapshot: ScoringModelSnapshotRecord;
+  // Per-repo maps/manifests keyed by lowercased full name. These are login-INDEPENDENT (they derive only
+  // from the registered-repo set), so the batch job builds them once here instead of re-deriving — and, for
+  // focus manifests, re-FETCHING over the network — for every contributor in the loop.
+  issueQualityByRepo: Map<string, IssueQualityReport>;
+  repoOutcomePatternsByRepo: Map<string, RepoOutcomePatterns>;
+  focusManifests: Map<string, FocusManifest>;
 };
 
 export async function loadDecisionPackSharedInputs(env: Env): Promise<DecisionPackSharedInputs> {
@@ -451,12 +457,34 @@ export async function loadDecisionPackSharedInputs(env: Env): Promise<DecisionPa
     listBounties(env),
     getOrCreateScoringModelSnapshot(env),
   ]);
-  return { repositories, syncStates, syncSegments, totals, allIssues, allPullRequests, bounties, scoringSnapshot };
+  // Depends on `repositories`, so it runs after the first wave. Built once per batch and reused across logins.
+  const [issueQualityByRepo, repoOutcomePatternsByRepo, focusManifests] = await Promise.all([
+    loadIssueQualityReportMap(env, repositories),
+    loadRepoOutcomePatternsMap(env, repositories),
+    loadRepoFocusManifests(
+      env,
+      repositories.filter((repo) => repo.isRegistered).map((repo) => repo.fullName),
+    ),
+  ]);
+  return {
+    repositories,
+    syncStates,
+    syncSegments,
+    totals,
+    allIssues,
+    allPullRequests,
+    bounties,
+    scoringSnapshot,
+    issueQualityByRepo,
+    repoOutcomePatternsByRepo,
+    focusManifests,
+  };
 }
 
 export async function buildAndPersistContributorDecisionPack(env: Env, login: string, shared?: DecisionPackSharedInputs): Promise<ContributorDecisionPack> {
   // The heavy full-table reads are login-independent; reuse caller-provided context (batch job) or load once here (single-login run).
-  const { repositories, syncStates, syncSegments, totals, allIssues, allPullRequests, bounties, scoringSnapshot } = shared ?? (await loadDecisionPackSharedInputs(env));
+  const { repositories, syncStates, syncSegments, totals, allIssues, allPullRequests, bounties, scoringSnapshot, issueQualityByRepo, repoOutcomePatternsByRepo, focusManifests } =
+    shared ?? (await loadDecisionPackSharedInputs(env));
   const [github, contributorPullRequests, contributorIssues, cachedRepoStats, gittensorSnapshot] = await Promise.all([
     fetchPublicContributorProfile(login, env),
     listContributorPullRequests(env, login),
@@ -466,15 +494,8 @@ export async function buildAndPersistContributorDecisionPack(env: Env, login: st
   ]);
   const repoStats = authoritativeContributorRepoStats(gittensorSnapshot, cachedRepoStats);
   await evaluateRecommendationOutcomes(env, login);
-  const [issueQualityByRepo, repoOutcomePatternsByRepo, recommendationOutcomeFeedback] = await Promise.all([
-    loadIssueQualityReportMap(env, repositories),
-    loadRepoOutcomePatternsMap(env, repositories),
-    getAgentRecommendationOutcomeSummary(env, login),
-  ]);
-  const focusManifests = await loadRepoFocusManifests(
-    env,
-    repositories.filter((repo) => repo.isRegistered).map((repo) => repo.fullName),
-  );
+  // Login-DEPENDENT, so it stays per-login; the login-independent maps/manifests above come from `shared`.
+  const recommendationOutcomeFeedback = await getAgentRecommendationOutcomeSummary(env, login);
   const profile = buildContributorProfile(login, github, contributorPullRequests, contributorIssues, repoStats, gittensorSnapshot);
   const pullRequestFiles = await loadContributorPullRequestFilePaths(env, {
     login,

--- a/test/unit/decision-pack-shared-inputs.test.ts
+++ b/test/unit/decision-pack-shared-inputs.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { persistSignalSnapshot } from "../../src/db/repositories";
+import * as repositoriesModule from "../../src/db/repositories";
+import * as issueQualityModule from "../../src/services/issue-quality";
+import * as repoOutcomeModule from "../../src/services/repo-outcome-patterns";
+import * as focusManifestModule from "../../src/signals/focus-manifest-loader";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
+import { loadDecisionPackSharedInputs } from "../../src/services/decision-pack";
+import { createTestEnv } from "../helpers/d1";
+import type { RepositoryRecord } from "../../src/types";
+
+// `Env` is the ambient Cloudflare Workers global (worker-configuration.d.ts), referenced unqualified.
+
+const REPO_A = "owner/alpha";
+const REPO_B = "owner/beta";
+
+function registeredRepo(fullName: string): RepositoryRecord {
+  const [owner = "owner", name = fullName] = fullName.split("/");
+  return { fullName, owner, name, isInstalled: true, isRegistered: true, isPrivate: false, defaultBranch: "main" };
+}
+
+async function seedRepoSignals(env: Env, fullName: string): Promise<void> {
+  await persistSignalSnapshot(env, {
+    id: `iq-${fullName}`,
+    signalType: "issue-quality",
+    targetKey: fullName,
+    repoFullName: fullName,
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    payload: { repoFullName: fullName, generatedAt: "2026-06-01T00:00:00.000Z", lane: { lane: "direct_pr" }, issues: [], summary: "seed" },
+  });
+  await persistSignalSnapshot(env, {
+    id: `rop-${fullName}`,
+    signalType: "repo-outcome-patterns",
+    targetKey: fullName,
+    repoFullName: fullName,
+    generatedAt: "2026-06-01T00:00:00.000Z",
+    payload: { repoFullName: fullName, generatedAt: "2026-06-01T00:00:00.000Z", totals: {}, evidenceCompleteness: { status: "complete" } },
+  });
+  // Default source "api_record" → the manifest cache read returns offline (no age check, no network fetch).
+  await upsertRepoFocusManifest(env, fullName, { source: "api_record" });
+}
+
+describe("decision-pack shared inputs — login-independent maps hoisted out of the per-login build", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("derives the three login-independent maps exactly once and carries them in the shared struct", async () => {
+    // No real network: the only outbound dependency (upstream scoring constants) degrades to defaults on 404.
+    vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));
+    const env = createTestEnv();
+    await seedRepoSignals(env, REPO_A);
+    await seedRepoSignals(env, REPO_B);
+    vi.spyOn(repositoriesModule, "listRepositories").mockResolvedValue([registeredRepo(REPO_A), registeredRepo(REPO_B)]);
+
+    // Spies keep the real implementation — we only count invocations.
+    const issueQualitySpy = vi.spyOn(issueQualityModule, "loadIssueQualityReportMap");
+    const outcomeSpy = vi.spyOn(repoOutcomeModule, "loadRepoOutcomePatternsMap");
+    const manifestSpy = vi.spyOn(focusManifestModule, "loadRepoFocusManifests");
+
+    const shared = await loadDecisionPackSharedInputs(env);
+
+    // The batch loads `shared` ONCE and reuses it across every contributor, so each of these heavy
+    // (DB-fanning / network-fetching) loaders must run exactly once per batch — not once per login.
+    expect(issueQualitySpy).toHaveBeenCalledTimes(1);
+    expect(outcomeSpy).toHaveBeenCalledTimes(1);
+    expect(manifestSpy).toHaveBeenCalledTimes(1);
+
+    // ...and the derived maps are actually present on the shared struct for the per-login build to read.
+    expect(shared.issueQualityByRepo.has(REPO_A)).toBe(true);
+    expect(shared.issueQualityByRepo.has(REPO_B)).toBe(true);
+    expect(shared.repoOutcomePatternsByRepo.has(REPO_A)).toBe(true);
+    expect(shared.repoOutcomePatternsByRepo.has(REPO_B)).toBe(true);
+    expect(shared.focusManifests.size).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

The `build-contributor-decision-packs` batch job loops over up to ~200 contributor logins and calls `buildAndPersistContributorDecisionPack` once per login. `loadDecisionPackSharedInputs` already exists precisely so the **login-independent** full-table reads are loaded **once per batch** and reused across all logins.

But three more login-independent inputs were left *inside* the per-login body, so they were re-derived (and, for focus manifests, **re-fetched over the network**) on every iteration:

| Input | Per-login cost |
| --- | --- |
| `loadIssueQualityReportMap` | 1 signal-snapshot read **per registered repo** |
| `loadRepoOutcomePatternsMap` | 1 signal-snapshot read **per registered repo** |
| `loadRepoFocusManifests` | 1 **network manifest fetch** per registered repo |

All three depend only on the registered-repo set — not on the login.

## Change

Move them into `DecisionPackSharedInputs` / `loadDecisionPackSharedInputs` so they are computed **once per batch** and reused per login (`src/services/decision-pack.ts`). The login-*dependent* `getAgentRecommendationOutcomeSummary` stays per-login.

For **R** registered repos and **L** logins in a batch run, this turns roughly:

```
L·R snapshot reads + L·R manifest fetches   →   R + R
```

i.e. ~**200×** fewer redundant reads/fetches in the scheduled batch (at L≈200).

## Correctness

- **Byte-identical output.** The maps are pure functions of the registered-repo set; only redundant I/O is removed.
- **Single-login path unchanged.** When no `shared` is provided (e.g. the live serving path), `buildAndPersistContributorDecisionPack` still self-loads exactly once via `loadDecisionPackSharedInputs`.
- This extends the optimization pattern already documented in `loadDecisionPackSharedInputs` (it previously hoisted 8 other full-table reads).

## Tests

- New `test/unit/decision-pack-shared-inputs.test.ts` asserts the three loaders run **exactly once** per `loadDecisionPackSharedInputs` and that the derived maps are present on the shared struct.
- Existing `test/unit/queue.test.ts` exercises the full batch + single-login decision-pack paths end-to-end (no behavior change).
- Full `npm run test:ci` green (typecheck, coverage, workers, MCP build/pack, UI openapi/lint/build, actionlint, migrations, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)