### PR TITLE
fix(ci): coalesce fork head-SHA resume resolution

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -813,16 +813,23 @@ const MAX_PREVIEW_POLLS = 5;
  * within CI_COALESCE_WINDOW_SECONDS (caller skips). KV-backed (REVIEW_CONFIG); a missing KV or a KV hiccup
  * degrades to NO coalescing (returns false — never blocks a re-review, never throws).
  */
-async function ciReReviewCoalesced(env: Env, repoFullName: string, prNumber: number): Promise<boolean> {
+async function ciCompletionCoalesced(env: Env, key: string): Promise<boolean> {
   if (!env.REVIEW_CONFIG) return false;
-  const key = `ci-coalesce:${repoFullName.toLowerCase()}#${prNumber}`;
   try {
-    if (await env.REVIEW_CONFIG.get(key)) return true; // re-reviewed within the window → skip this event
+    if (await env.REVIEW_CONFIG.get(key)) return true; // already handled within the window → skip this event
     await env.REVIEW_CONFIG.put(key, "1", { expirationTtl: CI_COALESCE_WINDOW_SECONDS }); // claim the window
     return false;
   } catch {
     return false;
   }
+}
+
+async function ciReReviewCoalesced(env: Env, repoFullName: string, prNumber: number): Promise<boolean> {
+  return ciCompletionCoalesced(env, `ci-coalesce:${repoFullName.toLowerCase()}#${prNumber}`);
+}
+
+async function ciHeadShaResolutionCoalesced(env: Env, repoFullName: string, headSha: string): Promise<boolean> {
+  return ciCompletionCoalesced(env, `ci-head-sha-resolve:${repoFullName.toLowerCase()}@${headSha.toLowerCase()}`);
 }
 
 /** Read the CI head SHA off a `check_suite`/`check_run` `completed` payload (the event node carries `head_sha`;
@@ -886,8 +893,15 @@ async function maybeReReviewOnCiCompletion(env: Env, deliveryId: string, eventNa
   if (!repoFullName || !installationId) return false;
   const node = (payload as Record<string, unknown>)[eventName] as { pull_requests?: Array<{ number?: number | null }> } | undefined;
   const populatedPrNumbers = [...new Set((node?.pull_requests ?? []).map((entry) => entry?.number).filter((value): value is number => typeof value === "number"))];
+  const headSha = ciCompletionHeadSha(eventName, payload);
   if (isConvergenceRepoAllowed(env, repoFullName)) {
-    const { numbers: prNumbers, viaHeadShaFallback } = await resolveCiCompletionPrNumbers(env, installationId, repoFullName, populatedPrNumbers, ciCompletionHeadSha(eventName, payload)).catch(() => ({
+    // GitHub can emit many empty-pull_requests CI completions for the same fork head SHA. Claim a head-SHA
+    // window before the fallback resolver so duplicate events do not repeat DB scans or commits/{sha}/pulls calls.
+    if (populatedPrNumbers.length === 0 && headSha && (await ciHeadShaResolutionCoalesced(env, repoFullName, headSha))) {
+      await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId, repositoryFullName: repoFullName, payloadHash: "processed", status: "processed" });
+      return true;
+    }
+    const { numbers: prNumbers, viaHeadShaFallback } = await resolveCiCompletionPrNumbers(env, installationId, repoFullName, populatedPrNumbers, headSha).catch(() => ({
       numbers: populatedPrNumbers,
       viaHeadShaFallback: false,
     }));

--- a/test/unit/ci-completion-fork-resume.test.ts
+++ b/test/unit/ci-completion-fork-resume.test.ts
@@ -10,6 +10,22 @@ import type { GitHubWebhookPayload, JobMessage } from "../../src/types";
 
 const FORK_SHA = "deadbeefcafe1234deadbeefcafe1234deadbeef";
 
+class MemoryKv {
+  readonly values = new Map<string, string>();
+  getCalls = 0;
+  putCalls = 0;
+
+  async get(key: string): Promise<string | null> {
+    this.getCalls += 1;
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.putCalls += 1;
+    this.values.set(key, value);
+  }
+}
+
 function checkSuitePayload(opts: { repo: string; installationId: number; headSha?: string; prNumbers?: number[] }): GitHubWebhookPayload {
   const [owner, name] = opts.repo.split("/");
   return {
@@ -135,6 +151,36 @@ describe("CI-completion fork PR resume (head-SHA fallback)", () => {
     // The CI-completion handler always records the webhook event as processed.
     const webhook = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("fork-delivery-1").first<{ status: string }>();
     expect(webhook?.status).toBe("processed");
+  });
+
+  it("dispatch: duplicate empty-pull_requests fork completions coalesce before head-SHA resolution", async () => {
+    const kv = new MemoryKv();
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", REVIEW_CONFIG: kv as unknown as KVNamespace });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 5001);
+
+    let commitPullsCalls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes(`/commits/${FORK_SHA}/pulls`)) commitPullsCalls += 1;
+      return Response.json([{ number: 99, state: "open" }]);
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: `fork-storm-${i}`,
+        eventName: "check_suite",
+        payload: checkSuitePayload({ repo: "JSONbored/gittensory", installationId: 5001, headSha: FORK_SHA, prNumbers: [] }),
+      });
+    }
+
+    expect(commitPullsCalls).toBe(1);
+    expect(kv.values.has(`ci-head-sha-resolve:jsonbored/gittensory@${FORK_SHA}`)).toBe(true);
+    expect(kv.putCalls).toBe(2); // one head-SHA resolution claim + one per-PR re-review claim
+
+    const audits = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+      .bind("github_app.ci_completion_fork_resume")
+      .first<{ n: number }>();
+    expect(audits?.n).toBe(1);
   });
 
   it("dispatch: a SAME-REPO check_suite (populated pull_requests[]) re-reviews WITHOUT the fork-resume audit", async () => {


### PR DESCRIPTION
### Motivation
- Empty `pull_requests[]` CI-completion events for fork (cross-repo) PRs were resolving PRs by head SHA before any per-PR coalescing, causing repeated expensive DB scans and GitHub `GET /commits/{sha}/pulls` calls during CI completion storms.

### Description
- Add a generic KV-backed coalescing helper `ciCompletionCoalesced` and head-SHA keyed wrapper `ciHeadShaResolutionCoalesced` to claim a per-head-SHA window and avoid repeated resolution work.
- Change `maybeReReviewOnCiCompletion` to extract the head SHA once and short-circuit duplicate empty-`pull_requests[]` fork events by checking the head-SHA claim before calling `resolveCiCompletionPrNumbers`.
- Preserve existing per-PR coalescing via `ciReReviewCoalesced` and unchanged same-repo behavior when `pull_requests[]` is populated.
- Add unit coverage (in `test/unit/ci-completion-fork-resume.test.ts`) that stubs an in-memory KV and verifies duplicate fork completions perform the expensive fallback resolution only once and emit a single fork-resume audit.

### Testing
- Ran typechecking with `npx tsc --noEmit` and `npm run typecheck`, which succeeded.
- Ran the focused unit suite with `npx vitest run test/unit/ci-completion-fork-resume.test.ts`, and all tests in that file passed (`10/10`).
- The new test confirms multiple duplicate empty-`pull_requests[]` events trigger a single head-SHA resolution and one audit event, validating the mitigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b19827e6c832ca5e6d12c08a6134e)