### PR TITLE
fix(github): follow rel=next when the reopen guard sees no rel=last

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -133,6 +133,27 @@ export async function getLastCloserLogin(env: Env, installationId: number, repoF
     const firstResponse = await requestPage(1);
     const firstEvents = firstResponse.data as Array<{ event?: string; actor?: { login?: string | null } | null }>;
     const lastPage = issueEventsLastPage(firstResponse.headers.link);
+    if (lastPage === null) {
+      // No rel="last" in the Link header. A genuine single page has no rel="next" either — return page 1 directly.
+      // But GitHub can paginate WITHOUT emitting rel="last" (only rel="next"); then trusting page 1 alone would let
+      // a later maintainer/bot close hide behind the un-enumerated tail and the reopen guard would fail OPEN. So
+      // follow rel="next" forward, tracking the latest close across pages (events are oldest-first → a later page's
+      // close supersedes), bounded by the same page budget. coveredAllPages holds ONLY if we reached the tail within
+      // budget; otherwise report not-covered so the caller fails closed. (#audit-rel-last)
+      if (!issueEventsHasNextPage(firstResponse.headers.link)) {
+        return { login: latestCloserInPage(firstEvents) ?? null, coveredAllPages: true };
+      }
+      let latestCloser = latestCloserInPage(firstEvents);
+      let hasNext = true;
+      for (let page = 2; hasNext && page <= ISSUE_EVENTS_RECENT_PAGE_LIMIT + 1; page += 1) {
+        const response = await requestPage(page);
+        const closer = latestCloserInPage(response.data as Array<{ event?: string; actor?: { login?: string | null } | null }>);
+        if (closer !== undefined) latestCloser = closer;
+        hasNext = issueEventsHasNextPage(response.headers.link);
+      }
+      const coveredAllPages = !hasNext;
+      return { login: coveredAllPages ? (latestCloser ?? null) : null, coveredAllPages };
+    }
     if (lastPage <= 1) return { login: latestCloserInPage(firstEvents) ?? null, coveredAllPages: true };
 
     // GitHub returns issue-events oldest-first. Use the Link header to inspect the newest bounded window instead
@@ -160,9 +181,17 @@ function latestCloserInPage(events: Array<{ event?: string; actor?: { login?: st
   return undefined;
 }
 
-function issueEventsLastPage(linkHeader: string | undefined): number {
-  if (!linkHeader) return 1;
+// The last page number from the Link header's rel="last", or null when GitHub did not emit rel="last" (no
+// header, a single page, or a paginated response where rel="last" was omitted — the caller follows rel="next"
+// forward in that case rather than assuming a single page). (#audit-rel-last)
+function issueEventsLastPage(linkHeader: string | undefined): number | null {
+  if (!linkHeader) return null;
   const lastLink = linkHeader.split(",").find((link) => /rel="last"/.test(link));
   const page = lastLink?.match(/[?&]page=(\d+)/)?.[1];
-  return page ? Number(page) : 1;
+  return page ? Number(page) : null;
+}
+
+// Whether the Link header advertises a rel="next" page (more events exist beyond the one just fetched).
+function issueEventsHasNextPage(linkHeader: string | undefined): boolean {
+  return linkHeader !== undefined && linkHeader.split(",").some((link) => /rel="next"/.test(link));
 }

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -187,20 +187,59 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 22)).resolves.toEqual({ login: "page1-closer", coveredAllPages: true });
   });
 
-  it("treats a link header without rel=last as a single-page result (issueEventsLastPage FALSE branch)", async () => {
-    // Link header present but only contains rel="next" — no rel="last" match → lastPage stays 1
-    // → firstEvents from page 1 is returned directly without a second request.
+  it("follows rel=next forward when GitHub omits rel=last, finding the later maintainer close (#audit-rel-last)", async () => {
+    // GitHub paginated WITHOUT rel="last" (only rel="next"). Trusting page 1 alone would surface the early
+    // contributor close and miss the later maintainer close on page 2 — a window-evasion fail-OPEN. The forward
+    // scan follows rel="next" to the tail (page 3, no Link) and reports the most recent close.
+    const fetchedPages: number[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "t" });
       if (url.includes("/issues/23/events")) {
-        return Response.json([{ event: "closed", actor: { login: "solo-closer" } }], {
-          headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=2>; rel="next"' },
-        });
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        fetchedPages.push(page);
+        if (page === 1) return Response.json([{ event: "closed", actor: { login: "early-contributor" } }], { headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=2>; rel="next"' } });
+        if (page === 2) return Response.json([{ event: "closed", actor: { login: "maintainer" } }], { headers: { link: '<https://api.github.test/issues/23/events?per_page=100&page=3>; rel="next"' } });
+        return Response.json([{ event: "labeled" }]); // page 3: the tail (no Link header)
       }
       return new Response("unexpected", { status: 500 });
     });
-    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toEqual({ login: "solo-closer", coveredAllPages: true });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 23)).resolves.toEqual({ login: "maintainer", coveredAllPages: true });
+    expect(fetchedPages).toEqual([1, 2, 3]);
+  });
+
+  it("fails CLOSED when rel=next never terminates within the page budget (no rel=last)", async () => {
+    // Every page advertises rel="next" and never a rel="last": the forward scan exhausts the page budget without
+    // reaching the tail, so it cannot prove no later close exists → coveredAllPages false, login null (fail-closed).
+    const fetchedPages: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/25/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        fetchedPages.push(page);
+        return Response.json([{ event: "labeled" }], { headers: { link: `<https://api.github.test/issues/25/events?per_page=100&page=${page + 1}>; rel="next"` } });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 25)).resolves.toEqual({ login: null, coveredAllPages: false });
+    expect(fetchedPages).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]); // page 1 + the 10-page budget
+  });
+
+  it("returns null but covered when a rel=next forward scan reaches the tail with no close at all", async () => {
+    // No rel="last", forward scan reaches the tail (page 2, no Link) and finds no close on any page → the latest
+    // close stays undefined → undefined ?? null = null, yet coveredAllPages is true (the whole timeline was read).
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/issues/26/events")) {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        if (page === 1) return Response.json([{ event: "labeled" }], { headers: { link: '<https://api.github.test/issues/26/events?per_page=100&page=2>; rel="next"' } });
+        return Response.json([{ event: "labeled" }]); // page 2: the tail (no Link header)
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 26)).resolves.toEqual({ login: null, coveredAllPages: true });
   });
 
   it("returns null when bounded window (firstPageToRead=2) AND page 1 also have no close event (?? null right branch)", async () => {


### PR DESCRIPTION
## Summary

`getLastCloserLogin` (the one-shot reopen guard's "who last closed this PR" lookup) bounds its newest-events window using the Link header's `rel="last"`. But `issueEventsLastPage` returned **`1` whenever `rel="last"` was absent — even when `rel="next"` was present** — so a paginated timeline that GitHub served *without* `rel="last"` was treated as a single page: only **page 1 (the oldest events)** was read, yet the result claimed **`coveredAllPages: true`**.

The consequence is a **fail-OPEN in a security guard**: a later maintainer/bot close on an un-enumerated page is missed, the guard concludes "no bot close" (or "contributor self-close"), and a disallowed reopen slips through — the exact window-evasion the bounded-window logic (#audit-2.4) was meant to prevent.

GitHub usually emits `rel="last"`, but not always (it can paginate with only `rel="next"`), so this is a real edge in the reopen enforcement path.

## Fix
- `issueEventsLastPage` now returns **`null`** when `rel="last"` is absent (instead of silently `1`).
- When `lastPage === null` **and** a `rel="next"` exists, `getLastCloserLogin` **follows `rel="next"` forward** from page 2, tracking the latest close across pages (events are oldest-first, so a later page's close supersedes), bounded by the **same page budget**. `coveredAllPages` is true only when the scan reaches the tail within budget; an un-terminated `rel="next"` exhausts the budget and reports **not-covered so the caller fails closed**.
- A genuine single page (no `rel="next"`) still returns page 1 directly.

## Scope
- [x] Backend only (`src/github/pr-actions.ts`); no schema change; no migration

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Replaced the prior test that *encoded* the bug (it asserted a `rel="next"`-only response was `coveredAllPages: true`) with three regression tests: rel=next reaching the tail (finds the later close), rel=next exhausting the budget (fail-closed `login: null, coveredAllPages: false`), and a covered tail with no close at all
- [x] Every changed line + branch covered

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; the change only ever makes the reopen guard *more* conservative (fail-closed on uncertainty)
- [x] No `site/` / `CNAME` / `lovable`

Credit: the missing-`rel="last"` case was independently flagged by #1226 (built on the pre-`coveredAllPages` shape); this re-implements it fresh on current `main` integrated with the bounded-window fail-closed contract.