### PR TITLE
feat(content-lane): source-evidence config from ContentRepoSpec + drop dead allowlist

### DIFF
--- a/src/review/content-lane/content-repo-spec.ts
+++ b/src/review/content-lane/content-repo-spec.ts
@@ -22,6 +22,16 @@ export interface ContentRepoSpec {
   domainOnlyExclusions: ReadonlySet<string>;
   /** Catalog roots that legitimately back MANY entries; a shared root alone is never strict (only a shared subpath). */
   multiEntryCatalogUrls: ReadonlySet<string>;
+  /** Scalar source-URL frontmatter fields, in extraction ORDER (the source-evidence gate reads them in sequence). */
+  sourceUrlFields: readonly string[];
+  /** Array-valued source-URL frontmatter fields (e.g. retrievalSources/sourceUrls) read as real source evidence. */
+  sourceUrlListFields: ReadonlySet<string>;
+  /** Source fields treated as distribution (download/package) rather than canonical provenance. */
+  distributionSourceFields: ReadonlySet<string>;
+  /** Hosts that classify any source URL as distribution regardless of field (package registries / artifact hosts). */
+  distributionSourceHosts: ReadonlySet<string>;
+  /** Canonical fields that anchor the close decision + block inconclusive-downgrade (the primary provenance links). */
+  primaryCanonicalSourceFields: ReadonlySet<string>;
 }
 
 /** The default curated-list spec — awesome-claude's categories, entry layout, and maintenance branches. */
@@ -86,4 +96,34 @@ export const AWESOME_CLAUDE_CONTENT_SPEC: ContentRepoSpec = {
     "https://github.com/snowflake-labs/mcp",
     "https://github.com/twilio-labs/mcp",
   ]),
+  sourceUrlFields: [
+    "documentationUrl",
+    "docsUrl",
+    "downloadUrl",
+    "githubUrl",
+    "packageUrl",
+    "repoUrl",
+    "repositoryUrl",
+    "sourceUrl",
+    "websiteUrl",
+  ],
+  sourceUrlListFields: new Set(["sourceUrls", "retrievalSources"]),
+  distributionSourceFields: new Set(["downloadUrl", "packageUrl"]),
+  distributionSourceHosts: new Set([
+    "crates.io",
+    "files.pythonhosted.org",
+    "hub.docker.com",
+    "marketplace.visualstudio.com",
+    "mvnrepository.com",
+    "npmjs.com",
+    "packagist.org",
+    "pkg.go.dev",
+    "plugins.gradle.org",
+    "pypi.org",
+    "registry.npmjs.org",
+    "repo1.maven.org",
+    "rubygems.org",
+    "www.npmjs.com",
+  ]),
+  primaryCanonicalSourceFields: new Set(["githubUrl", "repoUrl", "repositoryUrl", "sourceUrl"]),
 };

--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -55,8 +55,6 @@ export {
   sourceEvidenceCloseDecision,
   sourceEvidenceSummary,
   sourceEvidenceToDecisionEvidence,
-  DISTRIBUTION_SOURCE_HOSTS,
-  TRUSTED_SOURCE_HOSTS,
   type SourceEvidenceDecision,
   type SourceEvidenceItem,
   type SourceEvidenceReport,

--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -12,6 +12,10 @@
 //
 // PURE + testable: callers pass the raw MDX/markdown source string and may inject a fetchImpl
 // (defaults to global fetch). All I/O is the injected fetch.
+//
+// Source-field config (scalar/list source fields, distribution fields + hosts, primary-canonical fields) is sourced
+// from the per-repo ContentRepoSpec so a self-hosted curated list overrides it; the default preserves awesome-claude exactly.
+import { AWESOME_CLAUDE_CONTENT_SPEC, type ContentRepoSpec } from "./content-repo-spec";
 import { isSafeHttpUrl } from "./safe-url";
 
 // Browser-like request headers — major doc hosts return 403 to a missing/bot User-Agent even for
@@ -84,66 +88,11 @@ const SOURCE_EVIDENCE_LABELS = {
   close: "submission-closed-by-gate",
 } as const;
 
-const SOURCE_URL_FIELDS = [
-  "documentationUrl",
-  "docsUrl",
-  "downloadUrl",
-  "githubUrl",
-  "packageUrl",
-  "repoUrl",
-  "repositoryUrl",
-  "sourceUrl",
-  "websiteUrl",
-] as const;
-
-// Array-valued source fields. `retrievalSources` is the documented grounding field; read it (and
-// `sourceUrls`) as real source evidence.
-const SOURCE_URL_LIST_FIELDS = new Set(["sourceUrls", "retrievalSources"]);
 const SOURCE_EVIDENCE_TIMEOUT_MS = 5_000; // HEAD fast-path probe (failure falls through to the GET).
 const SOURCE_EVIDENCE_GET_TIMEOUT_MS = 12_000;
 const SOURCE_EVIDENCE_GET_ATTEMPTS = 2;
 const MAX_SOURCE_EVIDENCE_URLS = 10;
 const MAX_SOURCE_EVIDENCE_REDIRECTS = 4;
-const DISTRIBUTION_SOURCE_FIELDS = new Set(["downloadUrl", "packageUrl"]);
-
-export const DISTRIBUTION_SOURCE_HOSTS = new Set([
-  "crates.io",
-  "files.pythonhosted.org",
-  "hub.docker.com",
-  "marketplace.visualstudio.com",
-  "mvnrepository.com",
-  "npmjs.com",
-  "packagist.org",
-  "pkg.go.dev",
-  "plugins.gradle.org",
-  "pypi.org",
-  "registry.npmjs.org",
-  "repo1.maven.org",
-  "rubygems.org",
-  "www.npmjs.com",
-]);
-
-export const TRUSTED_SOURCE_HOSTS = new Set([
-  "bitbucket.org",
-  "crates.io",
-  "deno.land",
-  "docs.anthropic.com",
-  "docs.github.com",
-  "gist.github.com",
-  "github.com",
-  "gitlab.com",
-  "jsr.io",
-  "codeload.github.com",
-  "marketplace.visualstudio.com",
-  "npmjs.com",
-  "pkg.go.dev",
-  "pypi.org",
-  "raw.githubusercontent.com",
-  "www.npmjs.com",
-]);
-
-const TRUSTED_SOURCE_HOST_SUFFIXES: readonly string[] = [];
-const PRIMARY_CANONICAL_SOURCE_FIELDS = new Set(["githubUrl", "repoUrl", "repositoryUrl", "sourceUrl"]);
 
 function stripYamlComment(value: string): string {
   return value.replace(/\s+#.*$/, "").trim();
@@ -222,7 +171,7 @@ function scalarSourceUrlValues(value: string): string[] {
   return [unquoteYamlValue(trimmed)].filter(Boolean);
 }
 
-function listSourceUrlValues(source: string): SubmittedSourceUrl[] {
+function listSourceUrlValues(source: string, spec: ContentRepoSpec): SubmittedSourceUrl[] {
   const values: SubmittedSourceUrl[] = [];
   let activeField = "";
   for (const line of frontmatterBlock(source).split(/\r?\n/)) {
@@ -230,7 +179,7 @@ function listSourceUrlValues(source: string): SubmittedSourceUrl[] {
     if (topLevel) {
       const key = topLevel[1] as string;
       const value = topLevel[2] as string;
-      activeField = SOURCE_URL_LIST_FIELDS.has(key) ? key : "";
+      activeField = spec.sourceUrlListFields.has(key) ? key : "";
       if (activeField && value && value !== "|" && value !== ">") {
         for (const url of scalarSourceUrlValues(value)) {
           values.push({ field: activeField, url });
@@ -256,22 +205,25 @@ function isAbsoluteHttpUrl(url: string): boolean {
   }
 }
 
-export function extractSubmittedSourceUrls(source: string): SubmittedSourceUrl[] {
+export function extractSubmittedSourceUrls(
+  source: string,
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
+): SubmittedSourceUrl[] {
   const fields = parseSimpleFrontmatter(source);
   const urls: SubmittedSourceUrl[] = [];
-  for (const field of SOURCE_URL_FIELDS) {
+  for (const field of spec.sourceUrlFields) {
     for (const url of scalarSourceUrlValues(fields[field] || "")) {
       urls.push({ field, url });
     }
   }
-  urls.push(...listSourceUrlValues(source));
+  urls.push(...listSourceUrlValues(source, spec));
 
   const seen = new Set<string>();
   return urls.filter((item) => {
     // A DISTRIBUTION field (downloadUrl/packageUrl) with a SITE-RELATIVE value is the build's own
     // generated artifact (e.g. `/downloads/skills/<slug>.zip`) — not external provenance and not
     // fetchable as written, so drop it. External distribution URLs are absolute and remain verified.
-    if (DISTRIBUTION_SOURCE_FIELDS.has(item.field) && !isAbsoluteHttpUrl(item.url)) return false;
+    if (spec.distributionSourceFields.has(item.field) && !isAbsoluteHttpUrl(item.url)) return false;
     const key = `${item.field}\n${item.url}`;
     if (seen.has(key)) return false;
     seen.add(key);
@@ -279,11 +231,11 @@ export function extractSubmittedSourceUrls(source: string): SubmittedSourceUrl[]
   });
 }
 
-function sourceRole(item: SubmittedSourceUrl): SourceEvidenceRole {
-  if (DISTRIBUTION_SOURCE_FIELDS.has(item.field)) return "distribution";
+function sourceRole(item: SubmittedSourceUrl, spec: ContentRepoSpec): SourceEvidenceRole {
+  if (spec.distributionSourceFields.has(item.field)) return "distribution";
   try {
     const host = new URL(item.url).hostname.toLowerCase();
-    if (DISTRIBUTION_SOURCE_HOSTS.has(host)) return "distribution";
+    if (spec.distributionSourceHosts.has(host)) return "distribution";
   } catch {
     // Malformed URLs are classified separately as hard failures.
   }
@@ -293,11 +245,12 @@ function sourceRole(item: SubmittedSourceUrl): SourceEvidenceRole {
 function withSourceDefaults(
   item: SubmittedSourceUrl,
   values: Omit<SourceEvidenceItem, keyof SubmittedSourceUrl | "role" | "blocking">,
+  spec: ContentRepoSpec,
 ): SourceEvidenceItem {
   return {
     ...item,
     ...values,
-    role: sourceRole(item),
+    role: sourceRole(item, spec),
     blocking: true,
   };
 }
@@ -309,26 +262,6 @@ function sourceStatusFromHttpStatus(status: number): "passed" | "hard_failure" |
   if (status >= 400 && status < 500) return "hard_failure";
   return "retryable";
 }
-
-/* v8 ignore start -- Dead parity retainer: only ever called by _sourceHostIsTrusted (itself ignored, allowlist-free live gate). */
-function normalizeHostname(hostname: string): string {
-  return hostname.toLowerCase().replace(/\.$/, "");
-}
-/* v8 ignore stop */
-
-// Retained for parity with the reviewbot source (the allowlist is the gate's documented posture);
-// the live gate fetches any safe public host, not just an allowlist — see validateFetchableSourceUrl.
-/* v8 ignore start -- Dead parity retainer: never called (the live gate is allowlist-free); kept byte-faithful to reviewbot's documented allowlist posture. */
-function _sourceHostIsTrusted(hostname: string): boolean {
-  const normalized = normalizeHostname(hostname);
-  return (
-    TRUSTED_SOURCE_HOSTS.has(normalized) ||
-    DISTRIBUTION_SOURCE_HOSTS.has(normalized) ||
-    TRUSTED_SOURCE_HOST_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
-  );
-}
-/* v8 ignore stop */
-void _sourceHostIsTrusted;
 
 type FetchableValidation = { ok: true; parsed: URL } | { ok: false; outcome: string; error: string };
 
@@ -375,16 +308,21 @@ async function fetchSourceUrl(
   method: "HEAD" | "GET",
   fetchImpl: typeof fetch,
   timeoutMs: number = SOURCE_EVIDENCE_TIMEOUT_MS,
+  spec: ContentRepoSpec,
 ): Promise<SourceEvidenceItem> {
   let currentUrl = item.url;
   for (let redirects = 0; redirects <= MAX_SOURCE_EVIDENCE_REDIRECTS; redirects += 1) {
     const validation = validateFetchableSourceUrl(currentUrl);
     if (!validation.ok) {
-      return withSourceDefaults(item, {
-        status: "hard_failure",
-        outcome: validation.outcome,
-        error: validation.error,
-      });
+      return withSourceDefaults(
+        item,
+        {
+          status: "hard_failure",
+          outcome: validation.outcome,
+          error: validation.error,
+        },
+        spec,
+      );
     }
 
     const response = await fetchImpl(currentUrl, {
@@ -397,51 +335,71 @@ async function fetchSourceUrl(
     if (response.status >= 300 && response.status < 400) {
       const nextUrl = redirectLocation(response, currentUrl);
       if (!nextUrl) {
-        return withSourceDefaults(item, {
-          status: "retryable",
-          outcome: "redirect_without_location",
-          httpStatus: response.status,
-          finalUrl: currentUrl,
-        });
+        return withSourceDefaults(
+          item,
+          {
+            status: "retryable",
+            outcome: "redirect_without_location",
+            httpStatus: response.status,
+            finalUrl: currentUrl,
+          },
+          spec,
+        );
       }
       if (redirects === MAX_SOURCE_EVIDENCE_REDIRECTS) {
-        return withSourceDefaults(item, {
-          status: "retryable",
-          outcome: "too_many_redirects",
-          httpStatus: response.status,
-          finalUrl: currentUrl,
-        });
+        return withSourceDefaults(
+          item,
+          {
+            status: "retryable",
+            outcome: "too_many_redirects",
+            httpStatus: response.status,
+            finalUrl: currentUrl,
+          },
+          spec,
+        );
       }
       currentUrl = nextUrl;
       continue;
     }
 
     const status = sourceStatusFromHttpStatus(response.status);
-    return withSourceDefaults(item, {
-      status,
-      outcome: status === "passed" ? "reachable" : status === "hard_failure" ? "http_hard_failure" : "source_inconclusive",
-      httpStatus: response.status,
-      finalUrl: currentUrl,
-    });
+    return withSourceDefaults(
+      item,
+      {
+        status,
+        outcome: status === "passed" ? "reachable" : status === "hard_failure" ? "http_hard_failure" : "source_inconclusive",
+        httpStatus: response.status,
+        finalUrl: currentUrl,
+      },
+      spec,
+    );
   }
 
   /* v8 ignore next -- Unreachable: the loop runs redirects 0..MAX inclusive and always returns (the redirects===MAX hop returns too_many_redirects); this trailing return only satisfies the type checker. */
-  return withSourceDefaults(item, { status: "retryable", outcome: "too_many_redirects" });
+  return withSourceDefaults(item, { status: "retryable", outcome: "too_many_redirects" }, spec);
 }
 
-async function checkOneSourceUrl(item: SubmittedSourceUrl, fetchImpl: typeof fetch): Promise<SourceEvidenceItem> {
+async function checkOneSourceUrl(
+  item: SubmittedSourceUrl,
+  fetchImpl: typeof fetch,
+  spec: ContentRepoSpec,
+): Promise<SourceEvidenceItem> {
   const validation = validateFetchableSourceUrl(item.url);
   if (!validation.ok) {
     const invalidProtocol = validation.outcome === "invalid_url";
-    return withSourceDefaults(item, {
-      status: invalidProtocol ? "hard_failure" : "passed",
-      outcome: validation.outcome,
-      error: validation.error,
-    });
+    return withSourceDefaults(
+      item,
+      {
+        status: invalidProtocol ? "hard_failure" : "passed",
+        outcome: validation.outcome,
+        error: validation.error,
+      },
+      spec,
+    );
   }
 
   try {
-    const head = await fetchSourceUrl(item, "HEAD", fetchImpl, SOURCE_EVIDENCE_TIMEOUT_MS);
+    const head = await fetchSourceUrl(item, "HEAD", fetchImpl, SOURCE_EVIDENCE_TIMEOUT_MS, spec);
     if (head.status === "passed") return head;
   } catch {
     // Some source hosts reject HEAD or transiently fail it. Confirm with GET.
@@ -452,16 +410,20 @@ async function checkOneSourceUrl(item: SubmittedSourceUrl, fetchImpl: typeof fet
   let lastError: unknown;
   for (let attempt = 1; attempt <= SOURCE_EVIDENCE_GET_ATTEMPTS; attempt += 1) {
     try {
-      return await fetchSourceUrl(item, "GET", fetchImpl, SOURCE_EVIDENCE_GET_TIMEOUT_MS);
+      return await fetchSourceUrl(item, "GET", fetchImpl, SOURCE_EVIDENCE_GET_TIMEOUT_MS, spec);
     } catch (error) {
       lastError = error;
     }
   }
-  return withSourceDefaults(item, {
-    status: "retryable",
-    outcome: "fetch_error",
-    error: lastError instanceof Error ? lastError.message : "Source URL fetch failed before a response was returned.",
-  });
+  return withSourceDefaults(
+    item,
+    {
+      status: "retryable",
+      outcome: "fetch_error",
+      error: lastError instanceof Error ? lastError.message : "Source URL fetch failed before a response was returned.",
+    },
+    spec,
+  );
 }
 
 function sourceEvidenceHashInput(urls: SourceEvidenceItem[]): string {
@@ -479,48 +441,53 @@ function sourceEvidenceHashInput(urls: SourceEvidenceItem[]): string {
   );
 }
 
-function hasVerifiableCanonicalSource(urls: SourceEvidenceItem[]): boolean {
+function hasVerifiableCanonicalSource(urls: SourceEvidenceItem[], spec: ContentRepoSpec): boolean {
   const reachableCanonical = urls.filter(
     (item) => item.role === "canonical" && item.status === "passed" && item.outcome === "reachable",
   );
   return (
     reachableCanonical.length >= 2 ||
-    reachableCanonical.some((item) => PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field))
+    reachableCanonical.some((item) => spec.primaryCanonicalSourceFields.has(item.field))
   );
 }
 
-function isDowngradableInconclusiveSource(item: SourceEvidenceItem): boolean {
-  if (item.status === "retryable" && !PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field)) {
+function isDowngradableInconclusiveSource(item: SourceEvidenceItem, spec: ContentRepoSpec): boolean {
+  if (item.status === "retryable" && !spec.primaryCanonicalSourceFields.has(item.field)) {
     return true;
   }
   return item.status === "hard_failure" && item.role === "distribution" && item.outcome === "source_host_not_checked";
 }
 
-function downgradeInconclusiveSourceWarnings(urls: SourceEvidenceItem[]): SourceEvidenceItem[] {
-  if (!hasVerifiableCanonicalSource(urls)) return urls;
-  return urls.map((item) => (isDowngradableInconclusiveSource(item) ? { ...item, blocking: false } : item));
+function downgradeInconclusiveSourceWarnings(urls: SourceEvidenceItem[], spec: ContentRepoSpec): SourceEvidenceItem[] {
+  if (!hasVerifiableCanonicalSource(urls, spec)) return urls;
+  return urls.map((item) => (isDowngradableInconclusiveSource(item, spec) ? { ...item, blocking: false } : item));
 }
 
 export async function checkSubmittedSourceEvidence(
   source: string,
   fetchImpl: typeof fetch = fetch,
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
 ): Promise<SourceEvidenceReport> {
-  const extracted = extractSubmittedSourceUrls(source);
+  const extracted = extractSubmittedSourceUrls(source, spec);
   // Check the URLs in PARALLEL — each is independent. Promise.all preserves order, so the evidence
   // hash is unchanged.
   const checkedUrls: SourceEvidenceItem[] = await Promise.all(
-    extracted.slice(0, MAX_SOURCE_EVIDENCE_URLS).map((item) => checkOneSourceUrl(item, fetchImpl)),
+    extracted.slice(0, MAX_SOURCE_EVIDENCE_URLS).map((item) => checkOneSourceUrl(item, fetchImpl, spec)),
   );
   for (const item of extracted.slice(MAX_SOURCE_EVIDENCE_URLS)) {
     checkedUrls.push(
-      withSourceDefaults(item, {
-        status: "hard_failure",
-        outcome: "too_many_source_urls",
-        error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
-      }),
+      withSourceDefaults(
+        item,
+        {
+          status: "hard_failure",
+          outcome: "too_many_source_urls",
+          error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
+        },
+        spec,
+      ),
     );
   }
-  const urls = downgradeInconclusiveSourceWarnings(checkedUrls);
+  const urls = downgradeInconclusiveSourceWarnings(checkedUrls, spec);
   const blockingUrls = urls.filter((item) => item.blocking);
   const status = blockingUrls.some((item) => item.status === "hard_failure")
     ? "failed"
@@ -565,14 +532,17 @@ export function sourceEvidenceToDecisionEvidence(report: SourceEvidenceReport): 
     }));
 }
 
-function authoritativeSourceItems(report: SourceEvidenceReport): SourceEvidenceItem[] {
+function authoritativeSourceItems(report: SourceEvidenceReport, spec: ContentRepoSpec): SourceEvidenceItem[] {
   return report.urls.filter(
-    (item) => item.blocking && (item.role === "canonical" || PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field)),
+    (item) => item.blocking && (item.role === "canonical" || spec.primaryCanonicalSourceFields.has(item.field)),
   );
 }
 
-export function shouldHardCloseSourceEvidence(report: SourceEvidenceReport): boolean {
-  const authoritative = authoritativeSourceItems(report);
+export function shouldHardCloseSourceEvidence(
+  report: SourceEvidenceReport,
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
+): boolean {
+  const authoritative = authoritativeSourceItems(report, spec);
   if (!authoritative.length) return false;
   const hardFailures = authoritative.filter((item) => item.status === "hard_failure");
   if (!hardFailures.length) return false;
@@ -614,10 +584,13 @@ function sourceEvidenceManualDecision(
   };
 }
 
-export function sourceEvidenceCloseDecision(report: SourceEvidenceReport): SourceEvidenceDecision | null {
+export function sourceEvidenceCloseDecision(
+  report: SourceEvidenceReport,
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
+): SourceEvidenceDecision | null {
   const evidence = sourceEvidenceToDecisionEvidence(report);
   if (!evidence.length) return null;
-  if (!shouldHardCloseSourceEvidence(report)) {
+  if (!shouldHardCloseSourceEvidence(report, spec)) {
     return sourceEvidenceManualDecision(report, evidence);
   }
   return {

--- a/test/unit/content-lane-scope.test.ts
+++ b/test/unit/content-lane-scope.test.ts
@@ -125,6 +125,11 @@ describe("ContentRepoSpec (a self-hosted curated list parameterizes the lane)", 
     urlFields: new Set(["url"]),
     domainOnlyExclusions: new Set(["github.com"]),
     multiEntryCatalogUrls: new Set(),
+    sourceUrlFields: ["url"],
+    sourceUrlListFields: new Set(["urls"]),
+    distributionSourceFields: new Set(["downloadUrl"]),
+    distributionSourceHosts: new Set(["npmjs.com"]),
+    primaryCanonicalSourceFields: new Set(["url"]),
   };
 
   it("the default spec carries awesome-claude's categories + entry layout", () => {

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AWESOME_CLAUDE_CONTENT_SPEC, type ContentRepoSpec } from "../../src/review/content-lane/content-repo-spec";
 import {
   checkSubmittedSourceEvidence,
   extractSubmittedSourceUrls,
@@ -9,6 +10,8 @@ import {
   type SourceEvidenceItem,
   type SourceEvidenceReport,
 } from "../../src/review/content-lane/source-evidence";
+
+const customSpec = (over: Partial<ContentRepoSpec>): ContentRepoSpec => ({ ...AWESOME_CLAUDE_CONTENT_SPEC, ...over });
 
 const mdx = (frontmatter: Record<string, string>): string => {
   const lines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`);
@@ -934,5 +937,114 @@ describe("decision string rendering — empty field/url + manual finalUrl + clos
     expect(decision?.summary).not.toContain("returned HTTP");
     // Empty field → `source` label fallback.
     expect(decision?.summary).toContain("`source`");
+  });
+});
+
+describe("per-repo ContentRepoSpec override (a self-hosted curated list re-parameterizes source evidence)", () => {
+  it("extractSubmittedSourceUrls reads scalar URLs from the custom source-field set", () => {
+    const src = mdx({ myLink: "https://example.com/a", githubUrl: "https://github.com/o/r" });
+    // Default: githubUrl is a source field, myLink is not.
+    expect(extractSubmittedSourceUrls(src).map((u) => `${u.field}:${u.url}`)).toEqual([
+      "githubUrl:https://github.com/o/r",
+    ]);
+    // Custom: only myLink is read; githubUrl is ignored.
+    const spec = customSpec({ sourceUrlFields: ["myLink"] });
+    expect(extractSubmittedSourceUrls(src, spec).map((u) => `${u.field}:${u.url}`)).toEqual([
+      "myLink:https://example.com/a",
+    ]);
+  });
+
+  it("extractSubmittedSourceUrls reads array URLs from the custom list-field set", () => {
+    const src = ["---", "mySources:", "  - https://list.example/1", "---", "", "body"].join("\n");
+    // Default: mySources is not a recognized list field → nothing read.
+    expect(extractSubmittedSourceUrls(src)).toEqual([]);
+    // Custom: mySources is a list field → its items are read.
+    const spec = customSpec({ sourceUrlListFields: new Set(["mySources"]) });
+    expect(extractSubmittedSourceUrls(src, spec).map((u) => `${u.field}:${u.url}`)).toEqual([
+      "mySources:https://list.example/1",
+    ]);
+  });
+
+  it("a custom distribution-field set drops a site-relative artifact for the custom field (extract filter)", () => {
+    // The default treats githubUrl as canonical, so a site-relative value is kept; the custom spec
+    // marks githubUrl as a distribution field, so the same site-relative value is dropped.
+    const src = mdx({ githubUrl: "/local/artifact" });
+    expect(extractSubmittedSourceUrls(src).map((u) => u.field)).toEqual(["githubUrl"]);
+    const spec = customSpec({ distributionSourceFields: new Set(["githubUrl"]) });
+    expect(extractSubmittedSourceUrls(src, spec)).toEqual([]);
+  });
+
+  it("a custom distribution-FIELD set flips the sourceRole of a checked URL", async () => {
+    const src = mdx({ githubUrl: "https://github.com/acme/x" });
+    // Default: githubUrl is canonical.
+    const base = await checkSubmittedSourceEvidence(src, fakeFetch({ "https://github.com/acme/x": 200 }));
+    expect(base.urls.find((u) => u.field === "githubUrl")?.role).toBe("canonical");
+    // Custom: githubUrl is a distribution field → role becomes distribution.
+    const spec = customSpec({ distributionSourceFields: new Set(["githubUrl"]) });
+    const over = await checkSubmittedSourceEvidence(src, fakeFetch({ "https://github.com/acme/x": 200 }), spec);
+    expect(over.urls.find((u) => u.field === "githubUrl")?.role).toBe("distribution");
+  });
+
+  it("a custom distribution-HOST set flips the sourceRole of a canonical-field URL", async () => {
+    const src = mdx({ githubUrl: "https://custom-registry.example/pkg" });
+    // Default: custom-registry.example is not a distribution host → canonical.
+    const base = await checkSubmittedSourceEvidence(src, fakeFetch({ "https://custom-registry.example/pkg": 200 }));
+    expect(base.urls.find((u) => u.field === "githubUrl")?.role).toBe("canonical");
+    // Custom: custom-registry.example is a distribution host → distribution.
+    const spec = customSpec({ distributionSourceHosts: new Set(["custom-registry.example"]) });
+    const over = await checkSubmittedSourceEvidence(
+      src,
+      fakeFetch({ "https://custom-registry.example/pkg": 200 }),
+      spec,
+    );
+    expect(over.urls.find((u) => u.field === "githubUrl")?.role).toBe("distribution");
+  });
+
+  it("a custom primary-canonical-field set changes shouldHardCloseSourceEvidence", async () => {
+    // Two dead websiteUrl/docsUrl sources: by default neither is a PRIMARY canonical field, but both
+    // are canonical-ROLE, so they ARE authoritative → all-failed + >1 → hard-close is true under default.
+    const src = mdx({
+      websiteUrl: "https://site.example/dead1",
+      docsUrl: "https://docs.example/dead2",
+    });
+    const report = await checkSubmittedSourceEvidence(
+      src,
+      fakeFetch({ "https://site.example/dead1": 404, "https://docs.example/dead2": 404 }),
+    );
+    // Default close decision: both are canonical-role authoritative → hard-close.
+    expect(shouldHardCloseSourceEvidence(report)).toBe(true);
+    expect(sourceEvidenceCloseDecision(report)?.verdict).toBe("close");
+
+    // Custom spec makes websiteUrl/docsUrl a DISTRIBUTION field set so their role is distribution and
+    // primaryCanonicalSourceFields stays the awesome default (neither matches) → no authoritative items.
+    const spec = customSpec({ distributionSourceFields: new Set(["websiteUrl", "docsUrl"]) });
+    const overReport = await checkSubmittedSourceEvidence(
+      src,
+      fakeFetch({ "https://site.example/dead1": 404, "https://docs.example/dead2": 404 }),
+      spec,
+    );
+    expect(shouldHardCloseSourceEvidence(overReport, spec)).toBe(false);
+    // sourceEvidenceCloseDecision routes to MANUAL (still has blocking hard-failure evidence) under the spec.
+    expect(sourceEvidenceCloseDecision(overReport, spec)?.verdict).toBe("manual");
+  });
+
+  it("a custom primary-canonical-field set keeps a non-default field's retryable BLOCKING (downgrade rule)", async () => {
+    // websiteUrl is canonical but NOT a default primary field, so a flaky websiteUrl downgrades when a
+    // reachable primary (githubUrl) anchors. Promoting websiteUrl to primary keeps it blocking.
+    const src = mdx({
+      githubUrl: "https://github.com/acme/anchor",
+      websiteUrl: "https://flaky.example/site",
+    });
+    const status = { "https://github.com/acme/anchor": 200, "https://flaky.example/site": 503 };
+    const base = await checkSubmittedSourceEvidence(src, fakeFetch(status));
+    // Default: websiteUrl is non-primary retryable → downgraded to a non-blocking warning, report passes.
+    expect(base.urls.find((u) => u.field === "websiteUrl")?.blocking).toBe(false);
+    expect(base.status).toBe("passed");
+
+    const spec = customSpec({ primaryCanonicalSourceFields: new Set(["githubUrl", "websiteUrl"]) });
+    const over = await checkSubmittedSourceEvidence(src, fakeFetch(status), spec);
+    // Custom: websiteUrl is now primary → its retryable is NOT downgradable → stays blocking, report retryable.
+    expect(over.urls.find((u) => u.field === "websiteUrl")?.blocking).toBe(true);
+    expect(over.status).toBe("retryable");
   });
 });


### PR DESCRIPTION
## Summary

Continues the ContentRepoSpec migration (#1309 scope, #1336 dedup) to the deterministic **source-evidence** gate. Five awesome-claude-specific sets move onto `ContentRepoSpec` and thread through the gate so a self-hosted curated list overrides them via config: `sourceUrlFields`, `sourceUrlListFields`, `distributionSourceFields`, `distributionSourceHosts`, `primaryCanonicalSourceFields`. `AWESOME_CLAUDE_CONTENT_SPEC` carries the **exact** previous values → **byte-identical** for awesome-claude.

### The SSRF guard is untouched
`validateFetchableSourceUrl` still gates **every** fetch through the shared `isSafeHttpUrl` (https + non-loopback/private host, re-checked per redirect hop) — independent of these sets. The host config threaded here is **source-authority classification** (which hosts count as canonical/distribution for the close decision), *not* a fetch-safety gate, so making it per-repo never weakens SSRF.

### Dead-code removal
Removes the provably-dead trusted-host parity retainer — `_sourceHostIsTrusted` was `void`-ed and v8-ignored (*"never called — the live gate is allowlist-free"*): `TRUSTED_SOURCE_HOSTS`, `TRUSTED_SOURCE_HOST_SUFFIXES`, `normalizeHostname`, and the two now-dead `index.ts` re-exports (consumed nowhere).

## Validation
- [x] `npm run test:ci` green
- [x] 80 source-evidence tests pass (73 original byte-identical via the default spec + 7 new per-repo override tests) + 100% branch coverage on the diff.
- [x] Confirmed `isSafeHttpUrl` / `validateFetchableSourceUrl` unchanged.

Continues #1309 / #1336.