### PR TITLE
fix(outcomes): corroborate reversal_reverted; revive reversal_reopened

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -202,13 +202,32 @@ async function lastBotActionWasClose(env: Env, targetKey: string): Promise<boole
   try {
     const row = await env.DB
       .prepare(
+        // The executor records a performed action as outcome 'completed' (buildAgentActionAudit; a dry-run also
+        // maps to 'completed'); 'success' is only a legacy value. Matching just 'success' meant this recorder
+        // NEVER fired for real bot closes, so reversal_reopened was dead. Match both. (#audit-reversal-reopened)
         `SELECT event_type FROM audit_events
-         WHERE target_key = ? AND event_type LIKE 'agent.action.%' AND outcome = 'success'
+         WHERE target_key = ? AND event_type LIKE 'agent.action.%' AND outcome IN ('success', 'completed')
          ORDER BY created_at DESC LIMIT 1`,
       )
       .bind(targetKey)
       .first<{ event_type: string }>();
     return row?.event_type === "agent.action.close";
+  } catch {
+    return false;
+  }
+}
+
+/** True when our canonical ledger recorded PR #N as MERGED (a `pr_outcome`/decision=merged review_audit row —
+ *  the same store ops.ts reads for reversalRate). A "Reverts #N" PR only marks a reversal of an outcome WE
+ *  observed; otherwise an arbitrary "Reverts #N" in a contributor's merged PR would forge a reversal signal.
+ *  Fail-safe: a read error → false (record nothing rather than a false reversal). (#audit-3.2) */
+async function wasMergeRecorded(env: Env, targetId: string): Promise<boolean> {
+  try {
+    const row = await env.DB
+      .prepare(`SELECT 1 AS hit FROM review_audit WHERE target_id = ? AND event_type = 'pr_outcome' AND decision = 'merged' LIMIT 1`)
+      .bind(targetId)
+      .first<{ hit: number }>();
+    return Boolean(row);
   } catch {
     return false;
   }
@@ -258,9 +277,13 @@ export async function recordReversalSignals(env: Env, eventName: string, payload
     const reverted = parseRevertedPrNumber(pr.body);
     if (!reverted) return;
     const revertedTargetKey = reviewAuditTargetId(repoFullName, reverted);
-    // The reverted PR (#N) had a recorded pr_outcome=merged only if it merged; the reversal_reverted row marks
-    // that merge as later undone so reversalRate/calibration reflect it. (Auto-revert — opening a revert PR — is
-    // a separate, larger feature and intentionally NOT wired here; this records the human-driven revert signal.)
+    // Corroborate before recording: only count a reversal of a merge WE actually observed (#audit-3.2). Without
+    // this, a contributor's legitimately-merged PR whose body cites an arbitrary "Reverts #N" would stamp a
+    // spurious reversal against PR #N, inflating reversalRate/calibration. Mirrors reviewbot's bot-merged guard.
+    if (!(await wasMergeRecorded(env, revertedTargetKey))) return;
+    // The reverted PR (#N) had a recorded pr_outcome=merged; the reversal_reverted row marks that merge as later
+    // undone so reversalRate/calibration reflect it. (Auto-revert — opening a revert PR — is a separate, larger
+    // feature and intentionally NOT wired here; this records the human-driven revert signal.)
     await appendReviewAudit(env, { project, targetId: revertedTargetKey, eventType: "reversal_reverted", summary: `Merged PR #${reverted} was reverted by #${pr.number}.` });
     await recordAuditEvent(env, {
       eventType: "reversal_reverted",

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -32,7 +32,8 @@ async function auditEventRows(env: Env, eventType: string): Promise<Array<{ targ
 }
 
 /** Seed the bot's own last action on a PR into the agent-action audit ledger (audit_events). */
-async function seedBotAction(env: Env, targetKey: string, actionClass: "close" | "merge" | "approve", outcome: "success" | "denied" = "success"): Promise<void> {
+// Default outcome "completed" mirrors what the executor actually writes for a performed action (buildAgentActionAudit).
+async function seedBotAction(env: Env, targetKey: string, actionClass: "close" | "merge" | "approve", outcome: "success" | "completed" | "denied" = "completed"): Promise<void> {
   await recordAuditEvent(env, { eventType: `agent.action.${actionClass}`, targetKey, outcome });
 }
 
@@ -142,8 +143,27 @@ describe("recordReversalSignals — reversal_reopened", () => {
     expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(0);
   });
 
-  it("records reversal_reverted against PR #N for a merged \"Reverts #N\" PR", async () => {
+  it("still records reversal_reopened when the bot close was logged with the legacy 'success' outcome", async () => {
     const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close", "success");
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(1);
+  });
+
+  it("records reversal_reverted against PR #N for a merged \"Reverts #N\" PR — when #N's merge was recorded", async () => {
+    const env = createTestEnv();
+    // Corroboration: our ledger must have observed PR #50 merge first.
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 50, merged_at: "2026-06-19T00:00:00.000Z" }),
+      sender: { login: "owner", type: "User" },
+    });
     await recordReversalSignals(env, "pull_request", {
       action: "closed",
       repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
@@ -154,6 +174,32 @@ describe("recordReversalSignals — reversal_reopened", () => {
     expect(eval_).toHaveLength(1);
     expect(eval_[0]).toMatchObject({ target_id: "owner/repo#50" });
     expect(await auditEventRows(env, "reversal_reverted")).toHaveLength(1);
+  });
+
+  it("does NOT record reversal_reverted when the cited PR #N has no recorded merge (anti-forgery, #audit-3.2)", async () => {
+    const env = createTestEnv();
+    // No pr_outcome=merged recorded for #50 → a contributor's merged \"Reverts #50\" must not forge a reversal.
+    await recordReversalSignals(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50\n\nThis reverts the change." }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reverted")).toHaveLength(0);
+    expect(await auditEventRows(env, "reversal_reverted")).toHaveLength(0);
+  });
+
+  it("is fail-safe when the corroboration read throws — records nothing without throwing", async () => {
+    const env = createTestEnv();
+    const broken = { ...env, DB: null } as unknown as typeof env; // wasMergeRecorded's read throws → caught → false
+    await expect(
+      recordReversalSignals(broken, "pull_request", {
+        action: "closed",
+        repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+        pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50" }),
+        sender: { login: "contributor", type: "User" },
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("does NOT record reversal_reverted for a merged PR whose body is not a revert", async () => {


### PR DESCRIPTION
## Summary

Closes audit finding **3.2** and the dead-`reversal_reopened` issue from §4 — two telemetry-integrity gaps in the reversal signals that feed `reversalRate` / calibration.

- **3.2** — `reversal_reverted` was recorded from an attacker-controlled `Reverts #N` body with **no corroboration**. A contributor's legitimately-merged PR citing an arbitrary `Reverts #N` could stamp a spurious reversal against any PR #N, poisoning ops/calibration. It now records **only when our canonical ledger actually observed PR #N merge** (a `pr_outcome`/decision=merged `review_audit` row — the same store `ops.ts` reads), mirroring reviewbot's bot-merged guard. Fail-safe: a read error records nothing.
- **§4** — `lastBotActionWasClose` matched only `outcome='success'`, but the executor records a performed action as `'completed'` (`buildAgentActionAudit`). So `reversal_reopened` — the high-value "a human reopened a bot-closed PR" disagreement signal — **never fired**. It now matches `outcome IN ('success','completed')`. The test helper defaulted to the fabricated `'success'`, masking the bug; it now defaults to the real `'completed'`, with a regression test pinning the legacy value too.

`isHoldOnly` auto-clear (the other §4 item) is deferred to the breaker/freeze PR where it sits with the related circuit-breaker logic.

## Scope
- [x] Backend only (`src/review/outcomes-wire.ts`); no schema change; no migration

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New/updated tests: corroborated revert records; uncorroborated `Reverts #N` records nothing; reversal_reopened fires on `completed` (and legacy `success`); fail-safe on a broken-DB read
- [x] Every changed line + branch covered

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values
- [x] No `site/` / `CNAME` / `lovable`; telemetry-only change, fails toward recording nothing