### PR TITLE
fix(review): ignore dry-run close reversals

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -202,11 +202,12 @@ async function lastBotActionWasClose(env: Env, targetKey: string): Promise<boole
   try {
     const row = await env.DB
       .prepare(
-        // The executor records a performed action as outcome 'completed' (buildAgentActionAudit; a dry-run also
-        // maps to 'completed'); 'success' is only a legacy value. Matching just 'success' meant this recorder
-        // NEVER fired for real bot closes, so reversal_reopened was dead. Match both. (#audit-reversal-reopened)
+        // The executor records performed and dry-run actions as outcome 'completed', with the real mode only in
+        // metadata. Exclude dry-run shadows so a "would close" cannot masquerade as an actual bot close.
+        // 'success' is only a legacy value. (#audit-reversal-reopened)
         `SELECT event_type FROM audit_events
          WHERE target_key = ? AND event_type LIKE 'agent.action.%' AND outcome IN ('success', 'completed')
+           AND COALESCE(json_extract(metadata_json, '$.mode'), 'live') <> 'dry_run'
          ORDER BY created_at DESC LIMIT 1`,
       )
       .bind(targetKey)

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -33,8 +33,14 @@ async function auditEventRows(env: Env, eventType: string): Promise<Array<{ targ
 
 /** Seed the bot's own last action on a PR into the agent-action audit ledger (audit_events). */
 // Default outcome "completed" mirrors what the executor actually writes for a performed action (buildAgentActionAudit).
-async function seedBotAction(env: Env, targetKey: string, actionClass: "close" | "merge" | "approve", outcome: "success" | "completed" | "denied" = "completed"): Promise<void> {
-  await recordAuditEvent(env, { eventType: `agent.action.${actionClass}`, targetKey, outcome });
+async function seedBotAction(
+  env: Env,
+  targetKey: string,
+  actionClass: "close" | "merge" | "approve",
+  outcome: "success" | "completed" | "denied" = "completed",
+  mode?: "live" | "dry_run",
+): Promise<void> {
+  await recordAuditEvent(env, { eventType: `agent.action.${actionClass}`, targetKey, outcome, metadata: mode ? { mode } : undefined });
 }
 
 function pullRequestPayload(over: Partial<GitHubPullRequestPayload> = {}): GitHubPullRequestPayload {
@@ -146,6 +152,31 @@ describe("recordReversalSignals — reversal_reopened", () => {
   it("still records reversal_reopened when the bot close was logged with the legacy 'success' outcome", async () => {
     const env = createTestEnv();
     await seedBotAction(env, "owner/repo#7", "close", "success");
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(1);
+  });
+
+  it("does NOT record reversal_reopened when the latest bot close was only a dry-run shadow", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close", "completed", "dry_run");
+    await recordReversalSignals(env, "pull_request", {
+      action: "reopened",
+      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      pull_request: pullRequestPayload({ number: 7, state: "open" }),
+      sender: { login: "contributor", type: "User" },
+    });
+    expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(0);
+    expect(await auditEventRows(env, "reversal_reopened")).toHaveLength(0);
+  });
+
+  it("still records reversal_reopened when the latest bot close was completed in live mode", async () => {
+    const env = createTestEnv();
+    await seedBotAction(env, "owner/repo#7", "close", "completed", "live");
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
       repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },


### PR DESCRIPTION
### Motivation
- Dry-run agent-action audit rows were treated as real completed bot closes because the executor maps `dry_run` to audit outcome `completed`, which allowed dry-run shadows to trigger false `reversal_reopened` telemetry when a contributor reopened the PR.

### Description
- Update `lastBotActionWasClose` to exclude audit events whose `metadata_json.mode` is `dry_run` by adding `COALESCE(json_extract(metadata_json, '$.mode'), 'live') <> 'dry_run'` to the SQL filter.
- Extend the audit test helper to optionally seed `mode` in audit event metadata so tests can simulate `live` vs `dry_run` shadows.
- Add regression tests that assert a dry-run close shadow does NOT produce `reversal_reopened` while a real live completed close still does.
- Small defensive/formatting improvements around DB reads and logging in the same module to keep style consistent.

### Testing
- Ran the focused unit suite with `npx vitest run test/unit/outcomes-wire.test.ts --reporter verbose`, which passed (34 tests ✅).
- Verified `git diff --check` (no whitespace/conflict markers) succeeded ✅.
- Attempted the full gate `npm run test:ci`, which is blocked locally by typecheck failures due to missing optional self-host dev dependencies (`pg` / `ioredis`) in this environment (not a regression in these changes) ⚠️.
- `npm audit --audit-level=moderate` failed in this environment due to the registry audit endpoint returning `403` and could not complete here ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc9f0b12c832cb11c055b5e65d37c)