### PR TITLE
fix(gate): mirror the duplicate-winner rule in the maintainer activation preview

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2163,7 +2163,7 @@ export function createApp() {
       getRepositorySettings(c.env, fullName),
       listPullRequests(c.env, fullName),
     ]);
-    return c.json(buildMaintainerActivationPreview({ repoFullName: fullName, repo, settings, pullRequests, generatedAt: nowIso() }));
+    return c.json(buildMaintainerActivationPreview({ repoFullName: fullName, repo, settings, pullRequests, generatedAt: nowIso(), duplicateWinnerEnabled: c.env.GITTENSORY_DUPLICATE_WINNER === "true" }));
   });
 
   // #543 outcome-learning loop: is the slop score predictive, and are recommendations panning out? Read-only

--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -136,6 +136,11 @@ export function buildPredictedGateVerdict(args: {
   // Linked-issue finding is surfaced when the repo's public policy treats it as anything but `off`, so the
   // gate can evaluate it; evaluateGateCheck decides whether it actually blocks (block) or stays advisory.
   const requireLinkedIssue = gate.linkedIssue !== null && gate.linkedIssue !== "off";
+  // `duplicateWinnerEnabled` is INTENTIONALLY omitted (#dup-winner): the prospective PR is synthetic #0, but a
+  // real new PR opened into an existing duplicate cluster gets the HIGHEST number ⇒ it is always a duplicate
+  // LOSER, never the winner. So the predictor must keep showing the duplicate finding (the honest pre-submit
+  // answer). Threading the flag here would let isDuplicateClusterWinner(0, …) treat #0 as the winner and
+  // falsely suppress the block — a false-optimism regression. Do NOT add it without modeling #0 as the loser.
   const advisory = buildPullRequestAdvisory(repo, syntheticPr, { otherOpenPullRequests: pullRequests, requireLinkedIssue });
 
   // Pack-aware (#693): under `oss-anti-slop` the gate blocks ANY author, so drop the confirmed-contributor

--- a/src/services/maintainer-activation.ts
+++ b/src/services/maintainer-activation.ts
@@ -50,6 +50,9 @@ export function buildMaintainerActivationPreview(args: {
   pullRequests: PullRequestRecord[];
   generatedAt: string;
   sampleSize?: number;
+  /** GITTENSORY_DUPLICATE_WINNER (#dup-winner): mirror the live pipeline so the demo's duplicate findings
+   *  match the real gate — when ON, the cluster winner is spared. Defaults to off (byte-identical preview). */
+  duplicateWinnerEnabled?: boolean;
 }): MaintainerActivationPreview {
   const sampleSize = Math.min(Math.max(args.sampleSize ?? DEFAULT_SAMPLE_SIZE, 1), 25);
   const recent = [...args.pullRequests].sort((left, right) => recencyKey(right).localeCompare(recencyKey(left))).slice(0, sampleSize);
@@ -57,8 +60,12 @@ export function buildMaintainerActivationPreview(args: {
   const codeCounts = new Map<string, number>();
   const samples: MaintainerActivationSample[] = recent.map((pr) => {
     const advisory = buildPullRequestAdvisory(args.repo, pr, {
-      otherOpenPullRequests: args.pullRequests.filter((other) => other.number !== pr.number),
+      // Open-only siblings: a closed/merged PR isn't competing, and isDuplicateClusterWinner's invariant
+      // requires open-only numbers — match the live pipeline (processors.ts:559/800), which feeds the
+      // winner adjudication the same open-filtered set.
+      otherOpenPullRequests: args.pullRequests.filter((other) => other.number !== pr.number && other.state === "open"),
       requireLinkedIssue: args.settings.requireLinkedIssue || args.settings.linkedIssueGateMode !== "off",
+      duplicateWinnerEnabled: Boolean(args.duplicateWinnerEnabled),
     });
     for (const finding of advisory.findings) codeCounts.set(finding.code, (codeCounts.get(finding.code) ?? 0) + 1);
     return {

--- a/test/unit/maintainer-activation.test.ts
+++ b/test/unit/maintainer-activation.test.ts
@@ -163,6 +163,47 @@ describe("buildMaintainerActivationPreview", () => {
     });
     expect(undatedPreview.evaluatedCount).toBe(2);
   });
+
+  it("spares the duplicate-cluster winner when GITTENSORY_DUPLICATE_WINNER is on, flagging only the losers", () => {
+    const preview = buildMaintainerActivationPreview({
+      repoFullName: repo.fullName,
+      repo,
+      settings: settings(),
+      // Two OPEN PRs link the same issue (#42) → a duplicate cluster. Winner = lowest open number = #1.
+      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { linkedIssues: [42] })],
+      generatedAt: "2026-06-14T00:00:00.000Z",
+      duplicateWinnerEnabled: true,
+    });
+    const winner = preview.samples.find((sample) => sample.number === 1)!;
+    const loser = preview.samples.find((sample) => sample.number === 2)!;
+    expect(winner.findings.map((finding) => finding.code)).not.toContain("duplicate_pr_risk");
+    expect(loser.findings.map((finding) => finding.code)).toContain("duplicate_pr_risk");
+  });
+
+  it("flags every duplicate-cluster member when GITTENSORY_DUPLICATE_WINNER is off (default)", () => {
+    const preview = buildMaintainerActivationPreview({
+      repoFullName: repo.fullName,
+      repo,
+      settings: settings(),
+      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { linkedIssues: [42] })],
+      generatedAt: "2026-06-14T00:00:00.000Z",
+    });
+    expect(preview.findingCodeCounts).toContainEqual({ code: "duplicate_pr_risk", count: 2 });
+  });
+
+  it("ignores closed/merged siblings when detecting duplicate overlap", () => {
+    const preview = buildMaintainerActivationPreview({
+      repoFullName: repo.fullName,
+      repo,
+      settings: settings(),
+      // The only other PR linking #42 is CLOSED → not a live duplicate, so the open winner stays clean.
+      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { state: "closed", linkedIssues: [42] })],
+      generatedAt: "2026-06-14T00:00:00.000Z",
+      duplicateWinnerEnabled: true,
+    });
+    const open = preview.samples.find((sample) => sample.number === 1)!;
+    expect(open.findings.map((finding) => finding.code)).not.toContain("duplicate_pr_risk");
+  });
 });
 
 describe("recommendedAdvisoryActivationSettings", () => {


### PR DESCRIPTION
## Summary

- Mirror the `GITTENSORY_DUPLICATE_WINNER` (#dup-winner) adjudication into the maintainer **activation preview** so the demo's findings match what the live gate would actually do. The preview ran `buildPullRequestAdvisory` without `duplicateWinnerEnabled`, so once the flag goes live it would have shown the cluster **winner** still carrying a `duplicate_pr_risk` finding the real gate suppresses — a credibility gap in the install demo.
- Align the preview's sibling set with the live pipeline: pass **open-only** siblings (`processors.ts:559/800` already do). A closed/merged PR is not competing, and `isDuplicateClusterWinner`'s documented invariant requires open-only numbers — feeding it closed PRs would mis-elect the winner when the flag is enabled.
- Document why `predicted-gate.ts` **intentionally** omits the flag: its prospective PR is synthetic `#0`, but a real new PR opened into an existing cluster gets the **highest** number ⇒ it is always a duplicate **loser**, never the winner. Threading the flag there would let `isDuplicateClusterWinner(0, …)` treat `#0` as the winner and falsely suppress the block (false-optimism regression). The comment guards against a future naive "parity fix".

While `GITTENSORY_DUPLICATE_WINNER` stays `"false"` (current), the preview is byte-identical apart from no longer counting closed siblings as duplicates — a strict accuracy improvement.

No issue linked: this is a small, self-contained parity/correctness fix on an advisory-only surface (the maintainer activation demo); the rationale above explains it. Owner-authored.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `maintainer-activation.ts` and `predicted-gate.ts` at **100% branch**; the one changed `routes.ts` line is covered by the existing activation-preview integration test. New branches (`other.state === "open"`, winner-spared vs. flagged) covered by 3 added unit tests.
- [x] `npm run test:ci` (full gate) exits 0 — actionlint, db:migrations:check, typecheck, test:coverage, test:workers, build:mcp, test:mcp-pack, ui:openapi:check, ui:version-audit, ui:lint, ui:typecheck, ui:test, ui:build.
- [x] `npm run ui:openapi:check` — no OpenAPI drift (internal change only; route I/O unchanged).
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New behavior has unit tests for the new branches and the closed-sibling fallback path.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/session changes (the route already runs behind `requireRepoMaintainer`).
- [x] API/OpenAPI/MCP behavior unchanged — no schema change; verified by `ui:openapi:check`.
- [x] No UI changes.
- [x] No docs/changelog changes needed.

## Notes

- Follow-up parity tracking for the remaining `duplicateWinnerEnabled` surfaces is unnecessary: an audit of all `buildPullRequestAdvisory` call sites confirms the 4 `processors.ts` callers already thread the flag; `predicted-gate.ts` is correct-by-omission (documented here); this PR closes the only real gap (`maintainer-activation.ts`).
