### PR TITLE
fix(review): a "safe to merge" signal requires a clean merge state

### DIFF
--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -249,6 +249,17 @@ export function deriveUnifiedStatus(input: UnifiedReviewInput, ctx: UnifiedComme
   if (status === "ready" && input.readiness && input.readiness.ciState !== "passed") {
     return input.readiness.ciState === "failed" ? "blocked" : "held";
   }
+  // Merge-state gate — "safe to merge" also requires the PR to be MERGEABLE. A `dirty` (base conflict) PR
+  // cannot merge as-is → BLOCKED; a `behind` PR needs a rebase first → HELD. This stops the green "safe to
+  // merge" / "Approved" headline from contradicting a `dirty`/`behind` merge-state chip (the #4220 report,
+  // where the headline said "safe to merge" while the chip read `dirty`). Other states — clean, a not-yet-
+  // computed `unknown`, or a `blocked` that the bot's own pending approval will clear — do not downgrade.
+  // (#ready-needs-mergeable)
+  if (status === "ready" && input.readiness?.mergeStateLabel) {
+    const mergeState = input.readiness.mergeStateLabel.toLowerCase();
+    if (mergeState === "dirty") return "blocked";
+    if (mergeState === "behind") return "held";
+  }
   return status;
 }
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -406,7 +406,11 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // OWNER/automation PR is HELD via the needs-human label + the (non-blocking) unified review comment — never a
   // formal request-changes. (#no-request-changes) Either merge/approve, or close, with the rare manual hold left
   // open + commented, never blocked.
-  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
+  // Never APPROVE a base-conflicting PR: it is closed below (willClose on isConflict), so a "Gittensory approves —
+  // safe to merge" review on a PR we're about to close is incoherent (and a stale approval strands the PR if it
+  // later goes green). A `behind`/`blocked` PR is fine to approve (it is rebased pre-review or the approval clears
+  // the block); only a hard `dirty` conflict is excluded here. (#ready-needs-mergeable, the #4220 report) */
+  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && !isConflict && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -73,6 +73,18 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(failing).not.toContain("request_changes");
   });
 
+  it("NEVER approves a base-conflicting PR — it is closed, not approved (#4220)", () => {
+    // A green+passing but `dirty` (base-conflict) contributor PR is closed for the conflict; it must NOT also
+    // get a spurious "Gittensory approves — safe to merge" review on its way out.
+    const conflicting = classes(
+      planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", close: "auto" }, ciState: "passed", pr: { labels: [], mergeableState: "dirty" } })),
+    );
+    expect(conflicting).not.toContain("approve");
+    expect(conflicting).toContain("close");
+    // A clean PR with the same verdict DOES approve (the conflict is the only difference).
+    expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" }, ciState: "passed", pr: { labels: [], mergeableState: "clean" } })))).toContain("approve");
+  });
+
   describe("re-approval idempotency on the head SHA (stop the re-approve loop)", () => {
     const good = { conclusion: "success" as const, autonomy: { approve: "auto" as const }, ciState: "passed" as const };
 

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -52,6 +52,19 @@ describe("deriveUnifiedStatus", () => {
     expect(deriveUnifiedStatus({ ...base, recommendations: [], blockers: ["leaks a secret"] })).toBe("blocked");
   });
 
+  it("a non-mergeable merge state is NEVER safe-to-merge — dirty(conflict)→blocked, behind→held, even over a merge verdict (#4220)", () => {
+    // The reported bug: green CI + merge verdict but a `dirty` base conflict rendered "safe to merge".
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "dirty" } })).toBe("blocked");
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "DIRTY" } })).toBe("blocked"); // case-insensitive
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "behind" } })).toBe("held");
+    // A clean (or not-yet-computed / pending-bot-approval) merge state still renders ready.
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "clean" } })).toBe("ready");
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "unknown" } })).toBe("ready");
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed", mergeStateLabel: "blocked" } })).toBe("ready");
+    // No mergeStateLabel at all → no downgrade.
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed" } })).toBe("ready");
+  });
+
   it("an explicit merge verdict is authoritative — ready even with a raised concern", () => {
     expect(deriveUnifiedStatus({ ...base, decision: "merge", blockers: ["minor"] })).toBe("ready");
   });


### PR DESCRIPTION
## Summary

A live review on **awesome-claude #4220** rendered the green **"✅ Gittensory review — safe to merge / Approved"** headline while the merge-state chip read **`dirty`** — the PR had a base conflict and could not merge. `deriveUnifiedStatus` downgraded the ready headline for red/pending CI but **never checked the merge state**, so a conflicting (or behind-base) PR still showed "safe to merge."

- **unified-comment.ts** — a `ready` status is downgraded when the merge state is `dirty` (base conflict → **blocked**) or `behind` (needs a rebase → **held**). `clean`, a not-yet-computed `unknown`, or a pending-bot-approval `blocked` do not downgrade.
- **agent-actions.ts** — the APPROVE disposition now excludes a `dirty` PR. A conflicting PR is closed (`willClose` on `isConflict`), so a "Gittensory approves — safe to merge" review on a PR we're about to close was incoherent (and a stale approval strands the PR if it later goes green). `behind`/`blocked` stay approvable — they're rebased pre-review or the approval clears the block.

Closes #1337

## Scope
- [x] `src/` only — two small guards + tests; no migration/OpenAPI/binding change
- [x] No secrets/site/CNAME/lovable; no CHANGELOG

## Validation
- [x] `npm run test:ci` — exit 0; 4301 tests pass
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Every changed src line + branch covered (verified via lcov BRDA)
- [x] Tests: `deriveUnifiedStatus` (dirty→blocked, behind→held, clean/unknown/blocked→ready, case-insensitive, absent-label); `planAgentMaintenanceActions` (conflicting PR → close not approve; clean PR → approve)

## Safety
- [x] Strictly tightens the "ready/approve" signal — it can only ever turn a false "safe to merge" into blocked/held; it cannot newly approve or merge anything