### PR TITLE
fix(orb): require anonymization secret for export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,8 +164,8 @@ GITTENSORY_REVIEW_DRAFT=false
 # --- Gittensory Orb (#1255; opt-in fleet-calibration export) ---
 # Orb is the central collector + analytics that aggregates anonymized gate-calibration data UP from
 # self-hosted instances. There is NO separate Orb GitHub App and NO setup wizard: your existing main App
-# already records de-noised outcomes (merged/closed + reversals) locally — flip ORB_ENABLED to ship an
-# anonymized signal to gittensory's collector. That's it: no second App, no extra secret, no wizard.
+# already records de-noised outcomes (merged/closed + reversals) locally — set ORB_ENABLED plus a
+# stable per-instance ORB_WEBHOOK_SECRET to ship an anonymized signal to gittensory's collector.
 #
 # SECURITY MODEL (this image is self-hosted by many independent maintainers):
 #   • The image bakes NO secrets. repo/PR identifiers are HMAC-anonymized with YOUR own ORB_WEBHOOK_SECRET
@@ -173,7 +173,7 @@ GITTENSORY_REVIEW_DRAFT=false
 #   • Export carries NO shared key. The collector accepts the batch as untrusted, rate-limited, aggregate-only
 #     telemetry. Nothing in the container, if leaked, can compromise the collector, other operators, or any App.
 # ORB_ENABLED=false                          # master switch: set to true to export fleet-calibration signal (default off)
-# ORB_WEBHOOK_SECRET=<stable-random-string>  # the per-instance HMAC key used to anonymize repo/PR identifiers
+# ORB_WEBHOOK_SECRET=<32+ char stable random string>  # required when ORB_ANONYMIZE=true; per-instance HMAC key
 # ORB_AIR_GAP=false                          # set to true to compute locally but never send to the collector
 # ORB_ANONYMIZE=true                         # HMAC-hash repo/PR before export (default true; false = raw names)
 # ORB_COLLECTOR_URL=https://gittensory-api.aethereal.dev/v1/orb/ingest  # gittensory's hosted collector (default; override for your own)

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -134,6 +134,10 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
   const collectorUrl = process.env.ORB_COLLECTOR_URL ?? "https://gittensory-api.aethereal.dev/v1/orb/ingest";
   const secret = process.env.ORB_WEBHOOK_SECRET ?? "";
   const anonymize = (process.env.ORB_ANONYMIZE ?? "true").toLowerCase() !== "false";
+  if (anonymize && secret.trim().length < 32) {
+    incr("gittensory_orb_export_errors_total", { reason: "missing_anonymization_secret" });
+    return 0;
+  }
   const instance = instanceId();
 
   // Read this instance's export watermark (resumes where the last run left off).

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -57,7 +57,7 @@ describe("exportOrbBatch() — reads review_audit, ships anonymized reversal-awa
   beforeEach(() => {
     resetMetrics();
     process.env.ORB_ENABLED = "true";
-    process.env.ORB_WEBHOOK_SECRET = "test-secret";
+    process.env.ORB_WEBHOOK_SECRET = "test-secret-at-least-32-bytes-long";
     process.env.ORB_APP_ID = "555";
     process.env.ORB_ANONYMIZE = "true";
     delete process.env.ORB_AIR_GAP;
@@ -164,9 +164,32 @@ describe("exportOrbBatch() — reads review_audit, ships anonymized reversal-awa
     expect(sig).toMatch(/^sha256=[a-f0-9]{64}$/);
   });
 
-  it("falls back to GITHUB_APP_ID for the instance id and applies secret/anonymize defaults when ORB_* are unset", async () => {
+  it("fails closed when anonymized export has no strong per-instance secret", async () => {
+    delete process.env.ORB_WEBHOOK_SECRET;
+    delete process.env.ORB_ANONYMIZE; // → defaults to "true"
+    const db = makeDb();
+    await audit(db, "owner/repo", 1, "gate_decision", "merge", "2026-01-01T00:00:00Z");
+    await audit(db, "owner/repo", 1, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+    let called = false;
+    const n = await exportOrbBatch(db, 200, async () => { called = true; return new Response(null, { status: 200 }); });
+    expect(n).toBe(0);
+    expect(called).toBe(false);
+    expect(await renderMetrics()).toContain(`gittensory_orb_export_errors_total{reason="missing_anonymization_secret"} 1`);
+  });
+
+  it("fails closed when anonymized export has a weak per-instance secret", async () => {
+    process.env.ORB_WEBHOOK_SECRET = "short-secret";
+    const db = makeDb();
+    await audit(db, "owner/repo", 1, "gate_decision", "merge", "2026-01-01T00:00:00Z");
+    await audit(db, "owner/repo", 1, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+    let called = false;
+    const n = await exportOrbBatch(db, 200, async () => { called = true; return new Response(null, { status: 200 }); });
+    expect(n).toBe(0);
+    expect(called).toBe(false);
+  });
+
+  it("falls back to GITHUB_APP_ID for the instance id while using a configured anonymization secret", async () => {
     delete process.env.ORB_APP_ID; // → falls through to GITHUB_APP_ID
-    delete process.env.ORB_WEBHOOK_SECRET; // → secret defaults to ""
     delete process.env.ORB_ANONYMIZE; // → defaults to "true"
     (process.env as NodeJS.Dict<string>).GITHUB_APP_ID = "999";
     const db = makeDb();


### PR DESCRIPTION
### Motivation

- Prevent accidental de-anonymization when `ORB_ANONYMIZE` is enabled but `ORB_WEBHOOK_SECRET` is missing or trivially short, which allowed empty-key HMACs to be shipped to the collector.

### Description

- Require a stable per-instance anonymization secret when anonymization is on by returning early from `exportOrbBatch` if `ORB_WEBHOOK_SECRET` is not set or is shorter than 32 characters, and increment a metric `gittensory_orb_export_errors_total` with `reason=missing_anonymization_secret` (change in `src/selfhost/orb-collector.ts`).
- Update unit tests in `test/unit/selfhost-orb-collector.test.ts` to use a long test secret for normal flows and add regression tests that assert export fails closed and does not call the collector when the secret is missing or weak.
- Clarify the sample environment guidance in `.env.example` to document that `ORB_WEBHOOK_SECRET` is required (32+ characters) when `ORB_ANONYMIZE=true`.

### Testing

- Ran the targeted unit tests with `npm test -- --run test/unit/selfhost-orb-collector.test.ts`, and all tests in that file passed.
- Verified `git diff --check` produced no spacing/conflict issues locally.
- Attempted to run the full gate with `npm run test:ci`, which began but was blocked by local type resolution for optional native dependencies (`pg` / `ioredis`) during `tsc` and thus did not complete in this environment.
- `npm audit --audit-level=moderate` was attempted but could not complete due to the registry audit endpoint returning `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c49a96da8832cac1087c6019bfe78)