### PR TITLE
fix(ci): fail closed when a CI source fetch is incomplete; paginate statuses

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1994,6 +1994,12 @@ export async function fetchLiveCiAggregate(
   const nonRequiredFailingDetails: LiveCiAggregate["nonRequiredFailingDetails"] = [];
   let total = 0;
   let anyPending = false;
+  // CI visibility flags: a failed/short read of either source means we did NOT enumerate the commit's full check
+  // set, so we must not certify it "passed". They drive the fail-CLOSED degrade below. In enforce-required mode
+  // the absent-context guard already catches this; this additionally closes the fold-all (unknown-required) seam
+  // where a transient fetch failure plus one green check could otherwise read as "passed".
+  let checkRunsIncomplete = false;
+  let statusIncomplete = false;
   // Track which required context names actually appear in any API result. An absent required context
   // (never queued, in-progress, or complete) has no entry to push anyPending — without this guard it
   // would be silently ignored and ciState could become "passed" while it never ran.
@@ -2007,7 +2013,11 @@ export async function fetchLiveCiAggregate(
       `/commits/${headSha}/check-runs?per_page=100&page=${page}`,
       token,
     ).catch(() => undefined);
-    if (!result) break;
+    // A failed check-runs fetch (page 1 or mid-pagination) leaves the check set partially read — fail closed.
+    if (!result) {
+      checkRunsIncomplete = true;
+      break;
+    }
     for (const run of result.data.check_runs ?? []) {
       seenContextNames?.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
       if (isOwnGitHubAppCheckRun(env, run)) continue; // never wait on the bot's own Gate/Context check-runs (see above)
@@ -2029,14 +2039,25 @@ export async function fetchLiveCiAggregate(
 
   // 2) Classic commit-statuses (codecov/patch, codecov/project, and any other status-API context). The
   // combined endpoint returns the LATEST status per context, so a context that flipped red→green is counted
-  // once at its current state.
-  const statusResult = await githubJsonWithHeaders<{ statuses?: Array<{ context?: string | null; state?: string | null; description?: string | null; target_url?: string | null }> }>(
-    env,
-    repoFullName,
-    `/commits/${headSha}/status?per_page=100`,
-    token,
-  ).catch(() => undefined);
-  for (const ctx of statusResult?.data.statuses ?? []) {
+  // once at its current state. Paginated: the endpoint caps at 100 statuses/page, so a head with >100 contexts
+  // would silently drop the overflow (including a failing one) — accumulate every page before processing.
+  const commitStatuses: Array<{ context?: string | null; state?: string | null; description?: string | null; target_url?: string | null }> = [];
+  for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
+    const statusResult = await githubJsonWithHeaders<{ statuses?: Array<{ context?: string | null; state?: string | null; description?: string | null; target_url?: string | null }> }>(
+      env,
+      repoFullName,
+      `/commits/${headSha}/status?per_page=100&page=${page}`,
+      token,
+    ).catch(() => undefined);
+    // A failed status fetch leaves the status set partially read — fail closed (see the degrade below).
+    if (!statusResult) {
+      statusIncomplete = true;
+      break;
+    }
+    commitStatuses.push(...(statusResult.data.statuses ?? []));
+    if (!hasNextPage(statusResult.link)) break;
+  }
+  for (const ctx of commitStatuses) {
     const name = ctx.context ?? "status";
     total += 1;
     seenContextNames?.add(name);
@@ -2064,7 +2085,11 @@ export async function fetchLiveCiAggregate(
   // ciState reflects ONLY gate-failing (required, or all-when-unknown) checks. A repo whose only red check is a
   // non-required codecov/* therefore reports "passed" and is eligible to merge/approve, with the codecov
   // failure riding along in nonRequiredFailingDetails for the contributor to see.
-  const ciState: LiveCiAggregate["ciState"] = failingDetails.length > 0 ? "failed" : anyPending ? "pending" : total > 0 ? "passed" : "unverified";
+  let ciState: LiveCiAggregate["ciState"] = failingDetails.length > 0 ? "failed" : anyPending ? "pending" : total > 0 ? "passed" : "unverified";
+  // Fail CLOSED on incomplete visibility: if either CI source could not be fully read, we cannot certify the
+  // commit as passed/clean — hold (pending) so the gate waits and re-evaluates on the next sweep instead of
+  // auto-merging on partial data. An OBSERVED failure ("failed") is authoritative and preserved.
+  if ((checkRunsIncomplete || statusIncomplete) && ciState !== "failed") ciState = "pending";
   return { ciState, failingDetails, nonRequiredFailingDetails };
 }
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2800,6 +2800,96 @@ describe("GitHub backfill", () => {
       expect(aggregate.ciState).toBe("passed");
     });
 
+    it("fold-all: a failed check-runs fetch with an otherwise-green status reads PENDING, not passed (fail-closed)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        // Transient check-runs fetch failure → githubJsonWithHeaders throws → caught → check set unread.
+        if (url.includes("/check-runs?")) return new Response("upstream error", { status: 500 });
+        if (url.includes("/status?")) return Response.json({ statuses: [{ context: "ci/green", state: "success" }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      // Without the fail-closed degrade this would be "passed" (one green status, no failing) — the seam.
+      expect(aggregate.ciState).toBe("pending");
+      expect(aggregate.failingDetails).toEqual([]);
+    });
+
+    it("fold-all: a failed status fetch with an otherwise-green check-run reads PENDING, not passed (fail-closed)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "build", status: "completed", conclusion: "success" }] });
+        if (url.includes("/status?")) return new Response("upstream error", { status: 500 });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("pending");
+    });
+
+    it("an observed required failure stays FAILED even when a later check-runs page fetch fails", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?") && url.includes("&page=1")) {
+          return Response.json(
+            { check_runs: [{ name: "build", status: "completed", conclusion: "failure", output: { title: "boom" } }] },
+            { headers: { link: '<https://api.github.com/repos/x/y/commits/abc/check-runs?page=2>; rel="next"' } },
+          );
+        }
+        if (url.includes("/check-runs?")) return new Response("upstream error", { status: 500 }); // page 2 fails → incomplete
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      // Incomplete visibility does NOT override an authoritative observed failure.
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "build" })]);
+    });
+
+    it("reports unverified when both CI sources succeed but return no checks at all", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("unverified");
+    });
+
+    it("treats a status response with no statuses field as empty (nullish-coalesce branch)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "build", status: "completed", conclusion: "success" }] });
+        if (url.includes("/status?")) return Response.json({}); // no `statuses` key → exercises `?? []`
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("passed");
+    });
+
+    it("paginates commit-statuses so a failing status beyond page 1 is not silently dropped", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [] });
+        if (url.includes("/status?") && url.includes("&page=1")) {
+          return Response.json(
+            { statuses: [{ context: "ci/green", state: "success" }] },
+            { headers: { link: '<https://api.github.com/repos/x/y/commits/abc/status?page=2>; rel="next"' } },
+          );
+        }
+        if (url.includes("/status?")) return Response.json({ statuses: [{ context: "ci/overflow", state: "failure", description: "page-2 failure" }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "ci/overflow" })]);
+    });
+
   });
 
   describe("fetchRequiredStatusContexts", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1041,6 +1041,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/gate123/status")) return Response.json({ statuses: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       return new Response("not found", { status: 404 });
     });
@@ -1111,6 +1112,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/gate123/status")) return Response.json({ statuses: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       return new Response("not found", { status: 404 });
     });
@@ -1292,6 +1294,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/gate123/status")) return Response.json({ statuses: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       return new Response("not found", { status: 404 });
     });
@@ -1338,6 +1341,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/gate123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/gate123/status")) return Response.json({ statuses: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       return new Response("not found", { status: 404 });
     });
@@ -1425,6 +1429,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/commits/clean123/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/clean123/status")) return Response.json({ statuses: [] });
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       return new Response("not found", { status: 404 });
     });


### PR DESCRIPTION
## Summary

Closes audit finding **2.2** (HIGH): `fetchLiveCiAggregate` could read a red-Actions PR as `passed` in **fold-all mode** (installation lacks `administration:read`, so branch-protection required contexts are unknown).

The check-runs and commit-status sources were read independently with no per-source success flag. A transient check-runs fetch failure broke the loop with **zero** runs recorded; a single green commit-status then gave `total > 0`, no failing, no pending → `ciState = "passed"` even though the commit's Actions checks were never observed. That `passed` drives auto-merge. In enforce-required mode the existing absent-required-context guard already caught this; the seam was the fold-all path.

### Fix
- **Fail closed on incomplete visibility**: track whether each source was fully read. If the check-runs or status fetch fails (or short-reads mid-pagination), the aggregate degrades to `pending` so the gate waits and re-evaluates on the next sweep instead of merging on partial data. An **observed** failure (`"failed"`) stays authoritative.
- **Paginate the commit-status source**: the combined endpoint caps at 100 statuses/page; a failing status beyond page 1 was silently dropped. Now accumulated across pages (same `PR_DETAIL_MAX_PAGES` bound as check-runs).

The `githubJsonWithHeaders` retry/timeout regression (audit §5.5) is deferred to the reviewbot-regression PR since it's a shared-helper change with broader blast radius.

## Scope
- [x] Backend only (`src/github/backfill.ts`)
- [x] Narrow, single coherent change; no schema/API change; no migration

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New tests: check-runs fetch fail → pending (fold-all); status fetch fail → pending; observed failure stays failed despite an incomplete later page; status pagination catches a page-2 failure; no-`statuses`-field nullish branch; both-empty → unverified
- [x] Every changed line + branch covered; updated 5 end-to-end stubs to return a realistic 200 empty `/status` (a real commit's status endpoint never 404s)

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values
- [x] No `site/` / `CNAME` / `lovable`; fails toward holding (never toward an unsafe merge)