### PR TITLE
fix(review): de-duplicate failing check names in the unified-comment details path

### DIFF
--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -336,10 +336,16 @@ function failingChecksBlock(readiness: MergeReadiness | undefined): string {
   if (!readiness || readiness.ciState !== "failed") return "";
   const details = readiness.failingDetails ?? [];
   if (details.length > 0) {
+    // A check name can arrive more than once (a check-run and a same-named status context, or repeated
+    // contexts across pages), so dedupe by name — keeping the first entry's reason — exactly like the
+    // bare-names fallback below, which already collapses duplicates with a Set.
+    const seen = new Set<string>();
     const lines = details
       .map((detail) => {
-        const name = escapePublicHtmlAngles(detail.name.trim());
-        if (!name) return "";
+        const trimmed = detail.name.trim();
+        const name = escapePublicHtmlAngles(trimmed);
+        if (!name || seen.has(trimmed)) return "";
+        seen.add(trimmed);
         const reason = detail.summary?.trim() ? ` — ${escapePublicHtmlAngles(detail.summary.trim())}` : "";
         return `- ${name}${reason}`;
       })

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -197,6 +197,25 @@ describe("renderUnifiedReviewComment", () => {
     expect(md).toContain("- lint — 2 errors in src/foo.ts");
   });
 
+  it("de-duplicates repeated failing check names in the details path (matching the bare-names path)", () => {
+    const md = renderUnifiedReviewComment(
+      {
+        ...base,
+        readiness: {
+          ciState: "failed",
+          failingDetails: [
+            { name: "codecov/patch", summary: "60% of diff hit (target 97%)" },
+            { name: "codecov/patch", summary: "60% of diff hit (target 97%)" },
+            { name: "lint", summary: "2 errors in src/foo.ts" },
+          ],
+        },
+      },
+      {},
+    );
+    expect((md.match(/- codecov\/patch/g) ?? []).length).toBe(1);
+    expect((md.match(/- lint/g) ?? []).length).toBe(1);
+  });
+
   it("falls back to bare failing check names when no per-check detail is present (FIX D3)", () => {
     const md = renderUnifiedReviewComment({ ...base, readiness: { ciState: "failed", failingChecks: ["build", "e2e"] } }, {});
     expect(md).toContain("CI checks failing");


### PR DESCRIPTION
## Summary

The unified review comment's failing-checks section renders `failingDetails` (name + reason) when present and falls back to bare `failingChecks` names otherwise. The bare-names fallback collapses duplicates with `[...new Set(names)]`, but the preferred `failingDetails` path did **not** dedupe. Since both arrays derive from the **same** source (`failingChecks = failingDetails.map(d => d.name)` in `src/queue/processors.ts`), and that source (`computeLiveCiAggregate`) pushes failing checks from both the check-runs and commit-statuses endpoints with no dedup, a check that appears twice rendered duplicate bullets in the public PR comment. This dedupes the details path by name (keeping the first entry's reason), matching the names fallback.

Fixes #1147

## Scope

- [x] PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused single change; no unrelated backend/UI/MCP/docs/deploy mixing.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — added a dedup test (duplicate `codecov/patch` → one bullet); existing distinct-name + escape tests cover the other branches. Full unit suite green.
- [x] New behavior tested in `test/unit/unified-comment.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise.

## Notes

Pure renderer fix; aligns the two branches of one function. No new public surface.
