### PR TITLE
test(review): cover planner AI-Gateway route + title/body fallbacks

### DIFF
--- a/test/unit/planner.test.ts
+++ b/test/unit/planner.test.ts
@@ -40,6 +40,15 @@ describe("generateIssuePlan (#issue-coding-plan)", () => {
     expect(userMessage).toContain("We need a config flag.");
   });
 
+  it("covers the title/body fallbacks and routes through the AI Gateway when configured", async () => {
+    const run = vi.fn(async () => ({ response: "plan" }));
+    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_GATEWAY_ID: "gw-1" });
+    expect(await generateIssuePlan(env, { title: "only a title", body: "" })).toBe("plan"); // body fallback
+    expect(await generateIssuePlan(env, { title: "", body: "only a body" })).toBe("plan"); // title fallback
+    // the configured gateway id is threaded as the 3rd run() arg
+    expect((run.mock.calls[0] as unknown as unknown[])[2]).toEqual({ gateway: { id: "gw-1" } });
+  });
+
   it("returns null when there is no issue text to plan from (no AI call)", async () => {
     const run = vi.fn(async () => ({ response: "x" }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });


### PR DESCRIPTION
## Summary

Test-only follow-up to [#1360](https://github.com/JSONbored/gittensory/pull/1360). That PR's head ref was stuck on the pre-fix commit when it merged (a GitHub PR-sync lag), so the two extra `planner.ts` coverage cases were left behind. This restores them:

- the `AI_GATEWAY_ID` route in `runPlannerModel` (the gateway `extra` is threaded as the 3rd `AI.run` arg);
- the `title || "(none)"` / `body || "(no description provided)"` fallbacks in `generateIssuePlan`.

With these, `src/review/planner.ts` is back to 100% line + branch coverage.

No linked issue — a coverage-completion follow-up to #1360.

## Scope
- [x] Test-only (`test/unit/planner.test.ts`) — no `src/` change, so no `codecov/patch` obligation

## Validation
- [x] `npm run typecheck` — clean
- [x] `npx vitest run test/unit/planner.test.ts` — 11 pass
- [x] `npm run test:coverage` — `planner.ts` shows no uncovered lines and no partial branches