### PR TITLE
feat(notify): self-host Discord fallback via DISCORD_WEBHOOK_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,8 @@ GITTENSORY_REVIEW_DRAFT=false
 #                                            #   cache (prevents double-processing of GitHub retries). Off when unset.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
+# DISCORD_WEBHOOK_URL=                        # one Discord channel for per-action notifications (merged/closed/
+#                                            #   manual) on ANY repo you review. Unset = no Discord notifications.
 #                                            #   Collection and schema are auto-created at startup. Off when unset.
 # QDRANT_API_KEY=                            # Bearer token for an authenticated Qdrant (cloud / on-prem). Omit for
 #                                            #   the local --profile qdrant container (unauthenticated).

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -57,6 +57,9 @@ declare global {
     GITTENSORY_AUTO_FILE_DRIFT_ISSUES?: string;
     GITTENSORY_DRIFT_ISSUE_REPO?: string;
     GITTENSORY_DRIFT_ISSUE_TOKEN?: string;
+    /** Self-host default Discord webhook URL — per-action notifications (merged/closed/manual) for any repo
+     *  not in the built-in per-repo map. Lets a self-host operator wire one channel without a source edit. */
+    DISCORD_WEBHOOK_URL?: string;
     GITTENSORY_CONTRIBUTOR_ISSUE_TOKEN?: string;
     PRODUCT_USAGE_HASH_SALT?: string;
     GITTENSORY_API_TOKEN: string;

--- a/src/services/notify-discord.ts
+++ b/src/services/notify-discord.ts
@@ -26,10 +26,17 @@ const WEBHOOK_SECRET_BY_REPO: Record<string, string> = {
 };
 
 function resolveWebhook(env: Env, repoFullName: string): string | undefined {
+  // A repo with a specific mapping uses its own channel secret (the built-in map is gittensory's OWN repos).
   const name = WEBHOOK_SECRET_BY_REPO[repoFullName.toLowerCase()];
-  if (!name) return undefined;
-  const value = (env as unknown as Record<string, unknown>)[name];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (name) {
+    const mapped = (env as unknown as Record<string, unknown>)[name];
+    if (typeof mapped === "string" && mapped.length > 0) return mapped;
+  }
+  // Modular self-host default: ANY repo not in the built-in map falls back to a single DISCORD_WEBHOOK_URL, so a
+  // self-host operator gets per-action notifications for THEIR repos without editing this source map. Unset →
+  // undefined → no-notify, byte-identical to today.
+  const fallback = (env as unknown as Record<string, unknown>).DISCORD_WEBHOOK_URL;
+  return typeof fallback === "string" && fallback.length > 0 ? fallback : undefined;
 }
 
 export type NotifyOutcome = "merged" | "closed" | "manual";

--- a/test/unit/notify-discord.test.ts
+++ b/test/unit/notify-discord.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { notifyActionToDiscord } from "../../src/services/notify-discord";
+import { createTestEnv } from "../helpers/d1";
+
+const HOOK = "https://discord.com/api/webhooks/123/abc";
+const FALLBACK = "https://discord.com/api/webhooks/999/zzz";
+
+function stubFetch(): string[] {
+  const calls: string[] = [];
+  vi.stubGlobal("fetch", async (url: RequestInfo | URL) => {
+    calls.push(String(url));
+    return new Response(null, { status: 204 });
+  });
+  return calls;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+// The built-in per-repo secrets (GITTENSORY_DISCORD_WEBHOOK, …) are read via cast and not declared on Env, so
+// set them with Object.assign; DISCORD_WEBHOOK_URL is declared, so either path works.
+const withEnv = (over: Record<string, string>): Env => Object.assign(createTestEnv(), over) as Env;
+const notify = (env: Env, repo: string): Promise<void> =>
+  notifyActionToDiscord(env, { repoFullName: repo, pullNumber: 1, outcome: "merged", summary: "ok" });
+
+describe("notify-discord resolveWebhook (modular self-host fallback)", () => {
+  it("a mapped repo uses its own per-channel secret", async () => {
+    const calls = stubFetch();
+    await notify(withEnv({ GITTENSORY_DISCORD_WEBHOOK: HOOK }), "JSONbored/gittensory");
+    expect(calls).toEqual([HOOK]);
+  });
+
+  it("any UNmapped repo (a self-hoster's) falls back to DISCORD_WEBHOOK_URL", async () => {
+    const calls = stubFetch();
+    await notify(withEnv({ DISCORD_WEBHOOK_URL: FALLBACK }), "acme/widgets");
+    expect(calls).toEqual([FALLBACK]);
+  });
+
+  it("no mapping + no DISCORD_WEBHOOK_URL → no notification (byte-identical to today)", async () => {
+    const calls = stubFetch();
+    await notify(createTestEnv(), "acme/widgets");
+    expect(calls).toEqual([]);
+  });
+
+  it("a mapped repo whose channel secret is unset falls back to DISCORD_WEBHOOK_URL", async () => {
+    const calls = stubFetch();
+    // JSONbored/metagraphed is in the map, but METAGRAPHED_DISCORD_WEBHOOK is unset → fall through.
+    await notify(withEnv({ DISCORD_WEBHOOK_URL: FALLBACK }), "JSONbored/metagraphed");
+    expect(calls).toEqual([FALLBACK]);
+  });
+});


### PR DESCRIPTION
## Summary

The per-repo Discord notification map (`WEBHOOK_SECRET_BY_REPO` in `notify-discord.ts`) was hard-coded to **JSONbored's own repos** — a self-host operator reviewing *their* repos couldn't get the per-action (merged/closed/manual) Discord notifications without editing the source map.

Adds a **modular fallback**: any repo **not** in the built-in map uses a single **`DISCORD_WEBHOOK_URL`** env, so a self-hoster wires one channel for all their repos with zero source edits — the engine's idiomatic config (and correct for a **secret**, which can't live in committed `.gittensory.yml`).

- The built-in map stays as gittensory's own per-channel config and **takes precedence**.
- A mapped repo whose channel secret is *unset* also falls through to `DISCORD_WEBHOOK_URL`.
- Unset → `undefined` → no-notify, **byte-identical to today** for any repo.

First of the **modularity campaign** (engine-side config). Per the website-vs-engine boundary: this is an *engine* feature self-hosters run over their repos, so it gets config-driven — unlike the website's *global* surfaces (homepage stats, draft portal), which stay ours.

## Scope
- [x] Additive; `notify-discord.ts` + `env.d.ts` + `.env.example` + a new unit test. Notifications are best-effort (never affect the gate).

## Validation
- [x] `npm run test:ci` — green
- [x] **100% branch coverage** on the `resolveWebhook` change (mapped→own-secret; unmapped→fallback; neither→no-notify; mapped-but-unset→fallback)

Advances the not-single-repo / modularity directive.