### PR TITLE
feat(selfhost): App checks:write + an instance-wide write kill switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@
 # Example: GITTENSORY_REVIEW_REPOS="JSONbored/gittensory,JSONbored/awesome-claude"
 GITTENSORY_REVIEW_REPOS=
 
+# Instance-wide write kill switch for the cloud→self-host parallel-run migration. When set to "dry-run"
+# (or "disabled"), EVERY GitHub write from this instance is suppressed regardless of per-repo settings —
+# the instance can receive webhooks and compute verdicts but posts NOTHING (no check-run/comment/label/
+# merge), so it can shadow the live cloud App safely until cutover. "dry-run" audits as completed-shadow;
+# "disabled" audits as denied. Leave empty (= live) for normal operation. Flip to live only at cutover.
+# SELFHOST_DEPLOYMENT_MODE=dry-run
+
 # --- Per-PR capabilities (also require the repo in GITTENSORY_REVIEW_REPOS) ---
 
 # Safety scan: defangs untrusted PR title/body/diff (prompt-injection

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -51,6 +51,9 @@ declare global {
     SCORING_TIME_DECAY_ENABLED?: string;
     /** #776 agent-layer GLOBAL kill-switch — when truthy, halts ALL agent actions across every repo. */
     AGENT_ACTIONS_PAUSED?: string;
+    /** Self-host instance-wide write switch: "dry-run" | "disabled" forces EVERY installation write to be
+     *  suppressed regardless of per-repo mode (the cloud→self-host parallel-run kill switch). Unset = live. */
+    SELFHOST_DEPLOYMENT_MODE?: string;
     GITTENSORY_AUTO_FILE_DRIFT_ISSUES?: string;
     GITTENSORY_DRIFT_ISSUE_REPO?: string;
     GITTENSORY_DRIFT_ISSUE_TOKEN?: string;

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -56,14 +56,30 @@ function syntheticWriteResponse(url: string): { status: number; url: string; hea
 }
 
 /**
+ * Instance-wide self-host kill switch (#selfhost-deployment-mode). SELFHOST_DEPLOYMENT_MODE=dry-run|disabled
+ * forces write suppression for the WHOLE instance regardless of the per-call mode — so a self-host running in
+ * PARALLEL with the live cloud App can receive the same webhooks but provably post NOTHING (no check-run /
+ * comment / label / merge) until an explicit cutover, without relying on every call site threading the repo mode.
+ * Unset (the cloud Worker never sets it) → null → behavior is byte-identical to today.
+ */
+export function forcedSelfhostMode(env: { SELFHOST_DEPLOYMENT_MODE?: string | undefined }): AgentActionMode | null {
+  const m = (env.SELFHOST_DEPLOYMENT_MODE ?? "").trim().toLowerCase();
+  if (m === "disabled") return "paused"; // suppress + audit as denied
+  if (m === "dry-run" || m === "dry_run") return "dry_run"; // suppress + audit as completed-shadow
+  return null; // "live" / unset → no forcing
+}
+
+/**
  * Build an installation Octokit from an ALREADY-minted token. Takes the token (not the installationId) so this
  * module never imports createInstallationToken — the mint stays in app.ts via raw fetch and can never be reached
  * by the suppression hook. `mode` defaults to "live", so the action helpers (pr-actions) that are already gated by
  * the executor are not double-denied; surface callers (check-run / comment / label) pass the resolved repo mode.
+ * A SELFHOST_DEPLOYMENT_MODE override beats the per-call mode so the whole instance can be forced non-actuating.
  */
 export function makeInstallationOctokit(env: Env, token: string, mode: AgentActionMode = "live"): Octokit {
   const octokit = new Octokit({ auth: token, request: { fetch: timeoutFetch } });
-  if (mode !== "live") {
+  const effectiveMode = forcedSelfhostMode(env) ?? mode;
+  if (effectiveMode !== "live") {
     octokit.hook.wrap("request", async (request, options) => {
       const method = options.method.toUpperCase();
       if (!WRITE_METHODS.has(method)) return request(options); // reads + create-vs-update probes always run
@@ -72,9 +88,9 @@ export function makeInstallationOctokit(env: Env, token: string, mode: AgentActi
         eventType: "github.write.suppressed",
         actor: "gittensory",
         targetKey: url,
-        outcome: mode === "dry_run" ? "completed" : "denied",
-        detail: `${mode}: suppressed ${method} ${url}`,
-        metadata: { method, url, mode },
+        outcome: effectiveMode === "dry_run" ? "completed" : "denied",
+        detail: `${effectiveMode}: suppressed ${method} ${url}`,
+        metadata: { method, url, mode: effectiveMode },
       }).catch(
         /* v8 ignore next -- fail-safe: an audit-write failure never blocks the suppression itself */
         () => undefined,

--- a/src/selfhost/setup-wizard.ts
+++ b/src/selfhost/setup-wizard.ts
@@ -27,7 +27,9 @@ export function buildManifest(origin: string, state: string): Record<string, unk
       pull_requests: "write",
       contents: "write",
       issues: "write",
-      checks: "read",
+      // checks:write — the gate posts a check-run (POST /repos/{o}/{r}/check-runs in src/github/app.ts);
+      // checks:read would 403 that write (swallowed as a permission_missing warning → silent first-review failure).
+      checks: "write",
       metadata: "read",
       statuses: "read",
     },

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { makeInstallationOctokit, resolveRepoActionMode, timeoutFetch } from "../../src/github/client";
+import { forcedSelfhostMode, makeInstallationOctokit, resolveRepoActionMode, timeoutFetch } from "../../src/github/client";
 import { setGlobalAgentFrozen } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
@@ -73,6 +73,35 @@ describe("makeInstallationOctokit", () => {
     const label = await octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", { owner: "o", repo: "r", issue_number: 1, labels: ["x"] });
     expect((label.data as unknown as { dryRunSuppressed: boolean; id?: number }).dryRunSuppressed).toBe(true);
     expect((label.data as unknown as { id?: number }).id).toBeUndefined(); // the default route carries no id
+  });
+});
+
+describe("forcedSelfhostMode (instance-wide self-host kill switch)", () => {
+  it("maps SELFHOST_DEPLOYMENT_MODE to a forced action mode (else null)", () => {
+    expect(forcedSelfhostMode({ SELFHOST_DEPLOYMENT_MODE: "dry-run" })).toBe("dry_run");
+    expect(forcedSelfhostMode({ SELFHOST_DEPLOYMENT_MODE: "dry_run" })).toBe("dry_run"); // underscore variant
+    expect(forcedSelfhostMode({ SELFHOST_DEPLOYMENT_MODE: "DISABLED" })).toBe("paused"); // case-insensitive
+    expect(forcedSelfhostMode({ SELFHOST_DEPLOYMENT_MODE: "live" })).toBeNull();
+    expect(forcedSelfhostMode({})).toBeNull();
+  });
+
+  it("forces suppression for the WHOLE instance even when the caller passes mode=live", async () => {
+    const calls: RecordedCall[] = [];
+    stubFetchRecording(calls);
+    const env = { ...createTestEnv(), SELFHOST_DEPLOYMENT_MODE: "dry-run" };
+    const octokit = makeInstallationOctokit(env, "tok", "live"); // a LIVE caller…
+    const r = await octokit.request("POST /repos/{owner}/{repo}/check-runs", { owner: "o", repo: "r", name: "Gate", head_sha: "abc" });
+    expect(calls.some((c) => c.method === "POST")).toBe(false); // …but the instance switch suppresses it anyway
+    expect((r.data as unknown as { id: number }).id).toBe(-1);
+  });
+
+  it("'disabled' forces suppression audited as denied (vs dry-run's completed-shadow)", async () => {
+    stubFetchRecording([]);
+    const env = { ...createTestEnv(), SELFHOST_DEPLOYMENT_MODE: "disabled" };
+    const octokit = makeInstallationOctokit(env, "tok", "live");
+    await octokit.request("POST /repos/{owner}/{repo}/check-runs", { owner: "o", repo: "r", name: "Gate", head_sha: "abc" });
+    const audit = await env.DB.prepare("SELECT outcome FROM audit_events WHERE event_type = ?").bind("github.write.suppressed").first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("denied");
   });
 });
 


### PR DESCRIPTION
## Summary

Two **cloud→self-host migration** prerequisites (Phase 2 of the cutover plan), both gated so the live cloud Worker is **byte-identical** (it never sets the new env):

**1. `/setup` App manifest: `checks:read` → `checks:write`.** The gate posts a check-run (`POST /repos/{o}/{r}/check-runs`, [app.ts](src/github/app.ts)), which needs `checks:write` — but the manifest declared `checks:read`. GitHub 403s the write and the engine swallows it as a `permission_missing` warning, i.e. a **silent first-review failure** on a fresh self-host App. The rest of the system already treats `checks:write` as required (`backfill.test.ts:520`, `data-spine.test.ts`), so the manifest was the outlier. Existing self-host Apps must be recreated to pick up the permission.

**2. `SELFHOST_DEPLOYMENT_MODE` — an instance-wide write kill switch.** Added at the single octokit write chokepoint (`makeInstallationOctokit`): when set to `dry-run` (or `disabled`), it **forces write suppression for EVERY installation write regardless of the per-call mode**. A self-host running in parallel with the live cloud App can receive the same webhooks and compute verdicts but **provably post nothing** (check-run/comment/label/merge) until cutover — without depending on every call site threading the repo mode. `dry-run` audits as completed-shadow; `disabled` as denied; unset (cloud) → no forcing.

This is the load-bearing parallel-run safety the migration needs. (Notably, the earlier analysis also suggested `app_id` webhook filtering — I verified that's **unnecessary**: webhooks are HMAC-verified with each instance's *own* App secret, so a self-host never receives the cloud App's deliveries.)

## Scope
- [x] 5 files; gated so cloud is unaffected (new env unset on cloud → `forcedSelfhostMode` returns null → unchanged)
- [x] No new route/OpenAPI surface; `SELFHOST_DEPLOYMENT_MODE` typed in `env.d.ts` (self-host env, not a wrangler var)

## Validation
- [x] `npm run test:ci` — green (typecheck, coverage, workers, ui)
- [x] **100% branch coverage** on `client.ts` + `setup-wizard.ts` changes (all `forcedSelfhostMode` arms; the live-caller-still-suppressed case; dry-run vs disabled audit outcomes)

## Safety
- [x] Cloud byte-identical (the suppression only engages when the self-host-only env is set)
- [x] Strengthens, never weakens, the dry-run invariant — the structural "this instance writes nothing" guarantee for parallel-run

Advances the cloud→self-host migration.