### PR TITLE
fix(content-lane): route registry companions to manual review

### DIFF
--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -85,6 +85,11 @@ export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceRev
   }
   // A submission scope (entry/provider) always carries a directFile (classifier invariant; see classifyRegistryPrScope).
   const directFile = scope.directFile as string;
+  for (const file of input.changedFiles) {
+    const normalized = file.trim();
+    if (normalized === "" || normalized === directFile) continue;
+    return { verdict: "manual", summary: "Registry submission includes companion file changes — routing to review." };
+  }
   const headRaw = await input.loadFile(directFile, "head");
   if (scope.isProvider) {
     return fromProvider(assessProviderDocument(safeParseJson(headRaw), input.opts));

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -79,7 +79,7 @@ describe("runSurfaceReview (deterministic + decisive: merge/close, rarely manual
 
   it("ignores blank changed-file entries while enforcing the direct-file-only invariant", async () => {
     const r = await review(["", SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry]), [`base:${SUBNET}`]: doc([existing]) });
-    expect(r.verdict).toBe("merge");
+    expect(r?.verdict).toBe("merge");
   });
 
   it("closes a clean single append whose entry has a clear violation", async () => {

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -60,6 +60,28 @@ describe("runSurfaceReview (deterministic + decisive: merge/close, rarely manual
     expect(r?.verdict).toBe("merge");
   });
 
+  it("routes companion provider or artifact changes to manual review without trusting the entry verdict", async () => {
+    const calls: string[] = [];
+    const r = await runSurfaceReview(METAGRAPHED_LANE_SPEC, {
+      changedFiles: [SUBNET, PROVIDER],
+      loadFile: (path, ref) => {
+        calls.push(`${ref}:${path}`);
+        return Promise.resolve(ref === "head" ? doc([existing, newEntry]) : doc([existing]));
+      },
+    });
+
+    expect(r).toEqual({
+      verdict: "manual",
+      summary: "Registry submission includes companion file changes — routing to review.",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores blank changed-file entries while enforcing the direct-file-only invariant", async () => {
+    const r = await review(["", SUBNET], { [`head:${SUBNET}`]: doc([existing, newEntry]), [`base:${SUBNET}`]: doc([existing]) });
+    expect(r.verdict).toBe("merge");
+  });
+
   it("closes a clean single append whose entry has a clear violation", async () => {
     const bad = { ...newEntry, public_safe: false };
     const r = await review([SUBNET], { [`head:${SUBNET}`]: doc([existing, bad]), [`base:${SUBNET}`]: doc([existing]) });


### PR DESCRIPTION
### Motivation
- Prevent an unsafe bypass where a valid subnet entry append could be auto-merged while companion provider or artifact files included in the same PR were not validated.

### Description
- Add a pre-load guard in `runSurfaceReview` that inspects `input.changedFiles` and returns a `manual` verdict if any non-blank changed path other than the classified `directFile` is present, ensuring companion provider/artifact changes are not trusted implicitly (`src/review/content-lane/orchestrator.ts`).
- Add regression tests that prove a provider companion plus subnet append is routed to manual review without loading the direct file, and that blank changed-file entries are ignored (`test/unit/content-lane-orchestrator.test.ts`).

### Testing
- Ran the modified unit tests with `npx vitest run test/unit/content-lane-orchestrator.test.ts`, and the suite covering the changed file passed.
- Ran `npm run typecheck` and it completed successfully (no type errors).
- Attempted full coverage and CI commands (`npm run test:coverage` / `npm run test:ci`) but coverage remapping failed in this environment with `TypeError: jsTokens is not a function`, preventing a completed local CI run; this is an environment/tooling issue and not a regression in the change.
- `npm audit --audit-level=moderate` could not complete in this environment due to a registry audit endpoint error (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cac45499c832c8e94b844f766e84c)