### PR TITLE
fix(db): repair webhook_events.received_at rows holding the CURRENT_TIMESTAMP literal

### DIFF
--- a/migrations/0066_repair_webhook_received_at.sql
+++ b/migrations/0066_repair_webhook_received_at.sql
@@ -1,0 +1,28 @@
+-- One-off repair: webhook_events.received_at rows holding the literal string produced by an old bug.
+--
+-- ROOT CAUSE (already fixed in code): an earlier Drizzle schema used a STATIC default for received_at. Drizzle
+-- applies static defaults client-side, so an insert that omitted the column wrote the literal default STRING
+-- rather than reaching the database time function. The schema now uses a $defaultFn (real ISO via nowIso), so no
+-- NEW rows are corrupted. This migration repairs the ~20,472 historical rows.
+--
+-- Impact of leaving them: the literal sorts lexicographically after real ISO timestamps, so every time-range
+-- query on received_at is wrong (it once produced a false "20,835 webhooks in 9 minutes" reading).
+--
+-- Repair strategy:
+--   1. ~20,408 rows have a clean processed_at (a real ISO timestamp, verified never corrupted); received_at is
+--      always <= processed_at, so processed_at is the best available estimate.
+--   2. The remaining ~64 rows are queued webhooks that never processed (processed_at NULL); their receipt time is
+--      unrecoverable, so stamp an epoch sentinel (received_at is NOT NULL). They sort as oldest, which is correct.
+--
+-- The corrupted value is matched as the concatenation ('CURRENT_' || 'TIMESTAMP') — NOT a single literal token —
+-- so the self-host Postgres dialect shim (which rewrites that bare keyword) cannot mangle this WHERE clause. Both
+-- SQLite and Postgres evaluate the concatenation to the same string at runtime.
+UPDATE webhook_events
+   SET received_at = processed_at
+ WHERE received_at = ('CURRENT_' || 'TIMESTAMP')
+   AND processed_at IS NOT NULL
+   AND processed_at != ('CURRENT_' || 'TIMESTAMP');
+
+UPDATE webhook_events
+   SET received_at = '1970-01-01T00:00:00.000Z'
+ WHERE received_at = ('CURRENT_' || 'TIMESTAMP');

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -13,12 +13,15 @@ import {
   markPullRequestRegated,
   markPullRequestsRegated,
   recordAuditEvent,
+  recordWebhookEvent,
   upsertOfficialMinerDetection,
   upsertPullRequestFromGitHub,
   extractLinkedIssueNumbers,
   extractLinkedIssueNumbersWithOverflow,
   MAX_LINKED_ISSUE_NUMBERS,
 } from "../../src/db/repositories";
+import { getDb } from "../../src/db/client";
+import { webhookEvents } from "../../src/db/schema";
 import { createTestEnv } from "../helpers/d1";
 
 describe("database row parser hardening", () => {
@@ -122,6 +125,22 @@ describe("database row parser hardening", () => {
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:00:50.000Z", W)).toBe(false); // +50s, still inside → loses
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:01:31.000Z", W)).toBe(true); // +91s, outside window → wins again
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:01:40.000Z", W)).toBe(false); // back inside the new window → loses
+  });
+
+  it("REGRESSION: webhook_events.received_at is always a real ISO timestamp, never the 'CURRENT_TIMESTAMP' literal (#audit-ts-literal)", async () => {
+    const env = createTestEnv();
+    // Real path: recordWebhookEvent always passes nowIso().
+    await recordWebhookEvent(env, { deliveryId: "ts-1", eventName: "pull_request", payloadHash: "h", status: "queued" });
+    const r1 = await env.DB.prepare("select received_at from webhook_events where delivery_id = 'ts-1'").first<{ received_at: string }>();
+    expect(r1?.received_at).not.toBe("CURRENT_TIMESTAMP");
+    expect(Number.isFinite(Date.parse(r1?.received_at ?? "not-a-date"))).toBe(true);
+    // Backstop: a Drizzle insert that OMITS received_at must hit the $defaultFn (real ISO), not a static-default
+    // literal — this is the exact omit path that corrupted ~20,472 rows before the schema was switched to $defaultFn.
+    const db = getDb(env.DB);
+    await db.insert(webhookEvents).values({ deliveryId: "ts-2", eventName: "issues", payloadHash: "h2", status: "queued" });
+    const r2 = await env.DB.prepare("select received_at from webhook_events where delivery_id = 'ts-2'").first<{ received_at: string }>();
+    expect(r2?.received_at).not.toBe("CURRENT_TIMESTAMP");
+    expect(Number.isFinite(Date.parse(r2?.received_at ?? "not-a-date"))).toBe(true);
   });
 
   it("claimRegateFanoutSlot fails open (returns true) on a DB error so the fleet never stalls", async () => {


### PR DESCRIPTION
## Summary
~20,472 `webhook_events` rows have `received_at` stored as the **literal string `"CURRENT_TIMESTAMP"`**. **Root cause (already fixed in code):** an earlier Drizzle schema used a static default; Drizzle applies static defaults **client-side**, so an insert omitting the column wrote the literal instead of reaching the DB time function. The schema now uses `$defaultFn(() => nowIso())` and `recordWebhookEvent` passes `nowIso()`, so **no new rows corrupt** — this migration repairs the historical ones. The literal sorts lexicographically *after* real ISO timestamps, breaking every time-range query on `received_at` (it produced a false *"20,835 webhooks in 9 min"* incident reading).

## Fix
Migration **0066**:
- **~20,408 rows** → `received_at = processed_at` (a real ISO timestamp; `processed_at` verified **never** corrupted — 0).
- **~64 rows** (queued, never processed) → an epoch sentinel (`received_at` is `NOT NULL`); stale pre-fix rows, sort as oldest.

The WHERE matches the corrupted value as the concatenation **`('CURRENT_' || 'TIMESTAMP')`** — not a single token — so the self-host Postgres dialect shim (which rewrites the bare `CURRENT_TIMESTAMP` keyword to a `to_char` expression) can't mangle this clause. Both SQLite and Postgres evaluate the concat identically. *(The shim's rewrite-inside-string-literals behaviour is a separate, narrower issue; sidestepping it here avoids touching the translation of every existing migration.)*

## Scope
- [x] Migration `0066_repair_webhook_received_at.sql` + a regression test. **No `src` change** (source fixed previously; the concat keeps the migration dialect-safe).

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities · `db:migrations:check` — contiguous
- [x] Backfill verified against **prod** (read-only): `('CURRENT_' || 'TIMESTAMP')` matches exactly 20,472 (20,408 via `processed_at` + 64 sentinel); `processed_at` corruption = 0
- [x] Regression: an insert (real path + `$defaultFn` omit) yields valid ISO `received_at`, never the literal · idempotent (re-running matches 0 rows) · rebased onto latest `main`

## Safety
- [x] One-off data repair; no secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`