### PR TITLE
fix(public-stats): live accuracy reversal signal (off the frozen review_audit)

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -13,7 +13,7 @@
 // got a published surface (skipped drafts/bots, errors) simply don't appear — there is no ignored/manual/error.
 //   reviewed   = merged + closed + commented            (every distinct PR a review surface was published for)
 //   filteredPct = (reviewed - merged) / reviewed         (share resolved WITHOUT a merge — noise kept off humans)
-//   accuracyPct = 1 - reversed / (merged + closed)       (reversal-grounded; reversed from review_audit history)
+//   accuracyPct = 1 - reversed / (merged + closed)       (reversed = engine auto-actions a human overturned, live)
 //   minutesSaved = reviewed * MINUTES_SAVED_PER_PR        (estimated maintainer review time saved)
 //
 // PRIVACY: counts only — no PR content, authors, scores, or reward internals. Safe to serve publicly.
@@ -133,8 +133,8 @@ export interface PublicStatsPayload {
 // `github_app.pr_public_surface_published`, target_key "owner/repo#number"). Its terminal DISPOSITION
 // (merged / closed-without-merge / still-open-in-review) comes from the pull_requests cache. This replaces the
 // legacy review_targets ledger, which the convergence cutover orphaned (nothing writes it anymore). `reversed`
-// (the accuracy denominator) still comes from review_audit's historical reversal events — there is no live
-// reversal signal yet, so it acts as a floor. All reads are public-safe COUNTs and degrade to 0 via safeAll.
+// (the accuracy numerator) is computed LIVE from the same ledger: a terminal engine auto-action (close/merge)
+// that a human later overturned (see the reversal query below). All reads are public-safe COUNTs, degrade to 0.
 const PUBLISHED_PR_KEYS = `
   SELECT
     substr(target_key, 1, instr(target_key, '#') - 1) AS repo,
@@ -192,8 +192,22 @@ export async function getPublicStats(
     ),
     safeAll<{ project: string; reversed: number }>(
       env,
-      `SELECT project, COUNT(*) AS reversed FROM review_audit
-        WHERE event_type IN ('reversal_reverted', 'reversal_reopened') AND LOWER(project) IN (${inList})
+      // A "reversal" = a terminal engine auto-action (close/merge) a human later OVERTURNED, detected LIVE from the
+      // PR's current state: an engine-closed PR now reopened/merged, or an engine-merged PR now reopened. Counts
+      // the detectable subset — a merge undone via a SEPARATE revert PR isn't visible here yet (the revert detector
+      // is the follow-up). Replaces the orphaned review_audit reversal events, frozen at the convergence cutover.
+      `SELECT project, COUNT(DISTINCT pr_number) AS reversed FROM (
+         SELECT substr(target_key, 1, instr(target_key, '#') - 1) AS project,
+                CAST(substr(target_key, instr(target_key, '#') + 1) AS INTEGER) AS pr_number,
+                event_type
+           FROM audit_events
+          WHERE event_type IN ('agent.action.close', 'agent.action.merge')
+            AND outcome = 'completed' AND instr(target_key, '#') > 0
+       ) ev
+       JOIN pull_requests pr ON pr.repo_full_name = ev.project AND pr.number = ev.pr_number
+        WHERE LOWER(ev.project) IN (${inList})
+          AND ( (ev.event_type = 'agent.action.close' AND (pr.state = 'open' OR pr.merged_at IS NOT NULL))
+             OR (ev.event_type = 'agent.action.merge' AND pr.state = 'open') )
         GROUP BY project`,
       ...projects,
     ),

--- a/test/integration/public-stats-route.test.ts
+++ b/test/integration/public-stats-route.test.ts
@@ -3,7 +3,7 @@ import { createApp } from "../../src/api/routes";
 import { createTestEnv } from "../helpers/d1";
 
 /** Seed the LIVE ledger: a published-review surface per reviewed PR (audit_events) + each PR's terminal
- *  disposition (pull_requests state/merged_at), plus one reversal (review_audit). */
+ *  disposition (pull_requests state/merged_at), plus one live reversal (an engine close on a now-reopened PR). */
 async function seed(env: Env) {
   // [repo, number, state, mergedAt] — merged (merged_at set) / closed (state closed, no merge) / open (in review).
   const prs: Array<[string, number, string, string | null]> = [
@@ -32,9 +32,10 @@ async function seed(env: Env) {
       )
       .run();
   }
-  // One human reversal of a gittensory auto-merge (awesome-claude has none → exercises the per-project ?? 0).
+  // One live reversal: the engine CLOSED gittensory#3, but it is now reopened (state 'open') — a human overturned
+  // the auto-action. awesome-claude has none → exercises the per-project ?? 0 fallback.
   await env.DB.prepare(
-    `INSERT INTO review_audit (id, project, target_id, event_type, decision) VALUES ('rev1', 'JSONbored/gittensory', 'JSONbored/gittensory#1', 'reversal_reverted', 'merge')`,
+    `INSERT INTO audit_events (id, event_type, target_key, outcome) VALUES ('rev1', 'agent.action.close', 'JSONbored/gittensory#3', 'completed')`,
   ).run();
 }
 

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -10,7 +10,7 @@ type Row = Record<string, unknown>;
 // Stub D1: route reads by SQL signature. The three reads are distinguished by:
 //   - weekly:       contains `first_seen`
 //   - dispositions: contains `github_app.pr_public_surface_published` (and is NOT the weekly read)
-//   - reversals:    contains `FROM review_audit`
+//   - reversals:    inspects engine auto-actions (`agent.action.close`)
 function stubEnv(handler: (sql: string, args: unknown[]) => Row[]): Env {
   const make = (sql: string, args: unknown[]) => ({
     bind: (...a: unknown[]) => make(sql, a),
@@ -32,6 +32,10 @@ function isDispositions(sql: string): boolean {
   return (
     sql.includes("github_app.pr_public_surface_published") && !isWeekly(sql)
   );
+}
+// The reversal read is the only one that inspects engine auto-actions (close/merge) against pull_requests state.
+function isReversal(sql: string): boolean {
+  return sql.includes("agent.action.close");
 }
 
 describe("isPublicStatsEnabled", () => {
@@ -75,7 +79,7 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
         },
       ];
     }
-    if (sql.includes("FROM review_audit")) {
+    if (isReversal(sql)) {
       return [
         { project: "JSONbored/awesome-claude", reversed: 20 },
         { project: "JSONbored/metagraphed", reversed: 10 },
@@ -114,7 +118,7 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
   it("publishes only projects from the reviewed-repo allowlist", async () => {
     const out = await getPublicStats(
       stubEnv((sql, args) => {
-        if (sql.includes("FROM review_audit")) {
+        if (isReversal(sql)) {
           return [
             { project: "JSONbored/gittensory", reversed: 1 },
             { project: "CustomerCo/stealth-product", reversed: 1 },
@@ -215,8 +219,7 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     // the `reversedByProject.get(...) ?? 0` fallback; the weekly row is present but its fields are null.
     const out = await getPublicStats(
       stubEnv((sql) => {
-        if (sql.includes("FROM review_audit"))
-          return [{ project: "p1", reversed: null }];
+        if (isReversal(sql)) return [{ project: "p1", reversed: null }];
         if (isWeekly(sql)) return [{ reviewed: null, merged: null }];
         if (isDispositions(sql)) {
           return [


### PR DESCRIPTION
## Problem
The homepage **decision-accuracy** stat reads `reversed` from `review_audit`'s reversal events — a table the **convergence cutover orphaned** (nothing writes it anymore). It's frozen at **33**, while the denominator (`merged + closed`) grows live from `audit_events`. So `accuracyPct = 1 − 33/(ever-growing)` **drifts upward toward 100% forever**, independent of any real wrong decision — a publicly-displayed vanity metric, and (worse) no instrument to catch a review-quality regression.

## Fix (interim — read-only, isolated)
Compute `reversed` **live from the same `audit_events` ledger**: a terminal engine auto-action (`agent.action.close` / `agent.action.merge`) that a human later **overturned**, detected from the PR's current `pull_requests` state:
- engine **closed** a PR that is now **reopened or merged**, or
- engine **merged** a PR that is now **reopened**.

This removes the frozen-numerator drift and makes accuracy a genuine live instrument (it drops when a human overturns an auto-action). Live value today: **1** reversal (a metagraphed close that was reopened) → accuracy ~99.97%, honestly sourced.

### Known limitation (follow-up)
This captures only the **detectable subset**. A merge undone via a **separate revert PR** isn't visible from PR state (a revert is a new PR, not a reopen of the original) — the **revert detector** (parse `Reverts #N`, link to engine-merged PRs, write live reversal events + a regression alarm) is the deliberate follow-up.

## Safety
- **Isolated to `src/review/public-stats.ts`** — zero review-engine files touched; reads are public-safe COUNTs that degrade to 0 via `safeAll`.
- **`PublicStatsPayload` shape unchanged** → the homepage UI needs no changes.
- Query verified against prod D1 (returns `reversed: 1`, 2.4 ms). Tests reseeded to the live reversal signal; 11/11 pass, all changed lines covered (codecov/patch).