### PR TITLE
fix(gate): fail closed on reopen window-evasion; bind gate-override to head SHA

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3399,9 +3399,16 @@ export async function recordGateBlockOutcome(
     .values(values)
     .onConflictDoUpdate({
       target: [gateOutcomes.repoFullName, gateOutcomes.pullNumber],
-      // Refresh the codes/head/timestamp on a re-block; `overridden` is deliberately omitted so a true value
-      // is preserved.
-      set: { headSha: values.headSha, blockerCodesJson: values.blockerCodesJson, updatedAt: nowIso() },
+      // Refresh the codes/head/timestamp on a re-block. Preserve `overridden` ONLY when the head SHA is
+      // unchanged: a maintainer override applies to the exact commit it was granted on, so a NEW commit
+      // re-blocking must clear it — otherwise a one-time override would permanently disable the gate
+      // (and the draft-dodge auto-close) for every future push to the PR. (#audit-3.14)
+      set: {
+        headSha: values.headSha,
+        blockerCodesJson: values.blockerCodesJson,
+        updatedAt: nowIso(),
+        overridden: sql`CASE WHEN ${gateOutcomes.headSha} IS ${values.headSha} THEN ${gateOutcomes.overridden} ELSE 0 END`,
+      },
     });
 }
 

--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -114,10 +114,16 @@ export async function closePullRequest(env: Env, installationId: number, repoFul
   return { state: (response.data as { state: string }).state };
 }
 
+/** The last-closer lookup result. `coveredAllPages` is false when the bounded newest-events window did NOT reach
+ *  back to page 1 (a very long timeline), so a `login: null` may mean "no close found" OR "a close exists beyond
+ *  the inspected window". The reopen guard uses this to fail CLOSED rather than allow a window-evasion bypass. */
+export type LastCloserResult = { login: string | null; coveredAllPages: boolean };
+
 /** Reopen-prevention (#one-shot-reopen): the login of whoever LAST closed this PR (most recent `closed` event in
  *  the issue-events timeline), or null if none / on error. Lets the reopen handler distinguish a maintainer/bot
- *  close (one-shot — a contributor may not reopen) from a contributor self-close (which they MAY reopen). */
-export async function getLastCloserLogin(env: Env, installationId: number, repoFullName: string, issueNumber: number): Promise<string | null> {
+ *  close (one-shot — a contributor may not reopen) from a contributor self-close (which they MAY reopen).
+ *  `coveredAllPages` reports whether the bounded scan inspected the entire timeline (#audit-2.4). */
+export async function getLastCloserLogin(env: Env, installationId: number, repoFullName: string, issueNumber: number): Promise<LastCloserResult> {
   try {
     const { owner, repo } = splitRepo(repoFullName);
     const token = await createInstallationToken(env, installationId);
@@ -127,19 +133,22 @@ export async function getLastCloserLogin(env: Env, installationId: number, repoF
     const firstResponse = await requestPage(1);
     const firstEvents = firstResponse.data as Array<{ event?: string; actor?: { login?: string | null } | null }>;
     const lastPage = issueEventsLastPage(firstResponse.headers.link);
-    if (lastPage <= 1) return latestCloserInPage(firstEvents) ?? null;
+    if (lastPage <= 1) return { login: latestCloserInPage(firstEvents) ?? null, coveredAllPages: true };
 
     // GitHub returns issue-events oldest-first. Use the Link header to inspect the newest bounded window instead
     // of the oldest prefix, so a long self-generated timeline cannot hide a later maintainer/bot close.
     const firstPageToRead = Math.max(2, lastPage - ISSUE_EVENTS_RECENT_PAGE_LIMIT + 1);
+    // We inspected the entire timeline only when the window reached page 2 (page 1 is read separately above).
+    const coveredAllPages = firstPageToRead === 2;
     for (let page = lastPage; page >= firstPageToRead; page -= 1) {
       const response = await requestPage(page);
       const closer = latestCloserInPage(response.data as Array<{ event?: string; actor?: { login?: string | null } | null }>);
-      if (closer !== undefined) return closer;
+      if (closer !== undefined) return { login: closer, coveredAllPages };
     }
-    return firstPageToRead === 2 ? (latestCloserInPage(firstEvents) ?? null) : null;
+    return { login: coveredAllPages ? (latestCloserInPage(firstEvents) ?? null) : null, coveredAllPages };
   } catch {
-    return null;
+    // On error we cannot prove we read the whole timeline — report not-covered so the caller decides conservatively.
+    return { login: null, coveredAllPages: false };
   }
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3176,8 +3176,15 @@ async function maybeRecloseDisallowedReopen(
   if (await hasMaintainerPermission(reopener)) return false; // owner / admin / write collaborators may reopen
   // A non-maintainer reopened: re-close ONLY if gittensory or a maintainer closed it (one-shot). A contributor
   // reopening a PR they closed themselves is allowed (fail-open on an unknown closer).
-  const closer = (await getLastCloserLogin(env, installationId, repoFullName, pr.number))?.toLowerCase() ?? null;
-  if (!closer || !(closer === botLogin || (await hasMaintainerPermission(closer)))) return false;
+  const closerResult = await getLastCloserLogin(env, installationId, repoFullName, pr.number);
+  const closer = closerResult.login?.toLowerCase() ?? null;
+  const closerIsBotOrMaintainer = closer != null && (closer === botLogin || (await hasMaintainerPermission(closer)));
+  // #audit-2.4: getLastCloserLogin inspects only a bounded newest-events window, so a contributor who appends
+  // >1000 timeline events can push the real close out of view → null closer → bypass. When we could NOT inspect
+  // the whole timeline AND found no qualifying closer, fail CLOSED — a one-shot close stands. A genuine
+  // self-close sits at the timeline end and is found in-window, so legitimate self-close reopens stay allowed.
+  const windowEvasionSuspected = closer == null && !closerResult.coveredAllPages;
+  if (!closerIsBotOrMaintainer && !windowEvasionSuspected) return false;
   await createIssueComment(
     env,
     installationId,
@@ -3191,7 +3198,7 @@ async function maybeRecloseDisallowedReopen(
     actor: "gittensory",
     targetKey: `${repoFullName}#${pr.number}`,
     outcome: "completed",
-    detail: `re-closed a disallowed reopen by ${payload.sender?.login ?? reopener} (originally closed by ${closer}) — one-shot; resubmit a new PR`,
+    detail: `re-closed a disallowed reopen by ${reopener} (originally closed by ${closer ?? "Gittensory (close beyond the inspected event window)"}) — one-shot; resubmit a new PR`,
     metadata: { deliveryId, repoFullName },
   }).catch(() => undefined);
   return true;

--- a/test/unit/gate-precision.test.ts
+++ b/test/unit/gate-precision.test.ts
@@ -155,14 +155,33 @@ describe("loadGatePrecisionReport (env loader)", () => {
     expect(JSON.stringify(report)).not.toMatch(/reward|payout|trust score|wallet|hotkey|login|actor/i);
   });
 
-  it("preserves overridden across a later re-block (a re-block must not clear a maintainer override)", async () => {
+  it("preserves overridden across a SAME-head re-block (a re-block on the same commit keeps the override)", async () => {
     const env = createTestEnv();
-    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 5, blockerCodes: ["x"] });
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 5, headSha: "sha-a", blockerCodes: ["x"] });
     await markGateOutcomeOverridden(env, "owner/repo", 5);
-    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 5, blockerCodes: ["x", "y"] });
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 5, headSha: "sha-a", blockerCodes: ["x", "y"] });
     const [row] = await listGateOutcomes(env, { repoFullName: "owner/repo" });
     expect(row).toMatchObject({ overridden: true });
     expect(row!.blockerCodes).toEqual(["x", "y"]);
+  });
+
+  it("preserves overridden across a re-block when neither block records a head SHA (null-safe IS)", async () => {
+    const env = createTestEnv();
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 6, blockerCodes: ["x"] });
+    await markGateOutcomeOverridden(env, "owner/repo", 6);
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 6, blockerCodes: ["x", "y"] });
+    const [row] = await listGateOutcomes(env, { repoFullName: "owner/repo" });
+    expect(row).toMatchObject({ overridden: true });
+  });
+
+  it("CLEARS overridden when a NEW commit re-blocks (an override binds to the commit it was granted on, #audit-3.14)", async () => {
+    const env = createTestEnv();
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 7, headSha: "sha-old", blockerCodes: ["x"] });
+    await markGateOutcomeOverridden(env, "owner/repo", 7);
+    // The contributor pushes a new commit; the gate re-blocks on the new head → the prior override must NOT carry over.
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 7, headSha: "sha-new", blockerCodes: ["x"] });
+    const [row] = await listGateOutcomes(env, { repoFullName: "owner/repo" });
+    expect(row).toMatchObject({ headSha: "sha-new", overridden: false });
   });
 
   it("markGateOutcomeOverridden is a no-op when no block was recorded", async () => {

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -106,7 +106,7 @@ describe("GitHub PR action primitives (#778)", () => {
       return new Response("unexpected", { status: 500 });
     });
 
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 17)).resolves.toBe("maintainer");
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 17)).resolves.toEqual({ login: "maintainer", coveredAllPages: true });
     expect(calls.some((url) => url.includes("per_page=100") && url.includes("page=1"))).toBe(true);
     expect(calls.some((url) => url.includes("per_page=100") && url.includes("page=2"))).toBe(true);
   });
@@ -116,7 +116,7 @@ describe("GitHub PR action primitives (#778)", () => {
       if (input.toString().includes("/access_tokens")) return Response.json({ token: "t" });
       throw new Error("network failure");
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 18)).resolves.toBeNull();
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 18)).resolves.toEqual({ login: null, coveredAllPages: false });
   });
 
   it("records null lastCloser when the closed event has a null actor", async () => {
@@ -125,7 +125,7 @@ describe("GitHub PR action primitives (#778)", () => {
       if (input.toString().includes("/issues/19/events")) return Response.json([{ event: "closed", actor: null }]);
       return new Response("not found", { status: 404 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 19)).resolves.toBeNull();
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 19)).resolves.toEqual({ login: null, coveredAllPages: true });
   });
 
   it("reads the newest bounded event pages instead of the oldest prefix", async () => {
@@ -148,7 +148,7 @@ describe("GitHub PR action primitives (#778)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 20)).resolves.toBe("maintainer");
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 20)).resolves.toEqual({ login: "maintainer", coveredAllPages: false });
     expect(fetchedPages).toEqual([1, 12, 11]);
     expect(fetchedPages).not.toContain(2);
   });
@@ -166,7 +166,7 @@ describe("GitHub PR action primitives (#778)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 21)).resolves.toBeNull();
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 21)).resolves.toEqual({ login: null, coveredAllPages: false });
     expect(fetchedPages).toEqual([1, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3]);
   });
 
@@ -184,7 +184,7 @@ describe("GitHub PR action primitives (#778)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 22)).resolves.toBe("page1-closer");
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 22)).resolves.toEqual({ login: "page1-closer", coveredAllPages: true });
   });
 
   it("treats a link header without rel=last as a single-page result (issueEventsLastPage FALSE branch)", async () => {
@@ -200,7 +200,7 @@ describe("GitHub PR action primitives (#778)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toBe("solo-closer");
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toEqual({ login: "solo-closer", coveredAllPages: true });
   });
 
   it("returns null when bounded window (firstPageToRead=2) AND page 1 also have no close event (?? null right branch)", async () => {
@@ -216,7 +216,7 @@ describe("GitHub PR action primitives (#778)", () => {
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 24)).resolves.toBeNull();
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 24)).resolves.toEqual({ login: null, coveredAllPages: true });
   });
 
   it("updates branch without an expected head sha (omits expected_head_sha — FALSE branch of the spread ternary)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6078,6 +6078,36 @@ describe("one-shot reopen prevention", () => {
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
   });
 
+  it("re-closes when the close event is hidden beyond the inspected event window (window-evasion fail-closed, #audit-2.4)", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
+      if (url.includes("/issues/42/events")) {
+        // Long timeline (lastPage=12): the contributor padded the events so the real close sits before the
+        // inspected newest window. No "closed" appears in the read pages → null closer + coveredAllPages=false.
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        if (page === 1) {
+          return Response.json([{ event: "labeled", actor: { login: "contributor" } }], {
+            headers: { link: '<https://api.github.com/repos/owner/repo/issues/42/events?per_page=100&page=12>; rel="last"' },
+          });
+        }
+        return Response.json([{ event: "labeled", actor: { login: "contributor" } }]);
+      }
+      if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 });
+      if (url.endsWith("/pulls/42") && method === "PATCH") return Response.json({ state: "closed" });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await processJob(env, { type: "github-webhook", deliveryId: "window-evasion-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ detail: string }>();
+    expect(audit?.detail).toContain("beyond the inspected event window");
+  });
+
   it("re-closes when the bot itself was the last closer", async () => {
     const calls: Array<{ url: string; method: string }> = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

Closes audit findings **2.4** and **3.14** — two one-shot-enforcement gaps.

- **2.4** — `getLastCloserLogin` inspects only a bounded newest-events window (10 pages). A contributor who appends >1000 issue-timeline events can push the real close out of view → `null` closer → `maybeRecloseDisallowedReopen` fails **open** and the one-shot close is bypassed. The function now returns `{ login, coveredAllPages }`; when the scan could **not** reach the whole timeline **and** finds no qualifying closer, the reopen guard fails **closed** and re-closes. A genuine self-close sits at the timeline end and is found in-window, so legitimate self-close reopens stay allowed.
- **3.14** — `recordGateBlockOutcome` preserved `overridden` across **every** re-block, including a re-block on a **new commit**. A one-time `@gittensory gate-override` therefore permanently disabled the gate (and the draft-dodge auto-close) for all future pushes to the PR. The override is now preserved only when the head SHA is unchanged (null-safe `IS`); a new commit re-blocking clears it — binding the override to the commit it was granted on.

## Scope
- [x] Backend only (`src/github/pr-actions.ts`, `src/queue/processors.ts`, `src/db/repositories.ts`)
- [x] No schema change (uses the existing `gate_outcomes.head_sha` column); no migration

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New/updated tests: `getLastCloserLogin` returns `coveredAllPages` across every scenario; reopen guard re-closes on window-evasion; override preserved on same-head re-block (incl. null-safe), cleared on new-commit re-block
- [x] Every changed line + branch covered

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; both changes fail toward enforcing the one-shot close
- [x] No `site/` / `CNAME` / `lovable`