### PR TITLE
feat(scoring): add validation_evidence as a 4th graded lint component

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4630,7 +4630,7 @@ export type PrTextLintInput = {
 };
 
 export type PrTextLintComponent = {
-  key: "traceability" | "commit_message" | "pr_body";
+  key: "traceability" | "commit_message" | "pr_body" | "validation_evidence";
   label: string;
   status: "ok" | "weak";
   evidence: string;
@@ -4644,7 +4644,7 @@ export type PrTextLintReport = {
    * 0-100 PR-text quality score from the deterministic rubric (sum of per-component weights; weak
    * components score 25% of their weight). Advisory sub-signal only — `verdict` is authoritative.
    * Because traceability is a hard gate for the verdict but only one weighted component of the score,
-   * the two can rank-disagree (e.g. a strong commit + body with no linked issue scores ~78 yet the
+   * the two can rank-disagree (e.g. a strong commit + body with no linked issue scores ~81 yet the
    * verdict is "weak"). Rank by `verdict`, not `score`. Not a Gittensor reward/trust score.
    */
   score: number;
@@ -4660,7 +4660,7 @@ export const GENERIC_COMMIT_PATTERN = /^(?:(?:wip|fix(?:es|ed|ing)?|updat(?:e|es
 // then `: ` and a non-empty summary (e.g. `feat(api): add cursor pagination`). Single source of truth
 // with CONTRIBUTING.md "Commit And PR Titles".
 const CONVENTIONAL_COMMIT_PATTERN = /^(?:feat|fix|test|docs|refactor|build|ci|chore|revert)(?:\([^()\r\n]+\))?!?:\s+\S/i;
-const PR_TEXT_LINT_WEIGHTS = { traceability: 30, commit_message: 35, pr_body: 35 } as const;
+const PR_TEXT_LINT_WEIGHTS = { traceability: 25, commit_message: 30, pr_body: 30, validation_evidence: 15 } as const;
 
 function stripPrBodyScaffolding(body: string): string {
   return body
@@ -4674,10 +4674,11 @@ function stripPrBodyScaffolding(body: string): string {
 
 /**
  * Deterministic commit-message + PR-body rubric linter. Catches generic/empty AI-slop text before
- * submit and returns a quality verdict plus specific, public-safe fixes. Reuses the gittensor
- * traceability/no-issue-rationale rubric ({@link hasClearNoIssueRationale}, {@link tokenize},
- * {@link STOPWORDS}) shared with the public readiness score. All output is routed through
- * {@link sanitizePublicComment}; no private scoring is exposed.
+ * submit and returns a quality verdict plus specific, public-safe fixes. Grades four dimensions:
+ * traceability (25 pts), commit message (30 pts), PR body (30 pts), validation evidence (15 pts).
+ * Reuses the gittensor traceability/no-issue-rationale rubric ({@link hasClearNoIssueRationale},
+ * {@link tokenize}, {@link STOPWORDS}) shared with the public readiness score. All output is routed
+ * through {@link sanitizePublicComment}; no private scoring is exposed.
  */
 export function buildPrTextLint(input: PrTextLintInput): PrTextLintReport {
   const commitMessages = (input.commitMessages ?? []).map((message) => message.trim()).filter((message) => message.length > 0);
@@ -4749,7 +4750,18 @@ export function buildPrTextLint(input: PrTextLintInput): PrTextLintReport {
         fix: "Describe what changed, why, and how it was validated; fill in or remove unused template sections.",
       };
 
-  const components = [traceability, commitMessage, prBodyComponent];
+  const validationOk = hasValidationNote(prBody);
+  const validationEvidence: PrTextLintComponent = validationOk
+    ? { key: "validation_evidence", label: "Validation evidence", status: "ok", evidence: "PR body describes how the change was tested or validated." }
+    : {
+        key: "validation_evidence",
+        label: "Validation evidence",
+        status: "weak",
+        evidence: "PR body does not describe how the change was tested or validated.",
+        fix: "Add a short note describing how you validated this change — for example, 'Tested with npm run test:ci' or 'Manually verified the login flow in staging'.",
+      };
+
+  const components = [traceability, commitMessage, prBodyComponent, validationEvidence];
   const score = components.reduce((sum, component) => sum + (component.status === "ok" ? PR_TEXT_LINT_WEIGHTS[component.key] : Math.round(PR_TEXT_LINT_WEIGHTS[component.key] * 0.25)), 0);
   const weakCount = components.filter((component) => component.status === "weak").length;
   const verdict: PrTextLintReport["verdict"] = weakCount === 0 ? "strong" : traceabilityOk && weakCount === 1 ? "adequate" : "weak";

--- a/test/unit/pr-text-lint.test.ts
+++ b/test/unit/pr-text-lint.test.ts
@@ -115,7 +115,7 @@ describe("buildPrTextLint", () => {
   it("returns weak with all fixes when every dimension is low-effort", () => {
     const report = buildPrTextLint({ commitMessages: ["update"], prBody: "" });
     expect(report.verdict).toBe("weak");
-    expect(report.fixes).toHaveLength(3);
+    expect(report.fixes).toHaveLength(4);
     expect(report.score).toBeLessThan(50);
     expect(report.summary).toMatch(/low-effort/i);
     assertPublicSafe(report);
@@ -124,7 +124,24 @@ describe("buildPrTextLint", () => {
   it("handles entirely empty input deterministically", () => {
     const report = buildPrTextLint({});
     expect(report.verdict).toBe("weak");
-    expect(report.components).toHaveLength(3);
+    expect(report.components).toHaveLength(4);
+    assertPublicSafe(report);
+  });
+
+  it("grades validation_evidence ok when the body mentions testing", () => {
+    const body = "Adds retry logic to the fetch helper. Tested with npm run test:ci — all 142 tests pass.";
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: body, linkedIssue: 42 });
+    expect(component(report, "validation_evidence").status).toBe("ok");
+    expect(report.verdict).toBe("strong");
+    assertPublicSafe(report);
+  });
+
+  it("grades validation_evidence weak when the body has no test mention and surfaces a fix", () => {
+    const body = "Adds retry logic to the fetch helper to handle transient network errors on the labels endpoint.";
+    const report = buildPrTextLint({ commitMessages: [GOOD_COMMIT], prBody: body, linkedIssue: 42 });
+    expect(component(report, "validation_evidence").status).toBe("weak");
+    expect(component(report, "validation_evidence").fix).toMatch(/validated|test/i);
+    expect(report.verdict).toBe("adequate");
     assertPublicSafe(report);
   });
 });


### PR DESCRIPTION
## Summary

- `buildPrTextLint()` now grades four dimensions instead of three: traceability (25 pts), commit message (30 pts), PR body (30 pts), and **validation evidence** (15 pts). Weights are rebalanced so the total remains 100.
- The new `validation_evidence` component is `"ok"` when the PR body mentions testing or validation (pytest, vitest, npm test, verified, manual check, smoke, etc.) via the existing `hasValidationNote()` helper, and `"weak"` with an actionable fix message otherwise.
- This aligns `buildPrTextLint()` with `buildPublicReadinessScore()`, which already grades a 25-pt validation evidence component — previously the linter flagged a missing issue link or vague commit but never asked "did you describe how you tested this?"

**Behavior change:** A PR body that passes the length/token floor but contains no test/validation mention now yields `verdict: "adequate"` instead of `"strong"`. A PR with all four dimensions satisfied still yields `verdict: "strong"` with `score: 100`.

## Scope

- [x] Changes are scoped to `src/signals/engine.ts` and `test/unit/pr-text-lint.test.ts`
- [x] `PrTextLintComponent.key` union type extended to include `"validation_evidence"`
- [x] No migration, OpenAPI, or `cf-typegen` changes required
- [x] No secrets, trust scores, wallet addresses, or reward values introduced
- [x] `site/`, `CNAME`, and `**/lovable/**` untouched

## Validation

- [x] `npm run test:ci` fully green (3764 tests pass, 218 test files)
- [x] `git diff --check` clean
- [x] `npm run typecheck` passes with no errors

## Safety

- [x] No auth, session, or CORS paths changed
- [x] `sanitizePublicComment` applied to all new component text fields (same as the existing 3 components)
- [x] Existing tests updated where `toHaveLength(3)` → `toHaveLength(4)` to reflect the new 4-component shape; all score assertions still pass because `GOOD_BODY` already contains "Tested with vitest"