### PR TITLE
feat(content-lane): config-drive the curated-list lane via ContentRepoSpec

### DIFF
--- a/src/review/content-lane/content-repo-spec.ts
+++ b/src/review/content-lane/content-repo-spec.ts
@@ -1,0 +1,23 @@
+// Modular content-repository configuration for the curated-list content lane (the awesome-claude lane and any
+// self-hosted curated list). The curated-list analogue of RegistryLaneSpec (the metagraphed registry lane): a
+// maintainer whose list uses different categories or a different entry-file layout parameterizes the lane via
+// config instead of a gittensory code change. Defaults preserve the awesome-claude behaviour byte-for-byte.
+//
+// This is a LEAF module (no content-lane imports) so every consumer — scope, duplicates, source-evidence — can
+// import the spec without an import cycle. Fields are added here as each consumer is migrated.
+export interface ContentRepoSpec {
+  /** The content categories the list accepts (the first path segment under the entry root). */
+  categories: ReadonlySet<string>;
+  /** Matches one content entry file, capturing [category, slug] — e.g. /^content\/([^/]+)\/([^/]+)\.mdx$/i. */
+  entryPathPattern: RegExp;
+  /** Head-branch prefixes used by bulk maintenance automation (link-health, etc.); these legitimately edit many
+   *  entries in one PR and are ignored, never closed. */
+  maintenanceBranchPrefixes: readonly string[];
+}
+
+/** The default curated-list spec — awesome-claude's categories, entry layout, and maintenance branches. */
+export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
+  categories: new Set(["agents", "collections", "commands", "guides", "hooks", "mcp", "rules", "skills", "statuslines", "tools"]),
+  entryPathPattern: /^content\/([^/]+)\/([^/]+)\.mdx$/i,
+  maintenanceBranchPrefixes: ["links/"],
+};

--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -32,6 +32,7 @@ export {
   type ContentFile,
   type ContentScope,
 } from "./scope";
+export { AWESOME_CLAUDE_CONTENT_SPEC, type ContentRepoSpec } from "./content-repo-spec";
 export {
   buildContentDuplicateReview,
   directoryIndexToSignals,

--- a/src/review/content-lane/scope.ts
+++ b/src/review/content-lane/scope.ts
@@ -3,8 +3,10 @@
 // SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
 // src/agents/awesome-claude/review-logic.ts (itself a faithful port of the live submission-gate
 // classifyPullRequestFilesForContentReview). PURE — distinguishes ignore (no content entry) vs
-// scope_failure (CLOSE) vs deletion vs review. `slugify` is inlined (a one-liner) so the module
-// has zero imports.
+// scope_failure (CLOSE) vs deletion vs review. `slugify` is inlined (a one-liner). The accepted
+// categories, entry-file pattern, and maintenance-branch prefixes come from a ContentRepoSpec so a
+// self-hosted curated list can parameterize the lane (defaults preserve awesome-claude byte-for-byte).
+import { AWESOME_CLAUDE_CONTENT_SPEC, type ContentRepoSpec } from "./content-repo-spec";
 
 const MAX_SLUG_INPUT_CHARS = 4096;
 
@@ -19,23 +21,11 @@ function slugify(value: unknown): string {
     .slice(0, 120);
 }
 
-export const SUPPORTED_CONTENT_CATEGORIES = new Set([
-  "agents",
-  "collections",
-  "commands",
-  "guides",
-  "hooks",
-  "mcp",
-  "rules",
-  "skills",
-  "statuslines",
-  "tools",
-]);
+/** Back-compat re-export: the default lane's accepted categories (now sourced from the spec). */
+export const SUPPORTED_CONTENT_CATEGORIES = AWESOME_CLAUDE_CONTENT_SPEC.categories;
 
-const CONTENT_ENTRY = /^content\/([^/]+)\/([^/]+)\.mdx$/i;
-
-export function importContentPathParts(filePath: string): { category: string; slug: string } | null {
-  const match = CONTENT_ENTRY.exec(filePath);
+export function importContentPathParts(filePath: string, spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC): { category: string; slug: string } | null {
+  const match = spec.entryPathPattern.exec(filePath);
   if (!match) return null;
   return { category: (match[1] as string).toLowerCase(), slug: slugify(match[2]) };
 }
@@ -63,22 +53,22 @@ const SCOPE_MULTI =
 const SCOPE_STATUS =
   "Direct content submissions can only add a new content file or edit one existing content file. Deletes, renames, and generated-artifact updates are not accepted in this path.";
 
-// Branch prefixes the automated link-health routine uses for its bulk URL-canonicalization PRs —
-// these LEGITIMATELY edit many content files and should be ignored, never closed.
-const MAINTENANCE_BRANCH_PREFIXES = ["links/"];
-function isMaintenanceBranch(headRef?: string): boolean {
+// Branch prefixes (from the spec) the automated link-health routine uses for its bulk URL-canonicalization
+// PRs — these LEGITIMATELY edit many content files and should be ignored, never closed.
+function isMaintenanceBranch(headRef: string | undefined, spec: ContentRepoSpec): boolean {
   if (!headRef) return false;
   const ref = headRef.toLowerCase();
-  return MAINTENANCE_BRANCH_PREFIXES.some((p) => ref.startsWith(p));
+  return spec.maintenanceBranchPrefixes.some((p) => ref.startsWith(p));
 }
 
 /** Exact port of classifyPullRequestFilesForContentReview. */
 export function classifyContentFiles(
   files: ContentFile[],
   context: { headRepo?: string; baseRepo?: string; headRef?: string } = {},
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
 ): ContentClassification {
   const entryFiles = files
-    .map((file) => ({ file, pathParts: importContentPathParts(String(file.filename || "")) }))
+    .map((file) => ({ file, pathParts: importContentPathParts(String(file.filename || ""), spec) }))
     .filter((item): item is { file: ContentFile; pathParts: { category: string; slug: string } } =>
       Boolean(item.pathParts),
     );
@@ -91,7 +81,7 @@ export function classifyContentFiles(
     const sameRepo =
       !!context.headRepo && !!context.baseRepo && context.headRepo.toLowerCase() === context.baseRepo.toLowerCase();
     // 1. A dedicated same-repo maintenance branch legitimately edits many content files → ignore.
-    if (sameRepo && isMaintenanceBranch(context.headRef)) {
+    if (sameRepo && isMaintenanceBranch(context.headRef, spec)) {
       return {
         kind: "ignore",
         reason: "Same-repository maintenance branch; the gate reviews only exact one-file content submissions.",
@@ -123,11 +113,11 @@ export function classifyContentFiles(
 
   const entry = entryFiles[0] as { file: ContentFile; pathParts: { category: string; slug: string } };
   const parts = entry.pathParts;
-  if (!SUPPORTED_CONTENT_CATEGORIES.has(parts.category)) {
+  if (!spec.categories.has(parts.category)) {
     return {
       kind: "close",
       category: parts.category,
-      reason: `Unsupported content category \`${parts.category}\`. Supported categories are ${[...SUPPORTED_CONTENT_CATEGORIES].sort().join(", ")}.`,
+      reason: `Unsupported content category \`${parts.category}\`. Supported categories are ${[...spec.categories].sort().join(", ")}.`,
     };
   }
 
@@ -145,6 +135,6 @@ export function classifyContentFiles(
 }
 
 /** Cheap pre-check used in the classify phase: does this PR touch a content entry file at all? */
-export function touchesContentEntry(filenames: string[]): boolean {
-  return filenames.some((f) => CONTENT_ENTRY.test(f));
+export function touchesContentEntry(filenames: string[], spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC): boolean {
+  return filenames.some((f) => spec.entryPathPattern.test(f));
 }

--- a/test/unit/content-lane-scope.test.ts
+++ b/test/unit/content-lane-scope.test.ts
@@ -5,6 +5,7 @@ import {
   SUPPORTED_CONTENT_CATEGORIES,
   touchesContentEntry,
 } from "../../src/review/content-lane/scope";
+import { AWESOME_CLAUDE_CONTENT_SPEC, type ContentRepoSpec } from "../../src/review/content-lane/content-repo-spec";
 
 describe("importContentPathParts", () => {
   it("parses content/<cat>/<slug>.mdx, lowercasing category + slugifying slug", () => {
@@ -112,5 +113,43 @@ describe("classifyContentFiles", () => {
   it("exposes the supported categories set", () => {
     expect(SUPPORTED_CONTENT_CATEGORIES.has("skills")).toBe(true);
     expect(SUPPORTED_CONTENT_CATEGORIES.has("not-a-category")).toBe(false);
+  });
+});
+
+describe("ContentRepoSpec (a self-hosted curated list parameterizes the lane)", () => {
+  const custom: ContentRepoSpec = {
+    categories: new Set(["recipes", "tutorials"]),
+    entryPathPattern: /^entries\/([^/]+)\/([^/]+)\.md$/i,
+    maintenanceBranchPrefixes: ["bot/"],
+  };
+
+  it("the default spec carries awesome-claude's categories + entry layout", () => {
+    expect(AWESOME_CLAUDE_CONTENT_SPEC.categories.has("skills")).toBe(true);
+    expect(SUPPORTED_CONTENT_CATEGORIES).toBe(AWESOME_CLAUDE_CONTENT_SPEC.categories);
+  });
+
+  it("importContentPathParts honours a custom entry pattern", () => {
+    expect(importContentPathParts("entries/recipes/My Dish.md", custom)).toEqual({ category: "recipes", slug: "my-dish" });
+    expect(importContentPathParts("content/skills/x.mdx", custom)).toBeNull(); // the awesome layout no longer matches
+  });
+
+  it("touchesContentEntry honours a custom entry pattern", () => {
+    expect(touchesContentEntry(["entries/recipes/foo.md"], custom)).toBe(true);
+    expect(touchesContentEntry(["content/agents/foo.mdx"], custom)).toBe(false);
+  });
+
+  it("classifyContentFiles reviews a custom category and closes an unsupported one", () => {
+    expect(classifyContentFiles([{ filename: "entries/recipes/foo.md", status: "added" }], {}, custom)).toMatchObject({ kind: "review", category: "recipes" });
+    expect(classifyContentFiles([{ filename: "entries/unknown/foo.md", status: "added" }], {}, custom)).toMatchObject({ kind: "close" });
+    expect(classifyContentFiles([{ filename: "", status: "added" }], {}, custom)).toMatchObject({ kind: "ignore" }); // falsy filename → no entry
+  });
+
+  it("classifyContentFiles honours custom maintenance-branch prefixes", () => {
+    const files = [
+      { filename: "entries/recipes/a.md", status: "modified" },
+      { filename: "entries/recipes/b.md", status: "modified" },
+    ];
+    const ctx = { headRepo: "me/list", baseRepo: "me/list", headRef: "bot/link-fix" };
+    expect(classifyContentFiles(files, ctx, custom)).toMatchObject({ kind: "ignore" });
   });
 });


### PR DESCRIPTION
## Summary

The awesome-claude content lane hard-coded its accepted **categories**, the `content/<cat>/<slug>.mdx` **entry pattern**, and the link-health **maintenance-branch prefixes** — so a self-hoster running gittensory over *their own* curated list couldn't use different categories/layout without a code change. Extract them into a modular **`ContentRepoSpec`** (the curated-list analogue of `RegistryLaneSpec` for the metagraphed registry lane):

- new leaf `content-repo-spec.ts`: `ContentRepoSpec` interface + `AWESOME_CLAUDE_CONTENT_SPEC` default,
- `scope.ts`'s `classifyContentFiles` / `importContentPathParts` / `touchesContentEntry` now take an **optional `spec` defaulting to `AWESOME_CLAUDE_CONTENT_SPEC`** — config-absent behaviour is **byte-identical**.

First slice (scope.ts); the `duplicates.ts` + `source-evidence.ts` field sets (frontmatter/url/catalog) follow in subsequent PRs.

## Scope
- [x] Additive + byte-stable; `content-repo-spec.ts` + `scope.ts` + barrel export + tests. (scope.ts's exports have no live callers beyond the barrel — dormant content-lane scaffolding.)

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the diff (a custom spec exercising every spec field: custom categories review/close, custom entry pattern, custom maintenance prefixes, + the falsy-filename guard).

Advances the not-single-repo / modularity directive.