### PR TITLE
fix(gate): use case-insensitive comparisons for predicted-gate author history

### DIFF
--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -148,7 +148,7 @@ export function buildPredictedGateVerdict(args: {
   const pack: GatePolicyPack = gate.pack ?? "gittensor";
   const effectiveConfirmedContributor = pack === "oss-anti-slop" ? undefined : args.confirmedContributor;
 
-  const authorHistory = pullRequests.filter((pr) => pr.repoFullName === input.repoFullName && pr.authorLogin === input.contributorLogin);
+  const authorHistory = pullRequests.filter((pr) => sameRepo(pr.repoFullName, input.repoFullName) && sameLogin(pr.authorLogin, input.contributorLogin));
 
   const evaluation = evaluateGateCheck(advisory, {
     linkedIssueGateMode: gate.linkedIssue ?? undefined,
@@ -179,4 +179,12 @@ export function buildPredictedGateVerdict(args: {
     funnel: pack === "oss-anti-slop" ? { ...OSS_ANTI_SLOP_FUNNEL } : null,
     note: PREDICTED_GATE_NOTE,
   };
+}
+
+function sameLogin(value: string | null | undefined, login: string): boolean {
+  return value?.toLowerCase() === login.toLowerCase();
+}
+
+function sameRepo(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
 }

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -148,6 +148,97 @@ describe("buildPredictedGateVerdict", () => {
   });
 });
 
+describe("case-insensitive author-history matching", () => {
+  it("matches author history when the login differs only by case", () => {
+    // Prior merged PR has authorLogin "Miner1" (uppercase M), but the contributor input has "miner1" (lowercase).
+    // Before the fix, authorHistory would be empty → the contributor falsely gets first-time grace.
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        { ...openPr(9, "Earlier fix", [], "Miner1"), state: "merged", mergedAt: "2026-06-01T00:00:00.000Z" },
+      ],
+    });
+    // "miner1" (BASE_INPUT.contributorLogin) must match "Miner1" → authorMergedPrCount >= 1 → no grace → blocked.
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.some((b) => b.code === "duplicate_pr_risk")).toBe(true);
+  });
+
+  it("matches author history when the repoFullName differs only by case", () => {
+    // Prior merged PR has repoFullName "Acme/Widgets" but input uses "acme/widgets".
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        { ...openPr(9, "Earlier fix", [], "miner1"), repoFullName: "Acme/Widgets", state: "merged", mergedAt: "2026-06-01T00:00:00.000Z" },
+      ],
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.some((b) => b.code === "duplicate_pr_risk")).toBe(true);
+  });
+
+  it("counts closed-unmerged history correctly even with mixed-case logins", () => {
+    // Repeat-offender detection: 3 closed-unmerged PRs with "MINER1" must still count for "miner1".
+    const closedUnmerged = (number: number, title: string): PullRequestRecord => ({
+      ...openPr(number, title, [], "MINER1"),
+      state: "closed",
+    });
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        closedUnmerged(11, "Attempt one"),
+        closedUnmerged(12, "Attempt two"),
+        closedUnmerged(13, "Attempt three"),
+      ],
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.some((b) => b.code === "duplicate_pr_risk")).toBe(true);
+  });
+
+  it("does NOT match author history from a different login", () => {
+    // A PR from "other-miner" must not count toward "miner1" history even with case folding.
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        { ...openPr(9, "Earlier fix", [], "other-miner"), state: "merged", mergedAt: "2026-06-01T00:00:00.000Z" },
+      ],
+    });
+    // "other-miner" does not match "miner1" → authorMergedPrCount === 0 → newcomer → grace applies.
+    expect(result.conclusion).toBe("neutral");
+    expect(result.blockers).toHaveLength(0);
+  });
+
+  it("does NOT match author history from a different repo", () => {
+    // A merged PR in "acme/other-repo" must not count toward "acme/widgets" history.
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        { ...openPr(9, "Earlier fix", [], "miner1"), repoFullName: "acme/other-repo", state: "merged", mergedAt: "2026-06-01T00:00:00.000Z" },
+      ],
+    });
+    // Different repo → authorMergedPrCount === 0 → newcomer → grace.
+    expect(result.conclusion).toBe("neutral");
+    expect(result.blockers).toHaveLength(0);
+  });
+
+  it("handles a null authorLogin in the PR record without crashing", () => {
+    // Some PR records may have null authorLogin (deleted users); sameLogin must handle it.
+    const result = verdict({
+      gate: { duplicates: "block", firstTimeContributorGrace: true },
+      pullRequests: [
+        openPr(42, "Retry uploads on 5xx responses", [7], "someone-else"),
+        { ...openPr(9, "Ghost PR", [], "miner1"), authorLogin: null as unknown as string, state: "merged", mergedAt: "2026-06-01T00:00:00.000Z" },
+      ],
+    });
+    // null authorLogin does not match "miner1" → newcomer → grace.
+    expect(result.conclusion).toBe("neutral");
+    expect(result.blockers).toHaveLength(0);
+  });
+});
+
 describe("pack-aware prediction (#693)", () => {
   it("defaults to the gittensor pack and surfaces it", () => {
     expect(verdict({ gate: { duplicates: "block" } }).pack).toBe("gittensor");


### PR DESCRIPTION
## Summary

- `buildPredictedGateVerdict` used strict `===` for `authorLogin` and `repoFullName` when filtering author history (line 151), but GitHub treats both as case-insensitive. When casing diverged between cached PR records and prediction input, `authorMergedPrCount` and `authorClosedUnmergedPrCount` were silently undercounted — a returning contributor could be misclassified as a first-timer (false grace) and a repeat offender could dodge the closed-unmerged threshold.
- Replaced with local `sameLogin`/`sameRepo` helpers matching the identical pattern in `engine.ts:5151`, `local-branch.ts:1248`, `pending-pr-scenarios.ts:229`, and five other modules.
- No issue linked: this is a small, self-evident bug fix — the broken line, the correct pattern, and the existing analogues are all visible in the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped — full `npm run test:ci` passed locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. *(N/A — no auth/CORS changes.)*
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. *(N/A — no API/OpenAPI/MCP changes.)*
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. *(N/A — no UI changes.)*
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. *(N/A — no visible changes.)*
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. *(N/A — no docs/changelog changes.)*

## UI Evidence

N/A — backend-only change with no UI impact.

## Notes

- `predicted-gate.ts` coverage: 100% statements, 97.5% branches (the uncovered branch is a pre-existing `input.body ?? null` on line 122, not introduced by this PR), 100% functions, 100% lines.
- Six regression tests added: mixed-case login, mixed-case repoFullName, repeat-offender with mixed-case, negative-match (different login), cross-repo exclusion (different repo), and null authorLogin edge case.