### PR TITLE
ci: retry flaky tests once, shard tests 3-way, make version-audit offline-tolerant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies (retry on transient failures)
         run: |
           for attempt in 1 2 3; do
-            if npm ci; then
+            if npm ci --prefer-offline --no-audit --no-fund; then
               exit 0
             fi
             echo "::warning::npm ci failed (attempt ${attempt}/3); retrying in 10s"
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -132,7 +132,7 @@ jobs:
       - name: Install dependencies (retry on transient failures)
         run: |
           for attempt in 1 2 3; do
-            if npm ci; then
+            if npm ci --prefer-offline --no-audit --no-fund; then
               exit 0
             fi
             echo "::warning::npm ci failed (attempt ${attempt}/3); retrying in 10s"
@@ -142,16 +142,16 @@ jobs:
           exit 1
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
-      - name: Test with coverage (shard ${{ matrix.shard }}/2)
+      - name: Test with coverage (shard ${{ matrix.shard }}/3)
         id: coverage
         env:
           COVERAGE_NO_THRESHOLDS: "1"
           VITEST_JUNIT_PATH: reports/junit/vitest-shard-${{ matrix.shard }}.xml
-        run: npm run test:coverage -- --shard=${{ matrix.shard }}/2
+        run: npm run test:coverage -- --shard=${{ matrix.shard }}/3
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |
-          echo "::error title=Tests::A test in shard ${{ matrix.shard }}/2 failed."
+          echo "::error title=Tests::A test in shard ${{ matrix.shard }}/3 failed."
           echo "Coverage itself is gated by Codecov on changed lines (codecov/patch), computed from the merged shards."
           echo "Reproduce locally with the full suite: 'npm run test:coverage' (no sharding)."
       - name: Upload coverage to Codecov
@@ -191,7 +191,7 @@ jobs:
       - name: Install dependencies (retry on transient failures)
         run: |
           for attempt in 1 2 3; do
-            if npm ci; then
+            if npm ci --prefer-offline --no-audit --no-fund; then
               exit 0
             fi
             echo "::warning::npm ci failed (attempt ${attempt}/3); retrying in 10s"
@@ -222,7 +222,7 @@ jobs:
       - name: Install dependencies (retry on transient failures)
         run: |
           for attempt in 1 2 3; do
-            if npm ci; then
+            if npm ci --prefer-offline --no-audit --no-fund; then
               exit 0
             fi
             echo "::warning::npm ci failed (attempt ${attempt}/3); retrying in 10s"
@@ -257,7 +257,7 @@ jobs:
       - name: Install dependencies (retry on transient failures)
         run: |
           for attempt in 1 2 3; do
-            if npm ci; then
+            if npm ci --prefer-offline --no-audit --no-fund; then
               exit 0
             fi
             echo "::warning::npm ci failed (attempt ${attempt}/3); retrying in 10s"

--- a/scripts/check-ui-mcp-version-copy.mjs
+++ b/scripts/check-ui-mcp-version-copy.mjs
@@ -13,13 +13,28 @@ const targets = [
   "apps/gittensory-ui/src",
 ].map((target) => join(root, target));
 
-const latest = process.env.GITTENSORY_MCP_LATEST_VERSION ?? (await fetchLatestVersion());
+// The live npm-registry check is BEST-EFFORT: a transient registry blip must not fail CI, because a red
+// required check one-shot-closes a contributor PR. Set GITTENSORY_MCP_LATEST_VERSION to make it fully
+// offline/deterministic. The deterministic stale-version-string scan below always runs regardless.
+let latest = process.env.GITTENSORY_MCP_LATEST_VERSION ?? null;
+let latestSkipReason = null;
+if (!latest) {
+  try {
+    latest = await fetchLatestVersion();
+  } catch (error) {
+    latestSkipReason = error instanceof Error ? error.message : "unknown error";
+  }
+}
 const sourceLatest = readKnownLatestVersion(sourceLatestPath);
 const failures = [];
 
-if (sourceLatest !== latest) {
+if (latest && sourceLatest !== latest) {
   failures.push(
     `apps/gittensory-ui/src/lib/mcp-package.ts: known latest ${sourceLatest} does not match npm dist-tags.latest ${latest}`,
+  );
+} else if (!latest) {
+  console.warn(
+    `::warning::skipped the npm dist-tag drift check (registry unavailable: ${latestSkipReason}); set GITTENSORY_MCP_LATEST_VERSION to enforce it offline`,
   );
 }
 
@@ -56,7 +71,7 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`MCP UI version copy ok: npm latest ${latest}, scanned ${targets.length} target(s)`);
+console.log(`MCP UI version copy ok: npm latest ${latest ?? "unchecked"}, scanned ${targets.length} target(s)`);
 
 function collectSourceFiles(path) {
   const stat = statSync(path);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     environment: "node",
     globals: true,
     testTimeout: 15000,
+    // Retry a failed test once before failing the run. The gittensory gate auto-CLOSES a contributor PR
+    // on a red required CI, so a single transient flake must not kill an honest PR; a deterministic
+    // failure still fails both attempts (and vitest flags the retried test as flaky so it stays visible).
+    retry: 1,
     include: ["test/**/*.test.ts"],
     exclude: ["test/workers/**/*.test.ts"],
     reporters: junitPath ? ["default", "junit"] : ["default"],

--- a/vitest.workers.config.ts
+++ b/vitest.workers.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   ],
   test: {
     globals: true,
+    // Retry once before failing — a transient flake must not red the required CI and one-shot-close a PR.
+    retry: 1,
     include: ["test/workers/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
Faster, more reliable CI for the contributor-PR surge. Since the gate auto-CLOSES a contributor PR on a red required CI, a transient flake is an unfair close — these changes cut both the flake risk and the wall-clock.

## What changed
- **vitest `retry: 1`** (root + workers configs): a one-run flake retries before the job reds; a real failure still fails both attempts (vitest marks the retried test flaky so it stays visible).
- **Test sharding 2 → 3** (`ci.yml` matrix + `--shard=.../3` + labels): shorter critical-path test wall-clock. Codecov already merges N shards.
- **Faster installs:** `npm ci --prefer-offline --no-audit --no-fund` in every job.
- **`version-audit` offline-tolerant:** `scripts/check-ui-mcp-version-copy.mjs` now treats an npm-registry blip as a warning+skip (not a CI failure); the deterministic stale-version-string scan always runs; `GITTENSORY_MCP_LATEST_VERSION` enforces it offline.

## Validation
`npm run actionlint` ✓ · `npm run test:coverage` (full, unsharded) **3,609 passed / 1 skipped** ✓ · `npm run test:workers` ✓ · `npm run ui:version-audit` (online + env-override path) ✓. No `src/**` changes → no Codecov obligation.

## Linked issue
No issue — CI maintenance for review throughput + reliability.
