### PR TITLE
fix(agent): fail closed on unreadable required CI

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -135,13 +135,6 @@ declare global {
      *  percentage + an estimated-time-saved figure ONLY — never PR content, authors, scores, or reward internals.
      *  See review/public-stats.ts. */
     GITTENSORY_PUBLIC_STATS?: string;
-    /** Comma-separated fallback set of REQUIRED CI contexts (e.g. "Superagent Security Scan,validate,Gittensory Gate").
-     *  Used ONLY when the live branch-protection read in fetchRequiredStatusContexts fails — usually a 403 because the
-     *  installation token lacks `administration:read`. It keeps required-only CI evaluation (review starts once the
-     *  required checks pass; a non-required red does not drive an automated close) instead of conservatively folding
-     *  ALL checks. Unset/empty preserves the byte-identical fold-all default. The names MUST match the exact
-     *  check-run/status contexts. See github/backfill.ts:configuredRequiredCiContexts. */
-    GITTENSORY_REQUIRED_CI_CONTEXTS?: string;
     /** Convergence (port): public OAuth draft-submission flow ported from reviewbot. When truthy, the
      *  /v1/drafts endpoints accept a contributor draft -> GitHub OAuth -> fork PR against the content repo.
      *  Default OFF — unset/false makes every draft endpoint 404 and writes nothing (byte-identical worker). */

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1940,32 +1940,12 @@ export type LiveCiAggregate = {
 };
 
 /**
- * Operator-configured fallback set of REQUIRED CI contexts (comma-separated `GITTENSORY_REQUIRED_CI_CONTEXTS`,
- * e.g. "Superagent Security Scan,validate,Gittensory Gate"). This is the config-as-code belt for
- * fetchRequiredStatusContexts: when the LIVE branch-protection read fails — most commonly a 403 because the
- * installation token lacks `administration:read` — folding ALL checks into the gate makes review wait on
- * non-required checks (slow) and lets a non-required red (e.g. codecov variance) drive an automated close
- * (unfair). Using the configured trusted set instead keeps required-only behavior during that window. Returns
- * `null` when unset/empty so the caller keeps the conservative fold-all default (byte-identical to before).
- * The names MUST match the exact check-run / status contexts. Granting the App `administration:read` makes the
- * live read succeed (per-repo accurate) and reduces this fallback to a transient-failure safety net.
- */
-export function configuredRequiredCiContexts(env: { GITTENSORY_REQUIRED_CI_CONTEXTS?: string }): Set<string> | null {
-  const names = new Set<string>();
-  for (const part of (env.GITTENSORY_REQUIRED_CI_CONTEXTS ?? "").split(",")) {
-    const trimmed = part.trim();
-    if (trimmed.length > 0) names.add(trimmed);
-  }
-  return names.size > 0 ? names : null;
-}
-
-/**
  * RC2 best-effort fetch of the base branch's branch-protection REQUIRED status-check contexts. Returns the set
  * of required context names (covering both the legacy `contexts` array and the newer `checks[].context` shape),
- * or the operator-configured fallback (`GITTENSORY_REQUIRED_CI_CONTEXTS`) — else `null` — when none can be
- * determined: a 404 (no protection / no required checks), a 403 (token lacks `administration:read`, common for
- * installations/forks), or any other error. `null`/empty makes fetchLiveCiAggregate fall back to folding ALL
- * red checks into the gate, so a fetch failure can never silently pass a required red check.
+ * or `null` when none can be determined: a 404 (no protection / no required checks), a 403 (token lacks
+ * `administration:read`, common for installations/forks), or any other error. `null`/empty makes
+ * fetchLiveCiAggregate fall back to folding ALL red checks into the gate, so a fetch failure can never silently
+ * pass a required red check.
  */
 export async function fetchRequiredStatusContexts(env: Env, repoFullName: string, baseRef: string | null | undefined, token: string | undefined): Promise<Set<string> | null> {
   if (!baseRef) return null;
@@ -1975,7 +1955,7 @@ export async function fetchRequiredStatusContexts(env: Env, repoFullName: string
     `/branches/${encodeURIComponent(baseRef)}/protection/required_status_checks`,
     token,
   ).catch(() => undefined);
-  if (!result) return configuredRequiredCiContexts(env); // 404 / 403 (no admin:read) / error → configured fallback, else null (fold-all).
+  if (!result) return null; // 404 / 403 (no admin:read) / error → conservative fold-all.
   const names = new Set<string>();
   for (const ctx of result.data.contexts ?? []) {
     if (typeof ctx === "string" && ctx.trim().length > 0) names.add(ctx);

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -31,7 +31,6 @@ import {
   buildInstallationRepairDiagnostics,
   enqueueRepositoryOpenDataBackfill,
   enrichInstallationHealth,
-  configuredRequiredCiContexts,
   fetchAndStorePullRequestFilesForReview,
   fetchLiveCiAggregate,
   fetchRequiredStatusContexts,
@@ -2803,26 +2802,9 @@ describe("GitHub backfill", () => {
 
   });
 
-  describe("configuredRequiredCiContexts", () => {
-    it("returns null when the var is unset (preserves the fold-all default)", () => {
-      expect(configuredRequiredCiContexts({})).toBeNull();
-    });
-
-    it("returns null when the var is empty or only separators/whitespace", () => {
-      expect(configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "" })).toBeNull();
-      expect(configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "  , ,, " })).toBeNull();
-    });
-
-    it("parses a comma-separated set, trimming whitespace and dropping empty entries", () => {
-      const parsed = configuredRequiredCiContexts({ GITTENSORY_REQUIRED_CI_CONTEXTS: "Superagent Security Scan, validate ,,Gittensory Gate" });
-      expect(parsed).not.toBeNull();
-      expect([...(parsed as Set<string>)].sort()).toEqual(["Gittensory Gate", "Superagent Security Scan", "validate"]);
-    });
-  });
-
   describe("fetchRequiredStatusContexts", () => {
     it("returns null without fetching when baseRef is missing", async () => {
-      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "validate" });
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       const fetchSpy = vi.fn();
       vi.stubGlobal("fetch", fetchSpy);
       expect(await fetchRequiredStatusContexts(env, "JSONbored/gittensory", null, "public-token")).toBeNull();
@@ -2830,7 +2812,7 @@ describe("GitHub backfill", () => {
     });
 
     it("returns the live required set when branch protection is readable (both contexts and checks shapes)", async () => {
-      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "ignored-when-live-read-works" });
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         if (input.toString().includes("/protection/required_status_checks")) {
           return Response.json({ contexts: ["validate", "", null], checks: [{ context: "Superagent Security Scan" }, { context: "  " }] });
@@ -2841,15 +2823,9 @@ describe("GitHub backfill", () => {
       expect([...(required as Set<string>)].sort()).toEqual(["Superagent Security Scan", "validate"]);
     });
 
-    it("falls back to the configured set when the live read fails (e.g. 403, no admin:read)", async () => {
-      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", GITTENSORY_REQUIRED_CI_CONTEXTS: "Superagent Security Scan,validate,Gittensory Gate" });
-      vi.stubGlobal("fetch", async () => new Response("forbidden", { status: 403 }));
-      const required = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token");
-      expect([...(required as Set<string>)].sort()).toEqual(["Gittensory Gate", "Superagent Security Scan", "validate"]);
-    });
-
-    it("returns null when the live read fails and no fallback is configured (conservative fold-all)", async () => {
+    it("returns null when the live read fails, even if a stale global fallback is configured (conservative fold-all)", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      (env as Env & { GITTENSORY_REQUIRED_CI_CONTEXTS?: string }).GITTENSORY_REQUIRED_CI_CONTEXTS = "stale-required-context";
       vi.stubGlobal("fetch", async () => new Response("forbidden", { status: 403 }));
       expect(await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token")).toBeNull();
     });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -117,13 +117,6 @@
     // reviewed repos. Flag-OFF the endpoint 404s and the homepage band renders nothing (counts only, no PR
     // content/authors/scores/rewards). See src/review/public-stats.ts.
     "GITTENSORY_PUBLIC_STATS": "true",
-    // Fallback REQUIRED CI contexts, used ONLY when the live branch-protection read fails (a 403 when the
-    // installation token lacks `administration:read`, or a transient error). Keeps required-only CI evaluation
-    // — review starts once these pass; a non-required red (e.g. codecov variance) does NOT drive an automated
-    // close — instead of conservatively folding ALL checks in. Mirrors the repos' actual branch protection.
-    // Granting the App `administration:read` makes the live (per-repo) read succeed and reduces this to a
-    // transient-failure safety net. Names MUST match the exact check contexts. See src/github/backfill.ts.
-    "GITTENSORY_REQUIRED_CI_CONTEXTS": "Superagent Security Scan,validate,Gittensory Gate",
     // Duplicate-winner adjudication (#dup-winner): when a same-issue cluster of OPEN PRs forms, spare exactly
     // ONE winner — the lowest-numbered (earliest opened) open PR — instead of blocking/closing every sibling.
     // Only the LOSERS get the duplicate blocker + close reason + slop penalty + panel block; the winner is


### PR DESCRIPTION
### Motivation
- Prevent a fail-open regression where a global, operator-configured fallback list of required CI contexts could allow automation to treat real required CI failures as non-failing when the branch-protection read is unreadable.  

### Description
- Remove the global fallback parser and usage so unreadable branch-protection reads return `null` and the system conservatively folds all checks into the gate instead of trusting a stale global set.  
- Change `fetchRequiredStatusContexts` to return `null` on any failure to read branch protection (403/404/transient), restoring conservative "fold-all" behavior.  
- Drop the `GITTENSORY_REQUIRED_CI_CONTEXTS` production variable from `wrangler.jsonc` and remove its Env typing.  
- Update unit tests in `test/unit/backfill.test.ts` to assert the conservative behavior even if a stale env value is present.

### Testing
- Ran `git diff --check` and TypeScript typecheck via `npm run typecheck`, both succeeded.  
- Ran targeted unit tests with `npx vitest run test/unit/backfill.test.ts -t "fetchRequiredStatusContexts|fetchLiveCiAggregate"`, and the focused tests passed.  
- Attempted the full local gate via `npm run test:ci`; the run encountered unrelated long test timeouts and a Vitest coverage error (`jsTokens is not a function`) so the full-suite job did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b68a9c8a8832ca056dc93a9771868)