### PR TITLE
fix(scoring): audit upstream ref HEAD SHA + remove dead URL exports

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -56,10 +56,6 @@ export const DEFAULT_SCORING_CONSTANTS: Record<string, number> = {
 
 export const DEFAULT_GITTENSOR_UPSTREAM_REPO = "entrius/gittensor";
 export const DEFAULT_GITTENSOR_UPSTREAM_REF = "test";
-export const SCORING_CONSTANTS_URL =
-  "https://raw.githubusercontent.com/entrius/gittensor/test/gittensor/constants.py";
-export const PROGRAMMING_LANGUAGES_URL =
-  "https://raw.githubusercontent.com/entrius/gittensor/test/gittensor/validator/weights/programming_languages.json";
 
 function scoringUpstreamConfig(env: Env): { repo: string; ref: string } {
   return {
@@ -72,6 +68,19 @@ function upstreamRawUrl(config: { repo: string; ref: string }, path: string): st
   return `https://raw.githubusercontent.com/${config.repo}/${encodeURIComponent(config.ref)}/${path}`;
 }
 
+// Fetch the HEAD commit SHA of the upstream ref for audit trail. Fail-open: a network hiccup or a
+// missing administration token must never block the constants refresh itself.
+async function fetchUpstreamRefSha(upstream: { repo: string; ref: string }, token: string | undefined): Promise<string | null> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${upstream.repo}/commits/${encodeURIComponent(upstream.ref)}`, { headers: githubHeaders(token, "application/vnd.github+json") });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { sha?: string };
+    return typeof data.sha === "string" && data.sha.length > 0 ? data.sha : null;
+  } catch {
+    return null;
+  }
+}
+
 const SCORING_CONSTANT_NAMES = new Set([...Object.keys(DEFAULT_SCORING_CONSTANTS), "MIN_TOKEN_SCORE_FOR_BASE_SCORE", "MAX_CODE_DENSITY_MULTIPLIER"]);
 
 export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringModelSnapshotRecord> {
@@ -80,10 +89,11 @@ export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringMode
   const upstream = scoringUpstreamConfig(env);
   const constantsUrl = upstreamRawUrl(upstream, "gittensor/constants.py");
   const programmingLanguagesUrl = upstreamRawUrl(upstream, "gittensor/validator/weights/programming_languages.json");
-  const [registrySnapshot, constantsResult, languagesResult] = await Promise.all([
+  const [registrySnapshot, constantsResult, languagesResult, upstreamSourceSha] = await Promise.all([
     getLatestRegistrySnapshot(env),
     fetchText(constantsUrl, env.GITHUB_PUBLIC_TOKEN),
     fetchJson(programmingLanguagesUrl, env.GITHUB_PUBLIC_TOKEN),
+    fetchUpstreamRefSha(upstream, env.GITHUB_PUBLIC_TOKEN),
   ]);
 
   let sourceKind: ScoringModelSnapshotRecord["sourceKind"] = "raw-github";
@@ -126,13 +136,14 @@ export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringMode
       constants: constantsPayload,
       programmingLanguagesSourceUrl: programmingLanguagesUrl,
       registryRepoCount: registrySnapshot?.repoCount ?? 0,
+      ...(upstreamSourceSha ? { upstreamSourceSha } : {}),
     },
   };
   await persistScoringModelSnapshot(env, snapshot);
   if (constantsResult.ok) {
     await syncUnmodeledScoringConstantDrift(env, {
       unmodeledConstants: findUnmodeledUpstreamConstants(constantsResult.value),
-      source: { repo: upstream.repo, ref: upstream.ref, commitSha: null },
+      source: { repo: upstream.repo, ref: upstream.ref, commitSha: upstreamSourceSha },
     });
   }
   return snapshot;

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -431,9 +431,49 @@ NOVELTY_BONUS_SCALAR = 3
       affectedAreas: ["scoring_model"],
       payload: expect.objectContaining({
         unmodeledUpstreamConstants: ["NOVELTY_BONUS_SCALAR"],
+        // commitSha is null here because the test stub returns 404 for the API commits URL
         source: { repo: "custom/upstream", ref: "staging", commitSha: null },
       }),
     });
+  });
+
+  it("records the upstream ref HEAD commit SHA in the snapshot payload and drift-sync source (mutable-branch audit trail)", async () => {
+    const env = createTestEnv({ GITTENSOR_UPSTREAM_REPO: "custom/upstream", GITTENSOR_UPSTREAM_REF: "main" });
+    const EXPECTED_SHA = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response("MERGED_PR_BASE_SCORE = 25\n");
+      if (url.includes("programming_languages.json")) return Response.json({});
+      // Upstream HEAD SHA endpoint: api.github.com/repos/{owner}/{repo}/commits/{ref}
+      if (url.includes("api.github.com") && url.includes("/commits/main")) return Response.json({ sha: EXPECTED_SHA });
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    // The SHA is recorded in the snapshot payload for audit trail visibility.
+    expect(refreshed.payload.upstreamSourceSha).toBe(EXPECTED_SHA);
+    // Fail-open: the SHA is best-effort and never blocks the scoring refresh.
+    expect(refreshed.sourceKind).toBe("raw-github");
+  });
+
+  it("is fail-open when the upstream SHA fetch fails — constants still refresh without the SHA", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("constants.py")) return new Response("MERGED_PR_BASE_SCORE = 25\n");
+      if (url.includes("programming_languages.json")) return Response.json({});
+      // SHA endpoint fails — network error
+      if (url.includes("api.github.com") && url.includes("/commits/")) throw new Error("network error");
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshScoringModelSnapshot(env);
+
+    // SHA is absent from the payload but constants still apply (fail-open).
+    expect(refreshed.payload.upstreamSourceSha).toBeUndefined();
+    expect(refreshed.constants.MERGED_PR_BASE_SCORE).toBe(25);
+    expect(refreshed.sourceKind).toBe("raw-github");
   });
 
   it("uses saturation math as the active private preview model", () => {


### PR DESCRIPTION
## Summary

- Scoring constants are fetched from a mutable branch (`entrius/gittensor:test` or env-override `GITTENSOR_UPSTREAM_REF`). If that branch were tampered with, there was no audit trail showing which exact commit's constants were applied per scoring cycle.
- After a successful refresh, also fetch the HEAD commit SHA of the upstream ref via `GET /repos/{owner}/{repo}/commits/{ref}` and record it in `snapshot.payload.upstreamSourceSha`. This is **best-effort and fail-open** — a network hiccup on the SHA fetch never blocks the constants refresh or changes what constants are applied.
- Thread the SHA through to `syncUnmodeledScoringConstantDrift` (was always `commitSha: null`; now uses the real SHA when available).
- Remove the dead `SCORING_CONSTANTS_URL` / `PROGRAMMING_LANGUAGES_URL` exported constants. They were hard-coded to the default branch and were **not** used for fetching (`upstreamRawUrl` handles that dynamically). Grepped — no other files import them. Removing them eliminates a misleading suggestion that scoring always pulls from `test`.

+2 tests covering the SHA-present success path and the fail-open behavior when the SHA endpoint throws.

No issue linked: focused security/observability hardening.