### PR TITLE
fix(close): one-shot close comment — resubmit, don't invite reopen/ping

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -150,7 +150,7 @@ export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: bo
 }
 
 function closeMessage(reasons: string[]): string {
-  return `Gittensory is closing this pull request on the maintainer's behalf (${reasons.join("; ")}). This is an automated maintenance action — if you believe it's mistaken, reopen the PR or ping a maintainer and it will be reviewed.`;
+  return `Gittensory is closing this pull request on the maintainer's behalf (${reasons.join("; ")}). This is an automated maintenance action — to pursue this change, please open a new pull request with the issues resolved. Closed PRs are re-reviewed automatically, so an inaccurate close may be reopened, but that does not guarantee it can merge (e.g. if conflicts or failing CI remain).`;
 }
 
 /**


### PR DESCRIPTION
The auto-close comment told contributors to 'reopen the PR or ping a maintainer'. Closes are one-shot: they should open a NEW PR, and shouldn't be told to ping the maintainer. New wording: open a fresh PR with issues resolved; closed PRs are re-reviewed automatically (an inaccurate close may be reopened by the system) but that doesn't guarantee a merge if conflicts/failing CI remain.