### PR TITLE
fix(ai-review): keep advisory nits markdown-only

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -353,11 +353,10 @@ export function composeAdvisoryNotes(reviews: ModelReview[]): string | null {
     lines.push("");
   }
   if (safeNits.length > 0) {
-    // Nits go inside a collapsed <details> toggle so the body stays focused on the assessment + blockers;
-    // the blank line after </summary> lets GitHub render the markdown list inside the dropdown. (#focused-reviews)
-    lines.push("<details>", `<summary>Nits (${safeNits.length})</summary>`, "");
+    // Keep advisory notes markdown-only: downstream public comment renderers escape angle brackets
+    // in this blob, so raw HTML would render as literal tags instead of GitHub UI. (#focused-reviews)
+    lines.push(`**Nits (${safeNits.length})**`);
     lines.push(...safeNits.map((s) => `- ${s}`));
-    lines.push("</details>");
   }
   // Reaching here means at least one section was pushed (the all-empty case returned null above).
   return lines.join("\n").trim();

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -332,11 +332,12 @@ describe("pure helpers", () => {
     const assessmentOnly = composeAdvisoryNotes([review({ assessment: "Looks good." })]);
     expect(assessmentOnly).toBe("Looks good.");
     const nitsOnly = composeAdvisoryNotes([review({ nits: ["Add a test."] })]);
-    expect(nitsOnly).toContain("<summary>Nits");
+    expect(nitsOnly).toContain("**Nits (1)**");
+    expect(nitsOnly).not.toContain("<details>");
     expect(nitsOnly).not.toContain("**Blockers**");
     const blockersOnly = composeAdvisoryNotes([review({ blockers: ["Null deref in src/a.ts."] })]);
     expect(blockersOnly).toContain("**Blockers**");
-    expect(blockersOnly).not.toContain("<summary>Nits");
+    expect(blockersOnly).not.toContain("**Nits");
   });
 
   it("composeAdvisoryNotes merges + dedupes blockers/nits across two reviewers and renders both sections", () => {
@@ -346,7 +347,8 @@ describe("pure helpers", () => {
     expect(out).toContain("Solid change."); // first reviewer's assessment wins
     expect(out).toContain("**Blockers**");
     expect(out).toContain("Off-by-one in the loop bound.");
-    expect(out).toContain("<summary>Nits");
+    expect(out).toContain("**Nits (3)**");
+    expect(out).not.toContain("<details>");
     expect(out).toContain("Tighten the type."); // nits + suggestions merged
     // the shared blocker + the shared nit/suggestion each appear exactly once (dedupe across reviewers)
     expect(out.match(/Null deref in src\/a\.ts\./g)?.length).toBe(1);


### PR DESCRIPTION
### Motivation
- A recent change injected raw `<details>/<summary>` HTML into the advisory `aiReview.notes`, but downstream public renderers escape angle brackets, causing the collapsible nits UI to render as literal `&lt;details&gt;`/`&lt;summary&gt;` text instead of a GitHub details block.
- This is a formatting regression (non-security) that degrades the public comment UX and needs a minimal, conservative fix at the notes composition layer.

### Description
- Stop emitting raw HTML for nits in `composeAdvisoryNotes` and render a markdown-only heading `**Nits (N)**` followed by bullet lines instead of wrapping them in `<details>`/`<summary>`.
- Update unit tests in `test/unit/ai-review.test.ts` to assert the new `**Nits (N)**` heading and to explicitly check that no `<details>`/`<summary>` markup appears.
- Files modified: `src/services/ai-review.ts` and `test/unit/ai-review.test.ts`.

### Testing
- Ran `npx vitest run test/unit/ai-review.test.ts`, which completed and all tests in that file passed.
- Ran `npm run typecheck` (`tsc --noEmit`), which succeeded with no type errors.
- An initial invocation of the broader unit suite (`npm run test:unit`) ran unrelated long-running queue tests and showed failures/timeouts not caused by this focused change; the targeted test run above was used to validate the actual fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae3d090d0832c9961f4d647d7d5fc)