### PR TITLE
fix(github): reserve installation rate-limit headroom for webhooks

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -11,7 +11,6 @@ import {
   getLatestRepoGithubTotalsSnapshot,
   getRepoSyncSegment,
   getRepoSyncState,
-  listLatestGitHubRateLimitObservations,
   listOpenIssueNumbers,
   listOpenPullRequests,
   listInstallations,
@@ -61,6 +60,7 @@ import type {
 } from "../types";
 import { errorMessage, nowIso, repoParts, strippedErrorMessage } from "../utils/json";
 import { createInstallationToken, getAppInstallation, GITTENSORY_CONTEXT_CHECK_NAME, GITTENSORY_GATE_CHECK_NAME } from "./app";
+import { delayUntil, shouldWaitForGitHubRateLimit } from "./rate-limit";
 
 type GitHubLabelPayload = {
   name: string;
@@ -295,7 +295,6 @@ const DEFAULT_LIMITS: BackfillLimits = {
 
 const FRESH_SYNC_MS = 6 * 60 * 60 * 1000;
 const ERROR_BACKOFF_MS = 60 * 60 * 1000;
-const LOW_REST_RATE_LIMIT_REMAINING = 75;
 const SEGMENT_PAGE_BUDGET: Record<BackfillMode, number> = { light: 2, full: 10, resume: 10 };
 const PR_DETAIL_BATCH_SIZE: Record<BackfillMode, number> = { light: 12, full: 40, resume: 40 };
 const CURRENT_OPEN_SCAN_MARKER = "gittensory-current-open-scan-v1";
@@ -1496,14 +1495,6 @@ async function refreshRepoSyncStateFromSegments(env: Env, repo: RepositoryRecord
   });
 }
 
-async function shouldWaitForGitHubRateLimit(env: Env): Promise<string | undefined> {
-  const observations = await listLatestGitHubRateLimitObservations(env, 10);
-  const rest = observations.find((observation) => observation.resource === "rest" && observation.remaining !== null && observation.remaining !== undefined);
-  if (!rest?.resetAt || rest.remaining === null || rest.remaining === undefined || rest.remaining > LOW_REST_RATE_LIMIT_REMAINING) return undefined;
-  /* v8 ignore next -- Invalid reset timestamps are treated as not waiting; valid low-rate-limit waits are covered. */
-  return Date.parse(rest.resetAt) > Date.now() ? rest.resetAt : undefined;
-}
-
 function segmentJobResult(
   repoFullName: string,
   segmentName: BackfillSegmentName,
@@ -1521,12 +1512,6 @@ function segmentJobResult(
   };
 }
 
-function delayUntil(iso: string): number {
-  const ms = Date.parse(iso) - Date.now();
-  /* v8 ignore next -- Invalid reset timestamps use conservative delay; valid reset delays are covered through queueing. */
-  if (!Number.isFinite(ms)) return 60;
-  return Math.max(30, Math.min(900, Math.ceil(ms / 1000) + 15));
-}
 
 async function backfillRepository(env: Env, repo: RepositoryRecord, limits: BackfillLimits, mode: BackfillMode): Promise<RepoBackfillResult> {
   const startedAt = nowIso();

--- a/src/github/rate-limit.ts
+++ b/src/github/rate-limit.ts
@@ -1,0 +1,30 @@
+import { listLatestGitHubRateLimitObservations } from "../db/repositories";
+
+// All managed repos share ONE GitHub App installation → ONE hourly REST bucket. To keep heavy maintenance work
+// from draining the budget real webhook traffic needs, maintenance yields while there is still headroom:
+//   - backfill yields at LOW_REST_RATE_LIMIT_REMAINING;
+//   - the re-gate sweep + its per-PR jobs yield EARLIER, at MAINTENANCE_RESERVED_HEADROOM, reserving the budget
+//     between the two floors for webhooks. Webhooks never pre-yield — they run, and the queue retries them after
+//     the reset if the bucket is exhausted (the surviving event-loss path). (#audit-rate-headroom)
+export const LOW_REST_RATE_LIMIT_REMAINING = 75;
+export const MAINTENANCE_RESERVED_HEADROOM = 150;
+
+/** The REST rate-limit reset time to wait until when the latest recorded REST budget is at/below `floor`, or
+ *  undefined when there is headroom, no usable observation, or the reset is already in the past. Reads the latest
+ *  recorded observation (recordGitHubRateLimitObservation writes one per GitHub call) — no live GitHub call. */
+export async function shouldWaitForGitHubRateLimit(env: Env, floor: number = LOW_REST_RATE_LIMIT_REMAINING): Promise<string | undefined> {
+  const observations = await listLatestGitHubRateLimitObservations(env, 10);
+  // Type-guard the find so `remaining` narrows to a number — null/undefined observations are excluded here, so the
+  // headroom check below needs no further nullish guard.
+  const rest = observations.find((observation): observation is typeof observation & { remaining: number } => observation.resource === "rest" && observation.remaining !== null && observation.remaining !== undefined);
+  if (!rest?.resetAt || rest.remaining > floor) return undefined;
+  return Date.parse(rest.resetAt) > Date.now() ? rest.resetAt : undefined;
+}
+
+/** Seconds to defer a job until a GitHub rate-limit reset, clamped to [30, 900] with a 15s safety margin. An
+ *  unparseable reset uses a conservative 60s. */
+export function delayUntil(iso: string): number {
+  const ms = Date.parse(iso) - Date.now();
+  if (!Number.isFinite(ms)) return 60;
+  return Math.max(30, Math.min(900, Math.ceil(ms / 1000) + 15));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { createApp } from "./api/routes";
 import { RateLimiter } from "./auth/rate-limit";
+import { delayUntil, shouldWaitForGitHubRateLimit } from "./github/rate-limit";
 import { processDlqBatch } from "./queue/dlq";
 import { processJob } from "./queue/processors";
 import { isOpsEnabled } from "./review/ops-wire";
@@ -34,7 +35,12 @@ export default {
             error: error instanceof Error ? error.message : "unknown error",
           }),
         );
-        message.retry();
+        // If the shared GitHub REST budget is exhausted, this failure is most likely a rate-limit — retry AFTER the
+        // reset so a real webhook OUTLASTS a transient rate-limit window instead of burning its retries immediately
+        // and being dead-lettered (the surviving event-loss path). (#audit-rate-headroom)
+        const resetAt = await shouldWaitForGitHubRateLimit(env).catch(() => undefined);
+        if (resetAt) message.retry({ delaySeconds: delayUntil(resetAt) });
+        else message.retry();
       }
     }
   },

--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -1,4 +1,5 @@
 import { getWebhookEvent, recordAuditEvent } from "../db/repositories";
+import { delayUntil, shouldWaitForGitHubRateLimit } from "../github/rate-limit";
 import type { JobMessage, JsonValue } from "../types";
 
 /**
@@ -40,7 +41,11 @@ export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env)
     if (webhook && webhook.redriven !== true && webhook.deliveryId) {
       const event = await getWebhookEvent(env, webhook.deliveryId).catch(() => null);
       if (event?.status !== "processed") {
-        await env.WEBHOOKS.send({ type: "github-webhook", deliveryId: webhook.deliveryId, eventName: webhook.eventName, payload: webhook.payload, redriven: true }).catch(() => undefined);
+        // If the webhook dead-lettered because the shared GitHub REST budget was exhausted, re-drive it AFTER the
+        // reset (retry-until-recovered) rather than immediately re-failing it. (#audit-rate-headroom)
+        const resetAt = await shouldWaitForGitHubRateLimit(env).catch(() => undefined);
+        const options = resetAt ? { delaySeconds: delayUntil(resetAt) } : undefined;
+        await env.WEBHOOKS.send({ type: "github-webhook", deliveryId: webhook.deliveryId, eventName: webhook.eventName, payload: webhook.payload, redriven: true }, options).catch(() => undefined);
       }
     }
     message.ack();

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -116,6 +116,7 @@ import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetecti
 import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
 import { isRegateSweepDraining, selectRegateCandidates } from "../settings/agent-sweep";
+import { MAINTENANCE_RESERVED_HEADROOM, delayUntil, shouldWaitForGitHubRateLimit } from "../github/rate-limit";
 import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type PlannedAgentAction } from "../settings/agent-actions";
 import { executeAgentMaintenanceActions, pendingClosureLabelApplied } from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
@@ -572,6 +573,22 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   const candidates = selectRegateCandidates({ pulls: openPullRequests, now: nowIso() });
   // No stale PRs this tick — stay quiet rather than writing an empty heartbeat to the audit feed.
   if (candidates.length === 0) return;
+  // Reserve installation rate-limit headroom for real webhook traffic (#audit-rate-headroom): with the shared REST
+  // budget at/below the maintenance floor, defer the WHOLE sweep until the reset rather than fanning out per-PR
+  // jobs that would each have to defer. Webhooks never pre-yield, so this hands the remaining budget to them.
+  const sweepRateResetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM);
+  if (sweepRateResetAt) {
+    await env.JOBS.send({ type: "agent-regate-sweep", requestedBy: "schedule", repoFullName }, { delaySeconds: delayUntil(sweepRateResetAt) });
+    await recordAuditEvent(env, {
+      eventType: "agent.sweep.regate",
+      actor: "gittensory",
+      targetKey: repoFullName,
+      outcome: "queued",
+      detail: `re-gate sweep deferred: shared GitHub REST budget below the maintenance headroom floor; re-queued after ${sweepRateResetAt}`,
+      metadata: { repoFullName, mode, deferred: true, rateResetAt: sweepRateResetAt },
+    });
+    return;
+  }
   const requireLinkedIssue = settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off";
   const verdicts: Record<string, string> = {};
   const flaggedPulls: number[] = [];
@@ -618,6 +635,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
 // sweep's skipAiReview policy. Both steps degrade quietly on failure (logged, never rethrown) so one bad PR never
 // blocks the others; a stamp failure just re-selects the PR next sweep.
 async function regatePullRequest(env: Env, repoFullName: string, prNumber: number, installationId: number, deliveryId: string): Promise<void> {
+  // Reserve installation rate-limit headroom for real webhooks (#audit-rate-headroom): all repos share ONE GitHub
+  // App installation = ONE REST bucket, so when the shared budget is at/below the maintenance floor, DEFER this
+  // re-review until the reset instead of burning budget a webhook's re-review needs. Re-enqueue with the reset
+  // delay so the PR is still eventually re-gated.
+  const rateResetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM);
+  if (rateResetAt) {
+    await env.JOBS.send({ type: "agent-regate-pr", deliveryId, repoFullName, prNumber, installationId }, { delaySeconds: delayUntil(rateResetAt) });
+    return;
+  }
   const settings = await resolveRepositorySettings(env, repoFullName);
   await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, prNumber, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
     console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));

--- a/test/unit/dlq.test.ts
+++ b/test/unit/dlq.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { processDlqBatch } from "../../src/queue/dlq";
-import { recordWebhookEvent } from "../../src/db/repositories";
+import { recordGitHubRateLimitObservation, recordWebhookEvent } from "../../src/db/repositories";
 import type { JobMessage } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -149,6 +149,22 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
       expect(sent).toEqual([]); // cron self-heals maintenance jobs
       expect(batch.acked).toEqual(["mn-1"]);
+    });
+
+    it("re-drives a rate-limited webhook AFTER the reset delay when the shared REST budget is exhausted (#audit-rate-headroom)", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+      const env = createTestEnv();
+      await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 5, resetAt: "2026-06-24T12:30:00.000Z", observedAt: "2026-06-24T12:00:00.000Z" });
+      const options: Array<{ delaySeconds?: number } | undefined> = [];
+      env.WEBHOOKS = { send: async (_m: JobMessage, opts?: { delaySeconds?: number }) => void options.push(opts) } as unknown as typeof env.WEBHOOKS;
+      const batch = makeBatch([{ id: "wh-rl", body: { type: "github-webhook", deliveryId: "rl-1", eventName: "pull_request", payload: {} } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(options).toHaveLength(1);
+      expect(options[0]?.delaySeconds).toBe(900); // re-driven after the reset, not immediately
+      vi.useRealTimers();
     });
   });
 });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../../src/index";
+import { recordGitHubRateLimitObservation } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 describe("worker entrypoint", () => {
@@ -82,6 +83,31 @@ describe("worker entrypoint", () => {
     await worker.queue(batch, env);
     expect(acked).toEqual(["ok"]);
     expect(retried).toEqual(["bad"]);
+  });
+
+  it("retries a failed job AFTER the rate-limit reset when the shared REST budget is exhausted (#audit-rate-headroom)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const env = createTestEnv();
+    await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 5, resetAt: "2026-06-24T12:30:00.000Z", observedAt: "2026-06-24T12:00:00.000Z" });
+    vi.stubGlobal("fetch", async () => new Response("missing", { status: 404 }));
+    const retries: Array<{ delaySeconds?: number } | undefined> = [];
+    const batch = {
+      messages: [
+        {
+          id: "bad",
+          body: { type: "refresh-registry", requestedBy: "test" },
+          ack: () => undefined,
+          retry: (options?: { delaySeconds?: number }) => retries.push(options),
+        },
+      ],
+    } as unknown as MessageBatch<import("../../src/types").JobMessage>;
+
+    await worker.queue(batch, env);
+
+    expect(retries).toHaveLength(1);
+    expect(retries[0]?.delaySeconds).toBe(900); // re-queued after the reset, not retried immediately
+    vi.useRealTimers();
   });
 
   it("runs scheduled jobs through waitUntil", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -899,6 +899,40 @@ describe("queue processors", () => {
     errors.mockRestore();
   });
 
+  it("REGRESSION: the sweep DEFERS (re-queues, no fan-out) when the shared REST budget is below the maintenance floor (#audit-rate-headroom)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9200, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9200);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "PR7", state: "open", user: { login: "c" }, head: { sha: "a7" }, labels: [], body: "" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    // Low REST budget (10 ≤ 150 maintenance floor) with a future reset → maintenance must yield.
+    await repositoriesModule.recordGitHubRateLimitObservation(env, { repoFullName: "owner/agent-repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 10, resetAt: "2026-05-28T02:30:00.000Z", observedAt: "2026-05-28T02:00:00.000Z" });
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    expect(sent.filter((m) => m.type === "agent-regate-pr")).toEqual([]); // no fan-out while deferred
+    expect(sent.some((m) => m.type === "agent-regate-sweep" && m.repoFullName === "owner/agent-repo")).toBe(true); // re-queued
+    const audit = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("queued");
+    expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ deferred: true });
+  });
+
+  it("REGRESSION: a per-PR re-gate job DEFERS (re-queues, no re-review/stamp) when the REST budget is below the maintenance floor (#audit-rate-headroom)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await repositoriesModule.recordGitHubRateLimitObservation(env, { repoFullName: "owner/agent-repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 10, resetAt: "2026-05-28T02:30:00.000Z", observedAt: "2026-05-28T02:00:00.000Z" });
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated");
+
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "regate-sweep:owner/agent-repo#7", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9200 });
+
+    expect(sent.filter((m) => m.type === "agent-regate-pr")).toHaveLength(1); // re-queued for after the reset
+    expect(stamp).not.toHaveBeenCalled(); // deferred before any re-review or stamp
+    stamp.mockRestore();
+  });
+
   it("routes repo-scoped backfill jobs into resumable segment and detail processors", async () => {
     const sent: import("../../src/types").JobMessage[] = [];
     const env = createTestEnv({

--- a/test/unit/rate-limit.test.ts
+++ b/test/unit/rate-limit.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LOW_REST_RATE_LIMIT_REMAINING, MAINTENANCE_RESERVED_HEADROOM, delayUntil, shouldWaitForGitHubRateLimit } from "../../src/github/rate-limit";
+import { recordGitHubRateLimitObservation } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+const NOW = "2026-06-24T12:00:00.000Z";
+const nowMs = Date.parse(NOW);
+const inIso = (ms: number): string => new Date(nowMs + ms).toISOString();
+
+async function seedRest(env: ReturnType<typeof createTestEnv>, remaining: number | null, resetAt: string | null): Promise<void> {
+  await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining, resetAt, observedAt: NOW });
+}
+
+describe("rate-limit headroom (#audit-rate-headroom)", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("the maintenance floor reserves more headroom than the backfill floor", () => {
+    expect(MAINTENANCE_RESERVED_HEADROOM).toBeGreaterThan(LOW_REST_RATE_LIMIT_REMAINING);
+  });
+
+  describe("shouldWaitForGitHubRateLimit", () => {
+    it("returns undefined when there is no REST observation", async () => {
+      const env = createTestEnv();
+      expect(await shouldWaitForGitHubRateLimit(env)).toBeUndefined();
+    });
+
+    it("returns undefined when remaining is above the floor (headroom)", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(NOW));
+      const env = createTestEnv();
+      await seedRest(env, 500, inIso(3_600_000));
+      expect(await shouldWaitForGitHubRateLimit(env)).toBeUndefined(); // 500 > 75
+    });
+
+    it("returns the resetAt when remaining is at/below the floor and the reset is in the future", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(NOW));
+      const env = createTestEnv();
+      const resetAt = inIso(3_600_000);
+      await seedRest(env, 50, resetAt);
+      expect(await shouldWaitForGitHubRateLimit(env)).toBe(resetAt); // 50 <= 75
+    });
+
+    it("returns undefined when the reset is already in the past (no point waiting)", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(NOW));
+      const env = createTestEnv();
+      await seedRest(env, 50, inIso(-60_000)); // reset 1m ago
+      expect(await shouldWaitForGitHubRateLimit(env)).toBeUndefined();
+    });
+
+    it("returns undefined when the REST observation has no resetAt", async () => {
+      const env = createTestEnv();
+      await seedRest(env, 50, null);
+      expect(await shouldWaitForGitHubRateLimit(env)).toBeUndefined();
+    });
+
+    it("honors a higher maintenance floor — yields at 120 remaining for maintenance but not for the default backfill floor", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(NOW));
+      const env = createTestEnv();
+      const resetAt = inIso(3_600_000);
+      await seedRest(env, 120, resetAt);
+      expect(await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM)).toBe(resetAt); // 120 <= 150 → wait
+      expect(await shouldWaitForGitHubRateLimit(env)).toBeUndefined(); // 120 > 75 default → headroom
+    });
+  });
+
+  describe("delayUntil", () => {
+    it("delays until the reset plus a 15s margin, clamped to [30, 900]", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(NOW));
+      expect(delayUntil(inIso(100_000))).toBe(115); // 100s + 15s margin
+      expect(delayUntil(inIso(5_000))).toBe(30); // floor: 5s + 15s = 20 → clamped up to 30
+      expect(delayUntil(inIso(100_000_000))).toBe(900); // ceiling
+    });
+
+    it("uses a conservative 60s for an unparseable reset", () => {
+      expect(delayUntil("not-a-date")).toBe(60);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
All managed repos share **one GitHub App installation = one hourly REST bucket**, so isolating the Cloudflare queues (#1276) only fixed *scheduling-layer* starvation. A heavy sweep that drove the shared REST budget to zero could **still** make a real webhook's GitHub calls `403`, exhaust its retries, and dead-letter — the **surviving event-loss path**. This closes it.

## Fix
- **Shared rate-limit module** (`src/github/rate-limit.ts`): promote `shouldWaitForGitHubRateLimit` + `delayUntil` out of `backfill.ts` and add a **higher maintenance floor** (`MAINTENANCE_RESERVED_HEADROOM=150`) than backfill's (`75`), reserving the budget between the floors for webhooks.
- **Sweep + per-PR jobs yield:** both check headroom before the heavy re-review; below the maintenance floor they **defer** (re-enqueue after the reset) and audit it — the sweep yields, never the webhook.
- **Webhook outlasts the window:** the queue handler, on a failed job while the budget is exhausted, retries **after** the reset (`delayUntil`) so a real webhook survives a transient rate-limit window instead of burning its retries immediately and dead-lettering.
- **DLQ re-drive** applies the same reset delay (retry-until-recovered).

This is the GitHub-installation-rate-limit layer; with #1283 (bounded lane) + #1290 (per-PR fan-out + in-flight guard) already bounding the load that drives the bucket down, this is the defense-in-depth that guarantees webhooks aren't lost to the shared bucket.

## Scope
- [x] New `src/github/rate-limit.ts`; `src/github/backfill.ts` (import the promoted helpers); `src/queue/processors.ts` (sweep + per-PR defer); `src/index.ts` (rate-aware retry); `src/queue/dlq.ts` (rate-aware re-drive). No DB migration; no binding change.

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities · backfill behaviour unchanged (86 tests pass after the move)
- [x] **Invariants:** the maintenance floor > backfill floor; `shouldWaitForGitHubRateLimit` arms (no obs / above floor / at-or-below + future reset / past reset / no resetAt / custom floor); `delayUntil` clamp `[30,900]` + unparseable→60. **Regressions:** the sweep defers + re-queues (no fan-out) below the floor; a per-PR job defers (no re-review/stamp); a failed job retries after the reset when the budget is exhausted (and immediately otherwise); the DLQ re-drives a rate-limited webhook after the reset delay
- [x] Every changed line + branch covered (type-guarded `find` so no unreachable nullish arms) · rebased onto latest `main` immediately before opening

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit