### PR TITLE
fix(queue): add consumer for gittensory-jobs-dlq to prevent silent drops

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { createApp } from "./api/routes";
 import { RateLimiter } from "./auth/rate-limit";
+import { processDlqBatch } from "./queue/dlq";
 import { processJob } from "./queue/processors";
 import { isOpsEnabled } from "./review/ops-wire";
 import { isRagEnabled } from "./review/rag-wire";
@@ -13,6 +14,10 @@ export { RateLimiter };
 export default {
   fetch: app.fetch,
   async queue(batch: MessageBatch<JobMessage>, env: Env): Promise<void> {
+    if (batch.queue === "gittensory-jobs-dlq") {
+      await processDlqBatch(batch, env);
+      return;
+    }
     for (const message of batch.messages) {
       try {
         await processJob(env, message.body);

--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -1,0 +1,34 @@
+import { recordAuditEvent } from "../db/repositories";
+import type { JobMessage, JsonValue } from "../types";
+
+/**
+ * DLQ consumer for `gittensory-jobs-dlq`. Called when a job exhausts all retries on the main
+ * queue and is dead-lettered. Logs every dropped job for observability and records an audit event
+ * so maintainers can investigate persistent failures via the dashboard. Always acks — no further
+ * retries on DLQ messages.
+ */
+export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env): Promise<void> {
+  for (const message of batch.messages) {
+    const body = message.body as { type?: string; deliveryId?: string; eventName?: string } | null | undefined;
+    const jobType = body?.type ?? "unknown";
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "dlq_message_dead_lettered",
+        messageId: message.id,
+        jobType,
+        ...(jobType === "github-webhook" ? { deliveryId: body?.deliveryId, eventName: body?.eventName } : {}),
+      }),
+    );
+    // Best-effort audit record — never block the ack on a write failure.
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: `dlq:${jobType}:${message.id}`,
+      outcome: "error",
+      detail: `Job of type '${jobType}' exhausted all retries and was dead-lettered.`,
+      metadata: { messageId: message.id, jobType } satisfies Record<string, JsonValue>,
+    }).catch(() => undefined);
+    message.ack();
+  }
+}

--- a/test/unit/dlq.test.ts
+++ b/test/unit/dlq.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { processDlqBatch } from "../../src/queue/dlq";
+import { createTestEnv } from "../helpers/d1";
+
+function makeBatch(messages: Array<{ id: string; body: unknown }>, queue = "gittensory-jobs-dlq") {
+  const acked: string[] = [];
+  const retried: string[] = [];
+  return {
+    queue,
+    messages: messages.map((m) => ({
+      id: m.id,
+      body: m.body,
+      ack() {
+        acked.push(m.id);
+      },
+      retry() {
+        retried.push(m.id);
+      },
+    })),
+    acked,
+    retried,
+  };
+}
+
+describe("DLQ consumer (processDlqBatch)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("acks every message — never retries", async () => {
+    const env = createTestEnv();
+    const batch = makeBatch([
+      { id: "msg-1", body: { type: "github-webhook", deliveryId: "d1", eventName: "pull_request", payload: {} } },
+      { id: "msg-2", body: { type: "refresh-registry", requestedBy: "schedule" } },
+    ]);
+
+    await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+    expect(batch.acked).toEqual(["msg-1", "msg-2"]);
+    expect(batch.retried).toEqual([]);
+  });
+
+  it("records a dlq_dead_lettered audit event for each message", async () => {
+    const env = createTestEnv();
+    const batch = makeBatch([
+      { id: "msg-3", body: { type: "github-webhook", deliveryId: "evt-42", eventName: "check_suite", payload: {} } },
+      { id: "msg-4", body: { type: "backfill-registered-repos", requestedBy: "schedule" } },
+    ]);
+
+    await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+    const events = await env.DB.prepare("select event_type, target_key, outcome, detail from audit_events order by rowid").all<{
+      event_type: string;
+      target_key: string;
+      outcome: string;
+      detail: string;
+    }>();
+    expect(events.results).toHaveLength(2);
+    expect(events.results[0]).toMatchObject({ event_type: "github_app.dlq_dead_lettered", outcome: "error", target_key: "dlq:github-webhook:msg-3" });
+    expect(events.results[1]).toMatchObject({ event_type: "github_app.dlq_dead_lettered", outcome: "error", target_key: "dlq:backfill-registered-repos:msg-4" });
+    expect(events.results[0]?.detail).toContain("github-webhook");
+    expect(events.results[1]?.detail).toContain("backfill-registered-repos");
+  });
+
+  it("includes deliveryId + eventName in the structured log for github-webhook jobs", async () => {
+    const errorLogs: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errorLogs.push(String(args[0]));
+    });
+
+    const env = createTestEnv();
+    const batch = makeBatch([{ id: "msg-5", body: { type: "github-webhook", deliveryId: "delivery-99", eventName: "pull_request", payload: {} } }]);
+
+    await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+    const log = JSON.parse(errorLogs[0] ?? "{}") as Record<string, unknown>;
+    expect(log).toMatchObject({ event: "dlq_message_dead_lettered", jobType: "github-webhook", deliveryId: "delivery-99", eventName: "pull_request" });
+  });
+
+  it("handles an unknown / malformed message body without throwing", async () => {
+    const env = createTestEnv();
+    const batch = makeBatch([{ id: "msg-6", body: null }]);
+
+    await expect(processDlqBatch(batch as unknown as MessageBatch<never>, env)).resolves.toBeUndefined();
+    expect(batch.acked).toEqual(["msg-6"]);
+  });
+});

--- a/test/unit/dlq.test.ts
+++ b/test/unit/dlq.test.ts
@@ -84,4 +84,14 @@ describe("DLQ consumer (processDlqBatch)", () => {
     await expect(processDlqBatch(batch as unknown as MessageBatch<never>, env)).resolves.toBeUndefined();
     expect(batch.acked).toEqual(["msg-6"]);
   });
+
+  it("is fail-safe when recordAuditEvent throws — the catch body runs and ack is not blocked", async () => {
+    const env = createTestEnv();
+    // Break DB to force recordAuditEvent to throw → exercises the .catch(() => undefined) body
+    const brokenEnv = { ...env, DB: null } as unknown as typeof env;
+    const batch = makeBatch([{ id: "msg-7", body: { type: "github-webhook", deliveryId: "d99", eventName: "push", payload: {} } }]);
+
+    await expect(processDlqBatch(batch as unknown as MessageBatch<never>, brokenEnv)).resolves.toBeUndefined();
+    expect(batch.acked).toEqual(["msg-7"]);
+  });
 });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -13,6 +13,28 @@ describe("worker entrypoint", () => {
     expect(response.status).toBe(200);
   });
 
+  it("routes gittensory-jobs-dlq batches to the DLQ consumer (acks without retrying)", async () => {
+    const env = createTestEnv();
+    const acked: string[] = [];
+    const retried: string[] = [];
+    const batch = {
+      queue: "gittensory-jobs-dlq",
+      messages: [
+        {
+          id: "dlq-msg-1",
+          body: { type: "github-webhook", deliveryId: "d-dlq", eventName: "pull_request", payload: {} },
+          ack: () => acked.push("dlq-msg-1"),
+          retry: () => retried.push("dlq-msg-1"),
+        },
+      ],
+    } as unknown as MessageBatch<import("../../src/types").JobMessage>;
+
+    await worker.queue(batch, env);
+
+    expect(acked).toEqual(["dlq-msg-1"]);
+    expect(retried).toEqual([]);
+  });
+
   it("acks successful queue messages and retries failed messages", async () => {
     const env = createTestEnv();
     vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -205,11 +205,20 @@
         "queue": "gittensory-jobs",
         "max_batch_size": 10,
         "max_batch_timeout": 5,
-        // After max_retries failed attempts a job is dead-lettered instead of silently dropped, so a
-        // persistently-failing webhook is observable (inspect via `wrangler queues` / the dashboard)
-        // rather than vanishing. The DLQ is a landing pad with no consumer (house pattern).
+        // After max_retries failed attempts a job is dead-lettered so a persistently-failing webhook
+        // is observable rather than vanishing silently. The DLQ consumer below picks them up.
         "max_retries": 3,
         "dead_letter_queue": "gittensory-jobs-dlq",
+      },
+      {
+        // DLQ consumer: receives jobs that exhausted all main-queue retries. Logs each dead-lettered
+        // job for observability (Cloudflare Workers logs + audit_events) and acks immediately — no
+        // further retries (the job already failed max_retries times). max_retries: 0 prevents the
+        // DLQ consumer itself from sending messages to a secondary DLQ on handler error.
+        "queue": "gittensory-jobs-dlq",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
       },
     ],
   },


### PR DESCRIPTION
## Summary

`gittensory-jobs-dlq` existed as a dead-letter landing pad with no consumer. Jobs that exhausted `max_retries=3` on the main queue were silently discarded — no log, no audit trail, no way to investigate persistent failures.

**Fix:** add a `processDlqBatch` consumer that:
1. Logs each dead-lettered job as a structured `error`-level JSON event (level, messageId, jobType; plus deliveryId/eventName for `github-webhook` jobs)
2. Records a `github_app.dlq_dead_lettered` audit event in D1 so maintainers can see dropped jobs in the dashboard
3. Always acks — no further retries (the job already exhausted all main-queue retries)

The `wrangler.jsonc` consumer entry uses `max_retries: 0` so a handler error in the DLQ consumer doesn't dead-letter to a secondary queue (which would be indefinite). Audit writes are best-effort (`.catch(() => undefined)`) so a transient D1 error never blocks the ack.

**Implementation:**
- `src/queue/dlq.ts`: new file — `processDlqBatch` function
- `src/index.ts`: route `batch.queue === "gittensory-jobs-dlq"` to `processDlqBatch` before the main loop
- `wrangler.jsonc`: add DLQ consumer entry; update main-queue consumer comment to reference it
- `test/unit/dlq.test.ts`: 4 tests — always-acks, audit-event rows, structured log fields, null-body resilience

## Scope

- [x] This PR touches backend/API code (`src/`)
- [ ] This PR touches frontend/UI code (`apps/gittensory-ui/`)
- [ ] This PR adds or modifies DB schema (new migration required)
- [x] This PR changes queue/job processing logic
- [ ] This PR modifies public-facing API endpoints
- [ ] This PR changes auth/session/CORS behavior

## Validation

- [x] `npm run test:ci` — fully green (including typecheck, coverage, ui:build)
- [x] 4 new unit tests: acks all, audit events, structured log, malformed-body resilience
- [x] Both branches of the `jobType === "github-webhook"` spread covered
- [x] Null/missing body handled without throwing
- [x] `git diff --check` clean

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, or reward values added anywhere
- [x] No changes to `site/`, `CNAME`, or `**/lovable/**`
- [x] No `CHANGELOG.md` edits
- [x] No AI/Claude/agent attribution in commits or PR text
- [x] DLQ consumer is read-only observability — no state mutation, no re-enqueue, no side effects beyond audit write

Advances #1196