### PR TITLE
feat(orb): installation onboarding registry endpoints

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2926,6 +2926,36 @@ export function createApp() {
     return c.json({ instanceId, registered: registered === 1 });
   });
 
+  // Central Orb GitHub App installation registry — the onboarding gate. Every installation the Orb App webhook
+  // records lands at registered=0; only REGISTERED ones count toward the global public counter (getOrbGlobalStats)
+  // and are eligible for token brokering. Bearer-gated by the `/v1/internal/*` middleware (INTERNAL_JOB_TOKEN). The
+  // list shows pending + registered installs so an operator knows what they're opting in.
+  app.get("/v1/internal/orb/installations", async (c) => {
+    const rows = await c.env.DB
+      .prepare(
+        `SELECT installation_id AS installationId, account_login AS accountLogin, account_type AS accountType,
+                repository_selection AS repositorySelection, registered, suspended_at AS suspendedAt,
+                removed_at AS removedAt, first_seen_at AS firstSeenAt, last_event_at AS lastEventAt
+         FROM orb_github_installations ORDER BY last_event_at DESC`,
+      )
+      .all<{ installationId: number; accountLogin: string | null; accountType: string | null; repositorySelection: string | null; registered: number; suspendedAt: string | null; removedAt: string | null; firstSeenAt: string; lastEventAt: string }>();
+    return c.json({ installations: (rows.results ?? []).map((r) => ({ ...r, registered: r.registered === 1 })) });
+  });
+
+  // Opt an installation into (or out of) the registry. Body: { installationId, registered? } (registered defaults
+  // true). 404 when the installation isn't recorded yet — an install MUST arrive via the webhook first (unlike the
+  // fleet instances there's no account context to upsert a never-seen installation from).
+  app.post("/v1/internal/orb/installations/register", async (c) => {
+    const payload = (await c.req.json().catch(() => null)) as { installationId?: unknown; registered?: unknown } | null;
+    const installationId = Number(payload?.installationId);
+    if (!Number.isInteger(installationId) || installationId <= 0) return c.json({ error: "installationId required" }, 400);
+    const existing = await c.env.DB.prepare("SELECT installation_id FROM orb_github_installations WHERE installation_id = ?").bind(installationId).first();
+    if (!existing) return c.json({ error: "installation_not_found" }, 404);
+    const registered = payload?.registered === false ? 0 : 1;
+    await c.env.DB.prepare("UPDATE orb_github_installations SET registered = ? WHERE installation_id = ?").bind(registered, installationId).run();
+    return c.json({ installationId, registered: registered === 1 });
+  });
+
   // Convergence (ops / observability, flag GITTENSORY_REVIEW_OPS). Cross-repo review-OUTCOME aggregate (gate-block
   // ledger + recommendation/slop calibration) for an operator dashboard. Bearer-gated by the `/v1/internal/*`
   // middleware above (INTERNAL_JOB_TOKEN). Flag-OFF (default) → 404, so the endpoint does not exist and the

--- a/test/integration/orb-onboarding.test.ts
+++ b/test/integration/orb-onboarding.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createTestEnv, type TestD1Database } from "../helpers/d1";
+
+describe("Central Orb installation registry routes (/v1/internal/orb/installations)", () => {
+  const app = createApp();
+  const auth = { authorization: "Bearer dev-internal-token" };
+  const seed = (env: Env, id: number, registered = 0) =>
+    (env.DB as unknown as TestD1Database)
+      .prepare("INSERT INTO orb_github_installations (installation_id, account_login, account_type, registered) VALUES (?, 'acme', 'Organization', ?)")
+      .bind(id, registered)
+      .run();
+  const register = (env: Env, body: unknown) =>
+    app.request("/v1/internal/orb/installations/register", { method: "POST", headers: auth, body: typeof body === "string" ? body : JSON.stringify(body) }, env);
+
+  it("lists recorded installations (registered surfaced as a boolean)", async () => {
+    const env = createTestEnv();
+    await seed(env, 100);
+    const res = await app.request("/v1/internal/orb/installations", { headers: auth }, env);
+    expect(res.status).toBe(200);
+    const { installations } = (await res.json()) as { installations: Array<{ installationId: number; accountLogin: string; registered: boolean }> };
+    expect(installations).toEqual([expect.objectContaining({ installationId: 100, accountLogin: "acme", registered: false })]);
+  });
+
+  it("401 without the internal token", async () => {
+    expect((await app.request("/v1/internal/orb/installations", {}, createTestEnv())).status).toBe(401);
+  });
+
+  it("registers an installation, then unregisters it", async () => {
+    const env = createTestEnv();
+    await seed(env, 101);
+    expect(((await (await register(env, { installationId: 101 })).json()) as { registered: boolean }).registered).toBe(true);
+    expect(((await (await register(env, { installationId: 101, registered: false })).json()) as { registered: boolean }).registered).toBe(false);
+  });
+
+  it("404 when the installation has not been recorded by a webhook yet", async () => {
+    expect((await register(createTestEnv(), { installationId: 999 })).status).toBe(404);
+  });
+
+  it("400 when installationId is missing, non-numeric, or not positive", async () => {
+    expect((await register(createTestEnv(), {})).status).toBe(400); // missing → NaN
+    expect((await register(createTestEnv(), "{bad")).status).toBe(400); // unparseable JSON → null
+    expect((await register(createTestEnv(), { installationId: 0 })).status).toBe(400); // not positive
+  });
+
+  it("tolerates a list query that omits results (rows.results ?? [])", async () => {
+    const env = { ...createTestEnv(), DB: { prepare: () => ({ all: () => Promise.resolve({}) }) } } as unknown as Env;
+    const res = await app.request("/v1/internal/orb/installations", { headers: auth }, env);
+    expect(((await res.json()) as { installations: unknown[] }).installations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the central Orb App **installation onboarding gate** (mirrors the existing fleet-instance registry endpoints):
- `GET  /v1/internal/orb/installations` — list recorded installs (pending + registered) so an operator sees what to opt in
- `POST /v1/internal/orb/installations/register` — opt an installation in/out (`registered` 0↔1)

Both bearer-gated by the `/v1/internal/*` middleware (`INTERNAL_JOB_TOKEN`). An installation must arrive via the webhook first (404 otherwise) — unlike the fleet instances there's no account context to upsert a never-seen installation from. Only **registered** installs count toward `getOrbGlobalStats` + are broker-eligible.

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the new routes (list + register; 401 unauth; register/unregister; 404 unknown; 400 missing/non-numeric/non-positive; `rows.results ?? []`).

Advances #1255 (the central Orb data layer).