### PR TITLE
fix(review): hard-gate shadow parity cutover with freeze verification and rollback dry-run

### DIFF
--- a/migrations/0053_review_cutover_controls.sql
+++ b/migrations/0053_review_cutover_controls.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS review_cutover_controls (
+  repo_full_name TEXT PRIMARY KEY,
+  stage TEXT NOT NULL DEFAULT 'shadow',
+  freeze_verified_at TEXT,
+  freeze_verified_by TEXT,
+  rollback_dry_run_at TEXT,
+  rollback_dry_run_by TEXT,
+  last_live_at TEXT,
+  last_rollback_at TEXT,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -6,6 +6,15 @@ import { enforceRateLimit, routeClassForPath } from "../auth/rate-limit";
 import { handleShot } from "../review/visual/shot";
 import { isScreenshotsEnabled } from "../review/visual-wire";
 import {
+  activateReviewCutoverLive,
+  CutoverTransitionError,
+  getReviewCutoverStatus,
+  listReviewCutoverStatuses,
+  markReviewCutoverFreezeVerified,
+  markReviewCutoverRollbackDryRun,
+  rollbackReviewCutoverToShadow,
+} from "../review/cutover-control";
+import {
   BROWSER_SESSION_COOKIE,
   GITHUB_OAUTH_STATE_COOKIE,
   authenticateInternalToken,
@@ -2882,6 +2891,38 @@ export function createApp() {
   app.get("/v1/internal/parity", async (c) => {
     if (!isParityAuditEnabled(c.env)) return c.json({ error: "not_found" }, 404);
     return c.json(await computeParityReadiness(c.env));
+  });
+
+  app.get("/v1/internal/cutover", async (c) => {
+    const repo = c.req.query("repo");
+    return c.json(repo ? await getReviewCutoverStatus(c.env, repo) : await listReviewCutoverStatuses(c.env));
+  });
+
+  app.post("/v1/internal/cutover/repos/:owner/:repo", async (c) => {
+    const repoFullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const body = await c.req.json().catch(() => ({}));
+    const actor = typeof body?.actor === "string" && body.actor.trim() ? body.actor.trim() : null;
+    switch (body?.action) {
+      case "verify_freeze":
+        await markReviewCutoverFreezeVerified(c.env, repoFullName, actor);
+        return c.json(await getReviewCutoverStatus(c.env, repoFullName));
+      case "record_rollback_dry_run":
+        await markReviewCutoverRollbackDryRun(c.env, repoFullName, actor);
+        return c.json(await getReviewCutoverStatus(c.env, repoFullName));
+      case "activate_live":
+        try {
+          return c.json(await activateReviewCutoverLive(c.env, repoFullName));
+        } catch (error) {
+          if (error instanceof CutoverTransitionError) {
+            return c.json({ error: "cutover_transition_blocked", blockers: error.blockers, status: await getReviewCutoverStatus(c.env, repoFullName) }, 409);
+          }
+          throw error;
+        }
+      case "rollback_to_shadow":
+        return c.json(await rollbackReviewCutoverToShadow(c.env, repoFullName));
+      default:
+        return c.json({ error: "valid_action_required" }, 400);
+    }
   });
 
   app.post("/v1/internal/jobs/refresh-registry", async (c) => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -79,6 +79,18 @@ export const repositorySettings = sqliteTable("repository_settings", {
   updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
 });
 
+export const reviewCutoverControls = sqliteTable("review_cutover_controls", {
+  repoFullName: text("repo_full_name").primaryKey(),
+  stage: text("stage").notNull().default("shadow"),
+  freezeVerifiedAt: text("freeze_verified_at"),
+  freezeVerifiedBy: text("freeze_verified_by"),
+  rollbackDryRunAt: text("rollback_dry_run_at"),
+  rollbackDryRunBy: text("rollback_dry_run_by"),
+  lastLiveAt: text("last_live_at"),
+  lastRollbackAt: text("last_rollback_at"),
+  updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
+});
+
 // Maintainer BYOK provider keys (Anthropic/OpenAI), encrypted at rest with AES-256-GCM. Isolated in its
 // own table so the ciphertext is NEVER serialized by the repository-settings GET surface. The plaintext
 // key is never stored; `last4` is a display-only hint derived from the plaintext at write time.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -155,10 +155,10 @@ declare global {
      *  the actual COMPARISON vs reviewbot's authoritative decisions needs reviewbot's rows in the SAME table,
      *  written by the deploy-time dual-run shadow step (out of scope here). See src/review/parity-wire.ts. */
     GITTENSORY_REVIEW_PARITY_AUDIT?: string;
-    /** Convergence (cutover): comma-separated allowlist of repo full-names ("owner/repo") that may run the
-     *  PER-PR converged review features (safety defang + secret-leak, grounding, RAG, reputation AI-skip/record,
-     *  unified comment). A feature activates for a repo ONLY IF its existing global flag is ON AND the repo is
-     *  in this allowlist — letting the cutover roll forward (or back) one repo at a time. Matching is
+    /** Convergence (cutover): comma-separated allowlist of repo full-names ("owner/repo") that may be considered
+     *  for PER-PR converged review features (safety defang + secret-leak, grounding, RAG, reputation AI-skip/record,
+     *  unified comment). Live activation additionally requires the internal cutover control row to be promoted
+     *  to `stage='live'` after parity, freeze verification, and rollback dry-run have passed. Matching is
      *  case-insensitive on the trimmed "owner/repo". Default "" (unset/empty/whitespace) → NO repos → every
      *  per-PR converged feature stays OFF for ALL repos regardless of the global flags (byte-identical dormant
      *  deploy). The cron/endpoint flags (ops / selftune / parity / content-lane / draft) are NOT scoped by

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -178,6 +178,7 @@ import { loadHardGuardrailGlobs } from "../review/guardrail-config";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
+import { isConvergenceRepoLive } from "../review/cutover-control";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
 import type { AdvisoryFinding, ContributorEvidenceRecord, ContributorRepoStatRecord, DetectedNotificationEvent, GitHubWebhookPayload, IssueRecord, JobMessage, JsonValue, PullRequestFilePathRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../types";
 import { sha256Hex } from "../utils/crypto";
@@ -1570,15 +1571,12 @@ export async function runAiReviewForAdvisory(
     // review + grounding + RAG use these instead of re-reading the stored rows — so a review that fired before
     // detail-sync still sees the REAL diff (FIX B). Omitted (e.g. unit tests) → fall back to the stored read.
     files?: Awaited<ReturnType<typeof listPullRequestFiles>> | undefined;
+    convergedRepoAllowed?: boolean | undefined;
   },
 ): Promise<{ notes: string; reviewerCount: number } | undefined> {
   const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
   if (args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha) return undefined;
-  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the converged review features (reputation AI-skip,
-  // grounding, RAG) activate for THIS repo only when it is allowlisted. Computed once and ANDed into each
-  // feature's global flag below. Empty/unset allowlist → false → every converged branch here is unreachable
-  // (byte-identical to today) regardless of the global flags.
-  const convergedRepoAllowed = isConvergenceRepoAllowed(env, args.repoFullName);
+  const convergedRepoAllowed = args.convergedRepoAllowed ?? isConvergenceRepoAllowed(env, args.repoFullName);
   // Reputation anti-abuse (convergence, flag-gated by GITTENSORY_REVIEW_REPUTATION). Extends the AI-spend gate above:
   // an INTERNAL low-reputation / burst / new submitter is downgraded to a DETERMINISTIC-ONLY review — the
   // (paid) AI neurons are skipped here exactly as they are for an unconfirmed contributor, so a serial abuser
@@ -1632,6 +1630,7 @@ export async function runAiReviewForAdvisory(
       actor: args.author,
       mode: args.settings.aiReviewMode === "block" ? "block" : "advisory",
       providerKey,
+      convergedRepoAllowed,
       grounding,
       ragContext,
     });
@@ -1668,12 +1667,14 @@ export async function maybeAddSecretLeakFinding(
     repoFullName: string;
     pullNumber: number;
     files: Awaited<ReturnType<typeof listPullRequestFiles>> | null;
+    convergedRepoAllowed?: boolean | undefined;
   },
 ): Promise<void> {
+  const convergedRepoAllowed = args.convergedRepoAllowed ?? isConvergenceRepoAllowed(env, args.repoFullName);
   // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the secret-leak scan activates for THIS repo only when
   // it is allowlisted AND the global safety flag is ON. Empty/unset allowlist → no-op for every repo (the
   // advisory is byte-identical to today) regardless of GITTENSORY_REVIEW_SAFETY.
-  if (!isSafetyEnabled(env) || !isConvergenceRepoAllowed(env, args.repoFullName)) return;
+  if (!isSafetyEnabled(env) || !convergedRepoAllowed) return;
   try {
     const files = args.files ?? (await listPullRequestFiles(env, args.repoFullName, args.pullNumber));
     const finding = secretLeakFinding(buildAiReviewDiff(files));
@@ -1797,11 +1798,8 @@ async function maybePublishPrPublicSurface(
   webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined; previewPollAttempt?: number | undefined },
 ): Promise<ReturnType<typeof evaluateGateCheck> | undefined> {
   const author = pr.authorLogin ?? null;
-  // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the unified converged comment renders for THIS repo
-  // only when it is allowlisted AND the global GITTENSORY_REVIEW_UNIFIED_COMMENT flag is ON. Computed once and ANDed into
-  // both unified-comment sites below (closed/skipped + open). Empty/unset allowlist → false → both sites keep
-  // the LEGACY panel byte-identical for every repo regardless of GITTENSORY_REVIEW_UNIFIED_COMMENT.
-  const unifiedCommentAllowed = isUnifiedReviewCommentEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
+  const convergedRepoAllowed = await isConvergenceRepoLive(env, repoFullName);
+  const unifiedCommentAllowed = isUnifiedReviewCommentEnabled(env) && convergedRepoAllowed;
   // `settings` is the EFFECTIVE config (`.gittensory.yml` > DB > defaults), resolved by the caller via
   // resolveRepositorySettings — so gate on/off and every blocker mode already reflect the repo's config
   // file. The gate only chooses what to do; confirmedContributor governs WHO can be blocked.
@@ -2016,6 +2014,7 @@ async function maybePublishPrPublicSurface(
       pr,
       author,
       confirmedContributor,
+      convergedRepoAllowed,
       ...(aiReviewWillRun ? { files: await getReviewFiles() } : {}),
     });
 
@@ -2024,12 +2023,13 @@ async function maybePublishPrPublicSurface(
     // (safety flag ON + repo allowlisted), pass the shared resolved files so it scans the REAL diff (FIX B);
     // otherwise pass the already-loaded files (or null) and let the scan early-return. Flag-OFF (default) is an
     // immediate no-op → the advisory/gate is byte-identical.
-    const safetyWillRun = isSafetyEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
+    const safetyWillRun = isSafetyEnabled(env) && convergedRepoAllowed;
     await maybeAddSecretLeakFinding(env, {
       advisory,
       repoFullName,
       pullNumber: pr.number,
       files: safetyWillRun ? await getReviewFiles() : reviewFiles,
+      convergedRepoAllowed,
     });
 
     // First-time-contributor grace (#552): compute the author's complete per-repo PR history

--- a/src/review/cutover-control.ts
+++ b/src/review/cutover-control.ts
@@ -1,0 +1,238 @@
+import { computeParityReadiness, isParityAuditEnabled, type ParityReadinessRow } from "./parity-wire";
+import { isConvergenceRepoAllowed } from "./cutover-gate";
+import { nowIso } from "../utils/json";
+
+export type CutoverStage = "shadow" | "live";
+
+export interface ReviewCutoverControl {
+  repoFullName: string;
+  stage: CutoverStage;
+  freezeVerifiedAt: string | null;
+  freezeVerifiedBy: string | null;
+  rollbackDryRunAt: string | null;
+  rollbackDryRunBy: string | null;
+  lastLiveAt: string | null;
+  lastRollbackAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface ReviewCutoverStatus extends ReviewCutoverControl {
+  envAllowlisted: boolean;
+  parityAuditEnabled: boolean;
+  parity: ParityReadinessRow | null;
+  blockers: string[];
+  readyForLive: boolean;
+  liveAllowed: boolean;
+  sequenceIndex: number | null;
+}
+
+export class CutoverTransitionError extends Error {
+  readonly blockers: string[];
+
+  constructor(blockers: string[]) {
+    super("cutover_transition_blocked");
+    this.name = "CutoverTransitionError";
+    this.blockers = blockers;
+  }
+}
+
+const CUTOVER_SEQUENCE = ["JSONbored/awesome-claude", "JSONbored/gittensory", "JSONbored/metagraphed"] as const;
+
+function normalizeRepo(repoFullName: string): string {
+  return repoFullName.trim();
+}
+
+function defaultControl(repoFullName: string): ReviewCutoverControl {
+  return {
+    repoFullName,
+    stage: "shadow",
+    freezeVerifiedAt: null,
+    freezeVerifiedBy: null,
+    rollbackDryRunAt: null,
+    rollbackDryRunBy: null,
+    lastLiveAt: null,
+    lastRollbackAt: null,
+    updatedAt: null,
+  };
+}
+
+function toControl(row: Record<string, unknown> | null | undefined, repoFullName: string): ReviewCutoverControl {
+  if (!row) return defaultControl(repoFullName);
+  return {
+    repoFullName,
+    stage: row.stage === "live" ? "live" : "shadow",
+    freezeVerifiedAt: typeof row.freeze_verified_at === "string" ? row.freeze_verified_at : null,
+    freezeVerifiedBy: typeof row.freeze_verified_by === "string" ? row.freeze_verified_by : null,
+    rollbackDryRunAt: typeof row.rollback_dry_run_at === "string" ? row.rollback_dry_run_at : null,
+    rollbackDryRunBy: typeof row.rollback_dry_run_by === "string" ? row.rollback_dry_run_by : null,
+    lastLiveAt: typeof row.last_live_at === "string" ? row.last_live_at : null,
+    lastRollbackAt: typeof row.last_rollback_at === "string" ? row.last_rollback_at : null,
+    updatedAt: typeof row.updated_at === "string" ? row.updated_at : null,
+  };
+}
+
+async function rawFirst(env: Env, sql: string, ...binds: unknown[]): Promise<Record<string, unknown> | null> {
+  return await (env.DB as unknown as { prepare: (statement: string) => { bind: (...values: unknown[]) => { first: <T>() => Promise<T | null> } } })
+    .prepare(sql)
+    .bind(...binds)
+    .first<Record<string, unknown>>();
+}
+
+async function rawAll(env: Env, sql: string, ...binds: unknown[]): Promise<Record<string, unknown>[]> {
+  const res = await (env.DB as unknown as { prepare: (statement: string) => { bind: (...values: unknown[]) => { all: <T>() => Promise<{ results: T[] }> } } })
+    .prepare(sql)
+    .bind(...binds)
+    .all<Record<string, unknown>>();
+  return res.results;
+}
+
+async function rawRun(env: Env, sql: string, ...binds: unknown[]): Promise<void> {
+  await (env.DB as unknown as { prepare: (statement: string) => { bind: (...values: unknown[]) => { run: () => Promise<unknown> } } })
+    .prepare(sql)
+    .bind(...binds)
+    .run();
+}
+
+export async function getReviewCutoverControl(env: Env, repoFullName: string): Promise<ReviewCutoverControl> {
+  const repo = normalizeRepo(repoFullName);
+  const row = await rawFirst(env, "SELECT * FROM review_cutover_controls WHERE lower(repo_full_name) = lower(?) LIMIT 1", repo);
+  return toControl(row, repo);
+}
+
+export async function listReviewCutoverControls(env: Env): Promise<ReviewCutoverControl[]> {
+  const rows = await rawAll(env, "SELECT * FROM review_cutover_controls ORDER BY repo_full_name");
+  return rows.map((row) => toControl(row, typeof row.repo_full_name === "string" ? row.repo_full_name : ""));
+}
+
+export async function markReviewCutoverFreezeVerified(env: Env, repoFullName: string, actor: string | null = null): Promise<ReviewCutoverControl> {
+  const repo = normalizeRepo(repoFullName);
+  const at = nowIso();
+  await rawRun(
+    env,
+    `INSERT INTO review_cutover_controls (repo_full_name, stage, freeze_verified_at, freeze_verified_by, updated_at)
+     VALUES (?, 'shadow', ?, ?, ?)
+     ON CONFLICT(repo_full_name) DO UPDATE SET freeze_verified_at = excluded.freeze_verified_at, freeze_verified_by = excluded.freeze_verified_by, updated_at = excluded.updated_at`,
+    repo,
+    at,
+    actor,
+    at,
+  );
+  return getReviewCutoverControl(env, repo);
+}
+
+export async function markReviewCutoverRollbackDryRun(env: Env, repoFullName: string, actor: string | null = null): Promise<ReviewCutoverControl> {
+  const repo = normalizeRepo(repoFullName);
+  const at = nowIso();
+  await rawRun(
+    env,
+    `INSERT INTO review_cutover_controls (repo_full_name, stage, rollback_dry_run_at, rollback_dry_run_by, updated_at)
+     VALUES (?, 'shadow', ?, ?, ?)
+     ON CONFLICT(repo_full_name) DO UPDATE SET rollback_dry_run_at = excluded.rollback_dry_run_at, rollback_dry_run_by = excluded.rollback_dry_run_by, updated_at = excluded.updated_at`,
+    repo,
+    at,
+    actor,
+    at,
+  );
+  return getReviewCutoverControl(env, repo);
+}
+
+function sequenceIndex(repoFullName: string): number | null {
+  const index = CUTOVER_SEQUENCE.findIndex((entry) => entry.toLowerCase() === repoFullName.toLowerCase());
+  return index >= 0 ? index : null;
+}
+
+export async function getReviewCutoverStatus(env: Env, repoFullName: string): Promise<ReviewCutoverStatus> {
+  const repo = normalizeRepo(repoFullName);
+  const control = await getReviewCutoverControl(env, repo);
+  const parityAuditEnabled = isParityAuditEnabled(env);
+  const parityReport = parityAuditEnabled ? await computeParityReadiness(env, { project: repo }) : null;
+  const parity = parityReport?.rows.find((row) => row.project.toLowerCase() === repo.toLowerCase()) ?? null;
+  const blockers: string[] = [];
+  if (!isConvergenceRepoAllowed(env, repo)) blockers.push("explicit_signal_required");
+  if (!parityAuditEnabled) blockers.push("parity_audit_disabled");
+  else if (!parity?.cutoverReady) blockers.push("parity_not_ready");
+  if (!control.freezeVerifiedAt) blockers.push("freeze_not_verified");
+  if (!control.rollbackDryRunAt) blockers.push("rollback_dry_run_not_passed");
+  const repoSequenceIndex = sequenceIndex(repo);
+  if (repoSequenceIndex !== null) {
+    for (const priorRepo of CUTOVER_SEQUENCE.slice(0, repoSequenceIndex)) {
+      const prior = await getReviewCutoverControl(env, priorRepo);
+      if (prior.stage !== "live") {
+        blockers.push(`prior_repo_not_live:${priorRepo}`);
+        break;
+      }
+    }
+  }
+  const liveAllowed =
+    isConvergenceRepoAllowed(env, repo) &&
+    control.stage === "live" &&
+    Boolean(control.freezeVerifiedAt) &&
+    Boolean(control.rollbackDryRunAt);
+  return {
+    ...control,
+    envAllowlisted: isConvergenceRepoAllowed(env, repo),
+    parityAuditEnabled,
+    parity,
+    blockers,
+    readyForLive: blockers.length === 0,
+    liveAllowed,
+    sequenceIndex: repoSequenceIndex,
+  };
+}
+
+export async function listReviewCutoverStatuses(env: Env): Promise<ReviewCutoverStatus[]> {
+  const repos = new Set<string>(CUTOVER_SEQUENCE);
+  for (const repo of (env.GITTENSORY_REVIEW_REPOS ?? "").split(",")) {
+    const normalized = normalizeRepo(repo);
+    if (normalized) repos.add(normalized);
+  }
+  for (const control of await listReviewCutoverControls(env)) {
+    if (control.repoFullName) repos.add(control.repoFullName);
+  }
+  const statuses = await Promise.all([...repos].sort((left, right) => left.localeCompare(right)).map((repo) => getReviewCutoverStatus(env, repo)));
+  return statuses;
+}
+
+export async function activateReviewCutoverLive(env: Env, repoFullName: string): Promise<ReviewCutoverStatus> {
+  const repo = normalizeRepo(repoFullName);
+  const status = await getReviewCutoverStatus(env, repo);
+  if (!status.readyForLive) throw new CutoverTransitionError(status.blockers);
+  const at = nowIso();
+  await rawRun(
+    env,
+    `INSERT INTO review_cutover_controls (repo_full_name, stage, freeze_verified_at, freeze_verified_by, rollback_dry_run_at, rollback_dry_run_by, last_live_at, updated_at)
+     VALUES (?, 'live', ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(repo_full_name) DO UPDATE SET stage = 'live', last_live_at = excluded.last_live_at, updated_at = excluded.updated_at`,
+    repo,
+    status.freezeVerifiedAt,
+    status.freezeVerifiedBy,
+    status.rollbackDryRunAt,
+    status.rollbackDryRunBy,
+    at,
+    at,
+  );
+  return getReviewCutoverStatus(env, repo);
+}
+
+export async function rollbackReviewCutoverToShadow(env: Env, repoFullName: string): Promise<ReviewCutoverStatus> {
+  const repo = normalizeRepo(repoFullName);
+  const at = nowIso();
+  await rawRun(
+    env,
+    `INSERT INTO review_cutover_controls (repo_full_name, stage, last_rollback_at, updated_at)
+     VALUES (?, 'shadow', ?, ?)
+     ON CONFLICT(repo_full_name) DO UPDATE SET stage = 'shadow', freeze_verified_at = NULL, freeze_verified_by = NULL, last_rollback_at = excluded.last_rollback_at, updated_at = excluded.updated_at`,
+    repo,
+    at,
+    at,
+  );
+  return getReviewCutoverStatus(env, repo);
+}
+
+export async function isConvergenceRepoLive(env: Env, repoFullName: string): Promise<boolean> {
+  try {
+    return (await getReviewCutoverStatus(env, repoFullName)).liveAllowed;
+  } catch {
+    return false;
+  }
+}

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -18,8 +18,8 @@
 // are audited via `recordAiUsageEvent`.
 import { countByokAiEventsForRepoSince, recordAiUsageEvent, sumAiEstimatedNeuronsSince } from "../db/repositories";
 import { sanitizePublicComment } from "../queue-intelligence";
-import { defangReviewInput, isSafetyEnabled } from "../review/safety";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
+import { defangReviewInput, isSafetyEnabled } from "../review/safety";
 
 /**
  * The best free Workers-AI model pair for review accuracy — two different families for independence,
@@ -90,6 +90,7 @@ export type GittensoryAiReviewInput = {
    * to today — no section is appended.
    */
   ragContext?: string | null | undefined;
+  convergedRepoAllowed?: boolean | undefined;
 };
 
 /** A consensus critical defect, already public-safe, ready to become a gate blocker finding. */
@@ -398,7 +399,8 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the defang activates for THIS PR's repo only when it
   // is allowlisted AND the global safety flag is ON. Empty/unset allowlist → `input` passes through unchanged
   // for every repo (the prompt is byte-identical to today) regardless of GITTENSORY_REVIEW_SAFETY.
-  const promptInput = isSafetyEnabled(env) && isConvergenceRepoAllowed(env, input.repoFullName) ? { ...input, ...defangReviewInput(input) } : input;
+  const convergedRepoAllowed = input.convergedRepoAllowed ?? isConvergenceRepoAllowed(env, input.repoFullName);
+  const promptInput = isSafetyEnabled(env) && convergedRepoAllowed ? { ...input, ...defangReviewInput(input) } : input;
   const user = buildUserPrompt(promptInput);
   // Grounding-discipline SYSTEM suffix (convergence, flag-gated). When the caller supplied grounding, the
   // reviewers are told to verify claims against the attached CI/files; otherwise this is REVIEW_SYSTEM_PROMPT

--- a/test/unit/cutover-control.test.ts
+++ b/test/unit/cutover-control.test.ts
@@ -4,6 +4,8 @@ import {
   activateReviewCutoverLive,
   getReviewCutoverStatus,
   isConvergenceRepoLive,
+  listReviewCutoverControls,
+  listReviewCutoverStatuses,
   markReviewCutoverFreezeVerified,
   markReviewCutoverRollbackDryRun,
   rollbackReviewCutoverToShadow,
@@ -80,6 +82,100 @@ describe("review cutover control", () => {
     expect(rolledBack.liveAllowed).toBe(false);
     expect(await isConvergenceRepoLive(env, "acme/widgets")).toBe(false);
   });
+
+  it("lists persisted controls and preserves actor metadata", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await markReviewCutoverFreezeVerified(env, "acme/widgets", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "acme/widgets", "reviewwed");
+    const rows = await listReviewCutoverControls(env);
+    const control = rows.find((row) => row.repoFullName === "acme/widgets");
+    expect(control).toBeDefined();
+    expect(control?.freezeVerifiedBy).toBe("jsonbored");
+    expect(control?.rollbackDryRunBy).toBe("reviewwed");
+  });
+
+  it("lists statuses across sequence repos, allowlisted repos, and persisted controls", async () => {
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_PARITY_AUDIT: "true",
+      GITTENSORY_REVIEW_REPOS: "acme/widgets, other/repo , ,",
+    });
+    await seedPerfectParity(env, "acme/widgets");
+    await markReviewCutoverFreezeVerified(env, "acme/widgets", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "acme/widgets", "jsonbored");
+    await activateReviewCutoverLive(env, "acme/widgets");
+    const statuses = await listReviewCutoverStatuses(env);
+    expect(statuses.some((status) => status.repoFullName === "JSONbored/awesome-claude")).toBe(true);
+    expect(statuses.some((status) => status.repoFullName === "other/repo")).toBe(true);
+    const acme = statuses.find((status) => status.repoFullName === "acme/widgets");
+    expect(acme?.liveAllowed).toBe(true);
+  });
+
+  it("allows the next tracked repo once the prior tracked repo is already live", async () => {
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_PARITY_AUDIT: "true",
+      GITTENSORY_REVIEW_REPOS: "JSONbored/awesome-claude,JSONbored/gittensory",
+    });
+    await seedPerfectParity(env, "JSONbored/awesome-claude");
+    await markReviewCutoverFreezeVerified(env, "JSONbored/awesome-claude", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "JSONbored/awesome-claude", "jsonbored");
+    await activateReviewCutoverLive(env, "JSONbored/awesome-claude");
+
+    await seedPerfectParity(env, "JSONbored/gittensory");
+    await markReviewCutoverFreezeVerified(env, "JSONbored/gittensory", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "JSONbored/gittensory", "jsonbored");
+    const status = await getReviewCutoverStatus(env, "JSONbored/gittensory");
+    expect(status.blockers).not.toContain("prior_repo_not_live:JSONbored/awesome-claude");
+    expect(status.readyForLive).toBe(true);
+  });
+
+  it("throws a typed transition error when activation is attempted before hard gates pass", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await expect(activateReviewCutoverLive(env, "acme/widgets")).rejects.toMatchObject({
+      name: "CutoverTransitionError",
+      blockers: expect.arrayContaining(["parity_not_ready", "freeze_not_verified", "rollback_dry_run_not_passed"]),
+    });
+  });
+
+  it("marks a live-but-not-allowlisted repo as not liveAllowed", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true", GITTENSORY_REVIEW_REPOS: "" });
+    await seedPerfectParity(env, "acme/widgets");
+    await markReviewCutoverFreezeVerified(env, "acme/widgets", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "acme/widgets", "jsonbored");
+    await (env.DB as unknown as { prepare: (s: string) => { bind: (...v: unknown[]) => { run: () => Promise<unknown> } } })
+      .prepare(
+        `INSERT INTO review_cutover_controls (repo_full_name, stage, freeze_verified_at, rollback_dry_run_at, last_live_at, updated_at)
+         VALUES (?, 'live', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+         ON CONFLICT(repo_full_name) DO UPDATE SET stage = 'live', last_live_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP`,
+      )
+      .bind("acme/widgets")
+      .run();
+    const status = await getReviewCutoverStatus(env, "acme/widgets");
+    expect(status.stage).toBe("live");
+    expect(status.envAllowlisted).toBe(false);
+    expect(status.liveAllowed).toBe(false);
+    expect(status.blockers).toContain("explicit_signal_required");
+  });
+
+  it("fails safe when the cutover status read throws", async () => {
+    const env = createTestEnv();
+    env.DB.prepare = (() => {
+      throw new Error("db unavailable");
+    }) as typeof env.DB.prepare;
+    await expect(isConvergenceRepoLive(env, "acme/widgets")).resolves.toBe(false);
+  });
+
+  it("ignores persisted blank control rows when listing statuses", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await (env.DB as unknown as { prepare: (s: string) => { bind: (...v: unknown[]) => { run: () => Promise<unknown> } } })
+      .prepare(
+        `INSERT INTO review_cutover_controls (repo_full_name, stage, updated_at)
+         VALUES (?, 'shadow', CURRENT_TIMESTAMP)`,
+      )
+      .bind("")
+      .run();
+    const statuses = await listReviewCutoverStatuses(env);
+    expect(statuses.some((status) => status.repoFullName === "")).toBe(false);
+  });
 });
 
 describe("internal cutover routes", () => {
@@ -130,5 +226,22 @@ describe("internal cutover routes", () => {
     const body = (await res.json()) as { stage: string; liveAllowed: boolean };
     expect(body.stage).toBe("live");
     expect(body.liveAllowed).toBe(true);
+  });
+
+  it("supports repo-scoped GET and rejects an invalid action", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    const getRes = await app.request("/v1/internal/cutover?repo=JSONbored/gittensory", { headers: bearer(env) }, env);
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { repoFullName: string };
+    expect(getBody.repoFullName).toBe("JSONbored/gittensory");
+
+    const badRes = await app.request(
+      "/v1/internal/cutover/repos/acme/widgets",
+      { method: "POST", headers: bearer(env), body: JSON.stringify({ action: "nope" }) },
+      env,
+    );
+    expect(badRes.status).toBe(400);
+    expect(((await badRes.json()) as { error: string }).error).toBe("valid_action_required");
   });
 });

--- a/test/unit/cutover-control.test.ts
+++ b/test/unit/cutover-control.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import {
+  activateReviewCutoverLive,
+  getReviewCutoverStatus,
+  isConvergenceRepoLive,
+  markReviewCutoverFreezeVerified,
+  markReviewCutoverRollbackDryRun,
+  rollbackReviewCutoverToShadow,
+} from "../../src/review/cutover-control";
+import { recordNativeGateDecision } from "../../src/review/parity-wire";
+import { createTestEnv } from "../helpers/d1";
+
+async function seedReviewbotDecision(env: Env, project: string, pr: number, headSha: string, decision: string, summary: string): Promise<void> {
+  await (env.DB as unknown as { prepare: (s: string) => { bind: (...v: unknown[]) => { run: () => Promise<unknown> } } })
+    .prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at)
+       VALUES (?, ?, ?, 'gate_decision', ?, 'reviewbot', ?, ?, CURRENT_TIMESTAMP)`,
+    )
+    .bind(`gate:reviewbot:${project}#${pr}@${headSha}`, project, `${project}#${pr}`, decision, headSha, summary)
+    .run();
+}
+
+async function seedPerfectParity(env: Env, repoFullName: string, count = 35): Promise<void> {
+  for (let i = 1; i <= count; i += 1) {
+    const sha = `${repoFullName}-sha-${i}`;
+    await seedReviewbotDecision(env, repoFullName, i, sha, i % 2 === 0 ? "merge" : "hold", "gate_reason");
+    await recordNativeGateDecision(env, {
+      project: repoFullName,
+      pullNumber: i,
+      headSha: sha,
+      conclusion: i % 2 === 0 ? "success" : "failure",
+      reasonCode: "gate_reason",
+    });
+  }
+}
+
+describe("review cutover control", () => {
+  it("keeps converged review OFF until a repo is explicitly promoted live", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    expect(await isConvergenceRepoLive(env, "JSONbored/gittensory")).toBe(false);
+    const status = await getReviewCutoverStatus(env, "JSONbored/gittensory");
+    expect(status.stage).toBe("shadow");
+    expect(status.liveAllowed).toBe(false);
+  });
+
+  it("activates a non-sequenced repo only after parity, freeze verification, and rollback dry-run", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await seedPerfectParity(env, "acme/widgets");
+    await markReviewCutoverFreezeVerified(env, "acme/widgets", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "acme/widgets", "jsonbored");
+    const status = await activateReviewCutoverLive(env, "acme/widgets");
+    expect(status.stage).toBe("live");
+    expect(status.liveAllowed).toBe(true);
+    expect(await isConvergenceRepoLive(env, "acme/widgets")).toBe(true);
+  });
+
+  it("enforces the repo sequence for the tracked three-repo rollout", async () => {
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_PARITY_AUDIT: "true",
+      GITTENSORY_REVIEW_REPOS: "JSONbored/awesome-claude,JSONbored/gittensory",
+    });
+    await seedPerfectParity(env, "JSONbored/gittensory");
+    await markReviewCutoverFreezeVerified(env, "JSONbored/gittensory", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "JSONbored/gittensory", "jsonbored");
+    const status = await getReviewCutoverStatus(env, "JSONbored/gittensory");
+    expect(status.readyForLive).toBe(false);
+    expect(status.blockers).toContain("prior_repo_not_live:JSONbored/awesome-claude");
+  });
+
+  it("rollback returns a live repo to shadow and clears freeze verification", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await seedPerfectParity(env, "acme/widgets");
+    await markReviewCutoverFreezeVerified(env, "acme/widgets", "jsonbored");
+    await markReviewCutoverRollbackDryRun(env, "acme/widgets", "jsonbored");
+    await activateReviewCutoverLive(env, "acme/widgets");
+    const rolledBack = await rollbackReviewCutoverToShadow(env, "acme/widgets");
+    expect(rolledBack.stage).toBe("shadow");
+    expect(rolledBack.freezeVerifiedAt).toBeNull();
+    expect(rolledBack.liveAllowed).toBe(false);
+    expect(await isConvergenceRepoLive(env, "acme/widgets")).toBe(false);
+  });
+});
+
+describe("internal cutover routes", () => {
+  const bearer = (env: Env) => ({ authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}`, "content-type": "application/json" });
+
+  it("requires internal auth", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    expect((await app.request("/v1/internal/cutover", {}, env)).status).toBe(401);
+  });
+
+  it("returns 409 when activation is attempted before the hard gates pass", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    const res = await app.request(
+      "/v1/internal/cutover/repos/acme/widgets",
+      { method: "POST", headers: bearer(env), body: JSON.stringify({ action: "activate_live" }) },
+      env,
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; blockers: string[] };
+    expect(body.error).toBe("cutover_transition_blocked");
+    expect(body.blockers).toContain("parity_not_ready");
+    expect(body.blockers).toContain("freeze_not_verified");
+    expect(body.blockers).toContain("rollback_dry_run_not_passed");
+  });
+
+  it("promotes a repo live through the internal route once all hard gates pass", async () => {
+    const app = createApp();
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await seedPerfectParity(env, "acme/widgets");
+    await app.request(
+      "/v1/internal/cutover/repos/acme/widgets",
+      { method: "POST", headers: bearer(env), body: JSON.stringify({ action: "verify_freeze", actor: "jsonbored" }) },
+      env,
+    );
+    await app.request(
+      "/v1/internal/cutover/repos/acme/widgets",
+      { method: "POST", headers: bearer(env), body: JSON.stringify({ action: "record_rollback_dry_run", actor: "jsonbored" }) },
+      env,
+    );
+    const res = await app.request(
+      "/v1/internal/cutover/repos/acme/widgets",
+      { method: "POST", headers: bearer(env), body: JSON.stringify({ action: "activate_live" }) },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { stage: string; liveAllowed: boolean };
+    expect(body.stage).toBe("live");
+    expect(body.liveAllowed).toBe(true);
+  });
+});

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -55,6 +55,17 @@ describe("queue processors", () => {
     vi.unstubAllGlobals();
   });
 
+  async function seedLiveCutover(repoFullName: string, env: Env): Promise<void> {
+    await (env.DB as unknown as { prepare: (sql: string) => { bind: (...values: unknown[]) => { run: () => Promise<unknown> } } })
+      .prepare(
+        `INSERT INTO review_cutover_controls (repo_full_name, stage, freeze_verified_at, rollback_dry_run_at, last_live_at, updated_at)
+         VALUES (?, 'live', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+         ON CONFLICT(repo_full_name) DO UPDATE SET stage = 'live', updated_at = CURRENT_TIMESTAMP`,
+      )
+      .bind(repoFullName)
+      .run();
+  }
+
   it("processes registry, backfill, installation health, and signal snapshot jobs", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -2775,6 +2786,7 @@ describe("queue processors", () => {
   // and enables the gate so `maybePublishPrPublicSurface` takes the flag-ON branch.
   it("renders the unified PR-review comment when the flag is on and the gate evaluates", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_UNIFIED_COMMENT: "1" });
+    await seedLiveCutover("JSONbored/gittensory", env);
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(
@@ -2909,6 +2921,7 @@ describe("queue processors", () => {
   // under a "CI checks failing" section (not just a bare "CI failing" chip).
   it("inline-fetches the PR files and renders failing CI check names + reasons in the unified comment (FIX B + D3)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_UNIFIED_COMMENT: "1" });
+    await seedLiveCutover("JSONbored/gittensory", env);
     await persistRegistrySnapshot(
       env,
       normalizeRegistryPayload(


### PR DESCRIPTION
# Summary
This change fixes the cutover path for review convergence so a repo cannot go live on the new writer path just because it is env-allowlisted.
It adds a persistent cutover control layer that requires all blocking conditions from issue `#1027` before live activation:
- parity readiness passed
- freeze verified
- rollback dry-run recorded
- rollout order respected for the tracked repos

It also adds internal cutover APIs and tests for the new control flow.

# Related Issues
- Closes: #1027 
- Depends on `#1026`
- Builds on `#1024`
- Part of `#983`

# Change Type
- [x] Bug fix
- [x] New feature
- [x] Internal API change
- [x] Test coverage
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor only

# Problem
Before this change, per-repo convergence was effectively gated by env allowlisting, but issue `#1027` requires stronger operational hard gates:
- parity must pass first
- `freeze:<slug>` must be verified, not assumed
- rollback dry-run must pass before first live flip
- rollout must happen repo-by-repo

That gap allowed cutover logic to be enabled without persistent proof that the hard gates were satisfied.

# Real Behavior Proof
## Validation run
- [x] `npm install`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/cutover-control.test.ts`
- [x] `npx vitest run test/unit/parity-wire.test.ts`
- [x] `npx vitest run test/unit/safety-wiring.test.ts`
- [x] `npx vitest run test/unit/reputation-wiring.test.ts`
- [x] `npx vitest run test/unit/ai-review-advisory.test.ts`

## Verified outcomes
- [x] repo stays in shadow by default
- [x] live activation is blocked without parity/freeze/rollback gates
- [x] live activation succeeds after all gates pass
- [x] rollback returns repo to shadow
- [x] rollout order is enforced for tracked repos



# Checklist
- [x] Code builds
- [x] Targeted tests pass
- [x] Change is scoped to issue requirements
- [x] No unrelated behavior changes intended
- [ ] Deploy-time operational freeze verification still needs real production execution
- [ ] Real shared-audit parity data still needs production/shadow observation before actual repo flips

