### PR TITLE
fix(scoring): guard all credibility evidence counts against non-finite values

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -965,7 +965,9 @@ function inferCredibility(evidence?: ContributorEvidenceRecord | null): number {
   const merged = Number(payload?.mergedPullRequests ?? 0);
   const stale = Number(payload?.stalePullRequests ?? 0);
   const unlinked = Number(payload?.unlinkedPullRequests ?? 0);
-  if (!Number.isFinite(merged)) return 0.8;
+  // payload is Record<string, JsonValue>, so any of these counts can be a non-numeric cached value.
+  // Guard all three — a non-finite stale/unlinked would otherwise yield NaN and poison the whole score.
+  if (!Number.isFinite(merged) || !Number.isFinite(stale) || !Number.isFinite(unlinked)) return 0.8;
   return clamp(0.75 + merged * 0.04 - stale * 0.03 - unlinked * 0.02, 0.25, 1);
 }
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -472,6 +472,28 @@ NOVELTY_BONUS_SCALAR = 3
     expect(JSON.stringify(preview.scoreEstimate)).not.toMatch(/reward estimate|wallet|hotkey|farming|payout/i);
   });
 
+  it("falls back to neutral credibility when any cached evidence count is non-finite (no NaN poisoning)", () => {
+    const baseInput = { repoFullName: repo.fullName, sourceTokenScore: 60, totalTokenScore: 60, sourceLines: 50, openPrCount: 0 };
+    // A malformed stale count must not poison the score with NaN — the guard falls back to neutral 0.8.
+    const malformed = buildScorePreview({
+      repo,
+      snapshot,
+      input: baseInput,
+      contributorEvidence: { login: "dev", payload: { mergedPullRequests: 5, stalePullRequests: "n/a" }, generatedAt: "2026-06-01T00:00:00.000Z" },
+    });
+    expect(malformed.gates.credibilityObserved).toBe(0.8);
+    expect(Number.isNaN(malformed.scoreEstimate.estimatedMergedScore)).toBe(false);
+
+    // A well-formed payload exercises the arithmetic branch (0.75 + 5*0.04 - 1*0.03 - 0*0.02 = 0.92).
+    const wellFormed = buildScorePreview({
+      repo,
+      snapshot,
+      input: baseInput,
+      contributorEvidence: { login: "dev", payload: { mergedPullRequests: 5, stalePullRequests: 1, unlinkedPullRequests: 0 }, generatedAt: "2026-06-01T00:00:00.000Z" },
+    });
+    expect(wellFormed.gates.credibilityObserved).toBeCloseTo(0.92, 5);
+  });
+
   it("projects the saturation-model score with the full contribution bonus for density-era snapshots", () => {
     const densitySnapshot: ScoringModelSnapshotRecord = {
       ...snapshot,


### PR DESCRIPTION
## Summary

`inferCredibility` derives a contributor credibility multiplier from cached evidence counts. It coerces `mergedPullRequests`, `stalePullRequests`, and `unlinkedPullRequests` with `Number(...)`, but only finiteness-guards `merged`. Because the evidence `payload` is typed `Record<string, JsonValue>`, any field can be a non-numeric cached value, and a non-finite `stale`/`unlinked` yields `NaN` — which `clamp` cannot rescue — poisoning `credibilityObserved` and the entire `estimatedMergedScore`. This guards all three, matching the existing `merged` fallback to neutral `0.8`.

```ts
-  if (!Number.isFinite(merged)) return 0.8;
+  if (!Number.isFinite(merged) || !Number.isFinite(stale) || !Number.isFinite(unlinked)) return 0.8;
```

Fixes #1150

## Scope

- [x] PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused single change; no unrelated backend/UI/MCP/docs/deploy mixing.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — both branches covered: a malformed-`stale` payload exercises the guard (→ 0.8, finite score), a well-formed payload exercises the arithmetic (→ 0.92). Full suite green (3597 passing).
- [x] New unit test added in `test/unit/scoring.test.ts` via the exported `buildScorePreview({ contributorEvidence })`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise.

## Notes

Defensive parity fix in a pure function — extends an existing guard from one field to all three. No public surface change.
