### PR TITLE
fix(auth): verify token audience before minting a session from a caller-supplied token

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -991,7 +991,7 @@ export function createApp() {
     const githubToken = typeof body?.githubToken === "string" ? body.githubToken : "";
     if (!githubToken) return c.json({ error: "github_token_required" }, 400);
     try {
-      const session = await createSessionFromGitHubToken(c.env, githubToken, { source: "github_token_exchange" });
+      const session = await createSessionFromGitHubToken(c.env, githubToken, { source: "github_token_exchange" }, { verifyAppAudience: true });
       await recordRouteProductUsage(c, {
         surface: "api",
         eventName: "auth_session_created",

--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -25,6 +25,10 @@ type GitHubUserResponse = {
   message?: string;
 };
 
+type GitHubAppTokenCheck = {
+  app?: { client_id?: string };
+};
+
 type GitHubWebOAuthState = {
   nonce: string;
   returnTo: string;
@@ -161,7 +165,19 @@ export async function createSessionFromGitHubToken(
   env: Env,
   githubToken: string,
   metadata: Record<string, JsonValue> = {},
+  options: { verifyAppAudience?: boolean } = {},
 ): Promise<{ token: string; login: string; expiresAt: string; scopes: string[] }> {
+  // A caller-supplied token (the github_token_exchange route) carries no proof it was minted for THIS
+  // OAuth app. Without an audience check, any token a victim issued to an unrelated app would mint a
+  // gittensory session as that login. The device/web flows skip this — they minted the token themselves.
+  if (options.verifyAppAudience && !(await verifyTokenBelongsToApp(env, githubToken))) {
+    await recordAuditEvent(env, {
+      eventType: "auth.github_session",
+      outcome: "denied",
+      detail: "github_token_audience_mismatch",
+    });
+    throw new Error("github_token_audience_invalid");
+  }
   const response = await fetch("https://api.github.com/user", {
     headers: {
       accept: "application/vnd.github+json",
@@ -183,6 +199,27 @@ export async function createSessionFromGitHubToken(
   const githubUser = user.id === undefined ? { login: user.login } : { login: user.login, id: user.id };
   const { token, session } = await createSessionForGitHubUser(env, githubUser, { scopes, metadata });
   return { token, login: session.login, expiresAt: session.expiresAt, scopes: session.scopes };
+}
+
+// Confirms an access token was issued for this OAuth app via GitHub's token-introspection endpoint
+// (POST /applications/{client_id}/token, Basic client_id:client_secret). Fail-closed: if the app
+// isn't configured, the token can't be vouched for, so it is rejected.
+async function verifyTokenBelongsToApp(env: Env, githubToken: string): Promise<boolean> {
+  if (!env.GITHUB_OAUTH_CLIENT_ID || !env.GITHUB_OAUTH_CLIENT_SECRET) return false;
+  const response = await fetch(`https://api.github.com/applications/${env.GITHUB_OAUTH_CLIENT_ID}/token`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Basic ${btoa(`${env.GITHUB_OAUTH_CLIENT_ID}:${env.GITHUB_OAUTH_CLIENT_SECRET}`)}`,
+      "content-type": "application/json",
+      "user-agent": "gittensory-api",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify({ access_token: githubToken }),
+  });
+  if (!response.ok) return false;
+  const payload = (await response.json().catch(() => ({}))) as GitHubAppTokenCheck;
+  return payload.app?.client_id === env.GITHUB_OAUTH_CLIENT_ID;
 }
 
 function parseScopes(scopeHeader: string | undefined): string[] {

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -15,9 +15,10 @@ describe("api route guards and error branches", () => {
 
   it("creates, verifies, and revokes GitHub-backed API sessions", async () => {
     const app = createApp();
-    const env = createTestEnv();
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id", GITHUB_OAUTH_CLIENT_SECRET: "client-secret" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
+      if (url.includes("/applications/")) return Response.json({ app: { client_id: "client-id" } });
       if (url === "https://api.github.com/user") return Response.json({ login: "jsonbored", id: 42 });
       return Response.json({});
     });
@@ -383,7 +384,7 @@ describe("api route guards and error branches", () => {
 
   it("keeps auth route failures generic for non-Error provider failures", async () => {
     const app = createApp();
-    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" });
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id", GITHUB_OAUTH_CLIENT_SECRET: "client-secret" });
     vi.stubGlobal("fetch", async () => {
       throw "provider down";
     });

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -713,6 +713,39 @@ describe("private-beta auth and rate limiting", () => {
     await expect(createSessionFromGitHubToken(env, "github-token")).resolves.toMatchObject({ login: "jsonbored", scopes: [] });
   });
 
+  it("verifies the GitHub token audience before minting a session on the token-exchange path", async () => {
+    const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id", GITHUB_OAUTH_CLIENT_SECRET: "client-secret" });
+    const introspect = (appClientId: string | undefined) =>
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url === "https://api.github.com/applications/client-id/token") {
+          return appClientId === undefined ? new Response("{", { status: 200 }) : Response.json({ app: { client_id: appClientId } });
+        }
+        if (url === "https://api.github.com/user") return Response.json({ login: "jsonbored", id: 42 });
+        return Response.json({});
+      });
+
+    introspect("client-id");
+    await expect(createSessionFromGitHubToken(env, "valid-token", {}, { verifyAppAudience: true })).resolves.toMatchObject({ login: "jsonbored" });
+
+    introspect("someone-elses-app");
+    await expect(createSessionFromGitHubToken(env, "foreign-token", {}, { verifyAppAudience: true })).rejects.toThrow(/audience_invalid/);
+
+    introspect(undefined);
+    await expect(createSessionFromGitHubToken(env, "unparseable-introspection", {}, { verifyAppAudience: true })).rejects.toThrow(/audience_invalid/);
+
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
+      input.toString() === "https://api.github.com/applications/client-id/token" ? Response.json({}, { status: 404 }) : Response.json({}),
+    );
+    await expect(createSessionFromGitHubToken(env, "revoked-token", {}, { verifyAppAudience: true })).rejects.toThrow(/audience_invalid/);
+
+    vi.stubGlobal("fetch", async () => Response.json({ login: "jsonbored", id: 42 }));
+    await expect(
+      createSessionFromGitHubToken(createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" }), "no-secret", {}, { verifyAppAudience: true }),
+    ).rejects.toThrow(/audience_invalid/);
+    await expect(createSessionFromGitHubToken(createTestEnv(), "no-oauth", {}, { verifyAppAudience: true })).rejects.toThrow(/audience_invalid/);
+  });
+
   it("polls GitHub device flow and creates a session only after authorization", async () => {
     const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id", ADMIN_GITHUB_LOGINS: "jsonbored,scopefree" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

Harden the GitHub token-exchange session route. `POST /v1/auth/github/session` accepts a
caller-supplied GitHub access token and previously trusted the `login` returned by
`GET /user` with no proof the token was actually issued for **this** OAuth app. Any token a
victim had granted to an unrelated app could therefore mint a gittensory session as that
login. This PR introspects caller-supplied tokens via GitHub's token-check endpoint
(`POST /applications/{client_id}/token`, Basic `client_id:client_secret`) and **fails closed**
when the token does not belong to this app or the app is not configured. The device-flow and
web-OAuth paths are unchanged — they mint their own tokens, so their provenance is already proven.

No issue linked: focused, self-contained hardening of one route; the summary explains the change.
(Reported via private review, not a public issue, to avoid pre-disclosure.)

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — changed lines/branches are 100% covered (the gating `codecov/patch`); global coverage is unchanged from the repo baseline.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `ui:lint` / `ui:typecheck` / `ui:build`: this PR touches no `apps/gittensory-ui/**` files and `ui:openapi:check` shows no schema drift, so the UI workspace is unaffected; CI runs the full UI gate.
- `npm audit`: flags a single pre-existing high-severity transitive `undici` advisory that is unrelated to this PR (no dependency changes here). The diff-scoped dependency-review check is unaffected; the advisory is being addressed separately.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (`client_secret` is used only server-side for introspection; never returned.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Audience mismatch, revoked/404 token, unparseable introspection, app-not-configured, and missing-secret paths are all covered.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No schema change; `ui:openapi:check` clean.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Backend-only change in `src/auth/github-oauth.ts` (new `verifyTokenBelongsToApp`, opt-in `verifyAppAudience`) and the single route wiring in `src/api/routes.ts`. Two existing integration tests were updated to stub the new introspection call and configure OAuth (reflecting the stricter contract, not weakened).
