### PR TITLE
fix(surface): suppress public surface mutations when agentPaused is true

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2184,6 +2184,11 @@ async function maybePublishPrPublicSurface(
     if (!gateEnabled && decision.actions.length === 1 && decision.actions[0] === "none") return undefined;
   }
 
+  // Respect the per-repo agent pause: suppress all public surface mutations (label, comment, context
+  // check run) so a paused repo sees no gittensory-authored GitHub content. The Gittensory Gate check
+  // run still posts so the required-check status is not broken (#agent-pause).
+  if (settings.agentPaused) decision = { ...decision, willLabel: false, willComment: false, willCheckRun: false };
+
   let pendingGateCheckRunId: number | undefined;
   if (gateEnabled) {
     const pendingGateResult = await createOrUpdatePendingGateCheckRun(env, installationId, repoFullName, advisory);

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -4142,6 +4142,62 @@ describe("queue processors", () => {
     expect(cached?.snapshot_json).not.toMatch(/hotkey|wallet|coldkey|must-not-cache/i);
   });
 
+  it("suppresses labels and comments when agentPaused is true", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      publicSurface: "comment_and_label",
+      autoLabelEnabled: true,
+      createMissingLabel: false,
+      checkRunMode: "off",
+      agentPaused: true,
+    });
+    const calls = { labels: 0, comments: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([{ githubUsername: "paused-miner", githubId: "999", totalPrs: 1, totalMergedPrs: 1, isEligible: true, credibility: 1 }]);
+      if (url === "https://api.gittensor.io/miners/999") return Response.json({ repositories: [] });
+      if (url === "https://api.gittensor.io/miners/999/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/999/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/paused-miner")) return Response.json({ login: "paused-miner" });
+      if (url.includes("/users/paused-miner/repos")) return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/labels") && method === "POST") {
+        calls.labels += 1;
+        return Response.json([{ name: "gittensor" }]);
+      }
+      if (url.includes("/comments") && method === "POST") {
+        calls.comments += 1;
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "paused-surface",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
+        pull_request: { number: 88, title: "Paused repo PR", state: "open", user: { login: "paused-miner" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    // agentPaused suppresses ALL public surface mutations — no label, no comment.
+    expect(calls).toEqual({ labels: 0, comments: 0 });
+  });
+
   it("responds to authorized @gittensory mention commands with one public-safe comment", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {


### PR DESCRIPTION
## Summary

- `willLabel` / `willComment` / `willCheckRun` in `maybePublishPrPublicSurface` called GitHub APIs directly, bypassing the executor's pause gate — so labels (`gittensor_label`, e.g. `gittensory:reviewed`) and comments were still being applied even when `agent_paused = 1` in `repository_settings`.
- Added a guard immediately after the final `decision` is computed: if `settings.agentPaused` is true, zero out all three mutation flags before any GitHub write. The Gittensory Gate check run is intentionally unaffected (suppressing it would break required-check status).
- Paired with a regression test: confirmed miner + `comment_and_label` surface + `agentPaused: true` → zero labels and zero comments applied.

Note: also temporarily set `auto_label_enabled = 0` in D1 for `JSONbored/metagraphed` as an immediate hotfix while this PR's CI runs; that can be re-enabled once this lands.

## Scope

- [x] Only `src/` and `test/` changes
- [x] No secrets, no private scoring, no wallet/hotkey terms
- [x] No DB migration needed

## Validation

- `npx vitest run test/unit/queue.test.ts -t "suppresses labels"` — passes
- `npm run test:ci` — 217 test files, 3715 tests, all pass
- `npm run typecheck` — clean

## Safety

- No auth or CORS changes
- Read-only change to the pause check — tightens, never loosens