### PR TITLE
fix(selfhost): require ORB_WEBHOOK_SECRET for Orb exporter

### DIFF
--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -93,7 +93,11 @@ export async function exportOrbBatch(
   if ((process.env.ORB_AIR_GAP ?? "").toLowerCase() === "true") return 0;
 
   const collectorUrl = process.env.ORB_COLLECTOR_URL ?? "https://orb.gittensory.app/v1/ingest";
-  const secret = process.env.ORB_WEBHOOK_SECRET ?? "";
+  const secret = process.env.ORB_WEBHOOK_SECRET;
+  if (!secret) {
+    incr("gittensory_orb_export_errors_total");
+    return 0;
+  }
   const anonymize = (process.env.ORB_ANONYMIZE ?? "true").toLowerCase() !== "false";
 
   const { results } = await db

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -123,7 +123,7 @@ describe("exportOrbBatch()", () => {
   });
   afterEach(() => {
     delete process.env.ORB_ENABLED;
-    process.env.ORB_WEBHOOK_SECRET = undefined as unknown as string;
+    delete process.env.ORB_WEBHOOK_SECRET;
     delete process.env.ORB_ANONYMIZE;
     delete process.env.ORB_AIR_GAP;
     delete process.env.ORB_COLLECTOR_URL;
@@ -228,18 +228,19 @@ describe("exportOrbBatch()", () => {
     expect(sigHeader).toMatch(/^sha256=[a-f0-9]{64}$/);
   });
 
-  it("uses empty-string HMAC key when ORB_WEBHOOK_SECRET is unset (covers ?? '' branch)", async () => {
-    delete (process.env as NodeJS.Dict<string>)["ORB_WEBHOOK_SECRET"];
+  it("fails closed when ORB_WEBHOOK_SECRET is unset", async () => {
+    delete process.env.ORB_WEBHOOK_SECRET;
     const db = makeDb();
     await recordOrbEvent(db, { repo: "o/r", pr_number: 1, head_sha: "sha", outcome: "merged" });
-    let sigHeader: string | undefined;
-    const exported = await exportOrbBatch(db, 200, async (_u, init) => {
-      sigHeader = (init?.headers as Record<string, string>)?.["x-orb-signature"];
-      return new Response(null, { status: 200 });
-    });
-    expect(exported).toBe(1);
-    // Signature should still be formed (with empty-string key)
-    expect(sigHeader).toMatch(/^sha256=[a-f0-9]{64}$/);
+    const fakeFetch = vi.fn(async () => new Response(null, { status: 200 }));
+
+    const exported = await exportOrbBatch(db, 200, fakeFetch);
+
+    expect(exported).toBe(0);
+    expect(fakeFetch).not.toHaveBeenCalled();
+    expect(await renderMetrics()).toContain("gittensory_orb_export_errors_total");
+    const rows = (await allRows(db)) as Array<Record<string, unknown>>;
+    expect(rows[0]?.exported_at).toBeNull();
   });
 
   it("defaults ORB_ANONYMIZE to true when unset (covers ?? 'true' branch)", async () => {


### PR DESCRIPTION
### Motivation
- Prevent deterministic anonymization and signing with an empty HMAC key when the Orb exporter runs without a configured secret, which could leak reproducible repo/pr hashes for pending events.
- Fail-closed on missing secret so pending local events are not exported with a public empty key and the operator is signaled via metrics.

### Description
- Make `exportOrbBatch` return early when `ORB_WEBHOOK_SECRET` is unset and increment the `gittensory_orb_export_errors_total` metric instead of defaulting to an empty-string key.
- Keep existing anonymization logic and HMAC behavior unchanged when a secret is present.
- Update the unit tests in `test/unit/selfhost-orb-collector.test.ts` to delete the secret env var and assert the exporter does not call the collector, leaves rows unexported, and records the error metric.
- Replace the previous test that exercised the empty-key branch with a regression test that verifies the fail-closed behavior.

### Testing
- `npm test -- --run test/unit/selfhost-orb-collector.test.ts` passed (21 tests) and verifies the new fail-closed path and other exporter behaviors.
- `npm run test:coverage -- --run test/unit/selfhost-orb-collector.test.ts` ran but coverage remapping failed in the local environment with `TypeError: jsTokens is not a function` (tooling issue unrelated to logic changes).
- `npm run typecheck` failed in this environment due to missing local native deps/types (`pg`, `ioredis`) not present in `node_modules`, which is unrelated to the change.
- `npm run test:ci` exercised the pipeline until the repo-wide typecheck step and failed for the same missing-dependency type errors; `npm audit --audit-level=moderate` failed due to the registry audit endpoint returning `403`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc78b9258832ca6c69694cdc0f037)