### PR TITLE
feat(orb): surface fleet calibration analytics via dashboard + MCP

### DIFF
--- a/apps/gittensory-ui/src/routes/app.operator.tsx
+++ b/apps/gittensory-ui/src/routes/app.operator.tsx
@@ -24,6 +24,7 @@ type OperatorDashboardResponse = {
   noiseReduction: Array<{ label: string; value: number; spark: number[] }>;
   weeklyReport: string[];
   recommendationQuality?: RecommendationQualityReport;
+  fleetMetrics?: FleetMetrics;
   weeklyValueReport?: {
     freshness: { status: string; latestRollupDay?: string | null };
     warnings: string[];
@@ -31,6 +32,28 @@ type OperatorDashboardResponse = {
   };
   upstreamDrift?: { status?: string } | null;
 };
+
+type FleetMetrics = {
+  windowDays: number;
+  instanceCount: number;
+  fleet: {
+    mergePrecision: number | null;
+    closePrecision: number | null;
+    fpRate: number | null;
+    reversalRate: number | null;
+    cycleP50Ms: number | null;
+    cycleP95Ms: number | null;
+  };
+  outliers: Array<{ instanceId: string; metric: string; value: number; fleetMedian: number }>;
+};
+
+const formatPct = (v: number | null): string => (v === null ? "—" : `${Math.round(v * 100)}%`);
+const formatMs = (v: number | null): string =>
+  v === null
+    ? "—"
+    : v >= 3_600_000
+      ? `${(v / 3_600_000).toFixed(1)}h`
+      : `${Math.round(v / 60_000)}m`;
 
 type RecommendationQualityReport = {
   windowDays: number;
@@ -144,6 +167,51 @@ function OperatorDashboard() {
               />
             ))}
           </section>
+
+          {data.fleetMetrics && data.fleetMetrics.instanceCount > 0 ? (
+            <section className="rounded-token border border-border bg-transparent p-5">
+              <div className="flex items-center gap-2">
+                <BarChart3 className="size-4 text-mint" />
+                <h2 className="font-display text-token-lg font-semibold">Fleet health</h2>
+              </div>
+              <p className="mt-1 max-w-2xl text-token-xs text-muted-foreground">
+                Gate calibration aggregated (median) across {data.fleetMetrics.instanceCount}{" "}
+                self-hosted instance(s) over the last {data.fleetMetrics.windowDays} days.
+              </p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                <Stat
+                  label="Merge precision"
+                  value={formatPct(data.fleetMetrics.fleet.mergePrecision)}
+                  hint="approve → merged"
+                />
+                <Stat
+                  label="Close precision"
+                  value={formatPct(data.fleetMetrics.fleet.closePrecision)}
+                  hint="block → closed"
+                />
+                <Stat
+                  label="False-positive rate"
+                  value={formatPct(data.fleetMetrics.fleet.fpRate)}
+                  hint="approve → reverted/closed"
+                />
+                <Stat
+                  label="Reversal rate"
+                  value={formatPct(data.fleetMetrics.fleet.reversalRate)}
+                  hint="humans overrode the gate"
+                />
+                <Stat
+                  label="Cycle time (p50)"
+                  value={formatMs(data.fleetMetrics.fleet.cycleP50Ms)}
+                  hint="decision → close"
+                />
+                <Stat
+                  label="Instance outliers"
+                  value={String(data.fleetMetrics.outliers.length)}
+                  hint="off the fleet median"
+                />
+              </div>
+            </section>
+          ) : null}
 
           {quality ? (
             <section className="rounded-token border border-border bg-transparent p-5">

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -70,6 +70,7 @@ import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
 import { buildRepoOutcomeCalibration, outcomeCalibrationSummary } from "../services/outcome-calibration";
+import { computeFleetAnalytics } from "../orb/analytics";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -143,6 +144,18 @@ const ownerRepoWindowShape = {
   owner: z.string().min(1),
   repo: z.string().min(1),
   windowDays: z.number().int().positive().optional(),
+};
+
+const windowOnlyShape = {
+  windowDays: z.number().int().positive().optional(),
+};
+
+const fleetAnalyticsOutputSchema = {
+  windowDays: z.number().optional(),
+  instanceCount: z.number().optional(),
+  fleet: z.unknown().optional(),
+  instances: z.array(z.unknown()).optional(),
+  outliers: z.array(z.unknown()).optional(),
 };
 
 const loginShape = {
@@ -1056,6 +1069,17 @@ export class GittensoryMcp {
     );
 
     server.registerTool(
+      "gittensory_get_fleet_analytics",
+      {
+        description:
+          "Operator-only: aggregated gate-calibration analytics across the self-host fleet — median merge/close precision, false-positive + reversal rates, cycle-time percentiles, and per-instance outliers. Measurement only.",
+        inputSchema: windowOnlyShape,
+        outputSchema: fleetAnalyticsOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getFleetAnalytics(input)),
+    );
+
+    server.registerTool(
       "gittensory_get_contributor_profile",
       {
         description: "Return an evidence-backed Gittensory contributor profile for a GitHub login.",
@@ -1919,6 +1943,25 @@ export class GittensoryMcp {
     const report = await buildRepoOutcomeCalibration(this.env, fullName, input.windowDays);
     return {
       summary: outcomeCalibrationSummary(fullName, report.slop),
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // Operator-only gate: the fleet view aggregates ALL self-hosters' calibration, so a session must be an
+  // operator; private-token / static identities are trusted (the same model as the other measurement tools).
+  private async requireOperatorAccess(): Promise<void> {
+    if (this.identity.kind !== "session") return;
+    const scope = await this.loadSessionAccessScope();
+    if (scope.operator) return;
+    throw new Error("Forbidden: operator authority is required for fleet analytics.");
+  }
+
+  private async getFleetAnalytics(input: { windowDays?: number | undefined }): Promise<ToolPayload> {
+    await this.requireOperatorAccess();
+    const report = await computeFleetAnalytics(this.env, input.windowDays !== undefined ? { windowDays: input.windowDays } : {});
+    const merge = report.fleet.mergePrecision !== null ? `${Math.round(report.fleet.mergePrecision * 100)}%` : "n/a";
+    return {
+      summary: `Fleet calibration over ${report.windowDays}d: ${report.instanceCount} instance(s), median merge precision ${merge}, ${report.outliers.length} outlier(s).`,
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -25,6 +25,7 @@ import type {
   ScoringModelSnapshotRecord,
   WeeklyValueReport,
 } from "../types";
+import { computeFleetAnalytics, type FleetAnalytics } from "../orb/analytics";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
 import { buildRecommendationQualityReport, type RecommendationQualityReport } from "./recommendation-quality-report";
@@ -57,6 +58,7 @@ export type OperatorDashboardPayload = {
   registry: RegistrySnapshot | null;
   scoringModel: ScoringModelSnapshotRecord | null;
   upstreamDrift: UpstreamStatus;
+  fleetMetrics: FleetAnalytics;
 };
 
 const USAGE_WINDOW_DAYS = 7;
@@ -79,6 +81,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     mcpCompatibilityAdoption,
     commandUsefulness,
     recommendationQuality,
+    fleetMetrics,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -95,6 +98,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     summarizeMcpCompatibilityAdoption(env, usageSince),
     getCommandUsefulnessSummary(env),
     buildRecommendationQualityReport(env, { windowDays: 90 }),
+    computeFleetAnalytics(env, { windowDays: 90 }),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -145,6 +149,16 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
         delta: "current health cache",
       },
       { label: "Rate-limit events", value: String(rateLimits.length), delta: "latest observations" },
+      {
+        label: "Fleet instances",
+        value: String(fleetMetrics.instanceCount),
+        delta: fleetMetrics.outliers.length > 0 ? `${fleetMetrics.outliers.length} outlier(s)` : "self-host fleet",
+      },
+      {
+        label: "Fleet merge precision",
+        value: fleetMetrics.fleet.mergePrecision !== null ? `${Math.round(fleetMetrics.fleet.mergePrecision * 100)}%` : "—",
+        delta: "median across the fleet",
+      },
     ],
     noiseReduction: [
       {
@@ -177,6 +191,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     registry,
     scoringModel: scoring,
     upstreamDrift,
+    fleetMetrics,
   };
 }
 

--- a/test/unit/mcp-fleet-analytics.test.ts
+++ b/test/unit/mcp-fleet-analytics.test.ts
@@ -1,0 +1,60 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new GittensoryMcp(env, identity) : new GittensoryMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "fleet-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+let seq = 0;
+async function seedMergeSignals(env: Env, instance: string, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await env.DB
+      .prepare(`INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag) VALUES (?, ?, ?, 'merge', 'merged', 'none')`)
+      .bind(instance, `repo${seq}`, `pr${seq++}`)
+      .run();
+  }
+}
+
+describe("gittensory_get_fleet_analytics MCP tool", () => {
+  it("returns fleet analytics for a trusted (non-session) identity, honoring windowDays", async () => {
+    const env = createTestEnv();
+    await seedMergeSignals(env, "inst1", 5); // ≥ MIN_DECIDED → counts toward the fleet
+    const result = await (await connect(env)).callTool({ name: "gittensory_get_fleet_analytics", arguments: { windowDays: 30 } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { windowDays: number; instanceCount: number; fleet: { mergePrecision: number } };
+    expect(data.windowDays).toBe(30);
+    expect(data.instanceCount).toBe(1);
+    expect(data.fleet.mergePrecision).toBe(1);
+  });
+
+  it("returns an empty report (n/a summary) when there is no data and no windowDays", async () => {
+    const result = await (await connect(createTestEnv())).callTool({ name: "gittensory_get_fleet_analytics", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { instanceCount: number };
+    expect(data.instanceCount).toBe(0);
+  });
+
+  it("allows an operator session", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "boss" });
+    const { session } = await createSessionForGitHubUser(env, { login: "boss", id: 1 });
+    const result = await (await connect(env, { kind: "session", actor: "boss", session })).callTool({ name: "gittensory_get_fleet_analytics", arguments: {} });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("forbids a non-operator session", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "boss" });
+    const { session } = await createSessionForGitHubUser(env, { login: "rando", id: 2 });
+    const result = await (await connect(env, { kind: "session", actor: "rando", session })).callTool({ name: "gittensory_get_fleet_analytics", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/operator authority/i);
+  });
+});

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -23,6 +23,39 @@ describe("operator dashboard payload", () => {
     expect(payload.usageSummary).toMatchObject({ totalEvents: expect.any(Number), activeActors: expect.any(Number) });
     expect(payload.commandUsefulness.totals).toMatchObject({ feedbackCount: expect.any(Number) });
     expect(serialized).not.toMatch(FORBIDDEN_EXPORT_TERMS);
+    // Empty fleet → instanceCount 0, null precision card ("—"), no-outlier delta.
+    expect(payload.fleetMetrics.instanceCount).toBe(0);
+    expect(payload.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Fleet instances", value: "0", delta: "self-host fleet" }),
+        expect.objectContaining({ label: "Fleet merge precision", value: "—" }),
+      ]),
+    );
+  });
+
+  it("surfaces populated fleet metrics + outliers from orb_signals", async () => {
+    const env = createTestEnv();
+    let n = 0;
+    const seed = async (instance: string, count: number, outcome: string): Promise<void> => {
+      for (let i = 0; i < count; i++) {
+        await env.DB
+          .prepare(`INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag) VALUES (?, ?, ?, 'merge', ?, 'none')`)
+          .bind(instance, `r${n}`, `p${n++}`, outcome)
+          .run();
+      }
+    };
+    await seed("good1", 5, "merged"); // precision 1.0
+    await seed("good2", 5, "merged"); // precision 1.0
+    await seed("bad", 5, "closed"); // precision 0.0 → outlier vs the median (1.0)
+    const payload = await buildOperatorDashboardPayload(env);
+    expect(payload.fleetMetrics.instanceCount).toBe(3);
+    expect(payload.fleetMetrics.outliers.map((o) => o.instanceId)).toContain("bad");
+    expect(payload.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Fleet instances", value: "3", delta: "1 outlier(s)" }),
+        expect.objectContaining({ label: "Fleet merge precision", value: "100%" }),
+      ]),
+    );
   });
 
   it("picks the newest rollup day for adoption insights", () => {


### PR DESCRIPTION
## Summary

Exposes the fleet calibration analytics (`computeFleetAnalytics`, shipped in #1256) through the two operator-facing read surfaces that were deferred from #1255:

- **`gittensory_get_fleet_analytics` MCP tool** — operator-gated (a session must carry operator authority; trusted token/static identities pass, mirroring the other measurement tools), measurement only. Lets the owner audit fleet drift directly from an agent harness. Returns the same shape as the existing `/v1/internal/fleet/analytics` endpoint.
- **Operator dashboard `fleetMetrics`** — `buildOperatorDashboardPayload` now folds in the 90-day fleet report. Two summary cards (`Fleet instances`, `Fleet merge precision`) join the metrics grid, and a **Fleet health** panel on the operator route renders median merge/close precision, false-positive + reversal rates, p50 cycle time, and the per-instance outlier count.

Both surfaces are read-only aggregates over the anonymized `orb_signals` (HMAC'd instance/repo/pr hashes + counts); no per-repo identity or sensitive terms cross the boundary. The MCP result still runs through `redactSensitiveForMcp`, and the operator-dashboard test asserts the serialized payload contains none of the forbidden export terms.

Advances #1255 (the collector + analytics fn + internal endpoint landed in #1256; the per-instance App retirement + always-on hardwire is #1257). Auto-tune wiring and the live end-to-end fleet loop remain as separate follow-ups.

## Scope

- [x] Narrow, in `wantedPaths` (`src/`, `apps/gittensory-ui/`, `test/`)
- [x] No `blockedPaths`, no secrets / wallets / hotkeys / trust scores / reward values
- [x] No changelog edit; no generated-artifact drift (`ui:openapi:check` clean — the operator route is not an OpenAPI surface)

## Validation

- [x] `npm run test:ci` — green (actionlint, db:migrations:check, typecheck, test:coverage, test:workers, build:mcp, test:mcp-pack, ui:openapi:check, ui:version-audit, ui:lint, ui:typecheck, ui:test, ui:build)
- [x] `npm audit --audit-level=moderate` — clean
- [x] Patch coverage: **every changed line and branch** in `src/mcp/server.ts` and `src/services/operator-dashboard.ts` covered (verified against the v8 JSON report) — both sides of the metric-card ternaries and all three `requireOperatorAccess` arms (non-session / operator session / non-operator session)
- [x] New `test/unit/mcp-fleet-analytics.test.ts` (4 cases incl. the operator-gate matrix) + extended `test/unit/operator-dashboard.test.ts` (empty-fleet and populated-fleet-with-outlier cases)

## Safety

- [x] Operator-only: the MCP gate throws for non-operator sessions (negative-path test included); the data is fleet-aggregate, never per-repo
- [x] No public/private boundary leak — anonymized hashes + numeric aggregates only; forbidden-terms assertion in the operator-dashboard test
- [x] No auth/CORS/session changes

## UI Evidence

The operator route gains a **Fleet health** section (median precision / FP rate / reversal rate / cycle p50 / outliers) plus two cards in the existing metrics grid. It renders only when `instanceCount > 0`, so deployments with no fleet data see no empty panel. (Operator-only route; no public-facing visual change.)