### PR TITLE
fix(review): require would-close sample for close-precision breaker

### DIFF
--- a/src/review/auto-tune.ts
+++ b/src/review/auto-tune.ts
@@ -150,14 +150,15 @@ export async function maybeAutoClearHoldOnly(flags: FlagStore, report: GateEvalR
 // sample, the system DISABLES its own auto-CLOSE for that project (`closehold:<scope>`) so would-closes HOLD
 // for a person instead of executing a bad close. TIGHTENING-ONLY in the close direction (it only ever removes a
 // close + holds for review; it NEVER adds/enables a close, merge, or approve). Reads r.closePrecision /
-// r.wouldClose where the merge breaker reads r.mergePrecision / r.wouldMerge. Reuses AUTOTUNE_MIN_DECIDED and
-// AUTOCLEAR_AFTER_MS. Same forward-measured retry contract: a human clears it early; the cooldown auto-clears it
+// r.wouldClose where the merge breaker reads r.mergePrecision / r.wouldMerge. Reuses AUTOTUNE_MIN_DECIDED
+// as the minimum would-close sample and AUTOCLEAR_AFTER_MS. Same forward-measured retry contract: a human clears it early; the cooldown auto-clears it
 // once precision recovers so auto-close can resume.
 
 export interface CloseAutoTuneAction {
   project: string;
   closePrecision: number;
   decided: number;
+  wouldClose: number;
   message: string;
 }
 
@@ -166,13 +167,14 @@ export interface CloseAutoTuneAction {
 export function planCloseAutoTune(report: GateEvalReport): CloseAutoTuneAction[] {
   const actions: CloseAutoTuneAction[] = [];
   for (const r of report.rows) {
-    if (r.decided < AUTOTUNE_MIN_DECIDED || r.closePrecision == null) continue;
+    if (r.wouldClose < AUTOTUNE_MIN_DECIDED || r.closePrecision == null) continue;
     if (r.closePrecision < AUTOTUNE_CLOSE_PRECISION_FLOOR) {
       actions.push({
         project: r.project,
         closePrecision: r.closePrecision,
         decided: r.decided,
-        message: `Auto-CLOSE DISABLED for ${r.project}: close precision ${Math.round(r.closePrecision * 100)}% over ${r.decided} decided PR(s) (< ${Math.round(AUTOTUNE_CLOSE_PRECISION_FLOOR * 100)}%). Would-closes now HOLD for review. Investigate, then clear closehold:${r.project}.`,
+        wouldClose: r.wouldClose,
+        message: `Auto-CLOSE DISABLED for ${r.project}: close precision ${Math.round(r.closePrecision * 100)}% over ${r.wouldClose} would-close PR(s) (< ${Math.round(AUTOTUNE_CLOSE_PRECISION_FLOOR * 100)}%). Would-closes now HOLD for review. Investigate, then clear closehold:${r.project}.`,
       });
     }
   }
@@ -207,7 +209,7 @@ export function shouldAutoClearClose(report: GateEvalReport, project: string, se
   const setMs = Date.parse(hasZone ? t : `${t}Z`);
   if (!Number.isFinite(setMs) || nowMs - setMs < AUTOCLEAR_AFTER_MS) return false; // still in cooldown
   const row = report.rows.find((r) => r.project === project);
-  const stillFailing = !!row && row.closePrecision != null && row.decided >= AUTOTUNE_MIN_DECIDED && row.closePrecision < AUTOTUNE_CLOSE_PRECISION_FLOOR;
+  const stillFailing = !!row && row.closePrecision != null && row.wouldClose >= AUTOTUNE_MIN_DECIDED && row.closePrecision < AUTOTUNE_CLOSE_PRECISION_FLOOR;
   return !stillFailing; // cooldown elapsed + precision recovered (or no signal) → clear and let it retry
 }
 

--- a/test/unit/auto-tune.test.ts
+++ b/test/unit/auto-tune.test.ts
@@ -148,7 +148,10 @@ describe("planCloseAutoTune (#close-precision-breaker) — tightening-only, clos
     expect(a[0]?.message).toMatch(/Auto-CLOSE DISABLED/);
     expect(a[0]?.message).toContain("closehold:gittensory");
   });
-  it("does NOT engage on a thin sample (< min decided)", () => {
+  it("does NOT engage on a thin would-close sample even with enough total decided PRs", () => {
+    expect(planCloseAutoTune(report([row({ project: "p", decided: 20, wouldClose: 1, closeConfirmed: 0, closePrecision: 0 })]))).toHaveLength(0);
+  });
+  it("does NOT engage when both decided and would-close samples are thin", () => {
     expect(planCloseAutoTune(report([row({ project: "p", decided: 5, wouldClose: 5, closeConfirmed: 2, closePrecision: 0.4 })]))).toHaveLength(0);
   });
   it("does NOT engage when close precision is null (no would-close predictions with a known outcome)", () => {
@@ -202,8 +205,12 @@ describe("shouldAutoClearClose (#close-precision-breaker recovery-gated auto-cle
     expect(shouldAutoClearClose(recovered, "g", past, now)).toBe(true);
     expect(shouldAutoClearClose(report([]), "g", past, now)).toBe(true);
   });
-  it("keeps the breaker engaged if close precision is STILL failing after cooldown", () => {
+  it("keeps the breaker engaged if close precision is STILL failing over a real close sample after cooldown", () => {
     expect(shouldAutoClearClose(failing, "g", past, now)).toBe(false);
+  });
+  it("clears after cooldown when the only failing close precision signal is undersampled", () => {
+    const sparseFalseClose = report([row({ project: "g", decided: 20, wouldClose: 1, closeConfirmed: 0, closePrecision: 0 })]);
+    expect(shouldAutoClearClose(sparseFalseClose, "g", past, now)).toBe(true);
   });
   it("parses a SQLite 'YYYY-MM-DD HH:MM:SS' (UTC, no zone) timestamp as UTC, not local", () => {
     const sqlite = new Date(now - AUTOCLEAR_AFTER_MS - 3_600_000).toISOString().slice(0, 19).replace("T", " "); // 25h ago, SQLite format


### PR DESCRIPTION
### Motivation
- The close-side precision circuit-breaker used total `decided` outcomes as its minimum-sample gate while computing `closePrecision` over `wouldClose`, allowing a sparse would-close sample to incorrectly engage `closehold` and suppress heuristic closes.
- This made it possible for an attacker or noisy single prediction to disable auto-close for a repo despite no meaningful would-close sample.

### Description
- Require the actual `wouldClose` count to meet `AUTOTUNE_MIN_DECIDED` before engaging the close breaker by changing the plan predicate to `r.wouldClose >= AUTOTUNE_MIN_DECIDED` in `planCloseAutoTune`.
- Use `wouldClose` (added to `CloseAutoTuneAction`) in the close-alert message so the reported denominator matches the metric being checked.
- Make `shouldAutoClearClose` check `row.wouldClose >= AUTOTUNE_MIN_DECIDED` when deciding whether a failing close signal is still meaningful after cooldown.
- Add regression tests that cover an undersampled would-close signal (sparse false-close) and the auto-clear behavior so sparse would-close samples no longer engage or persist the breaker.

### Testing
- Ran targeted unit tests: `npx vitest run test/unit/auto-tune.test.ts --reporter=dot` (passed) and `npx vitest run test/unit/auto-tune.test.ts test/unit/outcomes-wire.test.ts test/unit/precision-breakers-chain.test.ts --reporter=dot` (passed; the three files ran and their tests passed).
- Ran `npm run typecheck` which completed with no type errors.
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate`, but the full CI run could not complete due to environment/external issues (actionlint network/DNS fallbacks, unrelated test timeouts in other suites, and a coverage-provider error `jsTokens is not a function`), and the audit endpoint returned a 403; these block completing the entire gate in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b78269b70832c98c03092893e51c8)