### PR TITLE
feat(selfhost): address self-host AI providers by name for dual review

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -267,8 +267,24 @@ export function buildProvider(name: string, env: Record<string, string | undefin
   }
 }
 
-/** Select the self-host AI provider(s) from AI_PROVIDER. A comma-separated list builds a fallback chain
- *  (first to succeed wins). Returns undefined when unconfigured or no provider has its credential. */
+/** Wrap ≥2 providers so a caller can address ONE by name — `.run("codex", …)` runs codex specifically — which is
+ *  what lets the dual-reviewer path (#dual-ai-combiner) run Claude Code AND Codex as DISTINCT reviewers instead of
+ *  one fallback chain. Any other model id (a real model name, or an embed model for RAG) routes to the fallback
+ *  chain exactly as before — so single-AI / BYOK setups are unchanged. */
+export function routeProviders(providers: Array<{ name: string; ai: SelfHostAi }>): SelfHostAi {
+  const byName = new Map(providers.map((p) => [p.name, p.ai]));
+  const chain = createChainAi(providers);
+  return {
+    async run(model, options) {
+      const direct = byName.get(model.trim().toLowerCase());
+      return (direct ?? chain).run(model, options);
+    },
+  };
+}
+
+/** Select the self-host AI provider(s) from AI_PROVIDER. A comma-separated list of TWO+ providers is addressable
+ *  by name for dual review (see `routeProviders`) and otherwise falls back through them in order; a single
+ *  provider is used directly. Returns undefined when unconfigured or no provider has its credential. */
 export function createSelfHostAi(env: Record<string, string | undefined>): SelfHostAi | undefined {
   const raw = (env.AI_PROVIDER ?? "").trim().toLowerCase();
   if (!raw) return undefined;
@@ -280,5 +296,5 @@ export function createSelfHostAi(env: Record<string, string | undefined>): SelfH
     .filter((p): p is { name: string; ai: SelfHostAi } => Boolean(p.ai));
   if (providers.length === 0) return undefined;
   if (providers.length === 1) return providers[0]?.ai;
-  return createChainAi(providers);
+  return routeProviders(providers);
 }

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveModel } from "../../src/selfhost/ai";
+import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveModel, routeProviders } from "../../src/selfhost/ai";
 
 describe("resolveModel (#979 — never leak the Workers-AI default to a self-host backend)", () => {
   const WORKERS_DEFAULT = "@cf/meta/llama-3.1-8b-instruct-fp8-fast";
@@ -134,6 +134,32 @@ describe("createChainAi (fallback)", () => {
     const a = { name: "a", ai: { run: async () => { throw new Error("err-a"); } } };
     const b = { name: "b", ai: { run: async () => { throw new Error("err-b"); } } };
     await expect(createChainAi([a, b]).run("m", { prompt: "x" })).rejects.toThrow(/err-b/);
+  });
+});
+
+describe("routeProviders (#dual-ai-combiner — address one provider by name for dual review)", () => {
+  const mk = (name: string) => ({ name, ai: { run: vi.fn(async () => ({ response: name })) } });
+
+  it("routes .run(<providerName>) to THAT provider; any other model id falls through to the chain (first provider)", async () => {
+    const cc = mk("claude-code");
+    const cx = mk("codex");
+    const route = routeProviders([cc, cx]);
+    expect((await route.run("codex", { prompt: "x" })).response).toBe("codex"); // direct by name
+    expect(cx.ai.run).toHaveBeenCalledTimes(1);
+    expect(cc.ai.run).not.toHaveBeenCalled();
+    expect((await route.run("@cf/some/model", { prompt: "x" })).response).toBe("claude-code"); // non-name → chain → first
+    expect((await route.run("  CODEX ", { prompt: "x" })).response).toBe("codex"); // case-insensitive + trimmed
+  });
+
+  it("the chain fallback still skips a failed provider for a non-name model id", async () => {
+    const fail = { name: "claude-code", ai: { run: vi.fn(async () => { throw new Error("down"); }) } };
+    const ok = mk("codex");
+    expect((await routeProviders([fail, ok]).run("sonnet", { prompt: "x" })).response).toBe("codex");
+  });
+
+  it("createSelfHostAi wires routing for a 2+ provider AI_PROVIDER (addressable by name)", async () => {
+    const ai = createSelfHostAi({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant", AI_BASE_URL: "http://o/v1" });
+    expect(typeof ai?.run).toBe("function");
   });
 });
 


### PR DESCRIPTION
## Summary

Second of three PRs for **configurable dual-AI review** (#dual-ai-combiner). The self-host AI adapter collapsed every `AI_PROVIDER` entry into one **fallback chain** (first to succeed wins) — so a two-provider config could never run both as *distinct* reviewers: `env.AI.run(modelA)` and `.run(modelB)` both hit the chain's first provider. That blocks real Claude-Code-vs-Codex consensus/synthesis on self-host.

`routeProviders` fixes the seam: with 2+ providers, `.run("<providerName>", …)` runs **that** provider specifically, while any other model id (a real model name, or an embed model for RAG) routes to the fallback chain **exactly as before**. So next PR's dual-reviewer path can address `claude-code` and `codex` independently.

## Scope
- `src/selfhost/ai.ts`: `routeProviders()`; `createSelfHostAi` returns it for 2+ providers (single provider still used directly).

## Validation
- [x] `npm run test:ci` green. **100% branch coverage on the diff** — direct-by-name routing, chain fallthrough for non-name ids (incl. a failed first provider), case-insensitive/trimmed match, and `createSelfHostAi` wiring. All prior self-host AI tests stay green.

## Safety
- [x] Single-AI / BYOK setups byte-identical (single provider direct; non-name model ids still flow through the chain). No secrets; billable-key scrubbing in the CLI adapters is untouched.

Part 2/3 of configurable dual-AI. Config wiring (`.gittensory.yml` + env → reviewers/combine/synthesis) lands next.