### PR TITLE
fix(review): scan added secret-bearing paths

### DIFF
--- a/src/review/safety.ts
+++ b/src/review/safety.ts
@@ -75,13 +75,18 @@ export function defangReviewInput(input: SafetyReviewInput): {
  * {@link isSafetyEnabled} — when OFF, no finding is produced so the advisory/gate is unchanged.
  */
 export function secretLeakFinding(diff: string): AdvisoryFinding | null {
-  // Scan ONLY added lines — the secrets THIS change introduces. A token on a removed/context line is not being
+  // Scan ONLY additions — the secrets THIS change introduces. A token on a removed/context line is not being
   // committed by the PR, so flagging it would wrongly block a change that merely REMOVES or refactors a
-  // secret-shaped string (e.g. deleting/defanging a test fixture, or rotating a credential out). The input is the
-  // buildAiReviewDiff/buildSecretScanDiff patch corpus, so keep `+` additions and drop the `+++`/`### …` headers.
+  // secret-shaped string (e.g. deleting/defanging a test fixture, or rotating a credential out). Added/renamed
+  // file paths are also committed PR state, but buildSecretScanDiff carries them only in `### path (status)`
+  // headers, so keep those metadata lines while still dropping modified/removed headers and `+++` patch headers.
   const added = diff
     .split("\n")
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .filter(
+      (line) =>
+        (line.startsWith("+") && !line.startsWith("+++")) ||
+        /^### .+ \((?:added|renamed)\) /.test(line),
+    )
     .join("\n");
   // Only CONCRETE credential formats hard-block. The raw scanner also returns the weak `seed_or_mnemonic` /
   // `bittensor_key` heuristics, which false-positive on `coldkey:` / `hotkey =` / "mnemonic" lines in

--- a/test/unit/safety-wiring.test.ts
+++ b/test/unit/safety-wiring.test.ts
@@ -363,4 +363,24 @@ describe("secretLeakFinding scans only ADDED lines", () => {
     const diff = `### src/config.ts (modified) +1/-0\n@@\n const token = "${fakeToken}";\n+const unrelated = 1;`;
     expect(secretLeakFinding(diff)).toBeNull();
   });
+
+  it("flags a secret introduced in an added file path", () => {
+    const diff = `### fixtures/${fakeToken}.txt (added) +1/-0\n@@\n+benign fixture content`;
+    expect(secretLeakFinding(diff)?.code).toBe("secret_leak");
+  });
+
+  it("flags a secret introduced in a renamed file path", () => {
+    const diff = `### fixtures/${fakeToken}.txt (renamed) +0/-0\n(no inline patch — binary or too large)`;
+    expect(secretLeakFinding(diff)?.code).toBe("secret_leak");
+  });
+
+  it("does NOT flag a secret in a modified file path header", () => {
+    const diff = `### fixtures/${fakeToken}.txt (modified) +1/-0\n@@\n+const unrelated = 1;`;
+    expect(secretLeakFinding(diff)).toBeNull();
+  });
+
+  it("does NOT flag a secret in a removed file path header", () => {
+    const diff = `### fixtures/${fakeToken}.txt (removed) +0/-1\n@@\n-const unrelated = 1;`;
+    expect(secretLeakFinding(diff)).toBeNull();
+  });
 });


### PR DESCRIPTION
### Motivation
- Fix a vulnerability where the secret scanner missed credential-shaped values present only in added/renamed file paths because the scan corpus was built from content `+` lines only and dropped `###` header metadata.
- Preserve the prior false-positive reduction (ignore removed/context lines) while ensuring secrets appearing in committed filenames/paths still hard-block a PR.

### Description
- Change `secretLeakFinding` (`src/review/safety.ts`) to include `### <path> (added)` and `### <path> (renamed)` header lines in the scan corpus in addition to `+` content lines, while continuing to exclude `+++`/modified/removed headers.
- Keep the concrete credential filters (`HARD_SECRET_KINDS`) and the call to `scanForSecrets` unchanged, so only real token formats still hard-block.
- Add regression tests in `test/unit/safety-wiring.test.ts` that assert secrets in added and renamed path headers are flagged and that modified/removed headers remain non-blocking.

### Testing
- Ran `npm test -- --run test/unit/safety-wiring.test.ts`, and the updated unit tests passed.
- Ran `npm run typecheck`, and `tsc --noEmit` passed with no type errors.
- Attempted full gate via `npm run test:ci`, but the run was blocked by environment/dependency issues (network fallback for `actionlint` and a coverage remapping error `TypeError: jsTokens is not a function`), so the full-suite CI could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b3fc8d43c832c8bd5607980e86439)