### PR TITLE
feat(rag): enable RAG retrieval (flag on)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -85,7 +85,7 @@
     // Default OFF — flag-OFF performs no retrieval, uses no adapter, makes no vector query, and keeps the
     // reviewer prompt byte-identical. Even when ON it is inert until a repo's vector index is populated (the
     // index-population job + cron is a deploy-time follow-up; a cold/missing index degrades to no context).
-    "GITTENSORY_REVIEW_RAG": "false",
+    "GITTENSORY_REVIEW_RAG": "true",
     // Convergence (self-improve / auto-tune): run the ported self-improvement loop on the cron tick over
     // gittensory's own review-outcome data — compute tuning recommendations, SHADOW-SOAK any strictly-
     // tightening one, and AUTO-PROMOTE it to live ONLY after the soak window passes the gate; every action is


### PR DESCRIPTION
Flips GITTENSORY_REVIEW_RAG to true. Reviewer now retrieves related-code context with the #1124 knobs (minScore 0.4 + bm25 + title-led query). Fail-safe: degrades to no-context until the Vectorize index warms (the flag also activates ingestion). Config-only.