### PR TITLE
feat(content-lane): surface-model entry + document validators

### DIFF
--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -74,6 +74,8 @@ export {
 export {
   assessCandidateDocument,
   assessProviderDocument,
+  assessSurfaceEntry,
+  assessSubnetDocument,
   assessFreshness,
   classifyPrScope,
   classifyRegistryPrScope,

--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -575,6 +575,103 @@ export function assessCandidateDocument(
   return { verdict: "merged", candidate };
 }
 
+/**
+ * Surface model (the candidate-file model's successor): a contribution appends ONE entry to `surfaces[]` of a
+ * `registry/subnets/<slug>.json`, whose `netuid` lives at the file ROOT (not on each entry). These two
+ * deterministic validators are the per-entry and whole-document analogues of assessCandidateDocument — gittensory
+ * is the sole adjudicator; no AI (surfaces are structured data). They take the appended entry / parsed document as
+ * arguments; resolving "exactly one appended entry" from a head-vs-base diff is the orchestrator's job (a follow-up).
+ */
+export function assessSurfaceEntry(
+  entry: unknown,
+  netuid: number,
+  opts: { secretsScan?: boolean; sourceUrlValidation?: boolean } = {},
+): Assessment {
+  const { secretsScan = true, sourceUrlValidation = true } = opts;
+  if (!entry || typeof entry !== "object") {
+    return fail("unsupported-shape", "Surface entry must be a JSON object.");
+  }
+  const surface = entry as CandidateLike;
+  if (secretsScan && containsSecretLikeText(JSON.stringify(surface))) {
+    return fail("secret-or-credential", "Surface entry appears to include secret, wallet, PAT, or private-key material.", surface);
+  }
+  const observedKey = Object.keys(surface as Record<string, unknown>).find((k) => OBSERVED_STATE_KEYS.has(k.toLowerCase()));
+  if (observedKey) {
+    return fail(
+      "observed-state-claim",
+      `Surface entry asserts observed runtime state (\`${observedKey}\`). Health / uptime / latency / status are probe-derived only and can never be part of a submission — remove the field and resubmit.`,
+      surface,
+    );
+  }
+  // netuid is carried by the subnet-document root in the surface model; an entry may omit it, but if it carries one
+  // it must not contradict the root (the document validator already proved the root netuid is an integer).
+  if (surface.netuid !== undefined && surface.netuid !== null && Number(surface.netuid) !== netuid) {
+    return fail("unsupported-shape", "Surface entry netuid must match the subnet document root.", surface);
+  }
+  const baseLayer = isBaseLayerKind(surface.kind);
+  if (!REVIEWER_SAFE_KINDS.has(String(surface.kind)) && !baseLayer) {
+    return fail("unsupported-shape", "Surface entry kind is not supported by the reviewer.", surface);
+  }
+  if (sourceUrlValidation) {
+    const urlSafe = baseLayer ? isSafeEndpointUrl(String(surface.url ?? "")) : isSafeHttpUrl(String(surface.url ?? ""));
+    if (!urlSafe) {
+      return fail(
+        "unsafe-url",
+        baseLayer ? "Surface entry URL must be a public HTTPS or WSS endpoint." : "Surface entry URL must be a public HTTPS URL.",
+        surface,
+      );
+    }
+    const sourceUrl = (surface.source_url as string) || (surface.source_urls as string[] | undefined)?.[0];
+    if (!isSafeHttpUrl(String(sourceUrl ?? ""))) {
+      return fail("unsafe-url", "Surface entry source URL must be a public HTTPS URL.", surface);
+    }
+  }
+  if (surface.public_safe !== true) {
+    return {
+      verdict: "closed",
+      summary: "Surface entry is not marked public_safe=true — declined. Resubmit with public_safe=true if the endpoint is genuinely public.",
+      candidate: surface,
+    };
+  }
+  if (surface.auth_required === true) {
+    return {
+      verdict: "manual-review",
+      summary:
+        "Authenticated interface — routing to review to confirm the declared auth scheme is documented publicly (verifiable without any secret) before it can be accepted.",
+      candidate: surface,
+    };
+  }
+  return { verdict: "merged", candidate: surface };
+}
+
+export function assessSubnetDocument(
+  document: unknown,
+  opts: { secretsScan?: boolean; sourceUrlValidation?: boolean; appendedEntry: unknown },
+): Assessment {
+  const { secretsScan = true, sourceUrlValidation = true, appendedEntry } = opts;
+  if (!document || typeof document !== "object") {
+    return fail("malformed-json", "Subnet document must be a JSON object.");
+  }
+  const doc = document as { netuid?: unknown; surfaces?: unknown };
+  if (!Number.isInteger(Number(doc.netuid))) {
+    return fail("unsupported-shape", "Subnet document netuid must be an integer.");
+  }
+  const netuid = Number(doc.netuid); // normalize once; thread the canonical integer to entry + (future) grounding
+  if (!Array.isArray(doc.surfaces)) {
+    return fail("unsupported-shape", "Subnet document must carry a surfaces[] array.");
+  }
+  // The orchestrator resolves the single appended entry by diffing head vs base surfaces[]; it passes null when
+  // the PR adds zero or more than one entry (or edits an existing one) — never a silent multi-entry merge.
+  if (appendedEntry === null || appendedEntry === undefined) {
+    return fail("unsupported-shape", "PR must append exactly one surface entry to surfaces[].");
+  }
+  // Whole-document secret scan catches material in the envelope (outside the entry); the entry is re-scanned below.
+  if (secretsScan && containsSecretLikeText(JSON.stringify(doc))) {
+    return fail("secret-or-credential", "Subnet document appears to include secret, wallet, PAT, or private-key material.");
+  }
+  return assessSurfaceEntry(appendedEntry, netuid, { secretsScan, sourceUrlValidation });
+}
+
 export type ProviderLike = Record<string, unknown> & {
   id?: unknown;
   name?: unknown;

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   assessCandidateDocument,
+  assessSurfaceEntry,
+  assessSubnetDocument,
   assessFreshness,
   assessProviderDocument,
   candidateRegistryKey,
@@ -150,6 +152,108 @@ describe("assessCandidateDocument", () => {
       { sourceUrlValidation: false },
     );
     expect(r.verdict).toBe("merged");
+  });
+});
+
+describe("assessSurfaceEntry (surface model — netuid supplied from the document root)", () => {
+  // A surface entry OMITS netuid (it lives at the subnet-document root); the validator receives it as a param.
+  const ok = { kind: "subnet-api", url: "https://api.example.ai", source_url: "https://github.com/x/y", public_safe: true };
+
+  it("merges a clean public surface entry", () => {
+    expect(assessSurfaceEntry(ok, 14).verdict).toBe("merged");
+  });
+
+  it("rejects a non-object entry (null and primitive)", () => {
+    expect(assessSurfaceEntry(null, 14).reason).toBe("unsupported-shape");
+    expect(assessSurfaceEntry("nope", 14).reason).toBe("unsupported-shape");
+  });
+
+  it("closes a secret-bearing entry, unless the secrets toggle is off", () => {
+    const dirty = { ...ok, note: "ghp_" + "a".repeat(25) };
+    expect(assessSurfaceEntry(dirty, 14).reason).toBe("secret-or-credential");
+    expect(assessSurfaceEntry(dirty, 14, { secretsScan: false }).verdict).toBe("merged");
+  });
+
+  it("closes an observed-state claim", () => {
+    expect(assessSurfaceEntry({ ...ok, latency: "12ms" }, 14).reason).toBe("observed-state-claim");
+  });
+
+  it("tolerates an omitted, null, or matching entry netuid but rejects a conflicting one", () => {
+    expect(assessSurfaceEntry(ok, 14).verdict).toBe("merged"); // omitted
+    expect(assessSurfaceEntry({ ...ok, netuid: null }, 14).verdict).toBe("merged"); // null
+    expect(assessSurfaceEntry({ ...ok, netuid: 14 }, 14).verdict).toBe("merged"); // matching
+    expect(assessSurfaceEntry({ ...ok, netuid: 99 }, 14).reason).toBe("unsupported-shape"); // conflicting
+  });
+
+  it("closes an unsupported kind", () => {
+    expect(assessSurfaceEntry({ ...ok, kind: "totally-unknown" }, 14).reason).toBe("unsupported-shape");
+  });
+
+  it("accepts a base-layer (wss) endpoint but closes an unsafe one", () => {
+    const base = { kind: "subtensor-rpc", url: "wss://rpc.example.ai", source_url: "https://github.com/x/y", public_safe: true };
+    expect(assessSurfaceEntry(base, 14).verdict).toBe("merged");
+    const baseBad = assessSurfaceEntry({ ...base, url: "wss://127.0.0.1" }, 14);
+    expect(baseBad.reason).toBe("unsafe-url");
+    expect(baseBad.summary).toContain("HTTPS or WSS");
+    expect(assessSurfaceEntry({ ...base, url: undefined }, 14).reason).toBe("unsafe-url"); // base-layer, missing url
+  });
+
+  it("closes an unsafe / missing content URL with the HTTPS message", () => {
+    expect(assessSurfaceEntry({ ...ok, url: "https://127.0.0.1" }, 14).summary).toContain("public HTTPS URL");
+    expect(assessSurfaceEntry({ ...ok, url: undefined }, 14).reason).toBe("unsafe-url");
+  });
+
+  it("falls back to source_urls[0] and closes when no safe source URL is present", () => {
+    expect(assessSurfaceEntry({ kind: "subnet-api", url: "https://api.example.ai", source_urls: ["https://github.com/a/b"], public_safe: true }, 14).verdict).toBe("merged");
+    expect(assessSurfaceEntry({ kind: "subnet-api", url: "https://api.example.ai", public_safe: true }, 14).reason).toBe("unsafe-url");
+  });
+
+  it("can skip URL checks when the toggle is off", () => {
+    expect(assessSurfaceEntry({ kind: "website", url: "http://insecure.example", public_safe: true }, 14, { sourceUrlValidation: false }).verdict).toBe("merged");
+  });
+
+  it("closes a non-public_safe entry and escalates an auth_required one", () => {
+    expect(assessSurfaceEntry({ ...ok, public_safe: false }, 14).verdict).toBe("closed");
+    expect(assessSurfaceEntry({ ...ok, auth_required: true }, 14).verdict).toBe("manual-review");
+  });
+});
+
+describe("assessSubnetDocument (whole-file gate: root netuid + exactly-one appended entry)", () => {
+  const entry = { kind: "subnet-api", url: "https://api.example.ai", source_url: "https://github.com/x/y", public_safe: true };
+  const doc = { netuid: 14, surfaces: [entry] };
+
+  it("merges a valid document whose single appended entry is clean", () => {
+    expect(assessSubnetDocument(doc, { appendedEntry: entry }).verdict).toBe("merged");
+  });
+
+  it("rejects a non-object document as malformed", () => {
+    expect(assessSubnetDocument(null, { appendedEntry: entry }).reason).toBe("malformed-json");
+    expect(assessSubnetDocument(42, { appendedEntry: entry }).reason).toBe("malformed-json");
+  });
+
+  it("rejects a non-integer root netuid", () => {
+    expect(assessSubnetDocument({ netuid: "abc", surfaces: [entry] }, { appendedEntry: entry }).reason).toBe("unsupported-shape");
+    expect(assessSubnetDocument({ surfaces: [entry] }, { appendedEntry: entry }).reason).toBe("unsupported-shape");
+  });
+
+  it("rejects a document without a surfaces[] array", () => {
+    expect(assessSubnetDocument({ netuid: 14 }, { appendedEntry: entry }).reason).toBe("unsupported-shape");
+  });
+
+  it("rejects when the orchestrator found zero-or-many appended entries (sentinel null/undefined)", () => {
+    expect(assessSubnetDocument(doc, { appendedEntry: null }).reason).toBe("unsupported-shape");
+    expect(assessSubnetDocument(doc, { appendedEntry: undefined }).reason).toBe("unsupported-shape");
+  });
+
+  it("catches a secret in the document envelope (outside the entry), unless the toggle is off", () => {
+    const dirty = { netuid: 14, surfaces: [entry], maintainer_token: "ghp_" + "b".repeat(25) };
+    expect(assessSubnetDocument(dirty, { appendedEntry: entry }).reason).toBe("secret-or-credential");
+    expect(assessSubnetDocument(dirty, { appendedEntry: entry, secretsScan: false }).verdict).toBe("merged");
+  });
+
+  it("threads the normalized root netuid to the entry (string root coerces; conflicting entry netuid rejected)", () => {
+    expect(assessSubnetDocument({ netuid: "14", surfaces: [entry] }, { appendedEntry: entry }).verdict).toBe("merged");
+    expect(assessSubnetDocument(doc, { appendedEntry: { ...entry, netuid: 99 } }).reason).toBe("unsupported-shape");
   });
 });
 


### PR DESCRIPTION
## Summary

The metagraphed content lane is migrating from the **candidate-file model** to the **surface model**: a contribution appends ONE entry to `surfaces[]` of a `registry/subnets/<slug>.json` whose `netuid` lives at the file **root** (not on each entry). This is the **safe, additive foundation** — the two deterministic validators that split `assessCandidateDocument`, building on the `RegistryLaneSpec` classifier from #1296:

- **`assessSurfaceEntry(entry, netuid, opts)`** — per-entry shape/safety gate (secret scan, observed-state claim, kind allow-list, URL safety with the base-layer wss exception, `public_safe`/`auth_required`), with `netuid` supplied from the document root. A stray entry `netuid` is tolerated only if it matches the root.
- **`assessSubnetDocument(doc, { appendedEntry, ... })`** — whole-file gate owning the document shape, the **root netuid** (normalized once to a canonical integer per the adversarial review), the `surfaces[]` array, the **exactly-one-appended-entry** invariant (the orchestrator passes the diffed entry; `null` sentinel ⇒ reject), and a **whole-document** secret scan, then delegates to `assessSurfaceEntry`.

No AI — surfaces are structured data; gittensory is the sole adjudicator.

## Scope
- [x] **Pure + additive**, `registry-logic.ts` + barrel export + tests. **Not wired to any review path** — the candidate model stays untouched, so this is a byte-identical deploy.

## Follow-up (deliberately out of scope)
A pre-build design review flagged that the live wiring needs: the correct seam (`maybeRunAgentMaintenance`, not `prReadyForReview`), a **new GitHub contents-fetch helper** (the gate only has diff hunks, not head/base blobs, so "exactly one appended entry" can't be computed yet), a per-repo flag + **cutover runbook** for open metagraphed PRs, and an explicit grounding/dedup composition decision. Those land in follow-up PRs; this one is the unblocked foundation.

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the diff (every validator branch: non-object, secret toggle, observed-state, the four netuid-guard arms, unsupported kind, base-layer wss accept + unsafe + missing-url, content HTTPS + missing-url, `source_url`/`source_urls[0]` fallback + absent, public_safe, auth_required; document malformed, non-integer/missing root netuid, missing surfaces[], appended-entry sentinel, envelope secret, normalized-netuid threading).

Advances the metagraphed surface-model migration.