### PR TITLE
fix(agent): preserve maintainer-configured AI-review hard blockers (do not auto-refute on green CI)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -179,7 +179,7 @@ import { resolveRepositorySettings } from "../settings/repository-settings";
 import type { LocalBranchAnalysisInput } from "../signals/local-branch";
 import { runGittensoryAiReview } from "../services/ai-review";
 import { secretLeakFinding } from "../review/safety";
-import { aiCiRefutationActive, buildReviewGroundingText, checkSummaryText as checkFailureSummaryText, isGroundingEnabled } from "../review/grounding-wire";
+import { buildReviewGroundingText, checkSummaryText as checkFailureSummaryText, isGroundingEnabled } from "../review/grounding-wire";
 import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
 import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
@@ -788,15 +788,6 @@ async function maybeRunAgentMaintenance(
   const planned = planAgentMaintenanceActions({
     conclusion: gate.conclusion,
     blockerTitles: gate.blockers.map((blocker) => blocker.title),
-    // CI-refutation (#ai-ci-refutation): thread the blocker CODES + the active gate so the planner suppresses an
-    // AI-judgment-only failure (ai_consensus_defect / ai_review_split) on a green-CI PR — the deterministic
-    // validator overrules the model hallucination, so a clean+green PR MERGES instead of being false-closed.
-    // `aiCiRefutationEnabled` is the SAME grounding+convergence gate the public-comment reconciliation uses, passed
-    // as a single boolean so the refutation condition is unit-tested in the planner and this site carries no branch.
-    // Enabled=false (non-convergence / grounding-off) ⇒ the refutation is a no-op ⇒ byte-identical verdict. The
-    // codes are public-safe finding identifiers (no rubric/scoring/reward terms).
-    gateBlockerCodes: gate.blockers.map((blocker) => blocker.code),
-    aiCiRefutationEnabled: aiCiRefutationActive(env, repoFullName),
     autonomy: settings.autonomy,
     autoMaintain: settings.autoMaintain,
     slopGateMinScore: settings.slopGateMinScore,
@@ -2743,13 +2734,9 @@ async function maybePublishPrPublicSurface(
         ...(failingDetails.length > 0 ? { failingChecks: failingDetails.map((detail) => detail.name) } : {}),
         ...(failingDetails.length > 0 ? { failingDetails } : {}),
       };
-      // CI-refutation for the PUBLIC comment (#ai-ci-refutation): when the gate FAILED solely on an AI-judgment
-      // blocker but the LIVE CI is GREEN, render the comment (headline + Gate panel row) as SUCCESS/advisory so it
-      // MATCHES the disposition (which merges such a PR) instead of a contradictory red "blocked/closed". Uses the
-      // SAME grounding+convergence gate as the disposition refutation (a single `aiCiRefutationActive` call so this
-      // site carries no branch), built AFTER the live CI is resolved and used for BOTH the panel rows and the
-      // comment body so the two never disagree. Gate OFF ⇒ commentGate === gateEvaluation (byte-identical comment).
-      const commentGate = reconcileGateEvaluationForGreenCi(gateEvaluation, ciState, aiCiRefutationActive(env, repoFullName));
+      // Keep the public comment aligned with the action planner: a maintainer-configured AI-review hard blocker
+      // remains a visible gate failure even when CI is green.
+      const commentGate = reconcileGateEvaluationForGreenCi(gateEvaluation, ciState, false);
       const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: commentGate, duplicateWinnerEnabled });
       // Visual before/after capture (visual-capture port). Fires ONLY when (1) the global flag + per-repo
       // cutover gate both allow it (screenshotsAllowed) AND (2) the PR touches WEB-VISIBLE files (isVisualPath

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -79,25 +79,15 @@ export function isAiJudgmentOnlyFailure(evaluation: GateCheckEvaluation): boolea
 }
 
 /**
- * Reconcile a gate evaluation with the deterministic CI for the PUBLIC review comment (#ai-ci-refutation).
- * When the gate FAILED solely on an AI-judgment blocker (ai_consensus_defect / ai_review_split) but the real CI
- * is GREEN, the AI claim is refuted by the validator — so the comment must render SUCCESS (advisory), matching
- * the disposition (planAgentMaintenanceActions merges such a PR) instead of a contradictory red "blocked/closed"
- * headline + Gate row. The AI concern stays VISIBLE without double-listing: the specific consensus defect still
- * surfaces from the advisory findings as a raised concern under the green verdict, so we only clear the gate's
- * hard blockers here. `enabled` is the caller's grounding+convergence gate (passed in so this stays a PURE,
- * unit-testable function and the processor carries no branch); `enabled` false, `ciState !== "passed"`, or a
- * non-AI-only failure ⇒ the evaluation is returned UNCHANGED.
+ * Preserve the gate evaluation for the PUBLIC review comment.
+ *
+ * This function intentionally keeps its historical signature because processors pass the live CI state and the
+ * former refutation flag through this boundary. Green CI is not a security oracle: when a maintainer configured
+ * AI-review findings to block, an AI-only gate failure must remain visible as a failure in both the disposition and
+ * the public comment.
  */
-export function reconcileGateEvaluationForGreenCi(evaluation: GateCheckEvaluation, ciState: "passed" | "failed" | "unverified", enabled: boolean): GateCheckEvaluation {
-  if (!enabled || ciState !== "passed" || !isAiJudgmentOnlyFailure(evaluation)) return evaluation;
-  return {
-    ...evaluation,
-    conclusion: "success",
-    title: "Gittensory Gate passed",
-    summary: "The AI review raised a concern, but the deterministic checks (CI) are green — the concern is advisory, not blocking.",
-    blockers: [],
-  };
+export function reconcileGateEvaluationForGreenCi(evaluation: GateCheckEvaluation, _ciState: "passed" | "failed" | "unverified", _enabled: boolean): GateCheckEvaluation {
+  return evaluation;
 }
 
 export function buildRepositoryAdvisory(repo: RepositoryRecord | null, fullName: string): Advisory {

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -1,5 +1,5 @@
 import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyPolicy } from "../types";
-import { AI_JUDGMENT_BLOCKER_CODES, type GateCheckConclusion } from "../rules/advisory";
+import type { GateCheckConclusion } from "../rules/advisory";
 import { DEFAULT_AUTO_MAINTAIN_POLICY, autonomyRequiresApproval, isActingAutonomyLevel, resolveAutonomy } from "./autonomy";
 import { changedPathsHittingGuardrail } from "../signals/change-guardrail";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
@@ -63,13 +63,11 @@ export type PlannedAgentAction = {
 export type AgentActionPlanInput = {
   conclusion: GateCheckConclusion;
   blockerTitles: string[];
-  // The gate's blocking finding CODES (parallel to blockerTitles). Used by the CI-refutation rule
-  // (#ai-ci-refutation): when the gate FAILED solely because of AI-judgment blockers and CI is green, the
-  // AI claim is refuted by the deterministic validator. Optional/absent ⇒ the refutation is a no-op.
+  // The gate's blocking finding CODES (parallel to blockerTitles). Retained for compatibility with callers that
+  // still provide the former CI-refutation metadata; policy decisions use `conclusion` directly.
   gateBlockerCodes?: string[] | undefined;
-  // Whether the AI CI-refutation is ACTIVE for this repo (the caller's grounding + convergence gate, passed as a
-  // single boolean so the refutation condition is fully unit-testable here and the processor carries no branch).
-  // Absent/false ⇒ the refutation never fires and the verdict is byte-identical to the raw gate.
+  // Retained for compatibility with callers that still provide the former CI-refutation metadata. Green CI never
+  // overrides a maintainer-configured hard AI-review gate.
   aiCiRefutationEnabled?: boolean | undefined;
   autonomy: AutonomyPolicy | null | undefined;
   // Optional so the trigger can pass raw repo settings; both fall back to conservative defaults here.
@@ -245,24 +243,11 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // Settle-before-decide: never approve / merge / close on a half-finished CI run.
   if (input.ciState === "pending") return actions;
 
-  // CI-refutation of an AI-judgment-only failure (#ai-ci-refutation). When the gate FAILED *solely* because the
-  // dual-model AI reviewer flagged a defect (ai_consensus_defect / ai_review_split) but the deterministic CI is
-  // GREEN, the AI claim is refuted by the real validator → downgrade the verdict to SUCCESS for the disposition so
-  // a clean+green PR MERGES instead of being false-closed on a model hallucination. Requires EVERY blocker to be an
-  // AI-judgment code (a mixed failure with any deterministic blocker — duplicate / secret / slop / missing-issue /
-  // manifest — keeps `failure` and still closes) AND CI === passed (a red/unverified CI is the real signal and is
-  // never overridden). Empty/absent codes (the rule gated OFF at the boundary, or a non-AI failure) ⇒ no-op, so the
-  // verdict is byte-identical. The effective `conclusion` drives every gate-verdict decision below; the AI concern
-  // still surfaces in the review comment (an advisory finding), it just no longer auto-closes a green PR.
-  // Resolve the blocker codes ONCE (so the nullish fallback is exercised for both a present and an absent list,
-  // and the checks below carry no further `??` branch). Absent ⇒ [] ⇒ no AI-judgment-only failure.
-  const gateBlockerCodes = input.gateBlockerCodes ?? [];
-  const aiJudgmentOnlyFailure =
-    input.aiCiRefutationEnabled === true && input.conclusion === "failure" && gateBlockerCodes.length > 0 && gateBlockerCodes.every((code) => AI_JUDGMENT_BLOCKER_CODES.has(code));
-  // The refutation only fires on a GREEN CI (the deterministic validator that overrules the AI). A red/unverified
-  // CI is the real signal and is never overridden, so the verdict stays as the raw gate `failure`.
-  const refuteAiFailureOnGreenCi = aiJudgmentOnlyFailure && ciPassed;
-  const conclusion: GateCheckConclusion = refuteAiFailureOnGreenCi ? "success" : input.conclusion;
+  // Respect the raw gate verdict. AI-review findings are configured by the maintainer's gate policy; green CI is
+  // necessary for an automated merge, but it is not a security oracle and must not downgrade a hard AI-review
+  // blocker into success. The optional CI-refutation inputs are retained for callers/tests across deploys, but the
+  // disposition always uses the gate's configured conclusion.
+  const conclusion: GateCheckConclusion = input.conclusion;
 
   // Only SUCCESS earns the review-good auto-merge. A NEUTRAL gate flows (no longer silently returns []) but is
   // NOT auto-merged — it falls through to a HELD + labeled state for review. (Auto-merging a neutral / grace

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -278,69 +278,36 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
-  describe("CI-refutation: an AI-judgment-only gate failure does NOT close a green-CI PR (#ai-ci-refutation)", () => {
-    const merging = { aiCiRefutationEnabled: true, autonomy: { merge: "auto" as const, approve: "auto" as const, close: "auto" as const, label: "auto" as const }, ciState: "passed" as const, pr: { labels: [], mergeableState: "clean" as const, reviewDecision: "APPROVED" as const } };
+  describe("AI-review hard blockers remain blocking on green CI", () => {
+    const greenClean = { aiCiRefutationEnabled: true, autonomy: { merge: "auto" as const, approve: "auto" as const, close: "auto" as const, label: "auto" as const }, ciState: "passed" as const, pr: { labels: [], mergeableState: "clean" as const, reviewDecision: "APPROVED" as const } };
 
-    it("a consensus-defect failure on a green, clean PR MERGES instead of closing (the validator overrules the model)", () => {
-      const plan = planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["AI reviewers agree on a likely critical defect"], gateBlockerCodes: ["ai_consensus_defect"], ...merging }));
+    it("keeps a consensus-defect failure blocking even when CI is green", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["AI reviewers agree on a likely critical defect"], gateBlockerCodes: ["ai_consensus_defect"], ...greenClean }));
       const cls = classes(plan);
-      expect(cls).toContain("merge");
-      expect(cls).not.toContain("close");
-      // Never routed to manual review — the guardrail path is the ONLY manual hold.
-      expect(plan.find((a) => a.actionClass === "label")?.label).not.toBe(AGENT_LABEL_NEEDS_REVIEW);
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
 
-    it("a review-split failure on a green PR is refuted too (a single minority model opinion never closes a green PR)", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["An AI reviewer flagged a likely blocking defect"], gateBlockerCodes: ["ai_review_split"], ...merging })));
-      expect(cls).toContain("merge");
-      expect(cls).not.toContain("close");
+    it("keeps a review-split failure blocking even when the former refutation flag is enabled", () => {
+      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["An AI reviewer flagged a likely blocking defect"], gateBlockerCodes: ["ai_review_split"], ...greenClean })));
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
     });
 
-    it("the refutation reports the EFFECTIVE verdict (verdict=success; CI green), not the contradictory raw failure", () => {
+    it("labels the raw failure verdict instead of reporting an effective success", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { label: "auto" }, ciState: "passed", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const label = plan.find((a) => a.actionClass === "label");
-      expect(label?.label).toBe(AGENT_LABEL_READY);
-      expect(label?.reason).toBe("verdict=success; CI green");
+      expect(label?.label).toBe(AGENT_LABEL_CHANGES);
+      expect(label?.reason).toBe("verdict=failure");
     });
 
-    it("is GATED by aiCiRefutationEnabled — enabled=false (the converged AI review off) still CLOSES the same PR", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: false, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("does NOT refute when CI is RED — a real failing check is the ground truth and still CLOSES", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "failed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("does NOT refute a MIXED failure — any deterministic blocker alongside the AI one still CLOSES", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect", "duplicate_open_pr"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("does NOT refute a deterministic-only failure (e.g. slop/duplicate) — those close normally on green CI", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["slop_high"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("does NOT refute ai_review_inconclusive — a 'could not review' hold is not a false defect", () => {
-      // inconclusive isn't a `failure` conclusion in practice (it HOLDS neutral), but even if a failure carried
-      // the code, it must NOT be treated as a refutable false positive.
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_review_inconclusive"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("is a no-op when codes are omitted (no AI blockers to refute) — byte-identical close", () => {
-      const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["AI reviewers agree on a likely critical defect"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
-      expect(cls).toContain("close");
-    });
-
-    it("a guardrail-touching AI-refuted PR is still HELD for the owner (refutation never overrides the guardrail hold)", () => {
+    it("does not route an AI-blocked green PR to the guardrail hold unless a guardrail path was touched", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, hardGuardrailGlobs: ["src/**"], changedPaths: ["src/index.ts"], ciState: "passed", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);
       expect(cls).not.toContain("merge");
       expect(cls).not.toContain("close");
-      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
   });
 

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1078,7 +1078,7 @@ describe("firstAddedLineFromPatch", () => {
     });
   });
 
-describe("CI-refutation of the public comment gate (#ai-ci-refutation)", () => {
+describe("AI-review public comment gate preservation", () => {
   const finding = (code: string): import("../../src/types").AdvisoryFinding => ({ code, severity: "critical", title: `t:${code}`, detail: `d:${code}` });
   const failure = (codes: string[]): import("../../src/rules/advisory").GateCheckEvaluation => ({
     enabled: true,
@@ -1102,16 +1102,15 @@ describe("CI-refutation of the public comment gate (#ai-ci-refutation)", () => {
     expect(isAiJudgmentOnlyFailure({ ...failure(["ai_consensus_defect"]), conclusion: "success" })).toBe(false);
   });
 
-  it("enabled + green CI + AI-judgment-only failure → SUCCESS with cleared blockers (matches the merge disposition)", () => {
-    const out = reconcileGateEvaluationForGreenCi(failure(["ai_consensus_defect"]), "passed", true);
-    expect(out.conclusion).toBe("success");
-    expect(out.blockers).toEqual([]);
-    expect(out.title).toBe("Gittensory Gate passed");
-    expect(out.summary).toContain("advisory, not blocking");
+  it("keeps an AI-judgment-only failure unchanged even when CI is green and the former flag is enabled", () => {
+    const fail = failure(["ai_consensus_defect"]);
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true)).toBe(fail);
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true).conclusion).toBe("failure");
   });
 
-  it("enabled + green CI + split-only failure → SUCCESS too", () => {
-    expect(reconcileGateEvaluationForGreenCi(failure(["ai_review_split"]), "passed", true).conclusion).toBe("success");
+  it("keeps a review-split failure unchanged too", () => {
+    const fail = failure(["ai_review_split"]);
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true)).toBe(fail);
   });
 
   it("is GATED by `enabled` — enabled=false returns the failure UNCHANGED even on green CI", () => {


### PR DESCRIPTION
### Motivation
- Prevent green CI from automatically downgrading a maintainer-configured AI hard-block (e.g. `ai_consensus_defect` / `ai_review_split`) into a mergeable success, which permitted an authorization/policy bypass in the automated merge planner.
- Keep the public PR comment and the disposition in lock-step so a maintainer-configured gate failure remains visible and actionable.
- Maintain conservative, defense-in-depth behavior: CI is necessary for merges but not a security oracle that overrides maintainer policy about AI blockers.

### Description
- Use the gate's configured `conclusion` directly in the auto-maintenance planner so AI-only failures remain blocking instead of being auto-refuted by green CI; removed the downgrade path. (`src/settings/agent-actions.ts`)
- Stop forwarding the CI-refutation inputs into the planner and stop calling the repo-level refutation gate from the processor so the disposition no longer treats green CI as an automatic refutation. (`src/queue/processors.ts`)
- Keep the public comment rendering aligned with the raw gate verdict by making `reconcileGateEvaluationForGreenCi` a no-op that preserves the original evaluation instead of clearing AI blockers when CI is green. (`src/rules/advisory.ts`)
- Update unit tests to assert that `ai_consensus_defect` and `ai_review_split` remain blocking on green CI and that public comment behavior preserves the raw failure; adjusted imports/wiring to reflect removed refutation wiring. (tests modified: `test/unit/agent-actions.test.ts`, `test/unit/rules.test.ts`)
- Files changed: `src/settings/agent-actions.ts`, `src/rules/advisory.ts`, `src/queue/processors.ts`, `test/unit/agent-actions.test.ts`, `test/unit/rules.test.ts`.

### Testing
- Ran targeted unit tests: `npm test -- --run test/unit/agent-actions.test.ts test/unit/rules.test.ts test/unit/grounding-wiring.test.ts`, and the modified test cases passed (the three target test files all passed).
- Ran full typecheck with `npm run typecheck` which succeeded.
- Ran `git diff --check` (hygiene) which succeeded.
- Attempted full coverage with `npm run test:coverage`; the run exercised many suites but the coverage remapping step failed with an upstream coverage remap error (`TypeError: jsTokens is not a function`), so the full coverage job did not complete successfully in this environment.
- `npm audit --audit-level=moderate` could not complete due to the npm registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cd795a624832ca2b774faaba20e3e)