### PR TITLE
fix(review): a guarded-path hold renders "held", not "safe to merge"

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -186,6 +186,7 @@ import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
 import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
+import { isGuardrailHit } from "../signals/change-guardrail";
 import { closePullRequest, createIssueComment, getLastCloserLogin } from "../github/pr-actions";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
@@ -2750,6 +2751,14 @@ async function maybePublishPrPublicSurface(
       // site carries no branch), built AFTER the live CI is resolved and used for BOTH the panel rows and the
       // comment body so the two never disagree. Gate OFF ⇒ commentGate === gateEvaluation (byte-identical comment).
       const commentGate = reconcileGateEvaluationForGreenCi(gateEvaluation, ciState, aiCiRefutationActive(env, repoFullName));
+      // Guarded-hold (#guarded-hold-comment): a clean+green PR whose diff touches a hard-guardrail path is HELD
+      // for owner review by the disposition (planAgentMaintenanceActions), never auto-merged — so the comment
+      // must render "held for review", not "✅ safe to merge". Compute the SAME guardrail-hit the disposition uses
+      // (shared isGuardrailHit) and thread it so the signal and the action agree (the #4220 class, clean variant).
+      const heldForReview = isGuardrailHit(
+        unifiedFiles.map((file) => file.path),
+        await loadHardGuardrailGlobs(env, repoFullName),
+      );
       const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: commentGate, duplicateWinnerEnabled });
       // Visual before/after capture (visual-capture port). Fires ONLY when (1) the global flag + per-repo
       // cutover gate both allow it (screenshotsAllowed) AND (2) the PR touches WEB-VISIBLE files (isVisualPath
@@ -2795,6 +2804,7 @@ async function maybePublishPrPublicSurface(
         changedFiles: unifiedFiles.length,
         ...(aiReview?.reviewerCount !== undefined ? { reviewerCount: aiReview.reviewerCount } : {}),
         mergeReadiness,
+        heldForReview,
         extraCollapsibles: buildPublicSafeCollapsibles({
           repo,
           pr,

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -218,6 +218,9 @@ export type UnifiedCommentBridgeArgs = {
    *  Public-safe: only URLs + route paths — no private terms. Default OFF (the processor passes this only
    *  when screenshotsAllowed + the PR touches web-visible files). */
   beforeAfter?: CaptureRoute[] | undefined;
+  /** The disposition holds this PR for owner review because its diff touches a hard-guardrail path — so an
+   *  otherwise-ready comment renders "held for review" instead of "safe to merge". (#guarded-hold-comment) */
+  heldForReview?: boolean | undefined;
 };
 
 /**
@@ -317,6 +320,7 @@ export function buildUnifiedCommentBody(args: UnifiedCommentBridgeArgs): string 
     footerMarkdown: args.footerMarkdown,
     ...(args.reRunLabel !== undefined ? { reRunLabel: args.reRunLabel } : {}),
     ...(extraCollapsibles !== undefined ? { extraCollapsibles } : {}),
+    ...(args.heldForReview ? { heldForReview: true } : {}),
   });
 
   // Prepend the marker verbatim (matching the legacy body, which leads with the marker then a blank line)

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -203,6 +203,9 @@ export interface UnifiedCommentContext {
   footerMarkdown?: string;
   /** Force the status (e.g. the host knows it auto-merged). */
   statusOverride?: UnifiedCommentStatus;
+  /** The host's disposition holds this PR for owner review (its diff touches a hard-guardrail path), so an
+   *  otherwise-ready status renders as "held for review" instead of "safe to merge". (#guarded-hold-comment) */
+  heldForReview?: boolean;
 }
 
 const STATUS_META: Record<UnifiedCommentStatus, { alert: string; square: string; icon: string }> = {
@@ -260,6 +263,12 @@ export function deriveUnifiedStatus(input: UnifiedReviewInput, ctx: UnifiedComme
     if (mergeState === "dirty") return "blocked";
     if (mergeState === "behind") return "held";
   }
+  // Guarded-hold gate — a clean + green PR whose diff touches a hard-guardrail path (CI config, the review
+  // engine, visuals) is HELD for owner review by the disposition, never auto-merged. The comment must then say
+  // "held for review", not "✅ safe to merge", so the signal matches the action (the same #4220 class: a green
+  // PR that won't actually merge). Applied LAST so it only ever downgrades an otherwise-ready status — a real
+  // CI / merge-state / gate block above still wins. (#guarded-hold-comment)
+  if (status === "ready" && ctx.heldForReview) return "held";
   return status;
 }
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyPolicy } from "../types";
 import { AI_JUDGMENT_BLOCKER_CODES, type GateCheckConclusion } from "../rules/advisory";
 import { DEFAULT_AUTO_MAINTAIN_POLICY, autonomyRequiresApproval, isActingAutonomyLevel, resolveAutonomy } from "./autonomy";
-import { changedPathsHittingGuardrail } from "../signals/change-guardrail";
+import { isGuardrailHit } from "../signals/change-guardrail";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
 
 // High-slop threshold default when a repo hasn't set slopGateMinScore (mirrors the gate's `high` band).
@@ -273,9 +273,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // not yet / no longer populated), we cannot prove the PR doesn't touch a guarded path, so treat it as a hit —
   // never auto-merge, auto-approve, or auto-close a PR whose diff we don't know. Repos with no guardrails
   // configured stay permissive.
-  const guardrailHit =
-    input.hardGuardrailGlobs.length > 0 &&
-    (input.changedPaths.length === 0 || changedPathsHittingGuardrail(input.changedPaths, input.hardGuardrailGlobs).length > 0);
+  const guardrailHit = isGuardrailHit(input.changedPaths, input.hardGuardrailGlobs);
   // Manual review is the RARE exception (the operator's minimize-manual goal): the ONLY thing that holds a PR for
   // a human instead of merge/close is an auto-merge-ready PR that touches a hard-guardrail path. (An owner PR that
   // is not review-good is held separately, via the owner close-exemption below — never auto-closed.) Submission

--- a/src/signals/change-guardrail.ts
+++ b/src/signals/change-guardrail.ts
@@ -50,3 +50,15 @@ export function changedPathsHittingGuardrail(changedPaths: string[], hardGuardra
   if (hardGuardrailGlobs.length === 0) return [];
   return changedPaths.filter((path) => path.length > 0 && matchesAny(path, hardGuardrailGlobs));
 }
+
+/**
+ * Whether a PR's diff trips a hard guardrail — the BOOLEAN form shared by the disposition (held for owner
+ * review) and the public comment (so the headline reads "held", not "safe to merge"). FAIL-SAFE on unknown
+ * paths (#1062): when guardrails ARE configured but the changed-file set is empty (the cache is not yet / no
+ * longer populated), we cannot prove the PR avoids a guarded path, so treat it as a hit. No guardrails
+ * configured ⇒ never a hit. Pure.
+ */
+export function isGuardrailHit(changedPaths: string[], hardGuardrailGlobs: string[]): boolean {
+  if (hardGuardrailGlobs.length === 0) return false;
+  return changedPaths.length === 0 || changedPathsHittingGuardrail(changedPaths, hardGuardrailGlobs).length > 0;
+}

--- a/test/unit/change-guardrail.test.ts
+++ b/test/unit/change-guardrail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { changedPathsHittingGuardrail, matchesAny } from "../../src/signals/change-guardrail";
+import { changedPathsHittingGuardrail, isGuardrailHit, matchesAny } from "../../src/signals/change-guardrail";
 
 describe("change-guardrail glob matching", () => {
   it("`**` matches across path separators (a guarded dir guards its whole subtree)", () => {
@@ -39,6 +39,19 @@ describe("change-guardrail glob matching", () => {
     expect(changedPathsHittingGuardrail(["docs/a.md", "src/scoring/x.ts", "scripts/y.mjs"], globs)).toEqual(["src/scoring/x.ts", "scripts/y.mjs"]);
     expect(changedPathsHittingGuardrail(["docs/a.md", "src/ui/b.tsx"], globs)).toEqual([]);
     expect(changedPathsHittingGuardrail(["src/scoring/x.ts"], [])).toEqual([]);
+  });
+
+  it("isGuardrailHit: boolean form shared by the disposition + the comment (#guarded-hold-comment)", () => {
+    const globs = ["src/scoring/**", "scripts/**"];
+    // No guardrails configured ⇒ never a hit (permissive).
+    expect(isGuardrailHit(["src/scoring/x.ts"], [])).toBe(false);
+    expect(isGuardrailHit([], [])).toBe(false);
+    // A changed path that hits a guarded glob ⇒ hit.
+    expect(isGuardrailHit(["docs/a.md", "scripts/y.mjs"], globs)).toBe(true);
+    // No changed path hits ⇒ not a hit.
+    expect(isGuardrailHit(["docs/a.md", "src/ui/b.tsx"], globs)).toBe(false);
+    // FAIL-SAFE (#1062): guardrails configured but the changed-file set is empty (unknown) ⇒ treat as a hit.
+    expect(isGuardrailHit([], globs)).toBe(true);
   });
 });
 

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -216,6 +216,19 @@ describe("buildUnifiedCommentBody", () => {
     const advisory = buildUnifiedCommentBody({ gate: gate({ conclusion: "skipped" }), panelRows, readinessTotal: 50, changedFiles: 2, footerMarkdown: footer });
     expect(advisory).toContain("> [!NOTE]"); // skipped → comment → advisory
   });
+
+  it("heldForReview renders a passing PR as HELD, never 'safe to merge' (#guarded-hold-comment)", () => {
+    const args = { gate: gate({ conclusion: "success" }), panelRows, readinessTotal: 90, changedFiles: 2, mergeReadiness: { ciState: "passed" as const }, footerMarkdown: footer };
+    // Without the hold, a success+green PR is the green "safe to merge" headline.
+    const ready = buildUnifiedCommentBody(args);
+    expect(ready).toContain("> [!TIP]");
+    expect(ready).toContain("safe to merge");
+    // With the guarded hold, the SAME PR renders held (WARNING), not safe-to-merge — matching the disposition.
+    const held = buildUnifiedCommentBody({ ...args, heldForReview: true });
+    expect(held).toContain("> [!WARNING]");
+    expect(held).toContain("Held for maintainer review");
+    expect(held).not.toContain("> [!TIP]");
+  });
 });
 
 // ── Reconciliation invariant (#1016): comment-verdict ↔ gate-conclusion alignment ──────────────────

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -69,6 +69,15 @@ describe("deriveUnifiedStatus", () => {
     expect(deriveUnifiedStatus({ ...base, decision: "merge", blockers: ["minor"] })).toBe("ready");
   });
 
+  it("a guarded-path hold downgrades a would-be-ready PR to held — never 'safe to merge' (#guarded-hold-comment)", () => {
+    // A clean+green PR that touches a hard-guardrail path is HELD for owner review, so the comment says held.
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed" } }, { heldForReview: true })).toBe("held");
+    // It only downgrades an otherwise-ready status — a real close/blocked verdict still wins over the hold.
+    expect(deriveUnifiedStatus({ ...base, decision: "close" }, { heldForReview: true })).toBe("blocked");
+    // Without the hold flag, the same clean+green PR is ready.
+    expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed" } }, { heldForReview: false })).toBe("ready");
+  });
+
   it("honors an explicit host status override", () => {
     expect(deriveUnifiedStatus({ ...base, decision: "close" }, { statusOverride: "ready" })).toBe("ready");
   });


### PR DESCRIPTION
## Summary

Follow-up to #1337 (the #4220 fix). A clean + green PR whose diff touches a **hard-guardrail path** is *held for owner review* by the disposition — never auto-merged — but the comment still rendered the green **"✅ safe to merge"** headline, because `deriveUnifiedStatus` had no knowledge of the guarded hold. #4220 happened to *also* be `dirty`, so the merge-state fix caught it; a **clean** guarded PR would still mislead (the same class: a green signal on a PR that won't actually merge).

- **change-guardrail.ts** — extract `isGuardrailHit` (the boolean the disposition already computed inline) so the disposition and the comment derive the guarded hold *identically*; `agent-actions` now calls it (DRY).
- **unified-comment.ts** — a `heldForReview` context flag downgrades an otherwise-ready status to `held`. Applied **last**, so a real CI / merge-state / gate block still wins over the hold.
- **processors.ts** — compute the guarded hold in the comment path (shared `isGuardrailHit` + the same hard-guardrail globs the disposition loads) and thread it into `buildUnifiedCommentBody`.

Closes #1338

## Scope
- [x] `src/` only — shared helper + a context flag + tests; no migration/OpenAPI/binding change
- [x] No secrets/site/CNAME/lovable; no CHANGELOG

## Validation
- [x] `npm run test:ci` — exit 0; 4304 tests pass
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Every changed src line + branch covered (verified via lcov BRDA across all 5 files)
- [x] Tests: `isGuardrailHit` (empty globs→false, hit→true, no-hit→false, fail-safe empty-paths→true); `deriveUnifiedStatus` (heldForReview downgrades ready→held, never overrides a close/blocked); bridge (success+green+held → WARNING/"Held", not TIP/"safe to merge")

## Safety
- [x] Strictly tightens the "ready" signal for guarded PRs — it can only turn a false "safe to merge" into "held"; it cannot newly approve/merge anything, and the disposition (which already held these PRs) is unchanged