### PR TITLE
fix(gate): spare duplicate winners from readiness penalties

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2228,20 +2228,21 @@ async function maybePublishPrPublicSurface(
       repoPullRequests,
       repoBounties,
     );
+    // Duplicate-winner adjudication (#dup-winner): compute the winner ONCE for this review run from the SAME
+    // open-only sibling source the gate uses, and thread the flag/result consistently into readiness, the slop
+    // penalty (below), and the public panel builders (further down) so they agree by construction. Flag-OFF
+    // (default) ⇒ duplicateWinnerEnabled is false and isDupWinner is false ⇒ every guard short-circuits
+    // (byte-identical).
+    const linkedDuplicatePrsForGate = linkedIssueDuplicatePullRequestsForGate(pr, repoPullRequests);
+    const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
+    const isDupWinner = duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, linkedDuplicatePrsForGate);
     const readiness = buildPublicReadinessScore({
       pr,
       preflight,
       queueHealth,
-      linkedDuplicatePrs: linkedIssueDuplicatePullRequestsForGate(pr, repoPullRequests),
+      linkedDuplicatePrs: isDupWinner ? [] : linkedDuplicatePrsForGate,
       scopedOverlapCount: unionScopedOverlapClusters(collisions, pr, preflight.collisions).length,
     });
-
-    // Duplicate-winner adjudication (#dup-winner): compute the winner ONCE for this review run from the SAME
-    // open-only sibling source the gate uses, and thread the flag/result consistently into the slop penalty
-    // (below) and the public panel builders (further down) so they agree by construction. Flag-OFF (default)
-    // ⇒ duplicateWinnerEnabled is false and isDupWinner is false ⇒ every guard short-circuits (byte-identical).
-    const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
-    const isDupWinner = duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, linkedIssueDuplicatePullRequestsForGate(pr, repoPullRequests));
 
     if (gateEnabled && author && !publicSurfaceSkipped && !official) {
       official = await getCachedOfficialMinerDetection(env, author, {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -5460,6 +5460,8 @@ describe("queue processors", () => {
       linkedIssueGateMode: "off",
       duplicatePrGateMode: "block",
       slopGateMode: "advisory",
+      qualityGateMode: "block",
+      qualityGateMinScore: 95,
     });
     // The shared issue + the HIGHER-numbered open sibling (#92) → forms the same-issue duplicate cluster.
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
@@ -5489,12 +5491,13 @@ describe("queue processors", () => {
         action: "opened",
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
-        pull_request: { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1" },
+        pull_request: { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1\n\nValidation: npm test" },
       },
     });
 
-    // Winner survives: the Gate did not fail on a duplicate block.
+    // Winner survives: a later duplicate sibling must not lower readiness below a blocking threshold.
     expect(gatePatchBody.conclusion).not.toBe("failure");
+    expect(gatePatchBody.output?.text ?? "").not.toContain("readiness_score_below_threshold");
     // The persisted advisory for the winner OMITS the duplicate finding (suppressed) — that is what suppresses
     // the gate failure and the auto-close duplicate cause.
     const winnerAdvisory = await env.DB.prepare("select findings_json from advisories where target_type = 'pull_request' and repo_full_name = ? and pull_number = ?").bind("JSONbored/gittensory", 91).first<{ findings_json: string }>();


### PR DESCRIPTION
### Motivation
- Duplicate-winner mode intended to spare the lowest-number open PR from duplicate blockers did not suppress the readiness "related_work" penalty because readiness was computed before the winner decision, allowing a later sibling to lower the winner's readiness and cause a blocking gate/auto-close.
- This is a logic/regression risk for repos using duplicate-winner plus a blocking quality/readiness gate and potentially auto-close/autonomy, so the winner must be judged without duplicate-related readiness penalties.

### Description
- Compute the open-sibling duplicate list once and derive `isDupWinner` from that same list so all downstream logic uses a consistent source (`src/queue/processors.ts`).
- When a PR is adjudicated as the duplicate-cluster winner, pass an empty `linkedDuplicatePrs` into `buildPublicReadinessScore` so the `related_work` readiness component is not reduced by sibling PRs.
- Update the duplicate-winner queue regression so the test exercises a blocking `qualityGate` threshold and asserts the winner is not failed by `readiness_score_below_threshold` while still suppressing the duplicate finding (`test/unit/queue.test.ts`).
- Files changed: `src/queue/processors.ts` and `test/unit/queue.test.ts`.

### Testing
- Ran the targeted unit test for the dup-winner scenario via `npx vitest run test/unit/queue.test.ts -t '#dup-winner: flag ON'` and the test passed. 
- Ran the broader dup-winner unit cases via `npx vitest run test/unit/queue.test.ts -t '#dup-winner'` and they passed. 
- Ran typechecking via `npm run typecheck` and it succeeded. 
- Attempted the full CI command `npm run test:ci` and `npm audit --audit-level=moderate`, but the full CI run encountered unrelated environment/timeouts and a coverage tooling error (`TypeError: jsTokens is not a function`) and an `npm audit` network/registry error; these failures are outside the changes in this patch and do not affect the targeted unit test regression that verifies the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b7e8d22b8832cb4216e3dfcbb330f)