### PR TITLE
fix(queue): avoid orphan gate checks on rerun

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2603,16 +2603,6 @@ async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payloa
 
   const { repo, advisory } = await buildAuthorizedPrActionAdvisory(env, repoFullName, pr, settings);
   await persistAdvisory(env, advisory);
-  // B (re-run visibility): flip the Gittensory Gate to in_progress NOW — before the (slow) refresh + AI
-  // re-review that run inside maybePublishPrPublicSurface below — so a maintainer who clicks "Re-run
-  // Gittensory review" sees the Gate check go running → concluded like a real CI step. The conclusion in
-  // maybePublishPrPublicSurface resolves the SAME run by name + headSha, so this never duplicates the check.
-  // Fail-safe: a transient check-run API error here must never abort the re-run (the conclusion still posts).
-  try {
-    await createOrUpdatePendingGateCheckRun(env, installationId, repoFullName, advisory);
-  } catch {
-    // The in_progress flip is cosmetic; the authoritative Gate conclusion is posted by the publish below.
-  }
   await recordAuditEvent(env, {
     eventType: "github_app.pr_panel_retriggered",
     actor,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1945,7 +1945,7 @@ describe("queue processors", () => {
       "",
       "- [x] <!-- gittensory-rerun-review:v1 --> Re-run Gittensory review",
     ].join("\n");
-    const calls = { token: 0, permission: 0, minerList: 0, commentGets: 0, commentPatches: 0 };
+    const calls = { token: 0, permission: 0, minerList: 0, commentGets: 0, commentPatches: 0, checkRuns: 0 };
     let patchedBody = "";
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -1968,6 +1968,10 @@ describe("queue processors", () => {
       if (url.includes("/access_tokens")) {
         calls.token += 1;
         return Response.json({ token: "installation-token" });
+      }
+      if (url.includes("/check-runs")) {
+        calls.checkRuns += 1;
+        return Response.json({ id: 888 });
       }
       if (url.includes("/collaborators/maintainer/permission")) {
         calls.permission += 1;
@@ -2000,7 +2004,7 @@ describe("queue processors", () => {
     });
 
     // token: 1 — the installation token is now cached + reused within the request (was 2: main + permission check).
-    expect(calls).toEqual({ token: 1, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1 });
+    expect(calls).toEqual({ token: 1, permission: 1, minerList: 1, commentGets: 1, commentPatches: 1, checkRuns: 0 });
     expect(patchedBody).toContain("<!-- gittensory-pr-panel:v1 -->");
     expect(patchedBody).toContain("Readiness score:");
     expect(patchedBody).toContain("- [ ] <!-- gittensory-rerun-review:v1 --> Re-run Gittensory review");


### PR DESCRIPTION
### Motivation
- Prevent an availability bug where clicking the PR-panel "Re-run" could create an orphaned in_progress Gittensory Gate check without checking `gateCheckMode` or ensuring the check would be finalized. 
- Ensure manual reruns follow the same protected Gate lifecycle used by normal publish logic so checks are only created and finalized when the Gate is enabled.

### Description
- Remove the unconditional `createOrUpdatePendingGateCheckRun` call from `maybeProcessPrPanelRetrigger` so reruns no longer flip the Gate to `in_progress` outside the guarded publish lifecycle. 
- Extend the rerun unit test in `test/unit/queue.test.ts` to track `/check-runs` calls by adding a `checkRuns` counter, stub the `/check-runs` response, and assert that no check-run is written when `gateCheckMode: "off"`. 
- Modified files: `src/queue/processors.ts` and `test/unit/queue.test.ts`.

### Testing
- Ran `npm test -- --run test/unit/queue.test.ts -t "reruns the sticky PR panel"`, which passed. 
- Ran `npm run typecheck` (runs `tsc --noEmit`), which passed. 
- Verified the unit assertions confirm no `/check-runs` writes occur during a rerun when `gateCheckMode` is `off`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad623c264832cbb21bc2514e45bd6)