### PR TITLE
fix(selfhost): don't --ignore-scripts when baking the AI CLIs into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ COPY --from=build /app/migrations ./migrations
 # work in-image. Build with `--build-arg INSTALL_AI_CLIS=true`. No credentials are baked — operators mint
 # CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token`) / codex auth at run time and pass it via the env.
 ARG INSTALL_AI_CLIS=false
-RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g @anthropic-ai/claude-code@2.1.187 @openai/codex@0.142.0 --ignore-scripts; fi
+# NB: NO --ignore-scripts here. claude-code's postinstall downloads its platform-native binary; skipping it makes
+# `claude` fail at runtime with "native binary not installed". These are trusted first-party CLIs, so their
+# install scripts are allowed to run.
+RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g @anthropic-ai/claude-code@2.1.187 @openai/codex@0.142.0; fi
 # Optional: enable visual review via an external Chrome sidecar (e.g. `browserless/chrome:latest`).
 # Build with `--build-arg INSTALL_VISUAL_REVIEW=true` then set BROWSER_WS_ENDPOINT=<ws-url> at runtime.
 ARG INSTALL_VISUAL_REVIEW=false


### PR DESCRIPTION
## Summary

`docker build --build-arg INSTALL_AI_CLIS=true` installed `@anthropic-ai/claude-code` with **`--ignore-scripts`**, which skips its postinstall — the step that downloads claude-code's **platform-native binary**. The baked `claude` then fails at runtime with `native binary not installed`, so the self-host **`claude-code` review provider never works** (it errors on every call and degrades). Dropping `--ignore-scripts` lets the trusted first-party CLIs run their install scripts and fetch the native binary.

## Validation
- [x] Found while standing up the self-host dual-AI stack: `claude --print` inside the container errored with *"native binary not installed. Either postinstall did not run (--ignore-scripts...)"*. Rebuilding without the flag fixes it (verified `claude --print` returns a real completion in-container).

## Safety
- [x] Dockerfile-only; no `src/**` change. The two CLIs are pinned, first-party (Anthropic/OpenAI) packages.

Found during the live self-host bring-up.