### PR TITLE
fix(sweep): converge the re-gate sweep over all open PRs via an internal marker

### DIFF
--- a/migrations/0062_pr_last_regated_at.sql
+++ b/migrations/0062_pr_last_regated_at.sql
@@ -1,0 +1,24 @@
+-- Sweep convergence: let the scheduled re-gate sweep advance through ALL open PRs.
+--
+-- BEFORE: selectRegateCandidates() sorts open PRs by staleness keyed on the PullRequestRecord's `updatedAt`,
+-- which toPullRequestRecordFromRow resolves as `payload.updated_at ?? row.updatedAt` — i.e. GitHub's value. A
+-- review normally freshens a PR because its comment/label WRITE bumps GitHub's updated_at (and fires a sync
+-- webhook). But when agent actions are SUPPRESSED (dry-run, or a paused/permission-blocked repo) that write
+-- never happens, so the 25 stalest PRs stay pinned at the head of the sort forever and the sweep re-selects the
+-- SAME 25 every tick, never covering the rest of the queue (observed: 5x recompute of "25 stale; 3 flagged").
+--
+-- AFTER: the sweep stamps an INTERNAL last_regated_at marker on every PR it re-gates (a plain D1 UPDATE, not a
+-- GitHub write — so it advances even when GitHub writes are suppressed). selectRegateCandidates keys the sort on
+-- last_regated_at instead of GitHub's updated_at, so a just-regated PR sorts freshest and the next sweep picks
+-- the next-stalest — full coverage of all open PRs in ceil(open/SWEEP_MAX_PRS) sweeps, convergent regardless of
+-- suppression. The GitHub-updatedAt freshness window is kept ONLY as the "don't race an in-flight webhook" guard.
+--
+-- last_regated_at is gittensory-computed (sweep-written), keyed to the PR (not the head SHA), and OMITTED from
+-- the upsertPullRequestFromGitHub SET clause so a later GitHub sync cannot clobber it. Mirrors approved_head_sha
+-- (0053) / merge_blocked_sha (0052). Nullable / no default → backward-compatible (existing rows = NULL = never
+-- swept = maximally stale = picked first).
+--
+-- pull_requests IS a Drizzle table (src/db/schema.ts), so this column is added to the Drizzle schema too; this
+-- raw migration is the production DDL applied by `wrangler d1 migrations apply` (drizzle-kit is not the runtime
+-- migrator here).
+ALTER TABLE pull_requests ADD COLUMN last_regated_at TEXT;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2563,6 +2563,20 @@ export async function markPullRequestApproved(env: Env, fullName: string, number
     .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number), eq(pullRequests.headSha, headSha)));
 }
 
+/** Sweep convergence: stamp the timestamp the scheduled re-gate sweep just recomputed this PR. A plain D1 UPDATE
+ *  — NOT routed through the agent-action-executor chokepoint (#1258) — so it advances even when GitHub writes are
+ *  suppressed (dry-run / paused). selectRegateCandidates orders the sweep by last_regated_at, so a just-regated PR
+ *  sorts freshest and the next sweep picks the next-stalest → the sweep converges over all open PRs. Keyed to the
+ *  PR (not the head SHA): a re-gate stamps the PR regardless of which commit is live. */
+export async function markPullRequestRegated(env: Env, fullName: string, number: number): Promise<void> {
+  const db = getDb(env.DB);
+  const now = nowIso();
+  await db
+    .update(pullRequests)
+    .set({ lastRegatedAt: now, updatedAt: now })
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number)));
+}
+
 export async function getIssue(env: Env, fullName: string, number: number): Promise<IssueRecord | null> {
   const db = getDb(env.DB);
   const [row] = await db.select().from(issues).where(and(eq(issues.repoFullName, fullName), eq(issues.number, number))).limit(1);
@@ -4010,6 +4024,8 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     mergeBlockedSha: row.mergeBlockedSha,
     mergeBlockedReason: row.mergeBlockedReason,
     approvedHeadSha: row.approvedHeadSha,
+    // Read straight from the row, NEVER the GitHub payload — this is a gittensory-internal sweep marker.
+    lastRegatedAt: row.lastRegatedAt,
   };
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -288,6 +288,11 @@ export const pullRequests = sqliteTable(
     // new commit makes the bot re-approve the new code. gittensory-computed (executor-written), omitted from
     // the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors merge_blocked_sha.)
     approvedHeadSha: text("approved_head_sha"),
+    // Sweep convergence: the timestamp the scheduled re-gate sweep last recomputed this PR. selectRegateCandidates
+    // orders the sweep by THIS marker (not GitHub's updated_at) so it advances through all open PRs even when the
+    // review WRITE that would bump updated_at is suppressed (dry-run / paused). gittensory-computed (sweep-written),
+    // omitted from the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors approved_head_sha.)
+    lastRegatedAt: text("last_regated_at"),
     createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
     updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
   },

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -39,6 +39,7 @@ import {
   markInstallationDeleted,
   markRepositoriesRemovedFromInstallation,
   persistAdvisory,
+  markPullRequestRegated,
   recordAgentCommandFeedback,
   recordAuditEvent,
   recordGateBlockOutcome,
@@ -582,6 +583,13 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
         console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
       });
     }
+    // Stamp the internal re-gate marker so the next sweep advances to the next-stalest PRs. This is a plain D1
+    // write (not a GitHub action), so it converges even when agent actions are suppressed — the dry-run/pause
+    // non-convergence fix. (#audit-sweep-converge) Degrade quietly on a D1 error: the PR is simply re-selected
+    // next sweep (the prior behaviour), never lost.
+    await markPullRequestRegated(env, repoFullName, pr.number).catch((error) => {
+      console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+    });
   }
   await recordAuditEvent(env, {
     eventType: "agent.sweep.regate",

--- a/src/settings/agent-sweep.ts
+++ b/src/settings/agent-sweep.ts
@@ -17,10 +17,16 @@ export const SWEEP_MAX_PRS = 25;
 export const SWEEP_FRESHNESS_MS = 2 * 60 * 1000;
 
 /**
- * Select the open PRs a single repo sweep should recompute: drop drafts and anything updated within
- * `freshnessWindowMs` of `now` (recently active → already gated), then take the `max` STALEST by `updatedAt`
- * ascending (a missing `updatedAt` sorts oldest — it has gone longest without a recorded refresh). Pure and
- * deterministic: same inputs → same ordered batch, which is what makes the sweep idempotent.
+ * Select the open PRs a single repo sweep should recompute: drop drafts and anything a webhook touched within
+ * `freshnessWindowMs` of `now` (don't race an in-flight review), then take the `max` PRs the sweep has gone
+ * longest WITHOUT re-gating — ordered by `lastRegatedAt` ascending, NOT GitHub's `updatedAt`.
+ *
+ * Why two different timestamps (#audit-sweep-converge): the review WRITE that bumps GitHub's `updatedAt` is
+ * SUPPRESSED under dry-run / pause, so ordering the sweep by `updatedAt` pins the stalest PRs forever and it
+ * never advances. The sweep instead stamps its own `lastRegatedAt` marker on every pass (a D1 write, never
+ * suppressed), so a just-regated PR sorts freshest and the next pass covers the next-stalest — full coverage of
+ * all open PRs in ceil(open/max) sweeps. GitHub's `updatedAt` is used ONLY for the freshness skip (a PR a
+ * webhook is actively gating), never for the sort. Pure + deterministic: same inputs → same ordered batch.
  */
 export function selectRegateCandidates(input: {
   pulls: PullRequestRecord[];
@@ -32,17 +38,27 @@ export function selectRegateCandidates(input: {
   const max = input.max ?? SWEEP_MAX_PRS;
   const nowMs = Date.parse(input.now);
   const freshCutoff = Number.isFinite(nowMs) ? nowMs - freshnessWindowMs : Number.NaN;
-  const staleness = (pr: PullRequestRecord): number => {
+  // Don't-race-webhook guard: a PR whose GitHub `updatedAt` is within the window was almost certainly just gated
+  // by its webhook. A missing/unparseable timestamp = not recently touched = eligible (epoch).
+  const webhookFreshness = (pr: PullRequestRecord): number => {
     const updated = pr.updatedAt ? Date.parse(pr.updatedAt) : Number.NaN;
-    // A missing/unparseable timestamp is treated as maximally stale (epoch) so it is never starved.
     return Number.isFinite(updated) ? updated : 0;
+  };
+  // Progress key: when the SWEEP last re-gated this PR. Falls back to createdAt, then epoch, so a never-regated
+  // PR sorts maximally stale and is picked first; ties broken by PR number. This is the convergence key — it
+  // advances on every sweep regardless of whether GitHub writes are suppressed.
+  const regateProgress = (pr: PullRequestRecord): number => {
+    const regated = pr.lastRegatedAt ? Date.parse(pr.lastRegatedAt) : Number.NaN;
+    if (Number.isFinite(regated)) return regated;
+    const created = pr.createdAt ? Date.parse(pr.createdAt) : Number.NaN;
+    return Number.isFinite(created) ? created : 0;
   };
   return input.pulls
     .filter((pr) => pr.state === "open" && !pr.isDraft)
     .filter((pr) => {
       if (!Number.isFinite(freshCutoff)) return true;
-      return staleness(pr) <= freshCutoff;
+      return webhookFreshness(pr) <= freshCutoff;
     })
-    .sort((a, b) => staleness(a) - staleness(b) || a.number - b.number)
+    .sort((a, b) => regateProgress(a) - regateProgress(b) || a.number - b.number)
     .slice(0, Math.max(0, max));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -422,6 +422,11 @@ export type PullRequestRecord = {
    *  disposition while approvedHeadSha === headSha (this commit is already approved by the bot); a new commit
    *  clears the match so the bot may re-approve the new code. Mirrors mergeBlockedSha. */
   approvedHeadSha?: string | null | undefined;
+  /** Sweep convergence: the timestamp the scheduled re-gate sweep last recomputed this PR. selectRegateCandidates
+   *  orders by this marker (not GitHub's updatedAt) so the sweep advances through all open PRs even when the
+   *  review write that would bump updatedAt is suppressed (dry-run / paused). Sweep-written; read straight from
+   *  the row (never the GitHub payload). */
+  lastRegatedAt?: string | null | undefined;
 };
 
 export type IssueRecord = {

--- a/test/unit/agent-sweep.test.ts
+++ b/test/unit/agent-sweep.test.ts
@@ -18,55 +18,119 @@ function pr(overrides: Partial<PullRequestRecord> & { number: number }): PullReq
 }
 
 describe("selectRegateCandidates (#777 re-gate sweep selection)", () => {
-  it("drops PRs updated within the freshness window (recently gated by their webhook)", () => {
-    const pulls = [pr({ number: 1, updatedAt: minutesAgo(1) }), pr({ number: 2, updatedAt: minutesAgo(120) })];
-    const picked = selectRegateCandidates({ pulls, now: NOW });
-    expect(picked.map((p) => p.number)).toEqual([2]); // #1 updated 1m ago is inside the 2-min freshness window
+  describe("don't-race-webhook freshness guard (GitHub updatedAt)", () => {
+    it("drops PRs whose GitHub updatedAt is within the freshness window (a webhook is gating them)", () => {
+      const pulls = [pr({ number: 1, updatedAt: minutesAgo(1) }), pr({ number: 2, updatedAt: minutesAgo(120) })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([2]); // #1 updated 1m ago is inside the 2-min window
+    });
+
+    it("treats a missing updatedAt as NOT recently touched (eligible, never starved by the freshness guard)", () => {
+      const pulls = [pr({ number: 1, updatedAt: minutesAgo(1) }), pr({ number: 2 })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([2]); // #1 fresh → dropped; #2 has no updatedAt → eligible
+    });
+
+    it("keeps a PR whose lastRegatedAt is old but whose updatedAt is fresh OUT (the guard wins over the sort key)", () => {
+      const pulls = [pr({ number: 1, updatedAt: minutesAgo(1), lastRegatedAt: minutesAgo(999) })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([]); // stalest by re-gate, but a webhook just touched it → skip
+    });
+
+    it("live case: when updatedAt and lastRegatedAt move together, the PR is eligible once outside the window (not double-excluded)", () => {
+      const pulls = [pr({ number: 1, updatedAt: minutesAgo(120), lastRegatedAt: minutesAgo(120) })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([1]); // both old → freshness allows it, re-gate orders it
+    });
+
+    it("keeps every open non-draft PR when `now` is unparseable (no freshness cutoff possible)", () => {
+      const pulls = [pr({ number: 1, createdAt: minutesAgo(5) }), pr({ number: 2, createdAt: minutesAgo(600) }), pr({ number: 3, isDraft: true })];
+      const picked = selectRegateCandidates({ pulls, now: "not-a-date", freshnessWindowMs: 30 * 60 * 1000 });
+      expect(picked.map((p) => p.number)).toEqual([2, 1]); // drafts still excluded; both non-draft kept, stalest-created first
+    });
   });
 
-  it("orders the stalest first and bounds to max (rate-aware)", () => {
-    const pulls = [
-      pr({ number: 1, updatedAt: minutesAgo(120) }),
-      pr({ number: 2, updatedAt: minutesAgo(600) }),
-      pr({ number: 3, updatedAt: minutesAgo(300) }),
-    ];
-    const picked = selectRegateCandidates({ pulls, now: NOW, max: 2 });
-    expect(picked.map((p) => p.number)).toEqual([2, 3]); // stalest (600m), then 300m; 120m dropped by cap
-  });
+  describe("convergence sort key (lastRegatedAt, NOT GitHub updatedAt)", () => {
+    it("INVARIANT arm (i): orders by lastRegatedAt ascending when present — the staler RE-GATE sorts first", () => {
+      // #1 was re-gated recently but created long ago; #2 was re-gated long ago but created recently. The re-gate
+      // marker — not createdAt — drives the order, so #2 (stalest re-gate) comes first.
+      const pulls = [
+        pr({ number: 1, lastRegatedAt: minutesAgo(10), createdAt: minutesAgo(1000) }),
+        pr({ number: 2, lastRegatedAt: minutesAgo(100), createdAt: minutesAgo(1) }),
+      ];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([2, 1]);
+    });
 
-  it("treats a missing updatedAt as maximally stale and never starves it", () => {
-    const pulls = [pr({ number: 1, updatedAt: minutesAgo(120) }), pr({ number: 2 })];
-    const picked = selectRegateCandidates({ pulls, now: NOW });
-    expect(picked.map((p) => p.number)).toEqual([2, 1]); // no-timestamp PR sorts oldest
+    it("INVARIANT arm (ii): falls back to createdAt when lastRegatedAt is absent — oldest-created sorts first", () => {
+      const pulls = [pr({ number: 1, createdAt: minutesAgo(10) }), pr({ number: 2, createdAt: minutesAgo(600) })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([2, 1]); // no lastRegatedAt on either → createdAt orders them
+    });
+
+    it("INVARIANT arm (iii): falls back to the epoch when both lastRegatedAt and createdAt are absent — tie broken by PR number", () => {
+      const pulls = [pr({ number: 9 }), pr({ number: 4 }), pr({ number: 7 })];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([4, 7, 9]); // all epoch → deterministic number order
+    });
+
+    it("a never-regated PR (lastRegatedAt absent) outranks a just-regated one — the property that makes the sweep converge", () => {
+      const pulls = [
+        pr({ number: 1, lastRegatedAt: minutesAgo(1), createdAt: minutesAgo(1000) }), // just re-gated → freshest
+        pr({ number: 2, createdAt: minutesAgo(50) }), // never re-gated → its createdAt (50m) is staler than #1's re-gate (1m)
+      ];
+      const picked = selectRegateCandidates({ pulls, now: NOW });
+      expect(picked.map((p) => p.number)).toEqual([2, 1]);
+    });
+
+    it("bounds the batch to max (rate-aware) after ordering by re-gate staleness", () => {
+      const pulls = [
+        pr({ number: 1, lastRegatedAt: minutesAgo(120) }),
+        pr({ number: 2, lastRegatedAt: minutesAgo(600) }),
+        pr({ number: 3, lastRegatedAt: minutesAgo(300) }),
+      ];
+      const picked = selectRegateCandidates({ pulls, now: NOW, max: 2 });
+      expect(picked.map((p) => p.number)).toEqual([2, 3]); // stalest re-gate (600m), then 300m; 120m dropped by cap
+    });
   });
 
   it("excludes drafts and non-open PRs", () => {
     const pulls = [
-      pr({ number: 1, updatedAt: minutesAgo(120), isDraft: true }),
-      pr({ number: 2, updatedAt: minutesAgo(120), state: "closed" }),
-      pr({ number: 3, updatedAt: minutesAgo(120) }),
+      pr({ number: 1, createdAt: minutesAgo(120), isDraft: true }),
+      pr({ number: 2, createdAt: minutesAgo(120), state: "closed" }),
+      pr({ number: 3, createdAt: minutesAgo(120) }),
     ];
     const picked = selectRegateCandidates({ pulls, now: NOW });
     expect(picked.map((p) => p.number)).toEqual([3]);
   });
 
-  it("is deterministic: equal staleness breaks ties by PR number", () => {
-    const ts = minutesAgo(200);
-    const pulls = [pr({ number: 9, updatedAt: ts }), pr({ number: 4, updatedAt: ts }), pr({ number: 7, updatedAt: ts })];
-    const picked = selectRegateCandidates({ pulls, now: NOW });
-    expect(picked.map((p) => p.number)).toEqual([4, 7, 9]);
-  });
-
-  it("keeps every open non-draft PR when `now` is unparseable (no freshness cutoff possible)", () => {
-    const pulls = [pr({ number: 1, updatedAt: minutesAgo(5) }), pr({ number: 2, updatedAt: minutesAgo(600) }), pr({ number: 3, isDraft: true })];
-    const picked = selectRegateCandidates({ pulls, now: "not-a-date", freshnessWindowMs: 30 * 60 * 1000 });
-    expect(picked.map((p) => p.number)).toEqual([2, 1]); // drafts still excluded; both non-draft kept, stalest first
+  it("REGRESSION (convergence): ceil(50/25)=2 sweeps with all GitHub writes suppressed cover ALL 50 open PRs, none re-selected before the rest are stamped", () => {
+    // Simulate the dry-run / paused world: a re-gate stamps lastRegatedAt (a D1 write, never suppressed) but the
+    // GitHub updatedAt is frozen. Without the fix the same 25 stalest would recur every sweep forever; with it,
+    // two sweeps of 25 (the cap) cover all 50 distinct PRs exactly once — full coverage in ceil(open/max) sweeps.
+    const pulls = Array.from({ length: 50 }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(1000 - i), updatedAt: minutesAgo(1000) }));
+    const stampedAt = new Map<number, string>();
+    const covered = new Set<number>();
+    let sweepNow = nowMs;
+    for (let sweep = 0; sweep < 2; sweep++) {
+      sweepNow += 5 * 60 * 1000; // each sweep runs ~5 min later (outside the freshness window)
+      const now = new Date(sweepNow).toISOString();
+      const view = pulls.map((p) => ({ ...p, lastRegatedAt: stampedAt.get(p.number) ?? p.lastRegatedAt }));
+      const picked = selectRegateCandidates({ pulls: view, now });
+      expect(picked.length).toBe(SWEEP_MAX_PRS); // each sweep fills the cap until the queue is drained
+      for (const p of picked) {
+        expect(covered.has(p.number)).toBe(false); // never re-selected before all are stamped
+        covered.add(p.number);
+        stampedAt.set(p.number, now); // the sweep stamps lastRegatedAt = now
+      }
+    }
+    expect(covered.size).toBe(50); // full coverage of every open PR
   });
 
   it("defaults: freshness window is two minutes and the cap is 25", () => {
     expect(SWEEP_FRESHNESS_MS).toBe(2 * 60 * 1000);
     expect(SWEEP_MAX_PRS).toBe(25);
-    const pulls = Array.from({ length: 40 }, (_, i) => pr({ number: i + 1, updatedAt: minutesAgo(120 + i) }));
+    const pulls = Array.from({ length: 40 }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(120 + i) }));
     expect(selectRegateCandidates({ pulls, now: NOW })).toHaveLength(25);
   });
 });

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -8,6 +8,7 @@ import {
   listPullRequestDetailSyncStates,
   listRepoSyncSegments,
   listRepoSyncStates,
+  markPullRequestRegated,
   upsertOfficialMinerDetection,
   upsertPullRequestFromGitHub,
   extractLinkedIssueNumbers,
@@ -78,6 +79,33 @@ describe("database row parser hardening", () => {
         expect.objectContaining({ number: 2, isDraft: false, mergeableState: "mergeable", reviewDecision: "APPROVED" }),
       ]),
     );
+  });
+
+  it("markPullRequestRegated stamps the internal last_regated_at marker (sweep convergence #audit-sweep-converge)", async () => {
+    const env = createTestEnv();
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 5, title: "Stale PR", state: "open", user: { login: "alice" }, labels: [] });
+
+    const before = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 5);
+    expect(before?.lastRegatedAt ?? null).toBeNull(); // never swept yet → marker absent
+
+    await markPullRequestRegated(env, "owner/repo", 5);
+    const after = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 5);
+    expect(typeof after?.lastRegatedAt).toBe("string"); // marker stamped with an ISO timestamp
+    expect(after?.title).toBe("Stale PR"); // INVARIANT: a plain D1 UPDATE — it touches only the marker, not PR content
+  });
+
+  it("REGRESSION: a later GitHub sync does NOT clobber last_regated_at (omitted from the upsert SET clause)", async () => {
+    const env = createTestEnv();
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 6, title: "First", state: "open", user: { login: "bob" }, labels: [] });
+    await markPullRequestRegated(env, "owner/repo", 6);
+    const stamped = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 6)?.lastRegatedAt;
+    expect(typeof stamped).toBe("string");
+
+    // A subsequent GitHub-sync upsert (new title) must NOT reset the sweep marker, or the sweep would loop again.
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 6, title: "Synced again", state: "open", user: { login: "bob" }, labels: [] });
+    const resynced = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 6);
+    expect(resynced?.title).toBe("Synced again"); // the sync ran
+    expect(resynced?.lastRegatedAt).toBe(stamped); // but the marker survived
   });
 
   it("computes complete case-insensitive repo author PR history for gate grace", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -731,6 +731,41 @@ describe("queue processors", () => {
     errors.mockRestore();
   });
 
+  it("agent re-gate sweep stamps last_regated_at on each recomputed PR so the next sweep advances (#audit-sweep-converge)", async () => {
+    const env = createTestEnv({});
+    await upsertInstallation(env, { action: "created", installation: { id: 9002, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9002);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "" });
+    const before = await env.DB.prepare("select last_regated_at from pull_requests where repo_full_name = ? and number = 7").bind("owner/agent-repo").first<{ last_regated_at: string | null }>();
+    expect(before?.last_regated_at).toBeNull(); // never swept yet
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    const after = await env.DB.prepare("select last_regated_at from pull_requests where repo_full_name = ? and number = 7").bind("owner/agent-repo").first<{ last_regated_at: string | null }>();
+    expect(typeof after?.last_regated_at).toBe("string"); // stamped via a D1 write — convergence does not need a GitHub write
+  });
+
+  it("agent re-gate sweep swallows a failing last_regated_at stamp and still completes (#audit-sweep-converge)", async () => {
+    const env = createTestEnv({});
+    await upsertInstallation(env, { action: "created", installation: { id: 9003, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9003);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated").mockRejectedValueOnce(new Error("D1 write error"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("completed"); // the sweep still records its verdict despite the stamp failure
+    expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_mark_regated_failed"))).toBe(true);
+    stamp.mockRestore();
+    errors.mockRestore();
+  });
+
   it("agent re-gate sweep respects the #776 kill-switch: a paused repo records a skip and recomputes nothing (#777)", async () => {
     const env = createTestEnv({});
     await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } });


### PR DESCRIPTION
## Summary

**Root cause of the sweep non-convergence (Flaw A).** The scheduled re-gate sweep ordered open PRs by staleness keyed on the `PullRequestRecord.updatedAt`, which `toPullRequestRecordFromRow` resolves as `payload.updated_at ?? row.updatedAt` — **GitHub's value**. A review normally freshens a PR because its comment/label **WRITE** bumps GitHub's `updated_at`. But when agent actions are **suppressed** (dry-run, or a paused/permission-blocked repo) that write never happens, so the 25 stalest PRs stay pinned at the head of the sort **forever** and the sweep re-selects the **same 25** every tick — never covering the rest of the queue (observed: 5× recompute of "25 stale; 3 flagged" during the metagraphed dry-run).

## Fix
Stamp an internal **`last_regated_at`** marker on every PR the sweep re-gates — a plain D1 `UPDATE` (`markPullRequestRegated`), **not** routed through the agent-action chokepoint, so it advances even when GitHub writes are suppressed. Key the sweep's **sort** on `last_regated_at` (→ `createdAt` → epoch) instead of GitHub's `updated_at`, so a just-regated PR sorts freshest and the next sweep picks the next-stalest: **full coverage of all open PRs in `ceil(open/max)` sweeps**. GitHub's `updated_at` is kept **only** as the "don't race an in-flight webhook" freshness guard, never as the sort key. The marker is **omitted from the `upsertPullRequestFromGitHub` SET clause** so a later sync can't clobber it (mirrors `approved_head_sha` / `merge_blocked_sha`).

## Scope
- [x] Migration `0062_pr_last_regated_at.sql` (`ALTER TABLE pull_requests ADD COLUMN last_regated_at TEXT`), Drizzle schema, `PullRequestRecord` type, `markPullRequestRegated` + the row read, `selectRegateCandidates` rekey, the sweep loop stamps the marker
- [x] Nullable/no-default → backward-compatible (existing rows NULL = never swept = maximally stale = picked first)

## Sequencing note
Convergence makes the sweep advance through **all** open PRs (vs looping 25), which raises total sweep GitHub-call volume per *live* repo over time. That load is bounded by the companion PRs (bound the maintenance lane / reserve rate-limit headroom / per-PR fan-out). This is safe to land now: every repo except low-volume `awesome-claude` is currently paused, and this PR never makes the paused/suppressed case worse — it's what *unblocks* convergence there.

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities · `db:migrations:check` — contiguous
- [x] **Invariants:** the three `lastRegatedAt ?? createdAt ?? epoch` coalesce arms; the don't-race-webhook guard still skips a fresh-`updatedAt` PR even when its re-gate marker is old; the live case (both move together) is **not** double-excluded; `markPullRequestRegated` is a plain D1 UPDATE (no agent-action-executor, no GitHub job). **Regressions:** `ceil(50/25)=2` sweeps cover **all 50** PRs with every GitHub write suppressed, none re-selected before the rest are stamped; a later GitHub sync does **not** clobber `last_regated_at`; the sweep swallows a failing stamp and still completes
- [x] Every changed line + branch covered · rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit