### PR TITLE
fix(deps): patch undici dev-dependency advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13949,9 +13949,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
Clears all **3 open Dependabot alerts**, which are the same dev-only transitive `undici`, all fixed in **6.27.0**:
- `GHSA-p88m-4jfj-68fv` (medium) — HTTP header injection via Set-Cookie percent-decoding
- `GHSA-g8m3-5g58-fq7m` (low) — Set-Cookie SameSite downgrade via permissive substring matching
- `GHSA-35p6-xmwp-9g52` (low) — HTTP response queue poisoning via keep-alive socket reuse

## Fix
`node-gyp` (a root **devDependency**) resolved `undici@6.26.0` (`< 6.27.0`). It declares `undici@^6.25.0`, so a **3-line lockfile bump to 6.27.0** satisfies it — no `package.json` / override needed. The other copy, `undici@7.28.0` (via `miniflare`), is **above** the vulnerable range and is deliberately left alone (a blanket override would have downgraded it and broken miniflare).

**No production impact** — `undici` here is build/test tooling only.

## Validation
`npm audit --audit-level=moderate` → **0 vulnerabilities** ✓ · `npm ls undici --all` shows no `< 6.27.0` remaining ✓ · `npm run test:ci` (full gate) green ✓. Change is `package-lock.json` only.

## Linked issue
No issue — security hygiene (Dependabot).
