### PR TITLE
feat(agent): config-driven linked-issue hard-rule auto-close

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2067,6 +2067,38 @@ export async function fetchLivePullRequestReviewDecision(env: Env, repoFullName:
   return result?.data?.repository?.pullRequest?.reviewDecision ?? undefined;
 }
 
+/** The deterministic linked-issue facts the hard-rule evaluator needs (labels / assignees / open-state). */
+export type LinkedIssueFactsResult = { number: number; labels: string[]; assignees: string[]; state: string };
+
+/**
+ * FETCH the facts for one linked issue via the REST issues endpoint. FAIL-OPEN: any fetch/parse error returns
+ * undefined so the caller skips that issue — a deterministic auto-close must NEVER fire (or be blocked) on a
+ * transient fetch failure. Uses the same authenticated REST client + public-token 404-fallback as the other
+ * live fetches. (Note: GitHub's issues endpoint also returns pull requests, which carry a `pull_request` field;
+ * a PR number passed here would simply fail the rules — we only treat real issues' labels/assignees.)
+ */
+export async function fetchLinkedIssueFacts(env: Env, repoFullName: string, issueNumber: number, token: string | undefined): Promise<LinkedIssueFactsResult | undefined> {
+  const result = await githubJsonWithHeaders<{
+    number?: number;
+    state?: string | null;
+    labels?: Array<{ name?: string | null } | string | null> | null;
+    assignees?: Array<{ login?: string | null } | null> | null;
+  }>(env, repoFullName, `/issues/${issueNumber}`, token).catch(() => undefined);
+  if (!result) return undefined;
+  const data = result.data;
+  const labels = (data.labels ?? []).flatMap((label) => {
+    if (typeof label === "string") return label.length > 0 ? [label] : [];
+    return label?.name ? [label.name] : [];
+  });
+  const assignees = (data.assignees ?? []).flatMap((assignee) => (assignee?.login ? [assignee.login] : []));
+  return {
+    number: data.number ?? issueNumber,
+    labels,
+    assignees,
+    state: String(data.state ?? "open").toLowerCase(),
+  };
+}
+
 async function fetchPullRequestDetailsFromGraphQl(
   env: Env,
   repoFullName: string,

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -64,6 +64,7 @@ import {
   backfillRepositorySegment,
   enqueueRepositoryOpenDataBackfill,
   fetchAndStorePullRequestFilesForReview,
+  fetchLinkedIssueFacts,
   fetchLiveCiAggregate,
   fetchLivePullRequestMergeState,
   fetchLivePullRequestReviewDecision,
@@ -175,6 +176,7 @@ import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
+import { evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
@@ -639,6 +641,26 @@ async function maybeRunAgentMaintenance(
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
 
+  // Linked-issue HARD-RULE close (#linked-issue-hard-rules). DETERMINISTIC: if the repo enabled any rule AND
+  // this PR links at least one issue, fetch each linked issue's facts (labels/assignees/state) and evaluate.
+  // Skip the fetch entirely when no rule is on OR there are no linked issues (no extra GitHub calls on the
+  // common path). Fetches are FAIL-OPEN per issue (a fetch error skips that issue, never blocks the review);
+  // the config load is FAIL-SAFE (a KV fault yields all-off, never a surprise close).
+  let linkedIssueHardRule: { violated: boolean; reason: string | null } | undefined;
+  const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, repoFullName);
+  const anyLinkedIssueRuleOn =
+    linkedIssueRulesConfig.ownerAssignedClose === "block" ||
+    linkedIssueRulesConfig.missingPointLabelClose === "block" ||
+    linkedIssueRulesConfig.maintainerOnlyLabelClose === "block";
+  if (anyLinkedIssueRuleOn && pr.linkedIssues.length > 0) {
+    const issueFacts = (
+      await Promise.all(pr.linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(env, repoFullName, issueNumber, ciToken ?? env.GITHUB_PUBLIC_TOKEN)))
+    ).flatMap((facts) => (facts ? [facts] : []));
+    if (issueFacts.length > 0) {
+      linkedIssueHardRule = evaluateLinkedIssueHardRules({ issues: issueFacts, config: linkedIssueRulesConfig, repoOwner });
+    }
+  }
+
   const planned = planAgentMaintenanceActions({
     conclusion: gate.conclusion,
     blockerTitles: gate.blockers.map((blocker) => blocker.title),
@@ -651,6 +673,7 @@ async function maybeRunAgentMaintenance(
     authorIsAutomationBot,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
+    ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
     pr: {
       mergeableState: liveMergeState ?? pr.mergeableState,
       reviewDecision: liveReviewDecision ?? pr.reviewDecision,

--- a/src/review/linked-issue-hard-rules.ts
+++ b/src/review/linked-issue-hard-rules.ts
@@ -1,0 +1,161 @@
+import type { JsonValue } from "../types";
+
+// Linked-issue HARD-RULE auto-close (#linked-issue-hard-rules). A DETERMINISTIC rule about the issue(s) a
+// contributor PR links — not an AI verdict. When a contributor links an issue that violates one of the
+// operator's hard rules, the PR is one-shot CLOSED with the SPECIFIC rule cited, so the contributor knows
+// exactly why (and which issue). The three rules (close when ANY linked OPEN issue trips one):
+//   1. owner-assigned    — the issue is assigned to the repo owner (reserved for the maintainer).
+//   2. missing-point     — a default-label repo AND the issue carries NONE of the point-bearing labels
+//                          (gittensor:bug / gittensor:feature / gittensor:priority) → not a scored contribution.
+//   3. maintainer-only   — the issue is labeled `maintainer-only` → not open for community PRs.
+//
+// Each rule is independently `"block"` (enforce) or `"off"` (ignore). Because this is deterministic (no
+// hallucination risk), the close fires REGARDLESS of a hard-guardrail path hit — but NEVER for the owner or
+// an automation bot (the planner's `isContributor` guard owns that exemption).
+
+export type LinkedIssueHardRulesMode = "block" | "off";
+
+export type LinkedIssueHardRulesConfig = {
+  ownerAssignedClose: LinkedIssueHardRulesMode;
+  missingPointLabelClose: LinkedIssueHardRulesMode;
+  maintainerOnlyLabelClose: LinkedIssueHardRulesMode;
+  // The point-bearing labels that make an issue eligible for a scored contribution.
+  pointBearingLabels: string[];
+  // The labels that mark an issue as maintainer-only (not open for community PRs).
+  maintainerOnlyLabels: string[];
+  // True when the repo uses the default gittensor labels, which is the precondition for the missing-point rule
+  // (a repo that does NOT use point labels must never auto-close for "missing point label").
+  defaultLabelRepo: boolean;
+};
+
+// Fail-SAFE default: every mode OFF, empty label lists, NOT a default-label repo. An unconfigured (or
+// KV-unbound, or KV-faulting) repo must never auto-close a contributor PR for a linked-issue rule. The default
+// point/maintainer label lists are only used when a repo turns the corresponding rule ON without listing its
+// own; an OFF rule never reads them.
+const DEFAULT_POINT_BEARING_LABELS = ["gittensor:bug", "gittensor:feature", "gittensor:priority"];
+const DEFAULT_MAINTAINER_ONLY_LABELS = ["maintainer-only"];
+
+export const DEFAULT_LINKED_ISSUE_HARD_RULES: LinkedIssueHardRulesConfig = {
+  ownerAssignedClose: "off",
+  missingPointLabelClose: "off",
+  maintainerOnlyLabelClose: "off",
+  pointBearingLabels: [],
+  maintainerOnlyLabels: [],
+  defaultLabelRepo: false,
+};
+
+function asMode(value: unknown): LinkedIssueHardRulesMode | null {
+  return value === "block" || value === "off" ? value : null;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const out = value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+  return out.length > 0 ? out : null;
+}
+
+type LinkedIssueHardRulesKvShape = {
+  ownerAssignedClose?: JsonValue;
+  missingPointLabelClose?: JsonValue;
+  maintainerOnlyLabelClose?: JsonValue;
+  pointBearingLabels?: JsonValue;
+  maintainerOnlyLabels?: JsonValue;
+  defaultLabelRepo?: JsonValue;
+};
+
+/**
+ * Resolve a repo's linked-issue hard-rule config from the shared REVIEW_CONFIG KV (key = repo slug, owner
+ * stripped — same convention as loadHardGuardrailGlobs). Reads the `linkedIssueHardRules` field. NEVER throws
+ * (the auto-maintain trigger is best-effort) and ALWAYS fail-SAFE: an absent binding / key / field, a partial
+ * config, OR a THROWN KV read (outage) all resolve to the all-OFF default so a deterministic close can never
+ * fire on an unconfigured repo or a KV fault. Partial KV objects are merged OVER the default (any field a repo
+ * omits keeps its safe default).
+ */
+export async function loadLinkedIssueHardRules(env: Env, repoFullName: string): Promise<LinkedIssueHardRulesConfig> {
+  if (!env.REVIEW_CONFIG) return DEFAULT_LINKED_ISSUE_HARD_RULES;
+  const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
+  try {
+    const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { linkedIssueHardRules?: LinkedIssueHardRulesKvShape } | null;
+    const raw = config?.linkedIssueHardRules;
+    if (!raw || typeof raw !== "object") return DEFAULT_LINKED_ISSUE_HARD_RULES;
+    return {
+      ownerAssignedClose: asMode(raw.ownerAssignedClose) ?? DEFAULT_LINKED_ISSUE_HARD_RULES.ownerAssignedClose,
+      missingPointLabelClose: asMode(raw.missingPointLabelClose) ?? DEFAULT_LINKED_ISSUE_HARD_RULES.missingPointLabelClose,
+      maintainerOnlyLabelClose: asMode(raw.maintainerOnlyLabelClose) ?? DEFAULT_LINKED_ISSUE_HARD_RULES.maintainerOnlyLabelClose,
+      pointBearingLabels: asStringArray(raw.pointBearingLabels) ?? DEFAULT_POINT_BEARING_LABELS,
+      maintainerOnlyLabels: asStringArray(raw.maintainerOnlyLabels) ?? DEFAULT_MAINTAINER_ONLY_LABELS,
+      defaultLabelRepo: raw.defaultLabelRepo === true,
+    };
+  } catch {
+    // A KV outage must NEVER let a deterministic close fire — fail safe to all-off (the opposite of the
+    // guardrail loader, which fails CLOSED: there a fault widens the manual-hold surface, here a fault must
+    // not manufacture a close).
+    return DEFAULT_LINKED_ISSUE_HARD_RULES;
+  }
+}
+
+export type LinkedIssueFacts = {
+  number: number;
+  labels: string[];
+  assignees: string[];
+  state: string;
+};
+
+export type LinkedIssueHardRuleResult = {
+  violated: boolean;
+  reason: string | null;
+};
+
+const NO_VIOLATION: LinkedIssueHardRuleResult = { violated: false, reason: null };
+
+function labelMatches(labels: string[], candidates: string[]): boolean {
+  const wanted = new Set(candidates.map((c) => c.toLowerCase()));
+  return labels.some((label) => wanted.has(label.toLowerCase()));
+}
+
+/**
+ * PURE evaluator. Walks the linked OPEN issues (closed issues are ignored — a stale close-link never blocks a
+ * PR) and returns on the FIRST hard-rule violation with a specific, cited reason naming the offending issue.
+ * Only rules in `"block"` mode are evaluated; the missing-point-label rule additionally requires the repo to be
+ * a default-label repo. Returns `{ violated: false, reason: null }` when nothing trips.
+ */
+export function evaluateLinkedIssueHardRules(input: {
+  issues: LinkedIssueFacts[];
+  config: LinkedIssueHardRulesConfig;
+  repoOwner: string;
+}): LinkedIssueHardRuleResult {
+  const { config, repoOwner } = input;
+  const ownerLower = repoOwner.toLowerCase();
+  const anyRuleOn = config.ownerAssignedClose === "block" || config.missingPointLabelClose === "block" || config.maintainerOnlyLabelClose === "block";
+  if (!anyRuleOn) return NO_VIOLATION;
+
+  for (const issue of input.issues) {
+    if (issue.state !== "open") continue;
+
+    // Rule 1 — owner-assigned. The maintainer reserved this issue; a contributor PR for it can't be auto-accepted.
+    if (config.ownerAssignedClose === "block" && ownerLower.length > 0 && issue.assignees.some((assignee) => assignee.toLowerCase() === ownerLower)) {
+      return {
+        violated: true,
+        reason: `Linked issue #${issue.number} is assigned to the maintainer (@${repoOwner}) — that work is reserved for the maintainer, so this PR cannot be auto-accepted.`,
+      };
+    }
+
+    // Rule 3 — maintainer-only label. Not open for community PRs.
+    if (config.maintainerOnlyLabelClose === "block" && labelMatches(issue.labels, config.maintainerOnlyLabels)) {
+      return {
+        violated: true,
+        reason: `Linked issue #${issue.number} is labeled \`maintainer-only\` — it is not open for community PRs.`,
+      };
+    }
+
+    // Rule 2 — missing point-bearing label (default-label repos only). Not eligible for a scored contribution.
+    if (config.missingPointLabelClose === "block" && config.defaultLabelRepo && !labelMatches(issue.labels, config.pointBearingLabels)) {
+      return {
+        violated: true,
+        reason: `Linked issue #${issue.number} has no point-bearing label (needs one of gittensor:bug, gittensor:feature, gittensor:priority) — it is not eligible for a scored contribution.`,
+      };
+    }
+  }
+
+  return NO_VIOLATION;
+}

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -74,6 +74,13 @@ export type AgentActionPlanInput = {
   // The names of the failing checks, surfaced in the close/request-changes reason so the contributor knows
   // WHY (e.g. "codecov/patch"). Empty unless ciState === "failed".
   failingCheckNames?: string[] | undefined;
+  // Linked-issue HARD-RULE result (#linked-issue-hard-rules). A DETERMINISTIC verdict about the issue(s) this PR
+  // links (owner-assigned / missing point-label / maintainer-only), pre-computed by the trigger. When
+  // `violated`, a CONTRIBUTOR PR is one-shot CLOSED citing `reason` — and because it is deterministic (no
+  // hallucination risk), that close fires REGARDLESS of a hard-guardrail path hit (the guard exists only for
+  // AI verdicts). It still NEVER fires for the owner or automation bots (the `isContributor` guard). Absent /
+  // not-violated ⇒ no effect.
+  linkedIssueHardRule?: { violated: boolean; reason: string | null } | undefined;
   pr: {
     mergeableState?: string | null | undefined;
     reviewDecision?: string | null | undefined;
@@ -152,6 +159,13 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // verifies and closes/merges. The BULK (non-guarded) contributor PRs still auto-close one-shot on a bad
   // verdict / conflict — only the small crucial set is held. Owner/automation PRs are never closed regardless.
   const willClose = !guardrailHit && isContributor && acting("close") && (!reviewGood || isConflict);
+  // Linked-issue HARD-RULE close (#linked-issue-hard-rules). A DETERMINISTIC verdict about the LINKED ISSUE
+  // (owner-assigned / missing point-label / maintainer-only) — NOT an AI verdict, so there is no hallucination
+  // to guard against: this close fires REGARDLESS of `guardrailHit`. It still only ever closes a CONTRIBUTOR
+  // PR (the `isContributor` guard owns the owner/automation exemption) and respects the `close` autonomy class.
+  // It takes PRECEDENCE over merge/approve below: a PR linking an ineligible issue must never auto-merge.
+  const linkedIssueHardRule = input.linkedIssueHardRule;
+  const willCloseForLinkedIssue = linkedIssueHardRule?.violated === true && isContributor && acting("close");
   const ciReason = ciFailed
     ? `CI is failing${failingCheckNames.length ? ` (${failingCheckNames.join(", ")})` : ""}`
     : ciUnverified
@@ -159,14 +173,18 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       : "";
 
   // 1) label — ready-to-merge (review-good, unguarded) / needs-human-review (review-good but guarded) /
-  // changes-requested (not review-good → will be closed for a contributor, held for the owner). Idempotent.
+  // changes-requested (not review-good → will be closed for a contributor, held for the owner). A pending
+  // linked-issue hard-rule close forces the changes-requested label regardless of the gate verdict (the PR is
+  // about to be closed for an ineligible linked issue). Idempotent.
   if (acting("label")) {
-    const label = !reviewGood ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
-    const reason = !reviewGood
-      ? `verdict=${input.conclusion}${ciReason ? `; ${ciReason}` : ""}`
-      : guardrailHit
-        ? `verdict=${input.conclusion}; guarded path → owner safety review`
-        : `verdict=${input.conclusion}; CI green`;
+    const label = willCloseForLinkedIssue || !reviewGood ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
+    const reason = willCloseForLinkedIssue
+      ? `linked-issue hard rule: ${linkedIssueHardRule?.reason ?? "ineligible linked issue"}`
+      : !reviewGood
+        ? `verdict=${input.conclusion}${ciReason ? `; ${ciReason}` : ""}`
+        : guardrailHit
+          ? `verdict=${input.conclusion}; guarded path → owner safety review`
+          : `verdict=${input.conclusion}; CI green`;
     if (!hasLabel(input.pr.labels, label)) {
       actions.push({ actionClass: "label", requiresApproval: approval("label"), reason, label });
     }
@@ -179,7 +197,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // OWNER/automation PR is HELD via the needs-human label + the (non-blocking) unified review comment — never a
   // formal request-changes. (#no-request-changes) Either merge/approve, or close, with the rare manual hold left
   // open + commented, never blocked.
-  if (reviewGood && !guardrailHit && acting("approve") && input.pr.reviewDecision !== "APPROVED") {
+  if (reviewGood && !guardrailHit && !willCloseForLinkedIssue && acting("approve") && input.pr.reviewDecision !== "APPROVED") {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),
@@ -188,10 +206,18 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     });
   }
 
-  // 3) disposition — MERGE (review-good, unguarded, mergeable, approvals) / CLOSE (not-good OR conflicting
-  // CONTRIBUTOR PR, one-shot) / MANUAL (guarded, or any not-good OWNER/automation PR — held, never closed).
-  // Mutually exclusive.
-  if (canMerge) {
+  // 3) disposition — LINKED-ISSUE HARD-RULE CLOSE (deterministic, fires even on a guarded path; precedes
+  // merge) / MERGE (review-good, unguarded, mergeable, approvals) / CLOSE (not-good OR conflicting CONTRIBUTOR
+  // PR, one-shot) / MANUAL (guarded, or any not-good OWNER/automation PR — held, never closed). Mutually
+  // exclusive.
+  if (willCloseForLinkedIssue) {
+    // A contributor linked an issue that violates a deterministic hard rule (owner-assigned / missing
+    // point-label / maintainer-only). Close one-shot, citing the SPECIFIC rule + issue so the contributor knows
+    // exactly why. This is the FIRST disposition branch: it wins over an otherwise-mergeable verdict (a PR for
+    // an ineligible issue must never auto-merge) and fires REGARDLESS of `guardrailHit` (deterministic, not AI).
+    const reason = linkedIssueHardRule?.reason ?? "the linked issue is not eligible for a community PR";
+    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason, closeComment: closeMessage([reason]) });
+  } else if (canMerge) {
     actions.push({
       actionClass: "merge",
       requiresApproval: approval("merge"),

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -269,6 +269,62 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(classes(planAgentMaintenanceActions(input({ ...base, ciState: "failed" })))).not.toContain("merge");
     });
   });
+
+  describe("linked-issue hard-rule close (#linked-issue-hard-rules)", () => {
+    const violation = { violated: true, reason: "Linked issue #5 is labeled `maintainer-only` — it is not open for community PRs." };
+
+    it("closes a CONTRIBUTOR PR with the cited reason on a hard-rule violation", () => {
+      const close = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })).find((a) => a.actionClass === "close");
+      expect(close).toBeTruthy();
+      expect(close?.reason).toBe(violation.reason);
+      // the cited reason is surfaced in the close comment too
+      expect(close?.closeComment).toContain(violation.reason);
+    });
+
+    it("does NOT close the same violation on an OWNER PR (the isContributor guard)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", authorIsOwner: true, linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(plan).not.toContain("close");
+    });
+
+    it("does NOT close the same violation on an automation-bot PR", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", authorIsAutomationBot: true, linkedIssueHardRule: violation, pr: { labels: [] } })));
+      expect(plan).not.toContain("close");
+    });
+
+    it("plans no hard-rule close when there is no violation (a clean review-good PR merges instead)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", close: "auto" }, ciState: "passed", linkedIssueHardRule: { violated: false, reason: null }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean" } })));
+      expect(plan).toContain("merge");
+      expect(plan).not.toContain("close");
+    });
+
+    it("plans no hard-rule close when the field is absent entirely", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", close: "auto" }, ciState: "passed", autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean" } })));
+      expect(plan).toContain("merge");
+      expect(plan).not.toContain("close");
+    });
+
+    it("does NOT close when the close autonomy class is not acting (even with a violation)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "observe", label: "auto" }, ciState: "passed", linkedIssueHardRule: violation, pr: { labels: [] } })));
+      expect(plan).not.toContain("close");
+    });
+
+    it("CLOSES even on a GUARDED path (deterministic rule, not an AI verdict — no hold-crucial exemption)", () => {
+      // Unlike a gate reject, the linked-issue rule is deterministic, so it fires regardless of guardrailHit.
+      const guarded = { changedPaths: ["src/scoring/model.ts"], hardGuardrailGlobs: ["src/scoring/**"] };
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", ...guarded, linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(plan).toContain("close");
+    });
+
+    it("takes PRECEDENCE over an otherwise-mergeable verdict (never auto-merges a PR linking an ineligible issue)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", close: "auto", approve: "auto", label: "auto" }, ciState: "passed", autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).toContain("close");
+      expect(cls).not.toContain("merge");
+      expect(cls).not.toContain("approve");
+      // labeled changes-requested, not ready-to-merge
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
+    });
+  });
 });
 
 describe("isProtectedAutomationAuthor", () => {

--- a/test/unit/linked-issue-hard-rules.test.ts
+++ b/test/unit/linked-issue-hard-rules.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_LINKED_ISSUE_HARD_RULES,
+  evaluateLinkedIssueHardRules,
+  loadLinkedIssueHardRules,
+  type LinkedIssueFacts,
+  type LinkedIssueHardRulesConfig,
+} from "../../src/review/linked-issue-hard-rules";
+
+function config(overrides: Partial<LinkedIssueHardRulesConfig> = {}): LinkedIssueHardRulesConfig {
+  return {
+    ownerAssignedClose: "off",
+    missingPointLabelClose: "off",
+    maintainerOnlyLabelClose: "off",
+    pointBearingLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
+    maintainerOnlyLabels: ["maintainer-only"],
+    defaultLabelRepo: false,
+    ...overrides,
+  };
+}
+
+function issue(overrides: Partial<LinkedIssueFacts> & { number: number }): LinkedIssueFacts {
+  return { labels: [], assignees: [], state: "open", ...overrides };
+}
+
+const OWNER = "jsonbored";
+
+describe("evaluateLinkedIssueHardRules", () => {
+  it("returns no violation when every rule is off (even if every condition is met)", () => {
+    const result = evaluateLinkedIssueHardRules({
+      issues: [issue({ number: 1, assignees: ["jsonbored"], labels: ["maintainer-only"] })],
+      config: config({ defaultLabelRepo: true }),
+      repoOwner: OWNER,
+    });
+    expect(result).toEqual({ violated: false, reason: null });
+  });
+
+  describe("rule 1: owner-assigned", () => {
+    it("fires when the issue is assigned to the owner and the rule is block", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 7, assignees: ["jsonbored"] })],
+        config: config({ ownerAssignedClose: "block" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#7");
+      expect(result.reason).toContain("assigned to the maintainer (@jsonbored)");
+    });
+
+    it("matches the owner login case-insensitively", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 7, assignees: ["JSONbored"] })],
+        config: config({ ownerAssignedClose: "block" }),
+        repoOwner: "jsonbored",
+      });
+      expect(result.violated).toBe(true);
+    });
+
+    it("is silent when the rule is off", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 7, assignees: ["jsonbored"] })],
+        config: config({ ownerAssignedClose: "off" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("does not fire when the assignee is someone other than the owner", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 7, assignees: ["contributor-x"] })],
+        config: config({ ownerAssignedClose: "block" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+  });
+
+  describe("rule 2: missing point-label", () => {
+    it("fires only when defaultLabelRepo is true AND no point label is present", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 9, labels: ["docs"] })],
+        config: config({ missingPointLabelClose: "block", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#9");
+      expect(result.reason).toContain("no point-bearing label");
+    });
+
+    it("is silent when defaultLabelRepo is false (even with no point label)", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 9, labels: ["docs"] })],
+        config: config({ missingPointLabelClose: "block", defaultLabelRepo: false }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("is silent when a point label IS present", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 9, labels: ["gittensor:bug"] })],
+        config: config({ missingPointLabelClose: "block", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("matches point labels case-insensitively", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 9, labels: ["GitTensor:Feature"] })],
+        config: config({ missingPointLabelClose: "block", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("is silent when the rule is off", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 9, labels: ["docs"] })],
+        config: config({ missingPointLabelClose: "off", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+  });
+
+  describe("rule 3: maintainer-only label", () => {
+    it("fires when the issue carries the maintainer-only label and the rule is block", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 3, labels: ["maintainer-only"] })],
+        config: config({ maintainerOnlyLabelClose: "block" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#3");
+      expect(result.reason).toContain("maintainer-only");
+    });
+
+    it("matches the maintainer-only label case-insensitively", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 3, labels: ["Maintainer-Only"] })],
+        config: config({ maintainerOnlyLabelClose: "block" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+    });
+
+    it("is silent when the rule is off", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 3, labels: ["maintainer-only"] })],
+        config: config({ maintainerOnlyLabelClose: "off" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+  });
+
+  describe("issue state + multiple issues", () => {
+    it("ignores CLOSED issues even when they would otherwise violate", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 5, state: "closed", labels: ["maintainer-only"], assignees: ["jsonbored"] })],
+        config: config({ maintainerOnlyLabelClose: "block", ownerAssignedClose: "block" }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("returns the FIRST violation across multiple issues", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 10, labels: ["gittensor:bug"] }), issue({ number: 11, labels: ["maintainer-only"] })],
+        config: config({ maintainerOnlyLabelClose: "block", missingPointLabelClose: "block", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#11"); // first eligible issue is clean, second trips maintainer-only
+    });
+
+    it("skips a clean open issue and finds the violation on a later one", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 20, labels: ["gittensor:feature"] }), issue({ number: 21, assignees: ["jsonbored"] })],
+        config: config({ ownerAssignedClose: "block", missingPointLabelClose: "block", defaultLabelRepo: true }),
+        repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#21");
+    });
+  });
+});
+
+function envWith(get: (key: string, type: string) => Promise<unknown>): Env {
+  return { REVIEW_CONFIG: { get } } as unknown as Env;
+}
+
+describe("loadLinkedIssueHardRules", () => {
+  it("returns the all-off default when REVIEW_CONFIG is unbound", async () => {
+    expect(await loadLinkedIssueHardRules({} as Env, "JSONbored/gittensory")).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+  });
+
+  it("returns the all-off default when the key / field is absent", async () => {
+    expect(await loadLinkedIssueHardRules(envWith(async () => null), "o/r")).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+    expect(await loadLinkedIssueHardRules(envWith(async () => ({})), "o/r")).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+    expect(await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: null })), "o/r")).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+  });
+
+  it("returns the all-off default when the KV read THROWS (outage must never manufacture a close)", async () => {
+    const result = await loadLinkedIssueHardRules(
+      envWith(async () => {
+        throw new Error("kv down");
+      }),
+      "o/r",
+    );
+    expect(result).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+  });
+
+  it("reads the config keyed by the repo slug (owner stripped)", async () => {
+    const get = vi.fn().mockResolvedValue({
+      linkedIssueHardRules: {
+        ownerAssignedClose: "block",
+        missingPointLabelClose: "block",
+        maintainerOnlyLabelClose: "block",
+        pointBearingLabels: ["gittensor:bug"],
+        maintainerOnlyLabels: ["reserved"],
+        defaultLabelRepo: true,
+      },
+    });
+    const cfg = await loadLinkedIssueHardRules(envWith(get), "JSONbored/gittensory");
+    expect(get).toHaveBeenCalledWith("gittensory", "json");
+    expect(cfg).toEqual({
+      ownerAssignedClose: "block",
+      missingPointLabelClose: "block",
+      maintainerOnlyLabelClose: "block",
+      pointBearingLabels: ["gittensor:bug"],
+      maintainerOnlyLabels: ["reserved"],
+      defaultLabelRepo: true,
+    });
+  });
+
+  it("merges a PARTIAL config over the safe default (omitted fields keep their default)", async () => {
+    const cfg = await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { maintainerOnlyLabelClose: "block" } })), "o/r");
+    expect(cfg.maintainerOnlyLabelClose).toBe("block");
+    expect(cfg.ownerAssignedClose).toBe("off");
+    expect(cfg.missingPointLabelClose).toBe("off");
+    expect(cfg.defaultLabelRepo).toBe(false);
+    // an enabled rule with no listed labels falls back to the default gittensor label lists
+    expect(cfg.pointBearingLabels).toEqual(["gittensor:bug", "gittensor:feature", "gittensor:priority"]);
+    expect(cfg.maintainerOnlyLabels).toEqual(["maintainer-only"]);
+  });
+
+  it("ignores an invalid mode value and keeps the default for that field", async () => {
+    const cfg = await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { ownerAssignedClose: "yes" } })), "o/r");
+    expect(cfg.ownerAssignedClose).toBe("off");
+  });
+
+  it("uses the whole name as the slug when there is no owner prefix", async () => {
+    const get = vi.fn().mockResolvedValue({ linkedIssueHardRules: { ownerAssignedClose: "block" } });
+    await loadLinkedIssueHardRules(envWith(get), "soloname");
+    expect(get).toHaveBeenCalledWith("soloname", "json");
+  });
+});


### PR DESCRIPTION
## What

Adds a **config-driven, deterministic** linked-issue hard-rule auto-close to the PR-review agent. When a contributor PR links an **OPEN** issue that violates a hard rule, the bot one-shot **CLOSES** the PR, citing the **specific rule + the offending issue number** in the close comment.

### The three rules (per-repo, each `block` | `off`)

Loaded from the shared `REVIEW_CONFIG` KV under `linkedIssueHardRules` (key = repo slug, owner stripped — same convention as `loadHardGuardrailGlobs`). Close when ANY linked open issue trips a rule set to `block`:

1. **owner-assigned** — the issue is assigned to the repo owner (e.g. `jsonbored`). Reserved for the maintainer.
2. **missing point-label** — the repo is a default-label repo (`defaultLabelRepo: true`) **AND** the issue has **none** of the point-bearing labels (`gittensor:bug`, `gittensor:feature`, `gittensor:priority`). Not eligible for a scored contribution.
3. **maintainer-only** — the issue carries the `maintainer-only` label. Not open for community PRs.

The evaluator returns on the **first** violation, ignores **closed** issues, and matches owner/labels **case-insensitively**.

## Guard invariants

- **Never the owner / automation bots** — the close only fires for a contributor (the existing `isContributor` guard owns the exemption).
- **Fail-SAFE config** — an absent binding/key/field, a partial config, **or a thrown KV read** all resolve to the all-`off` default. A KV outage can never manufacture a close.
- **Fail-OPEN fetch** — any linked-issue fetch error skips that issue; a review is never blocked on a fetch failure.
- **Deterministic, not an AI verdict** — because there is no hallucination risk, this close fires **regardless of a hard-guardrail path hit** (unlike a gate reject, which is held on guarded paths) and takes **precedence over an otherwise-mergeable verdict** (a PR linking an ineligible issue must never auto-merge).
- **No extra API calls on the common path** — the trigger skips the linked-issue fetch entirely when no rule is `block` or the PR links no issues.

## How the cited reason surfaces

The planner carries the cited reason as the close action's `reason` (audit record + Discord action summary) **and** wraps it in the templated `closeComment` via the existing `closeMessage()`, so it appears in the close comment posted to the PR.

## Files

- `src/review/linked-issue-hard-rules.ts` (new) — config type, fail-safe KV loader, pure evaluator.
- `src/github/backfill.ts` — `fetchLinkedIssueFacts` (fail-open REST fetch of labels/assignees/state).
- `src/queue/processors.ts` — wired into `maybeRunAgentMaintenance` (conditional fetch + evaluate, passed to the planner).
- `src/settings/agent-actions.ts` — new `linkedIssueHardRule` input + the deterministic close branch.
- `test/unit/linked-issue-hard-rules.test.ts` (new) + `test/unit/agent-actions.test.ts` (extended).

## Verification

- `npx tsc --noEmit` clean.
- Full `npx vitest run`: **3533 passed**, 1 skipped (pre-existing contract test).

**Do not merge — for human review.**