### PR TITLE
feat(gate): a dual-reviewer split closes the PR (reviewbot quorum)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1887,6 +1887,17 @@ export async function runAiReviewForAdvisory(
         action: "Resolve the flagged defect, or override if the AI reviewers are mistaken, then re-run the gate.",
       };
       args.advisory.findings.push(defect);
+    } else if (result.split) {
+      // The reviewers DISAGREED — exactly one flagged a blocking defect. reviewbot's quorum: ANY reviewer
+      // rejection closes the PR, so a split is a HARD BLOCKER (advisory.ts gates `ai_review_split` like a
+      // consensus defect → gate failure → close); the contributor resubmits a fresh PR. (#ai-review-split)
+      args.advisory.findings.push({
+        code: "ai_review_split",
+        severity: "critical",
+        title: "An AI reviewer flagged a likely blocking defect",
+        detail: "One AI reviewer independently flagged a concrete must-fix defect in this change (the other did not). Under the quorum rule, a single rejection closes the PR; see the review notes for specifics.",
+        action: "Resolve the flagged defect and open a new pull request, or override if the reviewers are mistaken.",
+      });
     }
     return result.advisoryNotes ? { notes: result.advisoryNotes, reviewerCount: result.reviewerCount } : undefined;
   } catch (error) {

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -626,7 +626,9 @@ function isConfiguredGateBlocker(code: string, policy: GateCheckPolicy): boolean
   // A dual-model AI consensus defect blocks ONLY when the maintainer opted into aiReview: block. It is the
   // most conservative AI signal (two independent models, high confidence) but still confirmed-contributor
   // gated by evaluateGateCheck, and advisory by default.
-  if (code === "ai_consensus_defect") return gateMode(policy.aiReviewGateMode ?? "advisory") === "block";
+  // A consensus defect (both reviewers) OR a SPLIT (one reviewer flagged a blocker the other did not) both block
+  // when aiReviewGateMode is `block` — reviewbot's quorum: ANY reviewer rejection closes the PR. (#ai-review-split)
+  if (code === "ai_consensus_defect" || code === "ai_review_split") return gateMode(policy.aiReviewGateMode ?? "advisory") === "block";
   // A leaked-secret finding (`secret_leak`) ALWAYS hard-blocks: a committed credential must be removed and
   // rotated before merge, with no opt-in. This finding is produced ONLY by the flag-gated safety scan
   // (GITTENSORY_REVIEW_SAFETY); when the flag is off the finding never exists, so this branch is unreachable and the

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -99,7 +99,7 @@ export type GittensoryAiReviewResult =
   | { status: "disabled"; reason: string }
   | { status: "unavailable"; reason: string }
   | { status: "quota_exceeded"; estimatedNeurons: number; remainingBudget: number }
-  | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; estimatedNeurons: number; reviewerCount: number };
+  | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; split: boolean; estimatedNeurons: number; reviewerCount: number };
 
 type ModelReview = {
   assessment: string;
@@ -480,6 +480,7 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
 
   let consensusDefect: AiConsensusDefect | null = null;
   let secondReview: ModelReview | null = null;
+  let aiReviewSplit = false;
   if (input.mode === "block") {
     // Consensus blocker ALWAYS uses the free Workers-AI pair (provider-independent, never BYOK).
     const [a, b] = await Promise.all([
@@ -487,7 +488,13 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
       runWorkersOpinion(env, BEST_REVIEW_MODELS[1], RELIABLE_FALLBACK_MODELS[1], system, user, maxTokens),
     ]);
     secondReview = b;
-    if (a && b) consensusDefect = consensusDefectOf(a, b, AI_CONSENSUS_FLOOR);
+    if (a && b) {
+      consensusDefect = consensusDefectOf(a, b, AI_CONSENSUS_FLOOR);
+      // SPLIT = the two reviewers DISAGREE (exactly one named a blocker). Lower confidence than a clean consensus,
+      // so the gate HOLDS it for review instead of auto-merging (only when there is no real consensus defect —
+      // a consensus is the stronger signal and blocks on its own). (#ai-review-split)
+      aiReviewSplit = !consensusDefect && (a.blockers.length > 0) !== (b.blockers.length > 0);
+    }
   }
 
   const reviewsForNotes = [advisoryReview, secondReview].filter((r): r is ModelReview => Boolean(r));
@@ -499,7 +506,7 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
     consensus: Boolean(consensusDefect),
     ...(byokFailure ? { byokFailure } : {}),
   });
-  return { status: "ok", advisoryNotes, consensusDefect, estimatedNeurons, reviewerCount: reviewsForNotes.length };
+  return { status: "ok", advisoryNotes, consensusDefect, split: aiReviewSplit, estimatedNeurons, reviewerCount: reviewsForNotes.length };
 }
 
 async function record(

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -221,6 +221,18 @@ describe("advisory rules", () => {
     expect(evaluateGateCheck(duplicateAdvisory, { duplicatePrGateMode: "block" }).conclusion).toBe("failure");
   });
 
+  it("a reviewer SPLIT (ai_review_split) blocks → close, gated like a consensus defect by aiReviewGateMode (#ai-review-split)", () => {
+    const splitAdvisory = {
+      ...buildPullRequestAdvisory(repo, null),
+      findings: [{ code: "ai_review_split", title: "An AI reviewer flagged a likely blocking defect", severity: "critical" as const, detail: "One reviewer flagged a blocker the other did not." }],
+    };
+    // reviewbot quorum: a single rejection (split) blocks → gate failure → close, but ONLY when aiReviewGateMode
+    // is `block` (advisory/off keep it non-blocking, exactly like ai_consensus_defect).
+    expect(evaluateGateCheck(splitAdvisory, { aiReviewGateMode: "block" }).conclusion).toBe("failure");
+    expect(evaluateGateCheck(splitAdvisory, { aiReviewGateMode: "advisory" }).conclusion).toBe("success");
+    expect(evaluateGateCheck(splitAdvisory).conclusion).toBe("success");
+  });
+
   it("only enforces readiness score when quality gate mode is block", () => {
     const advisory = buildPullRequestAdvisory(repo, {
       repoFullName: repo.fullName,


### PR DESCRIPTION
gittensory only blocked on a CONSENSUS defect (both reviewers), so a split (one flags a blocker, one doesn't) merged. reviewbot's quorum closed on ANY rejection. Now a split surfaces an `ai_review_split` finding gated like `ai_consensus_defect` (when aiReviewGateMode=block) → failure → one-shot close. A merge requires BOTH reviewers clean. +1 test, suite green (3642).