### PR TITLE
fix(review): always guard the gate's own config-as-code policy files

### DIFF
--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -13,6 +13,23 @@ import type { JsonValue } from "../types";
 // these, it never opens the gate wide.
 export const DEFAULT_CRUCIAL_GUARDRAIL_GLOBS = [".github/workflows/**", "scripts/**"];
 
+// The gate's OWN policy files, guarded for EVERY repo regardless of KV tuning. A PR that edits the
+// config-as-code that defines the gate or coverage policy (the `.gittensory.*` focus manifest the loader
+// reads, or `codecov.yml`) must always be HELD for the owner — otherwise one auto-merged config-only PR
+// could weaken the gate repo-wide before any subsequent PR is evaluated against the new policy. The
+// manifest filenames mirror signals/focus-manifest-loader's candidates; this only ever WIDENS the guard.
+export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
+  ".gittensory.yml",
+  ".gittensory.yaml",
+  ".gittensory.json",
+  ".github/gittensory.yml",
+  ".github/gittensory.yaml",
+  ".github/gittensory.json",
+  "**/codecov.yml",
+  "**/codecov.yaml",
+  "**/.codecov.yml",
+];
+
 // A KV READ FAULT (binding present but the read threw — an outage/transient error) must fail CLOSED, NOT fall
 // back to the narrow default: a config-read fault correlated with a contributor flood would otherwise silently
 // shrink the guarded surface to CI+scripts and let crown-jewel edits (scoring/auth/rules/the gate) auto-merge.
@@ -34,10 +51,11 @@ function asNonEmptyStringArray(value: unknown): string[] | null {
  */
 export async function loadHardGuardrailGlobs(env: Env, repoFullName: string): Promise<string[]> {
   const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
-  if (!env.REVIEW_CONFIG) return DEFAULT_CRUCIAL_GUARDRAIL_GLOBS;
+  // The config-as-code policy files are guarded for every repo; the fail-closed `**` already covers them.
+  if (!env.REVIEW_CONFIG) return [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
   try {
     const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { hardGuardrailGlobs?: JsonValue } | null;
-    return asNonEmptyStringArray(config?.hardGuardrailGlobs) ?? DEFAULT_CRUCIAL_GUARDRAIL_GLOBS;
+    return [...(asNonEmptyStringArray(config?.hardGuardrailGlobs) ?? DEFAULT_CRUCIAL_GUARDRAIL_GLOBS), ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
   } catch {
     return FAIL_CLOSED_GUARDRAIL_GLOBS;
   }

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,31 +1,42 @@
 import { describe, expect, it, vi } from "vitest";
-import { DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs } from "../../src/review/guardrail-config";
+import { matchesAny } from "../../src/signals/change-guardrail";
+import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs } from "../../src/review/guardrail-config";
 
 function envWith(get: (key: string, type: string) => Promise<unknown>): Env {
   return { REVIEW_CONFIG: { get } } as unknown as Env;
 }
 
 describe("loadHardGuardrailGlobs", () => {
-  it("returns the conservative default when REVIEW_CONFIG is unbound", async () => {
-    expect(await loadHardGuardrailGlobs({} as Env, "JSONbored/gittensory")).toEqual(DEFAULT_CRUCIAL_GUARDRAIL_GLOBS);
+  it("returns the conservative default plus the config-as-code guards when REVIEW_CONFIG is unbound", async () => {
+    expect(await loadHardGuardrailGlobs({} as Env, "JSONbored/gittensory")).toEqual([...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
   });
 
-  it("reads globs from KV keyed by the repo slug (owner stripped)", async () => {
+  it("reads globs from KV keyed by the repo slug (owner stripped) and always appends the config-as-code guards", async () => {
     const get = vi.fn().mockResolvedValue({ hardGuardrailGlobs: ["src/scoring/**", "scripts/**"] });
     const globs = await loadHardGuardrailGlobs(envWith(get), "JSONbored/gittensory");
-    expect(globs).toEqual(["src/scoring/**", "scripts/**"]);
+    expect(globs).toEqual(["src/scoring/**", "scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
     expect(get).toHaveBeenCalledWith("gittensory", "json");
   });
 
-  it("falls back to the default when the field is absent, null, or empty", async () => {
-    expect(await loadHardGuardrailGlobs(envWith(async () => ({})), "o/r")).toEqual(DEFAULT_CRUCIAL_GUARDRAIL_GLOBS);
-    expect(await loadHardGuardrailGlobs(envWith(async () => null), "o/r")).toEqual(DEFAULT_CRUCIAL_GUARDRAIL_GLOBS);
-    expect(await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: [] })), "o/r")).toEqual(DEFAULT_CRUCIAL_GUARDRAIL_GLOBS);
+  it("falls back to the default (plus config-as-code guards) when the field is absent, null, or empty", async () => {
+    const expected = [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
+    expect(await loadHardGuardrailGlobs(envWith(async () => ({})), "o/r")).toEqual(expected);
+    expect(await loadHardGuardrailGlobs(envWith(async () => null), "o/r")).toEqual(expected);
+    expect(await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: [] })), "o/r")).toEqual(expected);
   });
 
-  it("drops non-string entries and keeps the valid globs", async () => {
+  it("drops non-string entries and keeps the valid globs (plus config-as-code guards)", async () => {
     const globs = await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: [123, "scripts/**", ""] })), "o/r");
-    expect(globs).toEqual(["scripts/**"]);
+    expect(globs).toEqual(["scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
+  });
+
+  it("guards the gate's own policy files for every repo (the config-as-code self-weakening hole)", async () => {
+    const globs = await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: ["src/**"] })), "o/r");
+    for (const policyFile of [".gittensory.yml", ".github/gittensory.json", "codecov.yml", ".github/codecov.yml"]) {
+      expect(matchesAny(policyFile, globs)).toBe(true);
+    }
+    expect(matchesAny("src/utils/json.ts", globs)).toBe(true); // the repo's own KV glob still applies
+    expect(matchesAny("README.md", globs)).toBe(false); // an unrelated file is still auto-mergeable
   });
 
   it("fails CLOSED (guard everything) when the KV read throws — an outage must never open the gate", async () => {


### PR DESCRIPTION
## Summary

Close the config-as-code self-weakening hole. The hard-guardrail's conservative default only guarded
`.github/workflows/**` and `scripts/**`, so a PR that edits the gate's **own** policy files — the
`.gittensory.*` focus manifest (gate modes, blockers, autonomy) or `codecov.yml` (the coverage threshold)
— was eligible to auto-merge. One such config-only PR then governs the gate/coverage policy for every
subsequent PR. This unions a fixed `CONFIG_AS_CODE_GUARDRAIL_GLOBS` set into the resolved globs for every
repo (KV-configured or not), so any PR touching those files is always **held for the owner**.

The intended config-as-code autonomy feature (#773/#774) is preserved: owner-reviewed `.gittensory.yml`
still applies — we only close the *unattended* self-weakening path (a contributor sneaking weakened policy
onto `main`). The fail-closed `**` sentinel already covers these files, so it is unchanged.

No issue linked: focused, self-contained hardening of the guardrail resolver; the summary explains it.

## Scope

- [x] Conventional Commit title.
- [x] Focused; no unrelated backend/UI/MCP/docs/dependency/deploy changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`.
- [x] Small, self-contained; the summary explains why no issue is linked.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — `guardrail-config.ts` at 100%; changed lines/branches fully covered.
- [x] `npx vitest run` for `guardrail-config`, `queue`, `gate-check-policy`, `agent-guardrail-paths` — all green (the additive guard does not hold any existing test PR).
- [ ] `npm run ui:*` — N/A, no UI files touched; CI runs the UI gate.
- [ ] `npm audit --audit-level=moderate` — unchanged pre-existing transitive `undici` advisory only; no dependency changes here.

If any required check was skipped, explain why:

- Pure `src/review` config change with no API/OpenAPI/MCP/worker/DB/schema impact; CI runs the full gate.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, reward values, or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise. (No public-text change.)
- [x] Auth/cookie/CORS/session changes include negative-path tests. — N/A; the new test covers both the guarded (config files) and non-guarded (unrelated files) paths.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. — N/A.
- [x] No mock/demo UI fallbacks. — N/A.
- [x] Visible UI changes include UI Evidence. — N/A, no UI change.
- [x] Public docs/changelogs updated where needed. — N/A.

## Notes

- The change only ever WIDENS the guarded surface; no PR that was held becomes auto-mergeable. Operators
  with per-repo KV guardrail tuning keep their globs — the config-as-code guards are appended, not replaced.
- Deliberately did NOT strip `autonomy`/`autoMaintain` from repo-file manifests: that is an intended
  feature (#773/#774), and guarding the config file (held-for-owner) already closes the bootstrap attack
  without removing it.
