### PR TITLE
fix(queue): ensure blocking AI review runs during scheduled re-gate sweeps

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -564,10 +564,11 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     // re-gate above only recomputes the audit verdict; without this re-publish, an idle PR keeps a stale comment
     // (e.g. "safe to merge" from before a fix) and a stale status label forever. reReviewStoredPullRequest reads
     // the freshly-synced head + the live CI, so the comment + label + action all reflect reality. Paced at
-    // SWEEP_MAX_PRS per sweep; scheduled sweeps deliberately skip AI so the 2-minute cadence cannot amplify
-    // model/API spend for unchanged PR heads.
+    // SWEEP_MAX_PRS per sweep. Scheduled sweeps may skip advisory-only AI so the 2-minute cadence cannot
+    // amplify model/API spend for unchanged PR heads, but aiReview:block is part of the authoritative gate
+    // decision and must run before auto-maintenance can act on the recomputed verdict.
     if (sweepInstallationId != null) {
-      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number, undefined, { skipAiReview: true }).catch((error) => {
+      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
         console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
       });
     }
@@ -2248,8 +2249,8 @@ async function maybePublishPrPublicSurface(
     // BEFORE the gate evaluates, and returns advisory notes for the panel. Inside the try so any AI
     // failure is caught and the gate is still finalized (never left in_progress). Pass the shared resolved
     // files so the review (+ grounding + RAG) sees the REAL diff even on a pre-detail-sync first review (FIX B);
-    // resolve only when the review will actually run (aiReviewMode !== off + a head SHA + not a scheduled
-    // sweep backstop) to keep gate-only and sweep-only repos free of an extra file resolve.
+    // resolve only when the review will actually run (aiReviewMode !== off + a head SHA + not explicitly skipped)
+    // to keep gate-only and advisory-sweep repos free of an extra file resolve.
     const aiReviewWillRun = !webhook.skipAiReview && settings.aiReviewMode !== "off" && Boolean(advisory.headSha);
     if (aiReviewWillRun) {
       aiReview = await runAiReviewForAdvisory(env, {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -578,7 +578,7 @@ describe("queue processors", () => {
     expect(sent).toEqual([]);
   });
 
-  it("agent re-gate sweep skips AI review while refreshing the PR surface on a stale AI-enabled PR", async () => {
+  it("agent re-gate sweep skips advisory AI review while refreshing the PR surface on a stale AI-enabled PR", async () => {
     let aiCalls = 0;
     const env = createTestEnv({
       GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
@@ -597,7 +597,7 @@ describe("queue processors", () => {
     await upsertRepositorySettings(env, {
       repoFullName: "owner/agent-repo",
       autonomy: { merge: "auto" },
-      aiReviewMode: "block",
+      aiReviewMode: "advisory",
       gatePack: "oss-anti-slop",
       gateCheckMode: "enabled",
       checkRunMode: "off",
@@ -624,6 +624,59 @@ describe("queue processors", () => {
     const audit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string; metadata_json: string }>();
     expect(audit?.outcome).toBe("completed");
     expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ repoFullName: "owner/agent-repo", examined: 1 });
+  });
+
+  it("agent re-gate sweep runs blocking AI review before auto-maintenance (regression)", async () => {
+    let aiCalls = 0;
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      AI: {
+        run: async () => {
+          aiCalls += 1;
+          return { response: JSON.stringify({ assessment: "Critical defect found.", blockers: ["Unhandled null dereference in src/a.ts"], nits: [], suggestions: [] }) };
+        },
+      } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, {
+      repoFullName: "owner/agent-repo",
+      autonomy: { merge: "auto" },
+      aiReviewMode: "block",
+      gatePack: "oss-anti-slop",
+      gateCheckMode: "enabled",
+      checkRunMode: "off",
+      commentMode: "off",
+      publicSurface: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const ok = value.length;" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = value.length;" }]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.endsWith("/pulls/7/merge")) return new Response(null, { status: 204 });
+      if (url.endsWith("/pulls/7/reviews") && init?.method === "POST") return Response.json({ id: 1 });
+      if (url.endsWith("/pulls/7/reviews")) return Response.json([]);
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    expect(aiCalls).toBeGreaterThanOrEqual(2);
+    const blocker = await env.DB.prepare("select blocker_codes_json from gate_outcomes where repo_full_name = ? and pull_number = ? order by rowid desc limit 1").bind("owner/agent-repo", 7).first<{ blocker_codes_json: string }>();
+    expect(blocker?.blocker_codes_json).toContain("ai_consensus_defect");
+    const mergeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and detail like ?").bind("agent.action.merge", "%merged%").first<{ n: number }>();
+    expect(mergeAudit?.n).toBe(0);
   });
 
   it("agent re-gate sweep re-reviews each stale open PR (installation id) and swallows a failing re-review", async () => {


### PR DESCRIPTION
### Motivation
- Scheduled re-gate sweeps were forwarding `skipAiReview` into the full re-review path and thereby skipped the AI consensus check even for repos configured with `aiReviewMode: "block"`, which allowed auto-maintenance to act on a gate verdict that omitted AI blockers.

### Description
- Pass `skipAiReview: settings.aiReviewMode !== "block"` from the sweep so advisory-only skips remain but blocking-mode repos still run the AI consensus review before auto-maintenance.\n
- Clarify comments and adjust the AI-run gating remark so the skip is explicit (advisory-only) rather than unconditional for scheduled sweeps.\n
- Add a regression unit test that asserts a sweep on an `aiReviewMode: "block"` repo invokes the dual-model AI review, records an `ai_consensus_defect` in `gate_outcomes`, and prevents an automatic merge.\n
- Update the existing sweep test to exercise advisory-mode skipping (`aiReviewMode: "advisory"`).

### Testing
- Ran the focused unit tests: `npx vitest run test/unit/queue.test.ts -t "skips advisory AI review|blocking AI review"` and both relevant tests passed.\n
- Ran the regression test in verbose mode: `npx vitest run test/unit/queue.test.ts -t "blocking AI review"` and it passed after the change.\n
- Ran static typecheck with `npm run typecheck` and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b685e2090832caaf8cbbde975f312)