### PR TITLE
feat(review): pluggable AI reviewer combiner — single | consensus | synthesis

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -60,6 +60,18 @@ export type AiReviewProviderKey = {
   model?: string | null | undefined;
 };
 
+/**
+ * How the independent reviewer opinions are combined into ONE gate decision (#dual-ai-combiner):
+ *   • `single`     — one reviewer; its verdict IS the decision (a named blocker blocks).
+ *   • `consensus`  — two reviewers; block ONLY when BOTH name a blocker; lone blocker → split (hold). The
+ *                    historical cloud behavior — the default, so an unset `combine` is byte-identical.
+ *   • `synthesis`  — two reviewers run separately, then merge into ONE decision (no split/hold-on-disagree):
+ *                    `onMerge: either` blocks if EITHER flags a blocker; `both` only if all do.
+ */
+export type CombineStrategy = "single" | "consensus" | "synthesis";
+/** Synthesis merge rule — block if `either` reviewer flags a blocker, or only when `both` agree. */
+export type OnMerge = "either" | "both";
+
 export type GittensoryAiReviewInput = {
   repoFullName: string;
   prNumber: number;
@@ -70,6 +82,13 @@ export type GittensoryAiReviewInput = {
   actor?: string | null | undefined;
   /** Effective `aiReviewMode`. `block` additionally runs the consensus-defect pass. */
   mode: "advisory" | "block";
+  /**
+   * How to combine the two reviewer opinions in `block` mode (#dual-ai-combiner). Absent ⇒ `consensus` — the
+   * historical behavior, so the gate decision is byte-identical until a repo/self-host opts into another
+   * strategy. `onMerge` only applies to `synthesis` (default `either`).
+   */
+  combine?: CombineStrategy | null | undefined;
+  onMerge?: OnMerge | null | undefined;
   /** Present only when the repo has BYOK on AND a key configured; drives the advisory write-up. */
   providerKey?: AiReviewProviderKey | null | undefined;
   /**
@@ -114,7 +133,7 @@ export type GittensoryAiReviewResult =
   | { status: "quota_exceeded"; estimatedNeurons: number; remainingBudget: number }
   | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; split: boolean; inconclusive: boolean; estimatedNeurons: number; reviewerCount: number };
 
-type ModelReview = {
+export type ModelReview = {
   assessment: string;
   // blockers = concrete must-fix defects in the diff (drive the consensus defect / gate); nits = non-blocking
   // points; suggestions = concrete improvements (rendered alongside nits). reviewbot-parity shape. (#extensive-reviews)
@@ -436,6 +455,63 @@ export function consensusDefectOf(a: ModelReview, b: ModelReview): AiConsensusDe
   return { title, detail, confidence: 1 };
 }
 
+/** Deterministic SYNTHESIS of one public-safe defect from the reviews that named a blocker — same public-safe
+ *  discipline as `consensusDefectOf` (cite the primary blocker; an unsafe title drops the whole block, fail-safe).
+ *  Used by the `synthesis` and `single` combine strategies. */
+function synthesizeDefect(reviews: ReadonlyArray<ModelReview>): AiConsensusDefect | null {
+  const primary = reviews.flatMap((r) => r.blockers).map((b) => b.trim()).find((b) => b.length > 0);
+  if (!primary) return null;
+  const title = toPublicSafe(primary);
+  if (!title) return null; // unsafe title → drop the block entirely (fail-safe)
+  return { title, detail: title, confidence: 1 }; // cite the primary blocker as both title + detail
+}
+
+/** Combine the independent reviewer opinions into ONE gate decision per the configured strategy (#dual-ai-combiner).
+ *  `reviews` carries one slot per reviewer; a slot is `null` when that reviewer errored or returned unparseable
+ *  output. Returns the gate-relevant trio: a `defect` (→ blocker), `split` (reviewers disagree → HOLD), and
+ *  `inconclusive` (cannot certify → HOLD). FAIL-CLOSED: in every strategy, a missing opinion we needed to clear
+ *  the change yields `inconclusive` rather than a silent pass. The `consensus` branch is byte-identical to the
+ *  historical block-mode logic, so an unset strategy never changes the gate. */
+export function combineReviews(
+  reviews: ReadonlyArray<ModelReview | null>,
+  opts: { strategy: CombineStrategy; onMerge?: OnMerge | null | undefined },
+): { defect: AiConsensusDefect | null; split: boolean; inconclusive: boolean } {
+  const present = reviews.filter((r): r is ModelReview => Boolean(r));
+  const missing = reviews.length - present.length;
+
+  if (opts.strategy === "single") {
+    // One reviewer: its verdict IS the decision (no second opinion to require). A named blocker blocks; a
+    // missing review can't certify the change → hold.
+    const r = present[0];
+    if (!r) return { defect: null, split: false, inconclusive: true };
+    return { defect: r.blockers.length > 0 ? synthesizeDefect([r]) : null, split: false, inconclusive: false };
+  }
+
+  if (opts.strategy === "synthesis") {
+    // Both run separately, then merge into ONE decision — never a split/hold-on-disagreement.
+    const flagged = present.filter((r) => r.blockers.length > 0);
+    if ((opts.onMerge ?? "either") === "both") {
+      // Block only when EVERY expected reviewer is present AND each named a blocker.
+      if (missing > 0) return { defect: null, split: false, inconclusive: true };
+      const all = present.length > 0 && flagged.length === present.length;
+      return { defect: all ? synthesizeDefect(present) : null, split: false, inconclusive: false };
+    }
+    // `either`: any present reviewer's blocker blocks. With no present blocker but a missing opinion we cannot
+    // certify the change is clean → hold (fail-closed).
+    if (flagged.length > 0) return { defect: synthesizeDefect(flagged), split: false, inconclusive: false };
+    return { defect: null, split: false, inconclusive: missing > 0 };
+  }
+
+  // `consensus` (default) — BYTE-IDENTICAL to the historical block-mode pair logic.
+  const [a, b] = reviews;
+  if (a && b) {
+    const defect = consensusDefectOf(a, b);
+    const split = !defect && (a.blockers.length > 0) !== (b.blockers.length > 0);
+    return { defect, split, inconclusive: false };
+  }
+  return { defect: null, split: false, inconclusive: true };
+}
+
 /**
  * Run the AI maintainer review. Returns advisory notes (always, when AI is on) and — in `block` mode —
  * a consensus defect when the free Workers-AI pair agrees with high confidence. Fail-safe on every error
@@ -516,19 +592,13 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
       runWorkersOpinion(env, BEST_REVIEW_MODELS[1], RELIABLE_FALLBACK_MODELS[1], system, user, maxTokens),
     ]);
     secondReview = b;
-    // Fail-CLOSED: block mode requires BOTH independent reviews. If a model errored or returned unparseable
-    // output (a/b null), we cannot certify the change — signal `inconclusive` so the gate HOLDS the PR for a
-    // human instead of silently passing it through to auto-merge. A clean dual review (both present, no
-    // blocker) is NOT inconclusive and still passes normally.
-    if (a && b) {
-      consensusDefect = consensusDefectOf(a, b);
-      // SPLIT = the two reviewers DISAGREE (exactly one named a blocker). Lower confidence than a clean consensus,
-      // so the gate HOLDS it for review instead of auto-merging (only when there is no real consensus defect —
-      // a consensus is the stronger signal and blocks on its own). (#ai-review-split)
-      aiReviewSplit = !consensusDefect && (a.blockers.length > 0) !== (b.blockers.length > 0);
-    } else {
-      inconclusive = true;
-    }
+    // Combine the two opinions per the configured strategy (#dual-ai-combiner). Default `consensus` is
+    // byte-identical to the historical logic: block only on agreement, lone blocker → split, a missing
+    // opinion → inconclusive (fail-closed, HELD for a human rather than silently auto-merged).
+    const combined = combineReviews([a, b], { strategy: input.combine ?? "consensus", onMerge: input.onMerge });
+    consensusDefect = combined.defect;
+    aiReviewSplit = combined.split;
+    inconclusive = combined.inconclusive;
   }
 
   const reviewsForNotes = [advisoryReview, secondReview].filter((r): r is ModelReview => Boolean(r));
@@ -571,6 +641,8 @@ export const __aiReviewInternals = {
   coerceAiText,
   composeAdvisoryNotes,
   consensusDefectOf,
+  combineReviews,
+  synthesizeDefect,
   toPublicSafe,
   estimateNeurons,
   runWorkersOpinion,

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/services/ai-review";
 import { createTestEnv } from "../helpers/d1";
 
-const { parseModelReview, coerceAiText, composeAdvisoryNotes, consensusDefectOf, toPublicSafe, runWorkersOpinion } = __aiReviewInternals;
+const { parseModelReview, coerceAiText, composeAdvisoryNotes, consensusDefectOf, combineReviews, toPublicSafe, runWorkersOpinion } = __aiReviewInternals;
 
 function reviewJson(over: Partial<{ assessment: string; suggestions: string[]; nits: string[]; blockers: string[]; present: boolean; confidence: number; title: string; detail: string }> = {}): string {
   return JSON.stringify({
@@ -351,6 +351,46 @@ describe("pure helpers", () => {
     const fenced = '```json\n{"assessment":"ok","blockers":["X in src/a.ts"],"nits":[],"suggestions":[]}\n```';
     const parsed = parseModelReview(fenced);
     expect(parsed?.blockers).toEqual(["X in src/a.ts"]);
+  });
+
+  describe("combineReviews (#dual-ai-combiner)", () => {
+    const r = (blockers: string[]) => ({ assessment: "", suggestions: [], nits: [], blockers });
+    const clean = r([]);
+    const blocked = r(["Null deref in src/a.ts"]);
+
+    it("single: the lone reviewer's blocker IS the decision; a clean review passes; a missing review holds", () => {
+      expect(combineReviews([blocked], { strategy: "single" }).defect?.title).toContain("Null deref");
+      expect(combineReviews([clean], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(combineReviews([null], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: true });
+    });
+
+    it("consensus (default): blocks only when BOTH name a blocker; lone blocker → split; a missing opinion → inconclusive (byte-identical to the historical logic)", () => {
+      expect(combineReviews([blocked, blocked], { strategy: "consensus" }).defect).not.toBeNull();
+      expect(combineReviews([blocked, clean], { strategy: "consensus" })).toMatchObject({ defect: null, split: true, inconclusive: false });
+      expect(combineReviews([clean, clean], { strategy: "consensus" })).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(combineReviews([blocked, null], { strategy: "consensus" })).toEqual({ defect: null, split: false, inconclusive: true });
+    });
+
+    it("synthesis/either: ANY reviewer's blocker blocks (one decision, never a split); a missing opinion holds only when nothing present blocked", () => {
+      expect(combineReviews([clean, blocked], { strategy: "synthesis", onMerge: "either" })).toMatchObject({ split: false, inconclusive: false });
+      expect(combineReviews([clean, blocked], { strategy: "synthesis", onMerge: "either" }).defect).not.toBeNull();
+      expect(combineReviews([clean, clean], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(combineReviews([blocked, null], { strategy: "synthesis", onMerge: "either" }).defect).not.toBeNull(); // a present blocker decides despite the missing one
+      expect(combineReviews([clean, null], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: true }); // can't certify clean
+      expect(combineReviews([clean, blocked], { strategy: "synthesis" }).defect).not.toBeNull(); // onMerge defaults to either
+    });
+
+    it("synthesis/both: blocks only when EVERY present reviewer flags; disagreement passes (never a hold); a missing opinion holds; empty set passes", () => {
+      expect(combineReviews([blocked, blocked], { strategy: "synthesis", onMerge: "both" }).defect).not.toBeNull();
+      expect(combineReviews([blocked, clean], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(combineReviews([blocked, null], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: true });
+      expect(combineReviews([], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: false });
+    });
+
+    it("synthesized defect drops a blocker whose only finding is blank or unsafe (fail-safe, same discipline as consensus)", () => {
+      expect(combineReviews([r(["   "])], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: false }); // whitespace-only → no primary
+      expect(combineReviews([r(["Boost your reward payout"]), clean], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: false }); // unsafe title dropped
+    });
   });
 
   it("consensusDefectOf requires a concrete blocker in BOTH reviews and drops unsafe titles", () => {


### PR DESCRIPTION
## Summary

First of three PRs adding **configurable dual-AI review** (#dual-ai-combiner). Today the two-model review decision is hard-coded to one strategy: block only when **both** free Workers-AI models name a blocker, lone blocker → split/hold. This lifts that into a pluggable `combineReviews()` so a repo (or a self-host) can choose how two independent reviewers produce **one** gate decision:

| Strategy | Decision |
|---|---|
| **single** | One reviewer; its verdict IS the decision (a named blocker blocks). |
| **consensus** | Block only on agreement; lone blocker → split. **The default — byte-identical to today.** |
| **synthesis** | Both run separately, then merge into one decision (never a split/hold-on-disagreement): `onMerge: either` blocks if either flags, `both` only when all do. |

Every strategy stays **fail-closed**: a missing opinion we needed to clear the change yields `inconclusive` (HELD for a human), never a silent pass. `synthesizeDefect` reuses the exact public-safe discipline as `consensusDefectOf` (cite the primary blocker; an unsafe title drops the block).

`combine` / `onMerge` are new **optional** input fields — absent ⇒ `consensus` — so the gate is unchanged until a caller opts in. The config that resolves them from `.gittensory.yml` + self-host env, and the self-host provider routing that lets the two reviewers be *distinct* providers (Claude Code + Codex), land in the next two PRs.

## Scope
- `src/services/ai-review.ts`: `combineReviews()` + `synthesizeDefect()`; the block-mode decision now routes through the combiner (default `consensus`); `combine`/`onMerge` input fields; `ModelReview` + the combiner exported.

## Validation
- [x] `npm run test:ci` green. **100% branch coverage on the diff.** All 60 prior + new ai-review tests pass — the existing consensus tests prove the refactor is byte-identical.
- [x] No public/private-boundary regression — synthesized defects go through the same `toPublicSafe` drop as consensus.

## Safety
- [x] Cloud byte-identical (default `consensus`); no secrets; fail-closed + fail-safe preserved on every path.

Part 1/3 of configurable dual-AI (consensus/synthesis, 1-or-2 reviewers, per-repo + self-host).