### PR TITLE
fix(selfhost): make the Postgres backend usable — translate INSERT OR migrations + ON CONFLICT targets

### DIFF
--- a/src/selfhost/pg-dialect.ts
+++ b/src/selfhost/pg-dialect.ts
@@ -69,9 +69,23 @@ export function translateInsertOr(sql: string): string {
   return sql;
 }
 
+/** Strip table qualifiers from an ON CONFLICT target list. drizzle-orm/d1 emits the conflict target as
+ *  `ON CONFLICT ("table"."col")` — valid in SQLite, but Postgres requires an unqualified column list
+ *  (`ON CONFLICT ("col")`) and otherwise fails with a syntax error, breaking every Drizzle upsert
+ *  (e.g. recordWebhookEvent → webhook ingest) on the Postgres backend. Scoped to the conflict-target
+ *  parens so qualified column refs elsewhere (WHERE / SELECT / joins) are left intact. */
+export function stripConflictTargetQualifiers(sql: string): string {
+  // Capture the keyword + opening paren and the closing paren so the original casing/spacing is preserved
+  // (drizzle emits lowercase `on conflict`); only the inner target list is rewritten.
+  return sql.replace(
+    /(\bON\s+CONFLICT\s*\()([^)]*)(\))/gi,
+    (_full, open: string, target: string, close: string) => `${open}${target.replace(/"[^"]+"\s*\.\s*("[^"]+")/g, "$1")}${close}`,
+  );
+}
+
 /** Translate a runtime query (SQLite → Postgres). */
 export function translateSql(sql: string): string {
-  return toNumberedPlaceholders(translateFunctions(translateInsertOr(sql)));
+  return toNumberedPlaceholders(stripConflictTargetQualifiers(translateFunctions(translateInsertOr(sql))));
 }
 
 /** Translate a DDL statement (migrations). Column types (TEXT/INTEGER/REAL) are PG-native; only the SQLite

--- a/src/selfhost/pg-dialect.ts
+++ b/src/selfhost/pg-dialect.ts
@@ -88,8 +88,17 @@ export function translateSql(sql: string): string {
   return toNumberedPlaceholders(stripConflictTargetQualifiers(translateFunctions(translateInsertOr(sql))));
 }
 
-/** Translate a DDL statement (migrations). Column types (TEXT/INTEGER/REAL) are PG-native; only the SQLite
- *  default expressions need translating. No `?` placeholders in DDL. */
+/** Migrations are applied as whole multi-statement files via exec(), so the statement-anchored
+ *  translateInsertOr() can't reach an `INSERT OR IGNORE` embedded mid-file (e.g. the global_agent_controls
+ *  seed in 0059). Rewrite each such statement to Postgres `INSERT … ON CONFLICT DO NOTHING`. Only IGNORE
+ *  seeds exist in migrations; an INSERT OR REPLACE statement would need a known conflict key, so it is left
+ *  untouched (and would surface as a clear Postgres error) rather than guessed at. */
+export function translateMigrationInserts(sql: string): string {
+  return sql.replace(/INSERT\s+OR\s+IGNORE\s+INTO\b([^;]*);/gi, "INSERT INTO$1 ON CONFLICT DO NOTHING;");
+}
+
+/** Translate a DDL statement (migrations). Column types (TEXT/INTEGER/REAL) are PG-native; the SQLite
+ *  default expressions need translating, as does any `INSERT OR IGNORE` seed. No `?` placeholders in DDL. */
 export function translateDdl(sql: string): string {
-  return translateFunctions(sql);
+  return translateFunctions(translateMigrationInserts(sql));
 }

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateSql } from "../../src/selfhost/pg-dialect";
+import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateSql } from "../../src/selfhost/pg-dialect";
 
 describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("numbers placeholders, skipping `?` inside string literals", () => {
@@ -28,5 +28,36 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("translateSql composes all passes; translateDdl handles the ISO-now default", () => {
     expect(translateSql("SELECT * FROM t WHERE updated_at > datetime('now', ?)")).toMatch(/\$1/);
     expect(translateDdl("created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))")).toContain("to_char(now() AT TIME ZONE 'UTC'");
+  });
+
+  it("strips table qualifiers from an ON CONFLICT target (drizzle emits `\"t\".\"c\"`, which Postgres rejects)", () => {
+    // The exact shape drizzle-orm/d1 emits for recordWebhookEvent — a table-qualified conflict target.
+    expect(stripConflictTargetQualifiers('INSERT INTO "webhook_events" ("delivery_id") VALUES (?) ON CONFLICT ("webhook_events"."delivery_id") DO UPDATE SET "status" = ?'))
+      .toBe('INSERT INTO "webhook_events" ("delivery_id") VALUES (?) ON CONFLICT ("delivery_id") DO UPDATE SET "status" = ?');
+    // Multiple qualified conflict columns are each unqualified.
+    expect(stripConflictTargetQualifiers('... ON CONFLICT ("t"."a", "t"."b") DO NOTHING')).toBe('... ON CONFLICT ("a", "b") DO NOTHING');
+  });
+
+  it("leaves an already-unqualified ON CONFLICT and a bare ON CONFLICT DO NOTHING untouched", () => {
+    expect(stripConflictTargetQualifiers('ON CONFLICT ("key") DO UPDATE SET v=excluded.v')).toBe('ON CONFLICT ("key") DO UPDATE SET v=excluded.v');
+    expect(stripConflictTargetQualifiers("INSERT INTO t (a) VALUES (?) ON CONFLICT DO NOTHING")).toBe("INSERT INTO t (a) VALUES (?) ON CONFLICT DO NOTHING");
+    expect(stripConflictTargetQualifiers("SELECT 1")).toBe("SELECT 1"); // no ON CONFLICT at all
+  });
+
+  it("only de-qualifies inside the conflict target — qualified refs elsewhere are preserved", () => {
+    // The WHERE-clause qualifier must survive; only the ON CONFLICT target is rewritten.
+    const out = stripConflictTargetQualifiers('UPDATE x SET "x"."a"=? WHERE "x"."id"=? ON CONFLICT ("x"."id") DO NOTHING');
+    expect(out).toContain('"x"."a"=?');
+    expect(out).toContain('WHERE "x"."id"=?');
+    expect(out).toContain('ON CONFLICT ("id")');
+  });
+
+  it("translateSql de-qualifies the conflict target AND numbers placeholders (the real webhook upsert)", () => {
+    const drizzle = 'insert into "webhook_events" ("delivery_id", "status") values (?, ?) on conflict ("webhook_events"."delivery_id") do update set "status" = ?';
+    const out = translateSql(drizzle);
+    expect(out).toContain('on conflict ("delivery_id")'); // qualifier stripped → valid Postgres
+    expect(out).not.toContain('"webhook_events"."delivery_id"');
+    expect(out).toContain("values ($1, $2)"); // placeholders numbered
+    expect(out).toContain("set \"status\" = $3");
   });
 });

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateSql } from "../../src/selfhost/pg-dialect";
+import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateMigrationInserts, translateSql } from "../../src/selfhost/pg-dialect";
 
 describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("numbers placeholders, skipping `?` inside string literals", () => {
@@ -28,6 +28,26 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("translateSql composes all passes; translateDdl handles the ISO-now default", () => {
     expect(translateSql("SELECT * FROM t WHERE updated_at > datetime('now', ?)")).toMatch(/\$1/);
     expect(translateDdl("created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))")).toContain("to_char(now() AT TIME ZONE 'UTC'");
+  });
+
+  it("translates an INSERT OR IGNORE seed embedded in a (multi-statement) migration file", () => {
+    // The 0059_global_agent_controls seed — runSelfHostMigrations exec()s the whole file, so the
+    // statement-anchored translateInsertOr can't reach this; translateMigrationInserts handles it.
+    expect(translateMigrationInserts("INSERT OR IGNORE INTO global_agent_controls (id, frozen) VALUES ('singleton', 0);"))
+      .toBe("INSERT INTO global_agent_controls (id, frozen) VALUES ('singleton', 0) ON CONFLICT DO NOTHING;");
+    // Works mid-file alongside DDL, and leaves non-INSERT-OR statements untouched.
+    const file = "CREATE TABLE t (a INTEGER);\nINSERT OR IGNORE INTO t (a) VALUES (1);\n";
+    const out = translateMigrationInserts(file);
+    expect(out).toContain("CREATE TABLE t (a INTEGER);");
+    expect(out).toContain("INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING;");
+    expect(translateMigrationInserts("CREATE TABLE t (a INTEGER);")).toBe("CREATE TABLE t (a INTEGER);"); // no-op
+  });
+
+  it("translateDdl applies INSERT OR IGNORE + function translation together", () => {
+    const out = translateDdl("INSERT OR IGNORE INTO t (a, at) VALUES (1, CURRENT_TIMESTAMP);");
+    expect(out).toContain("ON CONFLICT DO NOTHING");
+    expect(out).toContain("to_char(now(),"); // CURRENT_TIMESTAMP still translated
+    expect(out).not.toMatch(/INSERT\s+OR\s+IGNORE/i);
   });
 
   it("strips table qualifiers from an ON CONFLICT target (drizzle emits `\"t\".\"c\"`, which Postgres rejects)", () => {


### PR DESCRIPTION
## Summary

Two SQLite→Postgres translation gaps in `pg-dialect` made the self-host **Postgres** backend unusable. Both are fixed here (they're CI-coupled: the second already turned the `selfhost-pg` integration test red on `main`).

**1. Startup crash — `INSERT OR IGNORE` in migrations.** `runSelfHostMigrations` applies each migration file as a whole multi-statement string via `exec()` → `translateDdl`, which only translated scalar functions. So the `INSERT OR IGNORE INTO global_agent_controls …` seed in `0059` reached Postgres untranslated → `syntax error at or near "OR"`, and **the app could not boot on Postgres at all**. `translateDdl` now also runs `translateMigrationInserts`, rewriting `INSERT OR IGNORE INTO … ;` → `INSERT INTO … ON CONFLICT DO NOTHING;` (the statement-anchored `translateInsertOr` can't reach a seed embedded mid-file).

**2. Runtime 500s — table-qualified `ON CONFLICT`.** `drizzle-orm/d1` emits `ON CONFLICT ("table"."column")` (valid in SQLite); Postgres requires an unqualified column list and otherwise fails with `syntax error at or near ")"`. That broke every Drizzle upsert — including `recordWebhookEvent`, so the **primary GitHub-webhook ingest path returned a 500**. `translateSql` now strips the qualifier, scoped to the `ON CONFLICT (...)` parens so qualified refs in WHERE/SELECT/joins are untouched (casing/spacing preserved).

## How they were found

The self-host observability dry-run (synthetic signed webhooks against a Postgres backend) surfaced both: the container crash-looped at startup (`syntax error at or near "OR"`), and once on SQLite the webhooks 500'd with the Drizzle `on conflict ("webhook_events"."delivery_id")` error.

## Validation

- [x] **Real-Postgres integration test** `selfhost-pg.test.ts` ("applies every migration, idempotently") — was **red on main**, now **passes** (verified locally against `pgvector/pgvector:pg16`)
- [x] **Real-Postgres runtime check**: the table-qualified `ON CONFLICT` errors; the de-qualified target `INSERT`s and takes the conflict→update path
- [x] `selfhost-pg-dialect.test.ts` — **100% branch coverage** on both new passes (qualified single/multi-column, scoping, bare `ON CONFLICT DO NOTHING`, passthrough; `INSERT OR IGNORE` single + multi-statement + no-op + combined with function translation)
- [x] `npm run typecheck`, `npm run db:migrations:check` — clean

## Scope / Safety

- [x] Two files: `src/selfhost/pg-dialect.ts` + its unit test. No SQLite behavior change. Self-host only; no secrets, no public-surface changes.
- [x] Note: there is a **CI gap** worth a follow-up — `build + boot smoke test` was already failing on `main` (the `0059` migration) yet PRs merged; the required-check config should be tightened so an untranslatable migration can't land green again.