### PR TITLE
fix(rag): prune stale chunks during full index

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -69,12 +69,12 @@ function ghHeaders(token: string | undefined, accept: string): Record<string, st
  * (fail-safe: a tree we can't read = nothing to index). `truncated` is honored (GitHub truncates very large
  * trees) — we index whatever it returned; the MAX_CHUNKS cap is the real bound anyway.
  */
-async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token: string | undefined): Promise<TreeEntry[]> {
+async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token: string | undefined): Promise<TreeEntry[] | null> {
   try {
     const { owner, name } = repoParts(repoFullName);
     const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
     const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github+json") });
-    if (!response.ok) return [];
+    if (!response.ok) return null;
     const body = (await response.json()) as { tree?: Array<{ path?: string; type?: string; size?: number }> } | null;
     const entries: TreeEntry[] = [];
     for (const node of body?.tree ?? []) {
@@ -84,7 +84,7 @@ async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token:
     return entries;
   } catch (error) {
     console.log(JSON.stringify({ ev: "rag_index_tree_error", repo: repoFullName, message: String(error).slice(0, 200) }));
-    return [];
+    return null;
   }
 }
 
@@ -168,6 +168,38 @@ async function upsertChunksCapped(env: Env, project: string, repo: string, chunk
   return upserted;
 }
 
+
+/** Return distinct paths currently retained for a repo in the chunk text store. Fail-safe: [] on error. */
+async function listStoredChunkPaths(infra: ReturnType<typeof createReviewAdapters>, project: string, repo: string): Promise<string[]> {
+  try {
+    const rows = await infra.storage
+      .prepare("SELECT DISTINCT path FROM repo_chunks WHERE project=? AND repo=?")
+      .bind(project, repo)
+      .all<{ path: string }>();
+    return (rows.results ?? []).map((row) => row.path).filter((path) => typeof path === "string" && path.length > 0);
+  } catch (error) {
+    console.log(JSON.stringify({ ev: "rag_list_paths_error", project, repo, message: String(error).slice(0, 200) }));
+    return [];
+  }
+}
+
+/**
+ * Prune chunks for paths that are no longer indexable in the current default-branch tree. This is the full-index
+ * counterpart to reindexChangedPaths' delete-first behavior and prevents deleted/renamed files from being retained
+ * indefinitely in repo_chunks/Vectorize.
+ */
+async function pruneMissingPaths(
+  infra: ReturnType<typeof createReviewAdapters>,
+  project: string,
+  repo: string,
+  currentIndexablePaths: Set<string>,
+): Promise<void> {
+  const storedPaths = await listStoredChunkPaths(infra, project, repo);
+  const stalePaths = storedPaths.filter((path) => !currentIndexablePaths.has(path));
+  if (stalePaths.length === 0) return;
+  await deleteChunksForPaths(infra, project, repo, stalePaths);
+}
+
 /** Split `owner/name` into the (project, repo) pair RAG namespaces on (same convention as rag-wire's splitRepo). */
 function splitRepo(repoFullName: string): [string, string] {
   const slash = repoFullName.indexOf("/");
@@ -204,10 +236,15 @@ export async function indexRepo(
     const token = await resolveReadToken(env, repo.installationId);
     const ref = indexRef(repo.defaultBranch);
 
-    // 1. Fetch the tree, filter to indexable code/docs, prioritize source before docs (so the cap keeps code).
-    const tree = (await fetchRepoTree(env, repoFullName, ref, token))
+    // 1. Fetch the tree, filter to indexable code/docs, and prune retained chunks for files that disappeared
+    //    or moved to a non-indexable path. If the tree fetch fails (null), skip pruning to avoid deleting good
+    //    chunks during a transient GitHub/API failure.
+    const rawTree = await fetchRepoTree(env, repoFullName, ref, token);
+    if (rawTree === null) return empty;
+    const tree = rawTree
       .filter((entry) => isIndexablePath(entry.path, entry.size))
       .sort((a, b) => filePriority(a.path) - filePriority(b.path) || a.path.localeCompare(b.path));
+    await pruneMissingPaths(infra, project, repoName, new Set(tree.map((entry) => entry.path)));
     if (tree.length === 0) return empty;
 
     // 2. Fetch + chunk + upsert, stopping once the per-repo vector cap is reached.

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -171,6 +171,33 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
     expect(vec.upserted.length).toBe(0);
   });
+
+  it("a tree fetch that THROWS degrades to nothing indexed (fetchRepoTree catch arm)", async () => {
+    const { env, vec } = indexEnv();
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes("/git/trees/")) throw new Error("network down");
+      return new Response("missing", { status: 404 });
+    });
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    expect(vec.upserted.length).toBe(0);
+  });
+
+  it("a storage error while listing stored paths is fail-safe (prunes nothing, still indexes)", async () => {
+    const { env } = indexEnv();
+    // Make ONLY the listStoredChunkPaths SELECT throw; everything else uses the real test D1.
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = ((query: string) =>
+      query.includes("SELECT DISTINCT path FROM repo_chunks")
+        ? ({ bind: () => ({ all: async () => { throw new Error("storage boom"); } }) } as unknown as ReturnType<typeof realPrepare>)
+        : realPrepare(query)) as typeof env.DB.prepare;
+    stubGithub({ tree: [{ path: "src/current.ts", size: 30 }], files: { "src/current.ts": "export const current = 1;\n" } });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    // The list failed → [] → nothing pruned, but the current file still indexes (fail-safe).
+    expect(result.files).toBe(1);
+    expect(await pathsFor(env, PROJECT, "gittensory")).toContain("src/current.ts");
+  });
 });
 
 describe("indexRepo: MAX_CHUNKS_PER_REPO cap holds", () => {

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -135,6 +135,25 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     expect(vec.upserted).toContain(`${ns}|src/a.ts::0`);
   });
 
+  it("prunes chunks for paths missing from the current full tree before returning retrieved context", async () => {
+    const { env, vec } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?,?,?,?,?,?,?)")
+      .bind(`${ns}|src/deleted-secret.ts::0`, PROJECT, "gittensory", "src/deleted-secret.ts", 0, "code", "deleted secret")
+      .run();
+
+    stubGithub({
+      tree: [{ path: "src/current.ts", size: 30 }],
+      files: { "src/current.ts": "export const current = 1;\n" },
+    });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    expect(result.files).toBe(1);
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["src/current.ts"]);
+    expect(vec.deleted).toContain(`${ns}|src/deleted-secret.ts::0`);
+  });
+
   it("skips a file that fails to fetch (404) and indexes the rest (fail-safe)", async () => {
     const { env } = indexEnv();
     stubGithub({

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -198,6 +198,22 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     expect(result.files).toBe(1);
     expect(await pathsFor(env, PROJECT, "gittensory")).toContain("src/current.ts");
   });
+
+  it("listStoredChunkPaths drops blank paths and tolerates an absent result set (defensive branches)", async () => {
+    const { env } = indexEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    let allReturn: { results?: Array<{ path: string }> } = { results: [{ path: "" }, { path: "src/stale.ts" }] };
+    env.DB.prepare = ((query: string) =>
+      query.includes("SELECT DISTINCT path FROM repo_chunks")
+        ? ({ bind: () => ({ all: async () => allReturn }) } as unknown as ReturnType<typeof realPrepare>)
+        : realPrepare(query)) as typeof env.DB.prepare;
+    // Empty tree → every stored path is stale; the blank "" is filtered out, "src/stale.ts" is pruned.
+    stubGithub({ tree: [], files: {} });
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+    // No `results` key at all → exercises the `?? []` defensive arm.
+    allReturn = {};
+    await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
+  });
 });
 
 describe("indexRepo: MAX_CHUNKS_PER_REPO cap holds", () => {


### PR DESCRIPTION
### Motivation
- Prevent stale repo chunk rows and vector entries for files deleted/renamed outside the incremental path from being retained and later retrieved into RAG prompts.
- Avoid accidental pruning when the GitHub tree fetch fails transiently so full re-indexing does not delete valid stored chunks.

### Description
- Change `fetchRepoTree` in `src/review/rag-index.ts` to return `null` on fetch/error (distinct from an empty tree) so pruning can be gated on a successful tree read.
- Add `listStoredChunkPaths` and `pruneMissingPaths` helpers that enumerate stored `repo_chunks` paths and delete those not present in the current indexable tree via the existing `deleteChunksForPaths` routine.
- Invoke `pruneMissingPaths` from `indexRepo` before upserting current chunks so full re-indexing removes stale deleted/renamed paths while preserving fail-safe behavior.
- Add a regression unit test in `test/unit/rag-index.test.ts` proving a previously-stored deleted path is removed from both `repo_chunks` and Vectorize during a full index run.

### Testing
- Ran unit tests with `npx vitest run test/unit/rag-index.test.ts` and all tests passed (31 tests in `test/unit/rag-index.test.ts`).
- Ran static type checks with `npm run typecheck` and they succeeded. 
- Ran `git diff --check` to verify no trailing-diff issues and it produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b27743bb0832c9515e83e241f34a2)