### PR TITLE
fix(queue): bound the maintenance lane so a retry storm cannot re-saturate it

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -218,12 +218,23 @@
         "dead_letter_queue": "gittensory-webhooks-dlq",
       },
       {
+        // Maintenance lane: the re-gate sweep, backfills, rag-index, snapshots. Webhooks have their own lane
+        // (above), so this lane is bounded to keep a heavy/retrying batch from re-saturating the consumer and
+        // amplifying GitHub-rate pressure (the metagraphed-dry-run overload). (#audit-bound-lane)
+        //  - max_batch_size 5 (was 10): one batch can't bundle as many heavy sweep/backfill jobs at once.
+        //  - max_concurrency 3: bounded fan-out — enough to drain metagraphed's worst sweep within the 2-min
+        //    cron interval, but not so wide it floods the shared GitHub installation rate bucket. (A follow-up
+        //    may tighten this to 2 once the sweep fans into tiny per-PR jobs.)
+        //  - retry_delay 30: a failed job backs off 30s instead of re-delivering immediately and re-hammering
+        //    the already-overloaded path.
         "queue": "gittensory-jobs",
-        "max_batch_size": 10,
+        "max_batch_size": 5,
         "max_batch_timeout": 5,
-        // After max_retries failed attempts a job is dead-lettered so a persistently-failing webhook
-        // is observable rather than vanishing silently. The DLQ consumer below picks them up.
+        "max_concurrency": 3,
+        // After max_retries failed attempts a job is dead-lettered so a persistently-failing job is observable
+        // rather than vanishing silently. The DLQ consumer below picks them up.
         "max_retries": 3,
+        "retry_delay": 30,
         "dead_letter_queue": "gittensory-jobs-dlq",
       },
       {


### PR DESCRIPTION
## Summary
The shared `gittensory-jobs` consumer had **no `max_concurrency`** (Cloudflare may fan out many concurrent consumers, each pulling a heavy sweep/backfill batch — amplifying GitHub-rate pressure) and **no `retry_delay`** (a failed job re-delivers immediately, re-hammering the already-overloaded path). This is the magnitude half of the overload (Flaw B). Now that webhooks have their own lane (#1276), bound this maintenance lane:

- **`max_batch_size` 5** (was 10): a batch can't bundle as many heavy jobs at once.
- **`max_concurrency` 3**: bounded fan-out — drains metagraphed's worst sweep (50 PRs) within the 2-min cron interval without flooding the shared installation rate bucket.
- **`retry_delay` 30**: back off a failed job 30s instead of re-hammering instantly.

Webhooks are unaffected (their own lane). A follow-up may tighten `max_concurrency` to 2 once the sweep fans into tiny per-PR jobs.

## Scope
- [x] `wrangler.jsonc` only — consumer config on the existing `gittensory-jobs` queue. No new binding, no DB migration, no `src` change (so no coverage obligation).

## Validation
- [x] Values verified against the documented Cloudflare Queues consumer options (`max_concurrency`, `retry_delay`, `max_batch_size`) via the Cloudflare docs — all within limits
- [x] `npx wrangler deploy --dry-run` succeeds (config parses + builds); `cf-typegen` produces no binding-type change; `tsc` clean
- [x] Rebased onto latest `main` immediately before opening · reversible config-only change

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit