### PR TITLE
fix(ci): constrain Gittensory check exclusion

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -92,6 +92,7 @@ type GitHubCheckRunPayload = {
   completed_at?: string | null;
   details_url?: string | null;
   html_url?: string | null;
+  app?: { id?: number | null; slug?: string | null } | null;
 };
 
 type BackfillLimits = {
@@ -1914,6 +1915,12 @@ const CI_PASSING_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
 // check is posted the same way and re-created the deadlock, so exclude ALL bot-owned checks.)
 const BOT_OWNED_CHECK_NAMES = new Set<string>([GITTENSORY_GATE_CHECK_NAME, GITTENSORY_CONTEXT_CHECK_NAME]);
 
+function isOwnGitHubAppCheckRun(env: Env, run: GitHubCheckRunPayload): boolean {
+  const appSlug = typeof run.app?.slug === "string" ? run.app.slug.trim().toLowerCase() : "";
+  const ownSlug = env.GITHUB_APP_SLUG.trim().toLowerCase();
+  return ownSlug.length > 0 && appSlug === ownSlug && BOT_OWNED_CHECK_NAMES.has(run.name);
+}
+
 export type LiveCiAggregate = {
   ciState: "passed" | "failed" | "pending" | "unverified";
   // Checks that FAIL the gate: every failing check when required contexts are unknown, else only the failing
@@ -1991,7 +1998,7 @@ export async function fetchLiveCiAggregate(
     ).catch(() => undefined);
     if (!result) break;
     for (const run of result.data.check_runs ?? []) {
-      if (BOT_OWNED_CHECK_NAMES.has(run.name)) continue; // never wait on the bot's own Gate/Context checks (see above)
+      if (isOwnGitHubAppCheckRun(env, run)) continue; // never wait on the bot's own Gate/Context check-runs (see above)
       total += 1;
       const conclusion = (run.conclusion ?? "").toLowerCase();
       const status = (run.status ?? "").toLowerCase();
@@ -2019,7 +2026,6 @@ export async function fetchLiveCiAggregate(
   ).catch(() => undefined);
   for (const ctx of statusResult?.data.statuses ?? []) {
     const name = ctx.context ?? "status";
-    if (BOT_OWNED_CHECK_NAMES.has(name)) continue; // never wait on the bot's own Gate/Context checks (see #gate-self-deadlock above)
     total += 1;
     const state = (ctx.state ?? "").toLowerCase();
     if (state === "failure" || state === "error") {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2695,8 +2695,8 @@ describe("GitHub backfill", () => {
               { name: "test", status: "completed", conclusion: "success" },
               // BOTH bot-posted checks, still in_progress (posted but not yet concluded). Counting EITHER would
               // defer the very review that concludes it — the self-deadlock that froze green-CI PRs as "CI pending".
-              { name: "Gittensory Gate", status: "in_progress", conclusion: null },
-              { name: "Gittensory Context", status: "in_progress", conclusion: null },
+              { name: "Gittensory Gate", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
+              { name: "Gittensory Context", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
             ],
           });
         }
@@ -2710,6 +2710,44 @@ describe("GitHub backfill", () => {
       expect(aggregate.ciState).toBe("passed"); // would be "pending" if either in_progress bot check were counted
       expect(aggregate.failingDetails).toEqual([]);
     });
+
+    it("does not ignore same-named Gate check-runs from a different GitHub App", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              { name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "Gittensory Gate", status: "completed", conclusion: "failure", output: { title: "External gate failed" }, app: { slug: "external-ci" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["test", "Gittensory Gate"]));
+
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "Gittensory Gate", summary: "External gate failed" })]);
+    });
+
+    it("does not ignore classic statuses named like the Gate", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [{ context: "Gittensory Gate", state: "failure", description: "External status failed" }] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "Gittensory Gate", summary: "External status failed" })]);
+    });
+
   });
 
 });


### PR DESCRIPTION
### Motivation
- The prior fix skipped checks solely by display name (e.g. `Gittensory Gate`), which allowed unrelated external check-runs or status contexts with the same name to be omitted from the CI aggregate and could produce a false `passed` CI state.  
- The goal is to avoid the gate self-deadlock while preserving CI safety by only excluding check-runs that are actually published by this GitHub App.

### Description
- Add the optional `app` shape to `GitHubCheckRunPayload` and introduce `isOwnGitHubAppCheckRun(env, run)` which verifies `run.app.slug` matches `env.GITHUB_APP_SLUG` and the check name is a known bot-owned name.  
- Use `isOwnGitHubAppCheckRun` to skip only the bot's own check-runs when building the live CI aggregate, instead of skipping by name alone.  
- Remove the broad skip for classic commit-status contexts named like the Gate so external status contexts with that name remain gateable.  
- Add regression tests that cover same-named external check-runs and classic statuses and update the existing bot-check fixtures to include `app.slug` for the bot's own runs.

### Testing
- Ran `npx vitest run test/unit/backfill.test.ts --reporter=verbose` and the unit tests in that file passed (71 tests passed).  
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors.  
- Ran `git diff --check` with no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b19bc3924832c873c9acde3493f5a)