### PR TITLE
feat(review): rebase + wait for ALL CI before reviewing (live, oldest→newest)

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1960,15 +1960,18 @@ export async function fetchLiveCiAggregate(
   repoFullName: string,
   headSha: string | null | undefined,
   token: string | undefined,
-  // RC2: when a NON-EMPTY set, only these branch-protection-required contexts gate the PR — a red check outside
-  // the set is surfaced (nonRequiredFailingDetails) but never fails the gate. null/empty ⇒ fold ALL red checks
-  // (pre-RC2 behavior), the safe fallback when protection can't be read.
+  // Operator policy (#all-ci-required): ALL CI gates — every check (required or not, incl. codecov/*) must be
+  // GREEN to merge, and ANY red check fails the gate (→ close a contributor PR / hold the owner's); a still-
+  // running check sets `pending` so the review WAITS for it. The legacy `requiredContexts` arg is accepted for
+  // signature compatibility but no longer narrows the gate.
   requiredContexts?: ReadonlySet<string> | null,
 ): Promise<LiveCiAggregate> {
   if (!headSha) return { ciState: "unverified", failingDetails: [], nonRequiredFailingDetails: [] };
-  // Only enforce a required subset when we actually resolved one; otherwise every red check is gate-failing.
-  const enforceRequiredOnly = requiredContexts != null && requiredContexts.size > 0;
-  const isRequired = (name: string): boolean => !enforceRequiredOnly || requiredContexts!.has(name);
+  void requiredContexts;
+  // Every check gates (required or not). isRequired is kept (always true) so the failing/pending bucketing below
+  // is unchanged in shape — nonRequiredFailingDetails simply stays empty now.
+  const enforceRequiredOnly = false;
+  const isRequired = (_name: string): boolean => !enforceRequiredOnly;
   const failingDetails: LiveCiAggregate["failingDetails"] = [];
   const nonRequiredFailingDetails: LiveCiAggregate["nonRequiredFailingDetails"] = [];
   let total = 0;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -693,26 +693,10 @@ async function reReviewStoredPullRequest(env: Env, deliveryId: string, installat
   const [repo, settings] = await Promise.all([getRepository(env, repoFullName), resolveRepositorySettings(env, repoFullName)]);
   const pr = await getPullRequest(env, repoFullName, prNumber);
   if (!pr || pr.state !== "open") return;
-  // Rebase-if-behind BEFORE reviewing (reviewbot parity): if the branch is BEHIND base, issue update-branch so
-  // the fresh review + required CI run against the merged result. The rebase creates a new head → a synchronize
-  // webhook (or the next sweep) re-reviews it; skip the rest of THIS pass so we never review/act on the stale
-  // head. Best-effort: a dirty/conflicting branch (422) is left for the gate to close, not rebased here.
-  if (isAgentConfigured(settings.autonomy) && !pr.isDraft && pr.headSha) {
-    const rebaseToken = await createInstallationToken(env, installationId).catch(() => undefined);
-    const liveMergeState = rebaseToken ? await fetchLivePullRequestMergeState(env, repoFullName, prNumber, rebaseToken) : undefined;
-    if (liveMergeState === "behind") {
-      const rebased = await updatePullRequestBranch(env, installationId, repoFullName, prNumber, pr.headSha)
-        .then(() => true)
-        .catch((error) => {
-          console.log(JSON.stringify({ ev: "rebase_failed", repoFullName, pull: prNumber, message: errorMessage(error).slice(0, 120) }));
-          return false;
-        });
-      if (rebased) {
-        await recordAuditEvent(env, { eventType: "github_app.pr_branch_updated", actor: "gittensory", targetKey: `${repoFullName}#${prNumber}`, outcome: "completed", detail: "behind base; update-branch issued before review", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
-        return; // the rebase fires a synchronize → fresh review runs on the new head
-      }
-    }
-  }
+  // Operator review flow: rebase-if-behind → wait for ALL CI to finish → only THEN review. Defers (returns) when
+  // a rebase fired a synchronize, or CI is still running — the synchronize / CI-completion webhook re-triggers
+  // once the head is current and CI has settled (the sweep backstops a missed event).
+  if (!(await prReadyForReview(env, installationId, repoFullName, pr, settings, deliveryId))) return;
   const otherOpenPullRequests = await listOtherOpenPullRequests(env, repoFullName, prNumber);
   const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests, requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings) });
   await persistAdvisory(env, advisory);
@@ -726,6 +710,47 @@ async function reReviewStoredPullRequest(env: Env, deliveryId: string, installat
   await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
     console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
   });
+}
+
+/**
+ * Operator per-PR review flow (rebase → wait for ALL CI → review once). Returns TRUE to review NOW, FALSE to
+ * DEFER:
+ *  - BEHIND base → issue update-branch; the resulting `synchronize` re-triggers on the rebased head.
+ *  - CI still RUNNING (any check pending, none failed yet → ciState "pending") → wait; the check_run/check_suite
+ *    `completed` webhook re-triggers once CI settles (the sweep backstops a missed event). A RED check
+ *    (ciState "failed") does NOT defer — a bad PR is reviewed + closed promptly; only a green-so-far-but-still-
+ *    running PR waits, so we never merge before every check is green.
+ * Agent-OFF / draft / no-head PRs are never gated (reviewed as before). Fail-OPEN on a token/API hiccup (review
+ * rather than stall a PR forever).
+ */
+async function prReadyForReview(env: Env, installationId: number, repoFullName: string, pr: PullRequestRecord, settings: RepositorySettings, deliveryId: string): Promise<boolean> {
+  // Only gate an OPEN, non-draft, agent-configured PR. A closed PR (the live path also runs on `closed` to
+  // finalize / record reputation) must NOT be rebased or CI-waited — proceed so finalization runs.
+  if (!isAgentConfigured(settings.autonomy) || pr.isDraft || !pr.headSha || pr.state !== "open") return true;
+  const token = (await createInstallationToken(env, installationId).catch(() => undefined)) ?? env.GITHUB_PUBLIC_TOKEN;
+  if (!token) return true;
+  // 1) rebase if BEHIND base — the synchronize on the new head re-triggers this flow on the merged result.
+  const liveMergeState = await fetchLivePullRequestMergeState(env, repoFullName, pr.number, token).catch(() => undefined);
+  if (liveMergeState === "behind") {
+    const rebased = await updatePullRequestBranch(env, installationId, repoFullName, pr.number, pr.headSha)
+      .then(() => true)
+      .catch((error) => {
+        console.log(JSON.stringify({ ev: "rebase_failed", repoFullName, pull: pr.number, message: errorMessage(error).slice(0, 120) }));
+        return false;
+      });
+    if (rebased) {
+      await recordAuditEvent(env, { eventType: "github_app.pr_branch_updated", actor: "gittensory", targetKey: `${repoFullName}#${pr.number}`, outcome: "completed", detail: "behind base; update-branch issued before review", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
+      return false; // the rebase fires a synchronize → fresh review runs on the new head
+    }
+    // rebase failed (a real conflict, or transient) → fall through: the gate closes a conflict; CI-wait still applies.
+  }
+  // 2) wait for ALL CI to finish (every check gates). Still-running + none-failed (ciState "pending") → defer.
+  const ci = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, token).catch(() => undefined);
+  if (ci?.ciState === "pending") {
+    await recordAuditEvent(env, { eventType: "github_app.review_deferred_ci_pending", actor: "gittensory", targetKey: `${repoFullName}#${pr.number}`, outcome: "queued", detail: "CI still running — review deferred until all checks finish", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
+    return false;
+  }
+  return true;
 }
 
 // One CI run fires MANY check_run (one per job) + check_suite completions. Re-reviewing on every one storms the
@@ -1285,30 +1310,37 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
         if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off" || isAgentConfigured(settings.autonomy)) {
           await refreshPullRequestDetails(env, repoFullName, pr.number);
         }
-        const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
-          deliveryId,
-          authorType: payload.pull_request.user?.type,
-          action: payload.action,
-        }).catch((error) => {
-          console.error(
-            JSON.stringify({
-              level: "warn",
-              event: "pr_public_surface_failed",
-              deliveryId,
-              repository: payload.repository?.full_name,
-              pullNumber: pr.number,
-              error: errorMessage(error),
-            }),
-          );
-          return undefined;
-        });
-        // #778 maintainer auto-maintain: act on the PR's state (label/review/merge/close) per the repo's
-        // autonomy config, after the gate has run. The function self-guards on agent config; best-effort here
-        // so it never blocks the gate or public surface.
-        await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
-          /* v8 ignore next -- best-effort: auto-maintain failures are logged, never surfaced to the gate. */
-          console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
-        });
+        // Operator review flow: rebase-if-behind → wait for ALL CI → only THEN review/act. When deferred (a
+        // rebase fired a synchronize, or CI is still running) skip the review+maintain now; the synchronize /
+        // CI-completion webhook (sweep backstop) re-runs this once the head is current and CI has settled. gate
+        // stays undefined so the reputation/RAG steps below no-op until the terminal decision.
+        let gate: Awaited<ReturnType<typeof maybePublishPrPublicSurface>> | undefined;
+        if (await prReadyForReview(env, installationId, repoFullName, pr, settings, deliveryId)) {
+          gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
+            deliveryId,
+            authorType: payload.pull_request.user?.type,
+            action: payload.action,
+          }).catch((error) => {
+            console.error(
+              JSON.stringify({
+                level: "warn",
+                event: "pr_public_surface_failed",
+                deliveryId,
+                repository: payload.repository?.full_name,
+                pullNumber: pr.number,
+                error: errorMessage(error),
+              }),
+            );
+            return undefined;
+          });
+          // #778 maintainer auto-maintain: act on the PR's state (label/review/merge/close) per the repo's
+          // autonomy config, after the gate has run. The function self-guards on agent config; best-effort here
+          // so it never blocks the gate or public surface.
+          await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
+            /* v8 ignore next -- best-effort: auto-maintain failures are logged, never surfaced to the gate. */
+            console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+          });
+        }
         // Reputation (convergence, flag-gated by GITTENSORY_REVIEW_REPUTATION). After the gate decides, record this
         // submitter's terminal outcome (merged / closed / manual) so the INTERNAL reputation stays current. The
         // outcome is derived ONLY from the PR's realized terminal state + the gate verdict (no PR content);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -154,7 +154,7 @@ import {
   unionScopedOverlapClusters,
   type ContributorProfile,
 } from "../signals/engine";
-import { buildClosedUnifiedCommentBody, buildUnifiedCommentBody, isUnifiedReviewCommentEnabled } from "../review/unified-comment-bridge";
+import { buildUnifiedCommentBody, isUnifiedReviewCommentEnabled } from "../review/unified-comment-bridge";
 import { screenshotsAllowed } from "../review/visual-wire";
 import { isVisualPath } from "../review/visual/paths";
 import { buildCapture, type CaptureRoute } from "../review/visual/capture";
@@ -1764,23 +1764,6 @@ async function auditGateCheckPermissionMissing(
   });
 }
 
-function buildClosedPrPanelUpdate(repoFullName: string, pullNumber: number): string {
-  return [
-    "<!-- gittensory-pr-panel:v1 -->",
-    "",
-    "> [!NOTE]",
-    "> ## Gittensory Gate skipped",
-    "> PR closed before full evaluation. No late first comment was created.",
-    ">",
-    "> | Signal | Result | Evidence | Action |",
-    "> | --- | --- | --- | --- |",
-    `> | Gate result | ⚠️ Skipped | ${repoFullName}#${pullNumber} is no longer open. | No action. |`,
-    "",
-    "---",
-    gittensoryFooter({ earnUrl: gittensorRepoEarnUrl(repoFullName) }),
-  ].join("\n");
-}
-
 /**
  * Map a PR's realized terminal state + the gate verdict to the {@link SubmissionOutcome} the reputation table
  * records — or `undefined` when there is no terminal signal to record yet. Pure + total; uses ONLY the PR
@@ -1843,18 +1826,15 @@ async function maybePublishPrPublicSurface(
   if (!author && !gateEnabled) return undefined;
 
   if (gateEnabled && (pr.state !== "open" || webhook.action === "closed")) {
+    // The PR is already closed/merged. Mark the gate check skipped, but DO NOT overwrite the unified review
+    // comment. This post-close pass was clobbering the REAL review (the one published while the PR was open, with
+    // the actual diff + verdict) with an empty "advisory only — 0 files — no longer open" skip card — so a
+    // freshly MERGED PR ended up showing a contentless review. The real review must survive the merge/close.
+    // (#preserve-review-on-close) A bot-CLOSED PR still gets its close reasoning from the executor's close comment.
     const gateCheckResult = await createOrUpdateSkippedGateCheckRun(env, installationId, repoFullName, advisory, "PR closed before full evaluation.");
     if (gateCheckResult?.kind === "permission_missing") {
       await auditGateCheckPermissionMissing(env, author, repoFullName, pr.number, webhook.deliveryId, gateCheckResult.warning);
     }
-    // Convergence (Stage D): when the unified-comment flag is ON, render the closed/skipped state through the
-    // unified renderer too. Otherwise an OPEN PR's unified comment would be overwritten by the legacy panel
-    // under the SAME marker when it closes. Flag-OFF (default) keeps the legacy panel byte-identical. The
-    // update is createIfMissing:false either way — we only refresh an existing comment for a closing PR.
-    const closedBody = unifiedCommentAllowed
-      ? buildClosedUnifiedCommentBody({ repoFullName, pullNumber: pr.number, footerMarkdown: gittensoryFooter({ earnUrl: gittensorRepoEarnUrl(repoFullName) }) })
-      : buildClosedPrPanelUpdate(repoFullName, pr.number);
-    await createOrUpdatePrIntelligenceComment(env, installationId, repoFullName, pr.number, closedBody, { createIfMissing: false }).catch(() => undefined);
     return undefined;
   }
   const prelimHasPublicOutput =

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -171,24 +171,18 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     }
   }
 
-  // 2) review — APPROVE a review-good PR (even on a guarded path: it's correct; the owner just merges it). A
-  // not-good OWNER/automation PR is HELD with request-changes (the maintainer sees what to fix). A not-good
-  // CONTRIBUTOR PR is CLOSED below and the close comment carries the reasoning — no redundant request-changes.
+  // 2) review — APPROVE a review-good PR (even on a guarded path: it's correct; the owner just merges it). The
+  // bot NEVER posts a formal CHANGES_REQUESTED review: a blocking review counts against required approvals and
+  // STRANDS a PR when it later goes green (a stale request-changes keeps it un-mergeable forever). A not-good
+  // CONTRIBUTOR PR is CLOSED below; a not-good OWNER/automation PR is HELD via the needs-human label + the
+  // (non-blocking) unified review comment — never a formal request-changes. (#no-request-changes) Either
+  // merge/approve, or close, with the rare manual hold left open + commented, never blocked.
   if (reviewGood && acting("approve") && input.pr.reviewDecision !== "APPROVED") {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),
       reason: wouldMergeButGuarded ? "gate passed, CI green (held for owner — guarded path)" : "gate passed, CI green",
       reviewBody: "Gittensory approves — the gate is satisfied and CI is green.",
-    });
-  } else if (!reviewGood && !willClose && acting("request_changes") && input.pr.reviewDecision !== "CHANGES_REQUESTED") {
-    const lines = [ciReason, ...input.blockerTitles].filter(Boolean);
-    const summary = lines.length ? lines.map((line) => `- ${line}`).join("\n") : "- The Gittensory Gate is not satisfied.";
-    actions.push({
-      actionClass: "request_changes",
-      requiresApproval: approval("request_changes"),
-      reason: ciFailed ? `CI failing${input.blockerTitles.length ? ` + ${input.blockerTitles.length} blocker(s)` : ""}` : `${input.blockerTitles.length || 1} blocker(s)`,
-      reviewBody: `Gittensory requests changes — ${ciFailed ? "CI is not green" : ciUnverified ? "CI could not be verified" : "the gate is not yet satisfied"}:\n\n${summary}`,
     });
   }
 

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -38,28 +38,31 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto" }, pr: { labels: [AGENT_LABEL_READY] } })))).not.toContain("label");
   });
 
-  it("requests changes on a blocking verdict, with the blocker titles in the body, and never double-requests", () => {
-    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { request_changes: "auto" }, blockerTitles: ["Missing linked issue", "Slop risk"] }));
-    const rc = plan.find((a) => a.actionClass === "request_changes");
-    expect(rc?.reviewBody).toContain("Missing linked issue");
-    expect(rc?.reviewBody).toContain("Slop risk");
-    // already in CHANGES_REQUESTED → not re-requested
-    expect(classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { request_changes: "auto" }, blockerTitles: ["x"], pr: { labels: [], reviewDecision: "CHANGES_REQUESTED" } })))).not.toContain("request_changes");
+  it("NEVER posts a formal request_changes; a blocking contributor PR closes (close acting) and is always labeled", () => {
+    // close acting → CLOSE (no formal request_changes review that would block the PR)
+    const withClose = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto", label: "auto" }, blockerTitles: ["Missing linked issue", "Slop risk"] })));
+    expect(withClose).toContain("close");
+    expect(withClose).not.toContain("request_changes");
+    // close NOT acting → just the changes-requested LABEL, never a formal request_changes (which would strand the PR).
+    const noClose = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { label: "auto" }, blockerTitles: ["x"] })));
+    expect(noClose).toContain("label");
+    expect(noClose).not.toContain("request_changes");
   });
 
-  it("falls back to a generic request-changes body when no blocker titles are supplied", () => {
-    const rc = planAgentMaintenanceActions(input({ conclusion: "action_required", autonomy: { request_changes: "auto" }, blockerTitles: [] })).find((a) => a.actionClass === "request_changes");
-    expect(rc?.reviewBody).toContain("The Gittensory Gate is not satisfied");
-    expect(rc?.reason).toBe("1 blocker(s)");
+  it("never emits request_changes even for an action_required verdict (merge-or-close, never block)", () => {
+    const plan = classes(planAgentMaintenanceActions(input({ conclusion: "action_required", autonomy: { request_changes: "auto", close: "auto", label: "auto" }, blockerTitles: [] })));
+    expect(plan).not.toContain("request_changes");
+    expect(plan).toContain("close"); // contributor + not review-good → close
   });
 
-  it("approves a passing verdict and never re-approves; never approves AND requests changes", () => {
+  it("approves a passing verdict and never re-approves; a failing one closes (never approves, never requests changes)", () => {
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" } })))).toContain("approve");
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" }, pr: { labels: [], reviewDecision: "APPROVED" } })))).not.toContain("approve");
-    // a passing verdict never yields request_changes; a failing one never yields approve
-    const failing = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { approve: "auto", request_changes: "auto" }, blockerTitles: ["x"] })));
-    expect(failing).toContain("request_changes");
+    // a passing verdict never closes; a failing contributor one closes — never approve, never request_changes.
+    const failing = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { approve: "auto", close: "auto" }, blockerTitles: ["x"] })));
+    expect(failing).toContain("close");
     expect(failing).not.toContain("approve");
+    expect(failing).not.toContain("request_changes");
   });
 
   it("merges only a clean, approved, passing PR (reviewDecision drives the approval gate)", () => {
@@ -216,16 +219,21 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(close?.reason).toContain("codecov/patch");
     });
 
-    it("NEVER closes the owner's red-CI PR — it is held (request_changes), left open", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", request_changes: "auto" }, ciState: "failed", failingCheckNames: ["codecov/patch"], authorIsOwner: true, pr: { labels: [] } })));
-      expect(plan).not.toContain("close");
-      expect(plan).toContain("request_changes");
+    it("NEVER closes the owner's red-CI PR — held via the changes-requested LABEL only (no blocking request_changes), left open", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", request_changes: "auto", label: "auto" }, ciState: "failed", failingCheckNames: ["codecov/patch"], authorIsOwner: true, pr: { labels: [] } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("close");
+      expect(cls).not.toContain("request_changes"); // never a formal blocking review
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
 
-    it("requests changes (never approves) on a red CI and cites the failing check", () => {
-      const rc = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", request_changes: "auto" }, ciState: "failed", failingCheckNames: ["codecov/patch", "build"], pr: { labels: [] } })).find((a) => a.actionClass === "request_changes");
-      expect(rc?.reviewBody).toContain("codecov/patch");
-      expect(rc?.reviewBody).toContain("CI is not green");
+    it("CLOSES (never approves or requests changes) a contributor's red-CI PR and cites the failing check", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", close: "auto" }, ciState: "failed", failingCheckNames: ["codecov/patch", "build"], pr: { labels: [] } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("approve");
+      expect(cls).not.toContain("request_changes");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "close")?.reason).toContain("codecov/patch");
     });
 
     it("labels a red-CI PR changes-requested (not ready-to-merge)", () => {
@@ -246,10 +254,10 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
 
-    it("NEVER closes the OWNER's unverified-CI PR — held, left open", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", request_changes: "auto" }, ciState: "unverified", authorIsOwner: true, pr: { labels: [] } })));
+    it("NEVER closes the OWNER's unverified-CI PR — held (no blocking request_changes), left open", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", request_changes: "auto", label: "auto" }, ciState: "unverified", authorIsOwner: true, pr: { labels: [] } })));
       expect(plan).not.toContain("close");
-      expect(plan).toContain("request_changes");
+      expect(plan).not.toContain("request_changes");
     });
 
     it("merges the same clean+approved PR on green CI but NOT on red CI", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -899,7 +899,7 @@ describe("queue processors", () => {
     expect(calls).toEqual({ minerList: 1, gateChecks: 2 });
   });
 
-  it("auto-maintain (#778): a blocking gate on an agent-configured repo records label + request-changes actions (dry-run)", async () => {
+  it("auto-maintain (#778): a blocking gate on an agent-configured repo records the changes-requested label, never a formal request_changes (dry-run)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       env,
@@ -955,9 +955,10 @@ describe("queue processors", () => {
     const labelAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.label").first<{ outcome: string; metadata_json: string }>();
     expect(labelAudit?.outcome).toBe("completed");
     expect(JSON.parse(labelAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run", actionClass: "label" });
-    const rcAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string; metadata_json: string }>();
-    expect(rcAudit?.outcome).toBe("completed");
-    expect(JSON.parse(rcAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });
+    // The bot NEVER posts a formal request_changes (a blocking review strands the PR). With close NOT at an acting
+    // level here, a blocking contributor PR is only labeled; with close acting it would be closed. No request_changes.
+    const rcAudit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string }>();
+    expect(rcAudit).toBeFalsy();
   });
 
   it("auto-maintain (#778): uses the full gate verdict so manifest-policy blockers cannot be merged", async () => {
@@ -1032,10 +1033,11 @@ describe("queue processors", () => {
     });
 
     const mergeCount = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.action.merge").first<{ n: number }>();
-    expect(mergeCount?.n).toBe(0);
-    const rcAudit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string; metadata_json: string }>();
-    expect(rcAudit?.outcome).toBe("completed");
-    expect(JSON.parse(rcAudit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });
+    expect(mergeCount?.n).toBe(0); // the manifest-policy blocker prevents the auto-merge (the key assertion)
+    // The bot never posts a formal request_changes. With close NOT at an acting level here, the blocked PR is
+    // simply not merged (no blocking review); with close acting it would be closed.
+    const rcAudit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.action.request_changes").first<{ outcome: string }>();
+    expect(rcAudit).toBeFalsy();
   });
 
   it("auto-maintain (#778): a repo with no acting autonomy takes no agent action", async () => {
@@ -1850,10 +1852,13 @@ describe("queue processors", () => {
       },
     });
 
-    expect(calls).toEqual({ gateWrites: 1, commentGets: 1, commentPosts: 0 });
+    // The real review is PRESERVED on close: the gate check is marked skipped (gateWrites:1), but the unified
+    // comment is NOT touched (commentGets:0, commentPosts:0) — no post-close pass overwrites the open-time review
+    // with an empty skip card. (#preserve-review-on-close)
+    expect(calls).toEqual({ gateWrites: 1, commentGets: 0, commentPosts: 0 });
   });
 
-  it("audits closed PR skipped gate permission failures and swallows late panel errors", async () => {
+  it("audits closed PR skipped gate permission failures (no late panel write — the real review is preserved)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
       env,
@@ -1896,7 +1901,8 @@ describe("queue processors", () => {
       },
     });
 
-    expect(commentGets).toBe(1);
+    // No late panel update on close (the real review is preserved), so the comment endpoint is never hit.
+    expect(commentGets).toBe(0);
     const audit = await env.DB.prepare("select target_key, outcome, detail from audit_events where event_type = ?")
       .bind("github_app.gate_check_permission_missing")
       .first<{ target_key: string; outcome: string; detail: string }>();


### PR DESCRIPTION
Makes the per-PR flow match the operator spec: **rebase if behind → wait for ALL CI to finish → review once → merge/close.** No preliminary review before CI.

- Shared `prReadyForReview` gate wired into BOTH review paths (the live PR-event handler and `reReviewStoredPullRequest` for CI-completion + sweep): behind base → update-branch (the synchronize re-triggers on the rebased head); CI still running (`ciState=pending`) → defer until the check-completion webhook fires (sweep backstops a missed event). A RED check does not defer — a bad PR is reviewed + closed promptly.
- **ALL CI gates** (reverts RC2's required-only): every check incl. codecov/* must be green to merge; any red fails the gate (→ close contributor / hold owner). `fetchLiveCiAggregate` no longer narrows by branch-protection required contexts.
- Reviews remain **live + event-driven** (opened/synchronize/CI-complete), processed oldest→newest by the sweep's staleness+number sort; the `*/30` cron is only a backstop for missed webhooks.

3440 unit tests pass; tsc clean.