### PR TITLE
fix(gate): preserve guardrails for unverified CI failures

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -609,6 +609,16 @@ export function applyPrecisionBreakers(planned: PlannedAgentAction[], holdOnly: 
 }
 
 /**
+ * #1177: a red CI may bypass the hard-guardrail manual hold (#ci-fail-closes-guarded) ONLY when we proved the
+ * failing checks are required branch-protection contexts. A null fetch (unreadable branch protection) or an
+ * EMPTY required set means `fetchLiveCiAggregate` may have folded an optional / third-party red into `failed`,
+ * which must keep a guarded PR held for a human rather than auto-close it.
+ */
+export function hasVerifiedRequiredContexts(requiredContexts: Set<string> | null): boolean {
+  return requiredContexts != null && requiredContexts.size > 0;
+}
+
+/**
  * #778 maintainer auto-maintain trigger. After the gate runs on a PR webhook, if the repo opted the agent in
  * (an acting autonomy level), reuse the CANONICAL verdict produced by the full gate evaluation, plan the
  * GitHub state actions, and run them through the
@@ -714,7 +724,7 @@ async function maybeRunAgentMaintenance(
     submissionFloodHit,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
-    ciRequiredContextsVerified: requiredContexts != null && requiredContexts.size > 0,
+    ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),
     ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
     // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
     // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -714,6 +714,7 @@ async function maybeRunAgentMaintenance(
     submissionFloodHit,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
+    ciRequiredContextsVerified: requiredContexts != null && requiredContexts.size > 0,
     ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
     // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
     // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -93,6 +93,10 @@ export type AgentActionPlanInput = {
   // The names of the failing checks, surfaced in the close/request-changes reason so the contributor knows
   // WHY (e.g. "codecov/patch"). Empty unless ciState === "failed".
   failingCheckNames?: string[] | undefined;
+  // True only when the caller proved the failing CI names are required branch-protection contexts. When required
+  // contexts are unavailable, ciState conservatively folds in all red checks; that fallback must not bypass hard
+  // guardrails because an optional or third-party check may be the only red signal.
+  ciRequiredContextsVerified?: boolean | undefined;
   // Linked-issue HARD-RULE result (#linked-issue-hard-rules). A DETERMINISTIC verdict about the issue(s) this PR
   // links (owner-assigned / missing point-label / maintainer-only), pre-computed by the trigger. When
   // `violated`, a CONTRIBUTOR PR is one-shot CLOSED citing `reason` — and because it is deterministic (no
@@ -281,11 +285,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // CONFLICT. NEVER close merely because CI is UNVERIFIED (a fork whose Actions await approval, or unreadable
   // checks) or otherwise not-yet-mergeable — those are HELD for review, not killed (#harm-stop fork-false-close).
   // Owner/automation PRs are never closed (isContributor). A guarded path is HELD for the AI/gate VERDICT and for
-  // a base conflict (don't kill a crucial change on an AI call or a rebaseable conflict). But a red REQUIRED CI is
-  // an OBJECTIVE failure — a broken change that cannot merge regardless — so it CLOSES a contributor PR even on a
-  // guarded path; the contributor fixes CI and resubmits, and a GREEN guarded resubmission is then held for review.
+  // a base conflict (don't kill a crucial change on an AI call or a rebaseable conflict). A red CI may close a
+  // guarded path only after the caller proves required-context data was available; otherwise the live aggregate may
+  // have folded in optional / third-party checks and must keep the hard-guardrail manual hold.
   // (Rebase-if-behind already ran above, so a red CI here is on the latest base — not a stale-base artifact.) (#ci-fail-closes-guarded)
-  const willClose = isContributor && acting("close") && (ciFailed || (!guardrailHit && (input.conclusion === "failure" || isConflict)));
+  const redVerifiedRequiredCi = ciFailed && input.ciRequiredContextsVerified === true;
+  const willClose = isContributor && acting("close") && (redVerifiedRequiredCi || (!guardrailHit && (ciFailed || input.conclusion === "failure" || isConflict)));
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules). A DETERMINISTIC verdict about the LINKED ISSUE
   // (owner-assigned / missing point-label / maintainer-only) — NOT an AI verdict, so there is no hallucination
   // to guard against: this close fires REGARDLESS of `guardrailHit`. It still only ever closes a CONTRIBUTOR

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -194,8 +194,20 @@ describe("planAgentMaintenanceActions (#778)", () => {
       // OBJECTIVE failure: the change cannot merge no matter what, so it closes even on a guarded path. The
       // contributor fixes CI and resubmits; a GREEN guarded resubmission is then held for review. conclusion is
       // 'neutral' here to prove it is the CI — not a verdict — driving the close.
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", pr: { labels: [] } })));
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", ciRequiredContextsVerified: true, pr: { labels: [] } })));
       expect(plan).toContain("close");
+    });
+
+    it("does NOT auto-close a guarded contributor PR when red CI comes from the unknown-required fallback", () => {
+      // When branch-protection required contexts cannot be fetched, ciState=failed may be caused by an optional
+      // or third-party status. Preserve the hard-guardrail hold unless required contexts were verified.
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", failingCheckNames: ["attacker/non-required-status"], ciRequiredContextsVerified: false, pr: { labels: [] } })));
+      expect(plan).not.toContain("close");
+    });
+
+    it("does NOT auto-close unknown changed paths with guardrails when red CI is not verified-required", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, changedPaths: [], hardGuardrailGlobs: ["src/scoring/**"], ciState: "failed", pr: { labels: [] } })));
+      expect(plan).not.toContain("close");
     });
 
     it("does NOT approve or auto-merge a passing PR on a guarded path", () => {

--- a/test/unit/agent-guardrail-paths.test.ts
+++ b/test/unit/agent-guardrail-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { changedPathsForGuardrail } from "../../src/queue/processors";
+import { changedPathsForGuardrail, hasVerifiedRequiredContexts } from "../../src/queue/processors";
 import type { PullRequestFileRecord } from "../../src/types";
 
 function file(path: string, previousFilename?: string | null): PullRequestFileRecord {
@@ -23,5 +23,19 @@ describe("changedPathsForGuardrail", () => {
 
   it("deduplicates current and previous filenames", () => {
     expect(changedPathsForGuardrail([file("scripts/deploy.sh", "scripts/deploy.sh")])).toEqual(["scripts/deploy.sh"]);
+  });
+});
+
+describe("hasVerifiedRequiredContexts (#1177)", () => {
+  it("verifies only a non-empty required-context set", () => {
+    expect(hasVerifiedRequiredContexts(new Set(["validate"]))).toBe(true);
+  });
+
+  it("does NOT verify when branch protection was unreadable (null)", () => {
+    expect(hasVerifiedRequiredContexts(null)).toBe(false);
+  });
+
+  it("does NOT verify when no contexts are required (empty set) — a red check is then optional/third-party", () => {
+    expect(hasVerifiedRequiredContexts(new Set())).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent guarded/hard-guardrail PRs from being auto-closed when `ciState="failed"` could be the result of fallback aggregation of non-required or third-party checks (required-context fetch failures). 
- Ensure the planner only lets a red CI bypass the hard-guardrail hold when the trigger proved the failing checks are required branch-protection contexts.

### Description
- Add a new planner input `ciRequiredContextsVerified?: boolean` to `AgentActionPlanInput` to signal that required-status-context data was successfully fetched and verified. 
- Change the close decision so a red CI only bypasses `guardrailHit` when `ciRequiredContextsVerified === true`; otherwise guarded/unknown-path PRs remain held. 
- Thread the verification flag from the queue processor into the planner (`ciRequiredContextsVerified: requiredContexts != null && requiredContexts.size > 0`).
- Add regression unit tests that cover: a guarded PR that closes when CI failure is verified-required, and guarded/unknown-path PRs that are NOT auto-closed when CI failure comes from the unknown-required fallback.

### Testing
- Ran unit tests for the modified logic with `npx vitest run test/unit/agent-actions.test.ts`, which passed (62 tests). 
- Type-check completed successfully with `npm run typecheck`. 
- Attempted coverage and full local gate: `npm run test:coverage` (coverage remapping failed with `TypeError: jsTokens is not a function` during V8->istanbul remap) and `npm run test:ci` (full gate); the full gate run exercised the suite but hit a long-running queue sweep test timeout and could not complete green in this environment. 
- `npm audit --audit-level=moderate` was attempted but the audit endpoint returned `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b63139078832cb8e3457f9fe98886)