### PR TITLE
fix(orb): point collector at the live receiver + rate-limit ingest + document the multi-tenant security model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,12 +164,23 @@ GITTENSORY_REVIEW_DRAFT=false
 # --- Gittensory Orb (#1219; opt-in outcome signal collection) ---
 # Run GET /orb/setup to create the Orb GitHub App (read-only; separate from the main App).
 # Credentials are written to /data/gittensory-orb.env on callback — load them here.
+#
+# SECURITY MODEL (this image is meant to be self-hosted by many independent maintainers):
+#   • The image bakes NO secrets. Every operator creates their OWN Orb App via /orb/setup, so the
+#     ORB_* secrets below are unique to YOUR instance and live only in YOUR /data — never shared,
+#     never sent to the collector. gittensory's own App secrets are never in the image.
+#   • Export to the central collector uses NO shared key: repo/PR identifiers are HMAC-anonymized
+#     with YOUR ORB_WEBHOOK_SECRET (so even the collector operator can't de-anonymize them), and the
+#     collector accepts the batch as untrusted, rate-limited, aggregate-only telemetry. Nothing in the
+#     container, if leaked, can compromise the collector, other operators, or the main App.
+#   • Prefer the *_FILE convention for the private key (mount a file, not an inline env value):
+#     ORB_PRIVATE_KEY_FILE=/run/secrets/orb_private_key  →  the server reads it into ORB_PRIVATE_KEY.
 # ORB_APP_ID=                                # App ID from /orb/setup callback
 # ORB_APP_SLUG=                              # App slug (human-readable name)
-# ORB_WEBHOOK_SECRET=                        # secret from /orb/setup callback — signs /orb/webhook requests
-# ORB_PRIVATE_KEY=                           # PEM from /orb/setup callback (JSON-stringified)
+# ORB_WEBHOOK_SECRET=                        # secret from /orb/setup callback — signs /orb/webhook + anonymizes export
+# ORB_PRIVATE_KEY=                           # PEM from /orb/setup callback (JSON-stringified); prefer ORB_PRIVATE_KEY_FILE
 # ORB_ENABLED=false                          # master switch: set to true to enable collection (default off)
 # ORB_AIR_GAP=false                          # set to true to keep all data local — never send to the collector
 # ORB_ANONYMIZE=true                         # HMAC-hash repo names before export (default true; false = raw names)
-# ORB_COLLECTOR_URL=https://orb.gittensory.app/v1/ingest  # central collector URL (set by default; override as needed)
+# ORB_COLLECTOR_URL=https://gittensory-api.aethereal.dev/v1/orb/ingest  # gittensory's hosted collector (default; override for your own)
 # ORB_SETUP_OUTPUT_PATH=/data/gittensory-orb.env          # where /orb/setup/callback writes the credentials file

--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -96,6 +96,9 @@ export async function enforceRateLimit(c: Context<{ Bindings: Env }>, routeClass
 
 export function routeClassForPath(path: string): RateLimitClass {
   if (path === "/v1/github/webhook") return "strict";
+  // Orb telemetry ingest: unauthenticated + write, accepting anonymized batches from untrusted
+  // self-host instances. Strict (10/min per IP) caps abuse — legitimate instances export hourly.
+  if (path === "/v1/orb/ingest") return "strict";
   if (path === "/v1/auth/session" || path === "/v1/auth/logout") return "normal";
   if (path.startsWith("/v1/auth/")) return "strict";
   if (

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -4,7 +4,7 @@
 //
 // Collection is always local (DB only). Export to the central collector is opt-in:
 //   ORB_ENABLED=true          — activates collection (off by default)
-//   ORB_COLLECTOR_URL=<url>   — endpoint to export batches to (default: https://orb.gittensory.app/v1/ingest)
+//   ORB_COLLECTOR_URL=<url>   — endpoint to export batches to (default: gittensory's hosted collector)
 //   ORB_AIR_GAP=true          — keep all events local, never send externally
 //   ORB_ANONYMIZE=true        — HMAC-hash repo/owner before export (default: true)
 //
@@ -92,7 +92,10 @@ export async function exportOrbBatch(
   if (!orbEnabled()) return 0;
   if ((process.env.ORB_AIR_GAP ?? "").toLowerCase() === "true") return 0;
 
-  const collectorUrl = process.env.ORB_COLLECTOR_URL ?? "https://orb.gittensory.app/v1/ingest";
+  // gittensory's hosted collector (the deployed /v1/orb/ingest receiver). No shared secret is sent:
+  // the batch is anonymized (HMAC of each operator's OWN ORB_WEBHOOK_SECRET) and accepted as untrusted,
+  // rate-limited telemetry. Override only to point at your own self-hosted collector.
+  const collectorUrl = process.env.ORB_COLLECTOR_URL ?? "https://gittensory-api.aethereal.dev/v1/orb/ingest";
   const secret = process.env.ORB_WEBHOOK_SECRET ?? "";
   const anonymize = (process.env.ORB_ANONYMIZE ?? "true").toLowerCase() !== "false";
 

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -80,6 +80,7 @@ describe("private-beta auth and rate limiting", () => {
 
   it("classifies rate-limit route costs", () => {
     expect(routeClassForPath("/v1/github/webhook")).toBe("strict");
+    expect(routeClassForPath("/v1/orb/ingest")).toBe("strict"); // open telemetry ingest — abuse-capped per IP
     expect(routeClassForPath("/v1/auth/github/device/start")).toBe("strict");
     expect(routeClassForPath("/v1/local/branch-analysis")).toBe("expensive");
     expect(routeClassForPath("/v1/scoring/preview")).toBe("expensive");

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -147,6 +147,15 @@ describe("exportOrbBatch()", () => {
     expect(await exportOrbBatch(db, 200, async () => new Response(null, { status: 200 }))).toBe(0);
   });
 
+  it("defaults to gittensory's hosted collector URL when ORB_COLLECTOR_URL is unset (regression: dead orb.gittensory.app)", async () => {
+    delete process.env.ORB_COLLECTOR_URL;
+    const db = makeDb();
+    await recordOrbEvent(db, { repo: "o/r", pr_number: 1, head_sha: "sha", outcome: "merged" });
+    let capturedUrl: string | undefined;
+    await exportOrbBatch(db, 200, async (url) => { capturedUrl = String(url); return new Response(null, { status: 200 }); });
+    expect(capturedUrl).toBe("https://gittensory-api.aethereal.dev/v1/orb/ingest");
+  });
+
   it("exports pending events and marks them as exported", async () => {
     const db = makeDb();
     await recordOrbEvent(db, { repo: "owner/repo", pr_number: 1, head_sha: "sha1", outcome: "merged", gate_verdict: "approve" });


### PR DESCRIPTION
## Summary

Makes Orb export actually work end-to-end and hardens/documents it for the multi-tenant self-host case (this image is run by many independent maintainers).

**1. Export was broken.** The default `ORB_COLLECTOR_URL` was `https://orb.gittensory.app/v1/ingest`, which **does not resolve** (verified: HTTP 000) — and the path didn't match the receiver route. Every export silently failed. Pointed it at the **deployed** receiver `https://gittensory-api.aethereal.dev/v1/orb/ingest` (verified responding live: HTTP 400 to bad input, the receiver from #1234).

**2. Hardened the open ingest endpoint.** `/v1/orb/ingest` is unauthenticated + write, accepting anonymized batches from untrusted instances. Classified it as the `strict` rate-limit class (10/min **per IP** — the limiter keys unauth requests by hashed client IP). Legitimate instances export hourly, so this is generous for them and caps abuse.

**3. Documented the multi-tenant security model** in `.env.example`.

## The security model (why no secret is exposed)

This is the key design point for "self-hosted by other maintainers":

- **The image bakes zero secrets** (the Dockerfile injects nothing at build).
- **Each operator creates their OWN Orb App** via `/orb/setup`. The resulting `ORB_*` secrets are unique to that instance and live only in its `/data` — never shared, never sent to the collector. gittensory's own App secrets are never in the image.
- **Export carries NO shared key.** repo/PR identifiers are HMAC-anonymized with each operator's *own* `ORB_WEBHOOK_SECRET` (so even the collector operator can't de-anonymize them), and the collector accepts the batch as untrusted, rate-limited, aggregate-only telemetry. Nothing in the container, if leaked, can compromise the collector, other operators, or the main App.
- Recommends the `ORB_PRIVATE_KEY_FILE` convention (mount the key as a file rather than an inline env value).

This mirrors the secret-hygiene principle in `entrius/das-github-mirror` (each service holds its own App secrets at runtime; consumers use per-consumer issued keys, never a shared secret) — adapted to Orb's push-telemetry direction.

## Validation

- [x] Verified the live collector responds (`gittensory-api.aethereal.dev/v1/orb/ingest` → 400 on bad input) and the old default is dead (`orb.gittensory.app` → 000)
- [x] `npm run typecheck` clean; `selfhost-orb-collector` + `auth` tests pass (42)
- [x] Added a **regression guard** test pinning the default collector URL (so it can't silently regress to a dead domain) and a rate-limit-class assertion for `/v1/orb/ingest`
- [x] Patch coverage on changed lines covered (orb-collector default URL + the new strict-class branch)

## Follow-up (not in this PR)

Per-instance **issued API keys** (a registration flow → the collector can authenticate + revoke a specific instance) would add abuse control beyond per-IP rate limiting — the pattern `das-github-mirror` uses for its read API (`API_KEYS`). Worth doing if poisoning of the aggregate calibration data becomes a concern; v1 relies on anonymization + per-IP limits + dedup + outlier-robust aggregation.