### PR TITLE
feat(self-improve): close-precision circuit-breaker (symmetric mirror of the merge breaker)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -109,7 +109,7 @@ import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetecti
 import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
 import { selectRegateCandidates } from "../settings/agent-sweep";
-import { downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions } from "../settings/agent-actions";
+import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type PlannedAgentAction } from "../settings/agent-actions";
 import { executeAgentMaintenanceActions, pendingClosureLabelApplied } from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
 import { loadIssueQualityReportMap } from "../services/issue-quality";
@@ -181,7 +181,7 @@ import { closePullRequest, createIssueComment, getLastCloserLogin } from "../git
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
-import { isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
+import { isCloseHoldOnly, isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
 import type { AdvisoryFinding, ContributorEvidenceRecord, ContributorRepoStatRecord, DetectedNotificationEvent, GitHubWebhookPayload, IssueRecord, JobMessage, JsonValue, PullRequestFilePathRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../types";
@@ -592,6 +592,20 @@ export function changedPathsForGuardrail(files: Awaited<ReturnType<typeof listPu
 }
 
 /**
+ * Chain the two INDEPENDENT precision circuit-breakers over a planned action set (the merge-side and close-side
+ * downgrades), in order. PURE — the live flag reads happen at the call site (each fail-open), so this composes
+ * only the transforms:
+ *   • holdOnly      → downgradeMergeToHold (would-MERGE → human HOLD), else passthrough.
+ *   • closeHoldOnly → downgradeCloseToHold (HEURISTIC would-CLOSE → human HOLD; deterministic close exempt), else passthrough.
+ * Both off (the common path) returns the plan byte-identically. The breakers don't interfere: the merge
+ * downgrade only touches `merge`/ready-label, the close downgrade only touches a heuristic `close`.
+ */
+export function applyPrecisionBreakers(planned: PlannedAgentAction[], holdOnly: boolean, closeHoldOnly: boolean): PlannedAgentAction[] {
+  const afterMerge = holdOnly ? downgradeMergeToHold(planned, true) : planned;
+  return closeHoldOnly ? downgradeCloseToHold(afterMerge, true) : afterMerge;
+}
+
+/**
  * #778 maintainer auto-maintain trigger. After the gate runs on a PR webhook, if the repo opted the agent in
  * (an acting autonomy level), reuse the CANONICAL verdict produced by the full gate evaluation, plan the
  * GitHub state actions, and run them through the
@@ -712,11 +726,14 @@ async function maybeRunAgentMaintenance(
       approvedHeadSha: pr.approvedHeadSha,
     },
   });
-  // Accuracy circuit-breaker (#self-improve / GAP-4): when the holdonly flag is set for this repo (the
-  // auto-tuner engaged it after merge precision dropped, or a human set it), convert a would-MERGE into a human
-  // HOLD before executing. Fail-safe: isHoldOnly reads false until a breaker actually engages, so the common
-  // path is byte-identical (downgradeMergeToHold returns the plan unchanged).
-  const breakerOnPlan = (await isHoldOnly(env, repoFullName)) ? downgradeMergeToHold(planned, true) : planned;
+  // Accuracy circuit-breakers (#self-improve / GAP-4): two INDEPENDENT, fail-open precision breakers, chained.
+  //   • MERGE breaker (holdonly:<scope>): when set, convert a would-MERGE into a human HOLD before executing.
+  //   • CLOSE breaker (closehold:<scope>): when set, convert a HEURISTIC would-CLOSE into a human HOLD (the
+  //     deterministic linked-issue-hard-rule close is exempt — downgradeCloseToHold scopes itself).
+  // Each read is independent and fail-open (isHoldOnly / isCloseHoldOnly read false until a breaker actually
+  // engages), so the common path is byte-identical (both downgrades return the plan unchanged). The chaining is
+  // extracted into the pure applyPrecisionBreakers below so it is unit-tested directly.
+  const breakerOnPlan = applyPrecisionBreakers(planned, await isHoldOnly(env, repoFullName), await isCloseHoldOnly(env, repoFullName));
   if (breakerOnPlan.length === 0) return;
 
   const installation = await getInstallation(env, installationId);

--- a/src/review/auto-tune.ts
+++ b/src/review/auto-tune.ts
@@ -52,7 +52,10 @@ export interface GateEvalReport {
 export interface FlagStore {
   /** Circuit-breaker: is auto-merge disabled (would-merge → hold) for this project (or globally)? */
   isHoldOnly(project: string): Promise<boolean>;
-  /** Set (or clear) a flag key (e.g. `holdonly:<project>`). */
+  /** CLOSE-side circuit-breaker: is auto-CLOSE disabled (would-close → hold) for this project (or globally)?
+   *  The symmetric mirror of {@link isHoldOnly} for the close-precision breaker (`closehold:<scope>` rows). */
+  isCloseHoldOnly(project: string): Promise<boolean>;
+  /** Set (or clear) a flag key (e.g. `holdonly:<project>` or `closehold:<project>`). */
   setFlag(key: string, on: boolean): Promise<void>;
   /** When a flag was set (its updated_at, UTC) — or null if unset. Used to age-out an auto-engaged breaker. */
   flagSetAt(key: string): Promise<string | null>;
@@ -63,6 +66,11 @@ export interface FlagStore {
 // Engage the breaker only with a real sample AND a meaningful precision drop — never on noise.
 export const AUTOTUNE_MIN_DECIDED = 10;
 export const AUTOTUNE_MERGE_PRECISION_FLOOR = 0.85;
+// The CLOSE-side floor for the symmetric close-precision breaker: when the gate eval shows close precision
+// (would-close AND human closed / would-close) dropping below this over a real sample, the system DISABLES its
+// own auto-CLOSE for that project (sets `closehold:<scope>`) so would-closes HOLD for a person instead of firing
+// a wrong close. Same value as the merge floor (0.85) — both directions tighten on the same precision bar.
+export const AUTOTUNE_CLOSE_PRECISION_FLOOR = 0.85;
 // Auto-clear an AUTO-engaged breaker after a cooldown IF precision is no longer failing. While held there are
 // no new auto-merges to score, so this is a time-boxed retry: clear → auto-merge resumes → re-engages next
 // eval if still bad. A human-set global freeze/holdonly is NEVER auto-cleared. (#272)
@@ -131,6 +139,85 @@ export async function maybeAutoClearHoldOnly(flags: FlagStore, report: GateEvalR
     const setAt = await flags.flagSetAt(`holdonly:${project}`);
     if (!shouldAutoClear(report, project, setAt, nowMs)) return false;
     await flags.setFlag(`holdonly:${project}`, false);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── CLOSE-precision circuit-breaker (symmetric mirror of the merge breaker above) ───────────────────────────
+// The close-direction twin: when the gate eval shows close precision dropping below the floor over a real
+// sample, the system DISABLES its own auto-CLOSE for that project (`closehold:<scope>`) so would-closes HOLD
+// for a person instead of executing a bad close. TIGHTENING-ONLY in the close direction (it only ever removes a
+// close + holds for review; it NEVER adds/enables a close, merge, or approve). Reads r.closePrecision /
+// r.wouldClose where the merge breaker reads r.mergePrecision / r.wouldMerge. Reuses AUTOTUNE_MIN_DECIDED and
+// AUTOCLEAR_AFTER_MS. Same forward-measured retry contract: a human clears it early; the cooldown auto-clears it
+// once precision recovers so auto-close can resume.
+
+export interface CloseAutoTuneAction {
+  project: string;
+  closePrecision: number;
+  decided: number;
+  message: string;
+}
+
+/** PURE: which projects' CLOSE precision has dropped enough to warrant engaging the close-side breaker?
+ *  Mirrors planAutoTune, testing closePrecision against AUTOTUNE_CLOSE_PRECISION_FLOOR. */
+export function planCloseAutoTune(report: GateEvalReport): CloseAutoTuneAction[] {
+  const actions: CloseAutoTuneAction[] = [];
+  for (const r of report.rows) {
+    if (r.decided < AUTOTUNE_MIN_DECIDED || r.closePrecision == null) continue;
+    if (r.closePrecision < AUTOTUNE_CLOSE_PRECISION_FLOOR) {
+      actions.push({
+        project: r.project,
+        closePrecision: r.closePrecision,
+        decided: r.decided,
+        message: `Auto-CLOSE DISABLED for ${r.project}: close precision ${Math.round(r.closePrecision * 100)}% over ${r.decided} decided PR(s) (< ${Math.round(AUTOTUNE_CLOSE_PRECISION_FLOOR * 100)}%). Would-closes now HOLD for review. Investigate, then clear closehold:${r.project}.`,
+      });
+    }
+  }
+  return actions;
+}
+
+/** Engage the CLOSE-side breaker for each flagged project that isn't already close-held. Returns the NEWLY
+ *  engaged actions (so the caller audits + alerts once, not every cron tick). Fail-safe — a write error is
+ *  swallowed. Mirrors applyAutoTune over the `closehold:<project>` flag. */
+export async function applyCloseAutoTune(flags: FlagStore, report: GateEvalReport): Promise<CloseAutoTuneAction[]> {
+  const engaged: CloseAutoTuneAction[] = [];
+  for (const action of planCloseAutoTune(report)) {
+    try {
+      if (await flags.isCloseHoldOnly(action.project)) continue; // already engaged → don't re-alert
+      await flags.setFlag(`closehold:${action.project}`, true);
+      engaged.push(action);
+    } catch (error) {
+      console.log(JSON.stringify({ ev: "close_tune_error", project: action.project, message: String(error).slice(0, 120) }));
+    }
+  }
+  return engaged;
+}
+
+/** PURE: should an auto-engaged CLOSE breaker for `project` be cleared now? Mirrors shouldAutoClear but tests
+ *  closePrecision. True when the per-project closehold flag was set ≥ AUTOCLEAR_AFTER_MS ago AND close precision
+ *  is no longer failing (recovered, or no recent close predictions to judge). Never considers a human-set global
+ *  closehold (no per-project row → setAt is null). */
+export function shouldAutoClearClose(report: GateEvalReport, project: string, setAtIso: string | null, nowMs: number): boolean {
+  if (!setAtIso) return false; // not auto-engaged for THIS project (global breaker is human-only)
+  const t = setAtIso.includes("T") ? setAtIso : setAtIso.replace(" ", "T");
+  const hasZone = t.endsWith("Z") || /[+-]\d\d:?\d\d$/.test(t);
+  const setMs = Date.parse(hasZone ? t : `${t}Z`);
+  if (!Number.isFinite(setMs) || nowMs - setMs < AUTOCLEAR_AFTER_MS) return false; // still in cooldown
+  const row = report.rows.find((r) => r.project === project);
+  const stillFailing = !!row && row.closePrecision != null && row.decided >= AUTOTUNE_MIN_DECIDED && row.closePrecision < AUTOTUNE_CLOSE_PRECISION_FLOOR;
+  return !stillFailing; // cooldown elapsed + precision recovered (or no signal) → clear and let it retry
+}
+
+/** Clear `project`'s auto-engaged CLOSE breaker if the cooldown elapsed + close precision recovered. Returns
+ *  true if cleared. Fail-CLOSED on a thrown read (returns false, breaker stays engaged). */
+export async function maybeAutoClearCloseHoldOnly(flags: FlagStore, report: GateEvalReport, project: string, nowMs: number): Promise<boolean> {
+  try {
+    const setAt = await flags.flagSetAt(`closehold:${project}`);
+    if (!shouldAutoClearClose(report, project, setAt, nowMs)) return false;
+    await flags.setFlag(`closehold:${project}`, false);
     return true;
   } catch {
     return false;

--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -26,7 +26,16 @@
 import { recordAuditEvent } from "../db/repositories";
 import type { GitHubWebhookPayload } from "../types";
 import { errorMessage, nowIso } from "../utils/json";
-import { applyAutoTune, AUTOTUNE_MERGE_PRECISION_FLOOR, type FlagStore, type GateEvalReport, maybeAutoClearHoldOnly } from "./auto-tune";
+import {
+  applyAutoTune,
+  applyCloseAutoTune,
+  AUTOTUNE_CLOSE_PRECISION_FLOOR,
+  AUTOTUNE_MERGE_PRECISION_FLOOR,
+  type FlagStore,
+  type GateEvalReport,
+  maybeAutoClearCloseHoldOnly,
+  maybeAutoClearHoldOnly,
+} from "./auto-tune";
 import { computeGateEval } from "./parity";
 
 /** PURE: parse the PR number an "Reverts #N / Reverts owner/repo#N" body refers to (GitHub's revert PRs).
@@ -58,7 +67,24 @@ export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
   }
 }
 
-/** A live FlagStore over system_flags for the circuit-breaker (applyAutoTune / maybeAutoClearHoldOnly). */
+/** CLOSE-side mirror of {@link isHoldOnly}: is auto-CLOSE disabled (would-close → hold) for this project (or
+ *  globally)? Reads the SAME system_flags table via a single scan and tests the `closehold:` namespace. This is
+ *  the read the close path consults to downgrade a would-CLOSE into a HOLD. Fail-OPEN (false) on a DB error so a
+ *  blip never silently changes the close path. */
+export async function isCloseHoldOnly(env: Env, project: string): Promise<boolean> {
+  try {
+    const res = await env.DB.prepare("SELECT key, value FROM system_flags").all<{ key: string; value: string }>();
+    const set = new Set<string>();
+    for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
+    return set.has("closehold:global") || set.has(`closehold:${project}`);
+  } catch (error) {
+    console.warn(JSON.stringify({ ev: "flags_read_error", message: errorMessage(error).slice(0, 120) }));
+    return false; // fail-OPEN: a DB blip must never silently change the close path
+  }
+}
+
+/** A live FlagStore over system_flags for the circuit-breaker (applyAutoTune / maybeAutoClearHoldOnly +
+ *  applyCloseAutoTune / maybeAutoClearCloseHoldOnly). */
 export function createFlagStore(env: Env): FlagStore {
   return {
     async isHoldOnly(project: string): Promise<boolean> {
@@ -66,6 +92,16 @@ export function createFlagStore(env: Env): FlagStore {
       // breaker is already engaged, so it must read the per-project key, not fold in the global one.
       try {
         const row = await env.DB.prepare("SELECT value FROM system_flags WHERE key = ?").bind(`holdonly:${project}`).first<{ value: string }>();
+        return flagTruthy(row?.value);
+      } catch {
+        return false;
+      }
+    },
+    async isCloseHoldOnly(project: string): Promise<boolean> {
+      // Per-key check (mirrors isHoldOnly): applyCloseAutoTune dedups on whether THIS project's CLOSE breaker is
+      // already engaged, so it reads the per-project `closehold:` key, not the global-or-project read above.
+      try {
+        const row = await env.DB.prepare("SELECT value FROM system_flags WHERE key = ?").bind(`closehold:${project}`).first<{ value: string }>();
         return flagTruthy(row?.value);
       } catch {
         return false;
@@ -244,13 +280,17 @@ const BREAKER_EVAL_WINDOW_DAYS = 90;
 
 /**
  * One precision-circuit-breaker tick, run on the scheduled (selftune) cron. Reads the gate-eval confusion
- * matrix over gittensory's OWN recorded pr_outcome/gate_decision rows, then:
- *   • ENGAGES the breaker (holdonly:<project>) for any repo whose merge precision dropped below the floor over
- *     a real sample (applyAutoTune) — the would-MERGE → HOLD downgrade then kicks in on the next merge path.
- *   • AUTO-CLEARS an auto-engaged breaker once its cooldown elapsed AND precision recovered (maybeAutoClearHoldOnly).
- * Strictly TIGHTENING-only: it only ever makes the system MORE cautious; a human clears a breaker that should
- * be cleared early. FAILS SAFE — a thrown error is logged and swallowed (tuning must never break the cron). With
- * no pr_outcome history the eval reads neutral → nothing engages → byte-identical.
+ * matrix over gittensory's OWN recorded pr_outcome/gate_decision rows, then engages/clears BOTH breakers:
+ *   • MERGE: ENGAGES holdonly:<project> for any repo whose merge precision dropped below the floor over a real
+ *     sample (applyAutoTune) — the would-MERGE → HOLD downgrade then kicks in on the next merge path; AUTO-CLEARS
+ *     an auto-engaged breaker once its cooldown elapsed AND precision recovered (maybeAutoClearHoldOnly).
+ *   • CLOSE (symmetric twin): ENGAGES closehold:<project> for any repo whose CLOSE precision dropped below the
+ *     floor (applyCloseAutoTune) — the would-CLOSE → HOLD downgrade kicks in next close path; AUTO-CLEARS the
+ *     same way (maybeAutoClearCloseHoldOnly).
+ * Strictly TIGHTENING-only in both directions: it only ever makes the system MORE cautious; a human clears a
+ * breaker that should be cleared early. FAILS SAFE — a thrown error is logged and swallowed (tuning must never
+ * break the cron). With no pr_outcome history the eval reads neutral → nothing engages → byte-identical. The
+ * close breaker is INERT until selftune is enabled AND close-outcome data is present, exactly like its merge twin.
  */
 export async function runSelfTuneBreaker(env: Env): Promise<void> {
   try {
@@ -261,10 +301,23 @@ export async function runSelfTuneBreaker(env: Env): Promise<void> {
     for (const action of engaged) {
       console.warn(JSON.stringify({ ev: "breaker_engaged", project: action.project, mergePrecision: action.mergePrecision, decided: action.decided, floor: AUTOTUNE_MERGE_PRECISION_FLOOR }));
     }
-    // Auto-clear any auto-engaged breaker that has cooled down + recovered (one per repo present in the report).
+    // CLOSE-side breaker: engage closehold for any repo whose close precision dropped below the floor.
+    const closeEngaged = await applyCloseAutoTune(flags, report);
+    for (const action of closeEngaged) {
+      console.warn(JSON.stringify({ ev: "close_breaker_engaged", project: action.project, closePrecision: action.closePrecision, decided: action.decided, floor: AUTOTUNE_CLOSE_PRECISION_FLOOR }));
+    }
+    // OBSERVABILITY: a single summary line of the engaged close-hold backlog so a human can see, at a glance,
+    // how many (and which) repos are currently holding would-closes for review. Only emitted when ≥1 engaged.
+    if (closeEngaged.length > 0) {
+      console.warn(JSON.stringify({ ev: "closehold_backlog", count: closeEngaged.length, projects: closeEngaged.map((a) => a.project) }));
+    }
+    // Auto-clear any auto-engaged breaker (merge AND close) that has cooled down + recovered (one per repo in the report).
     for (const row of report.rows) {
       if (await maybeAutoClearHoldOnly(flags, report, row.project, nowMs)) {
         console.log(JSON.stringify({ ev: "breaker_auto_cleared", project: row.project }));
+      }
+      if (await maybeAutoClearCloseHoldOnly(flags, report, row.project, nowMs)) {
+        console.log(JSON.stringify({ ev: "close_breaker_auto_cleared", project: row.project }));
       }
     }
   } catch (error) {

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -49,6 +49,13 @@ export type PlannedAgentAction = {
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;
+  // For a `close` action: WHICH kind of close this is, so the close-precision circuit-breaker can scope itself.
+  // "linked-issue-hard-rule" = the DETERMINISTIC flag-then-close state machine (zero hallucination risk — and on
+  // the verify path it posts a comment PROMISING closure); "heuristic" = a verdict-driven close (gate-verdict /
+  // duplicate / slop / CI). The breaker downgrades ONLY "heuristic" closes; the deterministic close is EXEMPT
+  // (silently holding a close whose comment already promised closure would be incoherent). Absent on non-close
+  // actions; treated as a heuristic close only when explicitly tagged "heuristic".
+  closeKind?: "linked-issue-hard-rule" | "heuristic";
   expectedHeadSha?: string;
 };
 
@@ -151,6 +158,48 @@ export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: bo
   }
   // Drop any ready-to-merge label add (the auto-merge it promised is now suppressed).
   return next.filter((action) => !(action.actionClass === "label" && action.label === AGENT_LABEL_READY && action.labelOp !== "remove"));
+}
+
+/**
+ * CLOSE-precision circuit-breaker (the symmetric mirror of {@link downgradeMergeToHold}): when auto-CLOSE is
+ * DISABLED for a repo (the auto-tuner engaged the `closehold` flag after CLOSE precision dropped, or a human set
+ * it), DOWNGRADE a would-CLOSE into a human HOLD — drop the `close` action(s) and surface the needs-human-review
+ * label so the PR is held for a person instead of auto-closed.
+ *
+ * TIGHTENING-ONLY in the close direction: it can ONLY remove a `close` action + ADD a label. It NEVER adds or
+ * enables a close, merge, or approve, and it never touches an existing merge/approve action.
+ *
+ * OWNER-REQUIRED SCOPING: it downgrades ONLY HEURISTIC (verdict-driven) closes — those tagged
+ * `closeKind: "heuristic"` (gate-verdict / duplicate / slop / CI). It EXEMPTS the DETERMINISTIC linked-issue
+ * hard-rule close (`closeKind: "linked-issue-hard-rule"`): that close is zero-hallucination, and on the verify
+ * path it posts a comment PROMISING closure — silently downgrading it to a hold while a comment promises closure
+ * would be incoherent. So a plan whose only close is the deterministic one is returned UNCHANGED. A plan with a
+ * heuristic close gets it dropped; a deterministic close present alongside is KEPT.
+ *
+ * The existing changes-requested label is KEPT (it correctly says the PR is not mergeable). PURE + idempotent:
+ * with `closeHoldOnly` false this returns the plan UNCHANGED (the common path); with no HEURISTIC close planned
+ * it is also a no-op. Only ever makes the system MORE cautious.
+ */
+export function downgradeCloseToHold(planned: PlannedAgentAction[], closeHoldOnly: boolean): PlannedAgentAction[] {
+  const isHeuristicClose = (action: PlannedAgentAction): boolean => action.actionClass === "close" && action.closeKind === "heuristic";
+  if (!closeHoldOnly || !planned.some(isHeuristicClose)) return planned;
+  // Drop ONLY the heuristic close(s); a deterministic linked-issue-hard-rule close (if any) is left intact.
+  const next = planned.filter((action) => !isHeuristicClose(action));
+  // The dropped close means the PR is held for a person — surface needs-human-review. Idempotent: only add when
+  // absent (e.g. a guarded-but-passing plan may already carry it). NEVER adds a merge/approve.
+  const alreadyNeedsReview = next.some((action) => action.actionClass === "label" && action.label === AGENT_LABEL_NEEDS_REVIEW && action.labelOp !== "remove");
+  const droppedClose = planned.find(isHeuristicClose);
+  if (!alreadyNeedsReview) {
+    next.push({
+      actionClass: "label",
+      requiresApproval: droppedClose?.requiresApproval ?? false,
+      reason: "close-precision circuit-breaker engaged — would-close held for human review",
+      label: AGENT_LABEL_NEEDS_REVIEW,
+      labelOp: "add",
+    });
+  }
+  // KEEP the changes-requested label (it correctly states the PR is not mergeable) and every other action.
+  return next;
 }
 
 function closeMessage(reasons: string[]): string {
@@ -351,7 +400,9 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     // exactly why. This is the FIRST disposition branch: it wins over an otherwise-mergeable verdict (a PR for
     // an ineligible issue must never auto-merge) and fires REGARDLESS of `guardrailHit` (deterministic, not AI).
     const reason = linkedIssueHardRule?.reason ?? "the linked issue is not eligible for a community PR";
-    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason, closeComment: closeMessage([reason]) });
+    // Tagged "linked-issue-hard-rule": the close-precision breaker EXEMPTS this deterministic close (it is not
+    // verdict-driven, and the verify path may already have promised closure in a comment).
+    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason, closeComment: closeMessage([reason]), closeKind: "linked-issue-hard-rule" });
   } else if (canMerge) {
     actions.push({
       actionClass: "merge",
@@ -369,7 +420,9 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     if (input.pr.slopRisk != null && input.pr.slopRisk >= slopGateMinScore) closeReasons.push(`slop score ${input.pr.slopRisk} ≥ ${slopGateMinScore}`);
     if ((input.pr.linkedDuplicateCount ?? 0) > 0) closeReasons.push("duplicate of another open PR");
     if (closeReasons.length === 0) closeReasons.push("the review gate is not satisfied");
-    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: closeReasons.join("; "), closeComment: closeMessage(closeReasons) });
+    // Tagged "heuristic": a verdict-driven close (gate-verdict / duplicate / slop / CI). This is the ONLY close
+    // the close-precision breaker downgrades to a hold when close precision has dropped.
+    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: closeReasons.join("; "), closeComment: closeMessage(closeReasons), closeKind: "heuristic" });
   }
   // else: guarded → manual (needs-human/changes label above); not-good OWNER/automation → held
   // (request-changes above); review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput } from "../../src/settings/agent-actions";
+import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput, type PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import type { GateCheckConclusion } from "../../src/rules/advisory";
 
@@ -489,5 +489,87 @@ describe("downgradeMergeToHold — accuracy circuit-breaker (#self-improve / GAP
   it("holdOnly=false leaves a real would-merge plan UNCHANGED (byte-identical common path)", () => {
     const plan = wouldMerge();
     expect(downgradeMergeToHold(plan, false)).toBe(plan);
+  });
+});
+
+describe("downgradeCloseToHold — close-precision circuit-breaker (#close-precision-breaker)", () => {
+  // A REAL heuristic would-close plan from the planner: red CI on a contributor PR → changes-requested label +
+  // a heuristic close.
+  const heuristicClosePlan = () =>
+    planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto", label: "auto" }, ciState: "failed", failingCheckNames: ["codecov/patch"], blockerTitles: ["x"], pr: { labels: [] } }));
+  // A REAL deterministic linked-issue-hard-rule close (the exempt kind).
+  const linkedIssueClosePlan = () =>
+    planAgentMaintenanceActions(
+      input({
+        conclusion: "success",
+        autonomy: { close: "auto", label: "auto" },
+        ciState: "passed",
+        linkedIssueHardRule: { violated: true, reason: "Linked issue #5 is labeled `maintainer-only` — it is not open for community PRs." },
+        linkedIssueVerify: { verifyBeforeClose: false, closeDelaySeconds: 0 },
+        pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" },
+      }),
+    );
+
+  it("a real heuristic would-CLOSE plan drops the close + adds needs-human-review + KEEPS changes-requested", () => {
+    const plan = heuristicClosePlan();
+    // sanity: the planner really would heuristically close, with a changes-requested label.
+    expect(plan.some((a) => a.actionClass === "close" && a.closeKind === "heuristic")).toBe(true);
+    expect(plan.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(true);
+    const held = downgradeCloseToHold(plan, true);
+    expect(held.some((a) => a.actionClass === "close")).toBe(false); // the would-close is downgraded...
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add")).toBe(true); // ...to a human hold
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(true); // changes-requested KEPT
+    expect(held.some((a) => a.actionClass === "merge" || a.actionClass === "approve")).toBe(false); // NEVER adds merge/approve
+  });
+
+  it("a deterministic linked-issue-hard-rule close is EXEMPT (NOT dropped, no needs-human-review added)", () => {
+    const plan = linkedIssueClosePlan();
+    expect(plan.some((a) => a.actionClass === "close" && a.closeKind === "linked-issue-hard-rule")).toBe(true);
+    const held = downgradeCloseToHold(plan, true);
+    // The deterministic close survives untouched (no heuristic close present → the whole plan is returned as-is).
+    expect(held).toBe(plan);
+    expect(held.some((a) => a.actionClass === "close" && a.closeKind === "linked-issue-hard-rule")).toBe(true);
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)).toBe(false);
+  });
+
+  it("when BOTH a heuristic and a deterministic close are present, drops ONLY the heuristic one", () => {
+    const linkedIssueClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "ineligible issue", closeKind: "linked-issue-hard-rule" };
+    const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failing", closeKind: "heuristic" };
+    const held = downgradeCloseToHold([linkedIssueClose, heuristicClose], true);
+    expect(held.some((a) => a.actionClass === "close" && a.closeKind === "heuristic")).toBe(false); // heuristic dropped
+    expect(held.some((a) => a.actionClass === "close" && a.closeKind === "linked-issue-hard-rule")).toBe(true); // deterministic KEPT
+    expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add")).toBe(true);
+  });
+
+  it("closeHoldOnly=false leaves a real would-close plan UNCHANGED (byte-identical common path)", () => {
+    const plan = heuristicClosePlan();
+    expect(downgradeCloseToHold(plan, false)).toBe(plan);
+  });
+
+  it("closeHoldOnly=true but NO heuristic close planned (e.g. a would-merge) → no-op (returns plan unchanged)", () => {
+    const mergePlan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", label: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean" } }));
+    expect(mergePlan.some((a) => a.actionClass === "merge")).toBe(true);
+    const out = downgradeCloseToHold(mergePlan, true);
+    expect(out).toBe(mergePlan); // unchanged: no heuristic close to drop, merge untouched
+    expect(out.some((a) => a.actionClass === "merge")).toBe(true);
+  });
+
+  it("does NOT re-add needs-human-review when it is already present (idempotent)", () => {
+    const needsReview: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "guarded", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "add" };
+    const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failing", closeKind: "heuristic" };
+    const held = downgradeCloseToHold([needsReview, heuristicClose], true);
+    expect(held.filter((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)).toHaveLength(1);
+    expect(held.some((a) => a.actionClass === "close")).toBe(false);
+  });
+
+  it("carries the dropped close's requiresApproval onto the new label, and defaults to false when it is nullish", () => {
+    // requiresApproval=true → carried through (the ?? false LEFT arm with a defined value).
+    const approvalClose: PlannedAgentAction = { actionClass: "close", requiresApproval: true, reason: "CI failing", closeKind: "heuristic" };
+    const heldApproval = downgradeCloseToHold([approvalClose], true);
+    expect(heldApproval.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)?.requiresApproval).toBe(true);
+    // requiresApproval nullish (defensive ?? false RIGHT arm) → the label defaults to requiresApproval=false.
+    const nullishClose = { actionClass: "close", reason: "CI failing", closeKind: "heuristic" } as unknown as PlannedAgentAction;
+    const heldNullish = downgradeCloseToHold([nullishClose], true);
+    expect(heldNullish.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)?.requiresApproval).toBe(false);
   });
 });

--- a/test/unit/auto-tune.test.ts
+++ b/test/unit/auto-tune.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AUTOCLEAR_AFTER_MS,
   applyAutoTune,
+  applyCloseAutoTune,
   computeTuningRecommendations,
   type FlagStore,
   type GateEvalReport,
   type GateEvalRow,
+  maybeAutoClearCloseHoldOnly,
   maybeAutoClearHoldOnly,
   planAutoTune,
+  planCloseAutoTune,
   shouldAutoClear,
+  shouldAutoClearClose,
 } from "../../src/review/auto-tune";
 
 const row = (over: Partial<GateEvalRow>): GateEvalRow => ({
@@ -31,14 +35,16 @@ const report = (rows: GateEvalRow[]): GateEvalReport => ({ rows, hasSignal: rows
 function stubFlags(over: Partial<FlagStore> = {}): {
   flags: FlagStore;
   isHoldOnly: ReturnType<typeof vi.fn>;
+  isCloseHoldOnly: ReturnType<typeof vi.fn>;
   setFlag: ReturnType<typeof vi.fn>;
   flagSetAt: ReturnType<typeof vi.fn>;
 } {
   const isHoldOnly = vi.fn(async (_project: string) => false);
+  const isCloseHoldOnly = vi.fn(async (_project: string) => false);
   const setFlag = vi.fn(async (_key: string, _on: boolean) => undefined);
   const flagSetAt = vi.fn(async (_key: string): Promise<string | null> => null);
-  const flags: FlagStore = { isHoldOnly, setFlag, flagSetAt, ...over };
-  return { flags, isHoldOnly, setFlag, flagSetAt };
+  const flags: FlagStore = { isHoldOnly, isCloseHoldOnly, setFlag, flagSetAt, ...over };
+  return { flags, isHoldOnly, isCloseHoldOnly, setFlag, flagSetAt };
 }
 
 describe("planAutoTune (#self-improve) — circuit-breaker is one-directional", () => {
@@ -121,12 +127,113 @@ describe("shouldAutoClear (#272 recovery-gated breaker auto-clear)", () => {
     const setFlag = vi.fn(async () => undefined);
     const flags: FlagStore = {
       isHoldOnly: vi.fn(async () => true),
+      isCloseHoldOnly: vi.fn(async () => true),
       setFlag,
       flagSetAt: vi.fn(async () => {
         throw new Error("d1 read down");
       }),
     };
     expect(await maybeAutoClearHoldOnly(flags, recovered, "g", now)).toBe(false);
+    expect(setFlag).not.toHaveBeenCalled();
+  });
+});
+
+// ── CLOSE-precision circuit-breaker (symmetric mirror of the merge breaker) ─────────────────────────────────
+
+describe("planCloseAutoTune (#close-precision-breaker) — tightening-only, close direction", () => {
+  it("engages when CLOSE precision drops below the floor over a real sample", () => {
+    const a = planCloseAutoTune(report([row({ project: "gittensory", decided: 20, wouldClose: 12, closeConfirmed: 8, closePrecision: 0.66 })]));
+    expect(a).toHaveLength(1);
+    expect(a[0]?.project).toBe("gittensory");
+    expect(a[0]?.message).toMatch(/Auto-CLOSE DISABLED/);
+    expect(a[0]?.message).toContain("closehold:gittensory");
+  });
+  it("does NOT engage on a thin sample (< min decided)", () => {
+    expect(planCloseAutoTune(report([row({ project: "p", decided: 5, wouldClose: 5, closeConfirmed: 2, closePrecision: 0.4 })]))).toHaveLength(0);
+  });
+  it("does NOT engage when close precision is null (no would-close predictions with a known outcome)", () => {
+    expect(planCloseAutoTune(report([row({ project: "p", decided: 30, wouldClose: 0, closeConfirmed: 0, closePrecision: null })]))).toHaveLength(0);
+  });
+  it("does NOT engage when close precision is healthy (it only ever tightens, never loosens)", () => {
+    expect(planCloseAutoTune(report([row({ project: "p", decided: 30, wouldClose: 30, closeConfirmed: 29, closePrecision: 0.97 })]))).toHaveLength(0);
+  });
+});
+
+describe("applyCloseAutoTune", () => {
+  it("sets the closehold flag for a newly-flagged project", async () => {
+    const { flags, setFlag } = stubFlags();
+    const engaged = await applyCloseAutoTune(flags, report([row({ project: "g", decided: 20, wouldClose: 10, closeConfirmed: 5, closePrecision: 0.5 })]));
+    expect(engaged).toHaveLength(1);
+    expect(setFlag).toHaveBeenCalledWith("closehold:g", true);
+  });
+  it("does not re-engage (or re-alert) a project already close-held", async () => {
+    const { flags, setFlag } = stubFlags({ isCloseHoldOnly: vi.fn(async () => true) });
+    const engaged = await applyCloseAutoTune(flags, report([row({ project: "g", decided: 20, wouldClose: 10, closeConfirmed: 5, closePrecision: 0.5 })]));
+    expect(engaged).toHaveLength(0);
+    expect(setFlag).not.toHaveBeenCalled();
+  });
+  it("swallows a write error and continues (fail-safe, ev:close_tune_error)", async () => {
+    const { flags } = stubFlags({
+      setFlag: vi.fn(async () => {
+        throw new Error("d1 down");
+      }),
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const engaged = await applyCloseAutoTune(flags, report([row({ project: "g", decided: 20, wouldClose: 10, closeConfirmed: 5, closePrecision: 0.5 })]));
+    expect(engaged).toHaveLength(0); // not pushed because the write threw
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("close_tune_error"));
+    log.mockRestore();
+  });
+});
+
+describe("shouldAutoClearClose (#close-precision-breaker recovery-gated auto-clear)", () => {
+  const now = Date.parse("2026-06-20T12:00:00Z");
+  const past = new Date(now - AUTOCLEAR_AFTER_MS - 3_600_000).toISOString(); // >24h ago
+  const recent = new Date(now - 3_600_000).toISOString(); // 1h ago
+  const recovered = report([row({ project: "g", decided: 20, wouldClose: 20, closeConfirmed: 20, closePrecision: 1.0 })]);
+  const failing = report([row({ project: "g", decided: 20, wouldClose: 10, closeConfirmed: 5, closePrecision: 0.5 })]);
+  it("never clears when not auto-engaged for this project (setAt null = global/human breaker)", () => {
+    expect(shouldAutoClearClose(recovered, "g", null, now)).toBe(false);
+  });
+  it("waits out the cooldown", () => {
+    expect(shouldAutoClearClose(recovered, "g", recent, now)).toBe(false);
+  });
+  it("clears after cooldown once close precision recovered (or there's no recent close signal)", () => {
+    expect(shouldAutoClearClose(recovered, "g", past, now)).toBe(true);
+    expect(shouldAutoClearClose(report([]), "g", past, now)).toBe(true);
+  });
+  it("keeps the breaker engaged if close precision is STILL failing after cooldown", () => {
+    expect(shouldAutoClearClose(failing, "g", past, now)).toBe(false);
+  });
+  it("parses a SQLite 'YYYY-MM-DD HH:MM:SS' (UTC, no zone) timestamp as UTC, not local", () => {
+    const sqlite = new Date(now - AUTOCLEAR_AFTER_MS - 3_600_000).toISOString().slice(0, 19).replace("T", " "); // 25h ago, SQLite format
+    expect(shouldAutoClearClose(recovered, "g", sqlite, now)).toBe(true);
+    const sqliteRecent = new Date(now - 3_600_000).toISOString().slice(0, 19).replace("T", " "); // 1h ago
+    expect(shouldAutoClearClose(recovered, "g", sqliteRecent, now)).toBe(false);
+  });
+  it("maybeAutoClearCloseHoldOnly clears the flag when due", async () => {
+    const { flags, setFlag } = stubFlags({ flagSetAt: vi.fn(async () => past) });
+    expect(await maybeAutoClearCloseHoldOnly(flags, recovered, "g", now)).toBe(true);
+    expect(setFlag).toHaveBeenCalledWith("closehold:g", false);
+  });
+  it("maybeAutoClearCloseHoldOnly does NOT clear while still in cooldown", async () => {
+    const { flags, setFlag } = stubFlags({ flagSetAt: vi.fn(async () => recent) });
+    expect(await maybeAutoClearCloseHoldOnly(flags, recovered, "g", now)).toBe(false);
+    expect(setFlag).not.toHaveBeenCalled();
+  });
+  it("maybeAutoClearCloseHoldOnly swallows a read error and stays held (fail-CLOSED catch)", async () => {
+    // flagSetAt throwing exercises the try/catch around the clear path: it must fail CLOSED (return false,
+    // breaker stays engaged) and never call setFlag — a DB blip can't silently re-enable auto-close.
+    const setFlag = vi.fn(async () => undefined);
+    const flags: FlagStore = {
+      isHoldOnly: vi.fn(async () => true),
+      isCloseHoldOnly: vi.fn(async () => true),
+      setFlag,
+      flagSetAt: vi.fn(async () => {
+        throw new Error("d1 read down");
+      }),
+    };
+    expect(await maybeAutoClearCloseHoldOnly(flags, recovered, "g", now)).toBe(false);
     expect(setFlag).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { processJob } from "../../src/queue/processors";
 import {
   createFlagStore,
+  isCloseHoldOnly,
   isHoldOnly,
   parseRevertedPrNumber,
   recordPrOutcome,
@@ -227,6 +228,81 @@ describe("isHoldOnly + createFlagStore (system_flags, migration 0054)", () => {
   });
 });
 
+describe("isCloseHoldOnly + createFlagStore.isCloseHoldOnly (closehold:<scope>, same system_flags table)", () => {
+  it("isCloseHoldOnly is false with no flags, true once closehold:<project> is set, with per-project isolation, and respects closehold:global", async () => {
+    const env = createTestEnv();
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+    const flags = createFlagStore(env);
+    await flags.setFlag("closehold:owner/repo", true);
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(true);
+    expect(await isCloseHoldOnly(env, "owner/other")).toBe(false); // per-project isolation
+    // the merge breaker is independent: a closehold does NOT set holdonly.
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+    await flags.setFlag("closehold:owner/repo", false);
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+    // global close breaker applies to every project.
+    await flags.setFlag("closehold:global", true);
+    expect(await isCloseHoldOnly(env, "any/repo")).toBe(true);
+  });
+
+  it("createFlagStore.isCloseHoldOnly reads the per-project closehold key (not the global one)", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    expect(await flags.isCloseHoldOnly("owner/repo")).toBe(false);
+    await flags.setFlag("closehold:owner/repo", true);
+    expect(await flags.isCloseHoldOnly("owner/repo")).toBe(true);
+    expect(await flags.isCloseHoldOnly("owner/other")).toBe(false);
+    // The per-key store read does NOT fold in the global flag (mirrors isHoldOnly's per-key dedup read).
+    await flags.setFlag("closehold:owner/repo", false);
+    await flags.setFlag("closehold:global", true);
+    expect(await flags.isCloseHoldOnly("owner/repo")).toBe(false);
+  });
+
+  it("isCloseHoldOnly ignores a closehold row whose value is falsy (flagTruthy false arm)", async () => {
+    const env = createTestEnv();
+    // A row exists for this project but its value is '0' (not truthy) → must NOT count as engaged.
+    await env.DB.prepare("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES ('closehold:owner/repo', '0', CURRENT_TIMESTAMP)").run();
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+  });
+
+  it("isCloseHoldOnly tolerates an all() result with no `results` array (the ?? [] fallback arm)", async () => {
+    const env = createTestEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = ((sql: string) => {
+      // Force the system_flags scan to return an object WITHOUT a `results` array so `res.results ?? []` falls back.
+      if (/SELECT key, value FROM system_flags/i.test(sql)) {
+        return { all: async () => ({}) } as unknown as ReturnType<typeof realPrepare>;
+      }
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false); // no rows → not engaged, no throw
+  });
+
+  it("createFlagStore.isCloseHoldOnly fails safe (returns false) when the store read throws", async () => {
+    const env = createTestEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = ((sql: string) => {
+      if (/system_flags/i.test(sql)) throw new Error("d1 down");
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+    const flags = createFlagStore(env);
+    expect(await flags.isCloseHoldOnly("owner/repo")).toBe(false); // catch arm → false, never throws
+  });
+
+  it("isCloseHoldOnly (env-level) fails OPEN (false) and logs flags_read_error when the scan throws", async () => {
+    const env = createTestEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    env.DB.prepare = ((sql: string) => {
+      if (/system_flags/i.test(sql)) throw new Error("d1 down");
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("flags_read_error"));
+    warn.mockRestore();
+  });
+});
+
 describe("applyAutoTune over the live FlagStore — engages holdonly on low merge precision", () => {
   it("engages holdonly:<project> when merge precision is below the floor over a real sample", async () => {
     const env = createTestEnv();
@@ -268,10 +344,55 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
     expect(await isHoldOnly(env, "owner/repo")).toBe(true);
   });
 
-  it("does NOT engage with no recorded outcome history (fail-safe / byte-identical)", async () => {
+  it("ENGAGES the CLOSE breaker when recorded outcomes show close precision below the floor", async () => {
+    const env = createTestEnv();
+    // 12 would-CLOSE predictions: 4 confirmed (human closed), 8 the human actually MERGED → 33% close precision.
+    for (let i = 0; i < 4; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+    for (let i = 4; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "merged");
+
+    await runSelfTuneBreaker(env);
+
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(true);
+    // The merge breaker is INDEPENDENT — close-precision failure must not engage holdonly.
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+  });
+
+  it("does NOT engage the CLOSE breaker when recorded close precision is healthy", async () => {
+    const env = createTestEnv();
+    // 12 would-CLOSE predictions: 12 confirmed (human closed) → 100% close precision, well above the floor.
+    for (let i = 0; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+
+    await runSelfTuneBreaker(env);
+
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+  });
+
+  it("does NOT engage with no recorded outcome history (fail-safe / byte-identical — both breakers)", async () => {
     const env = createTestEnv();
     await runSelfTuneBreaker(env);
     expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+  });
+
+  it("AUTO-CLEARS both breakers once the cooldown has elapsed AND precision recovered", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    // Engage both breakers directly, then backdate their updated_at past the 24h cooldown.
+    await flags.setFlag("holdonly:owner/repo", true);
+    await flags.setFlag("closehold:owner/repo", true);
+    await env.DB.prepare("UPDATE system_flags SET updated_at = datetime('now', '-2 days') WHERE key IN ('holdonly:owner/repo', 'closehold:owner/repo')").run();
+    expect(await isHoldOnly(env, "owner/repo")).toBe(true);
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(true);
+    // Seed RECOVERED outcomes for both directions: every merge prediction merged, every close prediction closed.
+    for (let i = 0; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
+    for (let i = 12; i < 24; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runSelfTuneBreaker(env);
+    log.mockRestore();
+
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false); // merge breaker auto-cleared
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false); // close breaker auto-cleared
   });
 
   it("never throws (fails safe) even when review_audit reads blow up", async () => {

--- a/test/unit/precision-breakers-chain.test.ts
+++ b/test/unit/precision-breakers-chain.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { applyPrecisionBreakers } from "../../src/queue/processors";
+import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, type PlannedAgentAction } from "../../src/settings/agent-actions";
+
+// The processors chaining at maybeRunAgentMaintenance:
+//   breakerOnPlan = applyPrecisionBreakers(planned, isHoldOnly, isCloseHoldOnly)
+// Both flag reads are independent + fail-open at the call site; this exercises the composed transform.
+
+const mergeAction: PlannedAgentAction = { actionClass: "merge", requiresApproval: false, reason: "ready", mergeMethod: "squash" };
+const readyLabel: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "ready", label: AGENT_LABEL_READY, labelOp: "add" };
+const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failing", closeKind: "heuristic" };
+const changesLabel: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "verdict=failure", label: AGENT_LABEL_CHANGES, labelOp: "add" };
+
+describe("applyPrecisionBreakers — chaining the merge + close precision breakers", () => {
+  it("close is downgraded when closeHoldOnly=true (merge breaker off)", () => {
+    const out = applyPrecisionBreakers([changesLabel, heuristicClose], false, true);
+    expect(out.some((a) => a.actionClass === "close")).toBe(false); // heuristic close dropped
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add")).toBe(true);
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(true); // changes-requested KEPT
+  });
+
+  it("passthrough when both breakers are off (byte-identical common path)", () => {
+    const plan = [readyLabel, mergeAction];
+    expect(applyPrecisionBreakers(plan, false, false)).toBe(plan);
+  });
+
+  it("merge is downgraded when holdOnly=true (close breaker off) without touching a heuristic close", () => {
+    const out = applyPrecisionBreakers([readyLabel, mergeAction], true, false);
+    expect(out.some((a) => a.actionClass === "merge")).toBe(false); // merge dropped
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false); // ready label dropped
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add")).toBe(true);
+  });
+
+  it("both breakers active do not interfere: merge AND a heuristic close are each downgraded", () => {
+    // A (contrived) plan carrying both a merge and a heuristic close exercises both transforms in one pass.
+    const out = applyPrecisionBreakers([readyLabel, mergeAction, changesLabel, heuristicClose], true, true);
+    expect(out.some((a) => a.actionClass === "merge")).toBe(false);
+    expect(out.some((a) => a.actionClass === "close")).toBe(false);
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false);
+    expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(true); // KEPT
+    // needs-human-review added exactly once (the second downgrade is idempotent on the label).
+    expect(out.filter((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **CLOSE-precision circuit-breaker** — a symmetric mirror of the existing MERGE-precision breaker. When the gate eval shows the bot's recent auto-CLOSE precision degrading below the floor over a real sample, would-closes are **downgraded to HOLD** (the `close` action is dropped and the `needs-human-review` label is added) instead of executed.

It is **tightening-only in the close direction**: it can ONLY remove a heuristic `close` action and add a label. It NEVER adds or enables a close, merge, or approve, and it never touches an existing merge/approve action. Like its merge twin, it is **inert until the selftune cron (`GITTENSORY_REVIEW_SELFTUNE`) is enabled AND close-outcome data is present** — with no recorded `pr_outcome` history the eval reads neutral, nothing engages, and the close path is byte-identical.

## What changed

- **`src/review/auto-tune.ts`** — `AUTOTUNE_CLOSE_PRECISION_FLOOR = 0.85` (beside the merge floor); `CloseAutoTuneAction` + `planCloseAutoTune` / `applyCloseAutoTune` / `shouldAutoClearClose` / `maybeAutoClearCloseHoldOnly`, mirroring the merge helpers and reusing `AUTOTUNE_MIN_DECIDED` + `AUTOCLEAR_AFTER_MS`. Reads `r.closePrecision` / `r.wouldClose` where the merge breaker reads `r.mergePrecision` / `r.wouldMerge`. The `FlagStore` interface gains `isCloseHoldOnly`.
- **`src/review/outcomes-wire.ts`** — env-level `isCloseHoldOnly` (a single `system_flags` scan over the `closehold:` namespace, fail-OPEN false); `createFlagStore.isCloseHoldOnly` (per-key dedup read); `runSelfTuneBreaker` now engages/clears the close breaker beside the merge one, logging `close_breaker_engaged` / `close_breaker_auto_cleared`. The new `closehold:<scope>` flags reuse the **SAME `system_flags` table — no new migration**.
- **`src/settings/agent-actions.ts`** — pure `downgradeCloseToHold`. **Owner-required scoping**: it downgrades ONLY heuristic (verdict-driven: gate-verdict / duplicate / slop / CI) closes and **EXEMPTS the deterministic linked-issue hard-rule close**. There was no clean tag to distinguish the two `actionClass: "close"` pushes, so a minimal `closeKind: "heuristic" | "linked-issue-hard-rule"` marker is added on each close action; the breaker exempts the deterministic one. Rationale: that close is zero-hallucination and on the verify path posts a comment **promising** closure — silently downgrading it to a hold while a comment promises closure would be incoherent. The existing changes-requested label is kept.
- **`src/queue/processors.ts`** — chains both fail-open breakers via a new pure `applyPrecisionBreakers(planned, holdOnly, closeHoldOnly)`: merge breaker first (`downgradeMergeToHold`), then close breaker (`downgradeCloseToHold`). The reads are independent and fail-open; the existing `length === 0` guard is preserved.

### Observability

`runSelfTuneBreaker` logs a per-project `close_breaker_engaged` line plus a single `closehold_backlog` summary line (count + the engaged projects) so a human can see the held-close backlog via Workers Logs — the same notify channel the merge breaker / ops anomalies use.

## Validation (backend; UI skipped per house rule — no UI surface touched)

- `git diff --check` → clean
- `npm run typecheck` → pass
- `npm run db:migrations:check` → `56 migrations OK — contiguous 0001..0054` (no new migration; the breaker reuses `system_flags`)
- `npm run test:coverage` (full unsharded suite) → **all green**; summary Lines 97.6%, Statements 96.77%, Branches 94.97%
- `npm run test:workers` → pass
- `npm audit --audit-level=moderate` → 0 vulnerabilities
- Patch coverage: every changed line **and branch** in `auto-tune.ts`, `outcomes-wire.ts`, `agent-actions.ts`, `processors.ts` verified covered via `coverage/lcov.info` (no `DA:<line>,0` and no uncovered `BRDA` on any added line).

New/extended tests: `planCloseAutoTune` (engage <floor / thin sample / null precision / healthy), `applyCloseAutoTune` (sets flag / skips already-held / swallows write error), `shouldAutoClearClose` + `maybeAutoClearCloseHoldOnly` (cooldown / recovery / fail-CLOSED), `downgradeCloseToHold` (heuristic close dropped + needs-human-review added + changes-requested kept; linked-issue-hard-rule EXEMPT; both-present drops only heuristic; no-op when false; never adds merge/approve; idempotent label; requiresApproval carry/default), `isCloseHoldOnly` + `createFlagStore` (none / set / per-project isolation / `closehold:global` / falsy-value / fail-open), `runSelfTuneBreaker` integration (engages on recorded false-closes, not on healthy; independent of the merge breaker; auto-clears both after cooldown+recovery), and `applyPrecisionBreakers` chaining (close downgraded when true / passthrough when false / both active without interfering).

Linked issue: none — this is an owner-initiated infrastructure addition (the symmetric close-side of the existing self-improvement accuracy breaker); it implements a design directive directly rather than resolving a tracked community issue.
