### PR TITLE
docs(skills): add contributing-to-gittensory contributor skill

### DIFF
--- a/.claude/skills/contributing-to-gittensory/SKILL.md
+++ b/.claude/skills/contributing-to-gittensory/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: contributing-to-gittensory
+description: >-
+  Use when writing, testing, or preparing ANY code contribution or pull request to the
+  JSONbored/gittensory repo — picking/validating an issue, implementing a change, writing tests
+  that pass Codecov, running the local CI gate, predicting the gittensory gate, and formatting the
+  commit + PR. gittensory reviews PRs ONE-SHOT via the gittensory gate (a GitHub App / CI) plus a
+  strict CI suite with Codecov (97% patch coverage, hard); there is no review back-and-forth, so a
+  PR must be correct, fully tested, house-style-compliant, and green before it is pushed. Invoke
+  for any "contribute to / open a PR against / fix a bug in / add a feature to gittensory" task.
+---
+
+# Contributing to gittensory — the one-shot PR playbook
+
+gittensory merges through an **automated, one-shot review**: the gittensory gate (a GitHub App that
+posts a check run + a single review verdict) and a **strict CI suite gated by Codecov**. There is no
+human ping-pong and no "fix it in review" — **the PR must be perfect before you push.** This skill is
+the end-to-end procedure to make that happen with AI tools (Claude Code / Codex).
+
+Work through the phases **in order**. Do not skip the verification phases. If you cannot get the full
+local gate green, **do not push** — an incomplete PR will be auto-closed or held, not coached.
+
+`reference.md` (next to this file) has the exhaustive tables (every CI job, the full Codecov rules,
+the gate config, the MCP tools, test helpers, the commit/PR rubric). Read it when a phase says to.
+
+---
+
+## What the gate does to your PR — it merges and closes, automatically
+
+gittensory's review engine has **real autonomy** here — it is **not advisory**. Within ~2 minutes of
+your PR's checks settling, for a **contributor** PR (you are not the repo owner or an automation bot)
+it takes a one-shot disposition:
+
+| Situation | Engine action |
+|---|---|
+| Gate passes **and** every CI check green **and** mergeable-clean (+ approvals) | **auto-approve → MERGE** |
+| **Any** CI check failed — required or not, **`codecov/patch` included** | **CLOSE** (one-shot) |
+| Gate **failure**, or base **conflict** (needs rebase), or a linked-issue **hard-rule** violation | **CLOSE** (one-shot) |
+| CI still **pending** | no action — waits for checks to finish |
+| CI **unverified** (e.g. a fork whose Actions await approval) | **held** for review |
+| PR touches a **crucial/guarded path** (CI config, the review engine, visual) | **held** for the owner |
+
+So a flawed contributor PR is **closed, not coached** — recovery means resolving the problem and
+opening a **fresh** PR. This is the entire reason to get it right before you push:
+**green CI + passing gate + clean mergeable + a valid linked issue ⇒ merged; any adverse signal ⇒ closed.**
+(Owner and automation-bot PRs are never auto-closed — but you should assume you are a contributor.)
+
+---
+
+## The non-negotiables (read once, hold throughout)
+
+1. **97%+ patch coverage is a HARD wall.** Codecov `codecov/patch` has `target: 97%, threshold: 0%`
+   — *zero slack* — and it counts **BRANCH** coverage, not just lines. **Aim for 100% on every line
+   you change, including invariants and a regression test for any bug you fix.** Only `src/**` counts;
+   `apps/**`, `test/**`, `scripts/**`, and `src/env.d.ts` are ignored by Codecov. (So a UI-only change
+   has no coverage obligation — but a backend change does, on *every changed line and branch*.)
+2. **No CI check may fail.** One command runs the whole gate locally: **`npm run test:ci`** (plus
+   `npm audit --audit-level=moderate` for the dependency-review job). If that is not green, the PR is
+   not ready. Period.
+3. **Anchor on existing code.** Before writing anything, find **≥2 existing analogues** in the repo
+   (cite them as `file:line`) and **trace the closest one end-to-end**. Match its structure, naming,
+   error handling, and comment density. The repo has a strong house style — imitate, don't invent.
+4. **Build for the class, not the one case.** If a change only handles your single scenario, it is
+   probably a special-case hack. Prefer the general, data-driven shape the codebase already uses.
+5. **Honesty clause.** Never open a WIP/partial PR. Never weaken or delete a test to make coverage
+   pass. Never mask a failing check. If a test legitimately can't be written, that means the code
+   needs restructuring — fix the code, don't fake the test.
+6. **Regenerate generated artifacts and commit them.** Stale generated files fail CI even when your
+   code is correct: `ui:openapi` (API/schema changes), `cf-typegen` (wrangler binding/var changes),
+   migrations (DB changes). See Phase 4.
+7. **Respect the hard boundaries** (from `CONTRIBUTING.md`): never put secrets, tokens, wallets,
+   hotkeys/coldkeys, raw trust scores, reward/payout values, or private scoring in code, comments,
+   tests, or PR text. Don't touch `site/`, `CNAME`, `**/lovable/**`. Don't edit the changelog in a
+   normal PR. **No AI/Claude/agent attribution** anywhere in commits or PR text.
+
+---
+
+## Phase 0 — Install the gittensory MCP (your pre-submit oracle)
+
+The gittensory MCP lets you **predict the gate before you push** — the single biggest win for a
+one-shot review. Install and use it:
+
+```sh
+npm install -g @jsonbored/gittensory-mcp@latest
+gittensory-mcp login          # GitHub device flow; needed for the auth'd preflight tools
+```
+
+Add it to your agent (Claude Code / Codex / Cursor) MCP config:
+
+```json
+{ "mcpServers": { "gittensory": { "command": "gittensory-mcp", "args": ["--stdio"] } } }
+```
+
+You'll use these tools in Phase 1 and Phase 6 (full list + inputs in `reference.md`):
+`gittensory_check_before_start`, `gittensory_validate_linked_issue`, `gittensory_check_slop_risk`,
+`gittensory_lint_pr_text`, `gittensory_predict_gate`. All run on **metadata only** (paths, counts,
+PR text) — no source upload, no secrets.
+
+---
+
+## Phase 1 — Pick and validate the work
+
+- **Search first.** Check open issues AND open PRs for duplicates — a duplicate PR is a close-worthy
+  signal. And only link an issue that is **open, not assigned to someone else, not maintainer-only,
+  and (on scored repos) carries a point label**: linking an owner-assigned / maintainer-only /
+  ineligible issue trips a **deterministic linked-issue hard rule that auto-closes your PR**. Verify
+  with `gittensory_check_before_start` + `gittensory_validate_linked_issue`.
+- **Open an issue first** for anything risky: public behavior changes, auth/session/CORS changes, DB
+  schema/migrations, large dependency bumps, deploy/secret changes, or frontend architecture. For a
+  small, self-evident fix, a direct PR with a clear rationale is fine (this repo's
+  `linkedIssuePolicy` is `preferred`, not required).
+- **Run the pre-start checks** via MCP: `gittensory_check_before_start` (is it claimed / a duplicate
+  cluster / already solved?) and, if linking an issue, `gittensory_validate_linked_issue`.
+- **Stay in scope.** The gate's `wantedPaths` are `src/`, `packages/`, `test/`, `migrations/`,
+  `scripts/`, `.github/workflows/`, `wrangler.jsonc`, `apps/gittensory-ui/`. Avoid `blockedPaths`
+  (`site/`, `CNAME`, `**/lovable/**`). Keep the PR narrow — one coherent change.
+
+---
+
+## Phase 2 — Implement (match the house style)
+
+1. **Trace the closest analogue end-to-end** before editing. Open the most similar existing
+   feature/route/signal and follow it through every file it touches.
+2. **Follow the conventions** (details + examples in `reference.md`):
+   - File naming: `kebab-case.ts`. Component pure helpers/types go in a sibling `*-model.ts` so the
+     component file only exports components (ESLint `react-refresh/only-export-components`).
+   - `*-wire.ts` = a flag-gated feature's guard + init. New capabilities are **flag-gated and OFF by
+     default** (truthy-string env flag in `wrangler.jsonc` `vars`), so the deploy is byte-identical
+     until the flag is set — mirror this for anything new and risky.
+   - DB: core tables use Drizzle (`src/db/schema.ts`); feature/aggregate tables use raw-SQL migrations.
+   - Comments: sparse but dense; explain *why*, anchor non-obvious logic to an issue number
+     (`(#1234)`). Don't narrate the obvious.
+   - **Config-as-code parity:** a new per-repo gate/setting field must be wired in *every* site
+     (DB migration + Drizzle/types + the settings resolver + OpenAPI + the `.gittensory.yml` schema)
+     in the **same** PR — partial wiring fails review. (See the per-repo-setting checklist in
+     `reference.md`.)
+   - UI: use design tokens (`text-token-*`, `rounded-token`, `border-hairline`, …) in
+     `src/components/site/**` and `src/routes/**` — raw Tailwind size/radius classes are ESLint
+     errors. Never import `server-only`.
+3. **Don't break the public/private boundary.** Public PR comments, check output, and any
+   contributor-facing surface must never leak wallet/hotkey/trust-score/reward/private-scoring terms;
+   the sanitizer drops them, and tests assert their absence — keep it that way.
+
+---
+
+## Phase 3 — Test to (effectively) 100%, including invariants + regressions
+
+This is where most PRs fail Codecov. The bar is **every changed line AND every changed branch covered**.
+
+- **Where tests go:** `test/unit/` (pure logic), `test/integration/` (API routes + D1 via
+  `createTestEnv()`), `test/workers/` (Cloudflare pool, separate config), plus `test/contract/`.
+  Use the `createTestEnv()` / `TestD1Database` helpers (in-memory SQLite, applies all migrations) and
+  `vi.stubGlobal("fetch", …)` for GitHub calls. Patterns + snippets in `reference.md`.
+- **Branch coverage is the trap.** Every `if/else`, ternary `? :`, `&&`/`||`, and especially every
+  nullish fallback `?? 0` / `?? []` is **two branches** — you must exercise *both* sides. The classic
+  miss: a `SUM(...)` over an empty set returns **NULL**, so `count ?? 0` needs a test where the value
+  is actually null/absent, not just present. A line at 100% line-coverage can still be a partial
+  *branch* and sink your patch %.
+  - For each new `??`/ternary/`&&`: write one case for the truthy/present side and one for the
+    nullish/absent/false side.
+  - Test fail-safe paths too: if a function swallows a thrown D1/fetch error and degrades, add a
+    test that makes it throw and asserts the degraded result.
+- **Invariants:** for anything with a public/private boundary, a state→tone/verdict mapping, sorting,
+  or gating, add an invariant test (table of states; assert the right output AND that no competing
+  state leaks). Mirror existing invariant suites.
+- **Regression test for every bug fix:** add a test named for the bug that reproduces it and pins the
+  fix. A fix without a regression test is incomplete.
+- **Measure honestly — unsharded:** `npm run test:coverage` runs the *whole* suite locally and is the
+  only faithful local coverage signal (CI shards the run and merges, so a single shard under-reports).
+  Read the coverage output; if any changed line/branch is uncovered or "partial", add the case.
+
+---
+
+## Phase 4 — Regenerate what your change invalidates (then commit it)
+
+Run the matching command(s) and **commit the regenerated file(s)** — CI fails on staleness:
+
+| You changed… | Run | Commit |
+|---|---|---|
+| API routes or OpenAPI schemas (`src/`) | `npm run ui:openapi` | `apps/gittensory-ui/public/openapi.json` |
+| A Cloudflare binding/var in `wrangler.jsonc` | `npm run cf-typegen` | `worker-configuration.d.ts` |
+| Drizzle schema (`src/db/schema.ts`) | `npm run drizzle:generate` | the new `migrations/NNNN_*.sql` |
+| Added a raw-SQL migration | (none — just author it) | next **contiguous** `migrations/NNNN_snake.sql` |
+| UI files (`apps/gittensory-ui/**`) | `npm --workspace @jsonbored/gittensory-ui run format` | formatted files |
+
+Migrations must use the **next free number** (contiguous, no gaps, no reuse) and match
+`NNNN_snake_case.sql`; `db:migrations:check` enforces it.
+
+---
+
+## Phase 5 — Run the FULL local gate (must be 100% green)
+
+```sh
+git diff --check                          # no trailing whitespace / conflict markers
+npm run test:ci                           # the entire CI gate, in one command (see below)
+npm audit --audit-level=moderate          # the dependency-review job's local equivalent
+```
+
+`npm run test:ci` runs, and must pass, **all of**: `actionlint`, `db:migrations:check`, `typecheck`,
+`test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:version-audit`,
+`ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. If any step fails, fix it and re-run — do not push a
+red tree. (Full per-check table in `reference.md`.)
+
+If `ui:lint` fails on formatting, run `npm --workspace @jsonbored/gittensory-ui run format`. If
+`ui:openapi:check` fails, you forgot Phase 4's `ui:openapi`.
+
+---
+
+## Phase 6 — Predict the gittensory gate before you push
+
+Run the MCP predictor with your actual PR shape:
+
+- `gittensory_check_slop_risk` — keep slop **low**: fill the PR description, include tests, keep the
+  diff focused (no lockfile/docs/generated noise dominating), real source ratio.
+- `gittensory_lint_pr_text` — your commit + PR body must read as **strong**: Conventional Commit
+  subject, traceability (linked issue or explicit no-issue rationale), and a body that says what
+  changed, why, and how it was validated.
+- `gittensory_predict_gate` — simulate the repo's public `.gittensory.yml` gate. Resolve any
+  predicted blocker (the duplicate-PR blocker is the one that hard-fails here) before opening.
+
+Resolve **every** finding before you push. The engine MERGES only a clean + green + gate-passing PR
+and **CLOSES** a contributor PR on any adverse signal (red CI, gate failure, base conflict, or an
+ineligible linked issue). A clean prediction plus a green `npm run test:ci` is what earns the one-shot
+merge instead of a one-shot close.
+
+---
+
+## Phase 7 — Commit and write the PR
+
+**Commit subject** — Conventional Commit, lowercase scope, specific, no trailing period, ≥15 chars
+and ≥2 real words, **no AI/Claude attribution**:
+
+```
+feat(api): add cursor pagination to the labels endpoint
+fix(review): pin comment tone to the gate conclusion (#1066)
+test(stats): cover the nullish SUM fallbacks in public-stats (#1059)
+```
+
+Allowed types: `feat fix test docs refactor build ci chore revert`. Avoid bare generic words
+(`update`, `fix`, `wip`, `cleanup`, `misc`).
+
+**PR body** — make it pass `lint_pr_text` as *strong* (template + the rubric in `reference.md`):
+
+```markdown
+## Summary
+<1–3 lines: what changed and why>
+
+## What changed
+- <specific change 1>
+- <specific change 2>
+
+## Validation
+Ran from repo root, all green:
+`npm run test:ci` · `npm audit --audit-level=moderate`
+<note new tests / coverage of changed branches>
+
+## Linked issue
+Fixes #<n>            <!-- or: No issue — small docs/maintenance fix, because … -->
+```
+
+For UI/visual changes, attach **JPG/PNG** screenshots as captioned, clickable thumbnails (HTML
+`<a><img></a>`), annotated — but do **not** commit screenshots to the repo. Note any
+API/OpenAPI/migration/secret implications.
+
+---
+
+## Phase 8 — Final pre-push checklist
+
+- [ ] Traced ≥2 existing analogues; the change matches house style and is general, not a special case.
+- [ ] In scope (`wantedPaths`), narrow, no `blockedPaths`, no secrets/private terms anywhere.
+- [ ] **Every changed line and branch is tested** (both sides of each `??`/ternary/`&&`); invariants +
+      a regression test for any fix; `npm run test:coverage` shows no uncovered/partial changed lines.
+- [ ] Regenerated + committed: OpenAPI / `cf-typegen` / migrations as applicable (Phase 4).
+- [ ] `git diff --check` clean · **`npm run test:ci` fully green** · `npm audit --audit-level=moderate` clean.
+- [ ] MCP: `predict_gate` = pass, `check_slop_risk` = low, `lint_pr_text` = strong; no advisory findings left.
+- [ ] Conventional Commit subject; PR body has summary + validation + linked issue/rationale; no AI attribution.
+- [ ] No changelog edit; no `site/`/`CNAME`/`lovable` changes.
+
+If every box is checked, the PR has the best possible chance of a one-shot approve-and-merge. If any
+box can't be checked, **keep working — don't push.**
+
+---
+
+When you need the exhaustive detail behind any phase, read **`reference.md`** in this skill directory.

--- a/.claude/skills/contributing-to-gittensory/reference.md
+++ b/.claude/skills/contributing-to-gittensory/reference.md
@@ -1,0 +1,241 @@
+# gittensory contribution — deep reference
+
+Exhaustive tables and patterns behind the `SKILL.md` playbook. Read the section you need; you don't
+need all of it for every change. All commands run from the repo root unless noted. Node is pinned by
+`.nvmrc` (use it: `nvm use`).
+
+---
+
+## 1. Every CI check → local command → what fails it
+
+The single **required** status check is **`validate`** (it aggregates `changes, lint, test, workers,
+mcp, ui, security`; a path-skipped job counts as success). **Codecov** posts `codecov/patch` (the real
+coverage gate) and `codecov/project` (informational) independently. On a PR, jobs run only if their
+path filter matched; on push to `main`, everything runs.
+
+| Check | Runs | Local command | Fails when |
+|---|---|---|---|
+| changes | `git diff --check` + path filter | `git diff --check` | trailing whitespace / conflict markers |
+| lint → actionlint | workflow lint | `npm run actionlint` | any `.github/workflows/*.yml` violation |
+| lint → migrations | migration guard | `npm run db:migrations:check` | duplicate/gap/misnamed migration number |
+| lint → typecheck | `tsc --noEmit` | `npm run typecheck` | any backend type error |
+| test (1/2) | sharded vitest + coverage | `npm run test:coverage` (unsharded) | any failing `test/**/*.test.ts` (excl. `test/workers/**`) |
+| workers | workers-pool vitest | `npm run test:workers` | any failing `test/workers/**` |
+| mcp → build | MCP pkg build | `npm run build:mcp` | MCP package build error |
+| mcp → pack | tarball hygiene | `npm run test:mcp-pack` | unexpected/forbidden file or stale README in the npm tarball |
+| ui → openapi drift | spec check | `npm run ui:openapi:check` | committed `openapi.json` is stale (run `npm run ui:openapi`) |
+| ui → version audit | MCP version copy | `npm run ui:version-audit` | stale MCP version strings / non-`@latest` install copy (hits npm registry) |
+| ui → lint | `eslint .` (UI) | `npm run ui:lint` | ESLint **incl. Prettier formatting** + design-token rules |
+| ui → typecheck | `tsc --noEmit` (UI) | `npm run ui:typecheck` | UI type error |
+| ui → tests | vitest jsdom (UI) | `npm run ui:test` | failing UI component test |
+| ui → build | UI build | `npm run ui:build` | build failure (note: it re-runs `ui:openapi` internally) |
+| security (PR only) | dependency-review (moderate+) | `npm audit --audit-level=moderate` | a **newly added** dep has a moderate+ advisory |
+
+**One command for everything except `security`:** `npm run test:ci`. There is **no** CodeQL/Analyze
+workflow in this repo. There is **no** root-level Prettier gate — Prettier is enforced only inside
+`ui:lint` (so it only bites `apps/gittensory-ui/**`).
+
+---
+
+## 2. Codecov — the real coverage gate (`codecov.yml`)
+
+- **`codecov/patch`: `target: 97%`, `threshold: 0%`, `if_ci_failed: error`.** Every line your PR
+  changes must be ≥97% covered. With 0% threshold and small diffs, **one uncovered branch can fail it.**
+- **It counts BRANCH coverage** (v8 → lcov `BRDA`). A changed line whose branches are only partially
+  exercised counts against you. "100% lines" ≠ "100% branches."
+- **`codecov/project`: `informational: true`** — a trend, never blocks.
+- **Ignored paths** (no coverage obligation): `apps/**`, `test/**`, `scripts/**`, `src/env.d.ts`.
+  Coverage `include` is `src/**/*.ts` only. → A UI-only / test-only / script-only change owes **no**
+  patch coverage; a backend `src/**` change owes coverage on **every changed line + branch**.
+- **Measure unsharded locally:** `npm run test:coverage`. CI shards into 2 and Codecov merges them,
+  so a single local shard under-reports — never trust it.
+
+---
+
+## 3. The gittensory gate — it auto-MERGES and auto-CLOSES (not advisory)
+
+The engine reviews every PR and **acts on it** with autonomy (`src/settings/agent-actions.ts`
+`planAgentMaintenanceActions`). A scheduled sweep re-evaluates open PRs roughly every ~2 minutes, so a
+disposition lands quickly once checks settle. For a **contributor** PR (not the repo owner, not an
+automation bot), the disposition is one-shot:
+
+| Condition | Disposition |
+|---|---|
+| gate `success` **and** CI `passed` (all checks, **codecov/patch included**) **and** mergeable `clean` **and** approvals satisfied **and** no guardrail hit | **auto-approve → MERGE** |
+| CI `failed` (any check) | **CLOSE** (cites the failing check) |
+| gate `failure` | **CLOSE** |
+| base `dirty` (merge conflict) | **CLOSE** |
+| linked-issue **hard-rule** violation (issue owner-assigned / maintainer-only / missing point label) | **CLOSE** (deterministic — fires even on a guarded path; optional flag-then-close two-pass) |
+| CI `pending` | **no action** — waits for the check-completion webhook |
+| CI `unverified` (fork Actions awaiting approval, unreadable checks) | **HELD** for review (never closed — fork false-close guard) |
+| changed path hits a **hard guardrail** (CI configs, the review engine, visual capture) | **HELD** for the owner — every would-merge/approve/close becomes a manual hold |
+| gate `neutral` (advisory-only on a non-confirmed contributor, or eval-not-ready) | **HELD** + labeled (not merged, not closed) |
+| gate `skipped` (genuinely not evaluated) | no action |
+
+Implications for you:
+- **Red CI = your PR is closed.** Not held, not commented — closed. `codecov/patch` is a CI check, so
+  a coverage miss closes the PR. This is why Phases 3–5 are non-negotiable.
+- **A merge conflict closes the PR** — keep your branch current with `main`.
+- **Linking the wrong issue closes the PR** — only link an open, unassigned, eligible issue (verify
+  with `gittensory_validate_linked_issue`).
+- Owner / automation-bot PRs are exempt from auto-close, and crucial guarded-path PRs are held — but
+  **assume you are a contributor** and that adverse = close.
+
+`.gittensory.yml` (the public config you can predict against) sets the gate *modes* (`linkedIssue:
+advisory`, `duplicates: block`, `readiness: advisory/60`, AI review off) and the focus manifest
+(`wantedPaths`: `src/ packages/ test/ migrations/ scripts/ .github/workflows/ wrangler.jsonc
+apps/gittensory-ui/`; `blockedPaths`: `site/ CNAME **/lovable/**`; `linkedIssuePolicy: preferred`;
+`testExpectations: npm run test:ci`). But the **modes are inputs to the disposition above** — the
+engine still auto-merges the clean case and auto-closes the adverse case. The MCP `predict_gate` uses
+the public config + safe defaults; a clean prediction is necessary but not sufficient (it can't see
+private overrides or AI-consensus), so the change must also be genuinely correct and fully green.
+
+---
+
+## 4. Slop signals — keep risk LOW (`src/signals/slop.ts`)
+
+PR-side signals that raise slop risk (band: clean 0 / low 1–24 / elevated 25–59 / high 60+):
+
+- **Trivial whitespace churn** (≥40 changed lines but <15% real source) → keep diffs source-dense;
+  split lockfile/docs/formatting-only changes out.
+- **Missing test evidence** (code changed, no test files / no test mention) → add `*.test.ts` or note
+  tests in the commit/body.
+- **Non-substantive padding** (majority generated/vendored/minified) → exclude generated output.
+- **Empty description** (code changed, blank body) → always fill the PR body.
+
+---
+
+## 5. MCP pre-submit tools (`@jsonbored/gittensory-mcp`)
+
+Install: `npm install -g @jsonbored/gittensory-mcp@latest && gittensory-mcp login`. All are
+metadata-only (no source upload). Run in this order:
+
+1. `gittensory_check_before_start` — `{owner, repo, issueNumber, plannedChange{title, paths}}` →
+   go/raise/avoid (claimed? duplicate cluster? already solved?).
+2. `gittensory_validate_linked_issue` — `{owner, repo, issueNumber, plannedChange}` → is the issue
+   open, valid, single-owner, solvable by this PR.
+3. `gittensory_check_slop_risk` — `{changedFiles[{path,additions,deletions}], description, tests,
+   testFiles}` → slopRisk 0–100 + band + findings.
+4. `gittensory_lint_pr_text` — `{commitMessages[], prBody, linkedIssue}` → verdict
+   strong/adequate/weak + specific fixes.
+5. `gittensory_predict_gate` — `{login, owner, repo, title, body, labels, linkedIssues}` → predicted
+   conclusion + blockers + warnings + readiness score.
+
+(Auth'd extras: `gittensory_preflight_pr` / `…_local_diff` for lane fit + collision + queue health.)
+
+---
+
+## 6. Tests — helpers, branch coverage, invariants, regressions
+
+**Layout:** `test/unit/` (pure, no I/O) · `test/integration/` (routes + D1) · `test/workers/`
+(Cloudflare pool, `vitest.workers.config.ts`) · `test/contract/` · `test/fixtures/` · `test/helpers/`
+· `test/stubs/`. Globals are on (no need to import `describe/it/expect`). Test timeout 15s.
+
+**D1 + env:** `test/helpers/d1.ts` exports `TestD1Database` (in-memory `node:sqlite`, applies every
+`migrations/*.sql`) and `createTestEnv(overrides?)`. Pattern:
+
+```ts
+import { createTestEnv } from "../helpers/d1";
+const env = createTestEnv({ GITTENSORY_REVIEW_REPOS: "JSONbored/gittensory" });
+await env.DB.prepare(`INSERT INTO repositories (full_name, owner, name) VALUES (?,?,?)`)
+  .bind("JSONbored/gittensory", "JSONbored", "gittensory").run();
+const row = await env.DB.prepare(`SELECT * FROM repositories WHERE full_name = ?`)
+  .bind("JSONbored/gittensory").first<RepoRow>();
+```
+
+**Route tests:** `createApp()` from `src/api/routes` + `app.request(path, init, env)`. **Fetch stub:**
+`vi.stubGlobal("fetch", async (input, init) => Response.json({...}))`, clean up in
+`afterEach(() => vi.unstubAllGlobals())`. **Clock:** `vi.useFakeTimers(); vi.setSystemTime(new
+Date("2026-05-28T00:00:00Z"))` then `vi.useRealTimers()`.
+
+**Branch coverage — the rule that fails most PRs.** Each of `if/else`, `? :`, `&&`, `||`, and `??`
+is two branches; exercise **both**.
+
+```ts
+// SUM(...) over an empty set returns NULL → the `?? 0` nullish arm IS reachable. Test it:
+it("coerces a null aggregate to 0", () => {
+  expect(rowFromDbWithNullCount.count ?? 0).toBe(0);      // nullish side
+});
+it("uses the real count when present", () => {
+  expect(rowFromDbWithCount.count ?? 0).toBe(7);          // present side
+});
+// Fail-safe path: make the dependency throw and assert the degraded result.
+it("degrades to neutral when the D1 read throws", async () => { /* env.DB.prepare → all() throws */ });
+```
+
+**Invariants** (mirror existing suites): for public/private boundaries, state→verdict/tone maps,
+sorting, gating — assert the correct output for each state **and** that no competing state leaks
+(e.g. a gate `failure` body contains the failure tone and **none** of the other tones; public output
+contains **no** wallet/hotkey/trust/reward terms). Seeded loops (LCG) are used instead of external
+property libs.
+
+**Regression tests:** every bug fix ships a test named for the bug (e.g. `"… (regression for #1066)"`)
+that reproduces the old failure and pins the fix.
+
+**CONTRIBUTING test expectations:** add/refresh tests for new branches, fallback paths, sanitizer
+rules; backend routes need success / denied / invalid-input / missing-auth / scoped-auth / rate-limit
+/ error-shape cases; auth needs cookie + bearer + logout + OAuth-failure + device-flow; CORS needs
+trusted-vs-untrusted; OpenAPI protected/public must match middleware; public comments must assert
+absence of forbidden terms.
+
+---
+
+## 7. Style, lint, naming
+
+- **Prettier (UI):** printWidth 100, double quotes, semicolons, `trailingComma: all`. Fix:
+  `npm --workspace @jsonbored/gittensory-ui run format`. (`routeTree.gen.ts` and lockfiles are ignored.)
+- **ESLint (UI):** `react-hooks/recommended`; `react-refresh/only-export-components` (non-component
+  exports must move to a `*-model.ts`); **design-token** `no-restricted-syntax` in
+  `src/components/site/**` + `src/routes/**` (use `text-token-*`, `leading-token-*`, `rounded-token`,
+  `border-hairline`, `divide-hairline` — not raw `text-sm`/`rounded-md`/`leading-*`/`border-*`);
+  **no `server-only`** import.
+- **Naming:** `camelCase` vars/functions, `SCREAMING_SNAKE_CASE` env/consts, `PascalCase`
+  types/components, `kebab-case.ts` files. Suffixes: `*-model.ts` (pure helpers/types for a
+  component), `*-wire.ts` (flag guard + init), `*.test.ts` / `*-route.test.ts`.
+- **Comments:** sparse, explain *why*, anchor non-obvious logic to `(#issue)`. Match surrounding density.
+- **DB:** core tables → Drizzle (`src/db/schema.ts`, use `$defaultFn(() => nowIso())` for timestamps,
+  not a static SQL default); feature/aggregate tables → raw-SQL migrations.
+
+### Config-as-code parity (a new per-repo gate/setting field)
+Wire it in **every** site in the **same** PR, or review fails:
+1. DB migration (`migrations/NNNN_*.sql`) for the new column/table.
+2. Drizzle schema + types (`src/db/schema.ts`, `src/types.ts`).
+3. The settings resolver / focus-manifest loader (so `.gittensory.yml` > DB > defaults still holds).
+4. OpenAPI (`npm run ui:openapi`) for any new request/response field.
+5. The `.gittensory.yml` schema + docs so contributors can set it.
+6. Tests covering the new field's resolution precedence + the gate behavior it drives.
+
+---
+
+## 8. Commits & PR text (what `lint_pr_text` scores)
+
+**Commit (Conventional):** `type(scope): summary` — types `feat fix test docs refactor build ci chore
+revert`; lowercase specific scope (`api ui mcp review signals stats scoring auth github data draft …`);
+no trailing period; ≥15 chars and ≥2 real tokens; not a bare generic word (`update/fix/wip/cleanup/
+misc/…`); **no AI/Claude/agent mention**. Changelogs are generated by `git-cliff` at release — **don't
+edit `CHANGELOG.md` in a normal PR.**
+
+**PR body verdict** = traceability (30) + commit message (35) + body (35); aim **strong**:
+- **Traceability** ok: a linked issue, or an explicit no-issue rationale (`no issue because …`,
+  `docs only`, `maintenance`, `typo`, `chore`).
+- **Body** ok: real prose (≥40 chars, specific) **and/or** a validation note (mentions
+  `test/tested/vitest/npm test/validated/verified/smoke`). Don't leave an unfilled template.
+- All evidence is run through the public-comment sanitizer — forbidden terms (`wallet, hotkey,
+  coldkey, payout, reward, trust score, scoreability, …`) are dropped; just don't use them.
+
+---
+
+## 9. What gittensory does NOT accept (from `CONTRIBUTING.md`)
+
+- `site/`, `CNAME`, VitePress/old static-docs surfaces; `**/lovable/**`.
+- Broad rewrites / framework swaps / redesigns without a maintainer-approved issue.
+- Production mock/fallback data, or UI claims not backed by the live API.
+- Public leaderboards, raw wallet/trust/reward/private-ranking exposure.
+- Auto-close/auto-merge/rewriting contributor work; labels outside confirmed-miner policy.
+- Storing contributor GitHub PATs; non-GitHub identity providers.
+- Large dependency upgrades bundled with unrelated changes.
+- Changelog edits in ordinary PRs.
+- Low-effort/reward-farming/bulk-generated/no-product-impact PRs.
+
+When in doubt: open an issue first, keep the PR narrow, anchor on an existing analogue, and make every
+changed line correct *and* tested.


### PR DESCRIPTION
## Summary
Adds a Claude Code / Codex **contributor skill** so anyone using an AI tool to contribute to gittensory produces PRs that have a much higher chance of passing the one-shot gate + CI on the first try.

## What changed
- `.claude/skills/contributing-to-gittensory/SKILL.md` — the phased one-shot-PR playbook (install MCP → pick/validate → implement to house style → test to ~100% incl. invariants + regressions → regenerate artifacts → run the full local gate → predict the gate → commit/PR → final checklist), auto-discovered by Claude Code via its `description`.
- `.claude/skills/contributing-to-gittensory/reference.md` — exhaustive companion tables: every CI check → local command, the exact Codecov rules (97% patch, branch coverage, ignored paths), the engine's **auto-merge / auto-close disposition** matrix, slop signals, the MCP pre-submit tools, test helpers + branch-coverage patterns, config-as-code parity, and the commit/PR rubric.

## Why
gittensory's engine reviews and **acts** on PRs with real autonomy — a contributor PR with red CI (incl. `codecov/patch`), a gate failure, a base conflict, or an ineligible linked issue is **auto-closed**, while a clean + green + passing PR is **auto-merged**. There's no fix-it-in-review loop, so contributors need a single authoritative procedure to get it right before pushing. The skill encodes exactly that, sourced from the live gate logic (`src/settings/agent-actions.ts`), `codecov.yml`, `.gittensory.yml`, the CI workflows, and `CONTRIBUTING.md`.

## Validation
Docs-only addition under `.claude/` (no `src/` impact → no Codecov obligation; no code paths touched). `git diff --check` clean; CI `validate` + Codecov run on the PR.

## Linked issue
No issue — contributor-tooling/docs addition.
