### PR TITLE
docs(skills): wire the contributor skill to Claude Code + Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# gittensory — AI contributor guide
+
+Loaded automatically by AI coding tools: **Codex** reads this `AGENTS.md`; **Claude Code** reads
+`CLAUDE.md` (a symlink to this file) and additionally auto-loads the on-demand skill at
+`.claude/skills/contributing-to-gittensory/`.
+
+**Before writing ANY code contribution or pull request to this repo, read and follow the skill:**
+
+- `.claude/skills/contributing-to-gittensory/SKILL.md` — the one-shot-PR playbook (phases + checklist)
+- `.claude/skills/contributing-to-gittensory/reference.md` — exhaustive tables (CI, Codecov, the gate, tests, style)
+
+That skill is the **single source of truth** for how to contribute here. Keep it updated as the
+process evolves — edits to those files improve both Claude Code and Codex.
+
+## The five things you must not get wrong
+
+1. **The gate auto-merges and auto-closes — it is not advisory.** A *contributor* PR with red CI
+   (including `codecov/patch`), a gate failure, a base conflict, or an ineligible linked issue is
+   **auto-CLOSED, one-shot** (recovery = open a fresh PR). Green CI + passing gate + mergeable-clean +
+   a valid linked issue is **auto-MERGED**. So make it perfect before you push.
+2. **97% patch coverage, branch-counted.** Aim for **100% of every changed line *and branch*** — test
+   both sides of every `??` / ternary / `&&` (a `SUM()` can return `NULL`, so the nullish arm is real),
+   plus invariant tests and a regression test for every fix. Only `src/**` is measured by Codecov.
+3. **The whole local gate must be green:** `npm run test:ci` (+ `npm audit --audit-level=moderate`).
+   Measure coverage **unsharded** with `npm run test:coverage` (CI shards + merges, so a single shard
+   under-reports).
+4. **Regenerate and commit generated artifacts:** `npm run ui:openapi` (API/schema changes),
+   `npm run cf-typegen` (wrangler binding/var changes), and a contiguous `migrations/NNNN_*.sql`
+   (DB changes). Stale generated files fail CI.
+5. **House rules:** Conventional Commits, **no AI/Claude/agent attribution** in commits or PR text;
+   no secrets / wallets / hotkeys / trust scores / reward values anywhere; stay inside `wantedPaths`
+   and out of `site/`, `CNAME`, `**/lovable/**`; never edit `CHANGELOG.md` in a normal PR.
+
+The full procedure, the gate disposition matrix, test patterns, the MCP pre-submit predictors
+(`@jsonbored/gittensory-mcp`), and the PR template are all in the skill files above — use them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
Wires the merged `contributing-to-gittensory` skill (from #1141) to **Claude Code** and **Codex** with one source of truth, so AI contributors get the playbook automatically in both tools.

## What changed
- **`AGENTS.md`** (repo root) — read by Codex and generic agents; a lean always-on entry that inlines the five must-not-get-wrong rules and points to the skill (`.claude/skills/contributing-to-gittensory/SKILL.md` + `reference.md`) as the source of truth.
- **`CLAUDE.md`** → symlink to `AGENTS.md` — always-on for Claude Code (complements the on-demand skill it already auto-discovers).

## Why
The skill is the authoritative one-shot-PR playbook; this makes it load for both tools without duplicating content (refine the skill files → both Claude Code and Codex benefit). Mirrors the phase-rs/phase model (canonical doc + symlinks). `.codex/skills → .claude/skills` is also set up per-machine, but `.codex/` is globally gitignored, so `AGENTS.md` is the committed Codex entry point.

## Validation
Docs-only (root markdown + a symlink; no `src/` impact → no Codecov obligation). `git diff --check` clean.

## Linked issue
No issue — follow-up tooling/docs to the contributor skill merged in #1141.
