### PR TITLE
fix(signals): require real test evidence for validation credit

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4565,8 +4565,13 @@ function validationComponent(pr: PullRequestRecord, preflight: PreflightResult):
   if (preflight.status === "hold") {
     return { score: 5, evidence: "Cached preflight status is hold.", action: "Fix blocker." };
   }
-  if (missingTests && !explicitValidation) {
-    return { score: 10, evidence: "No cached test files or validation note found.", action: "Add validation note." };
+  if (missingTests) {
+    // A body validation note is an UNBACKED claim when no test files accompany the change. Cap it just above the
+    // no-signal floor so a one-line "tested" cannot lift readiness over a configured gate threshold on a
+    // zero-test PR — full credit is reserved for actual test evidence in the branch below. (#audit-2.3)
+    return explicitValidation
+      ? { score: 12, evidence: "PR body claims validation but no test files accompany the change.", action: "Add tests covering the change." }
+      : { score: 10, evidence: "No cached test files or validation note found.", action: "Add validation note." };
   }
   if (explicitValidation) {
     return { score: 25, evidence: "PR body includes validation/test evidence.", action: "No action." };

--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -74,6 +74,10 @@ export const SLOP_RUBRIC_MARKDOWN = [
 
 const MIN_CHURN_LINES = 40;
 const MAX_SOURCE_LINE_SHARE = 0.15;
+// Minimum added lines for a changed test file to count as real test evidence. A genuine test needs at least a
+// describe/it/assert; an empty or stub file (0–2 added lines) does not — this stops an empty `*.test.ts` from
+// faking coverage to clear the missing-test finding. (#audit-3.1)
+const MIN_SUBSTANTIVE_TEST_ADDITIONS = 3;
 // A padded diff is one whose churn is dominated by non-substantive output. Set at half the diff so a PR
 // with any meaningful share of real, hand-authored files cannot trip it.
 const PADDING_DOMINANCE_SHARE = 0.5;
@@ -253,9 +257,15 @@ export function buildMissingTestEvidenceFinding(input: SlopAssessmentInput): Sig
   const codePaths = changedPaths.filter(isCodeFile);
   if (codePaths.length === 0) return null;
 
-  const hasChangedTestPaths =
-    changedPaths.some((path) => isTestFile(path) || isTestPath(path)) ||
-    hasLocalTestEvidence({ tests: input.tests, testFiles: input.testFiles });
+  // A changed test FILE only counts as real test evidence when it carries substantive content. An empty or
+  // no-op test (e.g. a committed `tests/noop.test.ts`) would otherwise clear this finding by path alone. When
+  // per-file line counts are unavailable we trust the path (can't prove emptiness); when known, require a few
+  // added lines so a stub can't fake coverage. (#audit-3.1)
+  const hasSubstantiveTestFile = changedFiles.some((file) => {
+    if (!(isTestFile(file.path) || isTestPath(file.path))) return false;
+    return file.additions === undefined || nonNegative(file.additions) >= MIN_SUBSTANTIVE_TEST_ADDITIONS;
+  });
+  const hasChangedTestPaths = hasSubstantiveTestFile || hasLocalTestEvidence({ tests: input.tests, testFiles: input.testFiles });
   if (hasChangedTestPaths) return null;
 
   const detail = ensurePublicSafeText(

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1292,6 +1292,24 @@ describe("signal coverage edge cases", () => {
     expect(scoreComponent(missingValidation, "pr_state")).toMatchObject({ score: 6, evidence: "PR is open as draft.", action: "Mark ready when done." });
     expect(scoreComponent(missingValidation, "queue_pressure")).toMatchObject({ score: 5, action: "Expect slower review." });
 
+    // A body validation NOTE without accompanying test files is capped at 12 (was 25): a one-line "tested" can no
+    // longer fake full validation evidence and lift readiness over a gate threshold on a zero-test PR. (#audit-2.3)
+    const notedButUntested = buildPublicReadinessScore({
+      pr: pr(directRepo.fullName, 43, "Claims tested, no tests", { body: "Tested locally, works fine.", linkedIssues: [1] }),
+      preflight: {
+        ...readyPreflight,
+        status: "ready",
+        reviewBurden: "low",
+        findings: [{ code: "missing_tests", severity: "warning", title: "Tests missing", detail: "No tests found." }],
+      },
+      queueHealth: queueHealthFixture(directRepo.fullName, "low"),
+    });
+    expect(scoreComponent(notedButUntested, "validation")).toMatchObject({
+      score: 12,
+      evidence: "PR body claims validation but no test files accompany the change.",
+      action: "Add tests covering the change.",
+    });
+
     const closedPr = pr(directRepo.fullName, 42, "Closed cleanup", { state: "closed", body: "cleanup", linkedIssues: [] });
     const weak = buildPublicReadinessScore({
       pr: closedPr,

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -331,6 +331,38 @@ describe("buildMissingTestEvidenceFinding", () => {
     });
     expect(JSON.stringify(finding)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
   });
+
+  it("counts a substantive changed test file as evidence (no finding)", () => {
+    expect(
+      buildMissingTestEvidenceFinding({
+        changedFiles: [
+          { path: "src/api/routes.ts", additions: 20, deletions: 0 },
+          { path: "test/api/routes.test.ts", additions: 18, deletions: 0 },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("does NOT count an empty/no-op test file as evidence — the finding still fires (#audit-3.1)", () => {
+    const finding = buildMissingTestEvidenceFinding({
+      changedFiles: [
+        { path: "src/api/routes.ts", additions: 20, deletions: 0 },
+        { path: "test/noop.test.ts", additions: 1, deletions: 0 }, // empty stub: 1 added line
+      ],
+    });
+    expect(finding).toMatchObject({ code: "missing_test_evidence" });
+  });
+
+  it("trusts a test path when per-file line counts are unavailable (no regression on metadata-only inputs)", () => {
+    expect(
+      buildMissingTestEvidenceFinding({
+        changedFiles: [
+          { path: "src/api/routes.ts", additions: 20, deletions: 0 },
+          { path: "test/api/routes.test.ts" }, // additions undefined → trust the path
+        ],
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("buildTrivialWhitespaceChurnFinding", () => {


### PR DESCRIPTION
## Summary

Closes audit findings **2.3** (HIGH) and **3.1**: two anti-gaming gaps where the quality signals could be satisfied by text or an empty file instead of real test evidence.

- **2.3** — `validationComponent` short-circuited to the full **25/25** "validation evidence" whenever `hasValidationNote(pr.body)` matched a keyword (`tested`, `verified`, …), *before* the missing-tests floor. A zero-test PR with "Tested locally." jumped validation 10→25 (+15 of the 100-pt readiness total), which can lift `readiness.total` over a configured `qualityGateMinScore` and clear the `readiness_score_below_threshold` blocker. A body note **without accompanying test files** is now capped at **12** (just above the no-signal floor); full credit is reserved for actual test evidence.
- **3.1** — `buildMissingTestEvidenceFinding` counted a changed test file by **path alone**, so an empty/no-op `*.test.ts` (e.g. a committed `tests/noop.test.ts`) cleared the missing-test slop weight. A changed test file now counts only when it carries **substantive additions** (≥3 added lines). When per-file line counts are unavailable, the path is trusted (no regression on metadata-only inputs).

## Scope
- [x] Backend only (`src/signals/engine.ts`, `src/signals/slop.ts`)
- [x] Narrow; no schema/API change; no migration

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New tests: note-without-tests caps validation at 12; substantive test file counts; empty stub test file still raises the finding; undefined additions trust the path
- [x] Every changed line + branch covered

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values
- [x] No `site/` / `CNAME` / `lovable`; both gates default to advisory, so no behavior change for non-block repos beyond a more honest score