### PR TITLE
fix(agent): restore submission flood hold

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1,6 +1,7 @@
 import {
   countOpenIssues,
   countOpenPullRequests,
+  countRecentSubmissionsByAuthor,
   getAgentCommandAnswer,
   getInstallation,
   getLatestRepoGithubTotalsSnapshot,
@@ -185,7 +186,7 @@ import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
-import { loadHardGuardrailGlobs } from "../review/guardrail-config";
+import { loadHardGuardrailGlobs, loadSubmissionFloodLimit } from "../review/guardrail-config";
 import { closePullRequest, createIssueComment, getLastCloserLogin } from "../github/pr-actions";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
@@ -747,9 +748,10 @@ async function maybeRunAgentMaintenance(
   // planner uses this to NEVER approve/merge a PR whose CI isn't green, to CLOSE a red-CI non-owner PR (citing
   // the failing checks) / HOLD the owner's, and to DEFER entirely while CI is still pending.
   const ciToken = await createInstallationToken(env, installationId).catch(() => undefined);
-  const [changedFiles, hardGuardrailGlobs, requiredContexts, liveMergeState, liveReviewDecision] = await Promise.all([
+  const [changedFiles, hardGuardrailGlobs, submissionFloodLimit, requiredContexts, liveMergeState, liveReviewDecision] = await Promise.all([
     resolvePullRequestFilesForReview(env, { installationId, repoFullName, pullNumber: pr.number }),
     loadHardGuardrailGlobs(env, repoFullName),
+    loadSubmissionFloodLimit(env, repoFullName),
     // RC2: branch-protection REQUIRED status contexts, so only a required red check gates the PR (a red
     // codecov/* is surfaced but never blocks merge/approve or forces request_changes). null ⇒ fold all red.
     fetchRequiredStatusContexts(env, repoFullName, pr.baseRef ?? args.repo?.defaultBranch, ciToken ?? env.GITHUB_PUBLIC_TOKEN),
@@ -768,6 +770,13 @@ async function maybeRunAgentMaintenance(
   const authorLogin = pr.authorLogin ?? "";
   const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
+  const submissionFloodHit =
+    submissionFloodLimit != null &&
+    authorLogin.length > 0 &&
+    !authorIsOwner &&
+    !authorIsAutomationBot &&
+    (await countRecentSubmissionsByAuthor(env, repoFullName, authorLogin, new Date(Date.now() - submissionFloodLimit.submissionWindowHours * 60 * 60 * 1000).toISOString())) >
+      submissionFloodLimit.maxSubmissionsPerAuthorWindow;
 
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules): when the repo enabled any rule, a body that links
   // MORE closing references than we can safely verify (overflow) is itself a violation; otherwise evaluate the
@@ -795,6 +804,7 @@ async function maybeRunAgentMaintenance(
     hardGuardrailGlobs,
     authorIsOwner,
     authorIsAutomationBot,
+    submissionFloodHit,
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -71,6 +71,29 @@ function asNonEmptyStringArray(value: unknown): string[] | null {
   return out.length > 0 ? out : null;
 }
 
+export type SubmissionFloodLimit = {
+  maxSubmissionsPerAuthorWindow: number;
+  submissionWindowHours: number;
+};
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+export async function loadSubmissionFloodLimit(env: Env, repoFullName: string): Promise<SubmissionFloodLimit | null> {
+  const slug = repoFullName.includes("/") ? repoFullName.slice(repoFullName.indexOf("/") + 1) : repoFullName;
+  if (!env.REVIEW_CONFIG) return null;
+  try {
+    const config = (await env.REVIEW_CONFIG.get(slug, "json")) as { maxSubmissionsPerAuthorWindow?: JsonValue; submissionWindowHours?: JsonValue } | null;
+    const maxSubmissionsPerAuthorWindow = positiveInteger(config?.maxSubmissionsPerAuthorWindow);
+    const submissionWindowHours = positiveInteger(config?.submissionWindowHours);
+    if (maxSubmissionsPerAuthorWindow == null || submissionWindowHours == null) return null;
+    return { maxSubmissionsPerAuthorWindow, submissionWindowHours };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Resolve a repo's hard-guardrail path globs from the shared REVIEW_CONFIG KV (key = repo slug). Never throws
  * (the auto-maintain trigger is best-effort). A legitimately-absent binding/key/field falls back to the narrow

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -71,6 +71,10 @@ export type AgentActionPlanInput = {
   // neither auto-merge, auto-approve, nor auto-close such a PR; it falls through to a human.
   changedPaths: string[];
   hardGuardrailGlobs: string[];
+  // Anti-farming guard: true when a non-owner, non-automation contributor exceeded the operator-configured
+  // per-repo submission volume cap. Like a guardrail path, this suppresses autonomous approve/merge/close and
+  // holds the PR for a human.
+  submissionFloodHit?: boolean | undefined;
   // True when the PR author is the repo owner (e.g. JSONbored). Standing rule: owner PRs are NEVER
   // auto-closed. They may still auto-merge when clean + passing.
   authorIsOwner: boolean;
@@ -248,12 +252,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const guardrailHit =
     input.hardGuardrailGlobs.length > 0 &&
     (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
-  // Manual review is the RARE exception (the operator's minimize-manual goal): the ONLY thing that holds a PR for
-  // a human instead of merge/close is an auto-merge-ready PR that touches a hard-guardrail path. (An owner PR that
-  // is not review-good is held separately, via the owner close-exemption below — never auto-closed.) Submission
-  // volume is NOT a hold reason: a high-volume author's clean PR still merges and their bad PR still closes — the
-  // quality gate, not a submission count, is the defense (anti-farming-by-manual-hold removed).
-  const heldForManualReview = guardrailHit;
+  // Manual review is the RARE exception (the operator's minimize-manual goal): a PR is held only when an
+  // auto-merge-ready PR touches a hard-guardrail path, or when an operator-configured submission-flood cap says
+  // a non-owner/non-automation contributor is flooding the repo. Owner PRs that are not review-good are held
+  // separately, via the owner close-exemption below — never auto-closed.
+  const submissionFloodHit = input.submissionFloodHit === true;
+  const heldForManualReview = guardrailHit || submissionFloodHit;
   // Canonical (reviewbot non-content-gate) policy, tuned to the operator's minimize-manual goal: merge-or-close
   // with high accuracy; manual review is the RARE exception. A PR is "review-good" when the gate passes AND CI is
   // green — that's the only thing that earns an auto-merge or an approve. Everything else, for a CONTRIBUTOR, is a
@@ -287,7 +291,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // have folded in optional / third-party checks and must keep the hard-guardrail manual hold.
   // (Rebase-if-behind already ran above, so a red CI here is on the latest base — not a stale-base artifact.) (#ci-fail-closes-guarded)
   const redVerifiedRequiredCi = ciFailed && input.ciRequiredContextsVerified === true;
-  const willClose = isContributor && acting("close") && (redVerifiedRequiredCi || (!guardrailHit && (ciFailed || input.conclusion === "failure" || isConflict)));
+  const willClose = isContributor && acting("close") && !submissionFloodHit && (redVerifiedRequiredCi || (!guardrailHit && (ciFailed || input.conclusion === "failure" || isConflict)));
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules). A DETERMINISTIC verdict about the LINKED ISSUE
   // (owner-assigned / missing point-label / maintainer-only) — NOT an AI verdict, so there is no hallucination
   // to guard against: this close fires REGARDLESS of `guardrailHit`. It still only ever closes a CONTRIBUTOR

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -256,17 +256,26 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
-  describe("submission volume is NOT a manual-hold reason — only guardrail paths hold (#minimize-manual)", () => {
-    it("a high-volume author's clean+green+approved PR MERGES (the quality gate, not a submission count, is the defense)", () => {
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+  describe("submission flood guard", () => {
+    it("holds a flooding contributor's clean+green+approved PR for manual review", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, submissionFloodHit: true, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);
-      expect(cls).toContain("merge"); // clean → merge, regardless of how many PRs the author has open
+      expect(cls).not.toContain("merge");
+      expect(cls).not.toContain("approve");
       expect(cls).not.toContain("close");
-      expect(plan.find((a) => a.actionClass === "label")?.label).not.toBe(AGENT_LABEL_NEEDS_REVIEW); // never held for review
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
     });
-    it("a high-volume author's red-CI PR still CLOSES (the normal close path)", () => {
-      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ciState: "failed", pr: { labels: [] } })));
-      expect(plan).toContain("close");
+    it("does not hold a clean+green+approved PR when the flood cap is not hit", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, submissionFloodHit: false, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).toContain("merge");
+      expect(cls).not.toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_READY);
+    });
+    it("a flooding author's red-CI PR is held rather than closed until a human reviews the flood", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto", label: "auto" }, submissionFloodHit: true, ciState: "failed", pr: { labels: [] } }));
+      expect(classes(plan)).not.toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
     it("ONLY a guardrail-touching review-good PR is held for manual review (needs-human, never merged/closed)", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, hardGuardrailGlobs: ["src/**"], changedPaths: ["src/index.ts"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { matchesAny } from "../../src/signals/change-guardrail";
-import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ENGINE_DECISION_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs } from "../../src/review/guardrail-config";
+import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ENGINE_DECISION_GUARDRAIL_GLOBS, FAIL_CLOSED_GUARDRAIL_GLOBS, loadHardGuardrailGlobs, loadSubmissionFloodLimit } from "../../src/review/guardrail-config";
 
 function envWith(get: (key: string, type: string) => Promise<unknown>): Env {
   return { REVIEW_CONFIG: { get } } as unknown as Env;
@@ -75,5 +75,31 @@ describe("loadHardGuardrailGlobs", () => {
     const get = vi.fn().mockResolvedValue({ hardGuardrailGlobs: ["a/**"] });
     await loadHardGuardrailGlobs(envWith(get), "soloname");
     expect(get).toHaveBeenCalledWith("soloname", "json");
+  });
+});
+
+describe("loadSubmissionFloodLimit", () => {
+  it("returns null when REVIEW_CONFIG is unbound", async () => {
+    expect(await loadSubmissionFloodLimit({} as Env, "JSONbored/gittensory")).toBeNull();
+  });
+
+  it("reads positive integer flood limits from KV keyed by repo slug", async () => {
+    const get = vi.fn().mockResolvedValue({ maxSubmissionsPerAuthorWindow: 10, submissionWindowHours: 24 });
+    await expect(loadSubmissionFloodLimit(envWith(get), "JSONbored/gittensory")).resolves.toEqual({ maxSubmissionsPerAuthorWindow: 10, submissionWindowHours: 24 });
+    expect(get).toHaveBeenCalledWith("gittensory", "json");
+  });
+
+  it("returns null when either flood limit is absent, invalid, or the KV read throws", async () => {
+    await expect(loadSubmissionFloodLimit(envWith(async () => ({ maxSubmissionsPerAuthorWindow: 10 })), "o/r")).resolves.toBeNull();
+    await expect(loadSubmissionFloodLimit(envWith(async () => ({ maxSubmissionsPerAuthorWindow: 0, submissionWindowHours: 24 })), "o/r")).resolves.toBeNull();
+    await expect(loadSubmissionFloodLimit(envWith(async () => ({ maxSubmissionsPerAuthorWindow: 10, submissionWindowHours: 1.5 })), "o/r")).resolves.toBeNull();
+    await expect(
+      loadSubmissionFloodLimit(
+        envWith(async () => {
+          throw new Error("kv down");
+        }),
+        "o/r",
+      ),
+    ).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation
- Reintroduce the operator-configured per-repo submission-flood protection that was removed, because without it high-volume contributors who pass automated checks could be auto-approved/merged or auto-closed, enabling PR farming and bypassing an intended anti-abuse control. 
- Preserve the existing autonomous behavior while ensuring repositories can opt to hold a contributor's PR for human review when a configured flood cap is exceeded.

### Description
- Re-added a KV loader `loadSubmissionFloodLimit` in `src/review/guardrail-config.ts` to read `maxSubmissionsPerAuthorWindow` and `submissionWindowHours` from `REVIEW_CONFIG`. 
- Wired the queue processor to fetch the flood limit and call `countRecentSubmissionsByAuthor`, computing `submissionFloodHit` and passing it into the planner input in `src/queue/processors.ts`. 
- Extended `AgentActionPlanInput` with `submissionFloodHit`, and updated planner logic in `src/settings/agent-actions.ts` to treat a flood hit like a guardrail: hold the PR for manual review (suppress auto-approve/merge/close) and prevent closes while the flag is present. 
- Added/updated unit tests in `test/unit/agent-actions.test.ts` and `test/unit/guardrail-config.test.ts` to cover the loader and flood-hold planner behavior.

### Testing
- Ran the targeted unit suites with `npx vitest run test/unit/agent-actions.test.ts test/unit/guardrail-config.test.ts`, and both test files passed. 
- Ran static type checks with `npm run typecheck`, which succeeded. 
- Attempted full coverage with `npm run test:coverage`, but the local Vitest coverage remapping failed (`TypeError: jsTokens is not a function`) after unrelated suite timeouts. 
- Attempted `npm audit --audit-level=moderate`, but the registry audit endpoint returned `403 Forbidden` so the audit could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbc557a74832c8faef220de02677a)