### PR TITLE
fix(github): preserve install health least privilege

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -731,9 +731,9 @@ export function enrichInstallationHealth(health: InstallationHealthRecord) {
   const requiredPermissions = {
     ...REQUIRED_INSTALLATION_PERMISSIONS,
     ...(missingPermissions.has("checks") ? OPTIONAL_CHECK_RUN_PERMISSION : {}),
-    // pull_requests is missing ONLY when the refresh required write (an acting autonomy) and it was not granted, so
-    // surface the write requirement in the remediation rather than the baseline read. (#audit-install-health)
-    ...(missingPermissions.has("pull_requests") ? OPTIONAL_PR_WRITE_PERMISSION : {}),
+    // Persisted health stores only the missing permission name. If pull_requests is already granted at read level,
+    // a missing pull_requests entry can only mean an acting autonomy needs write; otherwise preserve baseline read.
+    ...(missingPermissions.has("pull_requests") && permissionSatisfies(health.permissions.pull_requests, "read") ? OPTIONAL_PR_WRITE_PERMISSION : {}),
   };
   return {
     ...health,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -457,6 +457,27 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("keeps baseline pull_requests:read remediation when the permission is absent (#audit-install-health least privilege)", () => {
+    const health = enrichInstallationHealth({
+      installationId: 127,
+      accountLogin: "JSONbored",
+      repositorySelection: "selected",
+      installedReposCount: 1,
+      registeredInstalledCount: 1,
+      status: "needs_attention",
+      missingPermissions: ["pull_requests"],
+      missingEvents: [],
+      permissions: { metadata: "read", issues: "write" },
+      events: ["issues", "issue_comment", "pull_request", "repository"],
+      checkedAt: "2026-06-05T00:00:00.000Z",
+    });
+
+    expect(health.requiredPermissions).toMatchObject({ pull_requests: "read" });
+    expect(health.permissionRemediation).toEqual(
+      expect.arrayContaining([expect.objectContaining({ permission: "pull_requests", requiredAccess: "read", ok: false, action: "Set repository permission pull_requests to read." })]),
+    );
+  });
+
   it("requires Checks write only for repos with check runs enabled", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
### Motivation
- Prevent the install-health display from over-requesting `pull_requests:write` when the persisted `missingPermissions` list contains only the permission name and not the required access level, preserving least privilege.

### Description
- Change `enrichInstallationHealth` to only upgrade `pull_requests` to `write` when `missingPermissions` contains `pull_requests` and the stored `health.permissions.pull_requests` satisfies `read` (indicating an upgrade to `write` is required); otherwise keep the baseline `pull_requests: read` remediation. (`src/github/backfill.ts`)
- Add a unit test that covers the least-privilege display case where `pull_requests` is absent entirely and the remediation should request `read` rather than `write`. (`test/unit/backfill.test.ts`)

### Testing
- Ran the focused unit tests with `npx vitest run test/unit/backfill.test.ts -t "pull_requests"`, and the targeted tests passed.
- Attempted coverage with `npm run test:coverage -- test/unit/backfill.test.ts`, but V8 coverage remapping failed with `TypeError: jsTokens is not a function` while generating the local coverage report.
- A full `npm run test:ci` could not complete in this environment due to local dependency/registry issues (`pg` / `ioredis` type resolution and a `403` from the registry), so the complete gate was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c4ff217e4832ca383573ad24d6a18)