### PR TITLE
fix(ci): treat absent required CI context as pending, not passed

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2014,6 +2014,10 @@ export async function fetchLiveCiAggregate(
   const nonRequiredFailingDetails: LiveCiAggregate["nonRequiredFailingDetails"] = [];
   let total = 0;
   let anyPending = false;
+  // Track which required context names actually appear in any API result. An absent required context
+  // (never queued, in-progress, or complete) has no entry to push anyPending — without this guard it
+  // would be silently ignored and ciState could become "passed" while it never ran.
+  const seenContextNames = enforceRequiredOnly ? new Set<string>() : null;
 
   // 1) Check-runs (GitHub Actions jobs, CodeQL, app checks).
   for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
@@ -2025,6 +2029,7 @@ export async function fetchLiveCiAggregate(
     ).catch(() => undefined);
     if (!result) break;
     for (const run of result.data.check_runs ?? []) {
+      seenContextNames?.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
       if (isOwnGitHubAppCheckRun(env, run)) continue; // never wait on the bot's own Gate/Context check-runs (see above)
       total += 1;
       const conclusion = (run.conclusion ?? "").toLowerCase();
@@ -2054,6 +2059,7 @@ export async function fetchLiveCiAggregate(
   for (const ctx of statusResult?.data.statuses ?? []) {
     const name = ctx.context ?? "status";
     total += 1;
+    seenContextNames?.add(name);
     const state = (ctx.state ?? "").toLowerCase();
     if (state === "failure" || state === "error") {
       const summary = typeof ctx.description === "string" ? ctx.description.trim().slice(0, 200) : "";
@@ -2063,6 +2069,15 @@ export async function fetchLiveCiAggregate(
       // passing
     } else if (isRequired(name)) {
       anyPending = true; // pending — only a REQUIRED context holds the gate
+    }
+  }
+
+  // A required context that never appeared in any result is not safe to treat as passed — count it as pending
+  // so the gate waits rather than approving a PR whose required CI never ran (e.g. a workflow that doesn't
+  // trigger on forks, or a check that was skipped).
+  if (seenContextNames) {
+    for (const ctx of requiredContexts!) {
+      if (!seenContextNames.has(ctx)) anyPending = true;
     }
   }
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2750,6 +2750,57 @@ describe("GitHub backfill", () => {
       expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "Gittensory Gate", summary: "External status failed" })]);
     });
 
+    it("treats a required context that never ran (absent from results) as pending, not passed", async () => {
+      // Bypass: requiredContexts = {"validate"}, but CI only returns non-required checks (e.g. CodeQL). The
+      // "validate" job never triggered (fork workflow skipped, matrix split, etc.). Without the absent-check
+      // guard, total > 0 (CodeQL passed) → ciState = "passed" even though the required check never ran.
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              // Only non-required checks ran — "validate" is absent.
+              { name: "CodeQL", status: "completed", conclusion: "success", app: { slug: "github-advanced-security" } },
+              { name: "Superagent Security Scan", status: "completed", conclusion: "success", app: { slug: "superagent" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["validate"]));
+
+      expect(aggregate.ciState).toBe("pending"); // required "validate" never ran — must not be "passed"
+      expect(aggregate.failingDetails).toEqual([]);
+    });
+
+    it("keeps bot-owned required contexts as seen (not absent) even though they are excluded from gate logic", async () => {
+      // The existing deadlock-avoidance test: bot-owned required contexts (Gate, Context) in in_progress are
+      // skipped from gate logic, but seenContextNames must still mark them to avoid the absent-check guard
+      // treating them as missing and re-introducing a false anyPending.
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) {
+          return Response.json({
+            check_runs: [
+              { name: "validate", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "Gittensory Gate", status: "in_progress", conclusion: null, app: { slug: "gittensory" } },
+            ],
+          });
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "sha", "tok", new Set(["validate", "Gittensory Gate"]));
+
+      // "Gittensory Gate" is a bot check: present in results (so not absent), excluded from gate logic → passed
+      expect(aggregate.ciState).toBe("passed");
+    });
+
   });
 
   describe("configuredRequiredCiContexts", () => {


### PR DESCRIPTION
## Summary

- Close a CI gate bypass: a required status context that never ran (no check-run or commit-status entry at all) had no path to set `anyPending` or push to `failingDetails` in `fetchLiveCiAggregate`. When other non-required checks were present (`total > 0`), the function returned `ciState = "passed"` even though the required check never executed — the gate would approve or auto-merge without it.
- Fix: build a `seenContextNames` set during iteration over check-runs and statuses. After both loops, any required context absent from the set sets `anyPending = true` so review stays deferred.
- Bot-owned required contexts (Gittensory Gate, Context) are marked "seen" **before** the `isOwnGitHubAppCheckRun` skip so the guard doesn't re-introduce false pending on the existing deadlock-avoidance path.

Realistic trigger: a workflow that doesn't fire on forks, a job that's conditionally skipped, or a branch-protection entry whose workflow name changed — all leave a required context absent while other non-required checks (CodeQL, dependency scan) push `total > 0`.

+2 targeted tests covering the bypass scenario and the bot-owned-stay-seen invariant.

No issue linked: focused security fix.