### PR TITLE
fix(content-lane): make surface adjudication decisive (merge/close, rarely manual)

### DIFF
--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -13,7 +13,6 @@ import {
   assessProviderDocument,
   assessSubnetDocument,
   classifyRegistryPrScope,
-  isRegistrySubmissionScope,
   toCoreVerdict,
 } from "./registry-logic";
 
@@ -60,23 +59,29 @@ export function diffAppendedSurfaceEntry(headRaw: string | null, baseRaw: string
 }
 
 function fromProvider(assessment: ProviderAssessment): SurfaceReviewResult {
-  // Conservative routing: a valid provider merges; an invalid one goes to HUMAN review — never an auto-close.
+  // Decisive: a valid provider merges; an invalid one CLOSES (resubmit clean) — never a manual punt.
   return assessment.ok
     ? { verdict: "merge", summary: assessment.summary }
-    : { verdict: "manual", summary: assessment.summary, reason: assessment.reason };
+    : { verdict: "close", summary: assessment.summary, reason: assessment.reason };
 }
 
 /**
- * Adjudication policy (deterministic): auto-close is reserved for a clean single-append whose entry has a CLEAR
- * violation (secret, not public_safe, observed-state claim, unsafe URL, unsupported kind, non-integer root netuid)
- * — the unambiguous "resubmit clean" cases assessSubnetDocument already returns `closed` for. Everything ambiguous
- * (not a direct submission, not a clean single append, an invalid provider) routes to MANUAL review and is never
- * auto-closed, so a legitimate edit/refactor PR can't be one-shot-closed.
+ * Adjudication policy (deterministic, DECISIVE): the overwhelming majority of outcomes are merge or close —
+ * manual review is the rare exception. A clean valid submission MERGES; anything invalid or non-standard
+ * (a malformed/violating entry, a non-clean append, a bundled "mixed-files" PR, an invalid provider) CLOSES with
+ * a resubmit message. A PR that is NOT a registry submission at all returns `null` — the surface lane does not
+ * apply, so the caller falls through to the generic gate. The only residual MANUAL comes from the per-entry
+ * validator (an authenticated interface needing a human to confirm the public auth scheme) — a "very few" case.
  */
-export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceReviewInput): Promise<SurfaceReviewResult> {
+export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceReviewInput): Promise<SurfaceReviewResult | null> {
   const scope = classifyRegistryPrScope(spec, input.changedFiles);
-  if (!isRegistrySubmissionScope(scope.scope)) {
-    return { verdict: "manual", summary: "Not a direct registry surface or provider submission — routing to review." };
+  // Not a registry submission at all (no entry/provider file) — the surface lane doesn't apply; the generic gate does.
+  if (scope.scope === "not-direct-submission") {
+    return null;
+  }
+  // A submission bundled with other file changes — close decisively; resubmit the entry on its own.
+  if (scope.scope === "mixed-files") {
+    return { verdict: "close", summary: "A registry submission must not bundle other file changes — resubmit the entry on its own." };
   }
   // A submission scope (entry/provider) always carries a directFile (classifier invariant; see classifyRegistryPrScope).
   const directFile = scope.directFile as string;
@@ -87,7 +92,7 @@ export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceRev
   const baseRaw = await input.loadFile(directFile, "base");
   const appendedEntry = diffAppendedSurfaceEntry(headRaw, baseRaw, spec.collectionField);
   if (appendedEntry === null) {
-    return { verdict: "manual", summary: "PR does not cleanly append exactly one surface entry — routing to review." };
+    return { verdict: "close", summary: "A surface submission must append exactly one new surfaces[] entry — resubmit a clean single-entry append." };
   }
   const assessment = assessSubnetDocument(safeParseJson(headRaw), { ...input.opts, appendedEntry });
   return { verdict: toCoreVerdict(assessment.verdict), summary: assessment.summary, reason: assessment.reason };

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -37,33 +37,37 @@ describe("diffAppendedSurfaceEntry", () => {
   });
 });
 
-describe("runSurfaceReview (deterministic, conservative routing)", () => {
+describe("runSurfaceReview (deterministic + decisive: merge/close, rarely manual)", () => {
   const doc = (surfaces: unknown[]) => JSON.stringify({ netuid: 14, surfaces });
 
-  it("routes a non-submission PR to manual review", async () => {
-    expect((await review(["README.md"], {})).verdict).toBe("manual");
+  it("returns null for a non-submission PR (the surface lane defers to the generic gate)", async () => {
+    expect(await review(["README.md"], {})).toBeNull();
   });
 
-  it("merges a valid provider submission and routes an invalid one to manual (never auto-close)", async () => {
+  it("closes a submission bundled with other file changes (mixed-files)", async () => {
+    expect((await review([SUBNET, "src/index.ts"], {}))?.verdict).toBe("close");
+  });
+
+  it("merges a valid provider submission and CLOSES an invalid one (never manual)", async () => {
     const okProvider = { [`head:${PROVIDER}`]: JSON.stringify({ provider: { id: "acme", name: "Acme", website_url: "https://acme.example" } }) };
-    expect((await review([PROVIDER], okProvider)).verdict).toBe("merge");
+    expect((await review([PROVIDER], okProvider))?.verdict).toBe("merge");
     const badProvider = { [`head:${PROVIDER}`]: JSON.stringify({ provider: { name: "Acme", website_url: "https://acme.example" } }) };
-    expect((await review([PROVIDER], badProvider)).verdict).toBe("manual");
+    expect((await review([PROVIDER], badProvider))?.verdict).toBe("close");
   });
 
   it("merges a clean single append of a valid entry", async () => {
     const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry]), [`base:${SUBNET}`]: doc([existing]) });
-    expect(r.verdict).toBe("merge");
+    expect(r?.verdict).toBe("merge");
   });
 
   it("closes a clean single append whose entry has a clear violation", async () => {
     const bad = { ...newEntry, public_safe: false };
     const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, bad]), [`base:${SUBNET}`]: doc([existing]) });
-    expect(r.verdict).toBe("close");
+    expect(r?.verdict).toBe("close");
   });
 
-  it("routes a non-clean-append (multiple new entries) to manual, never auto-close", async () => {
+  it("CLOSES a non-clean append (multiple new entries) — resubmit clean, not a manual punt", async () => {
     const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry, { kind: "extra" }]), [`base:${SUBNET}`]: doc([existing]) });
-    expect(r.verdict).toBe("manual");
+    expect(r?.verdict).toBe("close");
   });
 });


### PR DESCRIPTION
## Summary

The surface orchestrator (#1304) routed every ambiguity to **manual review**, which inverts the intended bias: the **overwhelming majority of outcomes should be merge or close**, decisively — manual is the rare exception (a guardrail-touching, merge-ready PR). Surface submissions only touch `registry/*.json` (never guardrail paths), so they should essentially never go manual.

`runSurfaceReview` is now decisive:
- a **non-submission** PR returns `null` — the surface lane doesn't apply, so the caller falls through to the generic gate (instead of forcing a manual verdict on an unrelated PR),
- a bundled **mixed-files** submission, a **non-clean append**, and an **invalid provider** all **CLOSE** with a resubmit message (instead of manual),
- a clean valid submission still **merges**; the only residual manual is the per-entry validator's authenticated-interface case (a genuine "very few" exception).

## Scope
- [x] `orchestrator.ts` only (+ its test); return type now `SurfaceReviewResult | null`. **Still dormant** — not wired, byte-identical deploy. The wiring PR consumes `null` as "use the generic gate."

## Validation
- [x] `npm run test:ci` green
- [x] **100% coverage** on `orchestrator.ts` (non-submission→null, mixed-files→close, provider ok→merge / bad→close, clean→merge, violation→close, non-clean-append→close).

Advances the metagraphed surface-model migration.