### PR TITLE
ci: upload merged shard coverage to Codecov once to stop the patch flap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,13 @@ jobs:
         run: npm run typecheck
 
   # Unit/integration suite + coverage, sharded across parallel runners to cut the
-  # critical-path wall-clock. Each shard uploads its partial lcov; Codecov merges
-  # all shards for the commit before computing the patch/project status, so the
-  # gate sees the full picture. vitest's local 90% backstop is disabled here
-  # (COVERAGE_NO_THRESHOLDS) because a single shard only exercises part of the
-  # tree; the backstop still runs on the full local `npm run test:coverage`.
+  # critical-path wall-clock. Each shard publishes its PARTIAL lcov as a build
+  # artifact; the `coverage-upload` job merges all 3 and uploads to Codecov ONCE,
+  # so Codecov computes codecov/patch a single time on the complete report instead
+  # of flapping FAILURE->SUCCESS as each shard's partial upload arrived. vitest's
+  # local 90% backstop is disabled here (COVERAGE_NO_THRESHOLDS) because a single
+  # shard only exercises part of the tree; the backstop still runs on the full
+  # local `npm run test:coverage`.
   test:
     name: test
     needs: changes
@@ -154,13 +156,20 @@ jobs:
           echo "::error title=Tests::A test in shard ${{ matrix.shard }}/3 failed."
           echo "Coverage itself is gated by Codecov on changed lines (codecov/patch), computed from the merged shards."
           echo "Reproduce locally with the full suite: 'npm run test:coverage' (no sharding)."
-      - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Upload partial coverage artifact (shard ${{ matrix.shard }}/3)
+        # A passing shard writes coverage/lcov.info; a FAILING shard writes none
+        # (vitest coverage.reportOnFailure defaults to false). Gate on success() so a
+        # red shard skips this (and fails the job → fails `validate`), and use
+        # if-no-files-found:error so a green shard always ships exactly one lcov and
+        # the merge job can assert all 3 arrived. The single Codecov upload happens
+        # in the coverage-upload job below.
+        if: ${{ success() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          name: coverage-lcov-shard-${{ matrix.shard }}
+          path: ./coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
       - name: Upload Vitest results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -168,6 +177,67 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./reports/junit/vitest-shard-${{ matrix.shard }}.xml
           report_type: test_results
+          fail_ci_if_error: false
+
+  # Merge the 3 shard lcovs into one complete report and upload to Codecov ONCE.
+  # The shards no longer upload coverage directly: that made Codecov score
+  # codecov/patch on a partially-merged subset of shards as each upload arrived, so
+  # the status flapped FAILURE->SUCCESS until all 3 landed. A single upload of the
+  # merged report means Codecov computes patch exactly once on complete data. This
+  # job inherits `test`'s path filter and only runs when ALL shards passed, so a
+  # non-backend PR (which skips `test`) emits no codecov/patch context at all — and
+  # codecov/patch is intentionally NOT a required branch-protection context, so an
+  # absent status never strands the review gate at pending.
+  coverage-upload:
+    name: coverage-upload
+    needs: [changes, test]
+    if: ${{ (github.event_name == 'push' || needs.changes.outputs.backend == 'true') && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Full history so Codecov can resolve the merge base for patch coverage.
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - name: Download shard coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-lcov-shard-*
+          path: shard-coverage
+      - name: Collect the shard lcovs into stable paths
+        # download-artifact nests each artifact under its own directory, and
+        # upload-artifact's internal layout for a single file is version-dependent, so
+        # find the lcovs wherever they landed and copy them to fixed names for an
+        # explicit Codecov upload. Assert exactly 3 — fewer means an upload/runner
+        # anomaly (needs.test.result already gated this job to all-shards-green), and a
+        # hard CI failure (one-shot auto-close, recoverable) beats silently scoring
+        # codecov/patch on a subset.
+        run: |
+          mkdir -p merged-lcov
+          n=0
+          for f in $(find shard-coverage -name lcov.info | sort); do
+            n=$((n + 1))
+            cp "$f" "merged-lcov/shard-${n}.info"
+          done
+          echo "Collected ${n} shard lcov file(s)."
+          if [ "${n}" -ne 3 ]; then
+            echo "::error title=Coverage::Expected 3 shard lcov files, found ${n}."
+            exit 1
+          fi
+      - name: Upload all shard coverage to Codecov in one report
+        # All 3 partial lcovs in a SINGLE codecov-action invocation = ONE upload;
+        # Codecov merges them server-side before computing codecov/patch (it "always
+        # merges report data" and holds notifications until merge completes), so the
+        # status is computed once on the complete report — eliminating the partial
+        # flap that 3 separate per-shard uploads caused. fail_ci_if_error stays false
+        # so a Codecov outage cannot fail CI / auto-close an honest PR (codecov/patch
+        # is simply absent, which the gate treats as not-a-FAILURE).
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./merged-lcov/shard-1.info,./merged-lcov/shard-2.info,./merged-lcov/shard-3.info
           fail_ci_if_error: false
 
   # Worker-pool runtime tests (separate vitest config); split out of `test` so it
@@ -303,7 +373,7 @@ jobs:
   # Path-filtered jobs report "skipped", which is treated as success.
   validate:
     name: validate
-    needs: [changes, lint, test, workers, mcp, ui, security]
+    needs: [changes, lint, test, coverage-upload, workers, mcp, ui, security]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 2


### PR DESCRIPTION
## Summary

The recurring **`codecov/patch` FAILURE → SUCCESS flap** has a precise root cause: the `test` job shards across **3 runners**, and each shard uploaded its *partial* `coverage/lcov.info` to Codecov **independently**. Codecov computes `codecov/patch` as each upload arrives — so before all 3 shards landed, a changed line covered by a not-yet-uploaded shard read as *uncovered* → Codecov posted **FAILURE**, then flipped to **SUCCESS** once the final shard merged. (The codecov.yml comment even *assumed* a wait that nothing enforced.)

## Fix

Each shard now publishes its partial lcov as a **build artifact** instead of uploading to Codecov. A new **`coverage-upload`** job downloads all 3 and uploads them to Codecov in a **single `codecov-action` invocation**. Per Codecov's own docs, multiple files in one upload are *merged before* status computation (it "always merges report data" and holds notifications until merge completes) — so `codecov/patch` is computed **exactly once on the complete report**. No partial-merge window, no flap.

- `coverage-upload` is gated on the **same backend path-filter** as `test` **and** `needs.test.result == 'success'`, so it only runs when all shards passed. It's added to `validate`'s `needs` (a *skipped* job reports `skipped`, which `validate`'s `contains(needs.*.result, 'failure'/'cancelled')` check treats as OK — non-backend PRs are unaffected).
- The per-shard artifact upload uses `if: success()` + `if-no-files-found: error` (a failing shard writes no lcov), and the merge job asserts exactly 3 lcovs arrived — a hard CI failure beats silently scoring patch on a subset.
- `fail_ci_if_error: false` stays, so a Codecov *outage* can't fail CI / auto-close an honest PR.

## Why not `after_n_builds`?

Deliberately rejected (this was adversarially verified): the `test` job is **path-filtered**, so a docs/UI-only PR uploads **0** coverage reports. A global `after_n_builds: N` would make `codecov/patch` wait forever for uploads that never arrive → **stranded at pending**, which the review gate treats as "wait" indefinitely — strictly **worse** than the flap. The single-upload approach leaves `after_n_builds` at its default (1) with no count to under-deliver, and `codecov/patch` stays a **non-required** branch-protection context so an absent status never blocks.

## Scope
- [x] CI workflow only (`.github/workflows/ci.yml`); no `src/**`, no schema, no migration, no dependency change
- [x] Self-validating: `.github/workflows/**` triggers the backend filter, so this PR's own CI exercises the new `coverage-upload` job

## Validation
- [x] `actionlint` (the gate's workflow linter) — clean
- [x] `git diff --check` — clean
- [x] Artifact paths are resolved with `find` + copy-to-stable-names (robust to `upload`/`download-artifact`'s internal layout), not hardcoded
- [x] Reused the repo's already-pinned action SHAs (`upload-artifact` v7.0.1, `download-artifact` v8.0.1, `checkout` v7)

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values
- [x] No `site/` / `CNAME` / `lovable`; the change only restructures coverage upload, never weakens the gate