### PR TITLE
fix(content-lane): limit registry provider companions

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -679,9 +679,9 @@ export interface RegistryScopeResult {
 
 /**
  * Generic surface-model scope classifier: in scope when the PR edits exactly ONE entry file (or, entry-free,
- * one flat provider file); the spec's provider + artifact files are allowed companions. A registry-looking
- * submission with too many entry/provider files is malformed and stays in the lane as mixed-files; an unrelated
- * PR with no direct registry files remains not-direct-submission.
+ * one flat provider file); at most one provider plus the spec's artifact files are allowed companions. A
+ * registry-looking submission with too many entry/provider files is malformed and stays in the lane as
+ * mixed-files; an unrelated PR with no direct registry files remains not-direct-submission.
  */
 export function classifyRegistryPrScope(spec: RegistryLaneSpec, changedFiles: string[]): RegistryScopeResult {
   const files = (changedFiles ?? []).map((f) => String(f || "").trim()).filter(Boolean);
@@ -690,7 +690,7 @@ export function classifyRegistryPrScope(spec: RegistryLaneSpec, changedFiles: st
   if (entryFiles.length > 1 || (entryFiles.length === 0 && providerFiles.length > 1)) {
     return { scope: "mixed-files", directFile: null, isProvider: false };
   }
-  const isEntryPr = entryFiles.length === 1;
+  const isEntryPr = entryFiles.length === 1 && providerFiles.length <= 1;
   const isProviderPr = entryFiles.length === 0 && providerFiles.length === 1;
   if (!isEntryPr && !isProviderPr) {
     return { scope: "not-direct-submission", directFile: null, isProvider: false };

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -280,6 +280,17 @@ describe("classifyRegistryPrScope (generic surface model, metagraphed spec)", ()
     expect(r.directFile).toBe("registry/subnets/allways.json");
   });
 
+  it("rejects an entry-submission with multiple flat provider companions", () => {
+    const r = classifyRegistryPrScope(spec, [
+      "registry/subnets/allways.json",
+      "registry/providers/allways.json",
+      "registry/providers/extra.json",
+    ]);
+    expect(r.scope).toBe("not-direct-submission");
+    expect(r.directFile).toBeNull();
+    expect(r.isProvider).toBe(false);
+  });
+
   it("recognizes a standalone flat provider-submission (no subnet file)", () => {
     const r = classifyRegistryPrScope(spec, ["registry/providers/cacheon.json"]);
     expect(r.scope).toBe("provider-submission");


### PR DESCRIPTION
### Motivation
- The registry surface-model PR classifier allowed an entry submission to carry any number of flat provider files as "allowed companions", which could let extra provider changes ride along without receiving the proper provider-only scrutiny.

### Description
- Tighten `classifyRegistryPrScope` to require `providerFiles.length <= 1` when an entry file is present so an entry-submission may have at most one flat provider companion (changed the `isEntryPr` predicate in `src/review/content-lane/registry-logic.ts`).
- Update the function documentation to reflect the "at most one provider" rule in the header comment in `src/review/content-lane/registry-logic.ts`.
- Add a regression unit test in `test/unit/content-lane-registry-logic.test.ts` that asserts an entry plus two flat provider files is classified as `not-direct-submission` with `directFile` null.

### Testing
- Ran `npx vitest run test/unit/content-lane-registry-logic.test.ts` and the unit suite (147 tests) passed. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Attempted coverage generation with `npx vitest --coverage` and tests passed but coverage post-processing failed with `TypeError: jsTokens is not a function` originating in `ast-v8-to-istanbul`. 
- `npm audit --audit-level=moderate` could not complete in this environment due to an HTTP 403 from the npm audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cac46668c832c9fdab990d7c193c9)