### PR TITLE
fix(sweep): fan the re-gate sweep into bounded per-PR jobs + skip a draining repo

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2591,6 +2591,20 @@ export async function markPullRequestRegated(env: Env, fullName: string, number:
     .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number)));
 }
 
+/** In-flight guard input for the re-gate sweep fan-out (#audit-sweep-fanout): the MOST RECENT last_regated_at
+ *  across a repo's OPEN PRs (the freshest sweep stamp), or null if none has been swept. fanOutAgentRegateSweepJobs
+ *  passes this to isRegateSweepDraining to skip re-arming a repo whose prior sweep is still draining. */
+export async function getLatestRegatedAt(env: Env, fullName: string): Promise<string | null> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({ latest: sql<string | null>`max(${pullRequests.lastRegatedAt})` })
+    .from(pullRequests)
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.state, "open")));
+  /* v8 ignore next -- max() always returns exactly one row; the empty-array guard only satisfies the destructure type. */
+  if (!row) return null;
+  return row.latest;
+}
+
 export async function getIssue(env: Env, fullName: string, number: number): Promise<IssueRecord | null> {
   const db = getDb(env.DB);
   const [row] = await db.select().from(issues).where(and(eq(issues.repoFullName, fullName), eq(issues.number, number))).limit(1);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -40,6 +40,7 @@ import {
   markRepositoriesRemovedFromInstallation,
   persistAdvisory,
   markPullRequestRegated,
+  getLatestRegatedAt,
   recordAgentCommandFeedback,
   recordAuditEvent,
   recordGateBlockOutcome,
@@ -114,7 +115,7 @@ import { isAuthorizedGitHubSessionLogin, parseGitHubLoginList } from "../auth/se
 import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetection } from "../settings/command-authorization";
 import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
-import { selectRegateCandidates } from "../settings/agent-sweep";
+import { isRegateSweepDraining, selectRegateCandidates } from "../settings/agent-sweep";
 import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type PlannedAgentAction } from "../settings/agent-actions";
 import { executeAgentMaintenanceActions, pendingClosureLabelApplied } from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
@@ -334,6 +335,10 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       }
       await sweepRepoRegate(env, message.repoFullName);
       return;
+    case "agent-regate-pr":
+      // One bounded re-gate unit fanned out by the sweep (#audit-sweep-fanout): re-review + stamp a single PR.
+      await regatePullRequest(env, message.repoFullName, message.prNumber, message.installationId, message.deliveryId);
+      return;
     case "run-agent":
       await executeAgentRun(env, message.runId);
       return;
@@ -427,10 +432,21 @@ async function fanOutRepoSignalSnapshotJobs(env: Env, requestedBy: "schedule" | 
 // fan-out so each repo's sweep runs as its own bounded, retryable queue message.
 async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "api" | "test"): Promise<void> {
   const repositories = await listRepositories(env);
+  const now = nowIso();
   const configured: string[] = [];
+  let skippedDraining = 0;
   for (const repo of repositories) {
     const settings = await resolveRepositorySettings(env, repo.fullName);
-    if (isAgentConfigured(settings.autonomy)) configured.push(repo.fullName);
+    if (!isAgentConfigured(settings.autonomy)) continue;
+    // In-flight guard (#audit-sweep-fanout): skip a repo whose prior sweep is still draining — its per-PR jobs are
+    // mid-flight and stamping last_regated_at as they run, so the freshest stamp being within the sweep window
+    // means a sweep is active. Re-arming now would enqueue duplicate per-PR jobs for the not-yet-drained
+    // candidates, so this is what finally stops the 2-min cron piling a second full sweep on an unfinished one.
+    if (isRegateSweepDraining(await getLatestRegatedAt(env, repo.fullName), now)) {
+      skippedDraining += 1;
+      continue;
+    }
+    configured.push(repo.fullName);
   }
   await Promise.all(
     configured.map((repoFullName, index) => {
@@ -442,7 +458,7 @@ async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "a
   await recordAuditEvent(env, {
     eventType: "agent.sweep.fanout",
     outcome: "queued",
-    metadata: { repoCount: configured.length, requestedBy },
+    metadata: { repoCount: configured.length, skippedDraining, requestedBy },
   });
 }
 
@@ -561,7 +577,7 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   const flaggedPulls: number[] = [];
   const sweepInstallationId = repo?.installationId ?? null;
   const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
-  for (const pr of candidates) {
+  for (const [index, pr] of candidates.entries()) {
     const others = openPullRequests.filter((other) => other.number !== pr.number);
     // Thread linked-issue authors so the re-gate sweep applies the self-authored-linked-issue block too — without
     // this a self-authored PR re-gated by the sweep escapes a block the main webhook path applies. (#self-authored-parity)
@@ -570,34 +586,44 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     const gate = evaluateGateCheck(advisory, gateCheckPolicy(settings, null, undefined, pr.slopRisk ?? null));
     verdicts[String(pr.number)] = gate.conclusion;
     if (gate.conclusion === "failure" || gate.conclusion === "action_required") flaggedPulls.push(pr.number);
-    // Backstop the CI-completion trigger AND refresh the stale public comment: fully RE-REVIEW each stale open
-    // PR (rebuild advisory → re-publish the unified comment with the current head/CI → re-run auto-maintain). The
-    // re-gate above only recomputes the audit verdict; without this re-publish, an idle PR keeps a stale comment
-    // (e.g. "safe to merge" from before a fix) and a stale status label forever. reReviewStoredPullRequest reads
-    // the freshly-synced head + the live CI, so the comment + label + action all reflect reality. Paced at
-    // SWEEP_MAX_PRS per sweep. Scheduled sweeps may skip advisory-only AI so the 2-minute cadence cannot
-    // amplify model/API spend for unchanged PR heads, but aiReview:block is part of the authoritative gate
-    // decision and must run before auto-maintenance can act on the recomputed verdict.
+    // Fan the HEAVY re-review (rebuild advisory → re-publish the unified comment with the current head/CI →
+    // re-run auto-maintain → stamp the marker) into its own bounded, individually-retryable per-PR job, staggered
+    // like the repo fan-out, so it interleaves with other work instead of monopolizing the consumer for all
+    // SWEEP_MAX_PRS candidates at once (#audit-sweep-fanout). The cheap verdict summary above is computed inline
+    // and recorded below, preserving the advisory audit. With no installation to act with, stamp the marker
+    // inline so the sweep still converges (audit-only — no re-review is possible without an installation).
     if (sweepInstallationId != null) {
-      await reReviewStoredPullRequest(env, `regate-sweep:${repoFullName}#${pr.number}`, sweepInstallationId, repoFullName, pr.number, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
-        console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+      const job: JobMessage = { type: "agent-regate-pr", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId: sweepInstallationId };
+      const delaySeconds = Math.min(index * 10, 600);
+      await (delaySeconds > 0 ? env.JOBS.send(job, { delaySeconds }) : env.JOBS.send(job));
+    } else {
+      await markPullRequestRegated(env, repoFullName, pr.number).catch((error) => {
+        console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
       });
     }
-    // Stamp the internal re-gate marker so the next sweep advances to the next-stalest PRs. This is a plain D1
-    // write (not a GitHub action), so it converges even when agent actions are suppressed — the dry-run/pause
-    // non-convergence fix. (#audit-sweep-converge) Degrade quietly on a D1 error: the PR is simply re-selected
-    // next sweep (the prior behaviour), never lost.
-    await markPullRequestRegated(env, repoFullName, pr.number).catch((error) => {
-      console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
-    });
   }
   await recordAuditEvent(env, {
     eventType: "agent.sweep.regate",
     actor: "gittensory",
     targetKey: repoFullName,
     outcome: "completed",
-    detail: `scheduled re-gate recomputed ${candidates.length} stale open PR verdict(s); ${flaggedPulls.length} flagged`,
+    detail: `scheduled re-gate recomputed ${candidates.length} stale open PR verdict(s); ${flaggedPulls.length} flagged; fanned out per-PR re-review`,
     metadata: { repoFullName, mode, openCount: openPullRequests.length, examined: candidates.length, flagged: flaggedPulls.length, flaggedPulls, verdicts },
+  });
+}
+
+// #audit-sweep-fanout: one per-PR re-gate unit fanned out by sweepRepoRegate. Re-reviews + stamps a single PR as
+// its own bounded, retryable queue message. Routes through the #1258 chokepoint so a repo that paused or switched
+// to dry-run between fan-out and processing stays inert. Self-contained: resolves the repo settings to mirror the
+// sweep's skipAiReview policy. Both steps degrade quietly on failure (logged, never rethrown) so one bad PR never
+// blocks the others; a stamp failure just re-selects the PR next sweep.
+async function regatePullRequest(env: Env, repoFullName: string, prNumber: number, installationId: number, deliveryId: string): Promise<void> {
+  const settings = await resolveRepositorySettings(env, repoFullName);
+  await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, prNumber, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
+    console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
+  });
+  await markPullRequestRegated(env, repoFullName, prNumber).catch((error) => {
+    console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
   });
 }
 

--- a/src/settings/agent-sweep.ts
+++ b/src/settings/agent-sweep.ts
@@ -62,3 +62,19 @@ export function selectRegateCandidates(input: {
     .sort((a, b) => regateProgress(a) - regateProgress(b) || a.number - b.number)
     .slice(0, Math.max(0, max));
 }
+
+/**
+ * In-flight guard for the per-PR fan-out (#audit-sweep-fanout): is a re-gate sweep still draining for this repo?
+ * sweepRepoRegate fans out one staggered per-PR job per candidate, each of which stamps `last_regated_at` as it
+ * runs — so the MOST RECENT stamp across the repo's open PRs (`latestRegatedAt`) being within `windowMs` of `now`
+ * means a sweep is actively working through its queue. The cron re-arms every ~2 min, far faster than a sweep
+ * drains, so without this guard a second full sweep would pile duplicate per-PR jobs onto the unfinished one. A
+ * missing/never-regated/unparseable timestamp means no sweep is in flight (proceed). Pure + deterministic.
+ */
+export function isRegateSweepDraining(latestRegatedAt: string | null | undefined, now: string, windowMs: number = SWEEP_FRESHNESS_MS): boolean {
+  if (!latestRegatedAt) return false;
+  const stampedMs = Date.parse(latestRegatedAt);
+  const nowMs = Date.parse(now);
+  if (!Number.isFinite(stampedMs) || !Number.isFinite(nowMs)) return false;
+  return nowMs - stampedMs < windowMs;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,16 @@ export type JobMessage =
       attempt: number;
     }
   | {
+      // One bounded re-gate unit fanned out by the scheduled sweep (#audit-sweep-fanout): re-review + stamp a
+      // single PR. Each candidate becomes its own individually-retryable, rate-limited queue message so the heavy
+      // re-review work interleaves with other jobs instead of monopolizing the consumer for all 25 at once.
+      type: "agent-regate-pr";
+      deliveryId: string;
+      repoFullName: string;
+      prNumber: number;
+      installationId: number;
+    }
+  | {
       type: "refresh-registry";
       requestedBy: "schedule" | "api" | "test";
     }

--- a/test/unit/agent-sweep.test.ts
+++ b/test/unit/agent-sweep.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SWEEP_FRESHNESS_MS, SWEEP_MAX_PRS, selectRegateCandidates } from "../../src/settings/agent-sweep";
+import { SWEEP_FRESHNESS_MS, SWEEP_MAX_PRS, isRegateSweepDraining, selectRegateCandidates } from "../../src/settings/agent-sweep";
 import type { PullRequestRecord } from "../../src/types";
 
 const NOW = "2026-06-17T12:00:00.000Z";
@@ -132,5 +132,25 @@ describe("selectRegateCandidates (#777 re-gate sweep selection)", () => {
     expect(SWEEP_MAX_PRS).toBe(25);
     const pulls = Array.from({ length: 40 }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(120 + i) }));
     expect(selectRegateCandidates({ pulls, now: NOW })).toHaveLength(25);
+  });
+});
+
+describe("isRegateSweepDraining (#audit-sweep-fanout in-flight guard)", () => {
+  it("returns false when no PR has ever been regated (null/undefined marker → no sweep in flight)", () => {
+    expect(isRegateSweepDraining(null, NOW)).toBe(false);
+    expect(isRegateSweepDraining(undefined, NOW)).toBe(false);
+  });
+
+  it("returns true when the freshest regate is within the window (a sweep is actively draining)", () => {
+    expect(isRegateSweepDraining(minutesAgo(1), NOW)).toBe(true); // 1m ago < 2m window
+  });
+
+  it("returns false when the freshest regate is older than the window (prior sweep already drained)", () => {
+    expect(isRegateSweepDraining(minutesAgo(5), NOW)).toBe(false); // 5m ago > 2m window
+  });
+
+  it("returns false for an unparseable timestamp or unparseable now (fail-open: proceed)", () => {
+    expect(isRegateSweepDraining("not-a-date", NOW)).toBe(false);
+    expect(isRegateSweepDraining(minutesAgo(1), "not-a-date")).toBe(false);
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -44,6 +44,22 @@ import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
 import { createTestEnv } from "../helpers/d1";
 
+// The re-gate sweep now FANS OUT the heavy re-review + marker stamp into per-PR `agent-regate-pr` jobs
+// (#audit-sweep-fanout). A test asserting the re-review/stamp side effects must run the sweep AND drain the
+// per-PR jobs it enqueues. Returns the captured agent-regate-pr jobs for assertions.
+async function sweepAndDrainPerPr(env: Env, repoFullName: string): Promise<import("../../src/types").JobMessage[]> {
+  const fanned: import("../../src/types").JobMessage[] = [];
+  const send = env.JOBS.send.bind(env.JOBS);
+  env.JOBS.send = (async (message: import("../../src/types").JobMessage, options?: QueueSendOptions) => {
+    if (message.type === "agent-regate-pr") fanned.push(message);
+    return send(message, options);
+  }) as typeof env.JOBS.send;
+  await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName });
+  env.JOBS.send = send;
+  for (const job of fanned) await processJob(env, job);
+  return fanned;
+}
+
 describe("queue processors", () => {
   // Freshness-SLO fixtures are dated relative to late May 2026; pin the clock so staleness windows
   // stay deterministic regardless of when CI runs.
@@ -691,7 +707,7 @@ describe("queue processors", () => {
     });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
 
-    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+    await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     expect(aiCalls).toBeGreaterThanOrEqual(2);
     const blocker = await env.DB.prepare("select blocker_codes_json from gate_outcomes where repo_full_name = ? and pull_number = ? order by rowid desc limit 1").bind("owner/agent-repo", 7).first<{ blocker_codes_json: string }>();
@@ -718,7 +734,7 @@ describe("queue processors", () => {
       return realPrepare(sql);
     }) as typeof env.DB.prepare;
 
-    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+    await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     const audit = await realPrepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.sweep.regate").first<{
       outcome: string;
@@ -741,10 +757,10 @@ describe("queue processors", () => {
     expect(before?.last_regated_at).toBeNull(); // never swept yet
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
 
-    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+    await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     const after = await env.DB.prepare("select last_regated_at from pull_requests where repo_full_name = ? and number = 7").bind("owner/agent-repo").first<{ last_regated_at: string | null }>();
-    expect(typeof after?.last_regated_at).toBe("string"); // stamped via a D1 write — convergence does not need a GitHub write
+    expect(typeof after?.last_regated_at).toBe("string"); // stamped via a D1 write in the per-PR job — convergence does not need a GitHub write
   });
 
   it("agent re-gate sweep swallows a failing last_regated_at stamp and still completes (#audit-sweep-converge)", async () => {
@@ -757,10 +773,10 @@ describe("queue processors", () => {
     const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated").mockRejectedValueOnce(new Error("D1 write error"));
 
-    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+    await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string }>();
-    expect(audit?.outcome).toBe("completed"); // the sweep still records its verdict despite the stamp failure
+    expect(audit?.outcome).toBe("completed"); // the sweep still records its verdict; the per-PR stamp failure is swallowed
     expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_mark_regated_failed"))).toBe(true);
     stamp.mockRestore();
     errors.mockRestore();
@@ -808,6 +824,79 @@ describe("queue processors", () => {
 
     const count = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ n: number }>();
     expect(count?.n).toBe(0);
+  });
+
+  it("INVARIANT: the sweep fans out one agent-regate-pr job per candidate onto the JOBS lane, not inline (#audit-sweep-fanout)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9100, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9100);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "PR7", state: "open", user: { login: "c" }, head: { sha: "a7" }, labels: [], body: "" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 8, title: "PR8", state: "open", user: { login: "c" }, head: { sha: "a8" }, labels: [], body: "" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    const perPr = sent.filter((m): m is Extract<import("../../src/types").JobMessage, { type: "agent-regate-pr" }> => m.type === "agent-regate-pr");
+    expect(perPr.map((m) => m.prNumber).sort()).toEqual([7, 8]); // one per candidate
+    expect(perPr.every((m) => m.installationId === 9100 && m.repoFullName === "owner/agent-repo")).toBe(true);
+    expect(sent.every((m) => m.type === "agent-regate-pr")).toBe(true); // the heavy work is enqueued, never done inline
+  });
+
+  it("INVARIANT (in-flight guard): the fan-out SKIPS a repo whose prior sweep is still draining, enqueues an idle one (#audit-sweep-fanout)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9101, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    for (const name of ["draining", "idle"]) {
+      await upsertRepositoryFromGitHub(env, { name, full_name: `owner/${name}`, private: false, owner: { login: "owner" } }, 9101);
+      await upsertRepositorySettings(env, { repoFullName: `owner/${name}`, autonomy: { merge: "auto" } });
+      await upsertPullRequestFromGitHub(env, `owner/${name}`, { number: 1, title: "PR1", state: "open", user: { login: "c" }, head: { sha: "h1" }, labels: [], body: "" });
+    }
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    // owner/draining was just regated (a sweep is mid-drain); owner/idle has never been swept.
+    await repositoriesModule.markPullRequestRegated(env, "owner/draining", 1);
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "schedule" }); // no repoFullName → fan-out path
+
+    const sweepRepos = sent.filter((m): m is Extract<import("../../src/types").JobMessage, { type: "agent-regate-sweep" }> => m.type === "agent-regate-sweep").map((m) => m.repoFullName);
+    expect(sweepRepos).toEqual(["owner/idle"]); // the draining repo is skipped, the idle one enqueued
+    const fanout = await env.DB.prepare("select metadata_json from audit_events where event_type = ?").bind("agent.sweep.fanout").first<{ metadata_json: string }>();
+    expect(JSON.parse(fanout?.metadata_json ?? "{}")).toMatchObject({ repoCount: 1, skippedDraining: 1 });
+  });
+
+  it("the sweep stamps the marker INLINE when the repo has no installation (audit-only, still converges) (#audit-sweep-fanout)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    // Configured but NOT installed (no installationId) — there is no installation to re-review with.
+    await upsertRepositoryFromGitHub(env, { name: "no-install", full_name: "owner/no-install", private: false, owner: { login: "owner" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/no-install", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/no-install", { number: 7, title: "PR7", state: "open", user: { login: "c" }, head: { sha: "a7" }, labels: [], body: "" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/no-install" });
+
+    expect(sent.filter((m) => m.type === "agent-regate-pr")).toEqual([]); // no installation → no per-PR fan-out
+    const after = await env.DB.prepare("select last_regated_at from pull_requests where repo_full_name = ? and number = 7").bind("owner/no-install").first<{ last_regated_at: string | null }>();
+    expect(typeof after?.last_regated_at).toBe("string"); // stamped inline so the sweep still advances
+  });
+
+  it("the sweep swallows a failing INLINE stamp on a no-installation repo and still completes (#audit-sweep-fanout)", async () => {
+    const env = createTestEnv({ JOBS: { async send() {} } as unknown as Queue });
+    await upsertRepositoryFromGitHub(env, { name: "no-install", full_name: "owner/no-install", private: false, owner: { login: "owner" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/no-install", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/no-install", { number: 7, title: "PR7", state: "open", user: { login: "c" }, head: { sha: "a7" }, labels: [], body: "" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated").mockRejectedValueOnce(new Error("D1 write error"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/no-install" });
+
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("completed"); // the inline stamp failure is swallowed; the sweep still records its verdict
+    expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_mark_regated_failed"))).toBe(true);
+    stamp.mockRestore();
+    errors.mockRestore();
   });
 
   it("routes repo-scoped backfill jobs into resumable segment and detail processors", async () => {


### PR DESCRIPTION
## Summary
`sweepRepoRegate` did ~150-250 live GitHub calls + ~150-300 D1 writes for up to 25 PRs **sequentially inside one queue message**, and the cron re-armed a fresh full sweep **every ~2 min** regardless of whether the prior one finished — so a heavy sweep monopolized the consumer, and overlapping sweeps piled duplicate work. This is the per-message magnitude + re-arm half of Flaw B (the metagraphed-dry-run overload), complementing the bounded lane (#1283) and the convergence marker (#1282).

## Fix
- **Fan out:** the sweep computes the cheap deterministic verdict summary **inline** (the advisory audit — `examined`/`flagged`/`verdicts` — is preserved exactly), but enqueues the **heavy** re-review + marker stamp as its own staggered, individually-retryable **`agent-regate-pr`** job per candidate, on the **JOBS** maintenance lane (never the webhook lane). The heavy work now interleaves with other jobs instead of monopolizing the consumer for all 25 at once, and routes through the #1258 chokepoint so dry-run stays inert. With **no installation** to act with, the marker is stamped inline so the sweep still converges (audit-only).
- **In-flight guard:** `fanOutAgentRegateSweepJobs` **skips a repo whose prior sweep is still draining** — detected by the most-recent `last_regated_at` across its open PRs being within the sweep window (per-PR jobs stamp as they run, so a fresh stamp ⇒ a sweep is active). This is what finally stops the 2-min cron piling a second full sweep — and duplicate per-PR jobs — onto an unfinished one.

## Scope
- [x] `src/types.ts` (`agent-regate-pr` job), `src/settings/agent-sweep.ts` (`isRegateSweepDraining`), `src/db/repositories.ts` (`getLatestRegatedAt`), `src/queue/processors.ts` (fan-out + per-PR handler + in-flight guard). No DB migration; no binding change.

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities
- [x] **Invariants:** the sweep enqueues exactly one `agent-regate-pr` per candidate onto JOBS (never inline, never the webhook lane); the per-PR handler re-reviews + stamps one PR via the chokepoint; the in-flight guard skips a draining repo and enqueues an idle one (audited `skippedDraining`); `isRegateSweepDraining` arms (null / within-window / outside-window / unparseable). **Regressions:** the existing AI-block / re-review-swallow / stamp / stamp-failure behaviours still hold once the per-PR jobs are drained; a no-installation repo stamps inline (success **and** swallowed failure)
- [x] Every changed line + branch covered (one honest `v8 ignore` on the unreachable `max()` empty-row guard) · rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit