### PR TITLE
fix(review): trust only required CI contexts

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1951,27 +1951,25 @@ export async function fetchRequiredStatusContexts(env: Env, repoFullName: string
  * reviewbot `getAllChecksState` parity that the converged auto-maintain path needs: codecov (codecov/patch,
  * codecov/project) and many other tools post a classic COMMIT-STATUS, not a check-run — fetching only
  * `/check-runs` (what the backfill sync does) misses them entirely, which is why a red codecov was reported as
- * "CI green". We aggregate ANY failing check/status → "failed"; else any still-running → "pending"; else any
- * present → "passed"; none at all → "unverified". The disposition layer NEVER approves/merges unless "passed",
- * and closes (non-owner) / holds (owner) on "failed". Best-effort: a fetch error degrades that source to empty.
+ * "CI green". When branch-protection required contexts are known, only those trusted contexts gate review or
+ * automation; non-required failures are reported separately. When required contexts cannot be determined, we
+ * conservatively fold all checks/statuses into the gate so required red checks are not silently ignored.
+ * Best-effort: a fetch error degrades that source to empty.
  */
 export async function fetchLiveCiAggregate(
   env: Env,
   repoFullName: string,
   headSha: string | null | undefined,
   token: string | undefined,
-  // Operator policy (#all-ci-required): ALL CI gates — every check (required or not, incl. codecov/*) must be
-  // GREEN to merge, and ANY red check fails the gate (→ close a contributor PR / hold the owner's); a still-
-  // running check sets `pending` so the review WAITS for it. The legacy `requiredContexts` arg is accepted for
-  // signature compatibility but no longer narrows the gate.
+  // Branch-protection REQUIRED contexts are the trust boundary for CI gate authority. Non-required checks may be
+  // influenced by PR authors or third-party actors, so they are surfaced as advisory details but must not defer
+  // review, fail the merge gate, or drive automated close decisions. If required contexts are unavailable, fall
+  // back to gating on all contexts to avoid silently passing an unknown required failure.
   requiredContexts?: ReadonlySet<string> | null,
 ): Promise<LiveCiAggregate> {
   if (!headSha) return { ciState: "unverified", failingDetails: [], nonRequiredFailingDetails: [] };
-  void requiredContexts;
-  // Every check gates (required or not). isRequired is kept (always true) so the failing/pending bucketing below
-  // is unchanged in shape — nonRequiredFailingDetails simply stays empty now.
-  const enforceRequiredOnly = false;
-  const isRequired = (_name: string): boolean => !enforceRequiredOnly;
+  const enforceRequiredOnly = requiredContexts != null && requiredContexts.size > 0;
+  const isRequired = (name: string): boolean => !enforceRequiredOnly || requiredContexts.has(name);
   const failingDetails: LiveCiAggregate["failingDetails"] = [];
   const nonRequiredFailingDetails: LiveCiAggregate["nonRequiredFailingDetails"] = [];
   let total = 0;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -744,8 +744,9 @@ async function prReadyForReview(env: Env, installationId: number, repoFullName: 
     }
     // rebase failed (a real conflict, or transient) → fall through: the gate closes a conflict; CI-wait still applies.
   }
-  // 2) wait for ALL CI to finish (every check gates). Still-running + none-failed (ciState "pending") → defer.
-  const ci = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, token).catch(() => undefined);
+  // 2) wait for trusted required CI to finish. Non-required checks are advisory and must not stall review.
+  const requiredContexts = await fetchRequiredStatusContexts(env, repoFullName, pr.baseRef, token).catch(() => null);
+  const ci = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, token, requiredContexts).catch(() => undefined);
   if (ci?.ciState === "pending") {
     await recordAuditEvent(env, { eventType: "github_app.review_deferred_ci_pending", actor: "gittensory", targetKey: `${repoFullName}#${pr.number}`, outcome: "queued", detail: "CI still running — review deferred until all checks finish", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
     return false;

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -32,6 +32,7 @@ import {
   enqueueRepositoryOpenDataBackfill,
   enrichInstallationHealth,
   fetchAndStorePullRequestFilesForReview,
+  fetchLiveCiAggregate,
   refreshContributorActivity,
   refreshInstallationHealth,
   refreshPullRequestDetails,
@@ -2635,6 +2636,56 @@ describe("GitHub backfill", () => {
       await expect(fetchAndStorePullRequestFilesForReview(env, "JSONbored/gittensory", 99, "public-token")).resolves.toEqual([]);
     });
   });
+
+  describe("fetchLiveCiAggregate", () => {
+    it("keeps non-required failing and pending statuses advisory when required contexts are known", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              { name: "trusted-required-ci", status: "completed", conclusion: "success" },
+              { name: "attacker/non-required-check", status: "completed", conclusion: "failure", output: { title: "Injected failure" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) {
+          return Response.json({
+            statuses: [
+              { context: "trusted-required-ci", state: "success" },
+              { context: "attacker/non-required-status", state: "failure", description: "Injected failure" },
+              { context: "attacker/non-required-pending", state: "pending", description: "Never settles" },
+            ],
+          });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["trusted-required-ci"]));
+
+      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.failingDetails).toEqual([]);
+      expect(aggregate.nonRequiredFailingDetails.map((detail) => detail.name).sort()).toEqual(["attacker/non-required-check", "attacker/non-required-status"]);
+    });
+
+    it("falls back to gating all contexts when required contexts are unavailable", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [] });
+        if (url.includes("/status?")) return Response.json({ statuses: [{ context: "unknown-required-status", state: "failure", description: "Could be required" }] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "unknown-required-status" })]);
+      expect(aggregate.nonRequiredFailingDetails).toEqual([]);
+    });
+  });
+
 });
 
 async function seedRegisteredRepo(env: Env) {


### PR DESCRIPTION
### Motivation

- Prevent untrusted non-required CI statuses from stalling reviews, failing the merge gate, or driving automated closes or public bot output by restoring branch-protection required contexts as the CI gate trust boundary.

### Description

- Restore `fetchLiveCiAggregate` to treat only branch-protection `requiredContexts` as gate-authoritative when the required set is known, and treat non-required failures as advisory details instead of gate failures.
- Preserve fail-safe behavior: when required contexts cannot be determined (`null`), fall back to gating on all contexts so a real required failure is not silently ignored.
- Change pre-review gating (`prReadyForReview`) to fetch `requiredContexts` and pass them into `fetchLiveCiAggregate` so non-required pending checks do not defer review when trusted required contexts are known.
- Add unit tests in `test/unit/backfill.test.ts` exercising both the advisory non-required-path and the fallback-all-contexts path.

### Testing

- Ran targeted unit tests with `npx vitest run test/unit/backfill.test.ts`, and the backfill unit tests passed (regression coverage added).
- Ran TypeScript typecheck with `npm run typecheck` and `tsc --noEmit` (no errors).
- Attempting the full unit-suite via the project-wide test script expanded into unrelated long-running tests and hit existing timeouts outside the scope of these changes, so targeted tests + typecheck were used to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac794df54832c9c957b40dc2aa819)