### PR TITLE
feat(orb): post-install OAuth landing page (/v1/orb/oauth/callback)

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -124,6 +124,7 @@ import {
 import { handleGitHubWebhook } from "../github/webhook";
 import { handleOrbIngest, readOrbIngestBody } from "../orb/ingest";
 import { handleOrbWebhook } from "../orb/webhook";
+import { handleOrbOAuthCallback } from "../orb/oauth";
 import { computeFleetAnalytics } from "../orb/analytics";
 import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
@@ -2869,6 +2870,9 @@ export function createApp() {
   // Verifies the Orb App's OWN webhook secret, dedups, and records install + PR/review events (the homepage
   // fleet-metrics data spine). Separate App + secret from the review-app /v1/github/webhook above.
   app.post("/v1/orb/webhook", handleOrbWebhook);
+  // Post-install / OAuth landing — the App's Callback URL. Token-exempt; GitHub drives the redirect after a
+  // maintainer installs or updates the Orb App. Lands on a real page instead of a 401.
+  app.get("/v1/orb/oauth/callback", handleOrbOAuthCallback);
 
   // Gittensory Orb (#1255) — central fleet-calibration collector. Receives anonymized, reversal-aware
   // outcome batches from self-hosted instances. No auth required: all data is HMAC-anonymized by the sender;
@@ -4903,6 +4907,7 @@ function requiresApiToken(path: string): boolean {
   if (path.startsWith("/v1/auth/")) return false;
   if (path === "/v1/github/webhook") return false;
   if (path === "/v1/orb/webhook") return false;
+  if (path === "/v1/orb/oauth/callback") return false;
   if (path === "/v1/orb/ingest") return false;
   if (path.startsWith("/v1/internal/")) return false;
   return path.startsWith("/v1/");

--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -99,6 +99,7 @@ export function routeClassForPath(path: string): RateLimitClass {
   // Orb central-App inbound webhook — same class as the review-app webhook above (GitHub delivers from a
   // narrow IP range; the per-IP strict cap is proven for /v1/github/webhook and #1292 reserves headroom).
   if (path === "/v1/orb/webhook") return "strict";
+  if (path === "/v1/orb/oauth/callback") return "strict";
   // Orb telemetry ingest: unauthenticated + write, accepting anonymized batches from untrusted
   // self-host instances. Strict (10/min per IP) caps abuse — legitimate instances export hourly.
   if (path === "/v1/orb/ingest") return "strict";

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -1,0 +1,20 @@
+// Gittensory Orb central GitHub App (#1255) — the post-install / OAuth landing endpoint. GitHub redirects here
+// after a maintainer installs or updates the Orb App (the App's Callback URL, with OAuth-during-install ON). For
+// now it confirms the connection so the install flow lands on a real page instead of a 401; the full OAuth
+// code-exchange + container enrollment (the token-broker) layers onto this same endpoint next. Token-EXEMPT —
+// GitHub drives the redirect with no API token (see requiresApiToken). No request input is echoed into the
+// markup, so there is no injection surface.
+import type { Context } from "hono";
+
+function landingPage(heading: string, message: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${heading}</title><style>*{box-sizing:border-box}body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0b0b0d;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}.card{max-width:30rem;margin:1.5rem;padding:2.75rem;background:#16161a;border:1px solid #2a2a30;border-radius:14px;text-align:center}h1{font-size:1.35rem;font-weight:600;margin:0 0 .7rem}p{font-size:.95rem;line-height:1.6;color:#a8a8b0;margin:0 0 1.6rem}a{display:inline-block;padding:.6rem 1.4rem;background:#1f6feb;color:#fff;text-decoration:none;border-radius:8px;font-size:.9rem}</style></head><body><div class="card"><h1>${heading}</h1><p>${message}</p><a href="https://gittensory.aethereal.dev">Open the dashboard</a></div></body></html>`;
+}
+
+export function handleOrbOAuthCallback(c: Context<{ Bindings: Env }>): Response {
+  const updated = c.req.query("setup_action") === "update";
+  return c.html(
+    updated
+      ? landingPage("Gittensory Orb updated", "Your repository selection was updated — the dashboard reflects the change shortly.")
+      : landingPage("Gittensory Orb connected", "Your repositories are linked. Their review activity now flows to the global Gittensory dashboard."),
+  );
+}

--- a/test/integration/orb-oauth.test.ts
+++ b/test/integration/orb-oauth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/api/routes";
+import { createTestEnv } from "../helpers/d1";
+
+describe("GET /v1/orb/oauth/callback (post-install landing)", () => {
+  const app = createApp();
+
+  it("is token-exempt + returns the connected page on install (no 401)", async () => {
+    // Exercises requiresApiToken (exempt) + routeClassForPath (strict) for the path, then the handler.
+    const res = await app.request("/v1/orb/oauth/callback?installation_id=142475427&setup_action=install", {}, createTestEnv());
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Gittensory Orb connected");
+    expect(html).toContain("gittensory.aethereal.dev");
+  });
+
+  it("returns the updated page on a repo-selection update", async () => {
+    const res = await app.request("/v1/orb/oauth/callback?setup_action=update", {}, createTestEnv());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Gittensory Orb updated");
+  });
+
+  it("defaults to the connected page when setup_action is absent", async () => {
+    const res = await app.request("/v1/orb/oauth/callback", {}, createTestEnv());
+    expect(await res.text()).toContain("Gittensory Orb connected");
+  });
+
+  it("the new exemption + rate class are path-specific (a later orb path still routes)", async () => {
+    // /v1/orb/ingest falls through PAST the new callback checks, exercising their FALSE side in both
+    // requiresApiToken + routeClassForPath (the webhook path short-circuits earlier and wouldn't reach them).
+    const res = await app.request("/v1/orb/ingest", { method: "POST" }, createTestEnv());
+    expect([400, 413]).toContain(res.status); // reached the (exempt) ingest handler, failed only on the empty body
+  });
+});


### PR DESCRIPTION
## Summary

The Orb App's **Callback URL** is `https://gittensory-api.aethereal.dev/v1/orb/oauth/callback` with *Request user authorization (OAuth) during installation* ON — but that endpoint didn't exist. So after a maintainer installs, GitHub's post-install redirect hit a token-gated `/v1/` path and returned **401 "unauthorized"** (the install itself succeeds first — data still flows). 

Adds a **token-exempt** `GET /v1/orb/oauth/callback` that returns a real "Gittensory Orb connected" / "updated" landing page. No request input is echoed into the markup (no injection surface). Exempted in `requiresApiToken` + rate-classified `strict`, mirroring `/v1/orb/webhook`.

This is the post-install landing; the full OAuth code-exchange + container enrollment (the token-broker) layers onto the same Orb OAuth app in the follow-up PRs.

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the diff (connected/updated/default pages; the exemption + rate-class are path-specific — verified via a fall-through path).

Advances #1255 (the central Orb data layer).