### PR TITLE
fix(review): fail closed when the block-mode AI review is inconclusive

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1911,6 +1911,16 @@ export async function runAiReviewForAdvisory(
         detail: "One AI reviewer independently flagged a concrete must-fix defect in this change (the other did not). Under the quorum rule, a single rejection closes the PR; see the review notes for specifics.",
         action: "Resolve the flagged defect and open a new pull request, or override if the reviewers are mistaken.",
       });
+    } else if (result.inconclusive) {
+      // Fail-CLOSED (#ai-fail-closed): block-mode AI could not return a usable verdict. Hold the PR for a human
+      // (an evaluation-blocker code → neutral gate) rather than letting it pass to auto-merge uncertified.
+      args.advisory.findings.push({
+        code: "ai_review_inconclusive",
+        severity: "warning",
+        title: "AI review could not be completed",
+        detail: "The dual-model AI review did not return a usable verdict for this change.",
+        action: "The gate is held for a human reviewer rather than passed automatically; it re-evaluates on the next update.",
+      });
     }
     return result.advisoryNotes ? { notes: result.advisoryNotes, reviewerCount: result.reviewerCount } : undefined;
   } catch (error) {

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -351,6 +351,19 @@ export function evaluateGateCheck(advisoryResult: Advisory, policy: GateCheckPol
       warnings,
     };
   }
+  // Fail-CLOSED AI hold (#ai-fail-closed): the block-mode AI review could not return a usable verdict, so the
+  // gate is HELD (neutral) for a human rather than passed automatically. NEVER a failure → a contributor PR is
+  // never auto-CLOSED because an AI model hiccupped; it re-evaluates on the next update.
+  if (advisoryResult.findings.some((finding) => finding.code === "ai_review_inconclusive")) {
+    return {
+      enabled: true,
+      conclusion: "neutral",
+      title: "Gittensory Gate — held for human review",
+      summary: "The AI review could not be completed for this change, so the gate is held for a human reviewer rather than passed automatically. It re-evaluates on the next update.",
+      blockers: [],
+      warnings,
+    };
+  }
   // Merge-readiness composite (#551): when set, escalate every sub-gate to its mode so they roll into one
   // pass/fail. When off, this is a no-op and each sub-gate keeps its own mode.
   const effective = applyMergeReadinessGate(policy);

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -33,8 +33,6 @@ export const RELIABLE_FALLBACK_MODELS: readonly [string, string] = [
   "@cf/mistralai/mistral-small-3.1-24b-instruct",
 ];
 
-/** Default consensus confidence floor: BOTH models must be at/above this to report a defect. */
-export const AI_CONSENSUS_FLOOR = 0.9;
 
 const REVIEW_SYSTEM_PROMPT = [
   "You are a senior open-source maintainer giving a FOCUSED, high-signal code review of a single pull request diff.",
@@ -99,7 +97,7 @@ export type GittensoryAiReviewResult =
   | { status: "disabled"; reason: string }
   | { status: "unavailable"; reason: string }
   | { status: "quota_exceeded"; estimatedNeurons: number; remainingBudget: number }
-  | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; split: boolean; estimatedNeurons: number; reviewerCount: number };
+  | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; split: boolean; inconclusive: boolean; estimatedNeurons: number; reviewerCount: number };
 
 type ModelReview = {
   assessment: string;
@@ -396,10 +394,10 @@ export function composeAdvisoryNotes(reviews: ModelReview[]): string | null {
 }
 
 /** A CONSENSUS defect = BOTH reviews independently name at least one concrete blocker (the severity-disciplined
- *  reviewbot model: a lone blocker in a dual review is a split, not a hard block). `floor` retained for the
- *  caller signature; the consensus here is blocker PRESENCE in both reviews (the prompt's rubric keeps nits out). */
-export function consensusDefectOf(a: ModelReview, b: ModelReview, floor: number): AiConsensusDefect | null {
-  void floor;
+ *  reviewbot model: a lone blocker in a dual review is a split, not a hard block). Requiring two independent
+ *  models to AGREE is itself the precision mechanism — the free Workers-AI models emit no calibrated confidence
+ *  score, so there is no numeric floor to enforce; agreement is the signal. */
+export function consensusDefectOf(a: ModelReview, b: ModelReview): AiConsensusDefect | null {
   if (a.blockers.length === 0 || b.blockers.length === 0) return null;
   const title = toPublicSafe(a.blockers[0] || b.blockers[0] || "AI reviewers agree on a likely blocking defect");
   if (!title) return null; // unsafe title → drop the block entirely (fail-safe)
@@ -481,6 +479,7 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   let consensusDefect: AiConsensusDefect | null = null;
   let secondReview: ModelReview | null = null;
   let aiReviewSplit = false;
+  let inconclusive = false;
   if (input.mode === "block") {
     // Consensus blocker ALWAYS uses the free Workers-AI pair (provider-independent, never BYOK).
     const [a, b] = await Promise.all([
@@ -488,25 +487,33 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
       runWorkersOpinion(env, BEST_REVIEW_MODELS[1], RELIABLE_FALLBACK_MODELS[1], system, user, maxTokens),
     ]);
     secondReview = b;
+    // Fail-CLOSED: block mode requires BOTH independent reviews. If a model errored or returned unparseable
+    // output (a/b null), we cannot certify the change — signal `inconclusive` so the gate HOLDS the PR for a
+    // human instead of silently passing it through to auto-merge. A clean dual review (both present, no
+    // blocker) is NOT inconclusive and still passes normally.
     if (a && b) {
-      consensusDefect = consensusDefectOf(a, b, AI_CONSENSUS_FLOOR);
+      consensusDefect = consensusDefectOf(a, b);
       // SPLIT = the two reviewers DISAGREE (exactly one named a blocker). Lower confidence than a clean consensus,
       // so the gate HOLDS it for review instead of auto-merging (only when there is no real consensus defect —
       // a consensus is the stronger signal and blocks on its own). (#ai-review-split)
       aiReviewSplit = !consensusDefect && (a.blockers.length > 0) !== (b.blockers.length > 0);
+    } else {
+      inconclusive = true;
     }
   }
 
   const reviewsForNotes = [advisoryReview, secondReview].filter((r): r is ModelReview => Boolean(r));
   const advisoryNotes = reviewsForNotes.length > 0 ? composeAdvisoryNotes(reviewsForNotes) : null;
 
-  await record(env, input, "ok", estimatedNeurons, consensusDefect ? "consensus defect" : advisoryNotes ? "advisory notes" : "no usable output", {
+  await record(env, input, "ok", estimatedNeurons, consensusDefect ? "consensus defect" : aiReviewSplit ? "split" : inconclusive ? "inconclusive — held" : advisoryNotes ? "advisory notes" : "no usable output", {
     mode: input.mode,
     byok: Boolean(input.providerKey),
     consensus: Boolean(consensusDefect),
+    split: aiReviewSplit,
+    inconclusive,
     ...(byokFailure ? { byokFailure } : {}),
   });
-  return { status: "ok", advisoryNotes, consensusDefect, split: aiReviewSplit, estimatedNeurons, reviewerCount: reviewsForNotes.length };
+  return { status: "ok", advisoryNotes, consensusDefect, split: aiReviewSplit, inconclusive, estimatedNeurons, reviewerCount: reviewsForNotes.length };
 }
 
 async function record(

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildAiReviewDiff, runAiReviewForAdvisory } from "../../src/queue/processors";
+import { BEST_REVIEW_MODELS } from "../../src/services/ai-review";
 import { upsertRepositoryAiKey } from "../../src/db/repositories";
 import type { Advisory, PullRequestFileRecord, RepositorySettings } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
@@ -116,6 +117,23 @@ describe("runAiReviewForAdvisory", () => {
     expect(adv.findings.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
     expect(adv.findings[0]?.title).toContain("Null deref");
     expect(result?.notes).toContain("Likely crash.");
+  });
+
+  it("appends an ai_review_inconclusive finding (fail-closed hold) when block-mode AI lacks a second opinion", async () => {
+    const adv = advisory();
+    // The first slot parses; the second slot's primary AND its reliable fallback fail → no consensus possible.
+    const run = (async (model: string) => ({ response: model === BEST_REVIEW_MODELS[0] ? notesOnlyJson() : "garbage" })) as unknown as () => Promise<unknown>;
+    const env = aiEnv(run);
+    const result = await runAiReviewForAdvisory(env, {
+      settings: { aiReviewMode: "block" } as RepositorySettings,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+    });
+    expect(adv.findings.map((f) => f.code)).toEqual(["ai_review_inconclusive"]);
+    expect(result?.notes).toBeDefined(); // the single parseable opinion still produces advisory notes
   });
 
   it("uses the caller's pre-resolved files (FIX B) instead of the stored read, so the model sees the real diff", async () => {

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __aiReviewInternals,
-  AI_CONSENSUS_FLOOR,
   BEST_REVIEW_MODELS,
   runGittensoryAiReview,
   type GittensoryAiReviewInput,
@@ -164,7 +163,15 @@ describe("runGittensoryAiReview block mode (consensus)", () => {
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.consensusDefect).toBeNull();
+    expect(result.inconclusive).toBe(true); // FAIL-CLOSED: a missing second opinion holds the PR, never passes it
     expect(result.advisoryNotes).not.toBeNull(); // notes still come from the one parseable opinion
+  });
+
+  it("a clean dual review is NOT inconclusive (both models parsed, neither blocks → passes)", async () => {
+    const env = envWith(async () => ({ response: reviewJson({ present: false }) }));
+    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    expect(result.status === "ok" && result.consensusDefect).toBeNull();
+    expect(result.status === "ok" && result.inconclusive).toBe(false);
   });
 
   it("block mode with BYOK: provider writes the advisory, the free Workers-AI pair drives consensus", async () => {
@@ -304,21 +311,21 @@ describe("pure helpers", () => {
 
   it("consensusDefectOf requires a concrete blocker in BOTH reviews and drops unsafe titles", () => {
     const r = (blockers: string[]) => ({ assessment: "", suggestions: [], nits: [], blockers });
-    expect(consensusDefectOf(r(["Null deref in src/a.ts"]), r(["Null deref in src/a.ts"]), AI_CONSENSUS_FLOOR)).not.toBeNull();
-    expect(consensusDefectOf(r([]), r(["Null deref"]), AI_CONSENSUS_FLOOR)).toBeNull(); // one has no blocker → split, not consensus
-    expect(consensusDefectOf(r(["Null deref"]), r([]), AI_CONSENSUS_FLOOR)).toBeNull();
-    expect(consensusDefectOf(r(["Boost your reward payout"]), r(["Boost your reward payout"]), AI_CONSENSUS_FLOOR)).toBeNull(); // unsafe → dropped
+    expect(consensusDefectOf(r(["Null deref in src/a.ts"]), r(["Null deref in src/a.ts"]))).not.toBeNull();
+    expect(consensusDefectOf(r([]), r(["Null deref"]))).toBeNull(); // one has no blocker → split, not consensus
+    expect(consensusDefectOf(r(["Null deref"]), r([]))).toBeNull();
+    expect(consensusDefectOf(r(["Boost your reward payout"]), r(["Boost your reward payout"]))).toBeNull(); // unsafe → dropped
   });
 
   it("consensusDefectOf falls back to b's blocker when a's is blank", () => {
     const a = { assessment: "", suggestions: [], nits: [], blockers: [""] };
     const b = { assessment: "", suggestions: [], nits: [], blockers: ["Race condition in src/x.ts"] };
-    expect(consensusDefectOf(a, b, AI_CONSENSUS_FLOOR)?.title).toBe("Race condition in src/x.ts");
+    expect(consensusDefectOf(a, b)?.title).toBe("Race condition in src/x.ts");
   });
 
   it("consensusDefectOf uses the default title + detail when BOTH reviewers' blockers are blank", () => {
     const blank = { assessment: "", suggestions: [], nits: [], blockers: [""] };
-    const out = consensusDefectOf(blank, { ...blank, blockers: [""] }, AI_CONSENSUS_FLOOR);
+    const out = consensusDefectOf(blank, { ...blank, blockers: [""] });
     expect(out?.title).toContain("AI reviewers agree"); // both blockers[0] falsy → default title
     expect(out?.detail).toContain("independently flagged"); // joined detail empty → default detail
   });

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -98,6 +98,18 @@ describe(".gittensory.yml settings override (resolveEffectiveSettings)", () => {
   });
 });
 
+describe("AI fail-closed hold (#ai-fail-closed)", () => {
+  it("holds the gate NEUTRAL (held for human, never a failure-close) when an AI review is inconclusive", () => {
+    const adv: Advisory = {
+      ...missingIssueAdvisory(),
+      findings: [{ code: "ai_review_inconclusive", title: "AI review could not be completed", severity: "warning", detail: "no usable verdict", action: "held for human" }],
+    };
+    const result = evaluateGateCheck(adv, gateCheckPolicy(settings(), null, true));
+    expect(result.conclusion).toBe("neutral");
+    expect(result.blockers).toEqual([]);
+  });
+});
+
 describe("policy pack (#692)", () => {
   it("gittensor pack hard-blocks every author the same — confirmed status no longer changes the verdict (#gate-nonconfirmed)", () => {
     const gittensor = settings({ gatePack: "gittensor", linkedIssueGateMode: "block" });


### PR DESCRIPTION
## Summary

Make the block-mode AI consensus gate fail **closed**. The dual-model consensus blocker failed open:
if either Workers-AI model errored or returned unparseable output, no defect was computed and the PR
silently passed to auto-merge — defeating the only AI gate by breaking just one of two fixed, publicly
named models. Block mode now signals `inconclusive` when it cannot obtain **both** independent reviews,
and the gate **holds** the PR (neutral → held for a human) rather than passing it uncertified.

Crucially this is a **hold, never a close**: a contributor PR is never auto-closed because a model
hiccupped (that would be unfair) — it re-evaluates on the next update. A clean dual review (both models
parsed, neither blocks) is unaffected and still passes normally, so there is no impact on the common path.

Also removes the dead `AI_CONSENSUS_FLOOR` / `floor` parameter. The free Workers-AI models emit no
calibrated confidence, so the advertised 0.9 floor was never enforced (`void floor`); requiring two
independent models to agree is the actual precision mechanism, and the docs now say so honestly.

No issue linked (private security review, not public pre-disclosure); the summary explains the change.

## Scope

- [x] Conventional Commit title.
- [x] Focused (one concern: AI consensus fail-closed + dead-floor removal); no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`.
- [x] Small/self-contained; summary explains why no issue is linked.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full backend suite green (3638 passed, 1 skipped); changed lines at 100% patch coverage.
- [x] New tests: inconclusive→held in `runGittensoryAiReview` and `runAiReviewForAdvisory`, the neutral gate conclusion in `evaluateGateCheck`, and a clean dual review staying non-inconclusive.
- [ ] `npm run ui:*` — N/A, no UI files touched; CI runs the UI gate.
- [ ] `npm audit --audit-level=moderate` — unchanged pre-existing transitive `undici` advisory only; no dependency changes here.

If any required check was skipped, explain why:

- Backend-only change (`src/services`, `src/queue`, `src/rules`) with no API/OpenAPI schema change; CI runs the full gate.

## Safety

- [x] No secrets/wallets/hotkeys/trust scores/reward values/private evidence exposed. (The held message is public-safe and generic.)
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/session changes include negative-path tests. — N/A; the negative paths here (model error/unparse → held; clean → pass) are tested.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. — N/A, internal review-engine behavior.
- [x] No mock/demo UI fallbacks. — N/A.
- [x] Visible UI changes include UI Evidence. — N/A.
- [x] Public docs/changelogs updated where needed. — N/A.

## Notes

- The hold reuses the existing neutral-gate "held for review" disposition (the same shape as the
  "not evaluated yet" app-state holds), so no change to the disposition planner was needed.
- Only affects repos running `aiReview: block`; advisory-mode repos never reach the consensus path, so
  their behavior is byte-identical.
