### PR TITLE
fix(github): install-health requires pull_requests:write for acting repos

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -39,6 +39,7 @@ import {
   persistRepoSnapshot,
   extractLinkedIssueNumbers,
 } from "../db/repositories";
+import { agentRequiresPrWrite } from "../settings/agent-execution";
 import type {
   ContributorRepoStatRecord,
   GitHubRateLimitObservationRecord,
@@ -690,6 +691,13 @@ export const REQUIRED_INSTALLATION_PERMISSIONS: Record<string, string> = {
 export const OPTIONAL_CHECK_RUN_PERMISSION: Record<string, string> = {
   checks: "write",
 };
+// Conditionally required: an installation whose autonomy ACTS on PR state (merge/close/approve/request_changes/
+// update_branch) needs `pull_requests: write`, not the baseline `read`. Without this, install-health reported
+// "healthy" for a repo configured to act that could only ever 403 at runtime. Mirrors the checks:write pattern.
+// (#audit-install-health)
+export const OPTIONAL_PR_WRITE_PERMISSION: Record<string, string> = {
+  pull_requests: "write",
+};
 
 export const REQUIRED_INSTALLATION_EVENTS = ["issues", "issue_comment", "pull_request", "repository"] as const;
 export const OPTIONAL_VISIBLE_INSTALLATION_EVENTS = ["installation_target", "installation_repositories"] as const;
@@ -723,6 +731,9 @@ export function enrichInstallationHealth(health: InstallationHealthRecord) {
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
     ...(missingPermissions.has("checks") ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
+    // pull_requests is missing ONLY when the refresh required write (an acting autonomy) and it was not granted, so
+    // surface the write requirement in the remediation rather than the baseline read. (#audit-install-health)
+    ...(missingPermissions.has("pull_requests") ? OPTIONAL_PR_WRITE_PERMISSION : {}),
   };
   return {
     ...health,
@@ -763,12 +774,14 @@ export async function buildInstallationRepairDiagnostics(env: Env, health: Insta
   const labelRepoCount = installedSettings.filter(usesLabelMode).length;
   const checkRunRepoCount = installedSettings.filter((settings) => settings.checkRunMode === "enabled").length;
   const gateCheckRepoCount = installedSettings.filter((settings) => settings.gateCheckMode === "enabled").length;
+  const requiresPrWrite = installedSettings.some((settings) => agentRequiresPrWrite(settings.autonomy));
   const missingPermissions = new Set(health.missingPermissions);
   const requiredEventSet = new Set<string>(REQUIRED_INSTALLATION_EVENTS);
   const missingEvents = new Set(health.missingEvents.filter((event) => requiredEventSet.has(event)));
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
     ...(checkRunRepoCount > 0 || gateCheckRepoCount > 0 ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
+    ...(requiresPrWrite ? OPTIONAL_PR_WRITE_PERMISSION : {}), // acting autonomy → pull_requests:write (#audit-install-health)
   };
   const optionalPermissions = checkRunRepoCount > 0 || gateCheckRepoCount > 0 ? {} : OPTIONAL_CHECK_RUN_PERMISSION;
   const modeImpacts: InstallationModeImpact[] = [
@@ -928,9 +941,12 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
     const registeredInstalled = installedRepos.filter((repo) => repo.isRegistered);
     const installedSettings = await Promise.all(installedRepos.map((repo) => getRepositorySettings(env, repo.fullName)));
     const requiresChecks = installedSettings.some((settings) => settings.checkRunMode === "enabled");
+    const requiresPrWrite = installedSettings.some((settings) => agentRequiresPrWrite(settings.autonomy));
     const requiredPermissions = {
       ...REQUIRED_INSTALLATION_PERMISSIONS,
       ...(requiresChecks ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
+      // An acting autonomy upgrades the pull_requests requirement read -> write (spread last so it wins). (#audit-install-health)
+      ...(requiresPrWrite ? OPTIONAL_PR_WRITE_PERMISSION : {}),
     };
     const missingPermissions = Object.entries(requiredPermissions)
       .filter(([permission, expected]) => !permissionSatisfies(currentInstallation.permissions[permission], expected))

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -436,6 +436,27 @@ describe("GitHub backfill", () => {
     });
   });
 
+  it("surfaces pull_requests:write in the remediation when it is the missing permission (#audit-install-health display)", () => {
+    const health = enrichInstallationHealth({
+      installationId: 126,
+      accountLogin: "JSONbored",
+      repositorySelection: "selected",
+      installedReposCount: 1,
+      registeredInstalledCount: 1,
+      status: "needs_attention",
+      missingPermissions: ["pull_requests"],
+      missingEvents: [],
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["issues", "issue_comment", "pull_request", "repository"],
+      checkedAt: "2026-06-05T00:00:00.000Z",
+    });
+
+    expect(health.requiredPermissions).toMatchObject({ pull_requests: "write" }); // not the baseline read
+    expect(health.permissionRemediation).toEqual(
+      expect.arrayContaining([expect.objectContaining({ permission: "pull_requests", requiredAccess: "write", ok: false, action: "Set repository permission pull_requests to write." })]),
+    );
+  });
+
   it("requires Checks write only for repos with check runs enabled", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);
@@ -481,6 +502,49 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("REGRESSION (#audit-install-health): an acting autonomy requires pull_requests:write, so read-only is needs_attention not healthy", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await seedRegisteredRepo(env);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+        events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+      },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
+    // close:auto ACTS on PR state → the App needs pull_requests:write, not the baseline read.
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { close: "auto" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/app/installations/123")) {
+        return Response.json({
+          id: 123,
+          account: { login: "JSONbored", id: 1, type: "User" },
+          repository_selection: "selected",
+          permissions: { metadata: "read", pull_requests: "read", issues: "write" }, // only READ granted
+          events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const refreshed = await refreshInstallationHealth(env);
+
+    expect(refreshed.installations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          installationId: 123,
+          status: "needs_attention", // was falsely "healthy" before the fix
+          missingPermissions: ["pull_requests"],
+          requiredPermissions: expect.objectContaining({ pull_requests: "write" }),
+        }),
+      ]),
+    );
+  });
+
   it("marks comment, label, and check repair impacts disabled by repo settings", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
@@ -508,6 +572,7 @@ describe("GitHub backfill", () => {
 
     expect(repair.repairSteps).toEqual(["No repair needed."]);
     expect(repair.requiredPermissions).not.toHaveProperty("checks");
+    expect(repair.requiredPermissions.pull_requests).toBe("read"); // non-acting → baseline read, NOT upgraded to write
     expect(repair.modeImpacts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ mode: "comment", enabled: false, affectedRepoCount: 0, action: "No change needed." }),
@@ -515,6 +580,28 @@ describe("GitHub backfill", () => {
         expect.objectContaining({ mode: "check_run", enabled: false, affectedRepoCount: 0, requiredPermissions: [expect.objectContaining({ optional: true })] }),
       ]),
     );
+  });
+
+  it("repair diagnostics upgrade pull_requests to write for an acting autonomy (#audit-install-health display)", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto" } });
+
+    const repair = await buildInstallationRepairDiagnostics(env, {
+      installationId: 123,
+      accountLogin: "JSONbored",
+      repositorySelection: "selected",
+      installedReposCount: 1,
+      registeredInstalledCount: 0,
+      status: "needs_attention",
+      missingPermissions: ["pull_requests"],
+      missingEvents: [],
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+      checkedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    expect(repair.requiredPermissions.pull_requests).toBe("write");
   });
 
   it("counts comment-only and label-only repair surfaces separately", async () => {


### PR DESCRIPTION
## Summary

`REQUIRED_INSTALLATION_PERMISSIONS` demands only `pull_requests: read`, but the App **merges / closes / approves / request-changes / update-branch** — all `pull_requests: write`. So an installation configured to *act* with only `read` granted reported **"healthy"** while every action would 403 at runtime. (HIGH — the health surface actively misled the maintainer.)

## Fix
Mirror the existing `checkRunMode → checks:write` conditional: when any installed repo's autonomy **acts** on PR state (`agentRequiresPrWrite`, exported in #1259), upgrade the required `pull_requests` permission `read → write`. This flips the status to `needs_attention` and surfaces the write requirement in the remediation. **Non-acting installations keep the baseline `read`.**

Threaded through all three sites:
- **`refreshInstallationHealthRecords`** — the authoritative computation (status + `missingPermissions`).
- **`enrichInstallationHealth`** — display; upgrades the shown access via `missingPermissions.has("pull_requests")` (which is true only when write was required and ungranted).
- **`buildInstallationRepairDiagnostics`** — display; recomputes `requiresPrWrite` directly from the installed settings.

## Scope
- [x] Backend only (`src/github/backfill.ts`); no schema / migration / binding change

## Validation
- [x] `npm run test:ci` — full gate green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] **Regression:** an acting (`close:auto`) install with only `pull_requests:read` is now `needs_attention` + `missingPermissions:["pull_requests"]` + `requiredPermissions.pull_requests:"write"`. **Contrast:** a non-acting repair surface keeps `pull_requests:"read"`. **Display:** enrich + repair both surface `write` for the acting/missing case.
- [x] Every changed line + branch covered
- [x] Rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; the change only makes the health report *more* accurate
- [x] No `site/` / `CNAME` / `lovable`