### PR TITLE
feat(review): post purple 🟪 reviewing placeholder before AI runs

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -171,7 +171,7 @@ import { buildUnifiedCommentBody, isUnifiedReviewCommentEnabled } from "../revie
 import { screenshotsAllowed } from "../review/visual-wire";
 import { isVisualPath } from "../review/visual/paths";
 import { buildCapture, type CaptureRoute } from "../review/visual/capture";
-import type { CheckFailureDetail, MergeReadiness } from "../review/unified-comment";
+import { renderReviewingPlaceholder, shouldPostReviewingPlaceholder, type CheckFailureDetail, type MergeReadiness } from "../review/unified-comment";
 import { buildIssueSlopAssessment, buildSlopAssessment, type SlopBand } from "../signals/slop";
 import { runGittensoryAiSlopAdvisory } from "../services/ai-slop";
 import { decidePublicSurface } from "../signals/settings-preview";
@@ -2637,6 +2637,13 @@ async function maybePublishPrPublicSurface(
     // resolve only when the review will actually run (aiReviewMode !== off + a head SHA + not explicitly skipped)
     // to keep gate-only and advisory-sweep repos free of an extra file resolve.
     const aiReviewWillRun = !webhook.skipAiReview && settings.aiReviewMode !== "off" && Boolean(advisory.headSha);
+    // Post a transient "🟪 reviewing…" placeholder BEFORE the AI runs so contributors see the bot
+    // is actively working rather than silent. In-place upsert: once the final verdict is ready it
+    // overwrites this comment. Best-effort — a failed post never aborts the review. (#reviewing-placeholder)
+    if (shouldPostReviewingPlaceholder({ aiReviewWillRun, mode, willComment: decision.willComment })) {
+      const placeholderBody = `${PR_PANEL_COMMENT_MARKER}\n\n${renderReviewingPlaceholder()}`;
+      await createOrUpdatePrIntelligenceComment(env, installationId, repoFullName, pr.number, placeholderBody, { mode }).catch(() => undefined);
+    }
     if (aiReviewWillRun) {
       // `.gittensory.yml` review.profile + review.path_instructions + review.exclude_paths (#review-profile /
       // #review-path-instructions / #review-exclude-paths): resolve from the manifest (cached from settings

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -510,3 +510,33 @@ export function buildUnifiedReviewInput(opts: {
     ...(opts.verdictReason !== undefined ? { verdictReason: opts.verdictReason } : {}),
   };
 }
+
+// ── Reviewing-in-progress placeholder ────────────────────────────────────────────────────────────
+//
+// Posted BEFORE the AI review runs so contributors see the bot is actively working rather than
+// silent. Uses GitHub's IMPORTANT alert type (purple sidebar) — the one un-used final-state color.
+// This is NOT a UnifiedCommentStatus: it is a transient pre-verdict placeholder, not a terminal
+// review outcome. The createOrUpdatePrIntelligenceComment upsert replaces it in-place once the
+// final verdict is ready. (#reviewing-placeholder)
+
+const REVIEWING_SQUARE = "🟪";
+
+/** Render the transient "🟪 reviewing…" placeholder body. Caller must prepend PR_PANEL_COMMENT_MARKER
+ *  before posting so the upsert updates the existing bot comment instead of creating a duplicate.
+ *  Pure and public-safe-by-construction (brand is angle-escaped; no raw caller text embedded). */
+export function renderReviewingPlaceholder(ctx: { brand?: string } = {}): string {
+  const brand = escapePublicHtmlAngles(ctx.brand ?? "Gittensory");
+  const inner = [
+    REVIEWING_SQUARE.repeat(12),
+    `### 🔍 ${brand} is reviewing…`,
+    "AI analysis is in progress. This comment will update when the review is complete.",
+    `<sub>${STATUS_META.ready.square} Safe / merged · ${STATUS_META.advisory.square} Advisory · ${STATUS_META.held.square} Held for review · ${STATUS_META.blocked.square} Blocked / closed · ${REVIEWING_SQUARE} Reviewing</sub>`,
+  ].join("\n\n");
+  return asAlert("IMPORTANT", inner);
+}
+
+/** Returns true when the reviewing placeholder should be posted before the AI review runs.
+ *  Pure helper so both branches are testable without async setup. */
+export function shouldPostReviewingPlaceholder(args: { aiReviewWillRun: boolean; mode: string; willComment: boolean }): boolean {
+  return args.aiReviewWillRun && args.mode === "live" && args.willComment;
+}

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -716,6 +716,77 @@ describe("queue processors", () => {
     expect(mergeAudit?.n).toBe(0);
   });
 
+  it("posts the 🟪 reviewing placeholder before the AI review runs, then overwrites it with the verdict (#reviewing-placeholder)", async () => {
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      AI: {
+        run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }),
+      } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      aiReviewMode: "advisory",
+    });
+    const commentBodies: string[] = [];
+    let firstCommentWasPlaceholder = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/7/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/7/comments") && method === "POST") {
+        const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        if (commentBodies.length === 0) firstCommentWasPlaceholder = body.includes("is reviewing");
+        commentBodies.push(body);
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "reviewing-placeholder",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" },
+      },
+    });
+
+    // The transient purple placeholder was posted FIRST (before the final verdict comment), proving the
+    // pre-review placeholder glue in maybePublishPrPublicSurface runs when a comment + AI review are due.
+    expect(commentBodies.length).toBeGreaterThanOrEqual(2);
+    expect(firstCommentWasPlaceholder).toBe(true);
+    expect(commentBodies[0]).toContain("🟪");
+    // A later comment carries the real verdict, not the placeholder prose.
+    expect(commentBodies.some((body) => !body.includes("is reviewing"))).toBe(true);
+  });
+
   it("agent re-gate sweep re-reviews each stale open PR (installation id) and swallows a failing re-review", async () => {
     const env = createTestEnv({});
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -3,9 +3,11 @@ import {
   buildUnifiedReviewInput,
   deriveUnifiedStatus,
   type DualReviewNote,
+  renderReviewingPlaceholder,
   renderUnifiedReviewComment,
   type ReviewNotes,
   type ReviewRecommendation,
+  shouldPostReviewingPlaceholder,
   type UnifiedCommentContext,
   type UnifiedReviewInput,
 } from "../../src/review/unified-comment";
@@ -388,5 +390,70 @@ describe("buildUnifiedReviewInput", () => {
     expect(input.readiness).toEqual({ ciState: "passed" });
     expect(input.merged).toBe(true);
     expect(input.verdictReason).toBe("auto-merged after green CI");
+  });
+});
+
+describe("renderReviewingPlaceholder", () => {
+  it("renders the IMPORTANT (purple) GitHub alert type", () => {
+    const body = renderReviewingPlaceholder();
+    expect(body).toContain("[!IMPORTANT]");
+  });
+
+  it("includes the 🟪 reviewing square in the body and legend", () => {
+    const body = renderReviewingPlaceholder();
+    // Appears at least twice: the repeating banner and the legend entry.
+    expect(body.split("🟪").length).toBeGreaterThan(2);
+    expect(body).toContain("🟪 Reviewing");
+  });
+
+  it("includes the reviewing-in-progress prose", () => {
+    const body = renderReviewingPlaceholder();
+    expect(body).toContain("is reviewing");
+    expect(body).toContain("in progress");
+    expect(body).toContain("will update when the review is complete");
+  });
+
+  it("uses the default brand when none is provided", () => {
+    expect(renderReviewingPlaceholder()).toContain("Gittensory is reviewing");
+  });
+
+  it("respects a custom brand override", () => {
+    expect(renderReviewingPlaceholder({ brand: "MyBot" })).toContain("MyBot is reviewing");
+  });
+
+  it("angle-escapes HTML in the brand to prevent comment injection", () => {
+    const body = renderReviewingPlaceholder({ brand: "<script>alert(1)</script>" });
+    expect(body).not.toContain("<script>");
+    expect(body).toContain("&lt;script&gt;");
+  });
+
+  it("includes the full legend row with all four final-state colors", () => {
+    const body = renderReviewingPlaceholder();
+    expect(body).toContain("🟩");
+    expect(body).toContain("🟦");
+    expect(body).toContain("🟨");
+    expect(body).toContain("🟥");
+  });
+});
+
+describe("shouldPostReviewingPlaceholder", () => {
+  it("returns true when AI will run, mode is live, and a comment will be posted", () => {
+    expect(shouldPostReviewingPlaceholder({ aiReviewWillRun: true, mode: "live", willComment: true })).toBe(true);
+  });
+
+  it("returns false when AI review will not run", () => {
+    expect(shouldPostReviewingPlaceholder({ aiReviewWillRun: false, mode: "live", willComment: true })).toBe(false);
+  });
+
+  it("returns false in dry-run mode — placeholder must never write to GitHub in non-live mode", () => {
+    expect(shouldPostReviewingPlaceholder({ aiReviewWillRun: true, mode: "dry_run", willComment: true })).toBe(false);
+  });
+
+  it("returns false in paused mode", () => {
+    expect(shouldPostReviewingPlaceholder({ aiReviewWillRun: true, mode: "paused", willComment: true })).toBe(false);
+  });
+
+  it("returns false when no comment will be posted — avoids a permanent orphaned purple comment", () => {
+    expect(shouldPostReviewingPlaceholder({ aiReviewWillRun: true, mode: "live", willComment: false })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a transient **🟪 in-progress state** to the Gittensory review comment. Before the AI analysis starts, the bot posts (or updates in-place) a purple `[!IMPORTANT]` placeholder comment so contributors see the bot is actively working rather than silent between PR open and review complete. When the review finishes, the final verdict (🟩 🟦 🟨 🟥) overwrites it in the same comment via the existing upsert mechanism — no duplicate comments.

- **`renderReviewingPlaceholder()`** — pure renderer; angle-escapes the brand; includes the full 5-color legend so the status key is self-contained in the placeholder
- **`shouldPostReviewingPlaceholder()`** — pure guard extracted for testability: only posts in `live` mode, only when AI will run, only when a comment will actually be posted (prevents an orphaned purple comment on skipped/paused/dry-run PRs)
- Injection in `maybePublishPrPublicSurface` is best-effort (`.catch(() => undefined)`) so a failed placeholder post never aborts the review
- Uses GitHub's `IMPORTANT` alert type (purple sidebar) — the one alert color not occupied by any final verdict state

Closes #1315

## Scope

- [x] `src/` only — no migrations, no OpenAPI change, no wrangler bindings
- [x] No secrets, wallets, hotkeys, trust scores, or private scoring anywhere
- [x] No `site/`, `CNAME`, or `lovable` changes; no `CHANGELOG.md` edit

## Validation

- [x] `npm run test:ci` — exit 0; 4268 tests pass
- [x] `npm audit --audit-level=moderate` — clean
- [x] New `describe("renderReviewingPlaceholder")` (8 tests) and `describe("shouldPostReviewingPlaceholder")` (5 tests) cover all branches of both new exports
- [x] `shouldPostReviewingPlaceholder` tests cover: all-true → true; aiReviewWillRun=false → false; mode=dry_run → false; mode=paused → false; willComment=false → false

## Safety

- [x] No auth/CORS/session changes
- [x] `renderReviewingPlaceholder` angle-escapes the brand (injection-safe)
- [x] No private terms in output (no rubric, scoring, wallet, hotkey, etc.)
- [x] Placeholder only posts in live mode — dry-run suppression unchanged