### PR TITLE
fix(ci): fold-all CI read consults check-suites so an awaiting-approval workflow reads pending

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2083,6 +2083,29 @@ export async function fetchLiveCiAggregate(
     }
   }
 
+  // FOLD-ALL hardening (#ci-foldall-checksuites): when branch protection is UNREADABLE (no `administration:read`
+  // ⇒ requiredContexts null ⇒ fold-all), the check-run/status scan above can read "passed" for a fork PR whose
+  // required workflow is AWAITING APPROVAL — its check-RUNS don't exist yet (the workflow never ran), so only the
+  // always-on third-party checks are seen and nothing fails or pends. Read the check-SUITES too: a GitHub-Actions
+  // suite still `queued`/`requested`/`waiting`/`in_progress` (not `completed`) means the first-party CI has NOT
+  // run, so hold (pending) instead of certifying a never-run workflow as green. Enforce-required mode already
+  // catches this via the absent-context guard above, so this runs ONLY in fold-all (one extra call on the degraded
+  // path), and ONLY when we would otherwise certify "passed" (no failure, nothing else pending).
+  if (!enforceRequiredOnly && headSha && failingDetails.length === 0 && !anyPending && !checkRunsIncomplete && !statusIncomplete) {
+    const suitesResult = await githubJsonWithHeaders<{ check_suites?: Array<{ status?: string | null; app?: { slug?: string | null } | null }> }>(
+      env,
+      repoFullName,
+      `/commits/${headSha}/check-suites?per_page=100`,
+      token,
+    ).catch(() => undefined);
+    // ONLY downgrade on an AFFIRMATIVE signal — a GitHub-Actions suite that has not completed. The check-suites read
+    // is a bonus hardening, not a primary CI source, so an unreadable/absent result is left as-is (the original
+    // check-run/status verdict stands) rather than fail-closed, which would wrongly pend every fold-all-passing PR.
+    if (suitesResult && (suitesResult.data.check_suites ?? []).some((suite) => (suite.app?.slug ?? "").toLowerCase() === "github-actions" && (suite.status ?? "").toLowerCase() !== "completed")) {
+      anyPending = true; // a first-party GitHub Actions workflow has not completed (e.g. a fork PR awaiting approval)
+    }
+  }
+
   // ciState reflects ONLY gate-failing (required, or all-when-unknown) checks. A repo whose only red check is a
   // non-required codecov/* therefore reports "passed" and is eligible to merge/approve, with the codecov
   // failure riding along in nonRequiredFailingDetails for the contributor to see.

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2935,6 +2935,92 @@ describe("GitHub backfill", () => {
       expect(aggregate.ciState).toBe("pending");
     });
 
+    it("fold-all: a GitHub-Actions workflow AWAITING APPROVAL (suite not completed) reads PENDING, not passed (#ci-foldall-checksuites / #1799)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        // A fork PR awaiting CI approval: the required workflow never ran → no check-RUNS for it; only the
+        // always-on third-party checks posted (both pass) — the false-green seam.
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "Contributor trust", status: "completed", conclusion: "success", app: { slug: "superagent" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        // …but the check-SUITES show the GitHub-Actions workflow as `requested` (queued, awaiting approval).
+        if (url.includes("/check-suites?"))
+          return Response.json({
+            check_suites: [
+              { status: "requested", app: { slug: "github-actions" } },
+              { status: "completed", app: { slug: "superagent" } },
+            ],
+          });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/metagraphed", "forksha", "public-token", null);
+      // Without this hardening the always-on passes alone read "passed" → a false-green approve. Now: pending → held.
+      expect(aggregate.ciState).toBe("pending");
+    });
+
+    it("fold-all: all GitHub-Actions suites COMPLETED → still passed (no false-pending)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("passed");
+    });
+
+    it("fold-all: a non-completed THIRD-PARTY suite is ignored (only first-party GitHub-Actions suites gate)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        // A third-party app's suite is perpetually "queued" — must NOT pend the gate (only github-actions counts).
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }, { status: "queued", app: { slug: "some-other-app" } }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("passed");
+    });
+
+    it("ENFORCE-required mode does NOT consult check-suites (the absent-context guard already handles it)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      let suitesFetched = false;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-suites?")) suitesFetched = true;
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success" }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+      // Required = {test} and it passed → passed; the check-suites call is never made in enforce-required mode.
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["test"]));
+      expect(aggregate.ciState).toBe("passed");
+      expect(suitesFetched).toBe(false);
+    });
+
+    it("fold-all: tolerates malformed check-suites (missing app / missing status) without throwing", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "ci", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?"))
+          return Response.json({
+            check_suites: [
+              { status: "completed" }, // no app → app?.slug ?? "" = "" → not github-actions → ignored
+              { app: { slug: "github-actions" } }, // no status → status ?? "" = "" → not "completed" → pending
+            ],
+          });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      // The status-less github-actions suite is treated as not-completed (safe direction) → pending.
+      expect(aggregate.ciState).toBe("pending");
+    });
+
     it("an observed required failure stays FAILED even when a later check-runs page fetch fails", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

When the App can't read branch protection (no `administration:read` → `fetchRequiredStatusContexts` returns `null` → `fetchLiveCiAggregate` folds to gating all contexts), a **fork PR whose required workflow is awaiting approval** was read as **"CI green"**: the workflow never ran, so its check-*runs* don't exist, and only the always-on third-party checks (`Contributor trust` / `Superagent`) posted — both pass, nothing fails or pends. That false-green produced a spurious "safe to merge" **approve** — observed on metagraphed **#1799** (an external fork PR).

The `enforce-required` path already catches this via the absent-required-context guard, so the fix is scoped to **fold-all**: when we'd otherwise certify "passed," read the **check-*suites*** too — a first-party `github-actions` suite that is not `completed` (`queued`/`requested`/`waiting`/`in_progress`) means required CI hasn't run → **pending** → the gate holds.

- Only an **affirmative** non-completed signal downgrades; an unreadable/absent suites result is left as-is (**not** fail-closed), so the common fold-all-passing case is unchanged.
- **Third-party** app suites are ignored — only `github-actions` gates.
- One extra API call, **only** on the degraded (no-`administration:read`) path and **only** when otherwise-passing — zero cost when branch protection is readable.

This is belt-and-suspenders: the root fix for the affected installs is granting the App `administration:read` (already done for JSONbored's repos), but this also protects **self-host** installs and the token-cache window after granting the permission.

Closes #1343

## Scope
- [x] `src/github/backfill.ts` + tests only — no migration/OpenAPI/binding change
- [x] No secrets/site/CNAME/lovable; no CHANGELOG

## Validation
- [x] `npm run test:ci` — exit 0; 4305 tests pass
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Every changed line + branch covered (verified via lcov BRDA)
- [x] Tests: awaiting-approval suite → pending; all-completed → passed; third-party non-completed ignored; enforce-required mode never fetches suites; malformed suites tolerated

## Safety
- [x] Strictly tightens the CI read in the degraded path — it can only turn a false "passed" into "pending" (hold); it cannot newly certify anything as green
- [x] No effect when branch protection is readable (enforce-required mode)