### PR TITLE
fix(agent): config-as-code fallback for required CI contexts when branch-protection read fails

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -135,6 +135,13 @@ declare global {
      *  percentage + an estimated-time-saved figure ONLY — never PR content, authors, scores, or reward internals.
      *  See review/public-stats.ts. */
     GITTENSORY_PUBLIC_STATS?: string;
+    /** Comma-separated fallback set of REQUIRED CI contexts (e.g. "Superagent Security Scan,validate,Gittensory Gate").
+     *  Used ONLY when the live branch-protection read in fetchRequiredStatusContexts fails — usually a 403 because the
+     *  installation token lacks `administration:read`. It keeps required-only CI evaluation (review starts once the
+     *  required checks pass; a non-required red does not drive an automated close) instead of conservatively folding
+     *  ALL checks. Unset/empty preserves the byte-identical fold-all default. The names MUST match the exact
+     *  check-run/status contexts. See github/backfill.ts:configuredRequiredCiContexts. */
+    GITTENSORY_REQUIRED_CI_CONTEXTS?: string;
     /** Convergence (port): public OAuth draft-submission flow ported from reviewbot. When truthy, the
      *  /v1/drafts endpoints accept a contributor draft -> GitHub OAuth -> fork PR against the content repo.
      *  Default OFF — unset/false makes every draft endpoint 404 and writes nothing (byte-identical worker). */

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1940,11 +1940,32 @@ export type LiveCiAggregate = {
 };
 
 /**
+ * Operator-configured fallback set of REQUIRED CI contexts (comma-separated `GITTENSORY_REQUIRED_CI_CONTEXTS`,
+ * e.g. "Superagent Security Scan,validate,Gittensory Gate"). This is the config-as-code belt for
+ * fetchRequiredStatusContexts: when the LIVE branch-protection read fails — most commonly a 403 because the
+ * installation token lacks `administration:read` — folding ALL checks into the gate makes review wait on
+ * non-required checks (slow) and lets a non-required red (e.g. codecov variance) drive an automated close
+ * (unfair). Using the configured trusted set instead keeps required-only behavior during that window. Returns
+ * `null` when unset/empty so the caller keeps the conservative fold-all default (byte-identical to before).
+ * The names MUST match the exact check-run / status contexts. Granting the App `administration:read` makes the
+ * live read succeed (per-repo accurate) and reduces this fallback to a transient-failure safety net.
+ */
+export function configuredRequiredCiContexts(env: { GITTENSORY_REQUIRED_CI_CONTEXTS?: string }): Set<string> | null {
+  const names = new Set<string>();
+  for (const part of (env.GITTENSORY_REQUIRED_CI_CONTEXTS ?? "").split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.length > 0) names.add(trimmed);
+  }
+  return names.size > 0 ? names : null;
+}
+
+/**
  * RC2 best-effort fetch of the base branch's branch-protection REQUIRED status-check contexts. Returns the set
  * of required context names (covering both the legacy `contexts` array and the newer `checks[].context` shape),
- * or `null` when none can be determined — a 404 (no protection / no required checks), a 403 (token lacks
- * admin:repo, common for installations/forks), or any other error. `null`/empty makes fetchLiveCiAggregate fall
- * back to folding ALL red checks into the gate, so a fetch failure can never silently pass a required red check.
+ * or the operator-configured fallback (`GITTENSORY_REQUIRED_CI_CONTEXTS`) — else `null` — when none can be
+ * determined: a 404 (no protection / no required checks), a 403 (token lacks `administration:read`, common for
+ * installations/forks), or any other error. `null`/empty makes fetchLiveCiAggregate fall back to folding ALL
+ * red checks into the gate, so a fetch failure can never silently pass a required red check.
  */
 export async function fetchRequiredStatusContexts(env: Env, repoFullName: string, baseRef: string | null | undefined, token: string | undefined): Promise<Set<string> | null> {
   if (!baseRef) return null;
@@ -1954,7 +1975,7 @@ export async function fetchRequiredStatusContexts(env: Env, repoFullName: string
     `/branches/${encodeURIComponent(baseRef)}/protection/required_status_checks`,
     token,
   ).catch(() => undefined);
-  if (!result) return null; // 404 (no protection) / 403 (no admin) — treat as "unknown".
+  if (!result) return configuredRequiredCiContexts(env); // 404 / 403 (no admin:read) / error → configured fallback, else null (fold-all).
   const names = new Set<string>();
   for (const ctx of result.data.contexts ?? []) {
     if (typeof ctx === "string" && ctx.trim().length > 0) names.add(ctx);

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -31,8 +31,10 @@ import {
   buildInstallationRepairDiagnostics,
   enqueueRepositoryOpenDataBackfill,
   enrichInstallationHealth,
+  configuredRequiredCiContexts,
   fetchAndStorePullRequestFilesForReview,
   fetchLiveCiAggregate,
+  fetchRequiredStatusContexts,
   refreshContributorActivity,
   refreshInstallationHealth,
   refreshPullRequestDetails,
@@ -2748,6 +2750,58 @@ describe("GitHub backfill", () => {
       expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "Gittensory Gate", summary: "External status failed" })]);
     });
 
+  });
+
+  describe("configuredRequiredCiContexts", () => {
+    it("returns null when the var is unset (preserves the fold-all default)", () => {
+      expect(configuredRequiredCiContexts({})).toBeNull();
+    });
+
+    it("returns null when the var is empty or only separators/whitespace", () => {
+      expect(configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "" })).toBeNull();
+      expect(configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "  , ,, " })).toBeNull();
+    });
+
+    it("parses a comma-separated set, trimming whitespace and dropping empty entries", () => {
+      const parsed = configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "Superagent Security Scan, validate ,,Gittensory Gate" });
+      expect(parsed).not.toBeNull();
+      expect([...(parsed as Set<string>)].sort()).toEqual(["Gittensory Gate", "Superagent Security Scan", "validate"]);
+    });
+  });
+
+  describe("fetchRequiredStatusContexts", () => {
+    it("returns null without fetching when baseRef is missing", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "validate" });
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+      expect(await fetchRequiredStatusContexts(env, "JSONbored/gittensory", null, "public-token")).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns the live required set when branch protection is readable (both contexts and checks shapes)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "ignored-when-live-read-works" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        if (input.toString().includes("/protection/required_status_checks")) {
+          return Response.json({ contexts: ["validate", "", null], checks: [{ context: "Superagent Security Scan" }, { context: "  " }] });
+        }
+        return new Response("not found", { status: 404 });
+      });
+      const required = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token");
+      expect([...(required as Set<string>)].sort()).toEqual(["Superagent Security Scan", "validate"]);
+    });
+
+    it("falls back to the configured set when the live read fails (e.g. 403, no admin:read)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "Superagent Security Scan,validate,Gittensory Gate" });
+      vi.stubGlobal("fetch", async () => new Response("forbidden", { status: 403 }));
+      const required = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token");
+      expect([...(required as Set<string>)].sort()).toEqual(["Gittensory Gate", "Superagent Security Scan", "validate"]);
+    });
+
+    it("returns null when the live read fails and no fallback is configured (conservative fold-all)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async () => new Response("forbidden", { status: 403 }));
+      expect(await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token")).toBeNull();
+    });
   });
 
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -117,6 +117,13 @@
     // reviewed repos. Flag-OFF the endpoint 404s and the homepage band renders nothing (counts only, no PR
     // content/authors/scores/rewards). See src/review/public-stats.ts.
     "GITTENSORY_PUBLIC_STATS": "true",
+    // Fallback REQUIRED CI contexts, used ONLY when the live branch-protection read fails (a 403 when the
+    // installation token lacks `administration:read`, or a transient error). Keeps required-only CI evaluation
+    // — review starts once these pass; a non-required red (e.g. codecov variance) does NOT drive an automated
+    // close — instead of conservatively folding ALL checks in. Mirrors the repos' actual branch protection.
+    // Granting the App `administration:read` makes the live (per-repo) read succeed and reduces this to a
+    // transient-failure safety net. Names MUST match the exact check contexts. See src/github/backfill.ts.
+    "GITTENSORY_REQUIRED_CI_CONTEXTS": "Superagent Security Scan,validate,Gittensory Gate",
   },
   "routes": [
     {


### PR DESCRIPTION
## Summary
Stop folding **non-required** CI checks into the gate when the engine can't read branch protection. That fold-all fallback is why review **waits on slow non-required checks** (e.g. Codecov, 10–15 min) and why a **non-required red can auto-close** an honest PR.

## Root cause
`fetchRequiredStatusContexts` returns `null` on a 403 — the installation token lacks `administration:read` (common for GitHub App tokens). `null` makes `fetchLiveCiAggregate` gate on **all** checks instead of the required-only trust set.

## Fix (config-as-code, no migration)
- New `configuredRequiredCiContexts(env)` — when the live read fails, fall back to the operator-configured **`GITTENSORY_REQUIRED_CI_CONTEXTS`** trusted set, preserving required-only evaluation (review starts once required checks pass; a non-required red stays advisory).
- Unset/empty → **byte-identical** fold-all default. A successful live read is unchanged (per-repo accurate).
- Seeded in `wrangler.jsonc` with the repos' **actual** required set: `Superagent Security Scan, validate, Gittensory Gate` (verified against branch protection).

## Pairs with an ops change
Granting the App **`Administration: Read-only`** makes the live read succeed per-repo, reducing this fallback to a transient-failure safety net. (Belt **and** suspenders — "Both".)

## Validation
`npm run typecheck` ✓ · `npm run test:coverage` (full, unsharded) **3,616 passed** ✓ · new `configuredRequiredCiContexts` + `fetchRequiredStatusContexts` tests cover every branch (lcov: no uncovered lines in the diff) · `npm audit --audit-level=moderate` ✓. `worker-configuration.d.ts` deliberately not regenerated (repo types string vars via `src/env.d.ts`; the generated file is stale on `main` and not CI-enforced).

## Linked issue
No issue — CI fairness/throughput fix for the contributor surge.
