### PR TITLE
fix(queue): skip expensive automated review during scheduled regate sweeps

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -563,9 +563,10 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     // re-gate above only recomputes the audit verdict; without this re-publish, an idle PR keeps a stale comment
     // (e.g. "safe to merge" from before a fix) and a stale status label forever. reReviewStoredPullRequest reads
     // the freshly-synced head + the live CI, so the comment + label + action all reflect reality. Paced at
-    // SWEEP_MAX_PRS per sweep; cheap now that installation tokens are cached.
+    // SWEEP_MAX_PRS per sweep; scheduled sweeps deliberately skip AI so the 2-minute cadence cannot amplify
+    // model/API spend for unchanged PR heads.
     if (sweepInstallationId != null) {
-      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number).catch((error) => {
+      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number, undefined, { skipAiReview: true }).catch((error) => {
         console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
       });
     }
@@ -745,7 +746,15 @@ async function maybeRunAgentMaintenance(
  * "the CI event WAKES the existing row and re-runs the full review". The PR's persisted head SHA is used as-is
  * (never overwritten from the CI payload — reviewbot scope parity). Best-effort throughout.
  */
-async function reReviewStoredPullRequest(env: Env, deliveryId: string, installationId: number, repoFullName: string, prNumber: number, previewPollAttempt?: number): Promise<void> {
+async function reReviewStoredPullRequest(
+  env: Env,
+  deliveryId: string,
+  installationId: number,
+  repoFullName: string,
+  prNumber: number,
+  previewPollAttempt?: number,
+  options: { skipAiReview?: boolean } = {},
+): Promise<void> {
   const [repo, settings] = await Promise.all([getRepository(env, repoFullName), resolveRepositorySettings(env, repoFullName)]);
   const pr = await getPullRequest(env, repoFullName, prNumber);
   if (!pr || pr.state !== "open") return;
@@ -759,7 +768,11 @@ async function reReviewStoredPullRequest(env: Env, deliveryId: string, installat
   if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
     await refreshPullRequestDetails(env, repoFullName, prNumber).catch(() => undefined);
   }
-  const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, { deliveryId, ...(previewPollAttempt !== undefined ? { previewPollAttempt } : {}) }).catch((error) => {
+  const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
+    deliveryId,
+    ...(previewPollAttempt !== undefined ? { previewPollAttempt } : {}),
+    ...(options.skipAiReview ? { skipAiReview: true } : {}),
+  }).catch((error) => {
     console.error(JSON.stringify({ level: "warn", event: "pr_public_surface_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
     return undefined;
   });
@@ -2006,7 +2019,7 @@ async function maybePublishPrPublicSurface(
   repo: Awaited<ReturnType<typeof getRepository>>,
   settings: Awaited<ReturnType<typeof getRepositorySettings>>,
   advisory: Awaited<ReturnType<typeof buildPullRequestAdvisory>>,
-  webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined; previewPollAttempt?: number | undefined },
+  webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined; previewPollAttempt?: number | undefined; skipAiReview?: boolean | undefined },
 ): Promise<ReturnType<typeof evaluateGateCheck> | undefined> {
   const author = pr.authorLogin ?? null;
   // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the unified converged comment renders for THIS repo
@@ -2218,18 +2231,20 @@ async function maybePublishPrPublicSurface(
     // BEFORE the gate evaluates, and returns advisory notes for the panel. Inside the try so any AI
     // failure is caught and the gate is still finalized (never left in_progress). Pass the shared resolved
     // files so the review (+ grounding + RAG) sees the REAL diff even on a pre-detail-sync first review (FIX B);
-    // resolve only when the review will actually run (aiReviewMode !== off + a head SHA) to keep gate-only
-    // repos free of an extra file resolve.
-    const aiReviewWillRun = settings.aiReviewMode !== "off" && Boolean(advisory.headSha);
-    aiReview = await runAiReviewForAdvisory(env, {
-      settings,
-      advisory,
-      repoFullName,
-      pr,
-      author,
-      confirmedContributor,
-      ...(aiReviewWillRun ? { files: await getReviewFiles() } : {}),
-    });
+    // resolve only when the review will actually run (aiReviewMode !== off + a head SHA + not a scheduled
+    // sweep backstop) to keep gate-only and sweep-only repos free of an extra file resolve.
+    const aiReviewWillRun = !webhook.skipAiReview && settings.aiReviewMode !== "off" && Boolean(advisory.headSha);
+    if (aiReviewWillRun) {
+      aiReview = await runAiReviewForAdvisory(env, {
+        settings,
+        advisory,
+        repoFullName,
+        pr,
+        author,
+        confirmedContributor,
+        files: await getReviewFiles(),
+      });
+    }
 
     // Safety secrets-scan (convergence, flag-gated by GITTENSORY_REVIEW_SAFETY). Scans the diff and, on a hit,
     // appends a critical `secret_leak` blocker BEFORE the gate evaluates. When the scan will actually run

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1188,6 +1188,31 @@ describe("queue processors", () => {
     expect(updateBranchCalls).toBe(0); // no installation perms → the executor denies the write; the block falls through
   });
 
+  it("recapture-preview (#1158): a clean PR re-review threads previewPollAttempt into the public-surface publish", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9101, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "preview-repo", full_name: "owner/preview-repo", private: false, owner: { login: "owner" } }, 9101);
+    await upsertRepositorySettings(env, { repoFullName: "owner/preview-repo", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/preview-repo", { number: 9, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "c9" }, labels: [], body: "x" });
+    await upsertPullRequestFile(env, { repoFullName: "owner/preview-repo", pullNumber: 9, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = true;" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/9/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (/\/pulls\/9(?:\?|$)/.test(url)) return Response.json({ number: 9, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "c9" }, labels: [], body: "x" });
+      if (url.includes("/commits/c9/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/c9/status")) return Response.json({ state: "success", statuses: [] });
+      return new Response("not found", { status: 404 });
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    // attempt:2 → previewPollAttempt is defined, so the conditional spread at the publish call takes the
+    // `{ previewPollAttempt }` arm (the recapture-preview poll path; the sweep/webhook callers omit it).
+    await expect(
+      processJob(env, { type: "recapture-preview", deliveryId: "rp-9", installationId: 9101, repoFullName: "owner/preview-repo", prNumber: 9, attempt: 2 }),
+    ).resolves.toBeUndefined();
+  });
+
   it("auto-maintain (#778): a repo with no acting autonomy takes no agent action", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -578,6 +578,54 @@ describe("queue processors", () => {
     expect(sent).toEqual([]);
   });
 
+  it("agent re-gate sweep skips AI review while refreshing the PR surface on a stale AI-enabled PR", async () => {
+    let aiCalls = 0;
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      AI: {
+        run: async () => {
+          aiCalls += 1;
+          return { response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) };
+        },
+      } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, {
+      repoFullName: "owner/agent-repo",
+      autonomy: { merge: "auto" },
+      aiReviewMode: "block",
+      gatePack: "oss-anti-slop",
+      gateCheckMode: "enabled",
+      checkRunMode: "off",
+      commentMode: "off",
+      publicSurface: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "no linked issue here" });
+    await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = true;" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "no linked issue here" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      return new Response("not found", { status: 404 });
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    expect(aiCalls).toBe(0);
+    const aiUsage = await env.DB.prepare("select count(*) as n from ai_usage_events where feature = ?").bind("ai_review_pr").first<{ n: number }>();
+    expect(aiUsage?.n).toBe(0);
+    const audit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("completed");
+    expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ repoFullName: "owner/agent-repo", examined: 1 });
+  });
+
   it("agent re-gate sweep re-reviews each stale open PR (installation id) and swallows a failing re-review", async () => {
     const env = createTestEnv({});
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
### Motivation
- Scheduled regate sweeps run frequently after the cron cadence change and were invoking the full public-surface re-review path, which can perform costly external review work for every stale PR and amplify API / spend exhaustion risks. 
- Make the scheduled sweep cheap and safe by avoiding repeated invocations of the expensive automated review path while preserving live webhook/CI/manual behavior.

### Description
- Added a sweep-only skip flag when the fanout calls the per-repo re-review so scheduled sweeps call `reReviewStoredPullRequest(..., { skipAiReview: true })` for each stale PR. 
- Threaded the skip option through `reReviewStoredPullRequest` into the public-surface publisher and guarded the automated-review invocation so it only runs when the skip flag is absent and the review is otherwise eligible. 
- Left webhook, CI-completion, preview, and manual re-trigger paths unchanged so interactive/real-time reviews continue to run the full public-surface flow. 
- Added a regression unit test that seeds an opted-in repo with a stale PR and asserts that the scheduled sweep refreshes the PR surface without invoking the costly automated-review calls or recording `ai_review_pr` usage events.

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit` which succeeded. 
- Ran the targeted unit tests with `npx vitest run test/unit/queue.test.ts -t "skips AI review|hard-blocks a confirmed contributor on a dual-model AI consensus defect"` and the relevant tests passed. 
- The full local gate `npm run test:ci` reached the coverage run but could not complete in this environment due to pre-existing timeouts and a coverage remap error (`TypeError: jsTokens is not a function`). 
- `npm audit --audit-level=moderate` could not be run to completion here because the registry audit endpoint returned 403 from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b402ef144832c83cc6259f195c1c1)