### PR TITLE
feat(signals): recognize modern build, monorepo, and Cloudflare configs in path-matchers

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -65,6 +65,17 @@ const CONFIG_FILE_NAMES: ReadonlySet<string> = new Set([
   ".nvmrc",
   ".npmrc",
   ".browserslistrc",
+  // Monorepo / task-runner config (Turborepo, Nx, Lerna).
+  "turbo.json",
+  "nx.json",
+  "lerna.json",
+  // Linter / formatter config that does not follow the `.eslintrc` / `*.config.*` shapes (Biome).
+  "biome.json",
+  "biome.jsonc",
+  // VCS and build ignore/attribute config (siblings to the existing Dockerfile entry).
+  ".gitignore",
+  ".gitattributes",
+  ".dockerignore",
 ]);
 
 // Filename prefixes that identify build, lint, test-runner, and environment config files.
@@ -83,6 +94,9 @@ const CONFIG_FILE_PREFIXES: readonly string[] = [
   ".eslint",
   ".prettier",
   ".babel",
+  // Cloudflare Workers deploy config (`wrangler.toml`, `wrangler.jsonc`, `wrangler.vitest.jsonc`).
+  // The trailing dot keeps unrelated names like `wranglers-guide.md` from matching.
+  "wrangler.",
 ];
 
 /** Machine-generated output (codegen, protobuf, source maps, typegen). */
@@ -126,9 +140,9 @@ export function isDependencyManifestFile(path: string): boolean {
 }
 
 /**
- * Build, lint, test-runner, and environment configuration files. Distinct from dependency manifests
- * (which declare external dependencies) and source code. Config-only diffs are lower-effort than
- * genuine source changes, so slop signals can weight them differently (#561).
+ * Build, lint, test-runner, monorepo, deploy, and environment configuration files. Distinct from
+ * dependency manifests (which declare external dependencies) and source code. Config-only diffs are
+ * lower-effort than genuine source changes, so slop signals can weight them differently (#561).
  */
 export function isConfigFile(path: string): boolean {
   const base = basename(path);

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -148,6 +148,33 @@ describe("isConfigFile", () => {
     }
   });
 
+  it("matches monorepo, linter, and VCS/build config by exact basename", () => {
+    for (const path of [
+      "turbo.json",
+      "nx.json",
+      "lerna.json",
+      "biome.json",
+      "biome.jsonc",
+      "packages/app/.gitignore",
+      ".gitattributes",
+      "services/api/.dockerignore",
+    ]) {
+      expect(isConfigFile(path)).toBe(true);
+    }
+  });
+
+  it("matches Cloudflare Workers deploy config by the wrangler prefix", () => {
+    for (const path of ["wrangler.toml", "wrangler.jsonc", "apps/ui/wrangler.vitest.jsonc"]) {
+      expect(isConfigFile(path)).toBe(true);
+    }
+  });
+
+  it("does not treat names that merely start with wrangler as config", () => {
+    for (const path of ["docs/wranglers-guide.md", "src/wrangler-helpers.ts"]) {
+      expect(isConfigFile(path)).toBe(false);
+    }
+  });
+
   it("matches config files by known filename prefix", () => {
     for (const path of ["tsconfig.build.json", "vitest.config.ts", ".env.local", ".eslintrc.json", ".prettierrc.js"]) {
       expect(isConfigFile(path)).toBe(true);
@@ -183,6 +210,8 @@ describe("classifyChangedFile", () => {
       ["package.json", "dependency_manifest"],
       ["tsconfig.json", "config"],
       ["vitest.config.ts", "config"],
+      ["wrangler.jsonc", "config"],
+      ["turbo.json", "config"],
       ["test/unit/app.test.ts", "test"],
       ["README.md", "docs"],
       ["src/app.ts", "source"],


### PR DESCRIPTION
## Summary
Extends the deterministic config-file matcher in `src/signals/path-matchers.ts` (originally #561) so slop classification stops bucketing common build/CI/deploy config files as uncategorized `other`.

Newly recognized as `config`:
- **Cloudflare Workers** deploy config via a `wrangler.` prefix — `wrangler.toml`, `wrangler.jsonc`, `wrangler.vitest.jsonc`. This repo itself ships `wrangler.jsonc` / `wrangler.vitest.jsonc`, which the matcher previously missed.
- **Monorepo / task-runner** config: `turbo.json`, `nx.json`, `lerna.json`.
- **Biome** linter/formatter config (`biome.json` / `biome.jsonc`), which does not follow the existing `.eslintrc` / `*.config.*` shapes.
- **VCS / build ignore** config: `.gitignore`, `.gitattributes`, `.dockerignore` (siblings to the existing `Dockerfile` entry).

## Why
The matcher is pure, path-only, and side-effect-free. These are unambiguous build/tooling config files, but they don't match any existing rule, so they fell through to `other`. Recognizing them sharpens category accuracy for slop signals. There is **no behavioral change** to the non-substantive-padding signal: `slop.ts` only special-cases `minified`/`generated`/`vendored` and `source`/`test`; `config` is neutral, identical to `other`.

## Safety
The `wrangler.` prefix uses a trailing dot so unrelated names like `wranglers-guide.md` or `src/wrangler-helpers.ts` are **not** misclassified (covered by a negative test).

## Validation
- `npm run typecheck` — clean
- `npx vitest run test/unit/path-matchers.test.ts` — 25/25 passing
- New tests assert every added entry (exact basenames + all three `wrangler.*` variants) plus negative cases for `wrangler`-prefixed non-config files, and end-to-end `classifyChangedFile` returns `config` for `wrangler.jsonc` and `turbo.json`. Patch coverage 100%.

Related: #561