### PR TITLE
fix(agent): avoid linked-issue pending-close fail-open

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -710,7 +710,7 @@ async function maybeRunAgentMaintenance(
   const installation = await getInstallation(env, installationId);
   /* v8 ignore next -- an installed-App PR webhook always carries an installation record; the null is defensive. */
   const installationPermissions = installation?.permissions ?? null;
-  await executeAgentMaintenanceActions(
+  const actionOutcomes = await executeAgentMaintenanceActions(
     env,
     {
       installationId,
@@ -726,12 +726,12 @@ async function maybeRunAgentMaintenance(
     breakerOnPlan,
   );
 
-  // Flag-then-close double-check, Pass 2 trigger: when this pass FLAGGED the PR (added the pending-closure
-  // label), re-enqueue a delayed re-review after closeDelaySeconds so the verification pass runs promptly
-  // instead of waiting for the next CI-completion event or the hourly sweep. Best-effort — if the enqueue fails,
-  // the next sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review
-  // job (it just re-runs reReviewStoredPullRequest), so no new job type is needed.
-  const flaggedForLinkedIssue = breakerOnPlan.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add");
+  // Flag-then-close double-check, Pass 2 trigger: only re-enqueue when the pending-closure label mutation
+  // completed. Queued/failed/dry-run label actions do not establish the label-backed state that Pass 2 requires,
+  // so scheduling off the plan alone can create a verification loop. Best-effort — if the enqueue fails, the next
+  // sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review job.
+  const pendingFlagPlanIndexes = breakerOnPlan.flatMap((action, index) => (action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add" ? [index] : []));
+  const flaggedForLinkedIssue = pendingFlagPlanIndexes.some((index) => actionOutcomes[index]?.outcome === "completed");
   if (flaggedForLinkedIssue) {
     const delaySeconds = Math.max(0, linkedIssueRulesConfig.closeDelaySeconds);
     const verifyJob = { type: "recapture-preview" as const, deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId, attempt: 0 };

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -110,7 +110,7 @@ import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "..
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
 import { selectRegateCandidates } from "../settings/agent-sweep";
 import { downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions } from "../settings/agent-actions";
-import { executeAgentMaintenanceActions } from "../services/agent-action-executor";
+import { executeAgentMaintenanceActions, pendingClosureLabelApplied } from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
 import { loadIssueQualityReportMap } from "../services/issue-quality";
 import { generateWeeklyValueReport } from "../services/weekly-value-report";
@@ -177,7 +177,7 @@ import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
-import { AGENT_LABEL_PENDING_CLOSURE, evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
+import { evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
@@ -730,8 +730,7 @@ async function maybeRunAgentMaintenance(
   // completed. Queued/failed/dry-run label actions do not establish the label-backed state that Pass 2 requires,
   // so scheduling off the plan alone can create a verification loop. Best-effort — if the enqueue fails, the next
   // sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review job.
-  const pendingFlagPlanIndexes = breakerOnPlan.flatMap((action, index) => (action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add" ? [index] : []));
-  const flaggedForLinkedIssue = pendingFlagPlanIndexes.some((index) => actionOutcomes[index]?.outcome === "completed");
+  const flaggedForLinkedIssue = pendingClosureLabelApplied(breakerOnPlan, actionOutcomes);
   if (flaggedForLinkedIssue) {
     const delaySeconds = Math.max(0, linkedIssueRulesConfig.closeDelaySeconds);
     const verifyJob = { type: "recapture-preview" as const, deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId, attempt: 0 };

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -8,6 +8,7 @@ import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, reso
 import type { PlannedAgentAction } from "../settings/agent-actions";
 import type { AgentActionClass, AgentPendingActionParams, AutonomyLevel, AutonomyPolicy } from "../types";
 import { errorMessage } from "../utils/json";
+import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
 
 // The agent actor name on every audit record — the App acts on the maintainer's behalf per their configured
 // autonomy (the config IS the authorization; there is no human commenter to authorize, unlike #824).
@@ -35,6 +36,14 @@ export type AgentActionOutcome = {
   outcome: "completed" | "queued" | "denied" | "error" | "dry_run";
   detail: string;
 };
+
+// Pass-2 trigger predicate (flag-then-close double-check): true iff the executed plan included a pending-closure
+// label-ADD whose mutation actually COMPLETED. A queued (approval-gated) / failed / dry-run / denied label does NOT
+// establish the label-backed state the verification pass reads, so re-enqueuing the delayed re-review off the plan
+// alone would create a verification loop. `outcomes[i]` is the outcome of `planned[i]` (1:1, same order).
+export function pendingClosureLabelApplied(plan: PlannedAgentAction[], outcomes: AgentActionOutcome[]): boolean {
+  return plan.some((action, index) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add" && outcomes[index]?.outcome === "completed");
+}
 
 /**
  * Execute (or dry-run, or stage for approval) a planned auto-maintain action set on one PR. Each action runs

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -240,11 +240,16 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const verifyBeforeClose = input.linkedIssueVerify?.verifyBeforeClose === true;
   const closeDelaySeconds = input.linkedIssueVerify?.closeDelaySeconds ?? 0;
   const pendingClosureLabelPresent = hasLabel(input.pr.labels, AGENT_LABEL_PENDING_CLOSURE);
-  // Pass 1 — violation present, verify-mode on, label NOT yet on the PR → FLAG (label + comment), do NOT close.
-  const flagForLinkedIssue = linkedIssueViolated && verifyBeforeClose && !pendingClosureLabelPresent;
+  // Pass 1 is only safe when the pending-closure state can be written immediately. If labels are disabled or
+  // approval-gated, holding would fail open because Pass 2 is keyed on a label that cannot appear yet; fall back
+  // to the original immediate close in that case.
+  const canApplyPendingClosureFlagNow = acting("label") && !approval("label");
+  // Pass 1 — violation present, verify-mode on, label NOT yet on the PR, and the state label can be applied now
+  // → FLAG (label + comment), do NOT close.
+  const flagForLinkedIssue = linkedIssueViolated && verifyBeforeClose && !pendingClosureLabelPresent && canApplyPendingClosureFlagNow;
   // Close NOW when: verify-mode OFF (immediate, original GAP-5), OR Pass 2 (violation persists AND the
-  // pending-closure label is already present from a prior pass).
-  const willCloseForLinkedIssue = linkedIssueViolated && (!verifyBeforeClose || pendingClosureLabelPresent);
+  // pending-closure label is already present from a prior pass), OR verification cannot safely persist its flag.
+  const willCloseForLinkedIssue = linkedIssueViolated && (!verifyBeforeClose || pendingClosureLabelPresent || !canApplyPendingClosureFlagNow);
   // The violation has CLEARED (no longer violated) but the PR still carries a pending-closure flag from a prior
   // pass → remove the stale flag (never close). Independent of `isContributor`/`close` autonomy: clearing a stale
   // label is always safe and must happen even if the rule/author no longer qualifies for a close.

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -14,8 +14,9 @@ vi.mock("../../src/github/labels", () => ({
 
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
-import { actionParams, executeAgentMaintenanceActions, type AgentActionExecutionContext } from "../../src/services/agent-action-executor";
+import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
+import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import { createTestEnv } from "../helpers/d1";
 
 function ctx(over: Partial<AgentActionExecutionContext> = {}): AgentActionExecutionContext {
@@ -177,5 +178,34 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(outcomes[0]?.outcome).toBe("error");
     expect(outcomes[0]?.detail).toMatch(/not mergeable/i);
     expect((await auditFor(env, "merge"))?.outcome).toBe("error");
+  });
+});
+
+describe("pendingClosureLabelApplied (#1136 Pass-2 trigger)", () => {
+  const labelAdd: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "flag", label: AGENT_LABEL_PENDING_CLOSURE, labelOp: "add" };
+  const approve2: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "ok" };
+  const out = (outcome: AgentActionOutcome["outcome"], actionClass: AgentActionOutcome["actionClass"] = "label"): AgentActionOutcome => ({ actionClass, outcome, detail: "" });
+
+  it("true when the pending-closure label-add COMPLETED", () => {
+    expect(pendingClosureLabelApplied([labelAdd], [out("completed")])).toBe(true);
+  });
+  it("false when the label action did not complete (queued/error/dry_run/denied → state not established)", () => {
+    for (const o of ["queued", "error", "dry_run", "denied"] as const) expect(pendingClosureLabelApplied([labelAdd], [out(o)])).toBe(false);
+  });
+  it("false when no pending-closure label-add is planned", () => {
+    expect(pendingClosureLabelApplied([approve2], [out("completed", "approve")])).toBe(false);
+  });
+  it("false for a label REMOVE — only an ADD establishes the pending-closure flag", () => {
+    expect(pendingClosureLabelApplied([{ ...labelAdd, labelOp: "remove" }], [out("completed")])).toBe(false);
+  });
+  it("false for a completed add of a DIFFERENT label", () => {
+    expect(pendingClosureLabelApplied([{ ...labelAdd, label: "some-other-label" }], [out("completed")])).toBe(false);
+  });
+  it("matches the label's outcome by its OWN plan index (not assuming index 0)", () => {
+    expect(pendingClosureLabelApplied([approve2, labelAdd], [out("completed", "approve"), out("completed")])).toBe(true);
+    expect(pendingClosureLabelApplied([approve2, labelAdd], [out("completed", "approve"), out("error")])).toBe(false);
+  });
+  it("false when there is no outcome at the label's index (outcomes shorter than the plan)", () => {
+    expect(pendingClosureLabelApplied([approve2, labelAdd], [out("completed", "approve")])).toBe(false);
   });
 });

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -378,6 +378,18 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(flag?.comment).toContain("~30s");
     });
 
+    it("label disabled: falls back to immediate close instead of holding forever without a state label", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "observe" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [] } }));
+      expect(classes(plan)).toContain("close");
+      expect(pendingLabel(plan)).toBeFalsy();
+    });
+
+    it("label approval-gated: falls back to immediate close instead of queueing an unapplied state label", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto_with_approval" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [] } }));
+      expect(classes(plan)).toContain("close");
+      expect(pendingLabel(plan)).toBeFalsy();
+    });
+
     it("Pass 2 (verify on, label PRESENT, violation persists): CLOSES with the cited reason", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", label: "auto" }, ciState: "passed", linkedIssueHardRule: violation, linkedIssueVerify: verifyOn, pr: { labels: [AGENT_LABEL_PENDING_CLOSURE] } }));
       const close = plan.find((a) => a.actionClass === "close");


### PR DESCRIPTION
### Motivation
- The new linked-issue flag-then-close flow could fail-open when the planner assumed a `pending-closure` label would be applied even when label actions were disabled or approval-gated, allowing contributor PRs to bypass deterministic auto-close.
- The verification re-review was being scheduled based on planned actions rather than on completed label mutations, which can create indefinite verification loops when actions are queued or fail.

### Description
- In `planAgentMaintenanceActions` (`src/settings/agent-actions.ts`) restrict the Pass-1 flag behavior to only fire when the pending-closure label can be applied synchronously by checking `acting("label") && !approval("label")`, and fall back to immediate close when the label cannot be applied now by including that check in the `willCloseForLinkedIssue` predicate.
- In the maintenance runner (`src/queue/processors.ts`) capture action outcomes from `executeAgentMaintenanceActions` and only schedule the delayed verification job when the actual pending-closure label mutation completed (outcome `"completed"`) instead of when it was merely planned.
- Add unit tests (`test/unit/agent-actions.test.ts`) to cover the cases where label autonomy is disabled (`label: "observe"`) or approval-gated (`label: "auto_with_approval"`) to ensure the planner falls back to immediate close instead of holding without durable state.

### Testing
- Ran unit tests with `npx vitest run test/unit/agent-actions.test.ts --reporter=verbose` and all tests passed (59 passed).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) which succeeded.
- Ran a style/sanity check with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b27741140832c9af7a34b8716b9d8)