### PR TITLE
fix(scoring): cap non-code explicit totals

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -301,12 +301,11 @@ function computeScoreCore(
   const issueDiscoverySlice = repoSlice * issueDiscoveryShare;
   const sourceTokenScore = nonNegative(input.sourceTokenScore);
   // TEST_FILE_CONTRIBUTION_WEIGHT (#808): upstream weights test-file tokens at 0.05× relative to source tokens.
-  // Applied only when totalTokenScore is not explicitly provided — an explicit caller total is honoured as-is.
   const testFileWeight = constant(constants, "TEST_FILE_CONTRIBUTION_WEIGHT", 0.05);
   const cappedNonCodeTokenScore = applyNonCodeLineCap(input, constants);
-  const totalTokenScore = nonNegative(
-    input.totalTokenScore ?? sourceTokenScore + testFileWeight * nonNegative(input.testTokenScore) + cappedNonCodeTokenScore,
-  );
+  const derivedTotalTokenScore = sourceTokenScore + testFileWeight * nonNegative(input.testTokenScore) + cappedNonCodeTokenScore;
+  const totalTokenScore =
+    input.totalTokenScore === undefined ? nonNegative(derivedTotalTokenScore) : applyNonCodeCapToTotal(input.totalTokenScore, input, cappedNonCodeTokenScore);
   const sourceLines = Math.max(1, nonNegative(input.sourceLines ?? sourceTokenScore));
   const fixedBaseScore = input.fixedBaseScore ?? config?.fixedBaseScore ?? undefined;
   const rawDensity = sourceTokenScore / sourceLines;
@@ -976,6 +975,17 @@ function applyNonCodeLineCap(input: Pick<ScorePreviewInput, "nonCodeTokenScore" 
   if (score <= 0 || lines <= 0) return score;
   const maxLines = constant(constants, "MAX_LINES_SCORED_FOR_NON_CODE_EXT", 300);
   return lines <= maxLines ? score : score * (maxLines / lines);
+}
+
+function applyNonCodeCapToTotal(
+  totalTokenScore: number,
+  input: Pick<ScorePreviewInput, "nonCodeTokenScore" | "nonCodeLines">,
+  cappedNonCodeTokenScore: number,
+): number {
+  const total = nonNegative(totalTokenScore);
+  const nonCodeTokenScore = nonNegative(input.nonCodeTokenScore);
+  if (nonCodeTokenScore <= 0 || cappedNonCodeTokenScore >= nonCodeTokenScore) return total;
+  return Math.max(0, total - (nonCodeTokenScore - cappedNonCodeTokenScore));
 }
 
 function constant(constants: Record<string, number>, key: string, fallback: number): number {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -286,6 +286,25 @@ NOVELTY_BONUS_SCALAR = 3
       }).scoreEstimate.contributionBonus,
       5,
     );
+
+    const explicitTotalWithNonCode = buildScorePreview({
+      repo,
+      snapshot: {
+        ...snapshot,
+        constants: { ...snapshot.constants, MAX_LINES_SCORED_FOR_NON_CODE_EXT: 300, CONTRIBUTION_SCORE_FOR_FULL_BONUS: 1500, MAX_CONTRIBUTION_BONUS: 25 },
+      },
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 100,
+        totalTokenScore: 700,
+        nonCodeTokenScore: 600,
+        nonCodeLines: 600,
+        sourceLines: 100,
+        openPrCount: 0,
+        credibility: 1,
+      },
+    });
+    expect(explicitTotalWithNonCode.scoreEstimate.contributionBonus).toBeCloseTo(cappedNonCode.scoreEstimate.contributionBonus, 5);
   });
 
   it("detects the active model from fetched constants before default fallback constants", async () => {


### PR DESCRIPTION
### Motivation

- A recent change introduced a non-code line cap via `applyNonCodeLineCap`, but the cap was only applied when `totalTokenScore` was not provided, allowing callers (and the local-branch path which always sets `totalTokenScore`) to bypass the cap and inflate previews.
- The intent is to ensure the `MAX_LINES_SCORED_FOR_NON_CODE_EXT` cap affects both derived totals and caller-supplied aggregate `totalTokenScore` when `nonCodeTokenScore`/`nonCodeLines` are present.

### Description

- Use a derived total (`derivedTotalTokenScore`) when `input.totalTokenScore` is undefined and otherwise apply a new cap-adjustment to caller-supplied totals via `applyNonCodeCapToTotal` in `computeScoreCore` (`src/scoring/preview.ts`).
- Add the helper `applyNonCodeCapToTotal(totalTokenScore, input, cappedNonCodeTokenScore)` which subtracts the uncapped non-code excess from an explicit total without double-capping derived totals.
- Preserve previous behavior for derived totals so they continue to include the capped non-code component when `totalTokenScore` is not supplied.
- Add a regression test in `test/unit/scoring.test.ts` that verifies an explicit `totalTokenScore` with excessive `nonCodeLines` is normalized to match the capped non-code case.

### Testing

- Ran the targeted scoring unit suite with `npx vitest run test/unit/scoring.test.ts` and the suite passed (48 tests, 0 failures).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it succeeded with no errors.
- The change adds a focused regression test that demonstrates explicit totals no longer bypass `MAX_LINES_SCORED_FOR_NON_CODE_EXT`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad2a90074832c8ce8ea3f4adb63ec)