### PR TITLE
fix(mcp): classify supported-but-outdated clients as stale

### DIFF
--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -59,6 +59,9 @@ export function classifyMcpClientVersion(version: string | null | undefined): Mc
   const minimumComparison = compareMcpSemver(version, MINIMUM_SUPPORTED_MCP_VERSION);
   if (minimumComparison === null) return "unknown";
   if (minimumComparison < 0) return "incompatible";
+  // Supported but behind the latest recommended version → stale (an upgrade nudge, not a break).
+  const recommendedComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION);
+  if (recommendedComparison !== null && recommendedComparison < 0) return "stale";
   return "current";
 }
 

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -8,7 +8,12 @@ describe("MCP compatibility telemetry", () => {
     expect(classifyMcpClientVersion("0.2.1")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.3.0")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.4.0")).toBe("incompatible");
-    expect(classifyMcpClientVersion("0.5.0")).toBe("current");
+    // Supported (>= 0.5.0 minimum) but behind the 0.6.0 recommended version → stale.
+    expect(classifyMcpClientVersion("0.5.0")).toBe("stale");
+    expect(classifyMcpClientVersion("0.5.9")).toBe("stale");
+    // At or above the recommended version → current.
+    expect(classifyMcpClientVersion("0.6.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.7.1")).toBe("current");
     expect(classifyMcpClientVersion("not-a-version")).toBe("unknown");
     expect(classifyMcpClientVersion(undefined)).toBe("unknown");
   });
@@ -50,7 +55,8 @@ describe("MCP compatibility telemetry", () => {
       clientVersion: "0.5.0",
       metadata: {
         packageName: "@example/custom-mcp",
-        compatibilityStatus: "current",
+        // 0.5.0 is the supported minimum but behind 0.6.0 recommended → stale.
+        compatibilityStatus: "stale",
       },
     });
   });

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -57,7 +57,8 @@ describe("MCP server telemetry", () => {
         clientVersion: "0.5.0",
         metadata: expect.objectContaining({
           toolName: "gittensory_local_status",
-          compatibilityStatus: "current",
+          // 0.5.0 is the supported minimum but behind 0.6.0 recommended → stale.
+          compatibilityStatus: "stale",
         }),
       }),
     ]);


### PR DESCRIPTION
## Summary

`classifyMcpClientVersion` only compared the client version against `MINIMUM_SUPPORTED_MCP_VERSION` (`0.5.0`), returning `"current"` for everything at or above it. It never compared against `LATEST_RECOMMENDED_MCP_VERSION` (`0.6.0`), so the `"stale"` status was unreachable: `staleEvents` (aggregated in `getMcpCompatibilityAdoption`) was permanently `0`, and the operator-dashboard "MCP stale clients" metric (`staleEvents + incompatibleEvents`) was blind to a fleet sitting on the minimum while `0.6.0` is recommended.

This adds the missing comparison: supported (>= minimum) but behind the recommended version → `"stale"`.

```ts
if (minimumComparison < 0) return "incompatible";
// new: supported but behind recommended → stale (upgrade nudge, not a break)
const recommendedComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION);
if (recommendedComparison !== null && recommendedComparison < 0) return "stale";
return "current";
```

Closes #1120

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — the single added source line (`return "stale"` path) is covered by new unit assertions; targeted suites green. (The one failing test in a full-suite run, `mcp-cli-packets > stale decision-pack cache`, is a pre-existing time-dependent flake unrelated to this diff — it passes in isolation and touches none of the changed files.)
- [x] Updated the three existing assertions that encoded the bug (`0.5.0` → now `"stale"` in `mcp-compatibility.test.ts`, `mcp-server-telemetry.test.ts`) and added `0.5.9`/`0.6.0`/`0.7.1` boundary coverage.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] API/MCP behavior is updated and tested: the classifier now emits `"stale"`, which flows through telemetry storage and the adoption aggregation.

## Notes

`"stale"` is intentionally distinct from `"incompatible"` — it is an upgrade nudge for a still-supported client, not a break. Behavior at/above `0.6.0` and below `0.5.0` is unchanged.
