### PR TITLE
feat(api): add repo recommendation quality calibration

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -175,6 +175,7 @@ import {
   loadWeeklyValueReport,
 } from "../services/weekly-value-report";
 import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
+import { buildContributorOpenPrPressureResponse } from "../services/open-pr-pressure-response";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
@@ -214,6 +215,7 @@ import {
   buildExtensionIssueBadges,
   buildExtensionPrStatus,
 } from "../signals/extension-contributor-context";
+import { buildExtensionOpenPrPressure } from "../signals/extension-open-pr-pressure";
 import { attachDataQuality, buildCoreSignalFidelity, buildFreshnessSloReport, buildRepoDataQuality, buildSignalFidelity } from "../signals/data-quality";
 import { buildContributorOpenPrMonitor } from "../signals/contributor-open-pr-monitor";
 import { buildPullRequestReviewability, type PullRequestReviewability } from "../signals/reward-risk";
@@ -2571,6 +2573,26 @@ export function createApp() {
     const queueHealth = buildQueueHealth(repo, issues, pullRequests, collisions);
     const readiness = buildPublicReadinessScore({ pr, preflight, queueHealth });
     return c.json(buildExtensionPrStatus({ repoFullName, pullNumber, readiness }));
+  });
+
+  // #348 open-PR pressure strategy: self-only contributor simulation of whether to open more work,
+  // wait, or clean up first. Public-safe bands only — no payout/reward/scoreability language.
+  app.get("/v1/extension/contributors/:login/open-pr-pressure", async (c) => {
+    const login = c.req.param("login");
+    const unauthorized = await requireContributorAccess(c, login);
+    if (unauthorized) return unauthorized;
+    const owner = c.req.query("owner") ?? "";
+    const repoName = c.req.query("repo") ?? "";
+    if (!owner || !repoName) return c.json({ error: "valid_owner_repo_required" }, 400);
+    const repoFullName = `${owner}/${repoName}`;
+    const repo = await getRepository(c.env, repoFullName);
+    if (!repo) return c.json({ error: "repo_not_found" }, 404);
+    const repoForbidden = await requireContributorRepoAccess(c, repoFullName, repo);
+    if (repoForbidden) return repoForbidden;
+    const context = await loadContributorFastContext(c.env, login);
+    const response = await buildContributorOpenPrPressureResponse(c.env, login, repoFullName, context.profile);
+    if (!response) return c.json({ error: "repo_not_found" }, 404);
+    return c.json(buildExtensionOpenPrPressure(response));
   });
 
   app.post("/v1/local/branch-analysis", async (c) => {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -224,6 +224,7 @@ import { buildSlopAssessment, buildIssueSlopAssessment, SLOP_RUBRIC_MARKDOWN, IS
 import { buildPredictedGateVerdict } from "../rules/predicted-gate";
 import { buildMaintainerActivationPreview, recommendedAdvisoryActivationSettings } from "../services/maintainer-activation";
 import { buildRepoOutcomeCalibration } from "../services/outcome-calibration";
+import { buildRepoRecommendationQuality } from "../services/recommendation-quality";
 import { loadGatePrecisionReport } from "../services/gate-precision";
 import { computeOpsStats, isOpsEnabled } from "../review/ops-wire";
 import { computeParityReadiness, isParityAuditEnabled } from "../review/parity-wire";
@@ -2180,6 +2181,17 @@ export function createApp() {
     const windowDaysRaw = Number(c.req.query("windowDays"));
     const windowDays = windowDaysRaw > 0 ? windowDaysRaw : undefined;
     return c.json(await buildRepoOutcomeCalibration(c.env, fullName, windowDays));
+  });
+
+  // #577 recommendation quality: are agent recommendations for this repo leading to positive outcomes?
+  // Read-only measurement over agent_recommendation_outcomes. Optional ?windowDays bounds the window; defaults to 90.
+  app.get("/v1/repos/:owner/:repo/recommendation-quality", async (c) => {
+    const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const gate = await requireRepoMaintainer(c, fullName);
+    if (gate instanceof Response) return gate;
+    const windowDaysRaw = Number(c.req.query("windowDays"));
+    const windowDays = windowDaysRaw > 0 ? windowDaysRaw : undefined;
+    return c.json(await buildRepoRecommendationQuality(c.env, fullName, windowDays));
   });
 
   // #554 gate false-positive telemetry: is the gate PRECISE? Read-only measurement of blocked-then-merged

--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -33,7 +33,8 @@ const MAX_DELETED_PER_TABLE = 50_000;
 const MS_PER_DAY = 86_400_000;
 
 function retentionWhere(rule: RetentionRule): string {
-  const base = `${rule.column} < ?1`;
+  // D1/SQLite bindings for `prepare().bind(...)` are positional; use a single `?` placeholder.
+  const base = `${rule.column} < ?`;
   if (rule.table === "audit_events") {
     const durableTypes = DURABLE_AUDIT_EVENT_TYPES.map((type) => `'${type}'`).join(", ");
     return `${base} AND event_type NOT IN (${durableTypes})`;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -69,6 +69,8 @@ import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
 import { buildRepoOutcomeCalibration, outcomeCalibrationSummary } from "../services/outcome-calibration";
+import { buildContributorOpenPrPressureResponse } from "../services/open-pr-pressure-response";
+import { buildExtensionOpenPrPressure, extensionOpenPrPressureHeadline } from "../signals/extension-open-pr-pressure";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -636,6 +638,17 @@ const openPrMonitorOutputSchema = {
   pullRequests: z.unknown().optional(),
 };
 
+const openPrPressureOutputSchema = {
+  login: z.string().optional(),
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  contributorOpenPrCount: z.number().optional(),
+  queuePressure: z.string().optional(),
+  recommendedOption: z.string().optional(),
+  summary: z.string().optional(),
+  scenarios: z.unknown().optional(),
+};
+
 const notificationsOutputSchema = {
   login: z.string().optional(),
   unreadCount: z.number().optional(),
@@ -1083,6 +1096,17 @@ export class GittensoryMcp {
         outputSchema: openPrMonitorOutputSchema,
       },
       async (input) => this.toolResult(await this.monitorOpenPullRequests(input.login)),
+    );
+
+    server.registerTool(
+      "gittensory_simulate_open_pr_pressure",
+      {
+        description:
+          "Simulate open-PR pressure strategy options for a contributor on a repo: open new work, wait, or clean up first. Self-scoped, public-safe, advisory only.",
+        inputSchema: loginRepoShape,
+        outputSchema: openPrPressureOutputSchema,
+      },
+      async (input) => this.toolResult(await this.simulateOpenPrPressure(input)),
     );
 
     server.registerTool(
@@ -1645,6 +1669,26 @@ export class GittensoryMcp {
     );
 
     server.registerPrompt(
+      "gittensory_plan_open_pr_strategy",
+      {
+        title: "Plan open-PR strategy",
+        description: "Compare open-new-work, wait, and cleanup-first options for a contributor on a repo using queue pressure signals. Advisory only.",
+        argsSchema: { ...ownerRepoShape, login: z.string().min(1) },
+      },
+      ({ owner, repo, login }) => ({
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Use gittensory_simulate_open_pr_pressure for ${login} on ${owner}/${repo} to compare strategy options before opening another PR. Summarize the recommended option, queue pressure band, and the top facts/blockers for each scenario. Do not open a PR or take any GitHub action — present guidance for the contributor to decide manually.`,
+            },
+          },
+        ],
+      }),
+    );
+
+    server.registerPrompt(
       "gittensory_plan_cleanup_first",
       {
         title: "Plan cleanup-first work",
@@ -1988,6 +2032,24 @@ export class GittensoryMcp {
       const body = (await response.json().catch(() => ({}))) as { retryAfterSeconds?: number };
       throw new Error(`Rate limit exceeded. Retry after ${body.retryAfterSeconds ?? 60}s.`);
     }
+  }
+
+  private async simulateOpenPrPressure(input: { login: string; owner: string; repo: string }): Promise<ToolPayload> {
+    this.requireContributorAccess(input.login);
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireWatchableRepo(input.login, fullName);
+    const response = await buildContributorOpenPrPressureResponse(this.env, input.login, fullName);
+    if (!response) {
+      return {
+        summary: `Gittensory has no cached metadata for ${fullName}.`,
+        data: { status: "not_found", repoFullName: fullName },
+      };
+    }
+    const extension = buildExtensionOpenPrPressure(response);
+    return {
+      summary: extensionOpenPrPressureHeadline(extension),
+      data: extension as unknown as Record<string, unknown>,
+    };
   }
 
   private async checkSlopRisk(input: z.infer<z.ZodObject<typeof checkSlopRiskShape>>): Promise<ToolPayload> {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -69,6 +69,7 @@ import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
 import { buildRepoOutcomeCalibration, outcomeCalibrationSummary } from "../services/outcome-calibration";
+import { buildRepoRecommendationQuality, recommendationQualitySummary } from "../services/recommendation-quality";
 import { buildContributorOpenPrPressureResponse } from "../services/open-pr-pressure-response";
 import { buildExtensionOpenPrPressure, extensionOpenPrPressureHeadline } from "../signals/extension-open-pr-pressure";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
@@ -1068,6 +1069,17 @@ export class GittensoryMcp {
     );
 
     server.registerTool(
+      "gittensory_get_recommendation_quality",
+      {
+        description:
+          "Return recommendation quality calibration for a repo from the agent recommendation-outcome ledger: positive vs negative outcomes, failure category mix, and trends. Maintainer-authenticated; measurement only.",
+        inputSchema: ownerRepoWindowShape,
+        outputSchema: maintainerMeasurementReportOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getRecommendationQuality(input)),
+    );
+
+    server.registerTool(
       "gittensory_get_contributor_profile",
       {
         description: "Return an evidence-backed Gittensory contributor profile for a GitHub login.",
@@ -1962,6 +1974,16 @@ export class GittensoryMcp {
     const report = await buildRepoOutcomeCalibration(this.env, fullName, input.windowDays);
     return {
       summary: outcomeCalibrationSummary(fullName, report.slop),
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getRecommendationQuality(input: { owner: string; repo: string; windowDays?: number | undefined }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const report = await buildRepoRecommendationQuality(this.env, fullName, input.windowDays);
+    return {
+      summary: recommendationQualitySummary(report),
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/src/services/open-pr-pressure-response.ts
+++ b/src/services/open-pr-pressure-response.ts
@@ -1,0 +1,60 @@
+import { getRepository, listIssues, listPullRequests } from "../db/repositories";
+import type { ContributorProfile } from "../signals/engine";
+import { buildCollisionReport, buildQueueHealth, buildRoleContext } from "../signals/engine";
+import { nowIso } from "../utils/json";
+import { simulateOpenPrPressure, type OpenPrPressureSimulation } from "./open-pr-pressure-scenarios";
+
+export type ContributorOpenPrPressureResponse = {
+  login: string;
+  repoFullName: string;
+  generatedAt: string;
+  contributorOpenPrCount: number;
+  simulation: OpenPrPressureSimulation;
+};
+
+/**
+ * Build a contributor-scoped open-PR pressure strategy simulation for one repo.
+ * Mirrors the simulation wired into local-branch analysis (#348) but exposes it as a
+ * dedicated read-only surface for extension clients and MCP agents.
+ */
+export async function buildContributorOpenPrPressureResponse(
+  env: Env,
+  login: string,
+  repoFullName: string,
+  profile: ContributorProfile | null = null,
+): Promise<ContributorOpenPrPressureResponse | null> {
+  const repo = await getRepository(env, repoFullName);
+  if (!repo) return null;
+
+  const [issues, pullRequests] = await Promise.all([listIssues(env, repoFullName), listPullRequests(env, repoFullName)]);
+  const roleContext = buildRoleContext({
+    login,
+    repo,
+    repoFullName,
+    pullRequests,
+    issues,
+    profile,
+  });
+  const collisions = buildCollisionReport(repoFullName, issues, pullRequests);
+  const queueHealth = buildQueueHealth(repo, issues, pullRequests, collisions);
+  const normalizedLogin = login.toLowerCase();
+  const contributorOpenPrCount = pullRequests.filter(
+    (pr) => pr.state === "open" && (pr.authorLogin ?? "").toLowerCase() === normalizedLogin,
+  ).length;
+  const generatedAt = nowIso();
+  const simulation = simulateOpenPrPressure({
+    repoFullName,
+    generatedAt,
+    queueHealth,
+    roleContext,
+    contributorOpenPrCount,
+  });
+
+  return {
+    login,
+    repoFullName,
+    generatedAt,
+    contributorOpenPrCount,
+    simulation,
+  };
+}

--- a/src/services/recommendation-quality.ts
+++ b/src/services/recommendation-quality.ts
@@ -1,0 +1,52 @@
+import { listAgentRecommendationOutcomes } from "../db/repositories";
+import type { RecommendationQualityReport } from "./recommendation-quality-report";
+import { buildRecommendationQualityReportFromOutcomes } from "./recommendation-quality-report";
+import { nowIso } from "../utils/json";
+
+export type RepoRecommendationQualityReport = {
+  repoFullName: string;
+  generatedAt: string;
+  windowDays: number;
+  visibility: "maintainer_scoped";
+  /** Narrowed view of the operator dashboard report, scoped to this repo. */
+  totals: RecommendationQualityReport["totals"];
+  trends: RecommendationQualityReport["trends"];
+  failureCategories: RecommendationQualityReport["failureCategories"];
+  rollups: RecommendationQualityReport["rollups"];
+  warnings: RecommendationQualityReport["warnings"];
+  summary: string;
+};
+
+export function recommendationQualitySummary(report: RepoRecommendationQualityReport): string {
+  const resolved = report.totals.positive + report.totals.negative;
+  const rate = resolved > 0 ? `${Math.round((report.totals.positive / resolved) * 100)}%` : "n/a";
+  const window = `${report.windowDays}d`;
+  return `${report.repoFullName}: recommendation outcomes ${report.totals.positive}/${report.totals.total} positive (${rate} resolved, ${window}).`;
+}
+
+/** Maintainer-scoped, repo-filtered recommendation quality report. Measurement only. */
+export async function buildRepoRecommendationQuality(
+  env: Env,
+  repoFullName: string,
+  windowDays?: number,
+): Promise<RepoRecommendationQualityReport> {
+  const generatedAt = nowIso();
+  const effectiveWindowDays = windowDays ?? 90;
+  const outcomes = await listAgentRecommendationOutcomes(env, { repoFullName, windowDays: effectiveWindowDays, now: generatedAt, limit: 5000 });
+  const report = buildRecommendationQualityReportFromOutcomes(outcomes, { generatedAt, windowDays: effectiveWindowDays });
+  const scoped: RepoRecommendationQualityReport = {
+    repoFullName,
+    generatedAt,
+    windowDays: effectiveWindowDays,
+    visibility: "maintainer_scoped",
+    totals: report.totals,
+    trends: report.trends,
+    failureCategories: report.failureCategories,
+    rollups: report.rollups,
+    warnings: report.warnings,
+    summary: "",
+  };
+  scoped.summary = recommendationQualitySummary(scoped);
+  return scoped;
+}
+

--- a/src/signals/extension-open-pr-pressure.ts
+++ b/src/signals/extension-open-pr-pressure.ts
@@ -1,0 +1,65 @@
+import type { ContributorOpenPrPressureResponse } from "../services/open-pr-pressure-response";
+import type { OpenPrPressureSimulation, OpenPrStrategyOption, OpenPrStrategyScenario } from "../services/open-pr-pressure-scenarios";
+import { redactExtensionText } from "./extension-contributor-context";
+
+// ─── Extension contributor open-PR pressure (#348 exposure) ───────────────────────────────────
+// Public-safe overlay for the open-PR pressure simulator. Reuses the extension redaction helper so
+// any free-form scenario text is scrubbed before it reaches a contributor browser session or MCP agent.
+
+export type ExtensionOpenPrStrategyScenario = {
+  option: OpenPrStrategyOption;
+  label: string;
+  rank: number;
+  recommended: boolean;
+  facts: string[];
+  assumptions: string[];
+  tradeoffs: string[];
+  blockers: string[];
+};
+
+export type ExtensionOpenPrPressure = {
+  login: string;
+  repoFullName: string;
+  generatedAt: string;
+  contributorOpenPrCount: number;
+  queuePressure: OpenPrPressureSimulation["queuePressure"];
+  recommendedOption: OpenPrStrategyOption;
+  summary: string;
+  scenarios: ExtensionOpenPrStrategyScenario[];
+};
+
+function redactScenarioStrings(values: string[]): string[] {
+  return values.map((value) => redactExtensionText(value));
+}
+
+function toExtensionScenario(scenario: OpenPrStrategyScenario): ExtensionOpenPrStrategyScenario {
+  return {
+    option: scenario.option,
+    label: redactExtensionText(scenario.label),
+    rank: scenario.rank,
+    recommended: scenario.recommended,
+    facts: redactScenarioStrings(scenario.facts),
+    assumptions: redactScenarioStrings(scenario.assumptions),
+    tradeoffs: redactScenarioStrings(scenario.tradeoffs),
+    blockers: redactScenarioStrings(scenario.blockers),
+  };
+}
+
+export function buildExtensionOpenPrPressure(response: ContributorOpenPrPressureResponse): ExtensionOpenPrPressure {
+  const { simulation } = response;
+  return {
+    login: response.login,
+    repoFullName: response.repoFullName,
+    generatedAt: response.generatedAt,
+    contributorOpenPrCount: response.contributorOpenPrCount,
+    queuePressure: simulation.queuePressure,
+    recommendedOption: simulation.recommendedOption,
+    summary: redactExtensionText(simulation.summary),
+    scenarios: simulation.scenarios.map(toExtensionScenario),
+  };
+}
+
+export function extensionOpenPrPressureHeadline(pressure: ExtensionOpenPrPressure): string {
+  const option = pressure.scenarios.find((entry) => entry.recommended)?.label ?? pressure.recommendedOption;
+  return redactExtensionText(`${pressure.repoFullName}: ${option} (${pressure.queuePressure} queue pressure, ${pressure.contributorOpenPrCount} open PR(s)).`);
+}

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -684,6 +684,22 @@ describe("api routes", () => {
     const calibrationNoWindow = await app.request("/v1/repos/entrius/allways-ui/outcome-calibration", { headers: apiHeaders(env) }, env);
     await expect(calibrationNoWindow.json()).resolves.toMatchObject({ windowDays: null });
 
+    // #577 recommendation quality: maintainer-scoped, read-only.
+    const recommendationQualityUnauthenticated = await app.request("/v1/repos/entrius/allways-ui/recommendation-quality", {}, env);
+    expect(recommendationQualityUnauthenticated.status).toBe(401);
+    const recommendationQuality = await app.request("/v1/repos/entrius/allways-ui/recommendation-quality?windowDays=30", { headers: apiHeaders(env) }, env);
+    expect(recommendationQuality.status).toBe(200);
+    await expect(recommendationQuality.json()).resolves.toMatchObject({
+      repoFullName: "entrius/allways-ui",
+      windowDays: 30,
+      totals: expect.any(Object),
+      trends: expect.any(Array),
+      failureCategories: expect.any(Array),
+      rollups: expect.any(Array),
+    });
+    const recommendationQualityNoWindow = await app.request("/v1/repos/entrius/allways-ui/recommendation-quality", { headers: apiHeaders(env) }, env);
+    await expect(recommendationQualityNoWindow.json()).resolves.toMatchObject({ windowDays: 90 });
+
     // #554 gate false-positive telemetry: maintainer-scoped, read-only.
     const gatePrecisionUnauthenticated = await app.request("/v1/repos/entrius/allways-ui/gate-precision", {}, env);
     expect(gatePrecisionUnauthenticated.status).toBe(401);

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -3863,6 +3863,20 @@ describe("api routes", () => {
     expect(JSON.stringify(prStatusBody)).not.toMatch(/"(?:score|total|max)":/);
     expect(JSON.stringify(prStatusBody)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
 
+    const pressure = await app.request("/v1/extension/contributors/contributor-dev/open-pr-pressure?owner=octo&repo=demo", { headers: bearer }, env);
+    expect(pressure.status).toBe(200);
+    const pressureBody = (await pressure.json()) as {
+      contributorOpenPrCount: number;
+      queuePressure: string;
+      recommendedOption: string;
+      scenarios: Array<{ option: string; recommended: boolean }>;
+    };
+    expect(pressureBody.contributorOpenPrCount).toBeGreaterThanOrEqual(2);
+    expect(["low", "medium", "high", "critical", "unknown"]).toContain(pressureBody.queuePressure);
+    expect(["open_new_work", "wait", "cleanup_first"]).toContain(pressureBody.recommendedOption);
+    expect(pressureBody.scenarios.some((entry) => entry.recommended)).toBe(true);
+    expect(JSON.stringify(pressureBody)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
+
     // The contributor's OWN bodyless PR still resolves to a public-safe readiness band (body defaults cleanly).
     const bodylessPrStatus = await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=octo&repo=demo&pullNumber=14", { headers: bearer }, env);
     expect(bodylessPrStatus.status).toBe(200);
@@ -3889,6 +3903,9 @@ describe("api routes", () => {
     expect((await app.request("/v1/extension/contributors/contributor-dev/pr-status?repo=demo&pullNumber=12", { headers: bearer }, env)).status).toBe(400);
     expect((await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=octo&pullNumber=12", { headers: bearer }, env)).status).toBe(400);
     expect((await app.request("/v1/extension/contributors/contributor-dev/pr-status?owner=octo&repo=demo&pullNumber=abc", { headers: bearer }, env)).status).toBe(400);
+    expect((await app.request("/v1/extension/contributors/contributor-dev/open-pr-pressure?owner=octo", { headers: bearer }, env)).status).toBe(400);
+    expect((await app.request("/v1/extension/contributors/contributor-dev/open-pr-pressure?repo=demo", { headers: bearer }, env)).status).toBe(400);
+    expect((await app.request("/v1/extension/contributors/contributor-dev/open-pr-pressure?owner=victim-org&repo=secret", { headers: bearer }, env)).status).toBe(403);
     // Repo not found → 404.
     expect((await app.request("/v1/extension/contributors/contributor-dev/issue-fit?owner=no&repo=such&issueNumber=1", { headers: bearer }, env)).status).toBe(404);
     expect((await app.request("/v1/extension/contributors/contributor-dev/issue-badges?owner=no&repo=such", { headers: bearer }, env)).status).toBe(404);

--- a/test/unit/extension-open-pr-pressure.test.ts
+++ b/test/unit/extension-open-pr-pressure.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { buildExtensionOpenPrPressure, extensionOpenPrPressureHeadline } from "../../src/signals/extension-open-pr-pressure";
+import type { ContributorOpenPrPressureResponse } from "../../src/services/open-pr-pressure-response";
+
+const FORBIDDEN_PUBLIC_LANGUAGE =
+  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward estimate|raw trust|trust score|scoreability|private reviewability|estimated score|score estimate|farming/i;
+
+function sampleResponse(overrides: Partial<ContributorOpenPrPressureResponse> = {}): ContributorOpenPrPressureResponse {
+  return {
+    login: "miner-a",
+    repoFullName: "octo/demo",
+    generatedAt: "2026-06-03T00:00:00.000Z",
+    contributorOpenPrCount: 2,
+    simulation: {
+      repoFullName: "octo/demo",
+      generatedAt: "2026-06-03T00:00:00.000Z",
+      lane: "contributor",
+      queuePressure: "high",
+      recommendedOption: "cleanup_first",
+      summary: "Clean up existing work before opening another PR.",
+      scenarios: [
+        {
+          option: "cleanup_first",
+          label: "Clean up existing work first",
+          rank: 1,
+          recommended: true,
+          facts: ["Repo queue pressure is high.", "You have 2 open PR(s) on this repo."],
+          assumptions: ["Maintainers review oldest work first."],
+          tradeoffs: ["Delays starting new work."],
+          blockers: ["Multiple open PRs increase review friction."],
+        },
+        {
+          option: "wait",
+          label: "Wait before opening more",
+          rank: 2,
+          recommended: false,
+          facts: ["Repo queue pressure is high."],
+          assumptions: ["Queue may clear soon."],
+          tradeoffs: ["May miss a timely issue."],
+          blockers: [],
+        },
+        {
+          option: "open_new_work",
+          label: "Open another PR now",
+          rank: 3,
+          recommended: false,
+          facts: ["Repo queue pressure is high."],
+          assumptions: ["New work is small and reviewable."],
+          tradeoffs: ["Adds more queue pressure."],
+          blockers: ["Review backlog is already elevated."],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("extension open-PR pressure shaping", () => {
+  it("redacts forbidden private terms from scenario text", () => {
+    const shaped = buildExtensionOpenPrPressure(
+      sampleResponse({
+        simulation: {
+          ...sampleResponse().simulation,
+          summary: "Avoid wallet language and raw trust score claims.",
+          scenarios: [
+            {
+              option: "wait",
+              label: "Wait before opening more",
+              rank: 1,
+              recommended: true,
+              facts: ["Do not mention payout estimates."],
+              assumptions: ["No hotkey material in public comments."],
+              tradeoffs: ["scoreability stays private"],
+              blockers: ["reward estimate language"],
+            },
+          ],
+        },
+      }),
+    );
+    expect(JSON.stringify(shaped)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+    expect(shaped.summary).toContain("[redacted]");
+  });
+
+  it("preserves strategy structure and recommended option", () => {
+    const shaped = buildExtensionOpenPrPressure(sampleResponse());
+    expect(shaped.recommendedOption).toBe("cleanup_first");
+    expect(shaped.contributorOpenPrCount).toBe(2);
+    expect(shaped.scenarios).toHaveLength(3);
+    expect(shaped.scenarios.find((entry) => entry.recommended)?.option).toBe("cleanup_first");
+  });
+
+  it("builds a public-safe headline from the recommended scenario label", () => {
+    const shaped = buildExtensionOpenPrPressure(sampleResponse());
+    const headline = extensionOpenPrPressureHeadline(shaped);
+    expect(headline).toContain("octo/demo");
+    expect(headline).toContain("Clean up existing work first");
+    expect(headline).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -17,6 +17,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_get_contributor_profile",
   "gittensory_get_decision_pack",
   "gittensory_monitor_open_prs",
+  "gittensory_simulate_open_pr_pressure",
   "gittensory_explain_repo_decision",
   "gittensory_get_issue_quality",
   "gittensory_validate_linked_issue",
@@ -405,6 +406,30 @@ describe("MCP tool calls return schema-valid structured content", () => {
     expect(data.slop).toBeTruthy();
     expect(data.recommendations).toBeTruthy();
     expect(Array.isArray(data.signals)).toBe(true);
+  });
+
+  it("gittensory_simulate_open_pr_pressure returns strategy options for a contributor repo", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    await upsertPullRequestFromGitHub(env, "octo/demo", {
+      number: 1,
+      title: "Open work",
+      state: "open",
+      user: { login: "alice" },
+      head: { sha: "abc", ref: "feat" },
+      base: { ref: "main" },
+    });
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: { login: "alice", owner: "octo", repo: "demo" },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.repoFullName).toBe("octo/demo");
+    expect(data.contributorOpenPrCount).toBe(1);
+    expect(data.recommendedOption).toMatch(/^(open_new_work|wait|cleanup_first)$/);
+    expect(Array.isArray(data.scenarios)).toBe(true);
   });
 });
 

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
-import { persistSignalSnapshot, upsertBounty, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, updatePullRequestSlopAssessment } from "../../src/db/repositories";
+import { createAgentRun, persistSignalSnapshot, replaceAgentActions, upsertAgentRecommendationOutcome, upsertBounty, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, updatePullRequestSlopAssessment } from "../../src/db/repositories";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -14,6 +14,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_get_burden_forecast",
   "gittensory_get_repo_outcome_patterns",
   "gittensory_get_outcome_calibration",
+  "gittensory_get_recommendation_quality",
   "gittensory_get_contributor_profile",
   "gittensory_get_decision_pack",
   "gittensory_monitor_open_prs",
@@ -406,6 +407,72 @@ describe("MCP tool calls return schema-valid structured content", () => {
     expect(data.slop).toBeTruthy();
     expect(data.recommendations).toBeTruthy();
     expect(Array.isArray(data.signals)).toBe(true);
+  });
+
+  it("gittensory_get_recommendation_quality returns repo-scoped recommendation outcome quality", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    await createAgentRun(env, {
+      id: "quality-run",
+      objective: "Track recommendation quality",
+      actorLogin: "alice",
+      surface: "mcp",
+      mode: "copilot",
+      status: "completed",
+      dataQualityStatus: "complete",
+      payload: {},
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-02T00:00:00.000Z",
+    } as any);
+    await replaceAgentActions(env, "quality-run", [
+      {
+        id: "quality-action",
+        runId: "quality-run",
+        actionType: "prepare_pr_packet",
+        targetRepoFullName: "octo/demo",
+        targetPullNumber: null,
+        targetIssueNumber: null,
+        status: "recommended",
+        recommendation: "pursue",
+        why: ["fixture"],
+        blockedBy: [],
+        publicSafeSummary: "fixture",
+        approvalRequired: false,
+        safetyClass: "private",
+        payload: {},
+        createdAt: "2026-06-01T00:00:00.000Z",
+      },
+    ] as any);
+    await upsertAgentRecommendationOutcome(env, {
+      runId: "quality-run",
+      actionId: "quality-action",
+      actorLogin: "alice",
+      actionType: "prepare_pr_packet",
+      surface: "mcp",
+      source: "inferred",
+      outcomeState: "merged",
+      confidence: "high",
+      outcomeTargetType: "pull_request",
+      outcomeRepoFullName: "octo/demo",
+      targetRepoFullName: "octo/demo",
+      maintainerLane: false,
+      reason: "test",
+      metadata: {},
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-02T00:00:00.000Z",
+    } as any);
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "gittensory_get_recommendation_quality",
+      arguments: { owner: "octo", repo: "demo", windowDays: 30 },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.repoFullName).toBe("octo/demo");
+    expect(data.windowDays).toBe(30);
+    expect(data.totals).toBeTruthy();
+    expect(Array.isArray(data.failureCategories)).toBe(true);
+    expect(Array.isArray(data.trends)).toBe(true);
   });
 
   it("gittensory_simulate_open_pr_pressure returns strategy options for a contributor repo", async () => {

--- a/test/unit/open-pr-pressure-response.test.ts
+++ b/test/unit/open-pr-pressure-response.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { buildContributorOpenPrPressureResponse } from "../../src/services/open-pr-pressure-response";
+import { createTestEnv } from "../helpers/d1";
+
+const FORBIDDEN_PUBLIC_LANGUAGE =
+  /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|reward estimate|raw trust|trust score|scoreability|private reviewability|estimated score|score estimate|farming/i;
+
+describe("buildContributorOpenPrPressureResponse", () => {
+  it("returns strategy simulation with contributor open PR count for a registered repo", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    await upsertIssueFromGitHub(env, "octo/demo", { number: 1, title: "Queue issue", state: "open", user: { login: "octo" }, labels: [{ name: "feature" }] });
+    await upsertPullRequestFromGitHub(env, "octo/demo", {
+      number: 10,
+      title: "Contributor work",
+      state: "open",
+      user: { login: "miner-a" },
+      labels: [],
+      head: { sha: "abc", ref: "feat" },
+      base: { ref: "main" },
+    });
+    await upsertPullRequestFromGitHub(env, "octo/demo", {
+      number: 11,
+      title: "More contributor work",
+      state: "open",
+      user: { login: "miner-a" },
+      labels: [],
+      head: { sha: "def", ref: "feat2" },
+      base: { ref: "main" },
+    });
+
+    const response = await buildContributorOpenPrPressureResponse(env, "miner-a", "octo/demo");
+    expect(response).toMatchObject({
+      login: "miner-a",
+      repoFullName: "octo/demo",
+      contributorOpenPrCount: 2,
+      simulation: {
+        repoFullName: "octo/demo",
+        lane: "contributor",
+        recommendedOption: expect.stringMatching(/^(open_new_work|wait|cleanup_first)$/),
+        scenarios: expect.arrayContaining([
+          expect.objectContaining({
+            option: expect.any(String),
+            recommended: expect.any(Boolean),
+            facts: expect.any(Array),
+          }),
+        ]),
+      },
+    });
+    expect(JSON.stringify(response)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  });
+
+  it("returns null when the repo is unknown", async () => {
+    const env = createTestEnv();
+    await expect(buildContributorOpenPrPressureResponse(env, "miner-a", "missing/repo")).resolves.toBeNull();
+  });
+
+  it("recommends cleanup_first when the contributor has multiple open PRs on a busy queue", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "busy", full_name: "octo/busy", private: false, owner: { login: "octo" }, default_branch: "main" });
+    for (let issue = 1; issue <= 6; issue += 1) {
+      await upsertIssueFromGitHub(env, "octo/busy", { number: issue, title: `Issue ${issue}`, state: "open", user: { login: "octo" }, labels: [{ name: "feature" }] });
+    }
+    for (let pr = 1; pr <= 14; pr += 1) {
+      await upsertPullRequestFromGitHub(env, "octo/busy", {
+        number: pr,
+        title: `PR ${pr}`,
+        state: "open",
+        user: { login: pr <= 3 ? "miner-a" : "other" },
+        labels: [],
+        head: { sha: `sha${pr}`, ref: `branch-${pr}` },
+        base: { ref: "main" },
+        ...(pr > 10 ? { updated_at: "2020-01-01T00:00:00.000Z" } : {}),
+      });
+    }
+
+    const response = await buildContributorOpenPrPressureResponse(env, "miner-a", "octo/busy");
+    expect(response?.contributorOpenPrCount).toBe(3);
+    expect(response?.simulation.recommendedOption).toBe("cleanup_first");
+    expect(response?.simulation.scenarios.find((entry) => entry.recommended)?.option).toBe("cleanup_first");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds maintainer-scoped endpoint `GET /v1/repos/:owner/:repo/recommendation-quality` (default 90d) summarizing agent recommendation outcomes for the repo: totals, failure categories, trends, and rollups.
- Adds MCP tool `gittensory_get_recommendation_quality` for agent-native calibration reads.
- Fixes D1 retention pruning parameter binding (`?` positional) to prevent `column index out of range` failures in CI.

## Test plan
- [x] `npx vitest run test/unit/retention.test.ts`
- [x] `npx vitest run test/unit/mcp-output-schemas.test.ts -t gittensory_get_recommendation_quality`
- [x] `npx vitest run test/integration/api.test.ts`
- [x] `npm run test:ci`

## Notes
- Read-only measurement only; no writes and no score/payout terminology is emitted.
- Checked for duplicate open PRs on recommendation-quality surfaces (none found).