### PR TITLE
Treat linked-issue extraction overflow as unsafe to avoid silent truncation bypass

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5363,9 +5363,13 @@ function loginMatches(column: unknown, login: string) {
 
 export const MAX_LINKED_ISSUE_NUMBERS = 50;
 
-export function extractLinkedIssueNumbers(text: string, limit = MAX_LINKED_ISSUE_NUMBERS): number[] {
+export type LinkedIssueExtractionResult = {
+  numbers: number[];
+  overflow: boolean;
+};
+
+export function extractLinkedIssueNumbersWithOverflow(text: string, limit = MAX_LINKED_ISSUE_NUMBERS): LinkedIssueExtractionResult {
   const normalizedLimit = Math.max(0, Math.floor(limit));
-  if (normalizedLimit === 0) return [];
 
   const linkedIssues: number[] = [];
   const seen = new Set<number>();
@@ -5373,10 +5377,14 @@ export function extractLinkedIssueNumbers(text: string, limit = MAX_LINKED_ISSUE
     const value = Number(match[1]);
     if (!Number.isInteger(value) || value <= 0 || seen.has(value)) continue;
     seen.add(value);
+    if (linkedIssues.length >= normalizedLimit) return { numbers: linkedIssues, overflow: true };
     linkedIssues.push(value);
-    if (linkedIssues.length >= normalizedLimit) break;
   }
-  return linkedIssues;
+  return { numbers: linkedIssues, overflow: false };
+}
+
+export function extractLinkedIssueNumbers(text: string, limit = MAX_LINKED_ISSUE_NUMBERS): number[] {
+  return extractLinkedIssueNumbersWithOverflow(text, limit).numbers;
 }
 
 function extractLinkedPrNumbers(text: string): number[] {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -56,7 +56,6 @@ import {
   upsertIssueFromGitHub,
   upsertPullRequestFromGitHub,
   upsertRepositoryFromGitHub,
-  extractLinkedIssueNumbersWithOverflow,
 } from "../db/repositories";
 import { pruneExpiredRecords } from "../db/retention";
 import {
@@ -65,7 +64,6 @@ import {
   backfillRepositorySegment,
   enqueueRepositoryOpenDataBackfill,
   fetchAndStorePullRequestFilesForReview,
-  fetchLinkedIssueFacts,
   fetchLiveCiAggregate,
   fetchLivePullRequestMergeState,
   fetchLivePullRequestReviewDecision,
@@ -178,7 +176,7 @@ import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
-import { evaluateLinkedIssueHardRules, loadLinkedIssueHardRules } from "../review/linked-issue-hard-rules";
+import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
 import { isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
@@ -653,35 +651,21 @@ async function maybeRunAgentMaintenance(
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
 
-  // Linked-issue HARD-RULE close (#linked-issue-hard-rules). DETERMINISTIC: if the repo enabled any rule AND
-  // this PR links at least one issue, fetch each linked issue's facts (labels/assignees/state) and evaluate.
-  // Skip the fetch entirely when no rule is on OR there are no linked issues (no extra GitHub calls on the
-  // common path). Fetches are FAIL-OPEN per issue (a fetch error skips that issue, never blocks the review);
-  // the config load is FAIL-SAFE (a KV fault yields all-off, never a surprise close).
-  let linkedIssueHardRule: { violated: boolean; reason: string | null } | undefined;
+  // Linked-issue HARD-RULE close (#linked-issue-hard-rules): when the repo enabled any rule, a body that links
+  // MORE closing references than we can safely verify (overflow) is itself a violation; otherwise evaluate the
+  // linked issues' facts (fail-open per issue). The decision is extracted into resolveLinkedIssueHardRule (pure,
+  // dependency-injected) so it is unit-tested directly rather than only through this orchestrator. Config load is
+  // FAIL-SAFE (a KV fault yields all-off, never a surprise close).
   const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, repoFullName);
-  const anyLinkedIssueRuleOn =
-    linkedIssueRulesConfig.ownerAssignedClose === "block" ||
-    linkedIssueRulesConfig.missingPointLabelClose === "block" ||
-    linkedIssueRulesConfig.maintainerOnlyLabelClose === "block";
-  if (anyLinkedIssueRuleOn) {
-    const linkedIssueExtraction = extractLinkedIssueNumbersWithOverflow(pr.body ?? "");
-    if (linkedIssueExtraction.overflow) {
-      linkedIssueHardRule = {
-        violated: true,
-        reason: "PR body links more issues than Gittensory can safely verify automatically; please reduce linked closing references or request maintainer review.",
-      };
-    } else if (pr.linkedIssues.length > 0) {
-      // pr.linkedIssues is already capped at MAX_LINKED_ISSUE_NUMBERS at extraction (extractLinkedIssueNumbers),
-      // so the per-issue fetch fanout is bounded at the source — no extra cap needed here.
-      const issueFacts = (
-        await Promise.all(pr.linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(env, repoFullName, issueNumber, ciToken ?? env.GITHUB_PUBLIC_TOKEN)))
-      ).flatMap((facts) => (facts ? [facts] : []));
-      if (issueFacts.length > 0) {
-        linkedIssueHardRule = evaluateLinkedIssueHardRules({ issues: issueFacts, config: linkedIssueRulesConfig, repoOwner });
-      }
-    }
-  }
+  const linkedIssueHardRule = await resolveLinkedIssueHardRule({
+    env,
+    repoFullName,
+    repoOwner,
+    config: linkedIssueRulesConfig,
+    body: pr.body,
+    linkedIssues: pr.linkedIssues,
+    ciToken,
+  });
 
   const planned = planAgentMaintenanceActions({
     conclusion: gate.conclusion,

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -56,6 +56,7 @@ import {
   upsertIssueFromGitHub,
   upsertPullRequestFromGitHub,
   upsertRepositoryFromGitHub,
+  extractLinkedIssueNumbersWithOverflow,
 } from "../db/repositories";
 import { pruneExpiredRecords } from "../db/retention";
 import {
@@ -663,14 +664,22 @@ async function maybeRunAgentMaintenance(
     linkedIssueRulesConfig.ownerAssignedClose === "block" ||
     linkedIssueRulesConfig.missingPointLabelClose === "block" ||
     linkedIssueRulesConfig.maintainerOnlyLabelClose === "block";
-  if (anyLinkedIssueRuleOn && pr.linkedIssues.length > 0) {
-    // pr.linkedIssues is already capped at MAX_LINKED_ISSUE_NUMBERS at extraction (extractLinkedIssueNumbers),
-    // so the per-issue fetch fanout is bounded at the source — no extra cap needed here.
-    const issueFacts = (
-      await Promise.all(pr.linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(env, repoFullName, issueNumber, ciToken ?? env.GITHUB_PUBLIC_TOKEN)))
-    ).flatMap((facts) => (facts ? [facts] : []));
-    if (issueFacts.length > 0) {
-      linkedIssueHardRule = evaluateLinkedIssueHardRules({ issues: issueFacts, config: linkedIssueRulesConfig, repoOwner });
+  if (anyLinkedIssueRuleOn) {
+    const linkedIssueExtraction = extractLinkedIssueNumbersWithOverflow(pr.body ?? "");
+    if (linkedIssueExtraction.overflow) {
+      linkedIssueHardRule = {
+        violated: true,
+        reason: "PR body links more issues than Gittensory can safely verify automatically; please reduce linked closing references or request maintainer review.",
+      };
+    } else if (pr.linkedIssues.length > 0) {
+      // pr.linkedIssues is already capped at MAX_LINKED_ISSUE_NUMBERS at extraction (extractLinkedIssueNumbers),
+      // so the per-issue fetch fanout is bounded at the source — no extra cap needed here.
+      const issueFacts = (
+        await Promise.all(pr.linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(env, repoFullName, issueNumber, ciToken ?? env.GITHUB_PUBLIC_TOKEN)))
+      ).flatMap((facts) => (facts ? [facts] : []));
+      if (issueFacts.length > 0) {
+        linkedIssueHardRule = evaluateLinkedIssueHardRules({ issues: issueFacts, config: linkedIssueRulesConfig, repoOwner });
+      }
     }
   }
 

--- a/src/review/linked-issue-hard-rules.ts
+++ b/src/review/linked-issue-hard-rules.ts
@@ -1,4 +1,6 @@
 import type { JsonValue } from "../types";
+import { fetchLinkedIssueFacts } from "../github/backfill";
+import { extractLinkedIssueNumbersWithOverflow } from "../db/repositories";
 
 // Linked-issue HARD-RULE auto-close (#linked-issue-hard-rules). A DETERMINISTIC rule about the issue(s) a
 // contributor PR links — not an AI verdict. When a contributor links an issue that violates one of the
@@ -191,4 +193,39 @@ export function evaluateLinkedIssueHardRules(input: {
   }
 
   return NO_VIOLATION;
+}
+
+/**
+ * Orchestrate the per-PR linked-issue hard-rule decision (the testable core of maybeRunAgentMaintenance's
+ * linked-issue block). Returns the hard-rule result, or undefined when no rule applies. Takes the raw PR body +
+ * CI token so the overflow check and per-issue fact fetch happen here (the call-site stays branch-free):
+ *   - no rule in "block" mode → undefined (skip entirely, no fetch).
+ *   - the PR body links MORE closing references than the cap (overflow) → a violation: too many to verify safely.
+ *   - otherwise fetch each linked issue's facts (fail-open per issue) and run the deterministic evaluator.
+ */
+export async function resolveLinkedIssueHardRule(args: {
+  env: Env;
+  repoFullName: string;
+  repoOwner: string;
+  config: LinkedIssueHardRulesConfig;
+  body: string | null | undefined;
+  linkedIssues: number[];
+  ciToken: string | undefined;
+}): Promise<LinkedIssueHardRuleResult | undefined> {
+  const anyRuleOn =
+    args.config.ownerAssignedClose === "block" ||
+    args.config.missingPointLabelClose === "block" ||
+    args.config.maintainerOnlyLabelClose === "block";
+  if (!anyRuleOn) return undefined;
+  if (extractLinkedIssueNumbersWithOverflow(args.body ?? "").overflow) {
+    return {
+      violated: true,
+      reason: "PR body links more issues than Gittensory can safely verify automatically; please reduce linked closing references or request maintainer review.",
+    };
+  }
+  if (args.linkedIssues.length === 0) return undefined;
+  const token = args.ciToken ?? args.env.GITHUB_PUBLIC_TOKEN;
+  const issueFacts = (await Promise.all(args.linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(args.env, args.repoFullName, issueNumber, token)))).flatMap((facts) => (facts ? [facts] : []));
+  if (issueFacts.length === 0) return undefined;
+  return evaluateLinkedIssueHardRules({ issues: issueFacts, config: args.config, repoOwner: args.repoOwner });
 }

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -11,22 +11,28 @@ import {
   upsertOfficialMinerDetection,
   upsertPullRequestFromGitHub,
   extractLinkedIssueNumbers,
+  extractLinkedIssueNumbersWithOverflow,
   MAX_LINKED_ISSUE_NUMBERS,
 } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 describe("database row parser hardening", () => {
 
-  it("caps linked issues extracted from attacker-controlled PR bodies", () => {
+  it("caps linked issues extracted from attacker-controlled PR bodies and reports overflow", () => {
     const body = Array.from({ length: MAX_LINKED_ISSUE_NUMBERS + 25 }, (_, index) => `Fixes #${index + 1}`).join("\n");
 
     expect(extractLinkedIssueNumbers(body)).toEqual(Array.from({ length: MAX_LINKED_ISSUE_NUMBERS }, (_, index) => index + 1));
+    expect(extractLinkedIssueNumbersWithOverflow(body)).toEqual({
+      numbers: Array.from({ length: MAX_LINKED_ISSUE_NUMBERS }, (_, index) => index + 1),
+      overflow: true,
+    });
   });
 
   it("deduplicates linked issues before applying the extraction cap", () => {
     const body = [`Fixes #1`, ...Array.from({ length: MAX_LINKED_ISSUE_NUMBERS }, (_, index) => `Resolves #${index + 1}`)].join("\n");
 
     expect(extractLinkedIssueNumbers(body)).toEqual(Array.from({ length: MAX_LINKED_ISSUE_NUMBERS }, (_, index) => index + 1));
+    expect(extractLinkedIssueNumbersWithOverflow(body).overflow).toBe(false);
   });
 
   it("returns no linked issues when the cap is zero or negative", () => {

--- a/test/unit/linked-issue-hard-rules.test.ts
+++ b/test/unit/linked-issue-hard-rules.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestEnv } from "../helpers/d1";
 import {
   DEFAULT_LINKED_ISSUE_HARD_RULES,
   evaluateLinkedIssueHardRules,
   loadLinkedIssueHardRules,
+  resolveLinkedIssueHardRule,
   type LinkedIssueFacts,
   type LinkedIssueHardRulesConfig,
 } from "../../src/review/linked-issue-hard-rules";
@@ -280,5 +282,58 @@ describe("loadLinkedIssueHardRules", () => {
     expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: 9999 } })), "o/r")).closeDelaySeconds).toBe(300);
     expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: 45.9 } })), "o/r")).closeDelaySeconds).toBe(45);
     expect((await loadLinkedIssueHardRules(envWith(async () => ({ linkedIssueHardRules: { closeDelaySeconds: "30" } })), "o/r")).closeDelaySeconds).toBe(30);
+  });
+});
+
+describe("resolveLinkedIssueHardRule (#1144 — overflow + orchestration)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  // Defaults: body=null and ciToken=undefined so the `?? ""` and `?? env.GITHUB_PUBLIC_TOKEN` fallbacks are
+  // exercised; tests that need the other arm pass a string body / a CI token explicitly.
+  const args = (over: Record<string, unknown> = {}) => ({
+    env: createTestEnv({}),
+    repoFullName: "owner/repo",
+    repoOwner: "owner",
+    config: config(),
+    body: null as string | null | undefined,
+    linkedIssues: [] as number[],
+    ciToken: undefined as string | undefined,
+    ...over,
+  });
+
+  it("returns undefined and fetches nothing when no rule is in block mode", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    expect(await resolveLinkedIssueHardRule(args({ config: config(), body: "closes #1", linkedIssues: [1] }))).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("flags a body that overflows the cap (>50 closing refs) as a violation, without fetching", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const body = Array.from({ length: 60 }, (_, i) => `closes #${i + 1}`).join(" ");
+    const r = await resolveLinkedIssueHardRule(args({ config: config({ ownerAssignedClose: "block" }), body, linkedIssues: [1] }));
+    expect(r?.violated).toBe(true);
+    expect(r?.reason).toMatch(/more issues than Gittensory can safely verify/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when a rule is on but the PR links no issues (null body → no overflow)", async () => {
+    expect(await resolveLinkedIssueHardRule(args({ config: config({ ownerAssignedClose: "block" }), body: null, linkedIssues: [] }))).toBeUndefined();
+  });
+
+  it("is fail-open: undefined when every fetch fails (404), with no CI token → public-token fallback", async () => {
+    vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));
+    expect(await resolveLinkedIssueHardRule(args({ config: config({ ownerAssignedClose: "block" }), ciToken: undefined, linkedIssues: [1, 2] }))).toBeUndefined();
+  });
+
+  it("fetches with the CI token and runs the deterministic evaluator over the facts", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
+      input.toString().includes("/issues/")
+        ? Response.json({ number: 1, state: "open", labels: [], assignees: ["owner"] })
+        : new Response("missing", { status: 404 }),
+    );
+    const r = await resolveLinkedIssueHardRule(args({ config: config({ ownerAssignedClose: "block" }), ciToken: "tok", body: "closes #1", linkedIssues: [1] }));
+    expect(r).toBeDefined();
+    expect(typeof r?.violated).toBe("boolean");
   });
 });


### PR DESCRIPTION
### Motivation
- The extractor previously silently truncated linked-issue references at `MAX_LINKED_ISSUE_NUMBERS`, which allowed attacker-controlled PR bodies to hide later ineligible closing refs and bypass deterministic linked-issue hard-rule enforcement.
- The change aims to preserve the fanout cap while restoring integrity by surfacing overflow so automation can treat excess closing refs as unsafe.

### Description
- Add a `LinkedIssueExtractionResult` type and `extractLinkedIssueNumbersWithOverflow` which returns the bounded `numbers` array plus an `overflow` flag, and make `extractLinkedIssueNumbers` delegate to it for backward compatibility.
- Update the linked-issue hard-rule path to re-run extraction on the PR body via `extractLinkedIssueNumbersWithOverflow` and treat `overflow === true` as a deterministic hard-rule violation with an explanatory `reason` to block auto-merge.
- Extend `test/unit/db-parsers.test.ts` to assert overflow behavior for over-cap and dedup cases while keeping existing behavior unchanged.

### Testing
- Ran the unit tests with `npx vitest run test/unit/db-parsers.test.ts test/unit/linked-issue-hard-rules.test.ts test/unit/agent-actions.test.ts` and all tests passed (3 files, 95 tests).
- Ran the TypeScript check with `npx tsc --noEmit` which completed without errors.
- Verified repository formatting/checks with `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b39c9d468832ca2af82695f0162ff)