### PR TITLE
docs: document the auto-merge/auto-close disposition for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 - [ ] `git diff --check`
 - [ ] `npm run actionlint`
 - [ ] `npm run typecheck`
-- [ ] `npm run test:coverage` locally; global coverage stays at or above **97%** for lines, statements, functions, and branches (aim for **98%+** branch coverage locally so CI variance does not fail near the threshold)
+- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
 - [ ] `npm run test:workers`
 - [ ] `npm run build:mcp`
 - [ ] `npm run test:mcp-pack`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,26 @@ This project is maintained with a high review bar. PRs that ignore these guideli
 unrelated work, reintroduce retired architecture, or repeatedly fail the required gates may be
 closed without an extended review cycle.
 
+## What Happens to Your PR (reviewed and acted on automatically)
+
+gittensory reviews every PR with an automated gate (a GitHub App) and **acts on the outcome within a
+few minutes** — there is no extended human back-and-forth. For a contributor PR (you are not the repo
+owner or an automation bot):
+
+- **Auto-merged** when the gate passes, **all CI is green**, the branch is conflict-free, and any
+  required approvals are satisfied.
+- **Auto-closed (one-shot)** on a clear adverse signal: a failing CI check (including coverage,
+  `codecov/patch`), a gate failure, a base/merge conflict, or a linked issue that is ineligible
+  (assigned to someone else, maintainer-only, or missing a required label). To recover, fix the
+  problem and open a **fresh** PR; **reopening** the closed PR is how you dispute the decision.
+- **Held for a maintainer** (not closed) when CI is still running/unverified — e.g. a first-time fork
+  PR whose Actions await maintainer approval — or when the PR touches a protected/crucial path.
+
+So **get it green and correct before you push**: run the full local gate (`npm run test:ci`), keep your
+branch current with `main` (a conflict closes the PR), and link an eligible issue. If you use Claude
+Code or Codex, the `.claude/skills/contributing-to-gittensory` skill (and the root `AGENTS.md`) encode
+the whole procedure step by step.
+
 ## What We Accept
 
 Focused contributions are welcome in these areas:


### PR DESCRIPTION
## Summary
Make the gate's automatic behavior visible to **human** contributors (it was documented only in the AI-tool skill), and fix a misleading coverage line in the PR template.

## What changed
- **`CONTRIBUTING.md`** — new "What Happens to Your PR" section: the gate reviews + acts within minutes — auto-merge on clean+green+passing; one-shot auto-close on red CI (incl. `codecov/patch`), gate failure, base conflict, or an ineligible linked issue (reopen to dispute); held on pending/unverified-fork/crucial-path. Points at the local gate + the skill/`AGENTS.md`.
- **`.github/pull_request_template.md`** — the coverage checkbox said "97% **global**"; corrected to **`codecov/patch` ≥97% on changed lines + branches** (global is a non-blocking 90% backstop).

## Validation
Docs-only (no `src/**`/UI changes) → no Codecov obligation, no visible UI surface. `git diff --check` clean.

## Linked issue
No issue — docs accuracy for the contributor surge.
