### PR TITLE
feat(gate): flag-gated duplicate-winner adjudication (#dup-winner)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -171,6 +171,16 @@ declare global {
      *  deploy). The cron/endpoint flags (ops / selftune / parity / content-lane / draft) are NOT scoped by
      *  this allowlist — they stay global. See src/review/cutover-gate.ts. */
     GITTENSORY_REVIEW_REPOS?: string;
+    /** Duplicate-winner adjudication (#dup-winner): when truthy, a same-issue duplicate cluster of OPEN PRs
+     *  spares exactly ONE winner — the EARLIEST opened = the LOWEST PR number among the OPEN siblings — instead
+     *  of gate-blocking + auto-closing every sibling. Only the LOSERS get the `duplicate_pr_risk` blocker, the
+     *  "duplicate of another open PR" close reason, the slop duplicate-cluster penalty, and the panel hard
+     *  duplicate block; the winner is judged on its OWN merits (CI / conflict / gate / linked-issue / slop).
+     *  Default OFF — unset/false ⇒ every duplicate sibling dies (today's behavior, byte-identical: the new
+     *  guards short-circuit so the advisory finding, gate conclusion, close reason, slop, and panels are
+     *  unchanged). Once a winner closes, the next-lowest OPEN sibling becomes the winner on re-eval. See
+     *  src/signals/duplicate-winner.ts. */
+    GITTENSORY_DUPLICATE_WINNER?: string;
   }
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -155,6 +155,7 @@ import {
   unionScopedOverlapClusters,
   type ContributorProfile,
 } from "../signals/engine";
+import { isDuplicateClusterWinner } from "../signals/duplicate-winner";
 import { buildUnifiedReviewDiff } from "../review/review-diff";
 import { buildUnifiedCommentBody, isUnifiedReviewCommentEnabled } from "../review/unified-comment-bridge";
 import { screenshotsAllowed } from "../review/visual-wire";
@@ -553,9 +554,10 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   const verdicts: Record<string, string> = {};
   const flaggedPulls: number[] = [];
   const sweepInstallationId = repo?.installationId ?? null;
+  const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
   for (const pr of candidates) {
     const others = openPullRequests.filter((other) => other.number !== pr.number);
-    const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests: others, requireLinkedIssue });
+    const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests: others, requireLinkedIssue, duplicateWinnerEnabled });
     const gate = evaluateGateCheck(advisory, gateCheckPolicy(settings, null, undefined, pr.slopRisk ?? null));
     verdicts[String(pr.number)] = gate.conclusion;
     if (gate.conclusion === "failure" || gate.conclusion === "action_required") flaggedPulls.push(pr.number);
@@ -706,7 +708,12 @@ async function maybeRunAgentMaintenance(
       reviewDecision: liveReviewDecision ?? pr.reviewDecision,
       slopRisk: pr.slopRisk,
       labels: pr.labels,
-      linkedDuplicateCount: linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests).length,
+      // Duplicate-winner adjudication (#dup-winner): the gate's open-only duplicate siblings drive the close
+      // reason ("duplicate of another open PR" via agent-actions when count > 0). When the flag is ON and this
+      // PR is the cluster winner, force the count to 0 so the winner's close reason OMITS the duplicate cause
+      // (it can still close on its own merits — CI/conflict/blockers). Flag-OFF short-circuits ⇒ the real
+      // count is used (byte-identical). The sibling numbers are open-only, so the lowest is the open winner.
+      linkedDuplicateCount: dupWinnerLinkedDuplicateCount(linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests), pr.number, env.GITTENSORY_DUPLICATE_WINNER === "true"),
       headSha: pr.headSha,
       mergeBlockedSha: pr.mergeBlockedSha,
       approvedHeadSha: pr.approvedHeadSha,
@@ -773,7 +780,11 @@ async function reReviewStoredPullRequest(
   // once the head is current and CI has settled (the sweep backstops a missed event).
   if (!(await prReadyForReview(env, installationId, repoFullName, pr, settings, deliveryId))) return;
   const otherOpenPullRequests = await listOtherOpenPullRequests(env, repoFullName, prNumber);
-  const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests, requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings) });
+  const advisory = buildPullRequestAdvisory(repo, pr, {
+    otherOpenPullRequests,
+    requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
+    duplicateWinnerEnabled: env.GITTENSORY_DUPLICATE_WINNER === "true",
+  });
   await persistAdvisory(env, advisory);
   if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
     await refreshPullRequestDetails(env, repoFullName, prNumber).catch(() => undefined);
@@ -1531,6 +1542,7 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       const advisory = buildPullRequestAdvisory(repo, pr, {
         otherOpenPullRequests,
         requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
+        duplicateWinnerEnabled: env.GITTENSORY_DUPLICATE_WINNER === "true",
       });
       await persistAdvisory(env, advisory);
       if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
@@ -1976,6 +1988,18 @@ export async function runAiSlopForAdvisory(
   }
 }
 
+/**
+ * Duplicate-winner adjudication (#dup-winner) seam for the close-reason disposition. Given a PR's open
+ * duplicate-sibling numbers (from {@link linkedIssueDuplicatePullRequestsForGate}, open-only), return the
+ * `linkedDuplicateCount` the agent planner reads. When the flag is ON and this PR is the cluster winner, return
+ * 0 so the winner's close reason OMITS the "duplicate of another open PR" cause (agent-actions only adds it
+ * when count > 0). Flag-OFF (default) returns the real sibling count — byte-identical to today.
+ */
+export function dupWinnerLinkedDuplicateCount(openSiblingNumbers: number[], prNumber: number, duplicateWinnerEnabled: boolean): number {
+  if (duplicateWinnerEnabled && isDuplicateClusterWinner(prNumber, openSiblingNumbers)) return 0;
+  return openSiblingNumbers.length;
+}
+
 function linkedIssueDuplicatePullRequestsForGate(pr: PullRequestRecord, pullRequests: PullRequestRecord[]): number[] {
   const linkedIssues = new Set(pr.linkedIssues);
   if (linkedIssues.size === 0) return [];
@@ -2173,6 +2197,13 @@ async function maybePublishPrPublicSurface(
       scopedOverlapCount: unionScopedOverlapClusters(collisions, pr, preflight.collisions).length,
     });
 
+    // Duplicate-winner adjudication (#dup-winner): compute the winner ONCE for this review run from the SAME
+    // open-only sibling source the gate uses, and thread the flag/result consistently into the slop penalty
+    // (below) and the public panel builders (further down) so they agree by construction. Flag-OFF (default)
+    // ⇒ duplicateWinnerEnabled is false and isDupWinner is false ⇒ every guard short-circuits (byte-identical).
+    const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
+    const isDupWinner = duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, linkedIssueDuplicatePullRequestsForGate(pr, repoPullRequests));
+
     if (gateEnabled && author && !publicSurfaceSkipped && !official) {
       official = await getCachedOfficialMinerDetection(env, author, {
         targetKey: `${repoFullName}#${pr.number}`,
@@ -2201,7 +2232,9 @@ async function maybePublishPrPublicSurface(
         changedFiles: slopFiles.map((file) => ({ path: file.path, additions: file.additions, deletions: file.deletions })),
         description: pr.body,
         // Reuse the collision report already built for this gate run so a duplicate-cluster PR is flagged (#563).
-        inDuplicateCluster: isPullRequestInDuplicateCluster(collisions, pr.number),
+        // Duplicate-winner adjudication (#dup-winner): the winner is judged on its OWN merits, so it is NOT
+        // penalized for the cluster. Flag-OFF ⇒ isDupWinner is false ⇒ byte-identical to today.
+        inDuplicateCluster: !isDupWinner && isPullRequestInDuplicateCluster(collisions, pr.number),
       });
       slopRisk = slop.slopRisk;
       advisory.findings.push(...slop.findings);
@@ -2420,7 +2453,11 @@ async function maybePublishPrPublicSurface(
     // Maintainer review-content overrides from `.gittensory.yml` (footer text, row toggles, intro note).
     // Cached, so this is a DB read after the settings resolution already loaded the manifest.
     const reviewConfig = (await loadRepoFocusManifest(env, repoFullName)).review;
-    const commentArgs = { repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation, review: reviewConfig, aiReview };
+    // Duplicate-winner adjudication (#dup-winner): thread the flag into the public panel builders so the
+    // winner's hard-duplicate block is suppressed (they recompute the winner from their own open-only sibling
+    // list). Flag-OFF (default) ⇒ false ⇒ the panels are byte-identical to today.
+    const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
+    const commentArgs = { repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation, review: reviewConfig, aiReview, duplicateWinnerEnabled };
     let deterministicBody: string;
     // Convergence (Stage D): when the unified-review-comment flag is ON, render the single converged comment
     // (gittensory shape + reviewbot's review folded in). The gate stays authoritative (passed as `decision`),
@@ -2441,7 +2478,7 @@ async function maybePublishPrPublicSurface(
     //   3. The `ai_consensus_defect` surfaces exactly ONCE — as the Code-review blocker — never also in the
     //      gate signal row (which renders only the conclusion-derived status text, not the defect string).
     if (unifiedCommentAllowed && gateEvaluation) {
-      const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation });
+      const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation, duplicateWinnerEnabled });
       // FIX B: the unified comment's file count + visual-capture path filter need the real diff — reuse the
       // shared resolver (one resolve per review; inline-fetches when stored is still empty pre-detail-sync).
       const unifiedFiles = await getReviewFiles();
@@ -2955,6 +2992,7 @@ async function buildAuthorizedPrActionAdvisory(
   const advisory = buildPullRequestAdvisory(repo, pr, {
     otherOpenPullRequests,
     requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
+    duplicateWinnerEnabled: env.GITTENSORY_DUPLICATE_WINNER === "true",
   });
   return { repo, advisory };
 }

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -10,6 +10,7 @@ import type {
   RepositoryRecord,
 } from "../types";
 import type { CollisionCluster, CollisionReport } from "../signals/engine";
+import { isDuplicateClusterWinner } from "../signals/duplicate-winner";
 import { nowIso } from "../utils/json";
 
 export type GateCheckConclusion = "success" | "failure" | "action_required" | "neutral" | "skipped";
@@ -80,7 +81,15 @@ export function buildRepositoryAdvisory(repo: RepositoryRecord | null, fullName:
 export function buildPullRequestAdvisory(
   repo: RepositoryRecord | null,
   pr: PullRequestRecord | null,
-  context: { otherOpenPullRequests?: PullRequestRecord[]; requireLinkedIssue?: boolean } = {},
+  context: {
+    otherOpenPullRequests?: PullRequestRecord[];
+    requireLinkedIssue?: boolean;
+    /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest
+     *  open sibling number), the `duplicate_pr_risk` finding is suppressed so the winner is not gate-blocked /
+     *  closed as a duplicate. Default/false ⇒ every duplicate sibling keeps the finding (byte-identical). The
+     *  caller sets this to `env.GITTENSORY_DUPLICATE_WINNER === "true"`. */
+    duplicateWinnerEnabled?: boolean;
+  } = {},
 ): Advisory {
   const repoFullName = pr?.repoFullName ?? repo?.fullName ?? "unknown/unknown";
   const targetKey = pr ? `${repoFullName}#${pr.number}` : `${repoFullName}#unknown`;
@@ -105,7 +114,7 @@ export function buildPullRequestAdvisory(
       action: "Re-deliver the webhook or wait for the next sync.",
     });
   } else {
-    addPullRequestFindings(repo, pr, findings, context.otherOpenPullRequests ?? [], Boolean(context.requireLinkedIssue));
+    addPullRequestFindings(repo, pr, findings, context.otherOpenPullRequests ?? [], Boolean(context.requireLinkedIssue), Boolean(context.duplicateWinnerEnabled));
   }
   return advisory("pull_request", targetKey, repoFullName, findings, "Pull request advisory generated.", pr?.number, undefined, pr?.headSha ?? undefined);
 }
@@ -481,6 +490,7 @@ function addPullRequestFindings(
   findings: AdvisoryFinding[],
   otherOpenPullRequests: PullRequestRecord[],
   requireLinkedIssue: boolean,
+  duplicateWinnerEnabled: boolean,
 ): void {
   if (pr.state !== "open") {
     findings.push({
@@ -502,7 +512,12 @@ function addPullRequestFindings(
     const overlappingPrs = otherOpenPullRequests.filter((otherPr) =>
       otherPr.linkedIssues.some((issueNumber) => pr.linkedIssues.includes(issueNumber)),
     );
-    if (overlappingPrs.length > 0) {
+    // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the cluster winner (the
+    // lowest open sibling number), SKIP the duplicate finding — suppressing it suppresses the gate failure, so
+    // the winner survives while the losers (which still see overlap > 0 and a lower sibling) keep the finding.
+    // `overlappingPrs` is derived from the OPEN-only `otherOpenPullRequests`, so the numbers are open siblings.
+    // Flag-OFF (default) short-circuits ⇒ the finding is pushed exactly as before (byte-identical).
+    if (overlappingPrs.length > 0 && !(duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, overlappingPrs.map((otherPr) => otherPr.number)))) {
       findings.push({
         code: "duplicate_pr_risk",
         severity: "warning",

--- a/src/signals/duplicate-winner.ts
+++ b/src/signals/duplicate-winner.ts
@@ -1,0 +1,30 @@
+/**
+ * Duplicate-winner adjudication (#dup-winner). Flag-gated by GITTENSORY_DUPLICATE_WINNER.
+ *
+ * When several OPEN PRs link the same issue (a duplicate cluster), the legacy behavior gate-blocks +
+ * auto-closes EVERY sibling as a duplicate — no winner survives. With the flag ON, exactly ONE winner is
+ * spared: the EARLIEST opened = the LOWEST PR number among the OPEN siblings. Only the LOSERS are
+ * blocked/closed; the winner still must pass CI / conflict / gate / linked-issue / slop on its OWN merits.
+ *
+ * This module is PURE — no IO, no Date, no random — so the same inputs always yield the same verdict and the
+ * caller can compute the winner ONCE per review run and thread the result boolean consistently into every
+ * surface (advisory finding, close reason, slop, panels), so they agree by construction.
+ *
+ * INVARIANT (the caller MUST honor it): {@link openSiblingNumbers} carries OPEN-only sibling PR numbers. The
+ * existing sources (advisory `overlappingPrs`, gate `linkedIssueDuplicatePullRequestsForGate`, engine
+ * `linkedIssueDuplicatePullRequests`) already exclude closed/merged PRs, so the lowest number is the lowest
+ * OPEN number. Once the winner closes (e.g. red CI), it leaves the open set and the next-lowest OPEN sibling
+ * becomes the winner on re-eval — no permanently-orphaned cluster.
+ */
+
+/**
+ * True iff `prNumber` is the cluster winner: the minimum of `{prNumber} ∪ openSiblingNumbers`. An empty
+ * sibling list ⇒ the PR is alone in (or out of) the cluster ⇒ winner. A sibling list that happens to contain
+ * `prNumber` itself is harmless — the comparison is still min-based.
+ */
+export function isDuplicateClusterWinner(prNumber: number, openSiblingNumbers: number[]): boolean {
+  for (const sibling of openSiblingNumbers) {
+    if (sibling < prNumber) return false;
+  }
+  return true;
+}

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -27,6 +27,7 @@ import { nowIso } from "../utils/json";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { projectLinkedIssueMultiplierForPlannedSolve, type LinkedIssueMultiplierStatus } from "../scoring/preview";
 import { hasLocalTestEvidence } from "./test-evidence";
+import { isDuplicateClusterWinner } from "./duplicate-winner";
 import { PREFLIGHT_LIMITS } from "./preflight-limits";
 import type { UnifiedCollapsible } from "../review/unified-comment";
 
@@ -4151,6 +4152,10 @@ export function buildPublicPrIntelligenceComment(args: {
   review?: FocusManifestReviewConfig | undefined;
   /** Optional AI maintainer-review notes (already public-safe). Rendered as an advisory section. */
   aiReview?: { notes: string } | undefined;
+  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest open
+   *  sibling number among `linkedDuplicatePrs`), the hard-duplicate panel block is suppressed so the winner's
+   *  panel does not show a blocking duplicate. Default/false ⇒ byte-identical to today. */
+  duplicateWinnerEnabled?: boolean | undefined;
 }): string {
   const publicFindings = publicSafePreflightFindings(args.preflight, args.settings);
   const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
@@ -4178,7 +4183,13 @@ export function buildPublicPrIntelligenceComment(args: {
   const gateEnabled = args.settings.gateCheckMode === "enabled";
   const hardLinkedIssueBlock =
     args.settings.linkedIssueGateMode === "block" && args.pr.linkedIssues.length === 0 && !hasClearNoIssueRationale(args.pr);
-  const hardDuplicateBlock = args.settings.duplicatePrGateMode === "block" && linkedDuplicatePrs.length > 0;
+  // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the cluster winner (the
+  // lowest open sibling number), do NOT hard-block it as a duplicate — only the losers block. `linkedDuplicatePrs`
+  // is open-only (collision clusters exclude closed PRs). Flag-OFF (default) short-circuits ⇒ byte-identical.
+  const hardDuplicateBlock =
+    args.settings.duplicatePrGateMode === "block" &&
+    linkedDuplicatePrs.length > 0 &&
+    !(args.duplicateWinnerEnabled && isDuplicateClusterWinner(args.pr.number, linkedDuplicatePrs));
   const fallbackGateConclusion = !gateEnabled
     ? "success"
     : !args.repo
@@ -4376,6 +4387,10 @@ export function buildPublicPrPanelSignalRows(args: {
   preflight: PreflightResult;
   settings: RepositorySettings;
   gate?: PublicPrPanelGateEvaluation | undefined;
+  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest open
+   *  sibling number among `linkedDuplicatePrs`), the hard-duplicate block is suppressed. Default/false ⇒
+   *  byte-identical to today. Matches `buildPublicPrIntelligenceComment` so both panels agree. */
+  duplicateWinnerEnabled?: boolean | undefined;
 }): { rows: PublicPrPanelSignalRow[]; readinessTotal: number } {
   const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
   const linkedDuplicatePrs = linkedIssueDuplicatePullRequests(args.pr, prCollisionClusters);
@@ -4386,7 +4401,12 @@ export function buildPublicPrPanelSignalRows(args: {
   const relatedWorkResult = relatedWorkPanelResult(linkedDuplicatePrs, scopedOverlapCount);
   const gateEnabled = args.settings.gateCheckMode === "enabled";
   const hardLinkedIssueBlock = args.settings.linkedIssueGateMode === "block" && args.pr.linkedIssues.length === 0 && !hasClearNoIssueRationale(args.pr);
-  const hardDuplicateBlock = args.settings.duplicatePrGateMode === "block" && linkedDuplicatePrs.length > 0;
+  // Duplicate-winner adjudication (#dup-winner): suppress the winner's hard-duplicate block (see the comment
+  // builder). `linkedDuplicatePrs` is open-only; flag-OFF (default) short-circuits ⇒ byte-identical to today.
+  const hardDuplicateBlock =
+    args.settings.duplicatePrGateMode === "block" &&
+    linkedDuplicatePrs.length > 0 &&
+    !(args.duplicateWinnerEnabled && isDuplicateClusterWinner(args.pr.number, linkedDuplicatePrs));
   const fallbackGateConclusion = !gateEnabled ? "success" : !args.repo ? "neutral" : hardLinkedIssueBlock || hardDuplicateBlock ? "failure" : "success";
   const gateConclusion = args.gate?.conclusion ?? fallbackGateConclusion;
   const confirmedMiner = isOfficialContributorDetection(args.detection);

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -137,6 +137,20 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, pr: { labels: [], slopRisk: 90 } })))).not.toContain("close");
   });
 
+  it("#dup-winner disposition seam: the close reason includes the duplicate cause only when linkedDuplicateCount > 0", () => {
+    // Loser path (count > 0, the caller's real count): the duplicate cause IS cited in the close reason.
+    const loser = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], pr: { labels: [], linkedDuplicateCount: 2 } }));
+    const loserClose = loser.find((a) => a.actionClass === "close")!;
+    expect(loserClose.reason).toContain("duplicate of another open PR");
+
+    // Winner path (count forced to 0 by dupWinnerLinkedDuplicateCount): the PR STILL closes on its own merits
+    // (the gate failure), but the close reason OMITS the duplicate cause.
+    const winner = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], pr: { labels: [], linkedDuplicateCount: 0 } }));
+    const winnerClose = winner.find((a) => a.actionClass === "close")!;
+    expect(classes(winner)).toContain("close");
+    expect(winnerClose.reason).not.toContain("duplicate of another open PR");
+  });
+
   it("never plans both merge and close", () => {
     const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", close: "auto" }, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED", slopRisk: 95 } }));
     const cls = classes(plan);

--- a/test/unit/duplicate-winner.test.ts
+++ b/test/unit/duplicate-winner.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isDuplicateClusterWinner } from "../../src/signals/duplicate-winner";
+import { dupWinnerLinkedDuplicateCount } from "../../src/queue/processors";
+
+describe("isDuplicateClusterWinner (#dup-winner)", () => {
+  it("the lowest open sibling number wins", () => {
+    expect(isDuplicateClusterWinner(12, [13, 14])).toBe(true);
+  });
+
+  it("a lower open sibling beats this PR (loser)", () => {
+    expect(isDuplicateClusterWinner(14, [12, 13])).toBe(false);
+  });
+
+  it("an empty sibling list ⇒ winner (alone in/out of the cluster)", () => {
+    expect(isDuplicateClusterWinner(7, [])).toBe(true);
+  });
+
+  it("a sibling list that contains self is still min-based (winner when self is lowest)", () => {
+    expect(isDuplicateClusterWinner(12, [12, 13])).toBe(true);
+  });
+
+  it("a sibling list that contains self plus a lower sibling ⇒ loser", () => {
+    expect(isDuplicateClusterWinner(13, [12, 13])).toBe(false);
+  });
+
+  it("cascade: once the lowest sibling closes (drops out of the open set), the next-lowest becomes the winner", () => {
+    // Cluster {12, 13, 14}. PR 13 is a loser while 12 is still open.
+    expect(isDuplicateClusterWinner(13, [12, 14])).toBe(false);
+    // PR 12 closes (red CI) → it leaves the OPEN sibling set the caller passes. Re-eval of PR 13 now sees only
+    // {14} as the open sibling → 13 is the new winner. No permanently-orphaned cluster.
+    expect(isDuplicateClusterWinner(13, [14])).toBe(true);
+  });
+});
+
+describe("dupWinnerLinkedDuplicateCount (#dup-winner close-reason seam)", () => {
+  it("winner + flag ON ⇒ 0 (close reason omits the duplicate cause)", () => {
+    expect(dupWinnerLinkedDuplicateCount([13, 14], 12, true)).toBe(0);
+  });
+
+  it("loser + flag ON ⇒ real sibling count (close reason includes the duplicate cause)", () => {
+    expect(dupWinnerLinkedDuplicateCount([12, 13], 14, true)).toBe(2);
+  });
+
+  it("flag OFF ⇒ real sibling count even for a would-be winner (byte-identical)", () => {
+    expect(dupWinnerLinkedDuplicateCount([13, 14], 12, false)).toBe(2);
+  });
+
+  it("no siblings ⇒ 0 regardless of the flag", () => {
+    expect(dupWinnerLinkedDuplicateCount([], 12, true)).toBe(0);
+    expect(dupWinnerLinkedDuplicateCount([], 12, false)).toBe(0);
+  });
+});

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -5386,6 +5386,125 @@ describe("queue processors", () => {
     expect(refreshedFiles).toHaveLength(1);
   });
 
+  it("#dup-winner: flag ON spares the lowest open sibling — no duplicate block, slop not penalized for the cluster", async () => {
+    // GITTENSORY_DUPLICATE_WINNER ON. A same-issue cluster of OPEN PRs (#91 winner, #92 loser) under
+    // duplicatePrGateMode: block. The winner (#91, lowest open number) must NOT be gate-blocked or slop-
+    // penalized as a duplicate — it is judged on its own merits. This drives the flag-ON branch of the
+    // processors gate path (isDupWinner) + the advisory duplicate-finding suppression.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_DUPLICATE_WINNER: "true" });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      duplicatePrGateMode: "block",
+      slopGateMode: "advisory",
+    });
+    // The shared issue + the HIGHER-numbered open sibling (#92) → forms the same-issue duplicate cluster.
+    await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 92, title: "Also fix the cache", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib92" }, labels: [], body: "Fixes #1" });
+
+    let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/91/files")) return Response.json([{ filename: "src/cache.ts", status: "modified", additions: 12, deletions: 0, changes: 12 }]);
+      if (url.includes("/commits/win91/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "PATCH") {
+        gatePatchBody = JSON.parse(String(init?.body ?? "{}")) as typeof gatePatchBody;
+        return Response.json({ id: 960 });
+      }
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 960 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "dup-winner-on",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    // Winner survives: the Gate did not fail on a duplicate block.
+    expect(gatePatchBody.conclusion).not.toBe("failure");
+    // The persisted advisory for the winner OMITS the duplicate finding (suppressed) — that is what suppresses
+    // the gate failure and the auto-close duplicate cause.
+    const winnerAdvisory = await env.DB.prepare("select findings_json from advisories where target_type = 'pull_request' and repo_full_name = ? and pull_number = ?").bind("JSONbored/gittensory", 91).first<{ findings_json: string }>();
+    expect(winnerAdvisory?.findings_json ?? "").not.toContain("duplicate_pr_risk");
+  });
+
+  it("#dup-winner: flag OFF keeps every same-issue sibling blocked (byte-identical) — the winner is also closed-eligible", async () => {
+    // Same cluster, flag OFF (default). The lowest open PR (#91) STILL gets the duplicate block + finding,
+    // exactly like today — no winner is spared.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      duplicatePrGateMode: "block",
+      slopGateMode: "advisory",
+    });
+    await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 92, title: "Also fix the cache", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib92b" }, labels: [], body: "Fixes #1" });
+
+    let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/91/files")) return Response.json([{ filename: "src/cache.ts", status: "modified", additions: 12, deletions: 0, changes: 12 }]);
+      if (url.includes("/commits/win91b/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "PATCH") {
+        gatePatchBody = JSON.parse(String(init?.body ?? "{}")) as typeof gatePatchBody;
+        return Response.json({ id: 961 });
+      }
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 961 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "dup-winner-off",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91b" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    // Flag OFF: the duplicate block still fires for the lowest sibling — the Gate fails, the finding persists.
+    expect(gatePatchBody.conclusion).toBe("failure");
+    const winnerAdvisory = await env.DB.prepare("select findings_json from advisories where target_type = 'pull_request' and repo_full_name = ? and pull_number = ?").bind("JSONbored/gittensory", 91).first<{ findings_json: string }>();
+    expect(winnerAdvisory?.findings_json ?? "").toContain("duplicate_pr_risk");
+  });
+
   it("overrides the Gate to neutral for THIS commit only when a real write/admin maintainer runs gate-override", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -120,6 +120,82 @@ describe("advisory rules", () => {
     expect(advisory.findings.map((finding) => finding.code)).toContain("duplicate_pr_risk");
   });
 
+  it("#dup-winner: flag ON + winner (lowest open PR) ⇒ NO duplicate finding (gate success)", () => {
+    const winner: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 12,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: [],
+      linkedIssues: [4],
+    };
+    const higherSibling: PullRequestRecord = { ...winner, number: 13, title: "Alternative registry sync" };
+
+    const advisory = buildPullRequestAdvisory(repo, winner, { otherOpenPullRequests: [higherSibling], duplicateWinnerEnabled: true });
+
+    expect(advisory.findings.map((finding) => finding.code)).not.toContain("duplicate_pr_risk");
+  });
+
+  it("#dup-winner: flag ON + loser (a lower open sibling exists) ⇒ duplicate finding present", () => {
+    const loser: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 13,
+      title: "Alternative registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: [],
+      linkedIssues: [4],
+    };
+    const lowerSibling: PullRequestRecord = { ...loser, number: 12, title: "Add registry sync" };
+
+    const advisory = buildPullRequestAdvisory(repo, loser, { otherOpenPullRequests: [lowerSibling], duplicateWinnerEnabled: true });
+
+    expect(advisory.findings.map((finding) => finding.code)).toContain("duplicate_pr_risk");
+  });
+
+  it("#dup-winner: flag OFF + would-be-winner ⇒ duplicate finding STILL present (byte-identical)", () => {
+    const wouldBeWinner: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 12,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: [],
+      linkedIssues: [4],
+    };
+    const higherSibling: PullRequestRecord = { ...wouldBeWinner, number: 13, title: "Alternative registry sync" };
+
+    const advisory = buildPullRequestAdvisory(repo, wouldBeWinner, { otherOpenPullRequests: [higherSibling], duplicateWinnerEnabled: false });
+
+    expect(advisory.findings.map((finding) => finding.code)).toContain("duplicate_pr_risk");
+  });
+
+  it("#dup-winner: flag ON + no overlap ⇒ no duplicate finding (alone in cluster)", () => {
+    const lonePr: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 12,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: [],
+      linkedIssues: [4],
+    };
+    const unrelated: PullRequestRecord = { ...lonePr, number: 13, title: "Unrelated change", linkedIssues: [99] };
+
+    const advisory = buildPullRequestAdvisory(repo, lonePr, { otherOpenPullRequests: [unrelated], duplicateWinnerEnabled: true });
+
+    expect(advisory.findings.map((finding) => finding.code)).not.toContain("duplicate_pr_risk");
+  });
+
   it("keeps weak queue warnings advisory-only for the opt-in gate", () => {
     const pr: PullRequestRecord = {
       repoFullName: repo.fullName,

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -747,6 +747,53 @@ describe("signal coverage edge cases", () => {
     expect(duplicateBlocked.rows.find((r) => r.key === "gateResult")!.cells[1]).not.toBe(providedGate.cells[1]);
   });
 
+  it("#dup-winner: panel hard-duplicate block is suppressed for the winner, kept for the loser, byte-identical when flag OFF", () => {
+    const directRepo = repo("owner/dupwin");
+    const dupIssue = issue(directRepo.fullName, 42, "Cache invalidation race");
+    // Two open PRs on the same issue: 70 is the lowest open number (the winner), 88 is the loser.
+    const winnerPr = pr(directRepo.fullName, 70, "Fix the cache race", { authorLogin: "miner", linkedIssues: [42], body: "Fixes #42" });
+    const loserPr = pr(directRepo.fullName, 88, "Also fixes the cache race", { authorLogin: "other", linkedIssues: [42], body: "Fixes #42" });
+    const collisions = buildCollisionReport(directRepo.fullName, [dupIssue], [winnerPr, loserPr]);
+    const queueHealth = buildQueueHealth(directRepo, [dupIssue], [winnerPr, loserPr], collisions);
+    const blockSettings = { ...repoSettings(directRepo.fullName), gateCheckMode: "enabled" as const, duplicatePrGateMode: "block" as const };
+    const profile = buildContributorProfile("miner", { login: "miner", topLanguages: ["TypeScript"], source: "github" }, [], []);
+    const detection = { detected: true, source: "official_gittensor_api" as const, reason: "Confirmed.", priorPullRequests: 1, priorMergedPullRequests: 0, priorIssues: 0 };
+    const preflightFor = (target: PullRequestRecord) =>
+      buildPreflightResult({ repoFullName: directRepo.fullName, title: target.title, body: target.body ?? undefined, linkedIssues: target.linkedIssues }, directRepo, [dupIssue], [winnerPr, loserPr]);
+    const baseFor = (target: PullRequestRecord) => ({
+      repo: directRepo,
+      pr: target,
+      profile,
+      detection,
+      queueHealth,
+      collisions,
+      preflight: preflightFor(target),
+      settings: blockSettings,
+    });
+    const gateCell = (args: Parameters<typeof buildPublicPrPanelSignalRows>[0]) =>
+      buildPublicPrPanelSignalRows(args).rows.find((r) => r.key === "gateResult")!.cells[1];
+
+    // Flag OFF: BOTH the winner and the loser hard-block (today's behavior, byte-identical).
+    const offWinner = gateCell(baseFor(winnerPr));
+    const offLoser = gateCell(baseFor(loserPr));
+    expect(offWinner).toBe(offLoser);
+
+    // Flag ON: the winner is NOT blocked (its gate cell differs from the blocked loser's), the loser still blocks.
+    const onWinner = gateCell({ ...baseFor(winnerPr), duplicateWinnerEnabled: true });
+    const onLoser = gateCell({ ...baseFor(loserPr), duplicateWinnerEnabled: true });
+    expect(onWinner).not.toBe(offWinner);
+    expect(onLoser).toBe(offLoser);
+
+    // The comment builder must agree by construction: ON winner is NOT a blocking-merge panel; ON loser is.
+    const winnerComment = buildPublicPrIntelligenceComment({ ...baseFor(winnerPr), duplicateWinnerEnabled: true });
+    const loserComment = buildPublicPrIntelligenceComment({ ...baseFor(loserPr), duplicateWinnerEnabled: true });
+    expect(winnerComment).not.toContain("Gittensory Gate is blocking merge");
+    expect(loserComment).toContain("Gittensory Gate is blocking merge");
+    // Flag OFF on the winner is byte-identical to a blocking panel (today's behavior).
+    const offWinnerComment = buildPublicPrIntelligenceComment(baseFor(winnerPr));
+    expect(offWinnerComment).toContain("Gittensory Gate is blocking merge");
+  });
+
   it("renders opt-in gate panel states for collision and repo evaluation blockers", () => {
     const directRepo = repo("owner/gate");
     const existingIssue = issue(directRepo.fullName, 7, "Cache refresh websocket reconnect failure");

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,6 +124,12 @@
     // Granting the App `administration:read` makes the live (per-repo) read succeed and reduces this to a
     // transient-failure safety net. Names MUST match the exact check contexts. See src/github/backfill.ts.
     "GITTENSORY_REQUIRED_CI_CONTEXTS": "Superagent Security Scan,validate,Gittensory Gate",
+    // Duplicate-winner adjudication (#dup-winner): when a same-issue cluster of OPEN PRs forms, spare exactly
+    // ONE winner — the lowest-numbered (earliest opened) open PR — instead of blocking/closing every sibling.
+    // Only the LOSERS get the duplicate blocker + close reason + slop penalty + panel block; the winner is
+    // judged on its own merits. DEFAULT OFF — flag-OFF every duplicate sibling dies (today's behavior,
+    // byte-identical). See src/signals/duplicate-winner.ts.
+    "GITTENSORY_DUPLICATE_WINNER": "false",
   },
   "routes": [
     {


### PR DESCRIPTION
## Summary

Adds **duplicate-winner adjudication** as a flag-gated, default-OFF, byte-identical-when-off change. Today, when several OPEN PRs link the same issue (a duplicate cluster), EVERY sibling is gate-blocked + auto-closed as a duplicate — no winner survives. With `GITTENSORY_DUPLICATE_WINNER` ON, exactly ONE winner is spared: the **earliest opened = the lowest PR number** among the OPEN siblings. Only the LOSERS are blocked/closed. The winner still must pass CI / conflict / gate / linked-issue / slop on its own merits.

Default OFF preserves today's behavior exactly (every duplicate sibling dies).

## What changed

- **New pure module** `src/signals/duplicate-winner.ts` — `isDuplicateClusterWinner(prNumber, openSiblingNumbers)` = true iff `prNumber` is the minimum of `{prNumber} ∪ openSiblingNumbers` (empty siblings ⇒ winner). No IO / Date / random. Callers pass OPEN-only sibling numbers (confirmed: advisory `overlappingPrs` and `linkedIssueDuplicatePullRequestsForGate` exclude closed PRs; `buildCollisionReport` filters to open PRs).
- **New env flag** `GITTENSORY_DUPLICATE_WINNER` (default `"false"`) added to `wrangler.jsonc` "vars" + typed in `src/env.d.ts` with a convergence-style doc comment. (cf-typegen NOT run; `worker-configuration.d.ts` NOT committed — this repo types env vars in `src/env.d.ts`.)
- **`src/rules/advisory.ts`** (the real kill path): `buildPullRequestAdvisory` context accepts `duplicateWinnerEnabled`; the `duplicate_pr_risk` finding push is guarded so it is SKIPPED for the winner. Suppressing the finding suppresses the gate FAILURE → the winner is not closed.
- **`src/queue/processors.ts`**: computes the winner once per review run from the same open-only source the gate uses; threads it into (1) the advisory call sites (4 sites), (2) `linkedDuplicateCount` (0 for the winner via the new exported `dupWinnerLinkedDuplicateCount`, so `agent-actions` omits the duplicate close cause), (3) slop `inDuplicateCluster` (`!isDupWinner && …`), and (4) both public panel builders.
- **`src/signals/engine.ts`**: `buildPublicPrIntelligenceComment` + `buildPublicPrPanelSignalRows` accept `duplicateWinnerEnabled` and AND `!(… && isDuplicateClusterWinner(…))` into both `hardDuplicateBlock` conditions, so the winner's panel is honest. `settings-preview.ts` (a sample/preview surface with no live cluster context) leaves the flag unset → byte-identical (the documented "pass false" choice).

Flag OFF ⇒ every guard short-circuits ⇒ advisory finding, gate conclusion, close reason, slop, and panels are identical to today. Once a winner closes (e.g. red CI), it leaves the open set and the next-lowest OPEN sibling becomes the winner on re-eval — no permanently-orphaned cluster.

## Validation

Run from the repo root (fresh worktree, `npm ci` first):

- `git diff --check` → no whitespace errors
- `npm run typecheck` → clean
- `npm run test:coverage` (full unsharded backend suite) → **216 files passed / 1 skipped, 3652 tests passed / 1 skipped**
- `npm run test:workers` → 1 passed
- `npm audit --audit-level=moderate` → **0 vulnerabilities**
- Patch coverage: inspected `coverage/lcov.info` — **no `DA:<line>,0`** on any changed line, and **every new branch (`BRDA`) is taken on both/all arms** (advisory L520, engine L4192/L4409, processors L1999/L2205/L2237, duplicate-winner L27).

New tests: `test/unit/duplicate-winner.test.ts` (lowest wins / lower sibling loses / empty ⇒ winner / self-in-list / cascade + the `dupWinnerLinkedDuplicateCount` seam); advisory winner/loser/flag-OFF/no-overlap (`rules.test.ts`); panel winner/loser/flag-OFF (`signals-coverage.test.ts`); close-reason disposition seam (`agent-actions.test.ts`); flag-ON + flag-OFF end-to-end gate paths over a real duplicate cluster (`queue.test.ts`).

Linked issue: none — this is an owner-authored feature change (flag-gated, default-OFF) with no tracking issue; not a fix for a filed bug.
