### PR TITLE
fix(retention): preserve public stats audit events

### DIFF
--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -11,6 +11,8 @@ import { nowIso } from "../utils/json";
  */
 export type RetentionRule = { table: string; column: string; days: number };
 
+const DURABLE_AUDIT_EVENT_TYPES = ["github_app.pr_public_surface_published"] as const;
+
 export const RETENTION_POLICY: readonly RetentionRule[] = [
   { table: "audit_events", column: "created_at", days: 90 },
   { table: "ai_usage_events", column: "created_at", days: 90 },
@@ -29,6 +31,15 @@ const BATCH_SIZE = 1000;
 // the daily cron drains any remainder over subsequent runs.
 const MAX_DELETED_PER_TABLE = 50_000;
 const MS_PER_DAY = 86_400_000;
+
+function retentionWhere(rule: RetentionRule): string {
+  const base = `${rule.column} < ?1`;
+  if (rule.table === "audit_events") {
+    const durableTypes = DURABLE_AUDIT_EVENT_TYPES.map((type) => `'${type}'`).join(", ");
+    return `${base} AND event_type NOT IN (${durableTypes})`;
+  }
+  return base;
+}
 
 function cutoffIso(days: number, nowMs: number): string {
   return new Date(nowMs - days * MS_PER_DAY).toISOString();
@@ -57,7 +68,7 @@ export async function pruneExpiredRecords(
     const cutoff = cutoffIso(rule.days, nowMs);
 
     if (dryRun) {
-      const row = await env.DB.prepare(`SELECT count(*) AS n FROM ${rule.table} WHERE ${rule.column} < ?1`).bind(cutoff).first<{ n: number }>();
+      const row = await env.DB.prepare(`SELECT count(*) AS n FROM ${rule.table} WHERE ${retentionWhere(rule)}`).bind(cutoff).first<{ n: number }>();
       results.push({ table: rule.table, column: rule.column, cutoff, deleted: Number(row?.n ?? 0) });
       continue;
     }
@@ -65,7 +76,7 @@ export async function pruneExpiredRecords(
     let deleted = 0;
     // Batched delete by rowid so each statement is bounded; loop until a short batch or the per-run cap.
     for (;;) {
-      const result = await env.DB.prepare(`DELETE FROM ${rule.table} WHERE rowid IN (SELECT rowid FROM ${rule.table} WHERE ${rule.column} < ?1 LIMIT ${batchSize})`)
+      const result = await env.DB.prepare(`DELETE FROM ${rule.table} WHERE rowid IN (SELECT rowid FROM ${rule.table} WHERE ${retentionWhere(rule)} LIMIT ${batchSize})`)
         .bind(cutoff)
         .run();
       const changes = Number(result.meta?.changes ?? 0);

--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -48,6 +48,27 @@ describe("pruneExpiredRecords", () => {
     expect(aiCount?.n).toBe(1);
   });
 
+  it("keeps published public-surface audit events because public stats use them as durable review keys", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      `INSERT INTO audit_events (id, event_type, target_key, outcome, created_at)
+       VALUES
+         ('published-old', 'github_app.pr_public_surface_published', 'JSONbored/gittensory#1', 'completed', ?),
+         ('rate-limit-old', 'rate_limit.denied', 'actor', 'completed', ?),
+         ('rate-limit-recent', 'rate_limit.denied', 'actor', 'completed', ?)`,
+    )
+      .bind(daysAgo(100), daysAgo(100), daysAgo(2))
+      .run();
+
+    const results = await pruneExpiredRecords(env, {
+      nowMs: NOW,
+      policy: [{ table: "audit_events", column: "created_at", days: 90 }],
+    });
+    expect(results[0]?.deleted).toBe(1);
+    const rows = await env.DB.prepare("SELECT id FROM audit_events ORDER BY id").all<{ id: string }>();
+    expect(rows.results.map((row) => row.id)).toEqual(["published-old", "rate-limit-recent"]);
+  });
+
   it("deletes across multiple batches and stops at the per-table cap", async () => {
     const env = createTestEnv();
     const db = getDb(env.DB);


### PR DESCRIPTION
### Motivation

- Public lifetime stats were repointed to `audit_events` rows of type `github_app.pr_public_surface_published`, but `audit_events` is subject to a 90-day retention policy so lifetime counters would lose historical reviews as pruning ran.

### Description

- Add `DURABLE_AUDIT_EVENT_TYPES` and a `retentionWhere` predicate to exempt `github_app.pr_public_surface_published` from retention pruning in `src/db/retention.ts`.
- Apply the same `retentionWhere` predicate to both dry-run counting and batched deletes so the dry-run and actual deletes remain consistent.
- Add a unit test in `test/unit/retention.test.ts` that verifies old `github_app.pr_public_surface_published` rows are preserved while other old `audit_events` rows are pruned.
- Changes touch `src/db/retention.ts` and `test/unit/retention.test.ts` and keep the existing retention behaviour for other tables unchanged.

### Testing

- Ran `npx vitest run test/unit/retention.test.ts test/unit/public-stats.test.ts --reporter=dot` and observed the test suite pass (2 files, 17 tests passed).
- Ran `npm run typecheck` and observed TypeScript typechecking complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b17d454d8832c90081af89b4640c0)