### PR TITLE
fix(github): scan recent issue event pages

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -2,6 +2,9 @@ import { Octokit } from "@octokit/core";
 import { createInstallationToken } from "./app";
 import type { AutoMergeMethod } from "../types";
 
+const ISSUE_EVENTS_PAGE_SIZE = 100;
+const ISSUE_EVENTS_RECENT_PAGE_LIMIT = 10;
+
 // The GitHub write primitives the maintainer auto-maintain layer (#778) uses to act on a PR's STATE — never
 // its source. Thin wrappers over the installation-scoped REST API, mirroring labels.ts / comments.ts. Each
 // throws on a non-2xx response; the action executor owns the try/catch + audit so a failed mutation is
@@ -119,19 +122,38 @@ export async function getLastCloserLogin(env: Env, installationId: number, repoF
     const { owner, repo } = splitRepo(repoFullName);
     const token = await createInstallationToken(env, installationId);
     const octokit = new Octokit({ auth: token });
-    let lastCloser: string | null = null;
-    // Cap at 10 pages (1 000 events) — enough for any real PR timeline without risking API rate exhaustion.
-    for (let page = 1; page <= 10; page += 1) {
-      // issue-events are returned oldest-first; walk every page so the final `closed` entry is truly the latest.
-      const response = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/events", { owner, repo, issue_number: issueNumber, per_page: 100, page });
-      const events = response.data as Array<{ event?: string; actor?: { login?: string | null } | null }>;
-      for (const entry of events) {
-        if (entry.event === "closed") lastCloser = entry.actor?.login ?? null;
-      }
-      if (events.length < 100) return lastCloser;
+    const requestPage = (page: number) =>
+      octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/events", { owner, repo, issue_number: issueNumber, per_page: ISSUE_EVENTS_PAGE_SIZE, page });
+    const firstResponse = await requestPage(1);
+    const firstEvents = firstResponse.data as Array<{ event?: string; actor?: { login?: string | null } | null }>;
+    const lastPage = issueEventsLastPage(firstResponse.headers.link);
+    if (lastPage <= 1) return latestCloserInPage(firstEvents) ?? null;
+
+    // GitHub returns issue-events oldest-first. Use the Link header to inspect the newest bounded window instead
+    // of the oldest prefix, so a long self-generated timeline cannot hide a later maintainer/bot close.
+    const firstPageToRead = Math.max(2, lastPage - ISSUE_EVENTS_RECENT_PAGE_LIMIT + 1);
+    for (let page = lastPage; page >= firstPageToRead; page -= 1) {
+      const response = await requestPage(page);
+      const closer = latestCloserInPage(response.data as Array<{ event?: string; actor?: { login?: string | null } | null }>);
+      if (closer !== undefined) return closer;
     }
-    return lastCloser;
+    return firstPageToRead === 2 ? (latestCloserInPage(firstEvents) ?? null) : null;
   } catch {
     return null;
   }
+}
+
+function latestCloserInPage(events: Array<{ event?: string; actor?: { login?: string | null } | null }>): string | null | undefined {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const entry = events[i];
+    if (entry?.event === "closed") return entry.actor?.login ?? null;
+  }
+  return undefined;
+}
+
+function issueEventsLastPage(linkHeader: string | undefined): number {
+  if (!linkHeader) return 1;
+  const lastLink = linkHeader.split(",").find((link) => /rel="last"/.test(link));
+  const page = lastLink?.match(/[?&]page=(\d+)/)?.[1];
+  return page ? Number(page) : 1;
 }

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { closePullRequest, createIssueComment, createPullRequestReview, getLastCloserLogin, mergePullRequest } from "../../src/github/pr-actions";
+import { closePullRequest, createIssueComment, createPullRequestReview, getLastCloserLogin, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { createTestEnv } from "../helpers/d1";
 
 function envWithKey() {
@@ -168,6 +168,70 @@ describe("GitHub PR action primitives (#778)", () => {
     });
     await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 21)).resolves.toBeNull();
     expect(fetchedPages).toEqual([1, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
+  });
+
+  it("falls back to page-1 closer when bounded window (firstPageToRead=2) has no close event", async () => {
+    // lastPage=5 → firstPageToRead = max(2, 5-10+1) = 2; the bounded scan covers pages 5→2 and finds
+    // no closer there → falls through to line 140 with firstPageToRead===2 and returns the page-1 closer.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/22/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        const linkHeader = page === 1 ? '<https://api.github.test/issues/22/events?per_page=100&page=5>; rel="last"' : undefined;
+        const events = page === 1 ? [{ event: "closed", actor: { login: "page1-closer" } }] : [{ event: "labeled" }];
+        return Response.json(events, linkHeader ? { headers: { link: linkHeader } } : undefined);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 22)).resolves.toBe("page1-closer");
+  });
+
+  it("treats a link header without rel=last as a single-page result (issueEventsLastPage FALSE branch)", async () => {
+    // Link header present but only contains rel="next" — no rel="last" match → lastPage stays 1
+    // → firstEvents from page 1 is returned directly without a second request.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/23/events")) {
+        return Response.json([{ event: "closed", actor: { login: "solo-closer" } }], {
+          headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=2>; rel="next"' },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toBe("solo-closer");
+  });
+
+  it("returns null when bounded window (firstPageToRead=2) AND page 1 also have no close event (?? null right branch)", async () => {
+    // lastPage=5 → firstPageToRead=2; pages 2–5 have no closer; page 1 also has no closer →
+    // latestCloserInPage(firstEvents) returns undefined → undefined ?? null = null.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/24/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        const linkHeader = page === 1 ? '<https://api.github.test/issues/24/events?per_page=100&page=5>; rel="last"' : undefined;
+        return Response.json([{ event: "labeled" }], linkHeader ? { headers: { link: linkHeader } } : undefined);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 24)).resolves.toBeNull();
+  });
+
+  it("updates branch without an expected head sha (omits expected_head_sha — FALSE branch of the spread ternary)", async () => {
+    const requestBodies: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/55/update-branch")) {
+        requestBodies.push(String(init?.body ?? ""));
+        return new Response("{}", { status: 201, headers: { "content-type": "application/json" } });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(updatePullRequestBranch(envWithKey(), 123, "owner/repo", 55)).resolves.toBeUndefined();
+    expect(requestBodies.some((b) => !b.includes("expected_head_sha"))).toBe(true);
   });
 });
 

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -99,7 +99,7 @@ describe("GitHub PR action primitives (#778)", () => {
           return Response.json([
             ...Array.from({ length: 99 }, (_, index) => ({ event: "labeled", actor: { login: `labeler-${index}` } })),
             { event: "closed", actor: { login: "contributor" } },
-          ]);
+          ], { headers: { link: '<https://api.github.test/issues/17/events?per_page=100&page=2>; rel="last"' } });
         }
         if (page === "2") return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
       }
@@ -128,7 +128,7 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 19)).resolves.toBeNull();
   });
 
-  it("returns the best-known closer when the 10-page event cap is reached (page-cap exit path)", async () => {
+  it("reads the newest bounded event pages instead of the oldest prefix", async () => {
     const fetchedPages: number[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
@@ -136,18 +136,38 @@ describe("GitHub PR action primitives (#778)", () => {
       if (url.includes("/issues/20/events")) {
         const page = Number(new URL(url).searchParams.get("page") ?? "1");
         fetchedPages.push(page);
-        // Page 5 contains the close event; all pages return exactly 100 entries so the loop never exits early.
+        if (page === 1) {
+          return Response.json([{ event: "closed", actor: { login: "stale-contributor" } }], {
+            headers: { link: '<https://api.github.test/issues/20/events?per_page=100&page=12>; rel="last"' },
+          });
+        }
         const events = Array.from({ length: 100 }, (_, i) =>
-          page === 5 && i === 50 ? { event: "closed", actor: { login: "capped-closer" } } : { event: "labeled" },
+          page === 11 && i === 40 ? { event: "closed", actor: { login: "maintainer" } } : { event: "labeled" },
         );
         return Response.json(events);
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 20)).resolves.toBe("capped-closer");
-    // Loop ran pages 1–10 and then exited via the cap, never requesting page 11.
-    expect(fetchedPages).toHaveLength(10);
-    expect(fetchedPages).not.toContain(11);
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 20)).resolves.toBe("maintainer");
+    expect(fetchedPages).toEqual([1, 12, 11]);
+    expect(fetchedPages).not.toContain(2);
+  });
+
+  it("returns null when the newest bounded event pages contain no close event", async () => {
+    const fetchedPages: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/21/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        fetchedPages.push(page);
+        return Response.json(page === 1 ? [{ event: "closed", actor: { login: "stale-contributor" } }] : [{ event: "labeled" }],
+          page === 1 ? { headers: { link: '<https://api.github.test/issues/21/events?per_page=100&page=12>; rel="last"' } } : undefined);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 21)).resolves.toBeNull();
+    expect(fetchedPages).toEqual([1, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The prior 10-page oldest-first cap could miss a later maintainer/bot close on very long issue-event timelines and allow a contributor to bypass the one-shot reopen guard.

### Description
- Replace the oldest-prefix scan with a bounded newest-window scan by parsing the GitHub `Link` header and inspecting up to the most-recent N pages rather than the first N pages.
- Implement `ISSUE_EVENTS_PAGE_SIZE` and `ISSUE_EVENTS_RECENT_PAGE_LIMIT` constants and add helper functions `issueEventsLastPage` and `latestCloserInPage` used by `getLastCloserLogin`.
- Update `getLastCloserLogin` to fetch page 1 to read the `Link` header, compute the newest bounded window, walk newest→oldest within that window for a `closed` event, and preserve the request cap.
- Add and adjust unit tests in `test/unit/github-pr-actions.test.ts` to cover the newest-window behavior and the case where no recent close is found.

### Testing
- Ran the unit suite for the changed file with `npx vitest run test/unit/github-pr-actions.test.ts`, and all tests in that file passed.
- Ran static type checks with `npm run typecheck`, which passed with no errors.
- Attempted a full local coverage run with `npm run test:coverage`, but the run encountered unrelated long-running test timeouts in other suites and was stopped; a targeted `--coverage` run for the unit file failed coverage remapping locally with `TypeError: jsTokens is not a function` after the tests themselves passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b92066a44832ca842103b901da9ca)