### PR TITLE
fix(rag): align retrieval quality knobs with reviewbot — minScore 0.4 + bm25 rerank + title-led query (#GAP-2)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1719,6 +1719,7 @@ export async function runAiReviewForAdvisory(
     const ragContext = isRagEnabled(env) && convergedRepoAllowed
       ? await buildReviewRagContext(env, {
           repoFullName: args.repoFullName,
+          title: args.pr.title,
           files: files.map((file) => ({ path: file.path, patch: typeof file.payload?.patch === "string" ? file.payload.patch : undefined })),
         })
       : undefined;

--- a/src/review/rag-wire.ts
+++ b/src/review/rag-wire.ts
@@ -39,17 +39,28 @@ const MAX_QUERY_PATHS = 40;
 const MAX_QUERY_DIFF_CHARS = 4000;
 /** Default neighbours retrieved per review (rag.ts hard-caps at RAG_MAX_TOPK regardless). */
 const RAG_TOP_K = 12;
+/** Relevance floor for the cosine matches — drops low-relevance "neighbours" that are noise, not real context
+ *  (bge-m3 scores relevant code ~0.5-0.7 and clear noise <0.35; 0.4 is a conservative floor). Matches reviewbot's
+ *  core config (`rag: { minScore: 0.4 }`); gittensory previously used 0 (off), which kept that noise as
+ *  "relevant code" and itself drove false positives. (#GAP-2) */
+const RAG_MIN_SCORE = 0.4;
+/** Rerank the cosine top-K by exact-term overlap before injecting, to demote vector-accident matches (high
+ *  cosine, no real term overlap). Matches reviewbot's core config (`rag: { reranker: "bm25" }`); gittensory
+ *  previously left this off. (#283 / #GAP-2) */
+const RAG_RERANKER = "bm25" as const;
 
 /** The subset of a PR file record the query builder reads (filename + the patch text when present). */
 export type RagQueryFile = { path: string; patch?: string | undefined };
 
 /**
- * Compose the retrieval QUERY TEXT from the PR's changed files. We embed the changed PATHS plus a bounded slice
- * of the diff so the vector query finds code semantically near WHAT CHANGED (callers/related modules), not just
- * the PR title. The changed paths are ALSO returned as `excludePaths` so retrieval never echoes a file that is
- * itself part of the diff (that's already in the prompt). Returns "" when there's nothing to query on.
+ * Compose the retrieval QUERY TEXT from the PR's TITLE + changed files. We PREPEND the PR title (intent in natural
+ * language — recall parity with reviewbot, whose query is `${title}\n${diff}`), then embed the changed PATHS plus a
+ * bounded slice of the diff so the vector query finds code semantically near both WHY the PR exists and WHAT
+ * CHANGED (callers/related modules). The changed paths are ALSO returned as `excludePaths` so retrieval never
+ * echoes a file that is itself part of the diff (that's already in the prompt). Returns "" when there's nothing to
+ * query on (no files).
  */
-export function buildRagQuery(files: RagQueryFile[]): { queryText: string; excludePaths: string[] } {
+export function buildRagQuery(files: RagQueryFile[], title?: string): { queryText: string; excludePaths: string[] } {
   const paths = files.map((f) => f.path).filter(Boolean);
   const excludePaths = [...new Set(paths)];
   if (excludePaths.length === 0) return { queryText: "", excludePaths };
@@ -62,7 +73,9 @@ export function buildRagQuery(files: RagQueryFile[]): { queryText: string; exclu
     const patch = typeof file.patch === "string" ? file.patch : "";
     if (patch) diffSample += `${patch}\n`;
   }
-  const queryText = `Changed files:\n${pathList}\n\n${diffSample}`.slice(0, MAX_QUERY_DIFF_CHARS + 2000).trim();
+  // Prepend the PR title so the embedder sees the change's intent in plain language (recall parity with reviewbot).
+  const titleLine = typeof title === "string" && title.trim() ? `${title.trim()}\n\n` : "";
+  const queryText = `${titleLine}Changed files:\n${pathList}\n\n${diffSample}`.slice(0, MAX_QUERY_DIFF_CHARS + 2000).trim();
   return { queryText, excludePaths };
 }
 
@@ -78,22 +91,26 @@ export function buildRagQuery(files: RagQueryFile[]): { queryText: string; exclu
  */
 export async function buildReviewRagContext(
   env: Env,
-  args: { repoFullName: string; files: RagQueryFile[]; reranker?: "off" | "bm25" },
+  args: { repoFullName: string; files: RagQueryFile[]; title?: string; reranker?: "off" | "bm25" },
 ): Promise<string> {
   try {
-    const { queryText, excludePaths } = buildRagQuery(args.files);
+    const { queryText, excludePaths } = buildRagQuery(args.files, args.title);
     if (!queryText) return "";
     const infra = createReviewAdapters(env);
     // No vector index or no AI binding → the adapters omit the member and retrieveContext returns "" (no RAG).
     if (!infra.vector || !infra.inference) return "";
     const [project, repo] = splitRepo(args.repoFullName);
+    // Quality knobs match reviewbot's core config: drop low-relevance cosine matches (minScore) and BM25-rerank the
+    // survivors (reranker) so only genuinely-related code reaches the prompt — low-relevance "neighbours" are noise
+    // that themselves cause false positives. A caller-supplied reranker still wins (e.g. to force "off"). (#GAP-2)
     return await retrieveContext(infra, {
       project,
       repo,
       queryText,
       topK: RAG_TOP_K,
       excludePaths,
-      ...(args.reranker ? { reranker: args.reranker } : {}),
+      minScore: RAG_MIN_SCORE,
+      reranker: args.reranker ?? RAG_RERANKER,
     });
   } catch {
     return ""; // any error → review proceeds on the diff alone (fail-safe)

--- a/test/unit/rag-wiring.test.ts
+++ b/test/unit/rag-wiring.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runGittensoryAiReview } from "../../src/services/ai-review";
 import { runAiReviewForAdvisory } from "../../src/queue/processors";
+import * as ragModule from "../../src/review/rag";
 import { RAG_DIMENSIONS } from "../../src/review/rag";
 import { buildRagQuery, buildReviewRagContext, isRagEnabled, populateRepoIndexStub } from "../../src/review/rag-wire";
 import { createTestEnv } from "../helpers/d1";
@@ -92,8 +93,23 @@ describe("buildRagQuery composes the retrieval query from the changed files", ()
     expect(excludePaths).toEqual(["src/a.ts"]);
   });
 
+  it("PREPENDS the PR title to the query text (recall parity with reviewbot)", () => {
+    const { queryText } = buildRagQuery(changedFiles, "Refactor the auth middleware");
+    expect(queryText).toContain("Refactor the auth middleware");
+    // The title leads the query (before the "Changed files:" block).
+    expect(queryText.indexOf("Refactor the auth middleware")).toBeLessThan(queryText.indexOf("Changed files:"));
+    // The diff sample is still present (title is ADDITIVE, not a replacement).
+    expect(queryText).toContain("helper()");
+  });
+
+  it("omits a blank/whitespace title cleanly (query still starts with the Changed files block)", () => {
+    expect(buildRagQuery(changedFiles, "   ").queryText.startsWith("Changed files:")).toBe(true);
+    expect(buildRagQuery(changedFiles, undefined).queryText.startsWith("Changed files:")).toBe(true);
+  });
+
   it("returns an empty query (nothing to retrieve on) when there are no files", () => {
     expect(buildRagQuery([])).toEqual({ queryText: "", excludePaths: [] });
+    expect(buildRagQuery([], "Some title")).toEqual({ queryText: "", excludePaths: [] });
   });
 
   it("dedupes excluded paths", () => {
@@ -152,6 +168,32 @@ describe("buildReviewRagContext: retrieval wiring + fail-safe", () => {
     const out = await buildReviewRagContext(env, { repoFullName: "acme/rag-empty", files: [] });
     expect(out).toBe("");
     expect(vec.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── Quality knobs (#GAP-2): minScore + reranker + title flow into retrieveContext ──────────────────
+
+describe("buildReviewRagContext passes the quality knobs into retrieveContext (#GAP-2)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("invokes the retrieve call with minScore 0.4 + reranker 'bm25' and the title-led query (reviewbot parity)", async () => {
+    const spy = vi.spyOn(ragModule, "retrieveContext").mockResolvedValue("=== RELEVANT EXISTING CODE / DOCS ===");
+    const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
+    const out = await buildReviewRagContext(env, { repoFullName: "acme/widgets", title: "Add a feature", files: changedFiles });
+    expect(out).toContain("RELEVANT EXISTING CODE / DOCS");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const opts = spy.mock.calls[0]?.[1];
+    expect(opts).toMatchObject({ minScore: 0.4, reranker: "bm25", project: "acme", repo: "widgets" });
+    // The title leads the embedded query (recall parity with reviewbot).
+    expect(opts?.queryText).toContain("Add a feature");
+    expect(opts?.queryText.indexOf("Add a feature")).toBeLessThan(opts?.queryText.indexOf("Changed files:") ?? -1);
+  });
+
+  it("a caller-supplied reranker still wins over the default (e.g. forcing it off), minScore unchanged", async () => {
+    const spy = vi.spyOn(ragModule, "retrieveContext").mockResolvedValue("");
+    const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
+    await buildReviewRagContext(env, { repoFullName: "acme/widgets", files: changedFiles, reranker: "off" });
+    expect(spy.mock.calls[0]?.[1]).toMatchObject({ minScore: 0.4, reranker: "off" });
   });
 });
 


### PR DESCRIPTION
## Summary

Aligns the gittensory codebase-RAG retrieval seam (`src/review/rag-wire.ts`) with reviewbot's core config, fixing GAP-2 (the code half).

Before, the retrieve call used `minScore: 0` (off) and **no reranker**, so low-relevance cosine "neighbours" were injected as "RELEVANT EXISTING CODE" — noise that itself drives false positives. The query also omitted the PR title, hurting recall vs. reviewbot (which embeds `${title}\n${diff}`).

## Changes

- **`src/review/rag-wire.ts`**
  - `buildRagQuery(files, title?)` — PREPENDS the (trimmed) PR title to the query text; additive, omitted cleanly when blank/absent.
  - `buildReviewRagContext(...)` — always passes `minScore: 0.4` + `reranker: "bm25"` to `retrieveContext` (matches reviewbot `rag: { minScore: 0.4, reranker: "bm25" }`). A caller-supplied `reranker` still wins (e.g. forcing `"off"`); `minScore` is fixed.
- **`src/queue/processors.ts`** — feeds the PR title into the retrieval-context build at the (already flag+allowlist-gated) review call site.
- **`test/unit/rag-wiring.test.ts`** — new assertions: title leads the query; `retrieveContext` invoked with `minScore: 0.4` / `reranker: "bm25"`; caller override honored; blank-title handling.

## Scope / safety

Code knobs ONLY. RAG stays per-repo opt-in (`isRagEnabled(env)` flag AND the convergence repo allowlist) — this does not force-enable RAG globally; the operator enables + warms the index via runtime config separately. Fully fail-safe path unchanged.

Note: Task A (repoint public-stats to the live `audit_events` ledger) was already shipped on `main` in #1114, so this branch contains only the RAG (Task B) work.

## Verification

- `npx tsc --noEmit` — clean (`exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`)
- `npx vitest run` — **3546 passed, 1 skipped** (215 files); rag-wiring suite 16 → 21 tests