### PR TITLE
feat(self-improve): wire GAP-4 accuracy/eval feedback loop (pr_outcome + reversals + precision circuit-breaker)

### DIFF
--- a/migrations/0054_system_flags.sql
+++ b/migrations/0054_system_flags.sql
@@ -1,0 +1,26 @@
+-- Convergence (#self-improve, #kill-switch) — the D1-backed operational-flag store the accuracy
+-- circuit-breaker (GAP-4) reads/writes. A tiny key/value table the operator OR the autonomous self-tune
+-- loop can flip INSTANTLY (no deploy). Byte-faithful to the reviewbot canonical table (its 0012_system_flags),
+-- and exactly the columns the ported FlagStore binds (src/review/outcomes-wire.ts):
+--   • isHoldOnly  — SELECT key, value FROM system_flags
+--   • flagSetAt   — SELECT updated_at FROM system_flags WHERE key = ?
+--   • setFlag     — INSERT OR REPLACE ... / DELETE WHERE key = ?
+--
+-- Flag families (one table, scoped key `<family>:<scope>` where <scope> is `global` or a repo full name):
+--   holdonly:<scope>  — accuracy circuit-breaker: keep reviewing, but DOWNGRADE every would-MERGE to a human
+--                       HOLD. Set by the auto-tuner when a repo's merge precision drops below the floor over a
+--                       real sample (applyAutoTune), so the system stops repeating a bad call on its own; an
+--                       auto-engaged breaker auto-clears after a cooldown once precision recovers
+--                       (maybeAutoClearHoldOnly), and a human can clear it at any time.
+--
+-- FAIL-SAFE: both reads fail OPEN (last-known / null) so a DB blip never silently changes behavior, and with
+-- no rows present isHoldOnly is false → the merge path is byte-identical until a breaker actually engages.
+--
+-- Flip manually, e.g.:
+--   INSERT OR REPLACE INTO system_flags VALUES ('holdonly:owner/repo','1',CURRENT_TIMESTAMP);
+--   DELETE FROM system_flags WHERE key='holdonly:owner/repo';
+CREATE TABLE IF NOT EXISTS system_flags (
+  key TEXT PRIMARY KEY,
+  value TEXT,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -109,7 +109,7 @@ import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetecti
 import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
 import { selectRegateCandidates } from "../settings/agent-sweep";
-import { isProtectedAutomationAuthor, planAgentMaintenanceActions } from "../settings/agent-actions";
+import { downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions } from "../settings/agent-actions";
 import { executeAgentMaintenanceActions } from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
 import { loadIssueQualityReportMap } from "../services/issue-quality";
@@ -180,6 +180,7 @@ import { loadHardGuardrailGlobs } from "../review/guardrail-config";
 import { AGENT_LABEL_PENDING_CLOSURE, evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
+import { isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
 import type { AdvisoryFinding, ContributorEvidenceRecord, ContributorRepoStatRecord, DetectedNotificationEvent, GitHubWebhookPayload, IssueRecord, JobMessage, JsonValue, PullRequestFilePathRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../types";
@@ -347,7 +348,15 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // ENQUEUES this when the flag is ON, but a stale in-flight job that lands after a flag-flip must still
       // no-op, so flag-OFF does zero work here too. TIGHTENING-ONLY + shadow-soak + audited; never throws into
       // the queue (runSelfTune fails safe).
-      if (isSelfTuneEnabled(env)) await runSelfTune(env);
+      if (isSelfTuneEnabled(env)) {
+        await runSelfTune(env);
+        // GAP-4 accuracy circuit-breaker: read the gate-eval confusion matrix over the recorded pr_outcome
+        // ground truth and ENGAGE holdonly (would-merge → hold) for any repo whose merge precision dropped
+        // below the floor, plus AUTO-CLEAR a recovered breaker. Fail-safe: with no pr_outcome history the eval
+        // reads neutral → nothing engages → byte-identical. (applyAutoTune / maybeAutoClearHoldOnly, previously
+        // unwired — zero call-sites.)
+        await runSelfTuneBreaker(env);
+      }
       return;
     case "rag-index-repo":
       // Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). Defense-in-depth: the cron + webhook only
@@ -689,7 +698,12 @@ async function maybeRunAgentMaintenance(
       approvedHeadSha: pr.approvedHeadSha,
     },
   });
-  if (planned.length === 0) return;
+  // Accuracy circuit-breaker (#self-improve / GAP-4): when the holdonly flag is set for this repo (the
+  // auto-tuner engaged it after merge precision dropped, or a human set it), convert a would-MERGE into a human
+  // HOLD before executing. Fail-safe: isHoldOnly reads false until a breaker actually engages, so the common
+  // path is byte-identical (downgradeMergeToHold returns the plan unchanged).
+  const breakerOnPlan = (await isHoldOnly(env, repoFullName)) ? downgradeMergeToHold(planned, true) : planned;
+  if (breakerOnPlan.length === 0) return;
 
   const installation = await getInstallation(env, installationId);
   /* v8 ignore next -- an installed-App PR webhook always carries an installation record; the null is defensive. */
@@ -707,7 +721,7 @@ async function maybeRunAgentMaintenance(
       installationPermissions,
       authorLogin: pr.authorLogin,
     },
-    planned,
+    breakerOnPlan,
   );
 
   // Flag-then-close double-check, Pass 2 trigger: when this pass FLAGGED the PR (added the pending-closure
@@ -715,7 +729,7 @@ async function maybeRunAgentMaintenance(
   // instead of waiting for the next CI-completion event or the hourly sweep. Best-effort — if the enqueue fails,
   // the next sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review
   // job (it just re-runs reReviewStoredPullRequest), so no new job type is needed.
-  const flaggedForLinkedIssue = planned.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add");
+  const flaggedForLinkedIssue = breakerOnPlan.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add");
   if (flaggedForLinkedIssue) {
     const delaySeconds = Math.max(0, linkedIssueRulesConfig.closeDelaySeconds);
     const verifyJob = { type: "recapture-preview" as const, deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId, attempt: 0 };
@@ -1413,6 +1427,19 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
 
     if (payload.repository?.full_name && payload.pull_request) {
       const repoFullName = payload.repository.full_name;
+      // Accuracy/eval feedback loop (#self-improve / GAP-4). Independent of the review path + best-effort:
+      //   • pr_outcome — on `closed`, record the REALIZED merge-vs-close ground truth so computeGateEval can
+      //     score the gate's prediction against what the human actually did.
+      //   • reversal — on `reopened` of a bot-CLOSED PR (contributor dispute) / a merged "Reverts #N" PR,
+      //     record the human override so reversalRate/calibration are no longer blind. Both fail safe.
+      await recordPrOutcome(env, eventName, payload).catch((error) => {
+        /* v8 ignore next -- best-effort: outcome recording never blocks the webhook. */
+        console.warn(JSON.stringify({ level: "warn", event: "pr_outcome_record_failed", deliveryId, repository: repoFullName, error: errorMessage(error) }));
+      });
+      await recordReversalSignals(env, eventName, payload).catch((error) => {
+        /* v8 ignore next -- best-effort: reversal recording never blocks the webhook. */
+        console.warn(JSON.stringify({ level: "warn", event: "reversal_record_failed", deliveryId, repository: repoFullName, error: errorMessage(error) }));
+      });
       const pr = await upsertPullRequestFromGitHub(env, repoFullName, payload.pull_request);
       const [repo, settings, otherOpenPullRequests] = await Promise.all([
         getRepository(env, repoFullName),

--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -1,0 +1,267 @@
+// Convergence (#self-improve / GAP-4) — the accuracy/eval FEEDBACK LOOP recording + circuit-breaker wiring.
+//
+// This is the half of GAP-4 that lets the bot SEE the outcomes of its own decisions and self-correct. The pure
+// calibration logic already exists (src/review/auto-tune.ts: planAutoTune / applyAutoTune / maybeAutoClearHoldOnly,
+// and src/review/parity.ts: computeGateEval); this module closes the loop by:
+//   1. RECORDING GROUND TRUTH — when a PR closes, a `pr_outcome` row (merged vs closed) so computeGateEval can
+//      score the gate's prediction (gate_decision) against what the human actually did.
+//   2. RECORDING REVERSALS — when a HUMAN undoes a bot action (a bot-closed PR reopened, or a bot-merged PR
+//      reverted), a `reversal_reopened` / `reversal_reverted` row. This un-blinds the reversalRate/calibration
+//      reads (ops.ts already READS these but, with no writer, they sat at 0).
+//   3. The live D1-backed FlagStore (system_flags, migration 0054) the precision circuit-breaker engages /
+//      clears + reads, so applyAutoTune / maybeAutoClearHoldOnly and the merge→hold downgrade have real storage.
+//
+// STORAGE: the realized outcome + reversal rows are written to BOTH
+//   • `review_audit` — the canonical eval/parity store (migration 0049). computeGateEval reads
+//     event_type='pr_outcome' (decision column) joined to event_type='gate_decision' here; ops.ts joins
+//     reversal_* rows to review_targets. This is the store the feedback loop actually consumes.
+//   • `audit_events` — the general product-audit ledger, via the existing recordAuditEvent helper (per the
+//     GAP-4 task), so the outcome/reversal is also visible on the standard audit surface.
+// Both writes are best-effort (a failure is swallowed); recording telemetry must never break the webhook.
+//
+// FAIL-SAFE / BYTE-IDENTICAL CONTRACT: with no pr_outcome/reversal history yet, computeGateEval reads neutral →
+// applyAutoTune engages nothing → isHoldOnly is false → the merge path is unchanged. The breaker only engages
+// once a repo's merge precision actually drops below the floor over a real sample.
+
+import { recordAuditEvent } from "../db/repositories";
+import type { GitHubWebhookPayload } from "../types";
+import { errorMessage, nowIso } from "../utils/json";
+import { applyAutoTune, AUTOTUNE_MERGE_PRECISION_FLOOR, type FlagStore, type GateEvalReport, maybeAutoClearHoldOnly } from "./auto-tune";
+import { computeGateEval } from "./parity";
+
+/** PURE: parse the PR number an "Reverts #N / Reverts owner/repo#N" body refers to (GitHub's revert PRs).
+ *  Mirrors reviewbot runtime.ts parseRevertedPrNumber. Returns undefined when the body isn't a revert. */
+export function parseRevertedPrNumber(body: string | null | undefined): number | undefined {
+  const m = /Reverts\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/i.exec(body ?? "");
+  return m ? Number(m[1]) : undefined;
+}
+
+// ── Live D1-backed FlagStore (system_flags, migration 0054) ─────────────────────────────────────────────────
+// Byte-faithful to the reviewbot src/core/system-flags.ts holdonly accessors. <scope> is `global` or a repo full
+// name. Both reads fail OPEN (false / null) on a DB blip — a fault must never silently change behavior.
+
+function flagTruthy(v: string | null | undefined): boolean {
+  return v === "1" || v === "true" || v === "on" || v === "yes";
+}
+
+/** Is auto-merge disabled (would-merge → hold) for this project (or globally)? Fail-OPEN (false) on a DB error.
+ *  This is the read the merge path consults to downgrade a would-MERGE into a HOLD. */
+export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
+  try {
+    const res = await env.DB.prepare("SELECT key, value FROM system_flags").all<{ key: string; value: string }>();
+    const set = new Set<string>();
+    for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
+    return set.has("holdonly:global") || set.has(`holdonly:${project}`);
+  } catch (error) {
+    console.warn(JSON.stringify({ ev: "flags_read_error", message: errorMessage(error).slice(0, 120) }));
+    return false; // fail-OPEN: a DB blip must never silently change the merge path
+  }
+}
+
+/** A live FlagStore over system_flags for the circuit-breaker (applyAutoTune / maybeAutoClearHoldOnly). */
+export function createFlagStore(env: Env): FlagStore {
+  return {
+    async isHoldOnly(project: string): Promise<boolean> {
+      // Per-key check (NOT the global-or-project read above): applyAutoTune dedups on whether THIS project's
+      // breaker is already engaged, so it must read the per-project key, not fold in the global one.
+      try {
+        const row = await env.DB.prepare("SELECT value FROM system_flags WHERE key = ?").bind(`holdonly:${project}`).first<{ value: string }>();
+        return flagTruthy(row?.value);
+      } catch {
+        return false;
+      }
+    },
+    async setFlag(key: string, on: boolean): Promise<void> {
+      if (on) {
+        await env.DB.prepare("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES (?, '1', CURRENT_TIMESTAMP)").bind(key).run();
+      } else {
+        await env.DB.prepare("DELETE FROM system_flags WHERE key = ?").bind(key).run();
+      }
+    },
+    async flagSetAt(key: string): Promise<string | null> {
+      try {
+        const row = await env.DB.prepare("SELECT updated_at FROM system_flags WHERE key = ?").bind(key).first<{ updated_at: string }>();
+        return row?.updated_at ?? null;
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+// ── review_audit append (the canonical eval/parity store) ───────────────────────────────────────────────────
+
+/** The target_id the gate-decision writer (parity-wire.ts) stamps — `project#pr`. The pr_outcome/reversal rows
+ *  MUST use the same key so computeGateEval can join a prediction to its realized outcome. */
+function reviewAuditTargetId(repoFullName: string, pullNumber: number): string {
+  return `${repoFullName.slice(0, 200)}#${pullNumber}`;
+}
+
+/** Append one row to review_audit. Best-effort — a write failure is swallowed (telemetry must not break the
+ *  webhook). `decision` is the realized merge/close for a pr_outcome row; null for a reversal marker row. */
+async function appendReviewAudit(
+  env: Env,
+  input: { project: string; targetId: string; eventType: string; decision?: string | null; summary?: string | null },
+): Promise<void> {
+  try {
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at)
+       VALUES (?, ?, ?, ?, ?, 'gittensory-native', NULL, ?, ?)`,
+    )
+      .bind(`${input.eventType}:${input.targetId}:${nowIso()}:${Math.random().toString(36).slice(2, 8)}`, input.project, input.targetId, input.eventType, input.decision ?? null, input.summary ?? null, nowIso())
+      .run();
+  } catch (error) {
+    console.warn(JSON.stringify({ ev: "review_audit_record_error", event: input.eventType, project: input.project, message: errorMessage(error).slice(0, 160) }));
+  }
+}
+
+// ── 1) pr_outcome — realized ground truth (merged vs closed) ─────────────────────────────────────────────────
+
+/**
+ * Record a PR's REALIZED outcome (the eval's answer key) when it closes. Mirrors reviewbot runtime.ts (~164):
+ * on a `pull_request` `closed` webhook, write a `pr_outcome` row capturing merged-vs-closed so computeGateEval
+ * can score the gate's prediction against what the human actually did — even on repos where the bot didn't act.
+ *
+ * Writes to BOTH the canonical eval store (review_audit, with the decision column the eval reads) AND the
+ * general audit ledger (audit_events, via recordAuditEvent, per the GAP-4 task). Best-effort throughout. A
+ * non-closed action, or a payload with no PR number, records nothing.
+ */
+export async function recordPrOutcome(env: Env, eventName: string, payload: GitHubWebhookPayload): Promise<void> {
+  if (eventName !== "pull_request" || payload.action !== "closed") return;
+  const pr = payload.pull_request;
+  const repoFullName = payload.repository?.full_name;
+  if (!pr?.number || !repoFullName) return;
+
+  const merged = Boolean(pr.merged_at);
+  const decision = merged ? "merged" : "closed";
+  const targetId = reviewAuditTargetId(repoFullName, pr.number);
+  // Whether GITTENSORY itself was the actor that resolved this PR — for the metadata only (the bot's own
+  // close/merge action was already recorded as an agent.action.* audit row; this just annotates the outcome).
+  const botWasActor = payload.sender?.type === "Bot";
+
+  await appendReviewAudit(env, { project: repoFullName.slice(0, 200), targetId, eventType: "pr_outcome", decision });
+  await recordAuditEvent(env, {
+    eventType: "pr_outcome",
+    actor: payload.sender?.login ?? null,
+    targetKey: targetId,
+    outcome: "completed",
+    detail: decision,
+    metadata: { repoFullName, pullNumber: pr.number, merged, botWasActor },
+  }).catch((error) => console.warn(JSON.stringify({ ev: "pr_outcome_audit_error", message: errorMessage(error).slice(0, 160) })));
+}
+
+// ── 2) reversals — a human undid a bot action ────────────────────────────────────────────────────────────────
+
+/** Was the last GITTENSORY action on this PR a CLOSE? Reads the agent-action audit ledger (audit_events,
+ *  eventType `agent.action.<class>`, written by buildAgentActionAudit) — the most-recent SUCCESSFUL action for
+ *  this target. A reopen of a bot-CLOSED PR is the high-value "human disagreed with the close" reversal signal.
+ *  Fail-safe: a read error → false (record nothing rather than a false reversal). */
+async function lastBotActionWasClose(env: Env, targetKey: string): Promise<boolean> {
+  try {
+    const row = await env.DB
+      .prepare(
+        `SELECT event_type FROM audit_events
+         WHERE target_key = ? AND event_type LIKE 'agent.action.%' AND outcome = 'success'
+         ORDER BY created_at DESC LIMIT 1`,
+      )
+      .bind(targetKey)
+      .first<{ event_type: string }>();
+    return row?.event_type === "agent.action.close";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record a REVERSAL — a human overriding a gittensory auto-action — into the eval/audit stores (the
+ * ground-truth accuracy signal). Mirrors reviewbot recordReversalSignals (runtime.ts ~157/274):
+ *   • REOPEN of a bot-CLOSED PR by a CONTRIBUTOR → `reversal_reopened` (the high-value case). Reopens by the
+ *     repo OWNER (administrative re-queue) or by a BOT are NOT contributor disputes and are skipped, so the
+ *     reversal signal isn't inflated.
+ *   • a merged "Reverts #N" PR (a bot-MERGED PR a human reverted) → `reversal_reverted` against PR #N.
+ *
+ * Writes to BOTH review_audit (what ops.ts joins for reversalRate/calibration) and audit_events (the general
+ * ledger). Best-effort + independent of the review path. A non-reversal event records nothing.
+ */
+export async function recordReversalSignals(env: Env, eventName: string, payload: GitHubWebhookPayload): Promise<void> {
+  if (eventName !== "pull_request") return;
+  const pr = payload.pull_request;
+  const repoFullName = payload.repository?.full_name;
+  if (!pr?.number || !repoFullName) return;
+  const project = repoFullName.slice(0, 200);
+
+  // A bot-CLOSED PR REOPENED by a contributor — the genuine "human disagreed with this close" signal.
+  if (payload.action === "reopened") {
+    const ownerLogin = (repoFullName.split("/")[0] || "").toLowerCase();
+    const senderLogin = (payload.sender?.login || "").toLowerCase();
+    const senderIsOwner = !!ownerLogin && !!senderLogin && ownerLogin === senderLogin;
+    const senderIsBot = payload.sender?.type === "Bot";
+    if (senderIsBot || senderIsOwner) return; // administrative / bot reopen — not a contributor dispute
+    const targetId = reviewAuditTargetId(repoFullName, pr.number);
+    if (!(await lastBotActionWasClose(env, targetId))) return; // only a bot-CLOSED PR reopening is a reversal
+    await appendReviewAudit(env, { project, targetId, eventType: "reversal_reopened", summary: `Bot-closed PR #${pr.number} reopened by a contributor.` });
+    await recordAuditEvent(env, {
+      eventType: "reversal_reopened",
+      actor: payload.sender?.login ?? null,
+      targetKey: targetId,
+      outcome: "completed",
+      detail: `Bot-closed PR #${pr.number} reopened by a contributor.`,
+      metadata: { repoFullName, pullNumber: pr.number },
+    }).catch(() => undefined);
+    return;
+  }
+
+  // A merged "Reverts #N" PR — a bot-MERGED PR that a human reverted.
+  if (payload.action === "closed" && Boolean(pr.merged_at)) {
+    const reverted = parseRevertedPrNumber(pr.body);
+    if (!reverted) return;
+    const revertedTargetKey = reviewAuditTargetId(repoFullName, reverted);
+    // The reverted PR (#N) had a recorded pr_outcome=merged only if it merged; the reversal_reverted row marks
+    // that merge as later undone so reversalRate/calibration reflect it. (Auto-revert — opening a revert PR — is
+    // a separate, larger feature and intentionally NOT wired here; this records the human-driven revert signal.)
+    await appendReviewAudit(env, { project, targetId: revertedTargetKey, eventType: "reversal_reverted", summary: `Merged PR #${reverted} was reverted by #${pr.number}.` });
+    await recordAuditEvent(env, {
+      eventType: "reversal_reverted",
+      actor: payload.sender?.login ?? null,
+      targetKey: revertedTargetKey,
+      outcome: "completed",
+      detail: `Merged PR #${reverted} was reverted by #${pr.number}.`,
+      metadata: { repoFullName, revertedPullNumber: reverted, revertPullNumber: pr.number },
+    }).catch(() => undefined);
+  }
+}
+
+// ── 3) precision circuit-breaker tick (cron) ─────────────────────────────────────────────────────────────────
+
+/** How far back computeGateEval looks for the prediction-vs-outcome confusion matrix. */
+const BREAKER_EVAL_WINDOW_DAYS = 90;
+
+/**
+ * One precision-circuit-breaker tick, run on the scheduled (selftune) cron. Reads the gate-eval confusion
+ * matrix over gittensory's OWN recorded pr_outcome/gate_decision rows, then:
+ *   • ENGAGES the breaker (holdonly:<project>) for any repo whose merge precision dropped below the floor over
+ *     a real sample (applyAutoTune) — the would-MERGE → HOLD downgrade then kicks in on the next merge path.
+ *   • AUTO-CLEARS an auto-engaged breaker once its cooldown elapsed AND precision recovered (maybeAutoClearHoldOnly).
+ * Strictly TIGHTENING-only: it only ever makes the system MORE cautious; a human clears a breaker that should
+ * be cleared early. FAILS SAFE — a thrown error is logged and swallowed (tuning must never break the cron). With
+ * no pr_outcome history the eval reads neutral → nothing engages → byte-identical.
+ */
+export async function runSelfTuneBreaker(env: Env): Promise<void> {
+  try {
+    const nowMs = Date.now();
+    const report: GateEvalReport = await computeGateEval(env, { days: BREAKER_EVAL_WINDOW_DAYS, nowMs });
+    const flags = createFlagStore(env);
+    const engaged = await applyAutoTune(flags, report);
+    for (const action of engaged) {
+      console.warn(JSON.stringify({ ev: "breaker_engaged", project: action.project, mergePrecision: action.mergePrecision, decided: action.decided, floor: AUTOTUNE_MERGE_PRECISION_FLOOR }));
+    }
+    // Auto-clear any auto-engaged breaker that has cooled down + recovered (one per repo present in the report).
+    for (const row of report.rows) {
+      if (await maybeAutoClearHoldOnly(flags, report, row.project, nowMs)) {
+        console.log(JSON.stringify({ ev: "breaker_auto_cleared", project: row.project }));
+      }
+    }
+  } catch (error) {
+    console.warn(JSON.stringify({ ev: "breaker_tick_error", message: errorMessage(error).slice(0, 200) }));
+  }
+}

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -119,6 +119,36 @@ function hasLabel(labels: string[], name: string): boolean {
   return labels.some((label) => label.toLowerCase() === name.toLowerCase());
 }
 
+/**
+ * Accuracy circuit-breaker (#self-improve / GAP-4): when auto-merge is DISABLED for a repo (the auto-tuner
+ * engaged the holdonly flag after merge precision dropped, or a human set it), DOWNGRADE a would-MERGE into a
+ * human HOLD — drop the `merge` action and surface the needs-human-review label so the PR is held for a person
+ * instead of auto-merged. Mirrors reviewbot non-content-gate.ts (~212: a would-merge becomes a hold under the
+ * breaker; close/label/approve are untouched).
+ *
+ * PURE + idempotent: with `holdOnly` false this returns the plan UNCHANGED (byte-identical, the common path);
+ * with it true and no merge planned it is also a no-op. Only ever makes the system MORE cautious.
+ */
+export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: boolean): PlannedAgentAction[] {
+  if (!holdOnly || !planned.some((action) => action.actionClass === "merge")) return planned;
+  const next = planned.filter((action) => action.actionClass !== "merge");
+  // The dropped merge implies the PR is review-good — re-label it needs-human-review (replacing a stale
+  // ready-to-merge promise) so the held PR is clearly flagged for a person. Idempotent: only add when absent.
+  const alreadyNeedsReview = next.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_NEEDS_REVIEW && action.labelOp !== "remove");
+  const stagedMerge = planned.find((action) => action.actionClass === "merge");
+  if (!alreadyNeedsReview) {
+    next.push({
+      actionClass: "label",
+      requiresApproval: stagedMerge?.requiresApproval ?? false,
+      reason: "accuracy circuit-breaker engaged (merge precision dropped) — would-merge held for human review",
+      label: AGENT_LABEL_NEEDS_REVIEW,
+      labelOp: "add",
+    });
+  }
+  // Drop any ready-to-merge label add (the auto-merge it promised is now suppressed).
+  return next.filter((action) => !(action.actionClass === "label" && action.label === AGENT_LABEL_READY && action.labelOp !== "remove"));
+}
+
 function closeMessage(reasons: string[]): string {
   return `Gittensory is closing this pull request on the maintainer's behalf (${reasons.join("; ")}). This is an automated maintenance action — if you believe it's mistaken, reopen the PR or ping a maintainer and it will be reviewed.`;
 }

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
+import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import type { GateCheckConclusion } from "../../src/rules/advisory";
 
@@ -422,5 +422,25 @@ describe("isProtectedAutomationAuthor", () => {
     expect(isProtectedAutomationAuthor("some-contributor")).toBe(false);
     expect(isProtectedAutomationAuthor(null)).toBe(false);
     expect(isProtectedAutomationAuthor(undefined)).toBe(false);
+  });
+});
+
+describe("downgradeMergeToHold — accuracy circuit-breaker (#self-improve / GAP-4)", () => {
+  // A REAL would-merge plan from the planner: gate success + clean + approvals satisfied.
+  const wouldMerge = () =>
+    planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", label: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean" } }));
+
+  it("a real would-MERGE plan becomes a HOLD when the breaker is engaged (holdOnly=true)", () => {
+    const plan = wouldMerge();
+    expect(classes(plan)).toContain("merge"); // sanity: the planner really would auto-merge
+    const held = downgradeMergeToHold(plan, true);
+    expect(classes(held)).not.toContain("merge"); // the would-merge is downgraded...
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add")).toBe(true); // ...to a human hold
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false); // the ready-to-merge promise is dropped
+  });
+
+  it("holdOnly=false leaves a real would-merge plan UNCHANGED (byte-identical common path)", () => {
+    const plan = wouldMerge();
+    expect(downgradeMergeToHold(plan, false)).toBe(plan);
   });
 });

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from "vitest";
+import { processJob } from "../../src/queue/processors";
+import {
+  createFlagStore,
+  isHoldOnly,
+  parseRevertedPrNumber,
+  recordPrOutcome,
+  recordReversalSignals,
+  runSelfTuneBreaker,
+} from "../../src/review/outcomes-wire";
+import { applyAutoTune, type GateEvalReport } from "../../src/review/auto-tune";
+import { downgradeMergeToHold, type PlannedAgentAction } from "../../src/settings/agent-actions";
+import { recordAuditEvent } from "../../src/db/repositories";
+import type { GitHubPullRequestPayload } from "../../src/types";
+import { createTestEnv } from "../helpers/d1";
+
+// ── helpers ────────────────────────────────────────────────────────────────────────────────────────────────
+
+async function reviewAuditRows(env: Env, eventType: string): Promise<Array<{ project: string; target_id: string; decision: string | null; summary: string | null }>> {
+  const res = await env.DB.prepare("SELECT project, target_id, decision, summary FROM review_audit WHERE event_type = ?")
+    .bind(eventType)
+    .all<{ project: string; target_id: string; decision: string | null; summary: string | null }>();
+  return res.results ?? [];
+}
+
+async function auditEventRows(env: Env, eventType: string): Promise<Array<{ target_key: string | null; detail: string | null }>> {
+  const res = await env.DB.prepare("SELECT target_key, detail FROM audit_events WHERE event_type = ?")
+    .bind(eventType)
+    .all<{ target_key: string | null; detail: string | null }>();
+  return res.results ?? [];
+}
+
+/** Seed the bot's own last action on a PR into the agent-action audit ledger (audit_events). */
+async function seedBotAction(env: Env, targetKey: string, actionClass: "close" | "merge" | "approve", outcome: "success" | "denied" = "success"): Promise<void> {
+  await recordAuditEvent(env, { eventType: `agent.action.${actionClass}`, targetKey, outcome });
+}
+
+function pullRequestPayload(over: Partial<GitHubPullRequestPayload> = {}): GitHubPullRequestPayload {
+  return { number: 7, title: "PR", state: "closed", head: { sha: "s7" }, labels: [], ...over };
+}
+
+// ── 1) pr_outcome — realized ground truth (merged + closed) ───────────────────────────────────────────────────
+
+describe("recordPrOutcome — realized merge/close ground truth", () => {
+  it("writes a pr_outcome=merged row (review_audit + audit_events) on a merged PR close", async () => {
+    const env = createTestEnv();
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 42, merged_at: "2026-06-20T00:00:00.000Z" }),
+      sender: { login: "owner", type: "User" },
+    });
+    const eval_ = await reviewAuditRows(env, "pr_outcome");
+    expect(eval_).toHaveLength(1);
+    expect(eval_[0]).toMatchObject({ project: "owner/repo", target_id: "owner/repo#42", decision: "merged" });
+    const ledger = await auditEventRows(env, "pr_outcome");
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]).toMatchObject({ target_key: "owner/repo#42", detail: "merged" });
+  });
+
+  it("writes a pr_outcome=closed row when a PR is closed WITHOUT merging", async () => {
+    const env = createTestEnv();
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 43, merged_at: null }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({ target_id: "owner/repo#43", decision: "closed" });
+    expect((await auditEventRows(env, "pr_outcome"))[0]).toMatchObject({ detail: "closed" });
+  });
+
+  it("records NOTHING for a non-closed action or a payload with no PR number", async () => {
+    const env = createTestEnv();
+    await recordPrOutcome(env, "pull_request", { action: "opened", repository: { name: "repo", full_name: "owner/repo" }, pull_request: pullRequestPayload({ number: 44, state: "open" }) });
+    await recordPrOutcome(env, "pull_request", { action: "closed", repository: { name: "repo", full_name: "owner/repo" } });
+    expect(await reviewAuditRows(env, "pr_outcome")).toHaveLength(0);
+    expect(await auditEventRows(env, "pr_outcome")).toHaveLength(0);
+  });
+});
+
+// ── 2) reversal_reopened — a contributor reopened a bot-CLOSED PR ──────────────────────────────────────────────
+
+describe("recordReversalSignals — reversal_reopened", () => {
+  it("writes reversal_reopened (review_audit + audit_events) when a contributor reopens a bot-CLOSED PR", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close"); // the bot's last action on this PR was a close
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "contributor", type: "User" }, // not the owner, not a bot → a genuine dispute
+    });
+    const eval_ = await reviewAuditRows(env, "reversal_reopened");
+    expect(eval_).toHaveLength(1);
+    expect(eval_[0]).toMatchObject({ project: "owner/repo", target_id: "owner/repo#7" });
+    expect(await auditEventRows(env, "reversal_reopened")).toHaveLength(1);
+  });
+
+  it("does NOT record when the last bot action on the PR was NOT a close (e.g. merge/approve)", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "approve");
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(0);
+  });
+
+  it("does NOT record an OWNER reopen or a BOT reopen (administrative / not a contributor dispute)", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close");
+    // Owner reopen — administrative re-queue, not a dispute.
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "owner", type: "User" },
+    });
+    // Bot reopen — not a human dispute.
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "some-bot[bot]", type: "Bot" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(0);
+  });
+
+  it("records reversal_reverted against PR #N for a merged \"Reverts #N\" PR", async () => {
+    const env = createTestEnv();
+    await recordReversalSignals(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50\n\nThis reverts the change." }),
+      sender: { login: "contributor", type: "User" },
+    });
+    const eval_ = await reviewAuditRows(env, "reversal_reverted");
+    expect(eval_).toHaveLength(1);
+    expect(eval_[0]).toMatchObject({ target_id: "owner/repo#50" });
+    expect(await auditEventRows(env, "reversal_reverted")).toHaveLength(1);
+  });
+
+  it("does NOT record reversal_reverted for a merged PR whose body is not a revert", async () => {
+    const env = createTestEnv();
+    await recordReversalSignals(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "A normal feature PR." }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reverted")).toHaveLength(0);
+  });
+});
+
+describe("parseRevertedPrNumber (pure)", () => {
+  it("parses #N and owner/repo#N revert bodies; undefined otherwise", () => {
+    expect(parseRevertedPrNumber("Reverts #123")).toBe(123);
+    expect(parseRevertedPrNumber("Reverts owner/repo#7")).toBe(7);
+    expect(parseRevertedPrNumber("A normal PR")).toBeUndefined();
+    expect(parseRevertedPrNumber(null)).toBeUndefined();
+  });
+});
+
+// ── 3a) downgradeMergeToHold (pure) — the precision-breaker merge→hold transform ───────────────────────────────
+
+describe("downgradeMergeToHold (pure)", () => {
+  const mergeAction: PlannedAgentAction = { actionClass: "merge", requiresApproval: false, reason: "ready" };
+  const readyLabel: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "ready", label: "gittensory:ready-to-merge", labelOp: "add" };
+  const closeAction: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "bad" };
+
+  it("holdOnly=false → returns the plan UNCHANGED (byte-identical common path)", () => {
+    const plan = [readyLabel, mergeAction];
+    expect(downgradeMergeToHold(plan, false)).toBe(plan);
+  });
+
+  it("holdOnly=true + a planned merge → drops the merge + ready label, adds needs-human-review", () => {
+    const out = downgradeMergeToHold([readyLabel, mergeAction], true);
+    expect(out.some((a) => a.actionClass === "merge")).toBe(false);
+    expect(out.some((a) => a.actionClass === "label" && a.label === "gittensory:ready-to-merge")).toBe(false);
+    expect(out.some((a) => a.actionClass === "label" && a.label === "gittensory:needs-human-review" && a.labelOp === "add")).toBe(true);
+  });
+
+  it("holdOnly=true but NO merge planned (e.g. a close) → no-op (returns the plan unchanged)", () => {
+    const plan = [closeAction];
+    expect(downgradeMergeToHold(plan, true)).toBe(plan);
+  });
+});
+
+// ── 3b) live FlagStore + isHoldOnly + the breaker tick ─────────────────────────────────────────────────────────
+
+describe("isHoldOnly + createFlagStore (system_flags, migration 0054)", () => {
+  it("isHoldOnly is false with no flags, true once holdonly:<project> is set, and respects holdonly:global", async () => {
+    const env = createTestEnv();
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+    const flags = createFlagStore(env);
+    await flags.setFlag("holdonly:owner/repo", true);
+    expect(await isHoldOnly(env, "owner/repo")).toBe(true);
+    expect(await isHoldOnly(env, "owner/other")).toBe(false);
+    await flags.setFlag("holdonly:owner/repo", false);
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+    // global breaker applies to every project.
+    await flags.setFlag("holdonly:global", true);
+    expect(await isHoldOnly(env, "any/repo")).toBe(true);
+  });
+
+  it("flagSetAt round-trips the updated_at and is null when unset", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    expect(await flags.flagSetAt("holdonly:owner/repo")).toBeNull();
+    await flags.setFlag("holdonly:owner/repo", true);
+    expect(await flags.flagSetAt("holdonly:owner/repo")).toBeTruthy();
+  });
+});
+
+describe("applyAutoTune over the live FlagStore — engages holdonly on low merge precision", () => {
+  it("engages holdonly:<project> when merge precision is below the floor over a real sample", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    // 5 confirmed / 12 would-merge = ~42% precision over 12 decided → below the 85% floor with a real sample.
+    const report: GateEvalReport = {
+      rows: [{ project: "owner/repo", wouldMerge: 12, mergeConfirmed: 5, mergeFalse: 7, wouldClose: 0, closeConfirmed: 0, closeFalse: 0, hold: 0, decided: 12, mergePrecision: 5 / 12, closePrecision: null }],
+      hasSignal: true,
+    };
+    const engaged = await applyAutoTune(flags, report);
+    expect(engaged.map((a) => a.project)).toEqual(["owner/repo"]);
+    expect(await isHoldOnly(env, "owner/repo")).toBe(true);
+  });
+});
+
+describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engages/clears the breaker", () => {
+  // Seed a gate_decision prediction + the realized pr_outcome for one PR (the join computeGateEval folds).
+  async function seedDecisionAndOutcome(env: Env, project: string, pr: number, pred: "merge" | "close", truth: "merged" | "closed"): Promise<void> {
+    await env.DB.prepare(
+      "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?, ?, ?, 'gate_decision', ?, 'gittensory-native', ?, NULL, CURRENT_TIMESTAMP)",
+    )
+      .bind(`gd:${project}#${pr}`, project, `${project}#${pr}`, pred, `sha${pr}`)
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?, ?, ?, 'pr_outcome', ?, 'gittensory-native', NULL, NULL, CURRENT_TIMESTAMP)",
+    )
+      .bind(`po:${project}#${pr}`, project, `${project}#${pr}`, truth)
+      .run();
+  }
+
+  it("ENGAGES the breaker when recorded outcomes show merge precision below the floor", async () => {
+    const env = createTestEnv();
+    // 12 would-merge predictions: 4 confirmed merged, 8 the human actually CLOSED → 33% precision over 12 decided.
+    for (let i = 0; i < 4; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
+    for (let i = 4; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "closed");
+
+    await runSelfTuneBreaker(env);
+
+    expect(await isHoldOnly(env, "owner/repo")).toBe(true);
+  });
+
+  it("does NOT engage with no recorded outcome history (fail-safe / byte-identical)", async () => {
+    const env = createTestEnv();
+    await runSelfTuneBreaker(env);
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+  });
+
+  it("never throws (fails safe) even when review_audit reads blow up", async () => {
+    const env = createTestEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = ((sql: string) => {
+      if (/review_audit/i.test(sql)) throw new Error("poisoned");
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(runSelfTuneBreaker(env)).resolves.toBeUndefined();
+    warn.mockRestore();
+  });
+});
+
+// ── integration: the PR-closed webhook records pr_outcome through processJob ────────────────────────────────────
+
+describe("processJob(github-webhook) wires pr_outcome recording on a PR close", () => {
+  it("a closed+merged pull_request webhook records the pr_outcome ground truth", async () => {
+    const env = createTestEnv();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      return new Response("not found", { status: 404 });
+    });
+    try {
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "gap4-pr-outcome-merged",
+        eventName: "pull_request",
+        payload: {
+          action: "closed",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
+          pull_request: { number: 5151, title: "Merged PR", state: "closed", merged_at: "2026-06-20T00:00:00.000Z", user: { login: "contributor" }, head: { sha: "abc123" }, labels: [], body: "Adds a feature." },
+          sender: { login: "contributor", type: "User" },
+        },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const eval_ = await reviewAuditRows(env, "pr_outcome");
+    expect(eval_.some((r) => r.target_id === "JSONbored/gittensory#5151" && r.decision === "merged")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Closes the GAP-4 feedback loop so the bot can SEE the outcomes of its own decisions and self-correct. Three previously ported-but-unwired pieces are now live:

### 1. `pr_outcome` ground truth
On a `pull_request` `closed` webhook (`processGitHubWebhook`, `src/queue/processors.ts`), `recordPrOutcome` records the realized **merge-vs-close** decision to:
- **`review_audit`** (the canonical eval store `computeGateEval`/parity read — `decision` = `merged`/`closed`, joined to `gate_decision` by `target_id`), and
- **`audit_events`** via the existing `recordAuditEvent` helper (the general ledger, per the task).

Mirrors reviewbot `runtime.ts` (~164).

### 2. Reversals
`recordReversalSignals` records when a **human undoes a bot action**:
- **`reversal_reopened`** — a bot-CLOSED PR reopened by a **contributor** (not the owner, not a bot). Detects "the last bot action on this PR was a close" from the `agent.action.*` audit ledger. This is the high-value case — it un-blinds `reversalRate`/calibration (ops already READS these but they sat at 0 with no writer).
- **`reversal_reverted`** — a merged `Reverts #N` PR.

Mirrors reviewbot `recordReversalSignals` (`runtime.ts` ~157/274). **Auto-revert (opening revert PRs) is a separate, larger feature and intentionally NOT ported — noted as a follow-up.**

### 3. Precision circuit-breaker (fail-safe — reads zero until data accrues)
- **Merge path** (`maybeRunAgentMaintenance`): reads `isHoldOnly(env, repo)` and, when set, converts a would-**MERGE** into a human **HOLD** via the new pure `downgradeMergeToHold` (drops the merge + ready-to-merge label, adds needs-human-review). Mirrors reviewbot `non-content-gate.ts` (~212).
- **Cron tick** (`selftune` job): `runSelfTuneBreaker` reads the gate-eval confusion matrix over the recorded `pr_outcome` ground truth and calls **`applyAutoTune`** (engage `holdonly:<repo>` when merge precision drops below the floor over a real sample) + **`maybeAutoClearHoldOnly`** (auto-clear a recovered breaker). Both had **zero call-sites** before this PR.
- Backed by a new **`system_flags`** table (migration `0054`) for the live `FlagStore` (port of reviewbot `system-flags.ts`).

**Fail-safe contract:** with no `pr_outcome`/reversal history yet, `computeGateEval` reads neutral → `applyAutoTune` engages nothing → `isHoldOnly` is false → the merge path is byte-identical. The breaker only engages once a repo's merge precision actually drops.

## Files
- `migrations/0054_system_flags.sql` (new) — the holdonly flag store
- `src/review/outcomes-wire.ts` (new) — recorders + live FlagStore + breaker tick
- `src/settings/agent-actions.ts` — pure `downgradeMergeToHold`
- `src/queue/processors.ts` — wiring (webhook + cron + merge path)
- `test/unit/outcomes-wire.test.ts` (new, 19 tests) + `test/unit/agent-actions.test.ts` (+2)

## Verification
- `npx tsc --noEmit` clean (exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- `node scripts/check-migrations.mjs` — contiguous 0001..0054
- Full `npx vitest run` — **3584 passed**, 1 skipped (+21 vs baseline)

## Follow-ups (out of scope)
- Auto-revert (opening revert PRs on a post-merge red).
- Config-application of promoted tunable overrides into the live gate (already a documented seam in `selftune-wire.ts`).