### PR TITLE
feat(content-lane): deterministic surface-review orchestrator

### DIFF
--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -121,6 +121,7 @@ export {
   type ScopeResult,
   type Verdict,
 } from "./registry-logic";
+export { runSurfaceReview, diffAppendedSurfaceEntry, type SurfaceReviewInput, type SurfaceReviewResult } from "./orchestrator";
 export {
   checkNetuidExists,
   fetchSubnetRecord,

--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -1,0 +1,94 @@
+// Deterministic surface-model review orchestrator (no AI — surfaces are structured data; gittensory is the
+// sole adjudicator). Given a lane spec, the PR's changed files, and an injected file-content loader, it:
+//   1. classifies the PR via classifyRegistryPrScope (entry / provider / not-a-direct-submission),
+//   2. loads the head (+ base, for entries) document content,
+//   3. resolves the SINGLE appended surfaces[] entry by diffing head vs base, and
+//   4. returns a normalized verdict from assessSubnetDocument / assessProviderDocument.
+// Pure + injectable: unit tests pass a loadFile stub, so no network. The live wiring (a per-repo,
+// flag-gated branch in the review body) is a separate follow-up.
+import {
+  type ProviderAssessment,
+  type RegistryLaneSpec,
+  type Verdict,
+  assessProviderDocument,
+  assessSubnetDocument,
+  classifyRegistryPrScope,
+  isRegistrySubmissionScope,
+  toCoreVerdict,
+} from "./registry-logic";
+
+export interface SurfaceReviewInput {
+  changedFiles: string[];
+  /** Loads decoded file content at a ref; injected so unit tests need no network. Returns null when absent. */
+  loadFile: (path: string, ref: "head" | "base") => Promise<string | null>;
+  opts?: { secretsScan?: boolean; sourceUrlValidation?: boolean };
+}
+
+export interface SurfaceReviewResult {
+  verdict: Verdict;
+  summary?: string | undefined;
+  reason?: string | undefined;
+}
+
+function safeParseJson(raw: string | null): unknown {
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function surfacesOf(doc: unknown, field: string): unknown[] | null {
+  const arr = (doc as Record<string, unknown> | null)?.[field];
+  return Array.isArray(arr) ? arr : null;
+}
+
+/**
+ * The single surfaces[] entry present at head but absent at base — the deterministic "exactly one appended
+ * entry" rule. Returns null when head is unreadable / has no surfaces[] array, or when the count of added
+ * entries !== 1 (a reorder/reformat/edit of existing entries reads as multiple "added" and is rejected upstream).
+ * A missing base file (a brand-new entry file) means every head entry is new, so it passes only when there is one.
+ */
+export function diffAppendedSurfaceEntry(headRaw: string | null, baseRaw: string | null, field: string): unknown {
+  const headEntries = surfacesOf(safeParseJson(headRaw), field);
+  if (headEntries === null) return null;
+  const baseEntries = surfacesOf(safeParseJson(baseRaw), field) ?? [];
+  const baseKeys = new Set(baseEntries.map((entry) => JSON.stringify(entry)));
+  const added = headEntries.filter((entry) => !baseKeys.has(JSON.stringify(entry)));
+  return added.length === 1 ? added[0] : null;
+}
+
+function fromProvider(assessment: ProviderAssessment): SurfaceReviewResult {
+  // Conservative routing: a valid provider merges; an invalid one goes to HUMAN review — never an auto-close.
+  return assessment.ok
+    ? { verdict: "merge", summary: assessment.summary }
+    : { verdict: "manual", summary: assessment.summary, reason: assessment.reason };
+}
+
+/**
+ * Adjudication policy (deterministic): auto-close is reserved for a clean single-append whose entry has a CLEAR
+ * violation (secret, not public_safe, observed-state claim, unsafe URL, unsupported kind, non-integer root netuid)
+ * — the unambiguous "resubmit clean" cases assessSubnetDocument already returns `closed` for. Everything ambiguous
+ * (not a direct submission, not a clean single append, an invalid provider) routes to MANUAL review and is never
+ * auto-closed, so a legitimate edit/refactor PR can't be one-shot-closed.
+ */
+export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceReviewInput): Promise<SurfaceReviewResult> {
+  const scope = classifyRegistryPrScope(spec, input.changedFiles);
+  if (!isRegistrySubmissionScope(scope.scope)) {
+    return { verdict: "manual", summary: "Not a direct registry surface or provider submission — routing to review." };
+  }
+  // A submission scope (entry/provider) always carries a directFile (classifier invariant; see classifyRegistryPrScope).
+  const directFile = scope.directFile as string;
+  const headRaw = await input.loadFile(directFile, "head");
+  if (scope.isProvider) {
+    return fromProvider(assessProviderDocument(safeParseJson(headRaw), input.opts));
+  }
+  const baseRaw = await input.loadFile(directFile, "base");
+  const appendedEntry = diffAppendedSurfaceEntry(headRaw, baseRaw, spec.collectionField);
+  if (appendedEntry === null) {
+    return { verdict: "manual", summary: "PR does not cleanly append exactly one surface entry — routing to review." };
+  }
+  const assessment = assessSubnetDocument(safeParseJson(headRaw), { ...input.opts, appendedEntry });
+  return { verdict: toCoreVerdict(assessment.verdict), summary: assessment.summary, reason: assessment.reason };
+}

--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -824,6 +824,8 @@ export interface RegistryLaneSpec {
   providerFilePattern?: RegExp;
   /** Optional generated artifacts a valid PR must regenerate — allowed companions. */
   artifactPattern?: RegExp;
+  /** The array field on an entry file a contribution appends to (the surface model: "surfaces"). */
+  collectionField: string;
 }
 
 export type RegistryPrScope = "entry-submission" | "provider-submission" | "mixed-files" | "not-direct-submission";
@@ -876,4 +878,5 @@ export const METAGRAPHED_LANE_SPEC: RegistryLaneSpec = {
   entryFilePattern: SUBNET_ENTRY_PATTERN,
   providerFilePattern: FLAT_PROVIDER_PATTERN,
   artifactPattern: ARTIFACT_PATTERN,
+  collectionField: "surfaces",
 };

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { METAGRAPHED_LANE_SPEC } from "../../src/review/content-lane/registry-logic";
+import { diffAppendedSurfaceEntry, runSurfaceReview, type SurfaceReviewInput } from "../../src/review/content-lane/orchestrator";
+
+const existing = { kind: "website", url: "https://old.example.ai", source_url: "https://github.com/a/b", public_safe: true };
+const newEntry = { kind: "subnet-api", url: "https://api.example.ai", source_url: "https://github.com/x/y", public_safe: true };
+const SUBNET = "registry/subnets/foo.json";
+const PROVIDER = "registry/providers/acme.json";
+
+// Inject a file loader keyed by `${ref}:${path}` so the orchestrator never hits the network.
+function loader(files: Record<string, string | null>): SurfaceReviewInput["loadFile"] {
+  return (path, ref) => Promise.resolve(files[`${ref}:${path}`] ?? null);
+}
+const review = (changedFiles: string[], files: Record<string, string | null>) =>
+  runSurfaceReview(METAGRAPHED_LANE_SPEC, { changedFiles, loadFile: loader(files) });
+
+describe("diffAppendedSurfaceEntry", () => {
+  const doc = (surfaces: unknown[]) => JSON.stringify({ netuid: 14, surfaces });
+
+  it("returns the single entry added at head", () => {
+    expect(diffAppendedSurfaceEntry(doc([existing, newEntry]), doc([existing]), "surfaces")).toEqual(newEntry);
+  });
+
+  it("treats every entry as new when the base file is absent (passes only with exactly one)", () => {
+    expect(diffAppendedSurfaceEntry(doc([newEntry]), null, "surfaces")).toEqual(newEntry);
+    expect(diffAppendedSurfaceEntry(doc([existing, newEntry]), null, "surfaces")).toBeNull();
+  });
+
+  it("returns null for zero or multiple added entries", () => {
+    expect(diffAppendedSurfaceEntry(doc([existing]), doc([existing]), "surfaces")).toBeNull();
+    expect(diffAppendedSurfaceEntry(doc([existing, newEntry, { kind: "other" }]), doc([existing]), "surfaces")).toBeNull();
+  });
+
+  it("returns null when head is unparseable or has no surfaces[] array", () => {
+    expect(diffAppendedSurfaceEntry("{not json", doc([existing]), "surfaces")).toBeNull();
+    expect(diffAppendedSurfaceEntry(JSON.stringify({ netuid: 14 }), doc([existing]), "surfaces")).toBeNull();
+  });
+});
+
+describe("runSurfaceReview (deterministic, conservative routing)", () => {
+  const doc = (surfaces: unknown[]) => JSON.stringify({ netuid: 14, surfaces });
+
+  it("routes a non-submission PR to manual review", async () => {
+    expect((await review(["README.md"], {})).verdict).toBe("manual");
+  });
+
+  it("merges a valid provider submission and routes an invalid one to manual (never auto-close)", async () => {
+    const okProvider = { [`head:${PROVIDER}`]: JSON.stringify({ provider: { id: "acme", name: "Acme", website_url: "https://acme.example" } }) };
+    expect((await review([PROVIDER], okProvider)).verdict).toBe("merge");
+    const badProvider = { [`head:${PROVIDER}`]: JSON.stringify({ provider: { name: "Acme", website_url: "https://acme.example" } }) };
+    expect((await review([PROVIDER], badProvider)).verdict).toBe("manual");
+  });
+
+  it("merges a clean single append of a valid entry", async () => {
+    const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry]), [`base:${SUBNET}`]: doc([existing]) });
+    expect(r.verdict).toBe("merge");
+  });
+
+  it("closes a clean single append whose entry has a clear violation", async () => {
+    const bad = { ...newEntry, public_safe: false };
+    const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, bad]), [`base:${SUBNET}`]: doc([existing]) });
+    expect(r.verdict).toBe("close");
+  });
+
+  it("routes a non-clean-append (multiple new entries) to manual, never auto-close", async () => {
+    const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry, { kind: "extra" }]), [`base:${SUBNET}`]: doc([existing]) });
+    expect(r.verdict).toBe("manual");
+  });
+});

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -397,7 +397,7 @@ describe("classifyRegistryPrScope (generic surface model, metagraphed spec)", ()
   });
 
   it("works for a minimal spec with no provider/artifact patterns (a bare registry)", () => {
-    const bare: RegistryLaneSpec = { entryFilePattern: /^data\/[a-z]+\.json$/ };
+    const bare: RegistryLaneSpec = { entryFilePattern: /^data\/[a-z]+\.json$/, collectionField: "entries" };
     expect(classifyRegistryPrScope(bare, ["data/x.json"]).scope).toBe("entry-submission");
     expect(classifyRegistryPrScope(bare, ["data/x.json", "data/y.json"]).scope).toBe("not-direct-submission");
     expect(classifyRegistryPrScope(bare, ["data/x.json", "other.json"]).scope).toBe("mixed-files");


### PR DESCRIPTION
## Summary

Second piece of the metagraphed surface-model migration (after the validators in #1303). The deterministic, **AI-free** orchestrator that ties the lane spec + the PR's changed files + an injected file-content loader into one verdict:

- **`diffAppendedSurfaceEntry(head, base, field)`** — resolves the single `surfaces[]` entry added at head vs base; `null` when head is unreadable, `surfaces[]` is missing, or the count of added entries ≠ 1 (a reorder/edit/multi-add reads as multiple "added"). A missing base file (brand-new entry file) means every head entry is new — passes only with exactly one.
- **`runSurfaceReview(spec, { changedFiles, loadFile, opts })`** — classify → load head (+ base) → resolve the appended entry → `assessSubnetDocument` / `assessProviderDocument` → a normalized core `Verdict`. The real caller will pass a `loadFile` wrapping the existing `getFileContent(path, ref)` helper.

### Adjudication policy (conservative)
**Auto-close is reserved for a clean single-append whose entry has a CLEAR violation** (secret, not `public_safe`, observed-state claim, unsafe URL, unsupported kind, non-integer root netuid). **Everything ambiguous** — not a direct submission, not a clean single append, an invalid provider — **routes to MANUAL review and is never auto-closed**, so a legitimate edit/refactor PR can't be one-shot closed. (This directly answers the adversarial review's "open-PR cutover" risk at the logic level.)

## Scope
- [x] Pure + injectable; new `orchestrator.ts` + barrel export + `collectionField` on `RegistryLaneSpec` + tests. **Still dormant** — not wired to any review path, so byte-identical deploy.

## Follow-up
The per-repo, flag-gated wiring into the live review body (`maybeRunAgentMaintenance`) + the cutover runbook is the next PR — I'll flag the adjudication policy above for your sign-off before it goes live.

## Validation
- [x] `npm run test:ci` green
- [x] **100% coverage** on `orchestrator.ts` (diff helper: 1-added, base-absent, zero/multi-added, unparseable, no-surfaces; review: non-submission→manual, valid/invalid provider, clean-append→merge, violation→close, multi-add→manual).

Advances the metagraphed surface-model migration.