### PR TITLE
feat(orb): homepage counter folds in the global Orb aggregate

### DIFF
--- a/src/orb/outcomes.ts
+++ b/src/orb/outcomes.ts
@@ -34,15 +34,21 @@ export interface OrbGlobalStats {
  * only (registered = 1) — an install that hasn't been opted in never contributes to the public counter. SUM over
  * no matching rows is NULL, so each total is nullish-guarded to 0 (fail-safe on an empty/cold table).
  */
-export async function getOrbGlobalStats(env: Env): Promise<OrbGlobalStats> {
+export async function getOrbGlobalStats(env: Env, opts: { excludeAccount?: string } = {}): Promise<OrbGlobalStats> {
+  // excludeAccount de-dups an account already counted by another source — the homepage counts JSONbored's own
+  // repos via cloud review_audit, so it excludes that account here to avoid double-counting. "" = include all.
+  const exclude = (opts.excludeAccount ?? "").toLowerCase();
   const row = await env.DB.prepare(
     `SELECT
        SUM(CASE WHEN o.outcome = 'merged' THEN 1 ELSE 0 END) AS merged,
        SUM(CASE WHEN o.outcome = 'closed' THEN 1 ELSE 0 END) AS closed,
        COUNT(*) AS total
      FROM orb_pr_outcomes o
-     JOIN orb_github_installations i ON i.installation_id = o.installation_id AND i.registered = 1`,
-  ).first<{ merged: number | null; closed: number | null; total: number | null }>();
+     JOIN orb_github_installations i ON i.installation_id = o.installation_id AND i.registered = 1
+     WHERE ? = '' OR LOWER(COALESCE(i.account_login, '')) <> ?`,
+  )
+    .bind(exclude, exclude)
+    .first<{ merged: number | null; closed: number | null; total: number | null }>();
   /* v8 ignore next -- an aggregate query always returns exactly one row; this guards the nullable .first() type only */
   if (!row) return { merged: 0, closed: 0, total: 0 };
   return { merged: row.merged ?? 0, closed: row.closed ?? 0, total: row.total ?? 0 };

--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -17,6 +17,11 @@
 //   minutesSaved = reviewed * MINUTES_SAVED_PER_PR        (estimated maintainer review time saved)
 //
 // PRIVACY: counts only — no PR content, authors, scores, or reward internals. Safe to serve publicly.
+//
+// GLOBAL: the homepage total folds in every EXTERNAL registered Orb installation's outcomes (getOrbGlobalStats),
+// so the counter is worldwide, not just gittensory's own repos. JSONbored is counted here via the cloud ledger,
+// so it's excluded from the Orb side to avoid double-counting.
+import { getOrbGlobalStats } from "../orb/outcomes";
 
 /** Estimate of maintainer review/triage time saved per reviewed PR. Dial this to taste — it is the single knob
  *  behind the "time saved" stat (at current volume: 20 min ≈ 38 days saved; 15 min ≈ 28 days). */
@@ -267,6 +272,15 @@ export async function getPublicStats(
     })
     .filter((r) => r.reviewed > 0)
     .sort((a, b) => b.reviewed - a.reviewed);
+
+  // Global counter: fold in every EXTERNAL registered Orb install's outcomes so the homepage shows the worldwide
+  // total, not just gittensory's own repos. JSONbored is already counted above via cloud review_audit, so exclude
+  // that account to avoid double-counting; reversals/weekly stay cloud-only (the Orb captures merged/closed). The
+  // total grows automatically as external maintainers install + are registered.
+  const orb = await getOrbGlobalStats(env, { excludeAccount: "jsonbored" });
+  totals.merged += orb.merged;
+  totals.closed += orb.closed;
+  totals.handled += orb.total;
 
   const reviewed = reviewedOf(totals);
   const w = weeklyRows[0] ?? { reviewed: 0, merged: 0 };

--- a/test/integration/orb-outcomes.test.ts
+++ b/test/integration/orb-outcomes.test.ts
@@ -60,4 +60,15 @@ describe("getOrbGlobalStats", () => {
     await recordOrbPrOutcome(e, "pull_request", closedPr("acme/c", 3, "2026-06-24T00:00:00Z", 200)); // merged, UNREGISTERED → excluded
     expect(await getOrbGlobalStats(e)).toEqual({ merged: 1, closed: 1, total: 2 });
   });
+
+  it("excludeAccount drops an account already counted by another source (case-insensitive)", async () => {
+    const e = createTestEnv();
+    const db = e.DB as unknown as TestD1Database;
+    await db.prepare("INSERT INTO orb_github_installations (installation_id, account_login, registered) VALUES (1, 'JSONbored', 1)").run();
+    await db.prepare("INSERT INTO orb_github_installations (installation_id, account_login, registered) VALUES (2, 'acme', 1)").run();
+    await recordOrbPrOutcome(e, "pull_request", closedPr("jsonbored/x", 1, "2026-06-24T00:00:00Z", 1)); // JSONbored, merged
+    await recordOrbPrOutcome(e, "pull_request", closedPr("acme/y", 2, null, 2)); // acme, closed
+    expect(await getOrbGlobalStats(e, { excludeAccount: "jsonbored" })).toEqual({ merged: 0, closed: 1, total: 1 }); // JSONbored dropped
+    expect(await getOrbGlobalStats(e)).toEqual({ merged: 1, closed: 1, total: 2 }); // no exclude → both
+  });
 });

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -16,6 +16,7 @@ function stubEnv(handler: (sql: string, args: unknown[]) => Row[]): Env {
   const make = (sql: string, args: unknown[]) => ({
     bind: (...a: unknown[]) => make(sql, a),
     all: async () => ({ results: handler(sql, args) }),
+    first: async () => handler(sql, args)[0] ?? null,
   });
   return {
     DB: { prepare: (sql: string) => make(sql, []) },
@@ -114,6 +115,16 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
       "JSONbored/gittensory",
     ]);
     expect(out.updatedAt).toBe(out.generatedAt);
+  });
+
+  it("folds external Orb installs into the global totals (cloud + Orb, de-duped)", async () => {
+    const withOrb = (sql: string): Row[] =>
+      sql.includes("orb_pr_outcomes") ? [{ merged: 50, closed: 30, total: 80 }] : ledger(sql);
+    const out = await getPublicStats(stubEnv(withOrb), NOW);
+    expect(out.totals.merged).toBe(1392 + 50); // cloud + external Orb
+    expect(out.totals.closed).toBe(724 + 30);
+    expect(out.totals.handled).toBe(2742 + 80);
+    expect(out.totals.reviewed).toBe(1442 + 754 + 626); // reviewedOf = merged + closed + commented + manual
   });
 
   it("publishes only projects from the reviewed-repo allowlist", async () => {


### PR DESCRIPTION
## Summary

The homepage "proof of power" counter showed only gittensory's own (cloud) repos. This makes it the **worldwide total**: `getPublicStats` folds in every **external** registered Orb installation's outcomes (`getOrbGlobalStats`) on top of the cloud `review_audit` numbers — so as maintainers install the Orb App and are registered, the global counter grows automatically.

- `getOrbGlobalStats` gains an `excludeAccount` option; the homepage passes `"jsonbored"` so JSONbored's own repos (already counted via cloud `review_audit`) aren't double-counted. The two sources are **disjoint** — cloud = gittensory's own reviews, Orb = external maintainers' reviews captured via the App.
- Folded into `totals.merged/closed/handled`, so `reviewed` + accuracy% + time-saved all reflect the global total. Reversals/weekly stay cloud-sourced for now (the Orb captures merged/closed). **Byte-identical today** (no external installs → the Orb side is 0), then grows with onboarding.

*(This is the pragmatic, correct realization of "Orb as the global source": JSONbored keeps its rich cloud history; every other maintainer flows in via the Orb. A full migration of JSONbored's own history into `orb_pr_outcomes` — making the Orb the literal sole source — plus capturing gate check-runs for reviews-initiated and reversal detection, can follow if you want orb-only.)*

## Validation
- [x] `npm run test:ci` green
- [x] **100% branch coverage** on the diff (excludeAccount include/exclude, case-insensitive; the homepage fold-in with + without Orb data).

Advances #1255 (the central Orb data layer).