### PR TITLE
fix(services): key gate-precision PR index by repo+number, not bare number

### DIFF
--- a/src/services/gate-precision.ts
+++ b/src/services/gate-precision.ts
@@ -54,6 +54,11 @@ function sameRepo(a: string | null | undefined, b: string): boolean {
   return (a ?? "").toLowerCase() === b.toLowerCase();
 }
 
+// PR numbers are unique only within a repo, so index by repo+number to keep distinct repos' PRs apart.
+function prKey(repoFullName: string | null | undefined, pullNumber: number): string {
+  return `${(repoFullName ?? "").toLowerCase()}#${pullNumber}`;
+}
+
 /**
  * Per-gate-type false-positive measurement over recorded gate blocks. Pure. For each block row we look up the
  * PR's terminal outcome; a blocked PR that later MERGED is a false positive. Each blocker `code` on the row
@@ -67,11 +72,13 @@ export function buildGatePrecisionReport(
   options: { repoFullName?: string } = {},
 ): Omit<GatePrecisionReport, "repoFullName" | "generatedAt" | "windowDays"> {
   const repoFullName = options.repoFullName;
-  // Index PRs by number for an O(1) terminal-outcome lookup, scoped to the repo when one is given.
-  const prByNumber = new Map<number, PullRequestRecord>();
+  // Index PRs by repo+number for an O(1) terminal-outcome lookup, scoped to the repo when one is given.
+  // An unscoped call sees multi-repo data, so keying by bare number would let two repos sharing a PR
+  // number collide — the last-written PR would win and be matched to another repo's outcome.
+  const prByNumber = new Map<string, PullRequestRecord>();
   for (const pr of pullRequests) {
     if (repoFullName && !sameRepo(pr.repoFullName, repoFullName)) continue;
-    prByNumber.set(pr.number, pr);
+    prByNumber.set(prKey(pr.repoFullName, pr.number), pr);
   }
   const scoped = repoFullName ? outcomes.filter((o) => sameRepo(o.repoFullName, repoFullName)) : outcomes;
 
@@ -79,7 +86,7 @@ export function buildGatePrecisionReport(
   let overallBlocked = 0;
   let overallMerged = 0;
   for (const outcome of scoped) {
-    const pr = prByNumber.get(outcome.pullNumber);
+    const pr = prByNumber.get(prKey(outcome.repoFullName, outcome.pullNumber));
     // A blocked PR that later MERGED is a false positive; closed/open are not (the block held or is unresolved).
     const merged = pr ? terminalOutcome(pr) === "merged" : false;
     overallBlocked += 1;

--- a/test/unit/gate-precision.test.ts
+++ b/test/unit/gate-precision.test.ts
@@ -96,6 +96,20 @@ describe("buildGatePrecisionReport", () => {
     // Only owner/repo's single block counts; other/repo's block + merged PR (and the null-repo PR) are filtered out.
     expect(report.overall).toMatchObject({ blocked: 1, blockedThenMerged: 1 });
   });
+
+  it("does not match an outcome to a same-numbered PR in a different repo when called unscoped", () => {
+    // PR numbers are unique only within a repo. The only block belongs to owner/repo#1, which was CLOSED
+    // (the block held → not a false positive). A bare-number index would collide with other/repo#1 (MERGED)
+    // and wrongly report a blocked-then-merged false positive.
+    const blocked = { repoFullName: "owner/repo", pullNumber: 1, blockerCodes: ["x"], overridden: false };
+    const ownClosed: PullRequestRecord = { repoFullName: "owner/repo", number: 1, title: "owner PR 1", state: "closed", mergedAt: null, labels: [], linkedIssues: [] };
+    const otherMerged: PullRequestRecord = { repoFullName: "other/repo", number: 1, title: "other PR 1", state: "closed", mergedAt: "2026-06-01T00:00:00.000Z", labels: [], linkedIssues: [] };
+    // A PR with a null repoFullName exercises prKey's nullish-coalesce guard on the unscoped indexing path.
+    const nullRepoPr: PullRequestRecord = { repoFullName: null as unknown as string, number: 2, title: "null repo PR", state: "open", mergedAt: null, labels: [], linkedIssues: [] };
+    const report = buildGatePrecisionReport([blocked], [otherMerged, ownClosed, nullRepoPr]);
+    expect(report.overall).toMatchObject({ blocked: 1, blockedThenMerged: 0 });
+    expect(report.perGateType[0]).toMatchObject({ gateType: "x", blocked: 1, blockedThenMerged: 0 });
+  });
 });
 
 describe("buildGatePrecisionSignals", () => {


### PR DESCRIPTION
## Summary

`buildGatePrecisionReport` indexed pull requests by **bare PR number** for the terminal-outcome lookup that decides whether a blocked PR later merged (a false positive). PR numbers are unique only within a repo, so an **unscoped** call over multi-repo data let two repos sharing a PR number collide — the last-written PR won the map slot and could be matched to a different repo's gate outcome, producing a phantom blocked-then-merged false positive. This keys the index (and the lookup) by `repo#number`.

```ts
- const prByNumber = new Map<number, PullRequestRecord>();
- prByNumber.set(pr.number, pr);            ... prByNumber.get(outcome.pullNumber)
+ const prByNumber = new Map<string, PullRequestRecord>();
+ prByNumber.set(prKey(pr.repoFullName, pr.number), pr);  ... prByNumber.get(prKey(outcome.repoFullName, outcome.pullNumber))
```

Fixes #1153

## Scope

- [x] PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused single change; no unrelated backend/UI/MCP/docs/deploy mixing.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — added an unscoped two-repo collision test (owner/repo#1 closed + other/repo#1 merged → blockedThenMerged 0, not a phantom 1). Full suite green (3597 passing).
- [x] New unit test in `test/unit/gate-precision.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise.

## Notes

`GateOutcomeRecord` already carries `repoFullName` (used by the existing scoped filter), so no signature change is needed. Scoped calls are unaffected.
