### PR TITLE
feat(upstream): config-driven drift-issue assignees + dedup upstream-repo constant

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -60,6 +60,9 @@ declare global {
     GITTENSORY_AUTO_FILE_DRIFT_ISSUES?: string;
     GITTENSORY_DRIFT_ISSUE_REPO?: string;
     GITTENSORY_DRIFT_ISSUE_TOKEN?: string;
+    /** Comma-separated GitHub logins assigned to filed upstream-drift issues (default: the gittensory
+     *  maintainer). Lets a self-host operator route drift issues to their own team. */
+    GITTENSORY_DRIFT_ISSUE_ASSIGNEES?: string;
     /** Self-host default Discord webhook URL — per-action notifications (merged/closed/manual) for any repo
      *  not in the built-in per-repo map. Lets a self-host operator wire one channel without a source edit. */
     DISCORD_WEBHOOK_URL?: string;

--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -12,7 +12,7 @@ import {
 } from "../db/repositories";
 import { isGlobalAgentPause } from "../settings/agent-execution";
 import { normalizeRegistryPayload } from "../registry/normalize";
-import { detectActiveModel, findUnmodeledConstantKeys, parsePythonNumberConstants } from "../scoring/model";
+import { DEFAULT_GITTENSOR_UPSTREAM_REF, DEFAULT_GITTENSOR_UPSTREAM_REPO, detectActiveModel, findUnmodeledConstantKeys, parsePythonNumberConstants } from "../scoring/model";
 import { syncUnmodeledScoringConstantDrift } from "./unmodeled-scoring-drift";
 import type {
   JsonValue,
@@ -30,8 +30,8 @@ import type {
 } from "../types";
 import { errorMessage, jsonString, nowIso } from "../utils/json";
 
-const DEFAULT_UPSTREAM_REPO = "entrius/gittensor";
-const DEFAULT_UPSTREAM_REF = "test";
+// The Gittensor upstream repo/ref defaults are single-sourced from src/scoring/model.ts (where the same
+// env.GITTENSOR_UPSTREAM_* override is honoured) — see DEFAULT_GITTENSOR_UPSTREAM_REPO/REF.
 const DEFAULT_DRIFT_ISSUE_REPO = "JSONbored/gittensory";
 const UPSTREAM_STALE_MS = 2 * 60 * 60 * 1000;
 const REGISTRY_HYPERPARAMETER_DRIFT_LIMIT = 100;
@@ -275,6 +275,7 @@ export async function fileUpstreamDriftIssues(env: Env): Promise<Record<string, 
   const token = env.GITTENSORY_DRIFT_ISSUE_TOKEN ?? env.GITHUB_PUBLIC_TOKEN;
   if (!token) return { status: "skipped", reason: "missing_issue_token", created: 0, updated: 0, skipped: 0 };
   const repo = env.GITTENSORY_DRIFT_ISSUE_REPO || DEFAULT_DRIFT_ISSUE_REPO;
+  const assignees = resolveDriftAssignees(env);
   const reports = (await listUpstreamDriftReports(env, 20)).filter((report) => report.status === "open");
   let created = 0;
   let updated = 0;
@@ -282,7 +283,7 @@ export async function fileUpstreamDriftIssues(env: Env): Promise<Record<string, 
   for (const report of reports) {
     const existing = (await validateRecordedGitHubIssue(repo, token, report)) ?? (await findGitHubIssueForFingerprint(repo, token, report.fingerprint));
     if (existing) {
-      const issue = await updateGitHubDriftIssue(repo, token, existing.number, report);
+      const issue = await updateGitHubDriftIssue(repo, token, existing.number, report, assignees);
       if (!issue) {
         skipped += 1;
         continue;
@@ -291,7 +292,7 @@ export async function fileUpstreamDriftIssues(env: Env): Promise<Record<string, 
       updated += 1;
       continue;
     }
-    const issue = await createGitHubDriftIssue(repo, token, report);
+    const issue = await createGitHubDriftIssue(repo, token, report, assignees);
     if (!issue) {
       skipped += 1;
       continue;
@@ -392,8 +393,8 @@ export async function buildUpstreamDriftReport(current: UpstreamRulesetSnapshotR
 
 function upstreamConfig(env: Env): { repo: string; ref: string } {
   return {
-    repo: env.GITTENSOR_UPSTREAM_REPO || DEFAULT_UPSTREAM_REPO,
-    ref: env.GITTENSOR_UPSTREAM_REF || DEFAULT_UPSTREAM_REF,
+    repo: env.GITTENSOR_UPSTREAM_REPO || DEFAULT_GITTENSOR_UPSTREAM_REPO,
+    ref: env.GITTENSOR_UPSTREAM_REF || DEFAULT_GITTENSOR_UPSTREAM_REF,
   };
 }
 
@@ -1019,26 +1020,26 @@ async function findGitHubIssueForFingerprint(repo: string, token: string, finger
   }
 }
 
-async function createGitHubDriftIssue(repo: string, token: string, report: UpstreamDriftReportRecord): Promise<{ number: number; url: string } | null> {
+async function createGitHubDriftIssue(repo: string, token: string, report: UpstreamDriftReportRecord, assignees: string[]): Promise<{ number: number; url: string } | null> {
   const [owner, name] = repo.split("/");
   if (!owner || !name) return null;
   const response = await fetch(`https://api.github.com/repos/${owner}/${name}/issues`, {
     method: "POST",
     headers: githubHeaders(token, "application/vnd.github+json"),
-    body: jsonString(githubDriftIssuePayload(report)),
+    body: jsonString(githubDriftIssuePayload(report, assignees)),
   });
   if (!response.ok) return null;
   const payload = (await response.json()) as { number?: number; html_url?: string };
   return payload.number && payload.html_url ? { number: payload.number, url: payload.html_url } : null;
 }
 
-async function updateGitHubDriftIssue(repo: string, token: string, issueNumber: number, report: UpstreamDriftReportRecord): Promise<{ number: number; url: string } | null> {
+async function updateGitHubDriftIssue(repo: string, token: string, issueNumber: number, report: UpstreamDriftReportRecord, assignees: string[]): Promise<{ number: number; url: string } | null> {
   const [owner, name] = repo.split("/");
   if (!owner || !name || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
   const response = await fetch(`https://api.github.com/repos/${owner}/${name}/issues/${issueNumber}`, {
     method: "PATCH",
     headers: githubHeaders(token, "application/vnd.github+json"),
-    body: jsonString(githubDriftIssuePayload(report)),
+    body: jsonString(githubDriftIssuePayload(report, assignees)),
   });
   if (!response.ok) return null;
   const payload = (await response.json()) as { number?: number; html_url?: string };
@@ -1084,12 +1085,27 @@ function githubDriftIssueTitle(report: UpstreamDriftReportRecord): string {
   return `chore(upstream): reconcile Gittensor drift ${report.fingerprint.slice(0, 8)}`;
 }
 
-function githubDriftIssuePayload(report: UpstreamDriftReportRecord): Record<string, JsonValue> {
+/**
+ * Who upstream-drift issues are assigned to. Defaults to the gittensory maintainer, but a self-host operator
+ * can set GITTENSORY_DRIFT_ISSUE_ASSIGNEES (comma-separated logins; empty/whitespace = the default) so drift
+ * issues land on THEIR team instead of a login that doesn't exist on their fork. Pairs with the existing
+ * GITTENSORY_DRIFT_ISSUE_REPO override.
+ */
+export function resolveDriftAssignees(env: Env): string[] {
+  const raw = env.GITTENSORY_DRIFT_ISSUE_ASSIGNEES;
+  if (typeof raw !== "string" || !raw.trim()) return ["jsonbored"];
+  return raw
+    .split(",")
+    .map((login) => login.trim())
+    .filter((login) => login.length > 0);
+}
+
+function githubDriftIssuePayload(report: UpstreamDriftReportRecord, assignees: string[]): Record<string, JsonValue> {
   return {
     title: githubDriftIssueTitle(report),
     body: githubDriftIssueBody(report),
     labels: ["signals", "scoring", "data", report.severity === "high" || report.severity === "blocking" ? "high-impact" : "backend"],
-    assignees: ["jsonbored"],
+    assignees,
   };
 }
 

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -15,6 +15,7 @@ import {
   registryHyperparameterDriftWarningsForRepo,
   refreshUpstreamDrift,
   refreshUpstreamSourceSnapshots,
+  resolveDriftAssignees,
 } from "../../src/upstream/ruleset";
 import type { UpstreamDriftReportRecord, UpstreamRulesetSnapshotRecord, UpstreamSourceSnapshotRecord } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
@@ -877,6 +878,15 @@ describe("upstream ruleset drift tracking", () => {
     await expect(fileUpstreamDriftIssues(failingEnv)).resolves.toMatchObject({ status: "completed", created: 0, updated: 0, skipped: 1 });
   });
 
+  it("assigns filed drift issues to GITTENSORY_DRIFT_ISSUE_ASSIGNEES when a self-host operator sets it", async () => {
+    const env = createTestEnv({ GITTENSORY_AUTO_FILE_DRIFT_ISSUES: "true", GITTENSORY_DRIFT_ISSUE_TOKEN: "token", GITTENSORY_DRIFT_ISSUE_ASSIGNEES: "alice, ,bob" });
+    await upsertUpstreamDriftReport(env, driftReport("assignee-override"));
+    const calls: GitHubIssueFetchCall[] = [];
+    vi.stubGlobal("fetch", githubIssueFetch({ create: { number: 70, url: "https://github.com/acme/widgets/issues/70" }, calls }));
+    await expect(fileUpstreamDriftIssues(env)).resolves.toMatchObject({ status: "completed", created: 1 });
+    expect(calls.find((call) => call.method === "POST")?.body?.assignees).toEqual(["alice", "bob"]); // trimmed, empty segment dropped
+  });
+
   it("handles edge cases while filing upstream drift issues", async () => {
     const defaultRepoEnv = createTestEnv({ GITTENSORY_AUTO_FILE_DRIFT_ISSUES: "1", GITTENSORY_DRIFT_ISSUE_TOKEN: "token", GITTENSORY_DRIFT_ISSUE_REPO: "" });
     await upsertUpstreamDriftReport(defaultRepoEnv, driftReport("source-fingerprint", { severity: "medium", affectedAreas: [] }));
@@ -1472,3 +1482,16 @@ function driftReport(
     updatedAt: "2026-05-30T00:00:00.000Z",
   };
 }
+
+describe("resolveDriftAssignees", () => {
+  it("defaults to the gittensory maintainer when unset, empty, or whitespace-only", () => {
+    expect(resolveDriftAssignees(createTestEnv())).toEqual(["jsonbored"]);
+    expect(resolveDriftAssignees(createTestEnv({ GITTENSORY_DRIFT_ISSUE_ASSIGNEES: "" }))).toEqual(["jsonbored"]);
+    expect(resolveDriftAssignees(createTestEnv({ GITTENSORY_DRIFT_ISSUE_ASSIGNEES: "   " }))).toEqual(["jsonbored"]);
+  });
+
+  it("parses a comma-separated list, trimming and dropping empty segments", () => {
+    expect(resolveDriftAssignees(createTestEnv({ GITTENSORY_DRIFT_ISSUE_ASSIGNEES: "alice" }))).toEqual(["alice"]);
+    expect(resolveDriftAssignees(createTestEnv({ GITTENSORY_DRIFT_ISSUE_ASSIGNEES: " alice , ,bob " }))).toEqual(["alice", "bob"]);
+  });
+});


### PR DESCRIPTION
## Summary

Two `src/upstream/` config-hygiene fixes so a self-host operator isn't pinned to JSONbored's setup (modularity / not-single-repo directive — engine-side, not a website surface):

1. **Drift-issue assignees are now config-driven.** `fileUpstreamDriftIssues` hard-coded `assignees: ["jsonbored"]` on every filed issue — a login that doesn't exist on anyone else's fork. Resolve from a new **`GITTENSORY_DRIFT_ISSUE_ASSIGNEES`** (comma-separated logins; empty/whitespace = the maintainer default), threaded through the create/update issue payloads. Pairs with the existing `GITTENSORY_DRIFT_ISSUE_REPO` override.
2. **Single-source the upstream repo/ref default.** `ruleset.ts` re-declared its own `DEFAULT_UPSTREAM_REPO`/`REF`, duplicating the canonical constants already exported from `scoring/model.ts` (same `env.GITTENSOR_UPSTREAM_*` override path). Import the canonical ones — `ruleset.ts` already imports from `scoring/model`, so there's no new edge / cycle.

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the diff — a focused `resolveDriftAssignees` unit test (unset/empty/whitespace → default; comma list trimmed + empty segments dropped) + an end-to-end `fileUpstreamDriftIssues` test asserting the custom assignees reach the POST body.

Advances the not-single-repo / modularity directive.