### PR TITLE
fix(agent): never auto-merge/approve/close a draft PR

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -655,6 +655,11 @@ async function maybeRunAgentMaintenance(
   /* v8 ignore next -- defensive: the PR was upserted earlier in this same webhook, so it is always present. */
   if (!pr) return;
   if (pr.state !== "open") return;
+  // Drafts are work-in-progress: never auto-approve / merge / close / label a draft. Symmetric with the re-gate
+  // sweep, which drops drafts (agent-sweep.ts). A draft signals "not ready"; the agent acts once it is marked
+  // ready_for_review (which re-triggers this path on the now-undrafted PR). The converted_to_draft draft-dodge
+  // guard is a separate handler and is unaffected. (#audit-draft-maintenance)
+  if (pr.isDraft) return;
   if (!gate) return;
 
   // Convergence safety: feed the planner the PR's changed paths + the repo's hard-guardrail globs so guarded

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1165,6 +1165,69 @@ describe("queue processors", () => {
     expect(rcAudit).toBeFalsy();
   });
 
+  it("REGRESSION (#audit-draft-maintenance): a clean DRAFT PR is never auto-merged/approved/closed (drafts are WIP)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      action: "created",
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        target_type: "User",
+        repository_selection: "all",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    // Clean, mergeable, approved, green CI + merge:auto + close:auto + approve:auto — a NON-draft here would be
+    // auto-acted. The ONLY thing that must stop it is the draft guard in maybeRunAgentMaintenance.
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      autonomy: { merge: "auto", approve: "auto", close: "auto" },
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/draft1/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/draft1/status")) return Response.json({ statuses: [] });
+      if (url.includes("/check-runs")) return Response.json({ id: 901 }, { status: 201 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "draft-no-maintenance",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 49,
+          title: "Work in progress",
+          state: "open",
+          draft: true,
+          user: { login: "contributor" },
+          head: { sha: "draft1" },
+          labels: [],
+          body: "Closes #1",
+          mergeable_state: "clean",
+          reviewDecision: "APPROVED",
+        },
+      },
+    });
+
+    // No terminal maintenance action of ANY class fires on a draft.
+    const acted = await env.DB.prepare("select count(*) as n from audit_events where event_type in ('agent.action.merge','agent.action.approve','agent.action.close')").first<{ n: number }>();
+    expect(acted?.n).toBe(0);
+  });
+
   // #1092: prReadyForReview rebases a BEHIND-base PR through the agent executor (gated by update_branch autonomy
   // + pull_requests:write) before reviewing, then defers — the synchronize on the new head re-runs review.
   async function seedBehindRepo(env: Env, over: { autonomy?: Record<string, string>; agentPaused?: boolean; perms?: Record<string, string>; noInstall?: boolean } = {}) {


### PR DESCRIPTION
## Summary

The re-gate sweep already drops drafts (`agent-sweep.ts`), but the **per-webhook maintenance path did not**: `maybeRunAgentMaintenance` ran for a draft PR. So a clean, mergeable, approved draft with `merge: auto` could be **auto-merged/approved**, and a failing draft with `close: auto` **auto-closed** — the agent acting on work the contributor explicitly marked *not ready*.

## Fix
Add a draft guard to `maybeRunAgentMaintenance`, symmetric with the sweep: a draft signals "not ready", so the agent takes **no** maintenance action. It acts once the PR is marked `ready_for_review` (which re-triggers this path on the now-undrafted head). The `converted_to_draft` draft-dodge guard is a separate handler and is unaffected — converting an *open, gate-failed* PR to draft still closes it.

## Scope
- [x] Backend only (`src/queue/processors.ts`); no schema / migration / binding change

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] **Regression test:** a clean, mergeable, approved, green draft with `merge`/`approve`/`close` all at `auto` produces **zero** `agent.action.*` audits — only the draft guard stops it. (The non-draft arm is covered by the existing maintenance tests.)
- [x] Every changed line + branch covered
- [x] Rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; the change only ever *removes* an action (never acts on a draft)
- [x] No `site/` / `CNAME` / `lovable`