### PR TITLE
fix(public-stats): ignore dry-run reversals

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -203,6 +203,7 @@ export async function getPublicStats(
            FROM audit_events
           WHERE event_type IN ('agent.action.close', 'agent.action.merge')
             AND outcome = 'completed' AND instr(target_key, '#') > 0
+            AND COALESCE(json_extract(metadata_json, '$.mode'), 'live') <> 'dry_run'
        ) ev
        JOIN pull_requests pr ON pr.repo_full_name = ev.project AND pr.number = ev.pr_number
         WHERE LOWER(ev.project) IN (${inList})

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createTestEnv } from "../helpers/d1";
 import {
   getPublicStats,
   isPublicStatsEnabled,
@@ -172,6 +173,67 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(out.byProject.map((p) => p.project)).toEqual([
       "JSONbored/gittensory",
     ]);
+  });
+
+  it("excludes dry-run terminal actions from live reversal counts", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" });
+    const db = env.DB;
+
+    await db
+      .prepare(
+        `INSERT INTO pull_requests (id, repo_full_name, number, title, state, merged_at)
+         VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "pr-real",
+        "JSONbored/gittensory",
+        1,
+        "real auto-closed PR",
+        "closed",
+        null,
+        "pr-dry-run",
+        "JSONbored/gittensory",
+        2,
+        "dry-run close shadow",
+        "open",
+        null,
+      )
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO audit_events (id, event_type, target_key, outcome, metadata_json)
+         VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "published-real",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#1",
+        "completed",
+        "{}",
+        "published-dry-run",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#2",
+        "completed",
+        "{}",
+        "live-close",
+        "agent.action.close",
+        "JSONbored/gittensory#1",
+        "completed",
+        JSON.stringify({ mode: "live" }),
+        "dry-run-close",
+        "agent.action.close",
+        "JSONbored/gittensory#2",
+        "completed",
+        JSON.stringify({ mode: "dry_run" }),
+      )
+      .run();
+
+    const out = await getPublicStats(env, NOW);
+
+    expect(out.totals.closed).toBe(1);
+    expect(out.totals.commented).toBe(1);
+    expect(out.totals.reversed).toBe(0);
+    expect(out.totals.accuracyPct).toBe(100);
   });
 
   it("publishes no ledger data when the reviewed-repo allowlist is empty", async () => {


### PR DESCRIPTION
### Motivation
- The live reversal query in `public-stats` counted any `agent.action.close`/`agent.action.merge` audit row with `outcome='completed'` without excluding dry-run audit shadows, causing false reversal counts and skewed public accuracy metrics.
- Dry-run executor records are intentionally logged as completed but do not perform GitHub mutations, so they must be excluded from live reversal detection to preserve metric integrity.

### Description
- Exclude dry-run agent action audit rows from the reversal SQL by adding `AND COALESCE(json_extract(metadata_json, '$.mode'), 'live') <> 'dry_run'` to the reversal subquery in `src/review/public-stats.ts`.
- Add a regression unit test in `test/unit/public-stats.test.ts` that seeds in-memory D1 rows for one real terminal decision and one dry-run terminal-action shadow and asserts the dry-run shadow does not increment `reversed` or reduce `accuracyPct`.
- Wire the test to use the repository `createTestEnv` helper so it runs against the same in-memory D1 schema as production tests.

### Testing
- Ran the focused unit test suite with `npm exec vitest run test/unit/public-stats.test.ts -- --reporter=verbose`, and all tests passed (including the new dry-run exclusion test).
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully with no type errors.
- The change is limited to the reversal query and a unit test, and existing public-stats behavior for live `mode` remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b2a5affc8832c8f32edb4d734d2c5)