### PR TITLE
fix(engine): anchor suspicious-label regex so it stops over-matching

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1080,7 +1080,10 @@ export function buildLabelAudit(repo: RepositoryRecord | null, repoLabels: RepoL
       existsOnGitHub: liveLabels.includes(name),
     }));
   const missingConfiguredLabels = configuredLabels.filter((label) => !liveLabels.includes(label));
-  const suspiciousConfiguredLabels = configuredLabels.filter((label) => /^(status|state|source|bot|codex|gittensory|reward|score|miner|verified|risk)[:/-]?/i.test(label));
+  // Require a real separator (`:`/`/`/`-`) OR end-of-string after the keyword so this flags prefix-style labels
+  // (`status:ready`, `reward/x`) and bare keywords (`bot`) — but NOT mid-word matches like `bottleneck` (`bot`),
+  // `scoreboard` (`score`), or `riskier` (`risk`). The old optional+unanchored `[:/-]?` over-matched those.
+  const suspiciousConfiguredLabels = configuredLabels.filter((label) => /^(status|state|source|bot|codex|gittensory|reward|score|miner|verified|risk)([:/-]|$)/i.test(label));
   const findings: SignalFinding[] = [];
   if (repo?.registryConfig?.trustedLabelPipeline && missingConfiguredLabels.length > 0) {
     findings.push({

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -127,6 +127,17 @@ describe("v2 signal builders", () => {
     expect(audit.trustedPipelineReady).toBe(false);
   });
 
+  it("does not flag mid-word label matches like 'bottleneck' as suspicious", () => {
+    const repoWithLabels: RepositoryRecord = {
+      ...repo,
+      registryConfig: { ...repo.registryConfig!, labelMultipliers: { bottleneck: 1, scoreboard: 1, riskier: 1, "status:ready": 1, bot: 1 } },
+    };
+    const audit = buildLabelAudit(repoWithLabels, [], issues, pullRequests, repoWithLabels.fullName);
+    // bot→bottleneck, score→scoreboard, risk→riskier must NOT match; only real prefix-style labels
+    // (`status:ready`) and bare keywords (`bot`) are flagged. Pre-fix all five matched.
+    expect(audit.suspiciousConfiguredLabels.sort()).toEqual(["bot", "status:ready"]);
+  });
+
   it("uses recent merged PRs and linked issues in collision radar", () => {
     const report = buildCollisionReport(repo.fullName, issues, pullRequests, recentMergedPullRequests);
     expect(report.summary.itemsReviewed).toBe(4);


### PR DESCRIPTION
## The bug

`buildLabelAudit`'s suspicious-label detector (`src/signals/engine.ts`) used an **unanchored** pattern with an **optional** separator:

```ts
/^(status|state|source|bot|codex|gittensory|reward|score|miner|verified|risk)[:/-]?/i
```

Because `[:/-]?` is optional and there's no end anchor, it flags any label merely **starting with** one of those letter sequences. Legitimate labels that wrongly match:

| Label | Matched via |
| --- | --- |
| `bottleneck` | `bot` |
| `scoreboard` | `score` |
| `riskier` | `risk` |
| `sourcemap` | `source` |
| `state-machine` | `state` |

## Impact

A repo configuring a normal label like `bottleneck` gets a false `suspicious_configured_labels` warning **and** has `trustedPipelineReady` forced to `false` (the readiness check requires `suspiciousConfiguredLabels.length === 0`). That false signal then propagates into `repo-policy-readiness` (a remediation item) and the self-dogfood registration pack (`ready` → `needs_attention`).

## Fix

Require a real separator (`:`/`/`/`-`) **or** end-of-string after the keyword:

```ts
/^(...|risk)([:/-]|$)/i
```

Still flags prefix-style labels (`status:ready`, `reward/x`) and bare keywords (`bot`), but no longer matches mid-word.

## Correctness

- The existing assertion (`suspiciousConfiguredLabels === ["status:ready"]`) is unchanged.
- The new test adds `bottleneck`/`scoreboard`/`riskier` regression cases — it **fails without the fix**.
- Full `npm run test:ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)