### PR TITLE
fix: resume fork PRs on CI completion (head-SHA fallback)

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2053,6 +2053,29 @@ export async function fetchLivePullRequestMergeState(env: Env, repoFullName: str
   return result?.data.mergeable_state ?? undefined;
 }
 
+/** Resolve the OPEN PRs associated with a commit SHA via the REST `GET /repos/{owner}/{repo}/commits/{sha}/pulls`
+ *  endpoint. This is the only PR↔commit resolution that works for FORK (cross-repo) PRs, whose CI-completion
+ *  webhooks (`check_suite`/`check_run`) carry an EMPTY `pull_requests[]`. Returns the de-duplicated open PR numbers.
+ *  Best-effort: an empty/whitespace SHA or any API error yields `[]` (the caller must never stall a PR on a hiccup). */
+export async function fetchOpenPullRequestNumbersForCommit(env: Env, repoFullName: string, commitSha: string, token: string | undefined): Promise<number[]> {
+  const sha = commitSha.trim();
+  if (!sha) return [];
+  // GET /commits/{sha}/pulls returns the PRs (incl. cross-repo forks) whose head is this commit, on the default
+  // `application/vnd.github+json` accept that githubRestHeaders already sends.
+  const result = await githubJsonWithHeaders<Array<{ number?: number | null; state?: string | null }>>(
+    env,
+    repoFullName,
+    `/commits/${encodeURIComponent(sha)}/pulls?per_page=100`,
+    token,
+  ).catch(() => undefined);
+  if (!result) return [];
+  const numbers = result.data
+    .filter((pr) => pr?.state === "open")
+    .map((pr) => pr?.number)
+    .filter((value): value is number => typeof value === "number");
+  return [...new Set(numbers)];
+}
+
 /** RC1 (idempotent reviews): the PR's LIVE reviewDecision (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED) via
  *  GraphQL. The STORED reviewDecision is only written by the open-PR backfill and goes stale, so the action
  *  planner's approve/request-changes dedup was blind and re-posted a review every cycle — the re-review loop.

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -68,6 +68,7 @@ import {
   fetchLiveCiAggregate,
   fetchLivePullRequestMergeState,
   fetchLivePullRequestReviewDecision,
+  fetchOpenPullRequestNumbersForCommit,
   fetchRequiredStatusContexts,
   refreshContributorActivity,
   refreshInstallationHealth,
@@ -824,12 +825,58 @@ async function ciReReviewCoalesced(env: Env, repoFullName: string, prNumber: num
   }
 }
 
+/** Read the CI head SHA off a `check_suite`/`check_run` `completed` payload (the event node carries `head_sha`;
+ *  `check_run` also nests it under `check_suite.head_sha`). Returns "" when absent. The payload type doesn't model
+ *  these events, so we narrow off `Record<string, unknown>` the same way the `pull_requests[]` read does. */
+export function ciCompletionHeadSha(eventName: string, payload: GitHubWebhookPayload): string {
+  const node = (payload as Record<string, unknown>)[eventName] as { head_sha?: string | null; check_suite?: { head_sha?: string | null } | null } | undefined;
+  return (node?.head_sha ?? node?.check_suite?.head_sha ?? "").trim();
+}
+
+/**
+ * Resolve the OPEN PR number(s) a CI-completion event applies to. SAME-REPO PRs carry them in
+ * `payload[event].pull_requests[]` (reviewbot core/scope.ts parity) — that path is authoritative and tried FIRST.
+ * FORK (cross-repo) PRs get an EMPTY `pull_requests[]` from GitHub, so when that's empty we fall back to resolving
+ * by the CI head SHA: a fast STORED-DB lookup first (open `pull_requests` rows whose `headSha` matches), then the
+ * live GitHub `GET /commits/{sha}/pulls` (works for forks). Returns `{ numbers, viaHeadShaFallback }` so the caller
+ * can audit the fork-resume path. Fully FAIL-OPEN: any lookup error degrades to whatever was found so far / [].
+ */
+export async function resolveCiCompletionPrNumbers(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  populatedPrNumbers: number[],
+  headSha: string,
+): Promise<{ numbers: number[]; viaHeadShaFallback: boolean }> {
+  if (populatedPrNumbers.length > 0) return { numbers: populatedPrNumbers, viaHeadShaFallback: false };
+  if (!headSha) return { numbers: [], viaHeadShaFallback: false };
+  const resolved = new Set<number>();
+  // 1) Fast path: a stored open PR row whose head SHA matches the completed CI (no GitHub round-trip).
+  try {
+    const open = await listOpenPullRequests(env, repoFullName);
+    for (const pr of open) if (pr.headSha === headSha) resolved.add(pr.number);
+  } catch {
+    // fail-open: fall through to the live API
+  }
+  // 2) Fork fallback: GitHub's commit→PRs association, the only resolution that works for cross-repo PRs.
+  if (resolved.size === 0) {
+    const token = (await createInstallationToken(env, installationId).catch(() => undefined)) ?? env.GITHUB_PUBLIC_TOKEN;
+    if (token) {
+      const apiNumbers = await fetchOpenPullRequestNumbersForCommit(env, repoFullName, headSha, token).catch(() => []);
+      for (const number of apiNumbers) resolved.add(number);
+    }
+  }
+  return { numbers: [...resolved], viaHeadShaFallback: resolved.size > 0 };
+}
+
 /**
  * THE auto-merge / close-on-red TRIGGER. A `check_run`/`check_suite` `completed` event means a PR's CI just
  * settled — re-review the associated PR(s) so the now-green PR is merged and the now-red PR is closed (non-owner)
  * / held (owner). Without this, a PR reviewed at open-time (CI still pending → deferred) is never re-evaluated.
- * Resolves the PR number(s) from `payload[event].pull_requests[]` (reviewbot core/scope.ts parity), NOT from
- * the CI head SHA. COALESCED so one CI run's ~20 completions collapse to one re-review. Returns true (handled).
+ * SAME-REPO PRs are resolved from `payload[event].pull_requests[]` (reviewbot core/scope.ts parity). FORK PRs get
+ * an EMPTY `pull_requests[]` from GitHub, so they're resolved by the CI head SHA (stored DB → live commits/pulls)
+ * — without this fork PRs deferred at open-time never get their required gate posted and are BLOCKED forever.
+ * COALESCED so one CI run's ~20 completions collapse to one re-review. Returns true (handled).
  */
 async function maybeReReviewOnCiCompletion(env: Env, deliveryId: string, eventName: string, payload: GitHubWebhookPayload): Promise<boolean> {
   if (eventName !== "check_run" && eventName !== "check_suite") return false;
@@ -838,8 +885,22 @@ async function maybeReReviewOnCiCompletion(env: Env, deliveryId: string, eventNa
   const installationId = getInstallationId(payload);
   if (!repoFullName || !installationId) return false;
   const node = (payload as Record<string, unknown>)[eventName] as { pull_requests?: Array<{ number?: number | null }> } | undefined;
-  const prNumbers = [...new Set((node?.pull_requests ?? []).map((entry) => entry?.number).filter((value): value is number => typeof value === "number"))];
-  if (prNumbers.length > 0 && isConvergenceRepoAllowed(env, repoFullName)) {
+  const populatedPrNumbers = [...new Set((node?.pull_requests ?? []).map((entry) => entry?.number).filter((value): value is number => typeof value === "number"))];
+  if (isConvergenceRepoAllowed(env, repoFullName)) {
+    const { numbers: prNumbers, viaHeadShaFallback } = await resolveCiCompletionPrNumbers(env, installationId, repoFullName, populatedPrNumbers, ciCompletionHeadSha(eventName, payload)).catch(() => ({
+      numbers: populatedPrNumbers,
+      viaHeadShaFallback: false,
+    }));
+    if (viaHeadShaFallback && prNumbers.length > 0) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.ci_completion_fork_resume",
+        actor: "gittensory",
+        targetKey: `${repoFullName}#${prNumbers.join(",")}`,
+        outcome: "queued",
+        detail: "resumed fork PR via head-SHA fallback (empty check pull_requests[])",
+        metadata: { deliveryId, repoFullName, eventName, prNumbers },
+      }).catch(() => undefined);
+    }
     for (const prNumber of prNumbers) {
       // Coalesce the CI-completion storm: skip if this PR was re-reviewed within the window.
       if (await ciReReviewCoalesced(env, repoFullName, prNumber)) continue;

--- a/test/unit/ci-completion-fork-resume.test.ts
+++ b/test/unit/ci-completion-fork-resume.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ciCompletionHeadSha, processJob, resolveCiCompletionPrNumbers } from "../../src/queue/processors";
+import { upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, upsertRepositorySettings } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+import type { GitHubWebhookPayload, JobMessage } from "../../src/types";
+
+// The CI-completion re-review trigger (maybeReReviewOnCiCompletion) strands FORK PRs forever: GitHub leaves
+// check_suite/check_run `pull_requests[]` EMPTY for cross-repo PRs, so the only resolution that works is by the
+// CI head SHA. These tests pin the head-SHA resolver (the fix) + its fork-resume audit on the dispatch path.
+
+const FORK_SHA = "deadbeefcafe1234deadbeefcafe1234deadbeef";
+
+function checkSuitePayload(opts: { repo: string; installationId: number; headSha?: string; prNumbers?: number[] }): GitHubWebhookPayload {
+  const [owner, name] = opts.repo.split("/");
+  return {
+    action: "completed",
+    installation: { id: opts.installationId },
+    repository: { name: name ?? "", full_name: opts.repo, owner: { login: owner } },
+    // The payload type doesn't model check_suite; the dispatcher narrows it off Record<string, unknown>.
+    ...({
+      check_suite: {
+        head_sha: opts.headSha,
+        pull_requests: (opts.prNumbers ?? []).map((number) => ({ number })),
+      },
+    } as unknown as Partial<GitHubWebhookPayload>),
+  } as GitHubWebhookPayload;
+}
+
+async function seedForkResumeRepo(env: ReturnType<typeof createTestEnv>, repo: string, prNumber: number, headSha: string): Promise<void> {
+  const [owner] = repo.split("/");
+  await upsertRepositoryFromGitHub(env, { name: repo.split("/")[1] ?? "repo", full_name: repo, private: false, owner: { login: owner ?? "owner" } }, 5001);
+  // publicSurface/check/gate all OFF + no autonomy → reReviewStoredPullRequest is a clean no-op (no network),
+  // so the test isolates resolution + coalesce + audit, exactly the head-SHA fix surface.
+  await upsertRepositorySettings(env, { repoFullName: repo, publicSurface: "off", checkRunMode: "off", gateCheckMode: "off", autonomy: {} });
+  await upsertPullRequestFromGitHub(env, repo, { number: prNumber, title: "Fork PR", state: "open", user: { login: "outside-contributor" }, head: { sha: headSha }, labels: [], body: "fork change" });
+}
+
+describe("CI-completion fork PR resume (head-SHA fallback)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("ciCompletionHeadSha reads head_sha from check_suite and the nested check_run.check_suite", () => {
+    expect(ciCompletionHeadSha("check_suite", { check_suite: { head_sha: " abc " } } as unknown as GitHubWebhookPayload)).toBe("abc");
+    expect(ciCompletionHeadSha("check_run", { check_run: { head_sha: "xyz" } } as unknown as GitHubWebhookPayload)).toBe("xyz");
+    expect(ciCompletionHeadSha("check_run", { check_run: { check_suite: { head_sha: "nested" } } } as unknown as GitHubWebhookPayload)).toBe("nested");
+    expect(ciCompletionHeadSha("check_suite", {} as GitHubWebhookPayload)).toBe("");
+  });
+
+  it("(a) same-repo: populated pull_requests[] is returned verbatim, no head-SHA fallback", async () => {
+    const env = createTestEnv({});
+    // A throwing fetch proves the populated path never touches GitHub.
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("fetch must not be called for the same-repo populated path");
+    });
+    // The dispatcher de-dups before calling; the resolver returns the already-deduped same-repo set verbatim.
+    const result = await resolveCiCompletionPrNumbers(env, 5001, "JSONbored/gittensory", [42, 7], FORK_SHA);
+    expect(result).toEqual({ numbers: [42, 7], viaHeadShaFallback: false });
+  });
+
+  it("(b) fork: empty pull_requests[] → a stored open PR matching the head SHA is resolved (DB fast path)", async () => {
+    const env = createTestEnv({});
+    await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
+    // A throwing fetch proves the DB fast path resolves without the live commits/pulls call.
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("fetch must not be called when the stored DB row matches");
+    });
+    const result = await resolveCiCompletionPrNumbers(env, 5001, "JSONbored/gittensory", [], FORK_SHA);
+    expect(result).toEqual({ numbers: [99], viaHeadShaFallback: true });
+  });
+
+  it("(b2) fork: no stored row → falls back to GET /commits/{sha}/pulls (open only)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      calls.push(url);
+      if (url.includes(`/commits/${FORK_SHA}/pulls`)) {
+        return Response.json([
+          { number: 12, state: "open" },
+          { number: 13, state: "closed" },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const result = await resolveCiCompletionPrNumbers(env, 5001, "JSONbored/gittensory", [], FORK_SHA);
+    // Only the OPEN PR resolves; the closed one is dropped.
+    expect(result).toEqual({ numbers: [12], viaHeadShaFallback: true });
+    expect(calls.some((url) => url.includes(`/commits/${FORK_SHA}/pulls`))).toBe(true);
+  });
+
+  it("(c) no head-SHA match anywhere → empty, no throw", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async () => Response.json([])); // commits/pulls returns nothing
+    const result = await resolveCiCompletionPrNumbers(env, 5001, "JSONbored/gittensory", [], FORK_SHA);
+    expect(result).toEqual({ numbers: [], viaHeadShaFallback: false });
+  });
+
+  it("(c2) empty head SHA short-circuits to empty without any lookup", async () => {
+    const env = createTestEnv({});
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("fetch must not be called for an empty head SHA");
+    });
+    const result = await resolveCiCompletionPrNumbers(env, 5001, "JSONbored/gittensory", [], "");
+    expect(result).toEqual({ numbers: [], viaHeadShaFallback: false });
+  });
+
+  it("dispatch: a FORK check_suite (empty pull_requests[], matching head SHA) resumes the PR + audits the fallback", async () => {
+    const sent: JobMessage[] = [];
+    const env = createTestEnv({
+      JOBS: { async send(message: JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "fork-delivery-1",
+      eventName: "check_suite",
+      payload: checkSuitePayload({ repo: "JSONbored/gittensory", installationId: 5001, headSha: FORK_SHA, prNumbers: [] }),
+    });
+
+    const audit = await env.DB.prepare("select outcome, detail, target_key, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.ci_completion_fork_resume")
+      .first<{ outcome: string; detail: string; target_key: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("queued");
+    expect(audit?.detail).toMatch(/resumed fork PR via head-SHA fallback/i);
+    expect(audit?.target_key).toBe("JSONbored/gittensory#99");
+    expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ prNumbers: [99], eventName: "check_suite" });
+    // The CI-completion handler always records the webhook event as processed.
+    const webhook = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("fork-delivery-1").first<{ status: string }>();
+    expect(webhook?.status).toBe("processed");
+  });
+
+  it("dispatch: a SAME-REPO check_suite (populated pull_requests[]) re-reviews WITHOUT the fork-resume audit", async () => {
+    const env = createTestEnv({});
+    await seedForkResumeRepo(env, "JSONbored/gittensory", 99, FORK_SHA);
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("fetch must not be called for the populated same-repo path");
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "same-repo-delivery-1",
+      eventName: "check_suite",
+      payload: checkSuitePayload({ repo: "JSONbored/gittensory", installationId: 5001, headSha: FORK_SHA, prNumbers: [99] }),
+    });
+
+    const forkAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+      .bind("github_app.ci_completion_fork_resume")
+      .first<{ n: number }>();
+    expect(forkAudit?.n).toBe(0);
+    const webhook = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("same-repo-delivery-1").first<{ status: string }>();
+    expect(webhook?.status).toBe("processed");
+  });
+
+  it("dispatch: a head SHA that matches nothing is a no-op (no fork audit, no throw, webhook recorded)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 5001);
+    vi.stubGlobal("fetch", async () => Response.json([])); // commits/pulls finds nothing
+
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "no-match-delivery-1",
+        eventName: "check_suite",
+        payload: checkSuitePayload({ repo: "JSONbored/gittensory", installationId: 5001, headSha: "0000000000000000000000000000000000000000", prNumbers: [] }),
+      }),
+    ).resolves.toBeUndefined();
+
+    const forkAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+      .bind("github_app.ci_completion_fork_resume")
+      .first<{ n: number }>();
+    expect(forkAudit?.n).toBe(0);
+    const webhook = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("no-match-delivery-1").first<{ status: string }>();
+    expect(webhook?.status).toBe("processed");
+  });
+});


### PR DESCRIPTION
Fork PRs were getting stranded: `maybeReReviewOnCiCompletion` resolved the PR only from the `check_suite`/`check_run` payload `pull_requests[]`, which GitHub leaves **empty for fork (cross-repo) PRs**. So a fork PR deferred at open-time (CI still running) was never re-reviewed when CI finished → the required **Gittensory Gate** check was never posted → `BLOCKED` forever (operator merged by hand).

**Fix:** when `pull_requests[]` is empty, resolve the open PR(s) by the check **head SHA** — DB-first (`listOpenPullRequests` filtered on `headSha`), then `GET /commits/{sha}/pulls` fallback — and re-review with the existing coalescing. Same-repo path unchanged; fully fail-open; emits a `github_app.ci_completion_fork_resume` audit event. 9 new tests, full suite green (3542).