### PR TITLE
fix(agent): count update_branch as a PR-write in the readiness gate

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -15,8 +15,10 @@ import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
 const AGENT_ACTOR = "gittensory";
 
 // The PR-state action classes that require GitHub `pull_requests: write`. `label` mutates via the Issues API
-// (`issues: write`, always held), so it is exempt from the write-permission readiness gate.
-const PR_WRITE_CLASSES = new Set<AgentActionClass>(["request_changes", "approve", "merge", "close", "update_branch"]);
+// (`issues: write`, always held), so it is exempt from the write-permission readiness gate. Exported so the
+// agent-execution test can enforce the invariant that every member is also counted by agentRequiresPrWrite
+// (PR_WRITE_ACTION_CLASSES is a superset), so this runtime guard never disagrees with the readiness gate.
+export const PR_WRITE_CLASSES = new Set<AgentActionClass>(["request_changes", "approve", "merge", "close", "update_branch"]);
 
 export type AgentActionExecutionContext = {
   installationId: number;

--- a/src/settings/agent-execution.ts
+++ b/src/settings/agent-execution.ts
@@ -1,9 +1,16 @@
 import type { AgentActionClass, AuditEventRecord, AutonomyLevel, AutonomyPolicy } from "../types";
 import { isActingAutonomyLevel, resolveAutonomy } from "./autonomy";
 
-// The action classes that mutate a PR's review / merge / close state — these need GitHub `pull_requests: write`.
-// (`label` mutates via the Issues API, which the App already holds `issues: write` for.)
-const PR_WRITE_ACTION_CLASSES: readonly AgentActionClass[] = ["review", "request_changes", "approve", "merge", "close"];
+// The action classes that mutate a PR's review / merge / close / head state — these need GitHub
+// `pull_requests: write`. (`label` mutates via the Issues API, which the App already holds `issues: write` for.)
+// INVARIANT: the executor's PR_WRITE_CLASSES (src/services/agent-action-executor.ts) must be a SUBSET of this list
+// — every class the runtime readiness guard treats as a PR-write must be counted by agentRequiresPrWrite, or the
+// readiness gate under-reports and disagrees with the executor. (This list may be a superset: it also carries the
+// advisory `review` class for conservatism.) `update_branch` (PUT /pulls/{n}/update-branch) is a PR-write the
+// executor gates; omitting it here graded an update_branch-only autonomy "not_required", so the executor's
+// readiness guard denied it even WITH pull_requests:write granted (and it would 403 if it slipped). The
+// agent-execution test enforces this subset invariant against the exported PR_WRITE_CLASSES. (#audit-update-branch)
+const PR_WRITE_ACTION_CLASSES: readonly AgentActionClass[] = ["review", "request_changes", "approve", "merge", "close", "update_branch"];
 
 // Whether the agent actually executes an action, only logs what it WOULD do, or is halted entirely (#776).
 export type AgentActionMode = "paused" | "dry_run" | "live";

--- a/test/unit/agent-execution.test.ts
+++ b/test/unit/agent-execution.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentActionMode,
   resolveAgentPermissionReadiness,
 } from "../../src/settings/agent-execution";
+import { PR_WRITE_CLASSES } from "../../src/services/agent-action-executor";
 
 describe("resolveAgentActionMode (#776 safety gate)", () => {
   it("a global OR per-repo pause halts everything (safest wins)", () => {
@@ -82,8 +83,28 @@ describe("agent write-permission readiness (#775)", () => {
     expect(agentRequiresPrWrite({ merge: "observe" })).toBe(false);
     expect(agentRequiresPrWrite({})).toBe(false);
     expect(agentRequiresPrWrite(null)).toBe(false);
+    // update_branch (PUT /pulls/{n}/update-branch) is a PR-write the executor gates → it demands write too (#audit-update-branch)
+    expect(agentRequiresPrWrite({ update_branch: "auto" })).toBe(true);
+    expect(agentRequiresPrWrite({ update_branch: "auto_with_approval" })).toBe(true);
+    expect(agentRequiresPrWrite({ update_branch: "observe" })).toBe(false); // non-acting still no write
     // label acts via the Issues API (issues: write, already held), so it does NOT demand pull_requests: write
     expect(agentRequiresPrWrite({ label: "auto" })).toBe(false);
+  });
+
+  it("INVARIANT: every executor PR_WRITE_CLASS is counted by agentRequiresPrWrite (the readiness gate cannot disagree with the runtime guard)", () => {
+    // The executor denies a PR-write action whose readiness !== "ready". If a class it gates were missing from
+    // PR_WRITE_ACTION_CLASSES, agentRequiresPrWrite would grade it "not_required" and the gate would diverge — the
+    // exact #audit-update-branch bug. Enforce executor PR_WRITE_CLASSES ⊆ readiness write-classes for ALL members.
+    for (const actionClass of PR_WRITE_CLASSES) {
+      expect(agentRequiresPrWrite({ [actionClass]: "auto" })).toBe(true);
+    }
+  });
+
+  it("REGRESSION (#audit-update-branch): an update_branch-only acting autonomy resolves readiness instead of 'not_required'", () => {
+    // Before the fix update_branch was absent from PR_WRITE_ACTION_CLASSES, so this graded "not_required" and the
+    // executor's `!== "ready"` guard denied update_branch even WITH write granted (and would 403 if it slipped).
+    expect(resolveAgentPermissionReadiness({ autonomy: { update_branch: "auto" }, installationPermissions: { pull_requests: "write" } })).toBe("ready");
+    expect(resolveAgentPermissionReadiness({ autonomy: { update_branch: "auto" }, installationPermissions: { pull_requests: "read" } })).toBe("reconsent_required");
   });
 
   it("resolveAgentPermissionReadiness gates on the granted pull_requests scope", () => {


### PR DESCRIPTION
## Summary

The executor gates `update_branch` on `pull_requests: write` (`PR_WRITE_CLASSES` in `agent-action-executor.ts` includes it), but the readiness predicate's `PR_WRITE_ACTION_CLASSES` in `agent-execution.ts` **omitted** it. So an `update_branch`-only acting autonomy graded `agentRequiresPrWrite = false` → `resolveAgentPermissionReadiness` returned `"not_required"` → the executor's `readiness !== "ready"` guard **denied the `update_branch` even with `pull_requests: write` granted** (and it would 403 at runtime if it ever slipped past the gate).

The two lists must agree: every class the runtime guard treats as a PR-write must be counted by the readiness predicate.

## Fix
- Add `update_branch` to `PR_WRITE_ACTION_CLASSES`.
- **Export** the executor's `PR_WRITE_CLASSES` so the invariant is testable across the module boundary.
- **Invariant test:** every member of the executor's `PR_WRITE_CLASSES` is counted by `agentRequiresPrWrite` (executor set ⊆ readiness set) — this fails if anyone adds a runtime-gated PR-write without updating the readiness list, preventing the bug class from recurring.
- **Regression test (`#audit-update-branch`):** an `update_branch`-only autonomy now resolves `ready` (write granted) / `reconsent_required` (read) instead of `not_required`.

## Scope
- [x] Backend only; no schema / migration / binding change

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Every changed line + branch covered; invariant + regression added
- [x] Rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; the change only makes the permission gate *more* accurate
- [x] No `site/` / `CNAME` / `lovable`