### PR TITLE
fix(backfill): align installation health repair steps with normalized status

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -745,7 +745,7 @@ export function enrichInstallationHealth(health: InstallationHealthRecord) {
       action: missingEvents.has(event) ? `Subscribe to the ${event} webhook event.` : "No change needed.",
     })),
     repairSteps:
-      health.status === "healthy"
+      status === "healthy"
         ? ["No repair needed."]
         : [
             "Update the GitHub App permissions and subscribed events.",

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -433,6 +433,8 @@ describe("GitHub backfill", () => {
       missingEvents: [],
       optionalVisibleEvents: expect.arrayContaining(["installation_repositories"]),
     });
+    // Repair steps must follow the recomputed status, not the pre-normalization input status.
+    expect(health.repairSteps).toEqual(["No repair needed."]);
   });
 
   it("requires Checks write only for repos with check runs enabled", async () => {


### PR DESCRIPTION
## Summary

`enrichInstallationHealth` recomputes a normalized `status` (flipping `needs_attention` → `healthy` when there are no missing required permissions/events and no error). Every derived field keys off that recomputed value — except `repairSteps`, which still branched on the original input `health.status`. A record normalized to `healthy` was therefore returned with the full four-step "repair the installation" list, contradicting its own status. This branches `repairSteps` on the recomputed `status` instead.

```ts
const status = health.status === "needs_attention" && missingPermissions.size === 0 && ... ? "healthy" : health.status;
return {
  ...health, status,
-  repairSteps: health.status === "healthy" ? ["No repair needed."] : [ ...four steps... ],
+  repairSteps: status === "healthy" ? ["No repair needed."] : [ ...four steps... ],
};
```

Fixes #1145

## Scope

- [x] PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused single change; no unrelated backend/UI/MCP/docs/deploy mixing.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — both `repairSteps` branches are covered (the existing normalization test now asserts `["No repair needed."]`; the missing-permission test covers the four-step branch). Full backend suite green.
- [x] New behavior tested: extended the "normalizes stale automatic installation repository event health" test to assert `repairSteps` follows the recomputed status.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise.

## Notes

One-symbol behavioral fix in a pure function (`health.status` → `status`); no public surface or UI change.
