### PR TITLE
fix(github): require a handle boundary after @gittensory in mention parsing

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -162,7 +162,10 @@ export type MaintainerQueueDigest = {
 
 export function parseGittensoryMentionCommand(body: string | null | undefined): GittensoryMentionCommand | null {
   if (!body) return null;
-  const match = body.match(/(?:^|\s)@gittensory(?:\s+([a-z-]+))?([^\n\r]*)/i);
+  // `(?![\w-])` keeps the handle from matching as a PREFIX of a longer GitHub username: a comment that
+  // mentions a different account like `@gittensory-bot` / `@gittensory2` must NOT be parsed as a bare
+  // `@gittensory help`. GitHub usernames are word chars + hyphen, so the boundary excludes both.
+  const match = body.match(/(?:^|\s)@gittensory(?![\w-])(?:\s+([a-z-]+))?([^\n\r]*)/i);
   if (!match) return null;
   const requested = (match[1]?.toLowerCase() || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
   if (ACTION_COMMANDS.has(requested as GittensoryActionCommandName)) {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -39,6 +39,13 @@ describe("GitHub mention commands", () => {
       reason: "known false positive, shipping",
     });
     expect(parseGittensoryMentionCommand("gittensory preflight")).toBeNull();
+    // A mention of a DIFFERENT account whose handle merely starts with "gittensory" must not be parsed as a
+    // bare @gittensory command (GitHub never resolves @gittensory-bot to @gittensory).
+    expect(parseGittensoryMentionCommand("@gittensory-bot please take a look")).toBeNull();
+    expect(parseGittensoryMentionCommand("@gittensory2 ping")).toBeNull();
+    expect(parseGittensoryMentionCommand("@gittensorybot ask q")).toBeNull();
+    // ...but real punctuation/whitespace boundaries after the handle still parse.
+    expect(parseGittensoryMentionCommand("@gittensory, preflight please")?.name).toBe("help");
     expect(isMaintainerOnlyCommand("queue-summary")).toBe(true);
     expect(isMaintainerOnlyCommand("preflight")).toBe(false);
   });


### PR DESCRIPTION
## Summary

Fixes #1344.

`parseGittensoryMentionCommand` matched the bot handle with no boundary after `@gittensory`, so the handle matched as a prefix of a longer GitHub username. A comment mentioning a different account such as `@gittensory-bot` or `@gittensory2` was parsed as a bare `@gittensory help`, and the only caller then posted an unsolicited help reply on that thread.

## What changed

- Added a `(?![\w-])` boundary after `@gittensory` in the mention regex. GitHub usernames are word characters + hyphen, so the lookahead rejects `@gittensory-bot` / `@gittensory2` / `@gittensorybot` while still matching bare `@gittensory`, `@gittensory <command>`, and punctuation boundaries.

## Scope

- [x] Conventional Commit title.
- [x] Focused; no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked issue (#1344).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (github-commands suite green); the changed regex line is fully covered, including the now-rejected longer-handle cases and the retained positive cases.
- [x] `npm audit --audit-level=moderate`
- [x] New unit tests for `@gittensory-bot` / `@gittensory2` / `@gittensorybot` → null, and a punctuation-boundary positive case.

If any required check was skipped, explain why:

- OpenAPI/types unchanged — internal command-parsing logic only.

## Safety

- [x] No secrets, wallets, hotkeys, PATs, trust scores, or private evidence exposed.
- [x] Public text sanitized and low-noise.
- [x] GitHub App command-parsing change includes negative-path tests (mentions of other handles now correctly ignored).
- [x] API/OpenAPI/MCP behavior unchanged.
- [x] No UI changes.
- [x] No changelog edit.

## Notes

- Confined to the regex in `parseGittensoryMentionCommand` (`src/github/commands.ts`); no schema, migration, or binding changes.