### PR TITLE
fix(sweep): stamp the re-gate convergence marker at dispatch, not in the per-PR job

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2591,6 +2591,21 @@ export async function markPullRequestRegated(env: Env, fullName: string, number:
     .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.number, number)));
 }
 
+/** Batch variant: stamp the re-gate marker for every dispatched candidate in ONE write, at sweep DISPATCH time.
+ *  Stamping here — not in the downstream per-PR job — makes getLatestRegatedAt reflect the sweep immediately, so
+ *  the in-flight guard engages on the next cron tick before the staggered/deferred per-PR re-reviews complete.
+ *  This closes the overlapping-sweep runaway where the per-PR stamp lagged minutes behind under load. A plain D1
+ *  write — never the #1258 GitHub chokepoint — so dry-run stays inert. (#audit-sweep-dispatch-stamp) */
+export async function markPullRequestsRegated(env: Env, fullName: string, numbers: number[]): Promise<void> {
+  if (numbers.length === 0) return;
+  const db = getDb(env.DB);
+  const now = nowIso();
+  await db
+    .update(pullRequests)
+    .set({ lastRegatedAt: now, updatedAt: now })
+    .where(and(eq(pullRequests.repoFullName, fullName), inArray(pullRequests.number, numbers)));
+}
+
 /** In-flight guard input for the re-gate sweep fan-out (#audit-sweep-fanout): the MOST RECENT last_regated_at
  *  across a repo's OPEN PRs (the freshest sweep stamp), or null if none has been swept. fanOutAgentRegateSweepJobs
  *  passes this to isRegateSweepDraining to skip re-arming a repo whose prior sweep is still draining. */

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -39,7 +39,7 @@ import {
   markInstallationDeleted,
   markRepositoriesRemovedFromInstallation,
   persistAdvisory,
-  markPullRequestRegated,
+  markPullRequestsRegated,
   getLatestRegatedAt,
   recordAgentCommandFeedback,
   recordAuditEvent,
@@ -589,6 +589,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     });
     return;
   }
+  // Stamp the convergence marker for EVERY candidate NOW, at dispatch — not in the downstream per-PR job
+  // (#audit-sweep-dispatch-stamp). This makes getLatestRegatedAt() reflect this sweep immediately, so the in-flight
+  // guard (fanOutAgentRegateSweepJobs) skips re-arming this repo on the next cron tick BEFORE the staggered/
+  // rate-deferred per-PR re-reviews finish. Stamping in the per-PR job lagged minutes behind under load, so the
+  // guard never engaged and overlapping sweeps stacked up (the metagraphed dry-run runaway). It also advances
+  // selectRegateCandidates so the NEXT sweep picks the next-stalest 25. A plain D1 write → dry-run stays inert.
+  await markPullRequestsRegated(env, repoFullName, candidates.map((pr) => pr.number)).catch((error) => {
+    console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, error: errorMessage(error) }));
+  });
   const requireLinkedIssue = settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off";
   const verdicts: Record<string, string> = {};
   const flaggedPulls: number[] = [];
@@ -604,19 +613,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     verdicts[String(pr.number)] = gate.conclusion;
     if (gate.conclusion === "failure" || gate.conclusion === "action_required") flaggedPulls.push(pr.number);
     // Fan the HEAVY re-review (rebuild advisory → re-publish the unified comment with the current head/CI →
-    // re-run auto-maintain → stamp the marker) into its own bounded, individually-retryable per-PR job, staggered
-    // like the repo fan-out, so it interleaves with other work instead of monopolizing the consumer for all
-    // SWEEP_MAX_PRS candidates at once (#audit-sweep-fanout). The cheap verdict summary above is computed inline
-    // and recorded below, preserving the advisory audit. With no installation to act with, stamp the marker
-    // inline so the sweep still converges (audit-only — no re-review is possible without an installation).
+    // re-run auto-maintain) into its own bounded, individually-retryable per-PR job, staggered like the repo
+    // fan-out, so it interleaves with other work instead of monopolizing the consumer for all SWEEP_MAX_PRS
+    // candidates at once (#audit-sweep-fanout). The cheap verdict summary above is computed inline and recorded
+    // below, preserving the advisory audit. The convergence marker was already stamped for every candidate at
+    // dispatch (above); with no installation to act with there is simply no re-review to fan out (audit-only).
     if (sweepInstallationId != null) {
       const job: JobMessage = { type: "agent-regate-pr", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId: sweepInstallationId };
       const delaySeconds = Math.min(index * 10, 600);
       await (delaySeconds > 0 ? env.JOBS.send(job, { delaySeconds }) : env.JOBS.send(job));
-    } else {
-      await markPullRequestRegated(env, repoFullName, pr.number).catch((error) => {
-        console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
-      });
     }
   }
   await recordAuditEvent(env, {
@@ -629,16 +634,17 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   });
 }
 
-// #audit-sweep-fanout: one per-PR re-gate unit fanned out by sweepRepoRegate. Re-reviews + stamps a single PR as
-// its own bounded, retryable queue message. Routes through the #1258 chokepoint so a repo that paused or switched
-// to dry-run between fan-out and processing stays inert. Self-contained: resolves the repo settings to mirror the
-// sweep's skipAiReview policy. Both steps degrade quietly on failure (logged, never rethrown) so one bad PR never
-// blocks the others; a stamp failure just re-selects the PR next sweep.
+// #audit-sweep-fanout: one per-PR re-gate unit fanned out by sweepRepoRegate. Re-reviews a single PR as its own
+// bounded, retryable queue message. Routes through the #1258 chokepoint so a repo that paused or switched to
+// dry-run between fan-out and processing stays inert. Self-contained: resolves the repo settings to mirror the
+// sweep's skipAiReview policy. The convergence marker is NOT stamped here — the sweep already stamped every
+// candidate at dispatch (#audit-sweep-dispatch-stamp), so the in-flight guard does not wait on this job and a
+// deferred/failed re-review never stalls convergence (the next sweep after the window re-claims the PR).
 async function regatePullRequest(env: Env, repoFullName: string, prNumber: number, installationId: number, deliveryId: string): Promise<void> {
   // Reserve installation rate-limit headroom for real webhooks (#audit-rate-headroom): all repos share ONE GitHub
   // App installation = ONE REST bucket, so when the shared budget is at/below the maintenance floor, DEFER this
   // re-review until the reset instead of burning budget a webhook's re-review needs. Re-enqueue with the reset
-  // delay so the PR is still eventually re-gated.
+  // delay so the PR is still eventually re-reviewed.
   const rateResetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM);
   if (rateResetAt) {
     await env.JOBS.send({ type: "agent-regate-pr", deliveryId, repoFullName, prNumber, installationId }, { delaySeconds: delayUntil(rateResetAt) });
@@ -647,9 +653,6 @@ async function regatePullRequest(env: Env, repoFullName: string, prNumber: numbe
   const settings = await resolveRepositorySettings(env, repoFullName);
   await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, prNumber, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
     console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
-  });
-  await markPullRequestRegated(env, repoFullName, prNumber).catch((error) => {
-    console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
   });
 }
 

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -10,6 +10,7 @@ import {
   listRepoSyncSegments,
   listRepoSyncStates,
   markPullRequestRegated,
+  markPullRequestsRegated,
   recordAuditEvent,
   upsertOfficialMinerDetection,
   upsertPullRequestFromGitHub,
@@ -94,6 +95,22 @@ describe("database row parser hardening", () => {
     const after = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 5);
     expect(typeof after?.lastRegatedAt).toBe("string"); // marker stamped with an ISO timestamp
     expect(after?.title).toBe("Stale PR"); // INVARIANT: a plain D1 UPDATE — it touches only the marker, not PR content
+  });
+
+  it("markPullRequestsRegated batch-stamps every candidate at dispatch and no-ops on an empty list (#audit-sweep-dispatch-stamp)", async () => {
+    const env = createTestEnv();
+    for (const number of [5, 6, 7]) {
+      await upsertPullRequestFromGitHub(env, "owner/repo", { number, title: `PR${number}`, state: "open", user: { login: "alice" }, labels: [] });
+    }
+
+    await markPullRequestsRegated(env, "owner/repo", []); // empty → no-op (early return)
+    expect((await listPullRequests(env, "owner/repo")).every((p) => (p.lastRegatedAt ?? null) === null)).toBe(true);
+
+    await markPullRequestsRegated(env, "owner/repo", [5, 7]); // batch stamps only 5 and 7
+    const rows = await listPullRequests(env, "owner/repo");
+    expect(typeof rows.find((p) => p.number === 5)?.lastRegatedAt).toBe("string");
+    expect(typeof rows.find((p) => p.number === 7)?.lastRegatedAt).toBe("string");
+    expect(rows.find((p) => p.number === 6)?.lastRegatedAt ?? null).toBeNull(); // #6 not in the batch → untouched
   });
 
   it("REGRESSION: a later GitHub sync does NOT clobber last_regated_at (omitted from the upsert SET clause)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -760,7 +760,33 @@ describe("queue processors", () => {
     await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     const after = await env.DB.prepare("select last_regated_at from pull_requests where repo_full_name = ? and number = 7").bind("owner/agent-repo").first<{ last_regated_at: string | null }>();
-    expect(typeof after?.last_regated_at).toBe("string"); // stamped via a D1 write in the per-PR job — convergence does not need a GitHub write
+    expect(typeof after?.last_regated_at).toBe("string"); // stamped via a D1 write at dispatch — convergence does not need a GitHub write
+  });
+
+  it("REGRESSION (#audit-sweep-dispatch-stamp): ONE sweep stamps ALL candidates AT DISPATCH, so the next fan-out skips the repo as draining — no overlapping sweeps", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9300, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9300);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    for (const number of [7, 8, 9]) {
+      await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number, title: `PR${number}`, state: "open", user: { login: "c" }, head: { sha: `a${number}` }, labels: [], body: "" });
+    }
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    // Run ONE sweep — but do NOT drain the per-PR jobs (simulate the staggered/deferred re-reviews not having run yet).
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    // The marker is stamped for EVERY candidate immediately at dispatch — NOT waiting on the per-PR jobs.
+    const stamped = await env.DB.prepare("select count(*) as n from pull_requests where repo_full_name = ? and last_regated_at is not null").bind("owner/agent-repo").first<{ n: number }>();
+    expect(stamped?.n).toBe(3);
+
+    // So the very next cron fan-out sees the fresh stamp and SKIPS this repo as draining — the overlap that caused the runaway is gone.
+    sent.length = 0;
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "schedule" });
+    expect(sent.some((m) => m.type === "agent-regate-sweep" && m.repoFullName === "owner/agent-repo")).toBe(false);
+    const fanout = await env.DB.prepare("select metadata_json from audit_events where event_type = ? order by created_at desc limit 1").bind("agent.sweep.fanout").first<{ metadata_json: string }>();
+    expect(JSON.parse(fanout?.metadata_json ?? "{}").skippedDraining).toBeGreaterThanOrEqual(1);
   });
 
   it("agent re-gate sweep swallows a failing last_regated_at stamp and still completes (#audit-sweep-converge)", async () => {
@@ -771,12 +797,12 @@ describe("queue processors", () => {
     await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated").mockRejectedValueOnce(new Error("D1 write error"));
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestsRegated").mockRejectedValueOnce(new Error("D1 write error"));
 
     await sweepAndDrainPerPr(env, "owner/agent-repo");
 
     const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string }>();
-    expect(audit?.outcome).toBe("completed"); // the sweep still records its verdict; the per-PR stamp failure is swallowed
+    expect(audit?.outcome).toBe("completed"); // the sweep still records its verdict; the dispatch-time stamp failure is swallowed
     expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_mark_regated_failed"))).toBe(true);
     stamp.mockRestore();
     errors.mockRestore();
@@ -881,19 +907,19 @@ describe("queue processors", () => {
     expect(typeof after?.last_regated_at).toBe("string"); // stamped inline so the sweep still advances
   });
 
-  it("the sweep swallows a failing INLINE stamp on a no-installation repo and still completes (#audit-sweep-fanout)", async () => {
+  it("the sweep swallows a failing dispatch-time stamp on a no-installation repo and still completes (#audit-sweep-fanout)", async () => {
     const env = createTestEnv({ JOBS: { async send() {} } as unknown as Queue });
     await upsertRepositoryFromGitHub(env, { name: "no-install", full_name: "owner/no-install", private: false, owner: { login: "owner" } });
     await upsertRepositorySettings(env, { repoFullName: "owner/no-install", autonomy: { merge: "auto" } });
     await upsertPullRequestFromGitHub(env, "owner/no-install", { number: 7, title: "PR7", state: "open", user: { login: "c" }, head: { sha: "a7" }, labels: [], body: "" });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated").mockRejectedValueOnce(new Error("D1 write error"));
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestsRegated").mockRejectedValueOnce(new Error("D1 write error"));
 
     await processJob(env, { type: "agent-regate-sweep", requestedBy: "test", repoFullName: "owner/no-install" });
 
     const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.sweep.regate").first<{ outcome: string }>();
-    expect(audit?.outcome).toBe("completed"); // the inline stamp failure is swallowed; the sweep still records its verdict
+    expect(audit?.outcome).toBe("completed"); // the dispatch-time stamp failure is swallowed; the sweep still records its verdict
     expect(errors.mock.calls.some((call) => String(call[0]).includes("sweep_mark_regated_failed"))).toBe(true);
     stamp.mockRestore();
     errors.mockRestore();
@@ -924,12 +950,12 @@ describe("queue processors", () => {
     const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
     vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
     await repositoriesModule.recordGitHubRateLimitObservation(env, { repoFullName: "owner/agent-repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 10, resetAt: "2026-05-28T02:30:00.000Z", observedAt: "2026-05-28T02:00:00.000Z" });
-    const stamp = vi.spyOn(repositoriesModule, "markPullRequestRegated");
+    const stamp = vi.spyOn(repositoriesModule, "markPullRequestsRegated");
 
     await processJob(env, { type: "agent-regate-pr", deliveryId: "regate-sweep:owner/agent-repo#7", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9200 });
 
     expect(sent.filter((m) => m.type === "agent-regate-pr")).toHaveLength(1); // re-queued for after the reset
-    expect(stamp).not.toHaveBeenCalled(); // deferred before any re-review or stamp
+    expect(stamp).not.toHaveBeenCalled(); // the per-PR job NEVER stamps the convergence marker — the sweep already did, at dispatch
     stamp.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
**Fixes an overlapping-sweep runaway surfaced by a metagraphed dry-run.** The in-flight guard (`fanOutAgentRegateSweepJobs`) decides "is a sweep still draining for this repo?" from `getLatestRegatedAt` — the most recent `last_regated_at` across the repo's open PRs. But that marker was only stamped *inside the per-PR handler*, **after** the heavy re-review (staggered up to 600s, and under the #1292 rate-headroom defer it re-queues **without stamping at all**). So on a large repo the stamp lagged minutes — or never landed — behind the sweep, the guard never saw it, and every ~2-min cron re-armed another full sweep.

A metagraphed dry-run (55 open PRs) reproduced it exactly: **6 overlapping sweeps in ~4 min, ~150 fan-out jobs, `last_regated_at` never advancing past 0.** Because dry-run is inert (the #1258 chokepoint suppressed every GitHub write), it surfaced **safely — zero dead-letters, live repos unaffected.**

## Fix
Stamp the convergence marker for **every candidate at dispatch** (`markPullRequestsRegated`, one batch D1 write in `sweepRepoRegate`) instead of inside the per-PR job. Now `getLatestRegatedAt` reflects the sweep **immediately**, the guard engages on the next cron tick, and convergence advances **regardless** of whether a per-PR re-review defers, backlogs, or fails — the next sweep after the freshness window re-claims any PR whose re-review didn't land. The per-PR job now only does the heavy re-review. The marker is a plain D1 write (never the chokepoint), so dry-run stays inert.

## Scope
- [x] `src/db/repositories.ts` (`markPullRequestsRegated` batch helper), `src/queue/processors.ts` (stamp upfront in `sweepRepoRegate`; remove the lagging stamp from `regatePullRequest` + the no-installation inline stamp). No DB migration; no binding change.

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities
- [x] **Key regression test:** ONE sweep stamps **all** candidates at dispatch (without draining the per-PR jobs), so the next fan-out **skips** the repo as draining (`skippedDraining ≥ 1`) — the overlap that caused the runaway is gone. **Invariants:** `markPullRequestsRegated` batch-stamps the listed PRs and no-ops on `[]`; the per-PR job **never** touches the marker; a failing dispatch-time stamp is swallowed and the sweep still completes (with + without an installation).
- [x] Every changed line + branch covered · rebased onto latest `main` immediately before opening

## Residual / follow-up
- The deploy-restart **cron burst** (≈4 fan-outs in one minute) is now *bounded* — the first sweep's dispatch stamp makes the rest skip — instead of compounding. A fan-out-level dedup could eliminate even that one-time burst, but it's not required for correctness; tracking separately.

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit