### PR TITLE
fix(review): guard the engine's own decision paths for every repo

### DIFF
--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -30,6 +30,34 @@ export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
   "**/.codecov.yml",
 ];
 
+// The review engine's OWN decision + safety code — its crown jewels — guarded for EVERY repo regardless of KV
+// tuning. A contributor PR that edits how the gate decides a verdict, how a merge or close executes, the
+// action-mode kill-switch, scoring, auth, the CI aggregate the gate reads, or the guardrail itself must be HELD
+// for the owner: the engine must never auto-merge a change to the very code that governs its own autonomy. This
+// is the exact failure the FAIL_CLOSED comment warns about — but that fires only on a KV outage, so without this
+// the narrow DEFAULT (CI + scripts) let crown-jewel edits auto-merge on every normal request. These are
+// gittensory engine-specific paths, so they never match an unrelated reviewed repo's PR (e.g. metagraphed has no
+// src/rules/** or agent-action-executor.ts); like the config-as-code set above, this only ever WIDENS the guard.
+export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
+  "src/rules/**", // the gate verdict (advisory) + the predicted-gate mirror
+  "src/services/**", // the merge/close action executor, approval queue, and merge-failure handling — the write chokepoint
+  "src/settings/agent-actions.ts", // the disposition planner (canMerge / willClose / heldForManualReview)
+  "src/settings/agent-execution.ts", // the action-mode resolver + the env kill-switch backstop
+  "src/settings/agent-sweep.ts", // the re-gate maintenance sweep
+  "src/settings/autonomy.ts", // the autonomy-level ladder (observe → suggest → auto → auto_with_approval)
+  "src/queue/**", // webhook → gate → merge/close orchestration (processors) + dead-letter handling (dlq) — NOT in the KV dir-prefix guards
+  "src/github/pr-actions.ts", // the GitHub merge / close / review / comment write primitives
+  "src/github/app.ts", // installation auth + the per-installation token mint
+  "src/github/backfill.ts", // the live CI aggregate (fetchLiveCiAggregate) the gate verdict reads
+  "src/scoring/**", // the on-chain scoring model + previews
+  "src/auth/**", // session/bearer auth + the admin allowlist
+  "src/review/safety.ts", // the secret-leak + prompt-injection defenses
+  "src/review/guardrail-config.ts", // the guardrail globs themselves (this file)
+  "src/review/cutover-gate.ts", // the shadow → live cutover gate
+  "src/review/linked-issue-hard-rules.ts", // the deterministic linked-issue auto-close rules
+  "src/review/outcomes-wire.ts", // the pr_outcome + reversal telemetry that feeds self-tuning
+];
+
 // A KV READ FAULT (binding present but the read threw — an outage/transient error) must fail CLOSED, NOT fall
 // back to the narrow default: a config-read fault correlated with a contributor flood would otherwise silently
 // shrink the guarded surface to CI+scripts and let crown-jewel edits (scoring/auth/rules/the gate) auto-merge.
@@ -51,11 +79,12 @@ function asNonEmptyStringArray(value: unknown): string[] | null {
  */
 export async function loadHardGuardrailGlobs(env: Env, repoFullName: string): Promise<string[]> {
   const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
-  // The config-as-code policy files are guarded for every repo; the fail-closed `**` already covers them.
-  if (!env.REVIEW_CONFIG) return [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
+  // The config-as-code policy files AND the engine's own crown-jewel paths are guarded for every repo regardless
+  // of KV tuning (a narrow per-repo glob list never un-guards them); the fail-closed `**` already covers them.
+  if (!env.REVIEW_CONFIG) return [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS];
   try {
     const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { hardGuardrailGlobs?: JsonValue } | null;
-    return [...(asNonEmptyStringArray(config?.hardGuardrailGlobs) ?? DEFAULT_CRUCIAL_GUARDRAIL_GLOBS), ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
+    return [...(asNonEmptyStringArray(config?.hardGuardrailGlobs) ?? DEFAULT_CRUCIAL_GUARDRAIL_GLOBS), ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS];
   } catch {
     return FAIL_CLOSED_GUARDRAIL_GLOBS;
   }

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,33 +1,54 @@
 import { describe, expect, it, vi } from "vitest";
 import { matchesAny } from "../../src/signals/change-guardrail";
-import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs } from "../../src/review/guardrail-config";
+import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ENGINE_DECISION_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs } from "../../src/review/guardrail-config";
 
 function envWith(get: (key: string, type: string) => Promise<unknown>): Env {
   return { REVIEW_CONFIG: { get } } as unknown as Env;
 }
 
 describe("loadHardGuardrailGlobs", () => {
-  it("returns the conservative default plus the config-as-code guards when REVIEW_CONFIG is unbound", async () => {
-    expect(await loadHardGuardrailGlobs({} as Env, "JSONbored/gittensory")).toEqual([...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
+  it("returns the conservative default plus the config-as-code + engine guards when REVIEW_CONFIG is unbound", async () => {
+    expect(await loadHardGuardrailGlobs({} as Env, "JSONbored/gittensory")).toEqual([...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS]);
   });
 
-  it("reads globs from KV keyed by the repo slug (owner stripped) and always appends the config-as-code guards", async () => {
+  it("reads globs from KV keyed by the repo slug (owner stripped) and always appends the config-as-code + engine guards", async () => {
     const get = vi.fn().mockResolvedValue({ hardGuardrailGlobs: ["src/scoring/**", "scripts/**"] });
     const globs = await loadHardGuardrailGlobs(envWith(get), "JSONbored/gittensory");
-    expect(globs).toEqual(["src/scoring/**", "scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
+    expect(globs).toEqual(["src/scoring/**", "scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS]);
     expect(get).toHaveBeenCalledWith("gittensory", "json");
   });
 
-  it("falls back to the default (plus config-as-code guards) when the field is absent, null, or empty", async () => {
-    const expected = [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS];
+  it("falls back to the default (plus config-as-code + engine guards) when the field is absent, null, or empty", async () => {
+    const expected = [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS];
     expect(await loadHardGuardrailGlobs(envWith(async () => ({})), "o/r")).toEqual(expected);
     expect(await loadHardGuardrailGlobs(envWith(async () => null), "o/r")).toEqual(expected);
     expect(await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: [] })), "o/r")).toEqual(expected);
   });
 
-  it("drops non-string entries and keeps the valid globs (plus config-as-code guards)", async () => {
+  it("drops non-string entries and keeps the valid globs (plus config-as-code + engine guards)", async () => {
     const globs = await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: [123, "scripts/**", ""] })), "o/r");
-    expect(globs).toEqual(["scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS]);
+    expect(globs).toEqual(["scripts/**", ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS]);
+  });
+
+  it("guards the engine's own crown-jewel decision paths for every repo, even under a narrow KV glob list", async () => {
+    // A repo whose KV tuning is deliberately minimal must NOT thereby un-guard the review engine's own code.
+    const globs = await loadHardGuardrailGlobs(envWith(async () => ({ hardGuardrailGlobs: ["docs/**"] })), "o/r");
+    for (const enginePath of [
+      "src/rules/advisory.ts",
+      "src/services/agent-action-executor.ts",
+      "src/settings/agent-execution.ts",
+      "src/queue/processors.ts", // the orchestration + the direct-close paths — the gap this constant closes
+      "src/queue/dlq.ts",
+      "src/github/pr-actions.ts",
+      "src/scoring/model.ts",
+      "src/auth/session.ts",
+      "src/review/guardrail-config.ts",
+    ]) {
+      expect(matchesAny(enginePath, globs)).toBe(true);
+    }
+    expect(matchesAny("docs/readme.md", globs)).toBe(true); // the repo's own narrow KV glob still applies
+    expect(matchesAny("src/utils/json.ts", globs)).toBe(false); // a non-decision src file remains auto-mergeable
+    expect(matchesAny("src/db/repositories.ts", globs)).toBe(false); // the data layer stays non-crucial (env kill-switch backstops the freeze there)
   });
 
   it("guards the gate's own policy files for every repo (the config-as-code self-weakening hole)", async () => {


### PR DESCRIPTION
## Summary

The hard-guardrail **holds a PR for owner review** (no auto-merge / no auto-close) when it touches a guarded path. Reviewing the guarded surface against the paths the recent autonomy-safety work added/changed surfaced a real gap:

- The live per-repo KV tuning (`REVIEW_CONFIG["gittensory"]`, mirrored in `change-guardrail.test.ts`) already guards most of the engine via dir-prefix globs — `src/services/**`, `src/rules/**`, `src/scoring/**`, `src/settings/**`, `src/review/**`, `src/github/**`, `src/auth/**`.
- **But `src/queue/**` was in no guarded set** — the `webhook → gate → merge/close` orchestration (`processors.ts`, including the just-hardened direct-close paths) and the dead-letter handler (`dlq.ts`). A contributor PR editing the orchestration itself could pass CI + gate and **auto-merge**.
- And the guard relied **entirely on KV tuning**: only a KV *outage* fails closed (`["**"]`). A mis-tuned or narrowed glob list could silently un-guard the engine's crown jewels on a *normal* request.

This adds `ENGINE_DECISION_GUARDRAIL_GLOBS` — the engine's own decision + safety code — **appended for every repo regardless of KV tuning**, exactly like the existing always-on `CONFIG_AS_CODE_GUARDRAIL_GLOBS`. So a contributor PR touching how the gate decides, how a merge/close executes, the action-mode kill-switch, scoring, auth, the CI aggregate, or the guardrail itself is **held for the owner** — the engine never auto-merges a change to the very code that governs its own autonomy.

These globs are gittensory-engine-specific, so they never match an unrelated reviewed repo's PR (e.g. `metagraphed` has no `src/rules/**` or `agent-action-executor.ts`) — this only ever **widens** the guard.

### Deliberately left out
- `src/db/repositories.ts` stays **non-crucial** per the existing flood-readiness contract (`change-guardrail.test.ts:72`) — it's the broad data layer, and the DB global-freeze that lives there is independently backstopped by the `AGENT_ACTIONS_PAUSED` env switch (a hard stop that doesn't depend on the DB row).

## Scope
- [x] Backend only (`src/review/guardrail-config.ts`); no schema change; no migration; deploy is behavior-additive (only ever holds *more* PRs for review)

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New test: the engine crown-jewel paths are guarded even under a deliberately narrow KV glob list; a non-decision src file (`src/utils/json.ts`) and the data layer (`src/db/repositories.ts`) stay auto-mergeable
- [x] Existing exact-equality resolver tests updated to include the always-appended engine set
- [x] Every changed line + branch covered

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; the change only ever *adds* a manual-review hold, never removes one
- [x] No `site/` / `CNAME` / `lovable`