### PR TITLE
fix(gate): red required CI closes a contributor PR even on a guarded path

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -222,8 +222,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // CLOSE a contributor PR ONLY on a REAL adverse signal — a confirmed gate FAILURE, a red required CI, or a base
   // CONFLICT. NEVER close merely because CI is UNVERIFIED (a fork whose Actions await approval, or unreadable
   // checks) or otherwise not-yet-mergeable — those are HELD for review, not killed (#harm-stop fork-false-close).
-  // Owner/automation PRs are never closed (isContributor); guarded paths are held (guardrailHit).
-  const willClose = !guardrailHit && isContributor && acting("close") && (input.conclusion === "failure" || ciFailed || isConflict);
+  // Owner/automation PRs are never closed (isContributor). A guarded path is HELD for the AI/gate VERDICT and for
+  // a base conflict (don't kill a crucial change on an AI call or a rebaseable conflict). But a red REQUIRED CI is
+  // an OBJECTIVE failure — a broken change that cannot merge regardless — so it CLOSES a contributor PR even on a
+  // guarded path; the contributor fixes CI and resubmits, and a GREEN guarded resubmission is then held for review.
+  // (Rebase-if-behind already ran above, so a red CI here is on the latest base — not a stale-base artifact.) (#ci-fail-closes-guarded)
+  const willClose = isContributor && acting("close") && (ciFailed || (!guardrailHit && (input.conclusion === "failure" || isConflict)));
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules). A DETERMINISTIC verdict about the LINKED ISSUE
   // (owner-assigned / missing point-label / maintainer-only) — NOT an AI verdict, so there is no hallucination
   // to guard against: this close fires REGARDLESS of `guardrailHit`. It still only ever closes a CONTRIBUTOR

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -175,6 +175,15 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan).not.toContain("close");
     });
 
+    it("DOES auto-close a guarded contributor PR with red REQUIRED CI — a broken change can't merge regardless (#ci-fail-closes-guarded)", () => {
+      // The guardrail holds a crucial PR against the AI/gate VERDICT (the test above), but a red required CI is an
+      // OBJECTIVE failure: the change cannot merge no matter what, so it closes even on a guarded path. The
+      // contributor fixes CI and resubmits; a GREEN guarded resubmission is then held for review. conclusion is
+      // 'neutral' here to prove it is the CI — not a verdict — driving the close.
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", pr: { labels: [] } })));
+      expect(plan).toContain("close");
+    });
+
     it("does NOT approve or auto-merge a passing PR on a guarded path", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", merge: "auto" }, ...guarded, pr: { labels: [], mergeableState: "clean" } })));
       expect(plan).not.toContain("approve");


### PR DESCRIPTION
Operator policy: failed CI = auto-close. willClose required `!guardrailHit`, so a guarded PR with red required CI was held, not closed. A red required CI is an objective failure (can't merge regardless) — unlike an AI/gate verdict or conflict (which stay guarded). Now ciFailed closes even when guarded; verdict/conflict still require !guardrailHit. +1 test. Full suite green (3609).