### PR TITLE
feat(mcp): expose outcome calibration via gittensory_get_outcome_calibration

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -68,6 +68,7 @@ import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
+import { buildRepoOutcomeCalibration } from "../services/outcome-calibration";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -135,6 +136,12 @@ function decisionPackSummary(login: string, freshness: string, rebuildEnqueued: 
 const ownerRepoShape = {
   owner: z.string().min(1),
   repo: z.string().min(1),
+};
+
+const ownerRepoWindowShape = {
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  windowDays: z.number().int().positive().optional(),
 };
 
 const loginShape = {
@@ -587,6 +594,16 @@ const freshnessResponseOutputSchema = {
   report: z.unknown().optional(),
 };
 
+const maintainerMeasurementReportOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  windowDays: z.number().nullable().optional(),
+  slop: z.unknown().optional(),
+  recommendations: z.unknown().optional(),
+  signals: z.array(z.string()).optional(),
+  status: z.string().optional(),
+};
+
 const contributorProfileOutputSchema = {
   login: z.string().optional(),
   github: z.unknown().optional(),
@@ -1024,6 +1041,17 @@ export class GittensoryMcp {
         outputSchema: freshnessResponseOutputSchema,
       },
       async (input) => this.toolResult(await this.getRepoOutcomePatterns(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_outcome_calibration",
+      {
+        description:
+          "Return slop-band and recommendation outcome calibration for a repo: whether higher-slop bands merge less often and how agent recommendations are panning out. Maintainer-authenticated; measurement only.",
+        inputSchema: ownerRepoWindowShape,
+        outputSchema: maintainerMeasurementReportOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getOutcomeCalibration(input)),
     );
 
     server.registerTool(
@@ -1881,6 +1909,27 @@ export class GittensoryMcp {
           ? `Gittensory repo outcome patterns for ${fullName} (cached, ${response.freshness}).`
           : `Gittensory repo outcome patterns for ${fullName} (computed from cached metadata).`,
       data: response as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getOutcomeCalibration(input: { owner: string; repo: string; windowDays?: number | undefined }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const report = await buildRepoOutcomeCalibration(
+      this.env,
+      fullName,
+      input.windowDays !== undefined ? input.windowDays : undefined,
+    );
+    const slop = report.slop;
+    const summary =
+      slop.discriminates === true
+        ? `Outcome calibration for ${fullName}: slop bands are predictive across ${slop.totalResolved} resolved PRs.`
+        : slop.discriminates === false
+          ? `Outcome calibration for ${fullName}: slop bands are NOT discriminating on current data (${slop.totalResolved} resolved PRs).`
+          : `Outcome calibration for ${fullName}: not enough resolved PR data to judge slop calibration yet.`;
+    return {
+      summary,
+      data: report as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -4872,6 +4872,7 @@ describe("api routes", () => {
     expect(toolNames).toContain("gittensory_preflight_local_diff");
     expect(toolNames).toContain("gittensory_preview_local_pr_score");
     expect(toolNames).toContain("gittensory_explain_score_breakdown");
+    expect(toolNames).toContain("gittensory_get_outcome_calibration");
     expect(toolNames).toContain("gittensory_get_registry_changes");
     expect(toolNames).toContain("gittensory_get_upstream_drift");
     expect(toolNames).toContain("gittensory_explain_review_risk");

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
-import { persistSignalSnapshot, upsertBounty, upsertIssueFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { persistSignalSnapshot, upsertBounty, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, updatePullRequestSlopAssessment } from "../../src/db/repositories";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -13,6 +13,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_get_repo_context",
   "gittensory_get_burden_forecast",
   "gittensory_get_repo_outcome_patterns",
+  "gittensory_get_outcome_calibration",
   "gittensory_get_contributor_profile",
   "gittensory_get_decision_pack",
   "gittensory_monitor_open_prs",
@@ -379,6 +380,31 @@ describe("MCP tool calls return schema-valid structured content", () => {
     const cached = await client.callTool({ name: "gittensory_get_repo_outcome_patterns", arguments: { owner: "owner", repo: "cached" } });
     expect(cached.isError).toBeFalsy();
     expect(cached.structuredContent).toMatchObject({ status: "ready", source: "snapshot", freshness: "fresh", repoFullName: "owner/cached" });
+  });
+
+  it("gittensory_get_outcome_calibration returns structured slop calibration for a repo", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    await upsertPullRequestFromGitHub(env, "octo/demo", {
+      number: 1,
+      title: "merged clean",
+      state: "closed",
+      user: { login: "alice" },
+      merged_at: "2026-06-01T00:00:00.000Z",
+    });
+    await updatePullRequestSlopAssessment(env, "octo/demo", 1, { slopRisk: 0, slopBand: "clean" });
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "gittensory_get_outcome_calibration",
+      arguments: { owner: "octo", repo: "demo", windowDays: 30 },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.repoFullName).toBe("octo/demo");
+    expect(data.windowDays).toBe(30);
+    expect(data.slop).toBeTruthy();
+    expect(data.recommendations).toBeTruthy();
+    expect(Array.isArray(data.signals)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `gittensory_get_outcome_calibration` MCP tool wrapping the existing outcome-calibration service
- Optional `windowDays` filter; structured output schema + integration test coverage

## Test plan
- [x] `npx vitest run test/unit/mcp-output-schemas.test.ts test/unit/outcome-calibration.test.ts`
- [x] MCP tools/list includes new tool