### PR TITLE
fix(selfhost): route dual-AI reviewers to the provider's model, not its name

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -278,8 +278,15 @@ export function routeProviders(providers: Array<{ name: string; ai: SelfHostAi }
   const chain = createChainAi(providers);
   return {
     async run(model, options) {
-      const direct = byName.get(model.trim().toLowerCase());
-      return (direct ?? chain).run(model, options);
+      // A reviewer id of `<provider>` or `<provider>:<model>` addresses ONE provider directly (the dual-review
+      // path). When it matches, hand the provider the model PART (after the colon) — or "" so it falls to its own
+      // default — NOT the provider name, which is not a real model id (`claude --model claude-code` would fail).
+      // Any other id (a real model name, or an embed model for RAG) routes to the fallback chain unchanged.
+      const trimmed = model.trim();
+      const colon = trimmed.indexOf(":");
+      const name = (colon < 0 ? trimmed : trimmed.slice(0, colon)).toLowerCase();
+      const direct = byName.get(name);
+      return direct ? direct.run(colon < 0 ? "" : trimmed.slice(colon + 1), options) : chain.run(model, options);
     },
   };
 }

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -138,23 +138,31 @@ describe("createChainAi (fallback)", () => {
 });
 
 describe("routeProviders (#dual-ai-combiner — address one provider by name for dual review)", () => {
-  const mk = (name: string) => ({ name, ai: { run: vi.fn(async () => ({ response: name })) } });
+  // The mock echoes back the MODEL it received, so we can assert the router never passes the provider NAME
+  // through as a model id (`claude --model claude-code` would fail — the bug this guards).
+  const mk = (name: string) => ({ name, ai: { run: vi.fn(async (model: string) => ({ response: `${name}|${model}` })) } });
 
-  it("routes .run(<providerName>) to THAT provider; any other model id falls through to the chain (first provider)", async () => {
+  it("routes .run(<providerName>) to THAT provider with an EMPTY model (→ provider default), never the name", async () => {
     const cc = mk("claude-code");
     const cx = mk("codex");
     const route = routeProviders([cc, cx]);
-    expect((await route.run("codex", { prompt: "x" })).response).toBe("codex"); // direct by name
+    expect((await route.run("codex", { prompt: "x" })).response).toBe("codex|"); // direct; model is "" (default), NOT "codex"
     expect(cx.ai.run).toHaveBeenCalledTimes(1);
     expect(cc.ai.run).not.toHaveBeenCalled();
-    expect((await route.run("@cf/some/model", { prompt: "x" })).response).toBe("claude-code"); // non-name → chain → first
-    expect((await route.run("  CODEX ", { prompt: "x" })).response).toBe("codex"); // case-insensitive + trimmed
+    expect((await route.run("  CODEX ", { prompt: "x" })).response).toBe("codex|"); // case-insensitive + trimmed
+    expect((await route.run("@cf/some/model", { prompt: "x" })).response).toBe("claude-code|@cf/some/model"); // non-name → chain → first, model passed through
+  });
+
+  it("a `<provider>:<model>` id hands that provider the explicit model", async () => {
+    const cc = mk("claude-code");
+    const cx = mk("codex");
+    expect((await routeProviders([cc, cx]).run("claude-code:opus", { prompt: "x" })).response).toBe("claude-code|opus");
   });
 
   it("the chain fallback still skips a failed provider for a non-name model id", async () => {
     const fail = { name: "claude-code", ai: { run: vi.fn(async () => { throw new Error("down"); }) } };
     const ok = mk("codex");
-    expect((await routeProviders([fail, ok]).run("sonnet", { prompt: "x" })).response).toBe("codex");
+    expect((await routeProviders([fail, ok]).run("sonnet", { prompt: "x" })).response).toBe("codex|sonnet"); // chain passes the real model through
   });
 
   it("createSelfHostAi wires routing for a 2+ provider AI_PROVIDER (addressable by name)", async () => {


### PR DESCRIPTION
## Summary

A regression in the dual-AI wiring ([#1359](https://github.com/JSONbored/gittensory/pull/1359)/[#1362](https://github.com/JSONbored/gittensory/pull/1362)): the router addressed a provider by name (`env.AI.run("claude-code")`) but then passed that **name** to the provider adapter as the model id. `resolveModel` handed `claude-code` to `claude --model`, which fails — so the dual review silently degraded to `inconclusive` instead of actually running Claude Code + Codex.

`routeProviders` now parses a reviewer id of `<provider>` or `<provider>:<model>`: a match runs that provider with the model **part** (after the colon), or `""` so it falls to the provider's **own default** (`sonnet` for claude-code, `gpt-5` for codex) — never the provider name. Non-provider ids (a real model name, an embed model for RAG) still route to the fallback chain with the model passed through unchanged.

## Validation
- [x] `npm run test:ci` green. **100% branch coverage on the diff.** The mock now echoes the model it received, so the regression test asserts the provider gets the default (`""`), not `claude-code`; plus the explicit `<provider>:<model>` path and the chain-passthrough.

## Safety
- [x] Single-AI / BYOK unchanged (non-provider model ids still flow through the chain verbatim). No secrets.

Found while standing up the self-host dual-AI stack for a live test. Required before dual review works end-to-end.