### PR TITLE
fix(agent): submission volume is not a manual-review reason — merge or close

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1,7 +1,6 @@
 import {
   countOpenIssues,
   countOpenPullRequests,
-  countRecentSubmissionsByAuthor,
   getAgentCommandAnswer,
   getInstallation,
   getLatestRepoGithubTotalsSnapshot,
@@ -186,7 +185,7 @@ import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
-import { loadHardGuardrailGlobs, loadSubmissionFloodLimit } from "../review/guardrail-config";
+import { loadHardGuardrailGlobs } from "../review/guardrail-config";
 import { closePullRequest, createIssueComment, getLastCloserLogin } from "../github/pr-actions";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
@@ -770,20 +769,6 @@ async function maybeRunAgentMaintenance(
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
 
-  // Anti-farming (#anti-gaming-flood): a CONTRIBUTOR who has submitted more than the per-repo limit within the
-  // configured window is HELD for manual review (never auto-merged/approved) — this catches farming that merges
-  // fast, which an open-PR count alone would miss. Owner/automation are exempt; disabled (no hold) when the repo
-  // has no flood limit configured in KV, or on any read fault (fail-open, never false-hold).
-  let submissionFloodHit = false;
-  if (!authorIsOwner && !authorIsAutomationBot && authorLogin.length > 0) {
-    const floodLimit = await loadSubmissionFloodLimit(env, repoFullName).catch(() => null);
-    if (floodLimit) {
-      const sinceIso = new Date(Date.now() - floodLimit.windowHours * 3_600_000).toISOString();
-      const recent = await countRecentSubmissionsByAuthor(env, repoFullName, authorLogin, sinceIso).catch(() => 0);
-      submissionFloodHit = recent > floodLimit.maxPerWindow;
-    }
-  }
-
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules): when the repo enabled any rule, a body that links
   // MORE closing references than we can safely verify (overflow) is itself a violation; otherwise evaluate the
   // linked issues' facts (fail-open per issue). The decision is extracted into resolveLinkedIssueHardRule (pure,
@@ -810,7 +795,6 @@ async function maybeRunAgentMaintenance(
     hardGuardrailGlobs,
     authorIsOwner,
     authorIsAutomationBot,
-    submissionFloodHit,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -89,23 +89,3 @@ export async function loadHardGuardrailGlobs(env: Env, repoFullName: string): Pr
     return FAIL_CLOSED_GUARDRAIL_GLOBS;
   }
 }
-
-/**
- * Anti-farming submission-flood limit for a repo, read from the same shared REVIEW_CONFIG KV (key = repo slug):
- * `maxSubmissionsPerAuthorWindow` (the per-author cap) + `submissionWindowHours` (the window, default 24h). Returns
- * null when unset/invalid (the feature is DISABLED for that repo) or on a KV fault — never throws, and a fault
- * disables rather than false-holding a contributor. (#anti-gaming-flood)
- */
-export async function loadSubmissionFloodLimit(env: Env, repoFullName: string): Promise<{ maxPerWindow: number; windowHours: number } | null> {
-  const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
-  if (!env.REVIEW_CONFIG) return null;
-  try {
-    const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { maxSubmissionsPerAuthorWindow?: JsonValue; submissionWindowHours?: JsonValue } | null;
-    const maxPerWindow = Number(config?.maxSubmissionsPerAuthorWindow);
-    if (!Number.isFinite(maxPerWindow) || maxPerWindow <= 0) return null; // unset / invalid → disabled
-    const hours = Number(config?.submissionWindowHours);
-    return { maxPerWindow, windowHours: Number.isFinite(hours) && hours > 0 ? hours : 24 };
-  } catch {
-    return null; // KV fault → disabled (never false-hold)
-  }
-}

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -71,10 +71,6 @@ export type AgentActionPlanInput = {
   // neither auto-merge, auto-approve, nor auto-close such a PR; it falls through to a human.
   changedPaths: string[];
   hardGuardrailGlobs: string[];
-  // Anti-farming (#anti-gaming-flood): true when this PR's author has exceeded the per-repo submission-flood
-  // limit (more than N PRs in the configured window). Forces the SAME manual hold as a guarded path — a flooding
-  // author's PR is never auto-merged/approved; a human reviews the batch. Does NOT force a close.
-  submissionFloodHit?: boolean | undefined;
   // True when the PR author is the repo owner (e.g. JSONbored). Standing rule: owner PRs are NEVER
   // auto-closed. They may still auto-merge when clean + passing.
   authorIsOwner: boolean;
@@ -252,11 +248,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const guardrailHit =
     input.hardGuardrailGlobs.length > 0 &&
     (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
-  // A per-author submission FLOOD forces the SAME manual hold as a guarded path: a flooding author's PR is never
-  // auto-merged/approved — a human reviews the batch (anti-farming). It does NOT force a close (a clean flooding
-  // PR is HELD, not killed; a red-CI / conflict flooding PR still closes via the normal path). (#anti-gaming-flood)
-  const submissionFloodHit = input.submissionFloodHit === true;
-  const heldForManualReview = guardrailHit || submissionFloodHit;
+  // Manual review is the RARE exception (the operator's minimize-manual goal): the ONLY thing that holds a PR for
+  // a human instead of merge/close is an auto-merge-ready PR that touches a hard-guardrail path. (An owner PR that
+  // is not review-good is held separately, via the owner close-exemption below — never auto-closed.) Submission
+  // volume is NOT a hold reason: a high-volume author's clean PR still merges and their bad PR still closes — the
+  // quality gate, not a submission count, is the defense (anti-farming-by-manual-hold removed).
+  const heldForManualReview = guardrailHit;
   // Canonical (reviewbot non-content-gate) policy, tuned to the operator's minimize-manual goal: merge-or-close
   // with high accuracy; manual review is the RARE exception. A PR is "review-good" when the gate passes AND CI is
   // green — that's the only thing that earns an auto-merge or an approve. Everything else, for a CONTRIBUTOR, is a
@@ -341,7 +338,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       : !reviewGood
         ? `verdict=${input.conclusion}${ciReason ? `; ${ciReason}` : ""}`
         : heldForManualReview
-          ? `verdict=${input.conclusion}; ${submissionFloodHit ? "submission flood → manual review (anti-farming)" : "guarded path → owner safety review"}`
+          ? `verdict=${input.conclusion}; guarded path → manual review`
           : `verdict=${input.conclusion}; CI green`;
     if (!hasLabel(input.pr.labels, label)) {
       actions.push({ actionClass: "label", requiresApproval: approval("label"), reason, label });

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -256,22 +256,25 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
-  describe("anti-farming: a per-author submission flood forces a manual hold (#anti-gaming-flood)", () => {
-    it("HOLDS a flooding author's clean+green+approved PR — needs-human, never merged/approved/closed", () => {
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, submissionFloodHit: true, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+  describe("submission volume is NOT a manual-hold reason — only guardrail paths hold (#minimize-manual)", () => {
+    it("a high-volume author's clean+green+approved PR MERGES (the quality gate, not a submission count, is the defense)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).toContain("merge"); // clean → merge, regardless of how many PRs the author has open
+      expect(cls).not.toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).not.toBe(AGENT_LABEL_NEEDS_REVIEW); // never held for review
+    });
+    it("a high-volume author's red-CI PR still CLOSES (the normal close path)", () => {
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ciState: "failed", pr: { labels: [] } })));
+      expect(plan).toContain("close");
+    });
+    it("ONLY a guardrail-touching review-good PR is held for manual review (needs-human, never merged/closed)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, hardGuardrailGlobs: ["src/**"], changedPaths: ["src/index.ts"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);
       expect(cls).not.toContain("merge");
       expect(cls).not.toContain("approve");
-      expect(cls).not.toContain("close"); // a clean flooding PR is HELD for review, not killed
+      expect(cls).not.toContain("close");
       expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
-    });
-    it("still CLOSES a flooding author's red-CI PR (a broken PR closes regardless of the flood hold)", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, submissionFloodHit: true, ciState: "failed", pr: { labels: [] } })));
-      expect(plan).toContain("close");
-    });
-    it("does NOT hold a normal author (submissionFloodHit false) — a clean PR still auto-merges", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", label: "auto" }, submissionFloodHit: false, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
-      expect(plan).toContain("merge");
     });
   });
 


### PR DESCRIPTION
## Summary
The anti-farming **submission-flood guard** held *every* PR from any author who exceeded a per-repo submission count for **manual review** (never auto-merged/approved). On a high-volume-but-legitimate repo (metagraphed), that routed **~40 of ~60 PRs to manual review** — which **defeats the entire point of the agent: eliminating manual reviews.**

## Fix — the decision rule is now exactly:
A PR is held for a human **only** when:
1. it is **auto-merge-ready but touches a hard-guardrail path**, or
2. it is an **owner PR that is not review-good** (held via the owner close-exemption — never auto-closed).

**Everything else → merge** (review-good = gate passed + CI green) **or close** (not review-good). A high-volume author's clean PR merges and their bad PR closes — the **quality gate**, not a submission count, is the defense against farming.

This removes `submissionFloodHit` (agent-actions), its computation (processors.ts), and `loadSubmissionFloodLimit` (guardrail-config).

## Scope
- [x] `src/settings/agent-actions.ts`, `src/queue/processors.ts`, `src/review/guardrail-config.ts`, `test/unit/agent-actions.test.ts`. Net-removal; no new binding/migration. *(The now-unread `maxSubmissionsPerAuthorWindow` KV key + the orphaned `countRecentSubmissionsByAuthor` query are harmless and can be swept later.)*

## Validation
- [x] `npm run test:ci` — full gate green · `npm audit` — 0 vulnerabilities
- [x] **Tests (rewritten to the new behavior):** a high-volume author's clean+green+approved PR **merges** (never needs-review); their red-CI PR **closes**; **only** a guardrail-touching review-good PR is held for manual review
- [x] Every changed line + branch covered · rebased onto latest `main`

## Safety
- [x] No secrets / wallets / hotkeys / trust scores / reward values; no `site/` / `CNAME` / `lovable`; no changelog edit