### PR TITLE
feat(review): wire self-host dual-AI reviewers + combine strategy end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,8 +174,15 @@ GITTENSORY_REVIEW_DRAFT=false
 # --- AI review backend (optional; without it reviews run deterministically) ---
 # AI_SUMMARIES_ENABLED=true
 # AI_PROVIDER=ollama                         # ollama | openai-compatible | openai | anthropic | claude-code |
-#                                            #   codex. A COMMA-LIST is a fallback chain, e.g. "anthropic,ollama"
-#                                            #   (tries each in order until one succeeds). (see #979)
+#                                            #   codex. A COMMA-LIST of TWO providers is a DUAL reviewer pair
+#                                            #   (e.g. "claude-code,codex") combined per AI_COMBINE below; for a
+#                                            #   single provider it's just that one (extra entries are fallbacks).
+# AI_COMBINE=synthesis                       # how two reviewers decide (#dual-ai-combiner): single | consensus |
+#                                            #   synthesis. consensus = block only when BOTH flag a defect (lone
+#                                            #   flag → hold). synthesis (default for two) = both review, then ONE
+#                                            #   merged decision. single = one reviewer's verdict (auto when 1).
+# AI_ON_MERGE=either                         # synthesis merge rule: either (block if EITHER reviewer flags) |
+#                                            #   both (block only when both do). Ignored unless AI_COMBINE=synthesis.
 # AI_BASE_URL=http://ollama:11434/v1         # OpenAI-compatible endpoint (Ollama default; or your provider's)
 # AI_API_KEY=                                # generic key for the openai-compatible endpoint
 # ANTHROPIC_API_KEY=                         # for AI_PROVIDER=anthropic (native Messages API, BYOK)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -104,6 +104,19 @@ and only the AI **summary** degrades to "unavailable". To enable AI, set `AI_PRO
 e.g. `AI_PROVIDER=anthropic,ollama` uses the Anthropic API first and falls back to a local Ollama model if it
 errors. If every provider fails, the AI summary degrades to "unavailable" and the review still runs.
 
+**Dual review (consensus / synthesis).** With **two** providers, `AI_PROVIDER=claude-code,codex` runs *both* as
+independent reviewers and combines them per `AI_COMBINE` (#dual-ai-combiner):
+
+| `AI_COMBINE` | Decision | Notes |
+|---|---|---|
+| `single` | one reviewer's verdict (auto when only one provider) | a named blocker blocks |
+| `consensus` | block only when **both** flag a critical defect; lone flag → **hold** for a human | most conservative |
+| `synthesis` *(default for two)* | both review, then **one merged decision** | `AI_ON_MERGE=either` blocks if either flags (default), `both` only when both do |
+
+In `block` mode the combined decision drives the gate; in `advisory` mode it's notes only. Every strategy is
+fail-closed — if a reviewer can't return a usable verdict, the PR is **held** for a human, never auto-merged. The
+free Cloudflare Workers-AI pair remains the cloud default (`consensus`) — these knobs are for self-host providers.
+
 **Subscription CLIs in the image.** The `claude-code` / `codex` providers need their CLI present. Build the
 image with `--build-arg INSTALL_AI_CLIS=true` (or `docker compose build --build-arg INSTALL_AI_CLIS=true`) to
 bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. No credentials are baked in.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -35,6 +35,14 @@ declare global {
     /** Optional Cloudflare AI Gateway id. When set, free Workers-AI review calls route through the gateway
      *  for caching, rate-limiting, request logging, and fallback. Unset = direct binding calls (unchanged). */
     AI_GATEWAY_ID?: string;
+    /** Self-host AI provider selection + dual-review config (#dual-ai-combiner). `AI_PROVIDER` is a comma list of
+     *  providers (claude-code, codex, anthropic, ollama, …); `AI_COMBINE` picks single|consensus|synthesis (default
+     *  synthesis for two); `AI_ON_MERGE` is the synthesis rule either|both. `AI_REVIEW_PLAN` is the resolved plan
+     *  (computed from these at boot in server.ts and read at the review call site); undefined on cloud. */
+    AI_PROVIDER?: string;
+    AI_COMBINE?: string;
+    AI_ON_MERGE?: string;
+    AI_REVIEW_PLAN?: { reviewers: Array<{ model: string }>; combine: import("./services/ai-review").CombineStrategy; onMerge?: import("./services/ai-review").OnMerge | undefined };
     ADMIN_GITHUB_LOGINS?: string;
     GITHUB_WEBHOOK_SECRET: string;
     GITHUB_WEBHOOK_MAX_BODY_BYTES?: string;

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -6,6 +6,8 @@
 // review proceeds deterministically. Every path returns `{ response: string }` (or throws → the caller
 // records an error and degrades — never a silent wrong answer).
 
+import type { CombineStrategy, OnMerge } from "../services/ai-review";
+
 interface AiRunOptions {
   messages?: Array<{ role: string; content: string }>;
   prompt?: string;
@@ -282,19 +284,50 @@ export function routeProviders(providers: Array<{ name: string; ai: SelfHostAi }
   };
 }
 
+/** Build the credentialed providers named in AI_PROVIDER (any without a credential are silently dropped), in
+ *  order, lowercased. Shared by the adapter and the dual-review plan so they never disagree about which providers
+ *  exist (e.g. an uncredentialed entry can't become a "reviewer" the router would then miss). */
+function buildProviders(env: Record<string, string | undefined>): Array<{ name: string; ai: SelfHostAi }> {
+  return (env.AI_PROVIDER ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .map((name) => ({ name, ai: buildProvider(name, env) }))
+    .filter((p): p is { name: string; ai: SelfHostAi } => Boolean(p.ai));
+}
+
+/** The credentialed self-host provider names from AI_PROVIDER, in order. Empty when unconfigured. */
+export function resolveProviderNames(env: Record<string, string | undefined>): string[] {
+  return buildProviders(env).map((p) => p.name);
+}
+
 /** Select the self-host AI provider(s) from AI_PROVIDER. A comma-separated list of TWO+ providers is addressable
  *  by name for dual review (see `routeProviders`) and otherwise falls back through them in order; a single
  *  provider is used directly. Returns undefined when unconfigured or no provider has its credential. */
 export function createSelfHostAi(env: Record<string, string | undefined>): SelfHostAi | undefined {
-  const raw = (env.AI_PROVIDER ?? "").trim().toLowerCase();
-  if (!raw) return undefined;
-  const providers = raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map((name) => ({ name, ai: buildProvider(name, env) }))
-    .filter((p): p is { name: string; ai: SelfHostAi } => Boolean(p.ai));
+  const providers = buildProviders(env);
   if (providers.length === 0) return undefined;
   if (providers.length === 1) return providers[0]?.ai;
   return routeProviders(providers);
+}
+
+const COMBINE_STRATEGIES = new Set<CombineStrategy>(["single", "consensus", "synthesis"]);
+const ON_MERGE_RULES = new Set<OnMerge>(["either", "both"]);
+
+/** Resolve the self-host dual-review plan from env: the credentialed providers become the reviewer(s), `AI_COMBINE`
+ *  the strategy (default `synthesis` for two — "both review, one synthesized decision"), `AI_ON_MERGE` the
+ *  synthesis rule. Returns undefined when no provider is configured (cloud, or AI off) so ai-review keeps its
+ *  byte-identical Workers-AI consensus default; one provider ⇒ `single`; two+ ⇒ the configured strategy over the
+ *  first two. The result is attached to the self-host env at boot and passed to runGittensoryAiReview. */
+export function resolveAiReviewerPlan(
+  env: Record<string, string | undefined>,
+): { reviewers: Array<{ model: string }>; combine: CombineStrategy; onMerge: OnMerge | undefined } | undefined {
+  const names = resolveProviderNames(env);
+  if (names.length === 0) return undefined;
+  if (names.length === 1) return { reviewers: [{ model: names[0] as string }], combine: "single", onMerge: undefined };
+  const rawCombine = (env.AI_COMBINE ?? "").trim().toLowerCase() as CombineStrategy;
+  const combine: CombineStrategy = COMBINE_STRATEGIES.has(rawCombine) ? rawCombine : "synthesis";
+  const rawOnMerge = (env.AI_ON_MERGE ?? "").trim().toLowerCase() as OnMerge;
+  const onMerge = ON_MERGE_RULES.has(rawOnMerge) ? rawOnMerge : undefined;
+  return { reviewers: names.slice(0, 2).map((model) => ({ model })), combine, onMerge };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import { DatabaseSync } from "node:sqlite";
 import { serve } from "@hono/node-server";
 import worker from "./index";
 import { processJob } from "./queue/processors";
-import { createSelfHostAi } from "./selfhost/ai";
+import { createSelfHostAi, resolveAiReviewerPlan } from "./selfhost/ai";
 import {
   cookieValue,
   credentialsToEnv,
@@ -176,6 +176,10 @@ async function main(): Promise<void> {
 
   const ai = createSelfHostAi(process.env);
   if (ai) console.log(JSON.stringify({ event: "selfhost_ai_provider", provider: process.env.AI_PROVIDER }));
+  // Dual-review plan (#dual-ai-combiner): resolve which provider(s) review + how to combine, attached to env
+  // below so the review call site uses it. Undefined for a single provider's default review or no AI.
+  const aiReviewPlan = resolveAiReviewerPlan(process.env);
+  if (aiReviewPlan) console.log(JSON.stringify({ event: "selfhost_ai_review_plan", reviewers: aiReviewPlan.reviewers.map((r) => r.model), combine: aiReviewPlan.combine }));
 
   // Redis fixed-window rate limiter + webhook dedup cache (else absent when REDIS_URL is unset).
   let rateLimiter: DurableObjectNamespace | undefined;
@@ -205,6 +209,7 @@ async function main(): Promise<void> {
     DB: backend.db,
     JOBS: backend.queue.binding,
     AI: ai,
+    ...(aiReviewPlan ? { AI_REVIEW_PLAN: aiReviewPlan } : {}),
     // Qdrant takes priority; falls back to the backend's built-in vectorize (pgvector or sqlite-vec)
     ...(vectorizeOverride ? { VECTORIZE: vectorizeOverride } : backend.vectorize ? { VECTORIZE: backend.vectorize } : {}),
     ...(rateLimiter ? { RATE_LIMITER: rateLimiter } : {}),

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -89,6 +89,13 @@ export type GittensoryAiReviewInput = {
    */
   combine?: CombineStrategy | null | undefined;
   onMerge?: OnMerge | null | undefined;
+  /**
+   * The reviewer(s) to run (#dual-ai-combiner). Absent/empty ⇒ the free Workers-AI pair with per-slot fallbacks
+   * (byte-identical to today). A self-host plan supplies named providers instead — `{ model: "claude-code" }`,
+   * `{ model: "codex" }` — addressed by the self-host AI router; `fallback` is Workers-AI-only (a self-host
+   * provider has none). `single` (or a single entry) runs reviewer[0]; consensus/synthesis run [0] and [1].
+   */
+  reviewers?: ReadonlyArray<{ model: string; fallback?: string | null | undefined }> | null | undefined;
   /** Present only when the repo has BYOK on AND a key configured; drives the advisory write-up. */
   providerKey?: AiReviewProviderKey | null | undefined;
   /**
@@ -543,7 +550,22 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   // own provider account, so they are not counted here (and a BYOK advisory still runs when the free
   // budget is exhausted). Free calls = the consensus pair in block mode (always Workers AI), plus the
   // advisory leg only when it is NOT BYOK.
-  const freeAiCalls = (input.mode === "block" ? 2 : 0) + (input.providerKey ? 0 : 1);
+  // Reviewers + combine strategy (#dual-ai-combiner). DEFAULT = the free Workers-AI pair (per-slot fallbacks)
+  // combined by `consensus` — byte-identical to today. The self-host boot plan (`env.AI_REVIEW_PLAN`) supplies
+  // named providers (e.g. claude-code + codex) and a strategy; an explicit `input` field overrides it. `single`
+  // (or a single configured reviewer) runs ONE opinion; consensus/synthesis run two.
+  const plan = env.AI_REVIEW_PLAN;
+  const configured: ReadonlyArray<{ model: string; fallback?: string | null | undefined }> | null = (input.reviewers?.length ? input.reviewers : plan?.reviewers) ?? null;
+  const primary = configured?.[0] ?? { model: BEST_REVIEW_MODELS[0], fallback: RELIABLE_FALLBACK_MODELS[0] as string | null };
+  const secondary = configured?.[1] ?? { model: BEST_REVIEW_MODELS[1], fallback: RELIABLE_FALLBACK_MODELS[1] as string | null };
+  // Per-slot fallback model (Workers-AI default pair has one; a self-host provider has none → reuse its own model,
+  // i.e. runWorkersOpinion's single-model path).
+  const primaryFallback = primary.fallback ?? primary.model;
+  const secondaryFallback = secondary.fallback ?? secondary.model;
+  const combine: CombineStrategy = input.combine ?? plan?.combine ?? "consensus";
+  const onMerge: OnMerge | null | undefined = input.onMerge ?? plan?.onMerge;
+  const dual = combine !== "single" && (!configured || configured.length > 1);
+  const freeAiCalls = (input.mode === "block" ? (dual ? 2 : 1) : 0) + (input.providerKey ? 0 : 1);
   // Estimate against the EFFECTIVE system prompt (`system`) so grounding's extra context is billed against the
   // budget. Flag-OFF, `system === REVIEW_SYSTEM_PROMPT`, so the estimate is byte-identical to today.
   const estimatedNeurons = freeAiCalls === 0 ? 0 : estimateNeurons(system.length + user.length, maxTokens, freeAiCalls);
@@ -578,7 +600,7 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
     advisoryReview = outcome.review;
     byokFailure = outcome.failure;
   } else {
-    advisoryReview = await runWorkersOpinion(env, BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0], system, user, maxTokens);
+    advisoryReview = await runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens);
   }
 
   let consensusDefect: AiConsensusDefect | null = null;
@@ -586,19 +608,29 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   let aiReviewSplit = false;
   let inconclusive = false;
   if (input.mode === "block") {
-    // Consensus blocker ALWAYS uses the free Workers-AI pair (provider-independent, never BYOK).
-    const [a, b] = await Promise.all([
-      input.providerKey ? runWorkersOpinion(env, BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0], system, user, maxTokens) : Promise.resolve(advisoryReview),
-      runWorkersOpinion(env, BEST_REVIEW_MODELS[1], RELIABLE_FALLBACK_MODELS[1], system, user, maxTokens),
-    ]);
-    secondReview = b;
-    // Combine the two opinions per the configured strategy (#dual-ai-combiner). Default `consensus` is
-    // byte-identical to the historical logic: block only on agreement, lone blocker → split, a missing
-    // opinion → inconclusive (fail-closed, HELD for a human rather than silently auto-merged).
-    const combined = combineReviews([a, b], { strategy: input.combine ?? "consensus", onMerge: input.onMerge });
-    consensusDefect = combined.defect;
-    aiReviewSplit = combined.split;
-    inconclusive = combined.inconclusive;
+    if (dual) {
+      // Two independent reviewers (the free Workers-AI pair by default — provider-independent, never BYOK — or the
+      // configured provider pair on self-host). Reuse the advisory leg's review as the first opinion when it
+      // already ran it (non-BYOK), instead of paying for it twice.
+      const [a, b] = await Promise.all([
+        input.providerKey ? runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens) : Promise.resolve(advisoryReview),
+        runWorkersOpinion(env, secondary.model, secondaryFallback, system, user, maxTokens),
+      ]);
+      secondReview = b;
+      // Combine per the configured strategy (#dual-ai-combiner). Default `consensus` is byte-identical to the
+      // historical logic: block only on agreement, lone blocker → split, a missing opinion → inconclusive
+      // (fail-closed, HELD for a human). `synthesis` merges both into one decision (no split/hold-on-disagree).
+      const combined = combineReviews([a, b], { strategy: combine, onMerge });
+      consensusDefect = combined.defect;
+      aiReviewSplit = combined.split;
+      inconclusive = combined.inconclusive;
+    } else {
+      // Single reviewer: its verdict IS the decision. Reuse the advisory leg (non-BYOK) or run the one reviewer.
+      const a = input.providerKey ? await runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens) : advisoryReview;
+      const combined = combineReviews([a], { strategy: "single" });
+      consensusDefect = combined.defect;
+      inconclusive = combined.inconclusive;
+    }
   }
 
   const reviewsForNotes = [advisoryReview, secondReview].filter((r): r is ModelReview => Boolean(r));

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -294,6 +294,58 @@ describe("Workers AI fallback + degraded output", () => {
   });
 });
 
+describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () => {
+  const planEnv = (plan: { reviewers: Array<{ model: string }>; combine: string; onMerge?: string }, run: (model: string) => Promise<unknown>) =>
+    createTestEnv({ AI: { run: vi.fn(run) } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000", AI_REVIEW_PLAN: plan as never });
+
+  it("single provider: runs ONE named reviewer and its blocker IS the decision", async () => {
+    const seen: string[] = [];
+    const env = planEnv({ reviewers: [{ model: "claude-code" }], combine: "single" }, async (model) => {
+      seen.push(model);
+      return { response: reviewJson({ present: true, title: "Null deref in src/a.ts" }) };
+    });
+    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    expect(result.status === "ok" && result.consensusDefect?.title).toContain("Null deref");
+    expect(seen).toEqual(["claude-code"]); // exactly one reviewer, addressed by name
+  });
+
+  it("dual synthesis (either): runs claude-code AND codex; EITHER blocker decides, never a split", async () => {
+    const seen: string[] = [];
+    const env = planEnv({ reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis", onMerge: "either" }, async (model) => {
+      seen.push(model);
+      return model === "codex" ? { response: reviewJson({ present: true, title: "Race condition in src/x.ts" }) } : { response: reviewJson({ present: false }) };
+    });
+    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    if (result.status !== "ok") throw new Error("expected ok");
+    expect(result.consensusDefect?.title).toContain("Race condition"); // codex's lone blocker decides under synthesis/either
+    expect(result.split).toBe(false); // synthesis never splits
+    expect([...seen].sort()).toEqual(["claude-code", "codex"]);
+  });
+
+  it("single + BYOK: the provider writes the advisory; the one decision reviewer runs via the router", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "Frontier advisory." }) }] }), { status: 200 })));
+    const seen: string[] = [];
+    const env = planEnv({ reviewers: [{ model: "claude-code" }], combine: "single" }, async (model) => {
+      seen.push(model);
+      return { response: reviewJson({ present: true, title: "Bug in src/a.ts" }) };
+    });
+    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block", providerKey: { provider: "anthropic", key: "sk-ant" } });
+    if (result.status !== "ok") throw new Error("expected ok");
+    expect(result.consensusDefect?.title).toContain("Bug"); // the single Workers-AI/router reviewer's blocker decides
+    expect(seen).toEqual(["claude-code"]); // the decision reviewer ran once; the advisory came from BYOK (fetch)
+  });
+
+  it("explicit input.reviewers/combine/onMerge override the env plan", async () => {
+    const seen: string[] = [];
+    const env = planEnv({ reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis" }, async (model) => {
+      seen.push(model);
+      return { response: reviewJson({ present: false }) };
+    });
+    await runGittensoryAiReview(env, { ...baseInput, mode: "block", reviewers: [{ model: "ollama" }, { model: "groq" }], combine: "synthesis", onMerge: "both" });
+    expect([...seen].sort()).toEqual(["groq", "ollama"]); // input reviewers win over the env plan
+  });
+});
+
 describe("pure helpers", () => {
   it("toPublicSafe drops forbidden public text and neutralizes markdown, mentions, links, and control characters", () => {
     expect(toPublicSafe("This change is solid.")).toBe("This change is solid.");

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveModel, routeProviders } from "../../src/selfhost/ai";
+import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveAiReviewerPlan, resolveModel, resolveProviderNames, routeProviders } from "../../src/selfhost/ai";
 
 describe("resolveModel (#979 — never leak the Workers-AI default to a self-host backend)", () => {
   const WORKERS_DEFAULT = "@cf/meta/llama-3.1-8b-instruct-fp8-fast";
@@ -160,6 +160,27 @@ describe("routeProviders (#dual-ai-combiner — address one provider by name for
   it("createSelfHostAi wires routing for a 2+ provider AI_PROVIDER (addressable by name)", async () => {
     const ai = createSelfHostAi({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant", AI_BASE_URL: "http://o/v1" });
     expect(typeof ai?.run).toBe("function");
+  });
+});
+
+describe("resolveProviderNames + resolveAiReviewerPlan (#dual-ai-combiner)", () => {
+  it("resolveProviderNames: credentialed providers only, in order, lowercased/trimmed", () => {
+    expect(resolveProviderNames({})).toEqual([]);
+    expect(resolveProviderNames({ AI_PROVIDER: "  Claude-Code , CODEX " })).toEqual(["claude-code", "codex"]); // CLI providers always credentialed
+    expect(resolveProviderNames({ AI_PROVIDER: "anthropic,ollama" })).toEqual(["ollama"]); // anthropic dropped (no key); ollama needs none
+    expect(resolveProviderNames({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant" })).toEqual(["anthropic", "ollama"]);
+  });
+
+  it("resolveAiReviewerPlan: undefined with no provider; single ⇒ single; two ⇒ default synthesis", () => {
+    expect(resolveAiReviewerPlan({})).toBeUndefined(); // cloud / AI off
+    expect(resolveAiReviewerPlan({ AI_PROVIDER: "claude-code" })).toEqual({ reviewers: [{ model: "claude-code" }], combine: "single", onMerge: undefined });
+    expect(resolveAiReviewerPlan({ AI_PROVIDER: "claude-code,codex" })).toEqual({ reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis", onMerge: undefined });
+  });
+
+  it("resolveAiReviewerPlan: honors AI_COMBINE / AI_ON_MERGE, defaults invalid values, caps at two reviewers", () => {
+    expect(resolveAiReviewerPlan({ AI_PROVIDER: "claude-code,codex", AI_COMBINE: "consensus", AI_ON_MERGE: "both" })).toMatchObject({ combine: "consensus", onMerge: "both" });
+    expect(resolveAiReviewerPlan({ AI_PROVIDER: "claude-code,codex", AI_COMBINE: "garbage", AI_ON_MERGE: "nonsense" })).toMatchObject({ combine: "synthesis", onMerge: undefined }); // invalid → defaults
+    expect(resolveAiReviewerPlan({ AI_PROVIDER: "claude-code,codex,ollama" })?.reviewers).toEqual([{ model: "claude-code" }, { model: "codex" }]); // first two
   });
 });
 


### PR DESCRIPTION
## Summary

Third of three PRs for **configurable dual-AI review** (#dual-ai-combiner) — this connects the combiner ([#1358](https://github.com/JSONbored/gittensory/pull/1358)) and provider routing ([#1359](https://github.com/JSONbored/gittensory/pull/1359)) to config, so a self-host actually runs **Claude Code AND Codex as real dual reviewers**.

- **`resolveAiReviewerPlan`** (`selfhost/ai.ts`): the credentialed `AI_PROVIDER` entries become the reviewer(s), `AI_COMBINE` the strategy (default **synthesis** for two — both review, one merged decision), `AI_ON_MERGE` the synthesis rule. One provider ⇒ `single`. The self-host server computes this at boot and attaches it as `env.AI_REVIEW_PLAN` (codecov-ignored entry); the review path reads it, an explicit `input` field overrides it.
- **`ai-review.ts`** is generalized to run the configured reviewer(s) **by name** (via the self-host AI router) instead of the hard-coded Workers-AI pair: `single` runs one opinion, consensus/synthesis run two — fail-closed throughout.
- **`resolveProviderNames`** is shared by the adapter and the plan so they never disagree about which providers exist (an uncredentialed entry can't become a phantom reviewer).
- Documented in `.env.example` + `docs/self-hosting.md`.

## The dual-AI feature is now complete
`AI_PROVIDER=claude-code,codex` + `AI_COMBINE=synthesis` ⇒ both review every PR independently, merged into one decision; `consensus` and `single` are selectable; modes (`block`/`advisory`/`off`) are orthogonal.

## Scope
`ai-review.ts`, `selfhost/ai.ts`, `server.ts` (boot wiring), `env.d.ts`, `.env.example`, `docs/self-hosting.md`. The per-repo `.gittensory.yml` override for hosted repos is a follow-up.

## Validation
- [x] `npm run test:ci` green. **100% branch coverage on the measured diff** (`ai-review.ts` + `selfhost/ai.ts`) — `resolveProviderNames`/`resolveAiReviewerPlan` (cloud/single/dual, invalid-value defaults, two-reviewer cap) and the review path (single, dual synthesis, BYOK+single, input-overrides-plan).

## Safety
- [x] **Cloud byte-identical** — no plan ⇒ the Workers-AI pair combined by `consensus`; every prior ai-review test stays green. Fail-closed on every path (a reviewer that can't return a verdict ⇒ PR held, never auto-merged). No secrets.

Part 3/3 of configurable dual-AI.