### PR TITLE
feat(github): link the Gate check-run Details to the maintainer panel

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -1,5 +1,6 @@
 import type { Advisory, GitHubWebhookPayload } from "../types";
 import { makeInstallationOctokit } from "./client";
+import { maintainerControlPanelUrl } from "./footer";
 import type { AgentActionMode } from "../settings/agent-execution";
 import { signRs256Jwt } from "../utils/crypto";
 import { evaluateGateCheck, formatCheckRunOutput, formatGateCheckOutput, type CheckRunAnnotationContext, type CheckRunOutput, type GateCheckConclusion, type GateCheckPolicy } from "../rules/advisory";
@@ -281,6 +282,10 @@ async function createOrUpdateNamedCheckRun(
   // makeInstallationOctokit injects the shared per-request timeout (a stalled PATCH can never orphan the
   // in_progress check) AND suppresses the check-run writes under a non-live mode (dry-run / pause / freeze).
   const octokit = makeInstallationOctokit(env, token, check.mode);
+  // Point the merge-box "Details" link at the repo's Gittensory maintainer panel instead of GitHub's generic
+  // check page. Spread conditionally so a URL-construction failure (null) just omits it. (#audit-details-url)
+  const detailsUrl = maintainerControlPanelUrl(env, repoFullName);
+  const detailsUrlBody = detailsUrl ? { details_url: detailsUrl } : {};
 
   try {
     if (check.checkRunId) {
@@ -293,6 +298,7 @@ async function createOrUpdateNamedCheckRun(
         status: check.status ?? "completed",
         ...(check.conclusion ? { conclusion: check.conclusion } : {}),
         output: outputForCheckRunUpdate(check.output),
+        ...detailsUrlBody,
       });
       const data = response.data as CheckRunResponse;
       return publishedOutcome(data);
@@ -316,6 +322,7 @@ async function createOrUpdateNamedCheckRun(
         status: check.status ?? "completed",
         ...(check.conclusion ? { conclusion: check.conclusion } : {}),
         output: outputForCheckRunUpdate(check.output),
+        ...detailsUrlBody,
       });
       const data = response.data as CheckRunResponse;
       return publishedOutcome(data);
@@ -329,6 +336,7 @@ async function createOrUpdateNamedCheckRun(
       status: check.status ?? "completed",
       ...(check.conclusion ? { conclusion: check.conclusion } : {}),
       output: check.output,
+      ...detailsUrlBody,
     });
     const data = response.data as CheckRunResponse;
     return publishedOutcome(data);

--- a/src/github/footer.ts
+++ b/src/github/footer.ts
@@ -10,6 +10,21 @@
 
 /** The Gittensory product site (marketing on-ramp / attribution target). */
 export const GITTENSORY_SITE_URL = "https://gittensory.aethereal.dev";
+
+/** The maintainer control panel for a repo on the Gittensory site (`/app?view=maintainer&repo=…`). Used as the
+ *  check-run `details_url` so the merge-box "Details" link lands on the repo's review panel instead of GitHub's
+ *  generic check page, and as the in-comment control-panel link. Returns null only if URL construction throws. */
+export function maintainerControlPanelUrl(env: { PUBLIC_SITE_ORIGIN?: string | undefined }, repoFullName: string): string | null {
+  const origin = env.PUBLIC_SITE_ORIGIN ?? GITTENSORY_SITE_URL;
+  try {
+    const url = new URL("/app", origin);
+    url.searchParams.set("view", "maintainer");
+    url.searchParams.set("repo", repoFullName);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
 /** The Gittensor network — where GitHub contributors register to earn for their contributions. */
 export const GITTENSOR_HOME_URL = "https://gittensor.io";
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -81,7 +81,7 @@ import {
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot, fetchOfficialGittensorMiner, type GittensorContributorSnapshot, type OfficialGittensorMinerDetection } from "../gittensor/api";
 import { createInstallationToken, createOrUpdateCheckRun, createOrUpdateErroredGateCheckRun, createOrUpdateGateCheckRun, createOrUpdateOverriddenGateCheckRun, createOrUpdatePendingGateCheckRun, createOrUpdateSkippedGateCheckRun, getInstallationId, getRepositoryCollaboratorPermission } from "../github/app";
 import { AGENT_COMMAND_COMMENT_MARKER, createOrUpdateAgentCommandComment, createOrUpdatePrIntelligenceComment, PR_PANEL_COMMENT_MARKER } from "../github/comments";
-import { gittensoryFooter, gittensorRepoEarnUrl } from "../github/footer";
+import { gittensoryFooter, gittensorRepoEarnUrl, maintainerControlPanelUrl } from "../github/footer";
 import {
   buildMaintainerQueueDigest,
   buildPublicAgentCommandComment,
@@ -3619,18 +3619,6 @@ async function loadQueueCheckSummariesByPullNumber(
   const openPullRequests = pullRequests.filter((pr) => pr.state === "open").slice(0, 50);
   const entries = await Promise.all(openPullRequests.map(async (pr) => [pr.number, await listCheckSummaries(env, repoFullName, pr.number)] as const));
   return Object.fromEntries(entries);
-}
-
-function maintainerControlPanelUrl(env: Env, repoFullName: string): string | null {
-  const origin = env.PUBLIC_SITE_ORIGIN ?? "https://gittensory.aethereal.dev";
-  try {
-    const url = new URL("/app", origin);
-    url.searchParams.set("view", "maintainer");
-    url.searchParams.set("repo", repoFullName);
-    return url.toString();
-  } catch {
-    return null;
-  }
 }
 
 async function recordAgentCommandFeedbackPrompt(

--- a/test/unit/footer.test.ts
+++ b/test/unit/footer.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { gittensoryFooter, gittensorRepoEarnUrl, GITTENSOR_HOME_URL, GITTENSORY_SITE_URL } from "../../src/github/footer";
+import { gittensoryFooter, gittensorRepoEarnUrl, GITTENSOR_HOME_URL, GITTENSORY_SITE_URL, maintainerControlPanelUrl } from "../../src/github/footer";
 import { FORBIDDEN_PUBLIC_COMMENT_WORDS } from "../../src/queue-intelligence";
+
+describe("maintainerControlPanelUrl", () => {
+  it("builds the repo maintainer panel URL on the default site origin", () => {
+    expect(maintainerControlPanelUrl({}, "owner/repo")).toBe(`${GITTENSORY_SITE_URL}/app?view=maintainer&repo=owner%2Frepo`);
+  });
+
+  it("uses a configured PUBLIC_SITE_ORIGIN when present", () => {
+    expect(maintainerControlPanelUrl({ PUBLIC_SITE_ORIGIN: "https://panel.test" }, "o/r")).toBe("https://panel.test/app?view=maintainer&repo=o%2Fr");
+  });
+
+  it("returns null when the origin cannot form a URL", () => {
+    expect(maintainerControlPanelUrl({ PUBLIC_SITE_ORIGIN: "not-a-valid-origin" }, "o/r")).toBeNull();
+  });
+});
 
 describe("gittensory public-comment footer", () => {
   it("always shows the earn CTA + attribution (permanent marketing surface on every PR)", () => {

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -288,7 +288,7 @@ describe("GitHub check runs", () => {
 
   it("creates an in-progress Gate check without a conclusion", async () => {
     const privateKey = await generatePrivateKeyPem();
-    let capturedBody: { name?: string; status?: string; conclusion?: string; output?: { title?: string; text?: string } } = {};
+    let capturedBody: { name?: string; status?: string; conclusion?: string; details_url?: string; output?: { title?: string; text?: string } } = {};
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
@@ -311,6 +311,27 @@ describe("GitHub check runs", () => {
     expect(capturedBody).not.toHaveProperty("conclusion");
     // The Gate blocks every author the same on a configured blocker (confirmed status no longer gates the verdict).
     expect(capturedBody.output?.text).toContain("blocks every author");
+    // The "Details" link points at the repo's Gittensory maintainer panel, not GitHub's generic check page. (#audit-details-url)
+    expect(capturedBody.details_url).toBe("https://gittensory.aethereal.dev/app?view=maintainer&repo=JSONbored%2Fgittensory");
+  });
+
+  it("omits details_url when the site origin cannot form a URL (#audit-details-url null arm)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let capturedBody: { details_url?: string } = {};
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) {
+        capturedBody = JSON.parse(String(init?.body)) as typeof capturedBody;
+        return Response.json({ id: 90 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey, PUBLIC_SITE_ORIGIN: "not-a-valid-origin" });
+    await createOrUpdatePendingGateCheckRun(env, 123, "JSONbored/gittensory", gateAdvisory("pending-no-url"));
+    expect(capturedBody).not.toHaveProperty("details_url");
   });
 
   it("finalizes a known pending Gate check by id without listing check runs first", async () => {


### PR DESCRIPTION
## Summary

Our own Gate / Context check runs sent no `details_url`, so the merge-box **"Details"** link landed on GitHub's generic check page instead of the repo's review panel — a missed discoverability win (we read *other* apps' `details_url` pervasively but never set our own).

## Fix
Set `details_url` on all three check-run write bodies (the two PATCH paths + the POST), pointing at the repo's Gittensory maintainer control panel (`/app?view=maintainer&repo=…`). The URL builder `maintainerControlPanelUrl` moves from a private helper in `processors.ts` to the neutral `github/footer` module so `app.ts` can reuse it **without an `app` ↔ `processors` import cycle**. It's spread conditionally, so a URL-construction failure simply omits the field (never breaks the check write).

## Scope
- [x] Backend only (`github/app.ts`, `github/footer.ts`, `queue/processors.ts`); no schema / migration / binding change

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] `maintainerControlPanelUrl` unit-tested (default origin, configured `PUBLIC_SITE_ORIGIN`, and the null/throw arm); check-run body tested for `details_url` **present** (default origin) and **absent** (invalid origin → null arm)
- [x] Every changed line + branch covered
- [x] Rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; only adds a public panel link to our own check runs
- [x] No `site/` / `CNAME` / `lovable`