### PR TITLE
feat(anti-gaming): per-author submission-flood hold

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2627,6 +2627,19 @@ export async function countOpenPullRequests(env: Env, fullName: string): Promise
   return Number(row?.count ?? 0);
 }
 
+// Anti-farming (#anti-gaming-flood): how many PRs this author has SUBMITTED to this repo since `sinceIso` (ANY
+// state — open/merged/closed), so a flood that merges fast is still caught. createdAt is the row-insert time
+// (≈ when gittensory first saw the PR), a good proxy for submission time on live webhook-driven PRs.
+export async function countRecentSubmissionsByAuthor(env: Env, fullName: string, authorLogin: string, sinceIso: string): Promise<number> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(pullRequests)
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.authorLogin, authorLogin), gte(pullRequests.createdAt, sinceIso)));
+  /* v8 ignore next -- SQL aggregate count always returns one row; fallback protects D1 driver anomalies. */
+  return Number(row?.count ?? 0);
+}
+
 export async function markUnseenOpenPullRequestsClosed(env: Env, fullName: string, seenOpenAt: string): Promise<number> {
   const db = getDb(env.DB);
   const result = await db

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1,6 +1,7 @@
 import {
   countOpenIssues,
   countOpenPullRequests,
+  countRecentSubmissionsByAuthor,
   getAgentCommandAnswer,
   getInstallation,
   getLatestRepoGithubTotalsSnapshot,
@@ -175,7 +176,7 @@ import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
-import { loadHardGuardrailGlobs } from "../review/guardrail-config";
+import { loadHardGuardrailGlobs, loadSubmissionFloodLimit } from "../review/guardrail-config";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
@@ -652,6 +653,20 @@ async function maybeRunAgentMaintenance(
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
 
+  // Anti-farming (#anti-gaming-flood): a CONTRIBUTOR who has submitted more than the per-repo limit within the
+  // configured window is HELD for manual review (never auto-merged/approved) — this catches farming that merges
+  // fast, which an open-PR count alone would miss. Owner/automation are exempt; disabled (no hold) when the repo
+  // has no flood limit configured in KV, or on any read fault (fail-open, never false-hold).
+  let submissionFloodHit = false;
+  if (!authorIsOwner && !authorIsAutomationBot && authorLogin.length > 0) {
+    const floodLimit = await loadSubmissionFloodLimit(env, repoFullName).catch(() => null);
+    if (floodLimit) {
+      const sinceIso = new Date(Date.now() - floodLimit.windowHours * 3_600_000).toISOString();
+      const recent = await countRecentSubmissionsByAuthor(env, repoFullName, authorLogin, sinceIso).catch(() => 0);
+      submissionFloodHit = recent > floodLimit.maxPerWindow;
+    }
+  }
+
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules): when the repo enabled any rule, a body that links
   // MORE closing references than we can safely verify (overflow) is itself a violation; otherwise evaluate the
   // linked issues' facts (fail-open per issue). The decision is extracted into resolveLinkedIssueHardRule (pure,
@@ -678,6 +693,7 @@ async function maybeRunAgentMaintenance(
     hardGuardrailGlobs,
     authorIsOwner,
     authorIsAutomationBot,
+    submissionFloodHit,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -42,3 +42,23 @@ export async function loadHardGuardrailGlobs(env: Env, repoFullName: string): Pr
     return FAIL_CLOSED_GUARDRAIL_GLOBS;
   }
 }
+
+/**
+ * Anti-farming submission-flood limit for a repo, read from the same shared REVIEW_CONFIG KV (key = repo slug):
+ * `maxSubmissionsPerAuthorWindow` (the per-author cap) + `submissionWindowHours` (the window, default 24h). Returns
+ * null when unset/invalid (the feature is DISABLED for that repo) or on a KV fault — never throws, and a fault
+ * disables rather than false-holding a contributor. (#anti-gaming-flood)
+ */
+export async function loadSubmissionFloodLimit(env: Env, repoFullName: string): Promise<{ maxPerWindow: number; windowHours: number } | null> {
+  const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
+  if (!env.REVIEW_CONFIG) return null;
+  try {
+    const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { maxSubmissionsPerAuthorWindow?: JsonValue; submissionWindowHours?: JsonValue } | null;
+    const maxPerWindow = Number(config?.maxSubmissionsPerAuthorWindow);
+    if (!Number.isFinite(maxPerWindow) || maxPerWindow <= 0) return null; // unset / invalid → disabled
+    const hours = Number(config?.submissionWindowHours);
+    return { maxPerWindow, windowHours: Number.isFinite(hours) && hours > 0 ? hours : 24 };
+  } catch {
+    return null; // KV fault → disabled (never false-hold)
+  }
+}

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -64,6 +64,10 @@ export type AgentActionPlanInput = {
   // neither auto-merge, auto-approve, nor auto-close such a PR; it falls through to a human.
   changedPaths: string[];
   hardGuardrailGlobs: string[];
+  // Anti-farming (#anti-gaming-flood): true when this PR's author has exceeded the per-repo submission-flood
+  // limit (more than N PRs in the configured window). Forces the SAME manual hold as a guarded path — a flooding
+  // author's PR is never auto-merged/approved; a human reviews the batch. Does NOT force a close.
+  submissionFloodHit?: boolean | undefined;
   // True when the PR author is the repo owner (e.g. JSONbored). Standing rule: owner PRs are NEVER
   // auto-closed. They may still auto-merge when clean + passing.
   authorIsOwner: boolean;
@@ -195,6 +199,11 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const guardrailHit =
     input.hardGuardrailGlobs.length > 0 &&
     (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
+  // A per-author submission FLOOD forces the SAME manual hold as a guarded path: a flooding author's PR is never
+  // auto-merged/approved — a human reviews the batch (anti-farming). It does NOT force a close (a clean flooding
+  // PR is HELD, not killed; a red-CI / conflict flooding PR still closes via the normal path). (#anti-gaming-flood)
+  const submissionFloodHit = input.submissionFloodHit === true;
+  const heldForManualReview = guardrailHit || submissionFloodHit;
   // Canonical (reviewbot non-content-gate) policy, tuned to the operator's minimize-manual goal: merge-or-close
   // with high accuracy; manual review is the RARE exception. A PR is "review-good" when the gate passes AND CI is
   // green — that's the only thing that earns an auto-merge or an approve. Everything else, for a CONTRIBUTOR, is a
@@ -213,7 +222,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // reviewDecision to APPROVED, so reviewDecision alone can't dedup). A new commit makes the heads differ →
   // approve may fire again. Absent approved-head SHA (never approved by the bot) ⇒ not idempotent-skipped.
   const alreadyApprovedThisHead = input.pr.approvedHeadSha != null && input.pr.headSha != null && input.pr.approvedHeadSha === input.pr.headSha;
-  const canMerge = reviewGood && !guardrailHit && acting("merge") && mergeableClean && approvalsSatisfied && !mergeTerminallyBlocked;
+  const canMerge = reviewGood && !heldForManualReview && acting("merge") && mergeableClean && approvalsSatisfied && !mergeTerminallyBlocked;
   // A guarded/CRUCIAL path (CI, the review engine, visual) → ALWAYS held for the owner, never auto-actioned —
   // not auto-approved, not auto-merged, AND not auto-closed. Operator decision (#hold-crucial-on-reject): a
   // hallucinated reject on a crucial PR must NOT auto-close a good change (the #1528 near-miss); the owner
@@ -272,13 +281,13 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // linked-issue hard-rule close (flag OR close pass) forces the changes-requested label regardless of the gate
   // verdict (the PR is about to be closed for an ineligible linked issue). Idempotent.
   if (acting("label")) {
-    const label = linkedIssueCloseInFlight || !reviewGood ? AGENT_LABEL_CHANGES : guardrailHit ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
+    const label = linkedIssueCloseInFlight || !reviewGood ? AGENT_LABEL_CHANGES : heldForManualReview ? AGENT_LABEL_NEEDS_REVIEW : AGENT_LABEL_READY;
     const reason = linkedIssueCloseInFlight
       ? `linked-issue hard rule: ${linkedIssueHardRule?.reason ?? "ineligible linked issue"}`
       : !reviewGood
         ? `verdict=${input.conclusion}${ciReason ? `; ${ciReason}` : ""}`
-        : guardrailHit
-          ? `verdict=${input.conclusion}; guarded path → owner safety review`
+        : heldForManualReview
+          ? `verdict=${input.conclusion}; ${submissionFloodHit ? "submission flood → manual review (anti-farming)" : "guarded path → owner safety review"}`
           : `verdict=${input.conclusion}; CI green`;
     if (!hasLabel(input.pr.labels, label)) {
       actions.push({ actionClass: "label", requiresApproval: approval("label"), reason, label });
@@ -318,7 +327,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // OWNER/automation PR is HELD via the needs-human label + the (non-blocking) unified review comment — never a
   // formal request-changes. (#no-request-changes) Either merge/approve, or close, with the rare manual hold left
   // open + commented, never blocked.
-  if (reviewGood && !guardrailHit && !linkedIssueCloseInFlight && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
+  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -225,6 +225,25 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
+  describe("anti-farming: a per-author submission flood forces a manual hold (#anti-gaming-flood)", () => {
+    it("HOLDS a flooding author's clean+green+approved PR — needs-human, never merged/approved/closed", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, submissionFloodHit: true, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("merge");
+      expect(cls).not.toContain("approve");
+      expect(cls).not.toContain("close"); // a clean flooding PR is HELD for review, not killed
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
+    });
+    it("still CLOSES a flooding author's red-CI PR (a broken PR closes regardless of the flood hold)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, submissionFloodHit: true, ciState: "failed", pr: { labels: [] } })));
+      expect(plan).toContain("close");
+    });
+    it("does NOT hold a normal author (submissionFloodHit false) — a clean PR still auto-merges", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", label: "auto" }, submissionFloodHit: false, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
+      expect(plan).toContain("merge");
+    });
+  });
+
   describe("owner-PR guard: never auto-close the repo owner's own PRs", () => {
     it("does NOT auto-close a noisy failing PR authored by the repo owner", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], authorIsOwner: true, pr: { labels: [], slopRisk: 95 } })));


### PR DESCRIPTION
Anti-farming: a contributor who submits more than a per-repo limit within a window is HELD for manual review (needs-human) and never auto-merged/approved — catches fast-merging farming an open-count would miss. Owner/automation exempt; red-CI/conflict floods still close. Config (maxSubmissionsPerAuthorWindow + submissionWindowHours) per-repo in KV; disabled when unset / on fault. +3 tests, suite green (3634).