### PR TITLE
docs(orb): correct the anonymization-key description in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,9 +188,10 @@ GITTENSORY_REVIEW_DRAFT=false
 #
 # WHAT IS SENT (per resolved PR, hourly): the gate verdict, the realized outcome (merged/closed), a reversal
 # flag, a bucketed reason category, and cycle time. NEVER sent: repo/owner/PR names, commit SHAs, code,
-# diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized with a DEDICATED key derived from YOUR
-# OWN App private key (GITHUB_APP_PRIVATE_KEY) — high-entropy and independent of your webhook secret, so even
-# gittensory (running the collector) can never de-anonymize them.
+# diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized with a DEDICATED, randomly-generated
+# per-instance secret created once and stored in your instance's own database (never your App private key or
+# webhook secret) — and the collector never holds it, so even gittensory (running the collector) can never
+# de-anonymize them.
 # The export carries no shared key; the collector treats it as untrusted, rate-limited, aggregate-only data.
 # ORB_AIR_GAP=false                          # air-gapped/OFFLINE deployments only: compute locally, never send
 # ORB_ANONYMIZE=true                         # HMAC-hash repo/PR before export (default true; false = raw names)


### PR DESCRIPTION
## Summary
The Orb exporter anonymizes repo/PR identifiers with a **dedicated, randomly-generated per-instance secret** stored in `system_flags` (introduced in #1257), not a key derived from the App private key. The `.env.example` TELEMETRY NOTICE still described the old App-private-key derivation; this corrects the prose to match the shipped code (the `src/selfhost/orb-collector.ts` comments were already updated in #1257).

## Scope
Doc-only: one prose block in `.env.example`. No code/behavior change.

## Validation
`.env.example` only — no tests affected.