### PR TITLE
feat(gate): re-approval idempotency + linked-issue flag-then-close double-check

### DIFF
--- a/migrations/0053_pr_approved_head_sha.sql
+++ b/migrations/0053_pr_approved_head_sha.sql
@@ -1,0 +1,20 @@
+-- Re-approval idempotency: stop the auto-maintain re-approve loop.
+--
+-- BEFORE: planAgentMaintenanceActions() plans an `approve` whenever the PR is review-good and
+-- reviewDecision !== "APPROVED". A GitHub App's OWN approval review does NOT reliably flip the PR's
+-- reviewDecision to APPROVED (the decision aggregates human/CODEOWNERS reviews, and an App self-review often
+-- leaves it null), so the guard never trips — the bot re-approves the SAME commit on every webhook + every
+-- scheduled re-gate sweep, posting a redundant, contributor-visible approval review each time (observed 24x on
+-- one PR). (Mirrors the RC3 merge-retry-forever loop fixed in 0052 with merge_blocked_sha.)
+--
+-- AFTER: when the bot's `approve` action executes, it records the head SHA it just approved. The planner skips
+-- planning an approve while approved_head_sha == headSha (this exact commit is already approved). A NEW commit
+-- changes the head SHA, so approved_head_sha no longer matches and the bot may approve the new commit (correct).
+--
+-- approved_head_sha is keyed to the head SHA so a NEW commit (which upsertPullRequestFromGitHub writes) makes
+-- the bot re-approve the new code — no manual reset. Mirrors merge_blocked_sha's storage/threading exactly.
+--
+-- pull_requests IS a Drizzle table (src/db/schema.ts), so this column is added to the Drizzle schema too;
+-- this raw migration is the production DDL applied by `wrangler d1 migrations apply` (drizzle-kit is not the
+-- runtime migrator here). Nullable / no default → backward-compatible (existing rows = NULL = not yet approved).
+ALTER TABLE pull_requests ADD COLUMN approved_head_sha TEXT;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2525,6 +2525,18 @@ export async function markPullRequestMergeBlocked(env: Env, fullName: string, nu
     .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number), eq(pullRequests.headSha, headSha)));
 }
 
+/** Re-approval idempotency: record the head SHA the bot just auto-approved. The planner skips the `approve`
+ *  disposition while approved_head_sha == headSha (this commit is already approved by the bot). Scoped to
+ *  headSha so a later commit (the live head no longer matches) lets the bot re-approve the new code without
+ *  any manual reset. Mirrors markPullRequestMergeBlocked. */
+export async function markPullRequestApproved(env: Env, fullName: string, number: number, headSha: string): Promise<void> {
+  const db = getDb(env.DB);
+  await db
+    .update(pullRequests)
+    .set({ approvedHeadSha: headSha, updatedAt: nowIso() })
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number), eq(pullRequests.headSha, headSha)));
+}
+
 export async function getIssue(env: Env, fullName: string, number: number): Promise<IssueRecord | null> {
   const db = getDb(env.DB);
   const [row] = await db.select().from(issues).where(and(eq(issues.repoFullName, fullName), eq(issues.number, number))).limit(1);
@@ -3930,6 +3942,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     mergeAttemptCount: row.mergeAttemptCount,
     mergeBlockedSha: row.mergeBlockedSha,
     mergeBlockedReason: row.mergeBlockedReason,
+    approvedHeadSha: row.approvedHeadSha,
   };
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -282,6 +282,11 @@ export const pullRequests = sqliteTable(
     mergeAttemptCount: integer("merge_attempt_count").notNull().default(0),
     mergeBlockedSha: text("merge_blocked_sha"),
     mergeBlockedReason: text("merge_blocked_reason"),
+    // Re-approval idempotency: the head SHA the bot last auto-approved. The planner skips the `approve`
+    // disposition while approved_head_sha == headSha (this commit is already approved). Keyed to head SHA → a
+    // new commit makes the bot re-approve the new code. gittensory-computed (executor-written), omitted from
+    // the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors merge_blocked_sha.)
+    approvedHeadSha: text("approved_head_sha"),
     createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
     updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
   },

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -177,7 +177,7 @@ import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
-import { evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
+import { AGENT_LABEL_PENDING_CLOSURE, evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
@@ -675,6 +675,9 @@ async function maybeRunAgentMaintenance(
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
+    // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
+    // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).
+    linkedIssueVerify: { verifyBeforeClose: linkedIssueRulesConfig.verifyBeforeClose, closeDelaySeconds: linkedIssueRulesConfig.closeDelaySeconds },
     pr: {
       mergeableState: liveMergeState ?? pr.mergeableState,
       reviewDecision: liveReviewDecision ?? pr.reviewDecision,
@@ -683,6 +686,7 @@ async function maybeRunAgentMaintenance(
       linkedDuplicateCount: linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests).length,
       headSha: pr.headSha,
       mergeBlockedSha: pr.mergeBlockedSha,
+      approvedHeadSha: pr.approvedHeadSha,
     },
   });
   if (planned.length === 0) return;
@@ -705,6 +709,18 @@ async function maybeRunAgentMaintenance(
     },
     planned,
   );
+
+  // Flag-then-close double-check, Pass 2 trigger: when this pass FLAGGED the PR (added the pending-closure
+  // label), re-enqueue a delayed re-review after closeDelaySeconds so the verification pass runs promptly
+  // instead of waiting for the next CI-completion event or the hourly sweep. Best-effort — if the enqueue fails,
+  // the next sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review
+  // job (it just re-runs reReviewStoredPullRequest), so no new job type is needed.
+  const flaggedForLinkedIssue = planned.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add");
+  if (flaggedForLinkedIssue) {
+    const delaySeconds = Math.max(0, linkedIssueRulesConfig.closeDelaySeconds);
+    const verifyJob = { type: "recapture-preview" as const, deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId, attempt: 0 };
+    await (delaySeconds > 0 ? env.JOBS.send(verifyJob, { delaySeconds }) : env.JOBS.send(verifyJob)).catch(() => undefined);
+  }
 }
 
 /**

--- a/src/review/linked-issue-hard-rules.ts
+++ b/src/review/linked-issue-hard-rules.ts
@@ -26,6 +26,15 @@ export type LinkedIssueHardRulesConfig = {
   // True when the repo uses the default gittensor labels, which is the precondition for the missing-point rule
   // (a repo that does NOT use point labels must never auto-close for "missing point label").
   defaultLabelRepo: boolean;
+  // Flag-then-close double-check (#linked-issue-verify-before-close). When TRUE (default), a hard-rule
+  // violation does NOT close on first detection: the planner FLAGS the PR (adds the pending-closure label + a
+  // warning comment) and only CLOSES on the NEXT gate evaluation if the violation STILL holds AND the label is
+  // already present (a label-based two-pass state machine — the second pass is the verification). When FALSE,
+  // the close fires immediately on first detection (the original GAP-5 behavior).
+  verifyBeforeClose: boolean;
+  // How long (seconds) until the verification pass — surfaced in the flag comment, and used to delay the
+  // optional re-review re-enqueue so Pass 2 doesn't wait for the slow sweep. Clamped to [0, 300].
+  closeDelaySeconds: number;
 };
 
 // Fail-SAFE default: every mode OFF, empty label lists, NOT a default-label repo. An unconfigured (or
@@ -35,6 +44,16 @@ export type LinkedIssueHardRulesConfig = {
 const DEFAULT_POINT_BEARING_LABELS = ["gittensor:bug", "gittensor:feature", "gittensor:priority"];
 const DEFAULT_MAINTAINER_ONLY_LABELS = ["maintainer-only"];
 
+// The namespaced label that marks a PR as flagged-for-closure by the linked-issue hard rule (Pass 1). Its
+// presence + a persisting violation on the next evaluation is the verification trigger (Pass 2 → close). Cleared
+// when the violation resolves. Namespaced so it never collides with project labels (mirrors AGENT_LABEL_*).
+export const AGENT_LABEL_PENDING_CLOSURE = "gittensory:pending-closure";
+
+// Default verification delay (seconds) — how long until the second-pass close. Clamped to this range on load.
+const DEFAULT_CLOSE_DELAY_SECONDS = 30;
+const MIN_CLOSE_DELAY_SECONDS = 0;
+const MAX_CLOSE_DELAY_SECONDS = 300;
+
 export const DEFAULT_LINKED_ISSUE_HARD_RULES: LinkedIssueHardRulesConfig = {
   ownerAssignedClose: "off",
   missingPointLabelClose: "off",
@@ -42,7 +61,16 @@ export const DEFAULT_LINKED_ISSUE_HARD_RULES: LinkedIssueHardRulesConfig = {
   pointBearingLabels: [],
   maintainerOnlyLabels: [],
   defaultLabelRepo: false,
+  // Default ON: a hard-rule violation flags first, then closes on re-verification (the operator's double-check).
+  verifyBeforeClose: true,
+  closeDelaySeconds: DEFAULT_CLOSE_DELAY_SECONDS,
 };
+
+/** Clamp a KV-provided close delay to a sane range, falling back to the default for a non-finite / absent value. */
+function clampCloseDelaySeconds(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_CLOSE_DELAY_SECONDS;
+  return Math.min(MAX_CLOSE_DELAY_SECONDS, Math.max(MIN_CLOSE_DELAY_SECONDS, Math.trunc(value)));
+}
 
 function asMode(value: unknown): LinkedIssueHardRulesMode | null {
   return value === "block" || value === "off" ? value : null;
@@ -61,6 +89,8 @@ type LinkedIssueHardRulesKvShape = {
   pointBearingLabels?: JsonValue;
   maintainerOnlyLabels?: JsonValue;
   defaultLabelRepo?: JsonValue;
+  verifyBeforeClose?: JsonValue;
+  closeDelaySeconds?: JsonValue;
 };
 
 /**
@@ -85,6 +115,9 @@ export async function loadLinkedIssueHardRules(env: Env, repoFullName: string): 
       pointBearingLabels: asStringArray(raw.pointBearingLabels) ?? DEFAULT_POINT_BEARING_LABELS,
       maintainerOnlyLabels: asStringArray(raw.maintainerOnlyLabels) ?? DEFAULT_MAINTAINER_ONLY_LABELS,
       defaultLabelRepo: raw.defaultLabelRepo === true,
+      // Default ON: only an explicit `false` disables the flag-then-close double-check.
+      verifyBeforeClose: raw.verifyBeforeClose !== false,
+      closeDelaySeconds: clampCloseDelaySeconds(raw.closeDelaySeconds),
     };
   } catch {
     // A KV outage must NEVER let a deterministic close fire — fail safe to all-off (the opposite of the

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -1,7 +1,7 @@
-import { bumpPullRequestMergeAttempt, createPendingAgentActionIfAbsent, insertNotificationDeliveryIfAbsent, markPullRequestMergeBlocked, recordAuditEvent } from "../db/repositories";
+import { bumpPullRequestMergeAttempt, createPendingAgentActionIfAbsent, insertNotificationDeliveryIfAbsent, markPullRequestApproved, markPullRequestMergeBlocked, recordAuditEvent } from "../db/repositories";
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, type NotifyOutcome } from "./notify-discord";
-import { ensurePullRequestLabel } from "../github/labels";
+import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
 import { isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
@@ -91,6 +91,13 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     try {
       await performAction(env, ctx, action);
       await audit("completed", action.reason);
+      // Re-approval idempotency: record the head SHA we just approved so the planner skips re-approving this
+      // exact commit on the next sweep (a GitHub App's own approval does not reliably flip reviewDecision to
+      // APPROVED, so reviewDecision alone can't dedup). A new commit clears the match → the bot approves it.
+      // Best-effort: a failed persist only risks one redundant re-approval, never a wrong disposition.
+      if (action.actionClass === "approve" && ctx.headSha) {
+        await markPullRequestApproved(env, ctx.repoFullName, ctx.pullNumber, ctx.headSha).catch(() => undefined);
+      }
       // Per-repo Discord notification on a terminal/visible action (reviewbot parity): merge→merged,
       // close→closed, request_changes→manual review. Best-effort; never affects the action. RC1 dedups at the
       // action level, so this fires once per outcome per PR (no spam).
@@ -149,7 +156,14 @@ async function handleMergeFailure(env: Env, ctx: AgentActionExecutionContext, er
 async function performAction(env: Env, ctx: AgentActionExecutionContext, action: PlannedAgentAction): Promise<void> {
   switch (action.actionClass) {
     case "label":
-      await ensurePullRequestLabel(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, action.label ?? "", { createMissingLabel: true });
+      // Flag-then-close double-check: a `label` action may ADD (default) or REMOVE its label, and may carry an
+      // optional comment (the Pass-1 flag warning, or the resolved note) posted alongside the label mutation.
+      if (action.labelOp === "remove") {
+        await removePullRequestLabel(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, action.label ?? "");
+      } else {
+        await ensurePullRequestLabel(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, action.label ?? "", { createMissingLabel: true });
+      }
+      if (action.comment) await createIssueComment(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, action.comment);
       return;
     case "request_changes":
       await createPullRequestReview(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, "REQUEST_CHANGES", action.reviewBody ?? "");
@@ -174,6 +188,8 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
 export function actionParams(action: PlannedAgentAction): AgentPendingActionParams {
   return {
     ...(action.label !== undefined ? { label: action.label } : {}),
+    ...(action.labelOp !== undefined ? { labelOp: action.labelOp } : {}),
+    ...(action.comment !== undefined ? { comment: action.comment } : {}),
     ...(action.reviewBody !== undefined ? { reviewBody: action.reviewBody } : {}),
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -2,6 +2,7 @@ import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyPol
 import type { GateCheckConclusion } from "../rules/advisory";
 import { DEFAULT_AUTO_MAINTAIN_POLICY, autonomyRequiresApproval, isActingAutonomyLevel, resolveAutonomy } from "./autonomy";
 import { changedPathsHittingGuardrail } from "../signals/change-guardrail";
+import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
 
 // High-slop threshold default when a repo hasn't set slopGateMinScore (mirrors the gate's `high` band).
 const DEFAULT_SLOP_GATE_MIN_SCORE = 60;
@@ -38,6 +39,13 @@ export type PlannedAgentAction = {
   reason: string;
   // Action-specific payload (only the field for this actionClass is set):
   label?: string;
+  // For a `label` action: whether to ADD (default) or REMOVE the label. The flag-then-close double-check adds
+  // the pending-closure label on Pass 1 and removes it when the violation resolves; all other label actions add.
+  labelOp?: "add" | "remove";
+  // For a `label` action: an OPTIONAL issue comment posted alongside the label mutation (the flag-then-close
+  // warning on Pass 1, or the "resolved" note on flag-clear). Kept on the `label` action so the flag uses the
+  // already-held Issues-API `label` autonomy class (no new action class / no write-permission gate).
+  comment?: string;
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;
@@ -81,6 +89,14 @@ export type AgentActionPlanInput = {
   // AI verdicts). It still NEVER fires for the owner or automation bots (the `isContributor` guard). Absent /
   // not-violated ⇒ no effect.
   linkedIssueHardRule?: { violated: boolean; reason: string | null } | undefined;
+  // Flag-then-close double-check for the linked-issue hard rule (#linked-issue-verify-before-close). When
+  // `verifyBeforeClose` is true (the default), a violation FLAGS the PR (pending-closure label + warning comment)
+  // on first detection and only CLOSES on a LATER evaluation when the violation STILL holds AND the PR already
+  // carries the pending-closure label (a label-based two-pass state machine). When false, the close fires
+  // immediately (the original GAP-5 behavior). Absent ⇒ immediate close (back-compat for callers that don't
+  // pass it). `closeDelaySeconds` is surfaced in the flag comment so the contributor knows the verification
+  // window. The presence of the label is read from `input.pr.labels`.
+  linkedIssueVerify?: { verifyBeforeClose: boolean; closeDelaySeconds: number } | undefined;
   pr: {
     mergeableState?: string | null | undefined;
     reviewDecision?: string | null | undefined;
@@ -91,6 +107,11 @@ export type AgentActionPlanInput = {
     // (perms/required-check/conflict). When they match, the merge can't complete for this commit → suppress it.
     headSha?: string | null | undefined;
     mergeBlockedSha?: string | null | undefined;
+    // Re-approval idempotency: the head SHA the bot last auto-approved. When it equals the live headSha this
+    // exact commit is already bot-approved → suppress the `approve` disposition (a GitHub App's own approval
+    // does NOT reliably flip reviewDecision to APPROVED, so without this the bot re-approves every sweep). A new
+    // commit makes the live head differ → the bot may approve the new code (correct).
+    approvedHeadSha?: string | null | undefined;
   };
 };
 
@@ -152,6 +173,11 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // RC3: a prior merge attempt failed terminally for THIS exact head SHA (403/405/409/conflict) → never re-plan
   // the merge; it can't complete for this commit. A new commit makes the live head differ from mergeBlockedSha.
   const mergeTerminallyBlocked = input.pr.mergeBlockedSha != null && input.pr.headSha != null && input.pr.mergeBlockedSha === input.pr.headSha;
+  // Re-approval idempotency: this exact commit is already bot-approved when the stored approved-head SHA equals
+  // the live head SHA → never re-post an approval for it (a GitHub App's own approval does not reliably flip
+  // reviewDecision to APPROVED, so reviewDecision alone can't dedup). A new commit makes the heads differ →
+  // approve may fire again. Absent approved-head SHA (never approved by the bot) ⇒ not idempotent-skipped.
+  const alreadyApprovedThisHead = input.pr.approvedHeadSha != null && input.pr.headSha != null && input.pr.approvedHeadSha === input.pr.headSha;
   const canMerge = reviewGood && !guardrailHit && acting("merge") && mergeableClean && approvalsSatisfied && !mergeTerminallyBlocked;
   // A guarded/CRUCIAL path (CI, the review engine, visual) → ALWAYS held for the owner, never auto-actioned —
   // not auto-approved, not auto-merged, AND not auto-closed. Operator decision (#hold-crucial-on-reject): a
@@ -165,7 +191,28 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // PR (the `isContributor` guard owns the owner/automation exemption) and respects the `close` autonomy class.
   // It takes PRECEDENCE over merge/approve below: a PR linking an ineligible issue must never auto-merge.
   const linkedIssueHardRule = input.linkedIssueHardRule;
-  const willCloseForLinkedIssue = linkedIssueHardRule?.violated === true && isContributor && acting("close");
+  // Base condition: a CONTRIBUTOR PR links an issue tripping a deterministic hard rule AND the `close` autonomy
+  // class is acting. (The owner/automation exemption lives in `isContributor`.)
+  const linkedIssueViolated = linkedIssueHardRule?.violated === true && isContributor && acting("close");
+  // Flag-then-close double-check (#linked-issue-verify-before-close). Default behavior when the caller doesn't
+  // pass the config is IMMEDIATE close (back-compat). When verifyBeforeClose is on, the close is a TWO-PASS
+  // label-state machine: Pass 1 flags (adds the pending-closure label + a warning comment) and Pass 2 — the next
+  // evaluation, with the violation still present AND the label already on the PR — closes.
+  const verifyBeforeClose = input.linkedIssueVerify?.verifyBeforeClose === true;
+  const closeDelaySeconds = input.linkedIssueVerify?.closeDelaySeconds ?? 0;
+  const pendingClosureLabelPresent = hasLabel(input.pr.labels, AGENT_LABEL_PENDING_CLOSURE);
+  // Pass 1 — violation present, verify-mode on, label NOT yet on the PR → FLAG (label + comment), do NOT close.
+  const flagForLinkedIssue = linkedIssueViolated && verifyBeforeClose && !pendingClosureLabelPresent;
+  // Close NOW when: verify-mode OFF (immediate, original GAP-5), OR Pass 2 (violation persists AND the
+  // pending-closure label is already present from a prior pass).
+  const willCloseForLinkedIssue = linkedIssueViolated && (!verifyBeforeClose || pendingClosureLabelPresent);
+  // The violation has CLEARED (no longer violated) but the PR still carries a pending-closure flag from a prior
+  // pass → remove the stale flag (never close). Independent of `isContributor`/`close` autonomy: clearing a stale
+  // label is always safe and must happen even if the rule/author no longer qualifies for a close.
+  const clearLinkedIssueFlag = linkedIssueHardRule?.violated !== true && pendingClosureLabelPresent;
+  // True whenever a pending linked-issue close is in flight (flag OR close) — drives the changes-requested label
+  // and suppresses approve/merge below (a PR about to be closed for an ineligible issue must never auto-merge).
+  const linkedIssueCloseInFlight = flagForLinkedIssue || willCloseForLinkedIssue;
   const ciReason = ciFailed
     ? `CI is failing${failingCheckNames.length ? ` (${failingCheckNames.join(", ")})` : ""}`
     : ciUnverified
@@ -174,11 +221,11 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
 
   // 1) label — ready-to-merge (review-good, unguarded) / needs-human-review (review-good but guarded) /
   // changes-requested (not review-good → will be closed for a contributor, held for the owner). A pending
-  // linked-issue hard-rule close forces the changes-requested label regardless of the gate verdict (the PR is
-  // about to be closed for an ineligible linked issue). Idempotent.
+  // linked-issue hard-rule close (flag OR close pass) forces the changes-requested label regardless of the gate
+  // verdict (the PR is about to be closed for an ineligible linked issue). Idempotent.
   if (acting("label")) {
-    const label = willCloseForLinkedIssue || !reviewGood ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
-    const reason = willCloseForLinkedIssue
+    const label = linkedIssueCloseInFlight || !reviewGood ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
+    const reason = linkedIssueCloseInFlight
       ? `linked-issue hard rule: ${linkedIssueHardRule?.reason ?? "ineligible linked issue"}`
       : !reviewGood
         ? `verdict=${input.conclusion}${ciReason ? `; ${ciReason}` : ""}`
@@ -187,6 +234,32 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
           : `verdict=${input.conclusion}; CI green`;
     if (!hasLabel(input.pr.labels, label)) {
       actions.push({ actionClass: "label", requiresApproval: approval("label"), reason, label });
+    }
+    // Flag-then-close double-check, Pass 1: add the pending-closure label + a warning comment citing the specific
+    // rule and the verification window. The label's presence is the state that, persisting to the next pass with
+    // the violation still present, triggers the close. Idempotent (the flag only fires when the label is absent).
+    if (flagForLinkedIssue) {
+      const ruleReason = linkedIssueHardRule?.reason ?? "the linked issue is not eligible for a community PR";
+      const window = closeDelaySeconds > 0 ? `~${closeDelaySeconds}s` : "the next verification";
+      actions.push({
+        actionClass: "label",
+        requiresApproval: approval("label"),
+        reason: `linked-issue hard rule (flagged for verification): ${ruleReason}`,
+        label: AGENT_LABEL_PENDING_CLOSURE,
+        labelOp: "add",
+        comment: `⚠️ This PR links an ineligible issue (${ruleReason}) and will be closed on re-verification in ${window} unless the linked issue changes.`,
+      });
+    }
+    // Violation CLEARED but a stale pending-closure flag remains → remove it (+ a resolved note). Never closes.
+    if (clearLinkedIssueFlag) {
+      actions.push({
+        actionClass: "label",
+        requiresApproval: approval("label"),
+        reason: "linked-issue hard rule resolved — clearing the pending-closure flag",
+        label: AGENT_LABEL_PENDING_CLOSURE,
+        labelOp: "remove",
+        comment: "✓ The linked-issue hard-rule violation is resolved — this PR is no longer pending closure.",
+      });
     }
   }
 
@@ -197,7 +270,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // OWNER/automation PR is HELD via the needs-human label + the (non-blocking) unified review comment — never a
   // formal request-changes. (#no-request-changes) Either merge/approve, or close, with the rare manual hold left
   // open + commented, never blocked.
-  if (reviewGood && !guardrailHit && !willCloseForLinkedIssue && acting("approve") && input.pr.reviewDecision !== "APPROVED") {
+  if (reviewGood && !guardrailHit && !linkedIssueCloseInFlight && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),
@@ -206,11 +279,16 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     });
   }
 
-  // 3) disposition — LINKED-ISSUE HARD-RULE CLOSE (deterministic, fires even on a guarded path; precedes
-  // merge) / MERGE (review-good, unguarded, mergeable, approvals) / CLOSE (not-good OR conflicting CONTRIBUTOR
-  // PR, one-shot) / MANUAL (guarded, or any not-good OWNER/automation PR — held, never closed). Mutually
-  // exclusive.
-  if (willCloseForLinkedIssue) {
+  // 3) disposition — FLAG-HOLD (linked-issue Pass 1: flagged this pass, verification pending → NO disposition) /
+  // LINKED-ISSUE HARD-RULE CLOSE (deterministic, fires even on a guarded path; precedes merge) / MERGE
+  // (review-good, unguarded, mergeable, approvals) / CLOSE (not-good OR conflicting CONTRIBUTOR PR, one-shot) /
+  // MANUAL (guarded, or any not-good OWNER/automation PR — held, never closed). Mutually exclusive.
+  if (flagForLinkedIssue) {
+    // Pass 1 of the flag-then-close double-check: the PR was flagged in the label section above and is HELD this
+    // pass — no merge, no close. The NEXT evaluation (violation still present + the label now on the PR) closes.
+    // Falling through here also suppresses the general `willClose` path so a flagged red-CI PR isn't closed until
+    // the verification pass confirms the linked-issue violation.
+  } else if (willCloseForLinkedIssue) {
     // A contributor linked an issue that violates a deterministic hard rule (owner-assigned / missing
     // point-label / maintainer-only). Close one-shot, citing the SPECIFIC rule + issue so the contributor knows
     // exactly why. This is the FIRST disposition branch: it wins over an otherwise-mergeable verdict (a PR for

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,6 +418,10 @@ export type PullRequestRecord = {
   mergeAttemptCount?: number | null | undefined;
   mergeBlockedSha?: string | null | undefined;
   mergeBlockedReason?: string | null | undefined;
+  /** Re-approval idempotency: the head SHA the bot last auto-approved. The planner skips the `approve`
+   *  disposition while approvedHeadSha === headSha (this commit is already approved by the bot); a new commit
+   *  clears the match so the bot may re-approve the new code. Mirrors mergeBlockedSha. */
+  approvedHeadSha?: string | null | undefined;
 };
 
 export type IssueRecord = {
@@ -570,6 +574,10 @@ export type AutoMaintainPolicy = {
  *  action's class is set, mirroring PlannedAgentAction. */
 export type AgentPendingActionParams = {
   label?: string;
+  // Flag-then-close double-check: whether a `label` action ADDs (default/absent) or REMOVEs its label, plus an
+  // optional comment posted alongside the label mutation. Persisted so a staged label action replays faithfully.
+  labelOp?: "add" | "remove";
+  comment?: string;
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -9,10 +9,11 @@ vi.mock("../../src/github/pr-actions", () => ({
 }));
 vi.mock("../../src/github/labels", () => ({
   ensurePullRequestLabel: vi.fn(async () => ({ applied: true, created: false })),
+  removePullRequestLabel: vi.fn(async () => undefined),
 }));
 
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
-import { ensurePullRequestLabel } from "../../src/github/labels";
+import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
 import { actionParams, executeAgentMaintenanceActions, type AgentActionExecutionContext } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { createTestEnv } from "../helpers/d1";
@@ -65,6 +66,39 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
     expect(updatePullRequestBranch).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "sha7");
     expect((await auditFor(env, "merge"))?.outcome).toBe("completed");
+  });
+
+  it("LIVE label with labelOp=add + comment: adds the label AND posts the comment", async () => {
+    const env = createTestEnv({});
+    const flag: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "flag", label: "gittensory:pending-closure", labelOp: "add", comment: "⚠️ flagged" };
+    await executeAgentMaintenanceActions(env, ctx(), [flag]);
+    expect(ensurePullRequestLabel).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "gittensory:pending-closure", { createMissingLabel: true });
+    expect(removePullRequestLabel).not.toHaveBeenCalled();
+    expect(createIssueComment).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "⚠️ flagged");
+  });
+
+  it("LIVE label with labelOp=remove + comment: removes the label (never adds) AND posts the comment", async () => {
+    const env = createTestEnv({});
+    const clear: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "resolved", label: "gittensory:pending-closure", labelOp: "remove", comment: "✓ resolved" };
+    await executeAgentMaintenanceActions(env, ctx(), [clear]);
+    expect(removePullRequestLabel).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "gittensory:pending-closure");
+    expect(ensurePullRequestLabel).not.toHaveBeenCalled();
+    expect(createIssueComment).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "✓ resolved");
+  });
+
+  it("actionParams threads labelOp + comment so a staged flag replays faithfully", () => {
+    const flag: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "flag", label: "gittensory:pending-closure", labelOp: "add", comment: "⚠️ flagged" };
+    expect(actionParams(flag)).toEqual({ label: "gittensory:pending-closure", labelOp: "add", comment: "⚠️ flagged" });
+  });
+
+  it("LIVE approve persists the approved head SHA for re-approval idempotency", async () => {
+    const env = createTestEnv({});
+    await env.DB.prepare("insert into pull_requests (id, repo_full_name, number, title, state, head_sha, payload_json, created_at, updated_at) values (?,?,?,?,?,?,?,?,?)")
+      .bind("owner/repo#7", "owner/repo", 7, "t", "open", "sha7", "{}", "2026-06-23T00:00:00Z", "2026-06-23T00:00:00Z")
+      .run();
+    await executeAgentMaintenanceActions(env, ctx({ headSha: "sha7" }), [approve]);
+    const row = await env.DB.prepare("select approved_head_sha from pull_requests where id = ?").bind("owner/repo#7").first<{ approved_head_sha: string | null }>();
+    expect(row?.approved_head_sha).toBe("sha7");
   });
 
   it("PAUSED (per-repo): mutates nothing and audits denied", async () => {

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
+import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import type { GateCheckConclusion } from "../../src/rules/advisory";
 
 function input(overrides: Partial<AgentActionPlanInput> & { conclusion: GateCheckConclusion }): AgentActionPlanInput {
@@ -63,6 +64,35 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(failing).toContain("close");
     expect(failing).not.toContain("approve");
     expect(failing).not.toContain("request_changes");
+  });
+
+  describe("re-approval idempotency on the head SHA (stop the re-approve loop)", () => {
+    const good = { conclusion: "success" as const, autonomy: { approve: "auto" as const }, ciState: "passed" as const };
+
+    it("approves when approvedHeadSha is ABSENT (never approved this commit)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ ...good, pr: { labels: [], headSha: "abc123" } })));
+      expect(plan).toContain("approve");
+    });
+
+    it("approves when approvedHeadSha DIFFERS from the live headSha (a new commit pushed)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ ...good, pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } })));
+      expect(plan).toContain("approve");
+    });
+
+    it("SKIPS approve when approvedHeadSha EQUALS the live headSha (this commit already bot-approved)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ ...good, pr: { labels: [], headSha: "abc123", approvedHeadSha: "abc123" } })));
+      expect(plan).not.toContain("approve");
+    });
+
+    it("does not affect merge — an already-approved-this-head PR still merges when clean", () => {
+      const plan = classes(
+        planAgentMaintenanceActions(
+          input({ ...good, autonomy: { approve: "auto", merge: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean", headSha: "abc123", approvedHeadSha: "abc123" } }),
+        ),
+      );
+      expect(plan).not.toContain("approve");
+      expect(plan).toContain("merge");
+    });
   });
 
   it("merges only a clean, approved, passing PR (reviewDecision drives the approval gate)", () => {
@@ -323,6 +353,58 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(cls).not.toContain("approve");
       // labeled changes-requested, not ready-to-merge
       expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
+    });
+  });
+
+  describe("linked-issue flag-then-close double-check (#linked-issue-verify-before-close)", () => {
+    const violation = { violated: true, reason: "Linked issue #5 is labeled `maintainer-only` — it is not open for community PRs." };
+    const verifyOn = { verifyBeforeClose: true, closeDelaySeconds: 30 };
+    const pendingLabel = (plan: ReturnType<typeof planAgentMaintenanceActions>) => plan.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_PENDING_CLOSURE);
+
+    it("Pass 1 (verify on, label ABSENT): FLAGS (pending-closure label + warning comment), does NOT close", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [] } }));
+      expect(classes(plan)).not.toContain("close");
+      const flag = pendingLabel(plan);
+      expect(flag).toBeTruthy();
+      expect(flag?.labelOp).toBe("add");
+      expect(flag?.comment).toContain("ineligible issue");
+      expect(flag?.comment).toContain("~30s");
+    });
+
+    it("Pass 2 (verify on, label PRESENT, violation persists): CLOSES with the cited reason", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [AGENT_LABEL_PENDING_CLOSURE] } }));
+      const close = plan.find((a) => a.actionClass === "close");
+      expect(close).toBeTruthy();
+      expect(close?.reason).toBe(violation.reason);
+      // Pass 2 must NOT re-add the pending-closure label (it is already present).
+      expect(pendingLabel(plan)).toBeFalsy();
+    });
+
+    it("violation CLEARED with the label present: REMOVES the flag (+ resolved comment), never closes", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto", merge: "auto" }, ciState: "passed", autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, linkedIssueHardRule: { violated: false, reason: null }, linkedIssueVerify: verifyOn, pr: { labels: [AGENT_LABEL_PENDING_CLOSURE], mergeableState: "clean" } }));
+      expect(classes(plan)).not.toContain("close");
+      const remove = pendingLabel(plan);
+      expect(remove?.labelOp).toBe("remove");
+      expect(remove?.comment).toContain("resolved");
+    });
+
+    it("verifyBeforeClose = false: IMMEDIATE close on first detection (original GAP-5 behavior, no flag)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: { verifyBeforeClose: false, closeDelaySeconds: 30 }, pr: { labels: [] } }));
+      expect(classes(plan)).toContain("close");
+      expect(pendingLabel(plan)).toBeFalsy();
+    });
+
+    it("owner PR is NEVER flagged or closed even with verify on (isContributor guard)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto" }, ciState: "passed", authorIsOwner: true, linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [] } }));
+      expect(classes(plan)).not.toContain("close");
+      expect(pendingLabel(plan)).toBeFalsy();
+    });
+
+    it("Pass 1 does NOT approve or merge an otherwise-mergeable flagged PR (held for verification)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto", approve: "auto", merge: "auto" }, ciState: "passed", autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(plan).not.toContain("close");
+      expect(plan).not.toContain("approve");
+      expect(plan).not.toContain("merge");
     });
   });
 });

--- a/test/unit/linked-issue-hard-rules.test.ts
+++ b/test/unit/linked-issue-hard-rules.test.ts
@@ -15,6 +15,8 @@ function config(overrides: Partial<LinkedIssueHardRulesConfig> = {}): LinkedIssu
     pointBearingLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
     maintainerOnlyLabels: ["maintainer-only"],
     defaultLabelRepo: false,
+    verifyBeforeClose: true,
+    closeDelaySeconds: 30,
     ...overrides,
   };
 }
@@ -232,6 +234,9 @@ describe("loadLinkedIssueHardRules", () => {
       pointBearingLabels: ["gittensor:bug"],
       maintainerOnlyLabels: ["reserved"],
       defaultLabelRepo: true,
+      // verify config not specified in the KV object → defaults (verify ON, 30s).
+      verifyBeforeClose: true,
+      closeDelaySeconds: 30,
     });
   });
 
@@ -255,5 +260,25 @@ describe("loadLinkedIssueHardRules", () => {
     const get = vi.fn().mockResolvedValue({ linkedIssueHardRules: { ownerAssignedClose: "block" } });
     await loadLinkedIssueHardRules(envWith(get), "soloname");
     expect(get).toHaveBeenCalledWith("soloname", "json");
+  });
+
+  it("defaults verifyBeforeClose ON and closeDelaySeconds to 30 when unspecified", async () => {
+    const cfg = await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { ownerAssignedClose: "block" } })), "o/r");
+    expect(cfg.verifyBeforeClose).toBe(true);
+    expect(cfg.closeDelaySeconds).toBe(30);
+  });
+
+  it("disables verifyBeforeClose only on an explicit false (any other value keeps ON)", async () => {
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { verifyBeforeClose: false } })), "o/r")).verifyBeforeClose).toBe(false);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { verifyBeforeClose: "no" } })), "o/r")).verifyBeforeClose).toBe(true);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: {} })), "o/r")).verifyBeforeClose).toBe(true);
+  });
+
+  it("clamps closeDelaySeconds into [0, 300] and falls back to 30 for a non-number", async () => {
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: 120 } })), "o/r")).closeDelaySeconds).toBe(120);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: -5 } })), "o/r")).closeDelaySeconds).toBe(0);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: 9999 } })), "o/r")).closeDelaySeconds).toBe(300);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: 45.9 } })), "o/r")).closeDelaySeconds).toBe(45);
+    expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: "30" } })), "o/r")).closeDelaySeconds).toBe(30);
   });
 });


### PR DESCRIPTION
## Summary

Two **security-sensitive** gate-behavior hardenings for the auto-maintain layer (this controls auto-approve and auto-close of contributor PRs). **Do not merge — leave for human review.**

### Task 1 — Re-approval idempotency (stop the re-approve loop)

The bot re-approved an already-approved PR on every sweep (observed **24×** on one PR), posting redundant, contributor-visible approval reviews. Root cause: a GitHub App's own approval does **not** reliably flip `reviewDecision` to `APPROVED`, so the `reviewDecision !== "APPROVED"` guard never tripped.

Fix — make approve **idempotent on the current head SHA**, mirroring `mergeBlockedSha` end to end:
- New nullable `approved_head_sha` column (`migrations/0053_pr_approved_head_sha.sql`, Drizzle schema, `PullRequestRecord`, row mapper) — backward-compatible, omitted from the GitHub-sync SET clause so a sync can't clobber it.
- New `markPullRequestApproved()` repo fn (scoped to head SHA, like `markPullRequestMergeBlocked`); the executor calls it after a successful `approve`.
- Planner threads `input.pr.approvedHeadSha` and skips approve when `approvedHeadSha === headSha`. A new commit changes the head SHA → approve may fire again (correct).

### Task 2 — Linked-issue hard-rule flag-then-close double-check

A hard-rule violation (GAP-5) closed the PR immediately. Now there's a verifiable **double-check**: FLAG first, then close on re-confirmation, via a label-based two-pass state machine (the next gate eval is the verification — no fragile timers).

Config (`linked-issue-hard-rules.ts`, parsed from KV with safe defaults):
- `verifyBeforeClose: boolean` (default **true**)
- `closeDelaySeconds: number` (default **30**, clamped `[0, 300]`)

Behavior:
- **verifyBeforeClose=false** → immediate close (original GAP-5).
- **verifyBeforeClose=true**:
  - **Pass 1** (violation, label absent): FLAG — add `gittensory:pending-closure` + a warning comment citing the rule + window. No close.
  - **Pass 2** (violation persists, label present): CLOSE, cited reason.
  - **Violation cleared, label present**: remove the flag + a "✓ resolved" note. Never close.
- A delayed re-review is re-enqueued after `closeDelaySeconds` (reusing the existing `recapture-preview` job → `reReviewStoredPullRequest`) so Pass 2 doesn't wait for the slow sweep; the sweep / CI-completion event backstops it.

**Invariants preserved:** owner/automation exemption (`isContributor`); deterministic-close-fires-regardless-of-guardrail; a flagged PR is held (no approve/merge) until verification.

## Implementation notes
- The Pass-1 flag and Pass-2 close both reuse the existing `label` autonomy class (Issues-API, always held) — no new action class, no write-permission gate. `PlannedAgentAction` gained `labelOp: "add" | "remove"` and an optional `comment` (posted alongside the label mutation); both thread through `actionParams` so a staged action replays faithfully.

## Tests
New unit tests (full suite green: **3559 passed | 1 skipped**):

**Re-approval idempotency** (`agent-actions.test.ts`):
- approves when `approvedHeadSha` is absent
- approves when `approvedHeadSha` differs from headSha
- skips approve when `approvedHeadSha` equals headSha
- idempotency doesn't block merge

**Flag-then-close** (`agent-actions.test.ts`):
- Pass 1 flags (label + comment), no close
- Pass 2 closes with cited reason
- violation cleared → label removed, no close
- verifyBeforeClose=false → immediate close
- owner PR never flagged/closed
- flagged PR not approved/merged (held)

**Config loader** (`linked-issue-hard-rules.test.ts`): verify-default ON, explicit-false-only disable, closeDelaySeconds clamp/trunc/fallback.

**Executor** (`agent-action-executor.test.ts`): label add+comment, label remove+comment, approve persists `approved_head_sha`, `actionParams` threads `labelOp`/`comment`.

## Verification
- `npx tsc --noEmit` — clean (exactOptionalPropertyTypes, noUncheckedIndexedAccess)
- `npx vitest run` — 3559 passed | 1 skipped
- `node scripts/check-migrations.mjs` — 0053 contiguous / next-free
