### PR TITLE
fix(github): continue paginated issue-events when Link has rel="next" but no rel="last"

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -127,6 +127,7 @@ export async function getLastCloserLogin(env: Env, installationId: number, repoF
     const firstResponse = await requestPage(1);
     const firstEvents = firstResponse.data as Array<{ event?: string; actor?: { login?: string | null } | null }>;
     const lastPage = issueEventsLastPage(firstResponse.headers.link);
+    if (lastPage === null) return scanIssueEventsWithoutLastPage(requestPage, firstEvents);
     if (lastPage <= 1) return latestCloserInPage(firstEvents) ?? null;
 
     // GitHub returns issue-events oldest-first. Use the Link header to inspect the newest bounded window instead
@@ -151,9 +152,28 @@ function latestCloserInPage(events: Array<{ event?: string; actor?: { login?: st
   return undefined;
 }
 
-function issueEventsLastPage(linkHeader: string | undefined): number {
+async function scanIssueEventsWithoutLastPage(
+  requestPage: (page: number) => Promise<{ data: unknown; headers: { link?: string | undefined } }>,
+  firstEvents: Array<{ event?: string; actor?: { login?: string | null } | null }>,
+): Promise<string | null> {
+  let latestCloser = latestCloserInPage(firstEvents);
+  for (let page = 2; page <= ISSUE_EVENTS_RECENT_PAGE_LIMIT + 1; page += 1) {
+    const response = await requestPage(page);
+    const closer = latestCloserInPage(response.data as Array<{ event?: string; actor?: { login?: string | null } | null }>);
+    if (closer !== undefined) latestCloser = closer;
+    if (!issueEventsHasNextPage(response.headers.link)) return latestCloser ?? null;
+  }
+  return latestCloser ?? null;
+}
+
+function issueEventsLastPage(linkHeader: string | undefined): number | null {
   if (!linkHeader) return 1;
   const lastLink = linkHeader.split(",").find((link) => /rel="last"/.test(link));
   const page = lastLink?.match(/[?&]page=(\d+)/)?.[1];
-  return page ? Number(page) : 1;
+  if (page) return Number(page);
+  return issueEventsHasNextPage(linkHeader) ? null : 1;
+}
+
+function issueEventsHasNextPage(linkHeader: string | undefined): boolean {
+  return Boolean(linkHeader?.split(",").some((link) => /rel="next"/.test(link)));
 }

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -187,20 +187,43 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 22)).resolves.toBe("page1-closer");
   });
 
-  it("treats a link header without rel=last as a single-page result (issueEventsLastPage FALSE branch)", async () => {
-    // Link header present but only contains rel="next" — no rel="last" match → lastPage stays 1
-    // → firstEvents from page 1 is returned directly without a second request.
+  it("continues past page 1 when rel=next is present without rel=last (regression)", async () => {
+    const fetchedPages: number[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       if (url.includes("/issues/23/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        fetchedPages.push(page);
+        if (page === 1) {
+          return Response.json([{ event: "closed", actor: { login: "stale-contributor" } }], {
+            headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=2>; rel="next"' },
+          });
+        }
+        return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toBe("maintainer");
+    expect(fetchedPages).toEqual([1, 2]);
+  });
+
+  it("treats a link header without next or last as a single-page result", async () => {
+    const fetchedPages: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/25/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        fetchedPages.push(page);
         return Response.json([{ event: "closed", actor: { login: "solo-closer" } }], {
-          headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=2>; rel="next"' },
+          headers: { link: '<https://api.github.test/issues/25/events?per_page=100&page=1>; rel="prev"' },
         });
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toBe("solo-closer");
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 25)).resolves.toBe("solo-closer");
+    expect(fetchedPages).toEqual([1]);
   });
 
   it("returns null when bounded window (firstPageToRead=2) AND page 1 also have no close event (?? null right branch)", async () => {


### PR DESCRIPTION
### Motivation
- A regression treated a Link header lacking `rel="last"` as a single-page result, which can skip later issue-event pages when the header contains `rel="next"`, causing `getLastCloserLogin` to miss a later maintainer/bot close.

### Description
- Change `issueEventsLastPage` to return `number | null` and treat the absence of `rel="last"` with a present `rel="next"` as an unknown-last sentinel (null).
- Add `scanIssueEventsWithoutLastPage(requestPage, firstEvents)` and `issueEventsHasNextPage` to perform a bounded forward scan when the last page cannot be determined, preserving the most-recent closer seen across the scanned pages.
- Wire `getLastCloserLogin` to invoke the bounded forward scan when the sentinel is returned, while keeping the existing newest-window behavior when `rel="last"` is present.
- Add unit tests that cover the regression (page-2 maintainer close found when page 1 only had `rel="next"`) and a single-page case when the header contains neither `next` nor `last`.

### Testing
- `npm run typecheck` succeeded with no errors.
- `npx vitest run test/unit/github-pr-actions.test.ts` succeeded (all tests in that file passed).
- `npm run test:coverage` was attempted but coverage report generation failed in this environment due to a V8/coverage tooling error (`TypeError: jsTokens is not a function`), so full coverage verification is currently blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3badfe03ec832c9d2c696ae35028d9)