### PR TITLE
fix(signals): canonicalize guardrail path matching so guarded paths can't be evaded

### DIFF
--- a/src/signals/change-guardrail.ts
+++ b/src/signals/change-guardrail.ts
@@ -4,16 +4,26 @@
 // reviewbot core/change-classifier.ts — the mechanism that prevents the awesome-claude #4196 incident class
 // (a weakened policy script auto-merging because its path wasn't guarded). Pure + dependency-free.
 
-/** Convert a path glob (`*` matches within a segment, `**` matches across `/`) to an anchored RegExp. */
+// Canonicalize a path or glob so matching is case- and separator-insensitive: backslashes → `/`, drop a
+// leading `./` or `/`, and case-fold. Mirrors signals/focus-manifest `normalizePathForMatch` — without it a
+// guarded path is evaded with `.github/Workflows/` (capital W), a `./`-prefix, or a `\` separator, turning a
+// mandatory human hold on CI/policy files into an auto-merge.
+function canonicalize(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").toLowerCase();
+}
+
+/** Convert a path glob (`*` matches within a segment, `**` matches across `/`) to an anchored RegExp. The
+ *  glob is canonicalized first, so matching is case-insensitive against a canonicalized path. */
 function globToRegExp(glob: string): RegExp {
+  const canonical = canonicalize(glob);
   let re = "";
-  for (let i = 0; i < glob.length; i += 1) {
-    const c = glob.charAt(i);
+  for (let i = 0; i < canonical.length; i += 1) {
+    const c = canonical.charAt(i);
     if (c === "*") {
-      if (glob.charAt(i + 1) === "*") {
+      if (canonical.charAt(i + 1) === "*") {
         re += ".*";
         i += 1;
-        if (glob.charAt(i + 1) === "/") i += 1; // `**/` also matches zero segments
+        if (canonical.charAt(i + 1) === "/") i += 1; // `**/` also matches zero segments
       } else {
         re += "[^/]*";
       }
@@ -26,9 +36,10 @@ function globToRegExp(glob: string): RegExp {
   return new RegExp(`^${re}$`);
 }
 
-/** True if `path` matches any of the globs (`*` within a segment, `**` across `/`). */
+/** True if `path` matches any of the globs (`*` within a segment, `**` across `/`), case-insensitively. */
 export function matchesAny(path: string, globs: string[]): boolean {
-  return globs.some((g) => globToRegExp(g).test(path));
+  const canonicalPath = canonicalize(path);
+  return globs.some((g) => globToRegExp(g).test(canonicalPath));
 }
 
 /**

--- a/test/unit/change-guardrail.test.ts
+++ b/test/unit/change-guardrail.test.ts
@@ -18,6 +18,17 @@ describe("change-guardrail glob matching", () => {
     expect(matchesAny("src/auth/session.ts", ["src/*.ts"])).toBe(false);
   });
 
+  it("matches case-insensitively and canonicalizes `./`, leading `/`, and `\\` separators (evasion-proof)", () => {
+    expect(matchesAny(".github/Workflows/ci.yml", [".github/workflows/**"])).toBe(true); // capital W
+    expect(matchesAny("Scripts/Deploy.SH", ["scripts/**"])).toBe(true); // mixed case path
+    expect(matchesAny("scripts/build.mjs", ["Scripts/**"])).toBe(true); // mixed case glob
+    expect(matchesAny("./scripts/build.mjs", ["scripts/**"])).toBe(true); // leading ./
+    expect(matchesAny("/scripts/build.mjs", ["scripts/**"])).toBe(true); // leading /
+    expect(matchesAny("scripts\\win\\build.ps1", ["scripts/**"])).toBe(true); // backslash separators
+    expect(matchesAny("src/a/deep/model.ts", ["src/**/model.ts"])).toBe(true); // mid-path `**/` consumes the separator
+    expect(changedPathsHittingGuardrail([".github/Workflows/deploy.yml"], [".github/workflows/**"])).toEqual([".github/Workflows/deploy.yml"]);
+  });
+
   it("does not match unrelated paths", () => {
     expect(matchesAny("docs/readme.md", ["scripts/**", "src/scoring/**"])).toBe(false);
     expect(matchesAny("src/ui/button.tsx", ["src/scoring/**", "src/auth/**"])).toBe(false);


### PR DESCRIPTION
## Summary

Make the hard-guardrail path matcher evasion-proof. `signals/change-guardrail.ts` compiled globs
case-sensitively with no path normalization, so a guarded path (CI workflows, policy scripts, the
review engine, scoring, auth) could be slipped past the mandatory human hold with `.github/Workflows/`
(capital W), a `./`-prefix, a leading `/`, or a `\` separator — flipping a required owner review into an
auto-merge. This canonicalizes both glob and path (case-fold, strip `./` and leading `/`, `\`→`/`) before
matching, mirroring the existing `signals/focus-manifest` `normalizePathForMatch`. Matching becomes
case-insensitive and separator-normalized; nothing that matched before stops matching.

No issue linked: focused, self-contained hardening of one pure matcher; the summary explains it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — `change-guardrail.ts` at 100% statements/branches/functions/lines; changed lines fully covered.
- [x] New cases cover case-insensitive matching, `./`/leading-`/`/`\` canonicalization, and mid-path `**/`.
- [ ] `npm run ui:lint` / `ui:typecheck` / `ui:build` — N/A, no UI files touched; CI runs the UI gate.
- [ ] `npm audit --audit-level=moderate` — unchanged pre-existing transitive `undici` advisory only; no dependency changes here.

If any required check was skipped, explain why:

- Pure `src/signals` logic change with no API/MCP/worker/DB/schema impact, so `ui:openapi:check`, `test:workers`, `build:mcp`, and the UI workspace checks are unaffected; CI runs the full gate.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, reward values, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise. (No public-text change.)
- [x] Auth/cookie/CORS/session changes include negative-path tests. — N/A (no auth surface change); the matcher's negative paths (unrelated paths stay non-matching) are tested.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP change.
- [x] No mock/demo UI fallbacks. — N/A.
- [x] Visible UI changes include UI Evidence. — N/A, no UI change.
- [x] Public docs/changelogs updated where needed. — N/A.

## Notes

- Strictly widens what the guardrail catches (case-insensitive + normalized); it never narrows it, so no
  previously-held PR becomes auto-mergeable. The `matchesAny` helper is also used by `settings/pr-type-label.ts`
  (content-glob labeling) — that path is exercised by its existing tests and benefits from the same normalization.
