### PR TITLE
fix(signals): reuse canonical isTestPath in open-PR monitor

### DIFF
--- a/src/signals/contributor-open-pr-monitor.ts
+++ b/src/signals/contributor-open-pr-monitor.ts
@@ -10,6 +10,7 @@ import {
 import type { CheckSummaryRecord, PullRequestFileRecord, PullRequestRecord, PullRequestReviewRecord } from "../types";
 import { nowIso } from "../utils/json";
 import { buildRoleContext } from "./engine";
+import { isTestPath } from "./test-evidence";
 
 export type OpenPrWorkClassification =
   | "approved"
@@ -253,14 +254,6 @@ function missingTestsFromFiles(files: PullRequestFileRecord[]): boolean {
   const codeFiles = files.filter((file) => file.path && !isTestPath(file.path));
   const testFiles = files.filter((file) => file.path && isTestPath(file.path));
   return codeFiles.length > 0 && testFiles.length === 0;
-}
-
-function isTestPath(path: string): boolean {
-  return (
-    /(^|\/)(test|tests|spec|__tests__)\//i.test(path) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|go|rs)$/i.test(path) ||
-    /(^|\/)[^/]+_test\.go$/i.test(path)
-  );
 }
 
 function priorityRank(classification: OpenPrWorkClassification): number {

--- a/test/unit/contributor-open-pr-monitor.test.ts
+++ b/test/unit/contributor-open-pr-monitor.test.ts
@@ -261,6 +261,10 @@ describe("contributor open PR monitor", () => {
     expect(missingTestsFromFiles([{ path: "pkg/foo_test.go" } as never])).toBe(false);
     expect(missingTestsFromFiles([{ path: "pkg/foo.go" } as never])).toBe(true);
     expect(missingTestsFromFiles([{ path: "tests/integration.spec.ts" } as never])).toBe(false);
+    // Python/Ruby test conventions must count as test evidence, matching the canonical isTestPath.
+    expect(missingTestsFromFiles([{ path: "pkg/foo.py" } as never, { path: "pkg/foo_test.py" } as never])).toBe(false);
+    expect(missingTestsFromFiles([{ path: "app/user.rb" } as never, { path: "app/user_test.rb" } as never])).toBe(false);
+    expect(missingTestsFromFiles([{ path: "app/user.rb" } as never, { path: "app/user_spec.rb" } as never])).toBe(false);
   });
 
   it("returns an empty monitor when the contributor has no cached open PRs", async () => {


### PR DESCRIPTION
## Summary

`missingTestsFromFiles` in the contributor open-PR monitor classified changed files with a **local** `isTestPath` that only recognized Go tests (`_test.go`). PRs whose test evidence was `*_test.py`, `*_test.rb`, or `*_spec.rb` were therefore treated as shipping no tests and mislabeled `missing_tests`.

The repo already exports a canonical `isTestPath` from `src/signals/test-evidence.ts` (handling `_test.(go|py|rb)` and `_spec.rb`) that every other signal surface uses. This PR deletes the divergent local copy and imports the canonical helper, so Python/Ruby test conventions count as test evidence.

```ts
// before — local copy, Go-only non-JS/TS branch
/(^|\/)[^/]+_test\.go$/i.test(path)
// after — canonical helper: _test.(go|py|rb), _spec.rb, src/test/, .test|.spec.*
import { isTestPath } from "./test-evidence";
```

Closes #1117

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unit suite green: 3492 passing; the only added coverable source line is the import, exercised by the monitor tests)
- [x] New behavior has unit tests: added `_test.py`, `_test.rb`, `_spec.rb` assertions to the open-PR monitor file-heuristics test

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.

## Notes

Pure refactor toward the existing canonical helper — no new public surface, no UI changes.
