### PR TITLE
fix(queue): self-heal + observe both dead-letter queues

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1982,6 +1982,20 @@ export async function hasRecentAuditEvent(env: Env, actor: string, eventType: st
   return rows.length > 0;
 }
 
+/** Observability for the queue dead-letter rate (#1276): how many jobs (across BOTH the maintenance and webhook
+ *  lanes) were dead-lettered since `sinceIso`. Reads the `github_app.dlq_dead_lettered` audit events written by
+ *  processDlqBatch — NOT gated behind any review-ops flag, so the infra drop rate is always visible. */
+export async function countRecentDeadLetters(env: Env, sinceIso: string): Promise<number> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(auditEvents)
+    .where(and(eq(auditEvents.eventType, "github_app.dlq_dead_lettered"), gte(auditEvents.createdAt, sinceIso)));
+  /* v8 ignore next -- count(*) always returns exactly one row; the empty-array guard only satisfies the destructure type. */
+  if (!row) return 0;
+  return row.count;
+}
+
 export type PrVisibilitySkipAuditEvent = {
   repoFullName: string;
   pullNumber: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ export { RateLimiter };
 export default {
   fetch: app.fetch,
   async queue(batch: MessageBatch<JobMessage>, env: Env): Promise<void> {
-    if (batch.queue === "gittensory-jobs-dlq") {
+    // Both dead-letter queues (the maintenance lane's gittensory-jobs-dlq and the webhook lane's
+    // gittensory-webhooks-dlq, #1276) drain through the same observability + self-heal consumer.
+    if (batch.queue?.endsWith("-dlq")) {
       await processDlqBatch(batch, env);
       return;
     }

--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -1,23 +1,30 @@
-import { recordAuditEvent } from "../db/repositories";
+import { getWebhookEvent, recordAuditEvent } from "../db/repositories";
 import type { JobMessage, JsonValue } from "../types";
 
 /**
- * DLQ consumer for `gittensory-jobs-dlq`. Called when a job exhausts all retries on the main
- * queue and is dead-lettered. Logs every dropped job for observability and records an audit event
- * so maintainers can investigate persistent failures via the dashboard. Always acks — no further
+ * DLQ consumer for both `gittensory-jobs-dlq` (maintenance lane) and `gittensory-webhooks-dlq` (the
+ * webhook lane added with the dedicated WEBHOOKS queue, #1276). Called when a job exhausts all retries
+ * on its main queue and is dead-lettered. Logs every dropped job and records an audit event so the drop
+ * is observable rather than silent (countRecentDeadLetters surfaces the rate). Always acks — no further
  * retries on DLQ messages.
+ *
+ * Self-heal: a dead-lettered `github-webhook` carries a real GitHub event that GitHub will NOT redeliver
+ * (the HTTP handler already returned 202). So unless it was already processed, RE-DRIVE it ONCE back onto
+ * the webhook lane — bounded to a single attempt by the `redriven` marker so a genuinely-poison payload
+ * cannot loop the DLQ forever. Maintenance jobs are cron-self-healing, so they are audited-and-dropped.
  */
 export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env): Promise<void> {
   for (const message of batch.messages) {
-    const body = message.body as { type?: string; deliveryId?: string; eventName?: string } | null | undefined;
+    const body = message.body as { type?: string } | null | undefined;
     const jobType = body?.type ?? "unknown";
+    const webhook = jobType === "github-webhook" ? (message.body as Extract<JobMessage, { type: "github-webhook" }> & { redriven?: boolean }) : null;
     console.error(
       JSON.stringify({
         level: "error",
         event: "dlq_message_dead_lettered",
         messageId: message.id,
         jobType,
-        ...(jobType === "github-webhook" ? { deliveryId: body?.deliveryId, eventName: body?.eventName } : {}),
+        ...(webhook ? { deliveryId: webhook.deliveryId, eventName: webhook.eventName } : {}),
       }),
     );
     // Best-effort audit record — never block the ack on a write failure.
@@ -27,8 +34,15 @@ export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env)
       targetKey: `dlq:${jobType}:${message.id}`,
       outcome: "error",
       detail: `Job of type '${jobType}' exhausted all retries and was dead-lettered.`,
-      metadata: { messageId: message.id, jobType } satisfies Record<string, JsonValue>,
+      metadata: { messageId: message.id, jobType, redriven: webhook?.redriven === true } satisfies Record<string, JsonValue>,
     }).catch(() => undefined);
+    // Self-heal a recoverable webhook: re-drive ONCE (not already re-driven, and not already processed).
+    if (webhook && webhook.redriven !== true && webhook.deliveryId) {
+      const event = await getWebhookEvent(env, webhook.deliveryId).catch(() => null);
+      if (event?.status !== "processed") {
+        await env.WEBHOOKS.send({ type: "github-webhook", deliveryId: webhook.deliveryId, eventName: webhook.eventName, payload: webhook.payload, redriven: true }).catch(() => undefined);
+      }
+    }
     message.ack();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export type JobMessage =
       deliveryId: string;
       eventName: string;
       payload: GitHubWebhookPayload;
+      // Set when the DLQ consumer re-drives a dead-lettered webhook back onto the lane (#1276). Bounds the
+      // self-heal to a single re-drive so a genuinely-poison payload cannot loop the webhook DLQ forever.
+      redriven?: boolean;
     }
   | {
       // Delayed self-poll to re-capture a PR's before/after preview once its preview deploy is live — the first

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  countRecentDeadLetters,
   getLatestScorePreview,
   getRepoAuthorPullRequestHistory,
   getLatestScoringModelSnapshot,
@@ -9,6 +10,7 @@ import {
   listRepoSyncSegments,
   listRepoSyncStates,
   markPullRequestRegated,
+  recordAuditEvent,
   upsertOfficialMinerDetection,
   upsertPullRequestFromGitHub,
   extractLinkedIssueNumbers,
@@ -106,6 +108,18 @@ describe("database row parser hardening", () => {
     const resynced = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 6);
     expect(resynced?.title).toBe("Synced again"); // the sync ran
     expect(resynced?.lastRegatedAt).toBe(stamped); // but the marker survived
+  });
+
+  it("countRecentDeadLetters counts github_app.dlq_dead_lettered audits since a cutoff, independent of any ops flag (#1276)", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, { eventType: "github_app.dlq_dead_lettered", actor: "gittensory", targetKey: "dlq:github-webhook:a", outcome: "error", createdAt: "2026-06-24T10:00:00.000Z" });
+    await recordAuditEvent(env, { eventType: "github_app.dlq_dead_lettered", actor: "gittensory", targetKey: "dlq:backfill-repo-segment:b", outcome: "error", createdAt: "2026-06-24T12:00:00.000Z" });
+    // An unrelated audit event must NOT be counted (the event-type filter).
+    await recordAuditEvent(env, { eventType: "agent.sweep.regate", actor: "gittensory", targetKey: "owner/repo", outcome: "completed", createdAt: "2026-06-24T12:00:00.000Z" });
+
+    expect(await countRecentDeadLetters(env, "2026-06-24T09:00:00.000Z")).toBe(2); // both dead-letters in window
+    expect(await countRecentDeadLetters(env, "2026-06-24T11:00:00.000Z")).toBe(1); // only the 12:00 one
+    expect(await countRecentDeadLetters(env, "2026-06-24T13:00:00.000Z")).toBe(0); // none after the cutoff → count(*) returns 0
   });
 
   it("computes complete case-insensitive repo author PR history for gate grace", async () => {

--- a/test/unit/dlq.test.ts
+++ b/test/unit/dlq.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { processDlqBatch } from "../../src/queue/dlq";
+import { recordWebhookEvent } from "../../src/db/repositories";
+import type { JobMessage } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
 function makeBatch(messages: Array<{ id: string; body: unknown }>, queue = "gittensory-jobs-dlq") {
@@ -93,5 +95,60 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
     await expect(processDlqBatch(batch as unknown as MessageBatch<never>, brokenEnv)).resolves.toBeUndefined();
     expect(batch.acked).toEqual(["msg-7"]);
+  });
+
+  describe("webhook self-heal re-drive (#1276)", () => {
+    function captureWebhooks(env: ReturnType<typeof createTestEnv>) {
+      const sent: JobMessage[] = [];
+      env.WEBHOOKS = { send: async (m: JobMessage) => void sent.push(m) } as unknown as typeof env.WEBHOOKS;
+      return sent;
+    }
+
+    it("INVARIANT: re-drives a recoverable github-webhook ONCE onto the webhook lane (event not yet processed)", async () => {
+      const env = createTestEnv();
+      const sent = captureWebhooks(env);
+      // No webhook_events row for fresh-1 → status is undefined (≠ processed) → recoverable, re-drive.
+      const batch = makeBatch([{ id: "wh-1", body: { type: "github-webhook", deliveryId: "fresh-1", eventName: "pull_request", payload: { action: "opened" } } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({ type: "github-webhook", deliveryId: "fresh-1", eventName: "pull_request", redriven: true });
+      expect(batch.acked).toEqual(["wh-1"]);
+    });
+
+    it("REGRESSION (idempotency): does NOT re-drive a webhook whose event row is already 'processed'", async () => {
+      const env = createTestEnv();
+      await recordWebhookEvent(env, { deliveryId: "done-1", eventName: "pull_request", payloadHash: "processed", status: "processed" });
+      const sent = captureWebhooks(env);
+      const batch = makeBatch([{ id: "wh-2", body: { type: "github-webhook", deliveryId: "done-1", eventName: "pull_request", payload: {} } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(sent).toEqual([]); // already processed → no duplicate side effects
+      expect(batch.acked).toEqual(["wh-2"]);
+    });
+
+    it("REGRESSION (no DLQ loop): does NOT re-drive a webhook that was already re-driven once", async () => {
+      const env = createTestEnv();
+      const sent = captureWebhooks(env);
+      const batch = makeBatch([{ id: "wh-3", body: { type: "github-webhook", deliveryId: "loop-1", eventName: "push", payload: {}, redriven: true } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(sent).toEqual([]); // bounded to a single re-drive
+      expect(batch.acked).toEqual(["wh-3"]);
+    });
+
+    it("REGRESSION (no re-drive of maintenance jobs): a backfill job is audited and dropped, never re-driven", async () => {
+      const env = createTestEnv();
+      const sent = captureWebhooks(env);
+      const batch = makeBatch([{ id: "mn-1", body: { type: "backfill-repo-segment" } }], "gittensory-jobs-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(sent).toEqual([]); // cron self-heals maintenance jobs
+      expect(batch.acked).toEqual(["mn-1"]);
+    });
   });
 });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -35,6 +35,28 @@ describe("worker entrypoint", () => {
     expect(retried).toEqual([]);
   });
 
+  it("routes the webhook lane's gittensory-webhooks-dlq batches to the DLQ consumer too (#1276)", async () => {
+    const env = createTestEnv();
+    const acked: string[] = [];
+    const retried: string[] = [];
+    const batch = {
+      queue: "gittensory-webhooks-dlq",
+      messages: [
+        {
+          id: "wh-dlq-1",
+          body: { type: "github-webhook", deliveryId: "d-wh-dlq", eventName: "pull_request", payload: {}, redriven: true },
+          ack: () => acked.push("wh-dlq-1"),
+          retry: () => retried.push("wh-dlq-1"),
+        },
+      ],
+    } as unknown as MessageBatch<import("../../src/types").JobMessage>;
+
+    await worker.queue(batch, env);
+
+    expect(acked).toEqual(["wh-dlq-1"]); // handled by processDlqBatch (endsWith "-dlq"), not the processJob loop
+    expect(retried).toEqual([]);
+  });
+
   it("acks successful queue messages and retries failed messages", async () => {
     const env = createTestEnv();
     vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -247,6 +247,15 @@
         "max_batch_timeout": 30,
         "max_retries": 0,
       },
+      {
+        // Webhook-lane DLQ consumer (#1276): a dead-lettered github-webhook carries a real GitHub event that
+        // GitHub will not redeliver, so processDlqBatch audits it AND re-drives it once onto the webhook lane
+        // (bounded by the `redriven` marker). max_retries: 0 — a DLQ message must never re-loop the DLQ.
+        "queue": "gittensory-webhooks-dlq",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
+      },
     ],
   },
   "triggers": {


### PR DESCRIPTION
## Summary
Closes the residual event-loss + no-replay gap on the dead-letter queues. The webhook lane's `gittensory-webhooks-dlq` (added with the dedicated WEBHOOKS queue in #1276) had **no consumer**, and the existing DLQ consumer only **logged + audited** a dropped `github-webhook` before acking it — so a dead-lettered webhook (a real GitHub event GitHub will **not** redeliver, since the handler already returned `202`) was lost.

## Fix
- **Wire a consumer for `gittensory-webhooks-dlq`** and route *both* `*-dlq` queues through `processDlqBatch` (`batch.queue?.endsWith("-dlq")`).
- **Self-heal a recoverable webhook:** unless its event row is already `processed`, **re-drive it once** back onto the webhook lane — bounded by a `redriven` marker so a genuinely-poison payload can't loop the DLQ. Maintenance jobs are cron-self-healing, so they stay audited-and-dropped.
- **`countRecentDeadLetters`:** a flag-independent reader over the `github_app.dlq_dead_lettered` audit events (which `processDlqBatch` already writes) so the infra drop rate is observable.

The PROCESSING-path resilience (a rate-limited webhook retried-until-recovered *before* it ever dead-letters) is the companion follow-up; this PR is the scheduling-layer DLQ safety net.

## Scope
- [x] `wrangler.jsonc` (webhooks-dlq consumer), `src/index.ts` (route both `*-dlq`), `src/queue/dlq.ts` (bounded re-drive), `src/types.ts` (`redriven` marker), `src/db/repositories.ts` (`countRecentDeadLetters`). No DB migration; no binding-type change.

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities
- [x] **Invariants:** a recoverable webhook (event not `processed`) is audited **and** re-driven once with `redriven: true`; the webhooks-dlq batch routes to `processDlqBatch`. **Regressions:** an already-`processed` webhook is **not** re-driven (idempotent); an already-`redriven` webhook is **not** re-driven again (no DLQ loop); a maintenance job is audited-and-dropped; `countRecentDeadLetters` counts only `dlq_dead_lettered` since a cutoff (incl. the empty-window → 0 case) and is not behind any flag
- [x] Every changed line + branch covered (one honest `v8 ignore` on the unreachable `count(*)` empty-row guard) · rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit