### PR TITLE
fix(selfhost): scope Promtail Docker discovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,8 +309,11 @@ services:
     image: grafana/promtail:latest
     restart: unless-stopped
     profiles: ["observability"]
-    command: ["-config.file=/etc/promtail/promtail-config.yml"]
+    command: ["-config.file=/etc/promtail/promtail-config.yml", "-config.expand-env=true"]
     depends_on: [loki, docker-proxy]
+    environment:
+      # Promtail expands this into its Docker label filter so discovery stays inside this Compose project.
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-gittensory}
     volumes:
       - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
       # Persist read positions so restarts don't re-ship the whole log history.

--- a/promtail/promtail-config.yml
+++ b/promtail/promtail-config.yml
@@ -32,11 +32,11 @@ scrape_configs:
       # Read-only Docker API exposed by the docker-proxy service (no raw socket in this container).
       - host: tcp://docker-proxy:2375
         refresh_interval: 15s
-        # Only containers in THIS compose project (set automatically by compose).
-        # Avoids scraping unrelated containers on a shared host.
+        # Only containers in THIS compose project. A bare label filter matches every
+        # Docker Compose stack, so pin the exact project value expanded by Promtail.
         filters:
           - name: label
-            values: ["com.docker.compose.project"]
+            values: ["com.docker.compose.project=${COMPOSE_PROJECT_NAME}"]
 
     relabel_configs:
       # Compose service name -> `service` label (e.g. gittensory, prometheus, loki).


### PR DESCRIPTION
### Motivation
- Prevent Promtail from discovering and shipping logs from unrelated Docker Compose projects on a shared host by tightening the Docker service-discovery label filter.

### Description
- Change Promtail Docker SD filter to match the exact Compose project label value using `com.docker.compose.project=${COMPOSE_PROJECT_NAME}` in `promtail/promtail-config.yml`.
- Enable Promtail environment expansion (`-config.expand-env=true`) and pass `COMPOSE_PROJECT_NAME` into the Promtail container via `docker-compose.yml` so the label filter resolves at runtime.

### Testing
- Ran `git diff --check` and a local Node semantic verification that asserts the Promtail filter string and Promtail env expansion wiring, which succeeded.
- Attempted the full gate with `npm run test:ci`, which ran many unit/integration suites but failed in this environment due to unrelated test timeouts and a Vitest coverage remap error (`TypeError: jsTokens is not a function`).
- Attempted `npm audit --audit-level=moderate`, which could not complete here because the audit endpoint returned `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c5958c2f4832cab266f75b0692d5a)