### PR TITLE
fix(cron): tick every 2 min so the recovery sweep actually runs (was */30)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -208,6 +208,11 @@
     ],
   },
   "triggers": {
-    "crons": ["*/30 * * * *"],
+    // Tick every 2 minutes. The light auto-maintain/recovery sweep (agent-regate-sweep) runs on EVERY tick so an
+    // approved+clean PR merges and a red-CI / stuck PR is handled within ~2 min (see src/index.ts). Heavy sync/
+    // health jobs stay on their own cadence inside the handler via `minute % 30` (30-min) and `isHourly` (hourly),
+    // so they are unaffected by the faster tick. (Was "*/30": the sweep the code intends to run every ~2 min was
+    // actually firing only every 30 min, starving the recovery rail.)
+    "crons": ["*/2 * * * *"],
   },
 }


### PR DESCRIPTION
One-line cadence fix. `src/index.ts` enqueues the light auto-maintain/recovery sweep on EVERY cron tick (heavy jobs self-gate via `minute%30`/`isHourly`), but the cron was `*/30` — so the sweep meant to run every ~2 min only ran every 30 min, starving recovery (an approved/stuck PR could wait up to 30 min for its merge/close pass). `*/2` restores the intended cadence; heavy jobs are unaffected. Verified the gating in index.ts:49-91.