### PR TITLE
fix(engine): match outcome history to opportunities case-insensitively

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3502,9 +3502,12 @@ export function buildContributorStrategy(args: {
   scoringSnapshot: ScoringModelSnapshotRecord;
   outcomeHistory?: ContributorOutcomeHistory | null | undefined;
 }): ContributorStrategy {
-  const outcomeByRepo = new Map((args.outcomeHistory?.repoOutcomes ?? []).map((outcome) => [outcome.repoFullName, outcome]));
+  // Key/lookup case-insensitively: outcome repo names can come from the Gittensor API (unnormalized casing)
+  // while opportunity repo names use registry casing — match the sibling sites (buildRepoFitRecommendation /
+  // buildPullRequestReviewIntelligence) that already compare `repoFullName.toLowerCase()`.
+  const outcomeByRepo = new Map((args.outcomeHistory?.repoOutcomes ?? []).map((outcome) => [outcome.repoFullName.toLowerCase(), outcome]));
   const bestFitRepos = args.fit.opportunities.slice(0, 10).map((opportunity) => {
-    const outcome = outcomeByRepo.get(opportunity.repoFullName);
+    const outcome = outcomeByRepo.get(opportunity.repoFullName.toLowerCase());
     const privateScoringReadiness: ContributorStrategy["bestFitRepos"][number]["privateScoringReadiness"] =
       /* v8 ignore next -- Maintainer-lane strategy readiness is already represented in repo-fit and reward-risk outputs. */
       outcome?.maintainerLane

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -26,6 +26,9 @@ import {
   buildRegistryChangeReport,
   buildRepoFitRecommendation,
   buildRoleContext,
+  type ContributorFit,
+  type ContributorOutcomeHistory,
+  type ContributorScoringProfile,
 } from "../../src/signals/engine";
 import {
   buildContributorRewardRiskStrategy,
@@ -598,6 +601,28 @@ describe("v2 signal builders", () => {
     expect(scoringProfile.evidence.credibilityAssumption).toBeGreaterThanOrEqual(0.8);
     expect(strategy.nextActions).toContain("Start with the highest-fit repo that has low duplicate and queue pressure.");
     expect(JSON.stringify(strategy)).not.toMatch(/wallet|farming|reward/i);
+  });
+
+  it("matches outcome history to opportunities case-insensitively despite registry-vs-API repo casing", () => {
+    // The opportunity uses registry casing; the outcome (Gittensor-API-sourced) carries a different casing for the
+    // SAME repo. A case-sensitive Map lookup would miss it, promoting a high-closed-rate repo and dropping its risks.
+    const fit = {
+      opportunities: [{ repoFullName: "Owner/Repo", lane: "direct_pr", fit: "good", score: 80, reasons: ["Good first target."], warnings: [] }],
+    } as unknown as ContributorFit;
+    const scoringProfile = {
+      evidence: { credibilityAssumption: 0.9, unlinkedPullRequests: 0, languageMatches: 1 },
+    } as unknown as ContributorScoringProfile;
+    const outcomeHistory = {
+      repoOutcomes: [
+        { repoFullName: "owner/repo", maintainerLane: false, closedPullRequestRate: 0.5, credibility: 1, openPullRequests: 0, strengths: ["Strong prior work here."], risks: ["High closed-PR rate."] },
+      ],
+    } as unknown as ContributorOutcomeHistory;
+
+    const strategy = buildContributorStrategy({ login: "dev", fit, scoringProfile, scoringSnapshot: scoringSnapshot(), outcomeHistory });
+    const best = strategy.bestFitRepos.find((entry) => entry.repoFullName === "Owner/Repo");
+    expect(best?.privateScoringReadiness).toBe("hold"); // 0.5 closed-PR rate now applies (was promoted to "good" pre-fix)
+    expect(best?.warnings).toEqual(expect.arrayContaining(["High closed-PR rate."]));
+    expect(best?.reasons).toEqual(expect.arrayContaining(["Strong prior work here."]));
   });
 
   it("builds role-aware maintainer lanes, outcome history, and review intelligence", () => {


### PR DESCRIPTION
## The bug

`buildContributorStrategy` (`src/signals/engine.ts`) builds and queries its outcome lookup with **raw, case-sensitive** repo names:

```ts
const outcomeByRepo = new Map((args.outcomeHistory?.repoOutcomes ?? []).map((o) => [o.repoFullName, o]));
const outcome = outcomeByRepo.get(opportunity.repoFullName);
```

The two sides come from **different sources with independent casing**:
- `opportunity.repoFullName` → registry casing.
- `outcome.repoFullName` → can carry the **Gittensor API**'s repo name verbatim (unnormalized — `src/gittensor/api.ts`).

When the casing differs, `.get()` returns `undefined` and the repo's outcome context is silently dropped:
- a **maintainer-lane / high-closed-PR-rate repo that should be `hold`** is instead promoted to `good`/`caution`, and
- its `strengths`/`risks` never reach the strategy's `reasons`/`warnings`.

## Why it's a real bug (not intent)

This is the **lone case-sensitive outlier**. Every sibling consumer of the same Gittensor-API repo names already compares `repoFullName.toLowerCase()` — `buildRepoFitRecommendation` (engine.ts ~2255), `buildPullRequestReviewIntelligence` (~2767), and the outcome-history/role builders. The fix normalizes both the key and the lookup to match them.

## Correctness

- **No change when casing already agrees** — the existing strategy tests pass unchanged.
- The new test (`signals-v2.test.ts`) feeds divergent casing (`Owner/Repo` opportunity vs `owner/repo` outcome) and asserts the outcome is applied: the `0.5` closed-PR-rate repo is held and its risk surfaces. It **fails without the fix** and passes with it.
- Full `npm run test:ci` green; changed line covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)