### PR TITLE
fix: ignore contributor PR self-closes in outcomes

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -133,11 +133,17 @@ export async function recordPrOutcome(env: Env, eventName: string, payload: GitH
   if (!pr?.number || !repoFullName) return;
 
   const merged = Boolean(pr.merged_at);
+  const senderLogin = (payload.sender?.login ?? "").toLowerCase();
+  const authorLogin = (pr.user?.login ?? "").toLowerCase();
+  const botWasActor = payload.sender?.type === "Bot";
+  // A PR author can close their own unmerged PR without maintainer approval. Those self-closes are not
+  // authoritative ground truth for the repository's merge/close decision and must not feed the precision
+  // circuit-breaker; otherwise contributors can poison merge precision by closing their own mergeable PRs.
+  // Merges remain trusted because GitHub requires merge permission, and maintainer/bot closes are not self-closes.
+  if (!merged && !botWasActor && senderLogin && authorLogin && senderLogin === authorLogin) return;
+
   const decision = merged ? "merged" : "closed";
   const targetId = reviewAuditTargetId(repoFullName, pr.number);
-  // Whether GITTENSORY itself was the actor that resolved this PR — for the metadata only (the bot's own
-  // close/merge action was already recorded as an agent.action.* audit row; this just annotates the outcome).
-  const botWasActor = payload.sender?.type === "Bot";
 
   await appendReviewAudit(env, { project: repoFullName.slice(0, 200), targetId, eventType: "pr_outcome", decision });
   await recordAuditEvent(env, {

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -58,16 +58,28 @@ describe("recordPrOutcome — realized merge/close ground truth", () => {
     expect(ledger[0]).toMatchObject({ target_key: "owner/repo#42", detail: "merged" });
   });
 
-  it("writes a pr_outcome=closed row when a PR is closed WITHOUT merging", async () => {
+  it("writes a pr_outcome=closed row when a maintainer closes a PR WITHOUT merging", async () => {
     const env = createTestEnv();
     await recordPrOutcome(env, "pull_request", {
       action: "closed",
       repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 43, merged_at: null }),
-      sender: { login: "contributor", type: "User" },
+      pull_request: pullRequestPayload({ number: 43, merged_at: null, user: { login: "contributor", type: "User" } }),
+      sender: { login: "owner", type: "User" },
     });
     expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({ target_id: "owner/repo#43", decision: "closed" });
     expect((await auditEventRows(env, "pr_outcome"))[0]).toMatchObject({ detail: "closed" });
+  });
+
+  it("records NOTHING for an unmerged contributor PR self-close", async () => {
+    const env = createTestEnv();
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 43, merged_at: null, user: { login: "contributor", type: "User" } }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "pr_outcome")).toHaveLength(0);
+    expect(await auditEventRows(env, "pr_outcome")).toHaveLength(0);
   });
 
   it("records NOTHING for a non-closed action or a payload with no PR number", async () => {


### PR DESCRIPTION
### Motivation
- The `pr_outcome` recording treated any `pull_request` `closed` webhook as authoritative ground truth, allowing PR authors to self-close unmerged PRs and poison the merge-precision signal that can engage the hold-only circuit-breaker.
- Self-closes by contributors are not maintainer-approved decisions and must not count toward auto-tune/precision calculations that can disable automation for a repo.

### Description
- Add a guard in `recordPrOutcome` (`src/review/outcomes-wire.ts`) to skip recording unmerged closes when `payload.sender.login` equals the PR author login, while preserving merged outcomes and maintainer/bot closes. 
- Retain `botWasActor` metadata and continue writing to both `review_audit` and `audit_events` when an outcome is recorded. 
- Update unit tests (`test/unit/outcomes-wire.test.ts`) to assert that maintainer closes still record `pr_outcome=closed` and that contributor self-closes record nothing. 
- No behavioral changes to merges or the reversal signals; the change only prevents contributor self-closes from feeding the precision circuit-breaker.

### Testing
- Ran the unit tests with `npx vitest run test/unit/outcomes-wire.test.ts`, all tests passed (`20 passed`).
- Ran static type checking with `npm run typecheck` (`tsc --noEmit`) and it succeeded. 
- Ran `git diff --check` to verify no whitespace/errors from diffs and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b24ffa5f4832c9e9a9a6e0149f00c)