### PR TITLE
fix(selfhost): correct the codex provider for codex-cli 0.142 + ChatGPT-account auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY --from=build /app/migrations ./migrations
 # work in-image. Build with `--build-arg INSTALL_AI_CLIS=true`. No credentials are baked — operators mint
 # CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token`) / codex auth at run time and pass it via the env.
 ARG INSTALL_AI_CLIS=false
+# codex's native (Rust) binary loads the SYSTEM CA trust store (rustls-native-certs); node:slim ships none, so the
+# `codex` provider fails every call with "no native root CA certificates found" without ca-certificates.
+RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*; fi
 # NB: NO --ignore-scripts here. claude-code's postinstall downloads its platform-native binary; skipping it makes
 # `claude` fail at runtime with "native binary not installed". These are trusted first-party CLIs, so their
 # install scripts are allowed to run.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -121,6 +121,16 @@ free Cloudflare Workers-AI pair remains the cloud default (`consensus`) — thes
 image with `--build-arg INSTALL_AI_CLIS=true` (or `docker compose build --build-arg INSTALL_AI_CLIS=true`) to
 bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. No credentials are baked in.
 
+- **Claude Code:** set `CLAUDE_CODE_OAUTH_TOKEN` (a 1-year token from `claude setup-token`, run once in a real
+  terminal — it's browser-interactive and prints the token; it has no headless mode). The provider forces the
+  subscription token (it scrubs `ANTHROPIC_API_KEY`), so an API key won't be used here — use `AI_PROVIDER=anthropic`
+  for API-key billing.
+- **Codex:** codex reads `auth.json` from `$CODEX_HOME` (default `~/.codex`) and **must have a WRITABLE home** — it
+  refreshes the token in place, so a read-only mount fails with *"Read-only file system"*. Set `CODEX_HOME` to a
+  writable path and **copy** your `~/.codex/auth.json` there (don't bind-mount it read-only). With a ChatGPT-
+  subscription login, leave `AI_MODEL` unset for codex — pinning `gpt-5*` returns *"not supported … with a ChatGPT
+  account"*; codex picks the entitled default. (`ca-certificates` for codex's native TLS is baked in by `INSTALL_AI_CLIS`.)
+
 **Local RAG (retrieval-augmented review).** Self-host ships a SQLite-backed vector store, so RAG works without
 Cloudflare Vectorize. Enable it with `GITTENSORY_REVIEW_RAG=true` + the repo in `GITTENSORY_REVIEW_REPOS`, and
 point at an **embedding-capable** OpenAI-compatible provider (Ollama) with a **1024-dimensional** model via

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -206,15 +206,24 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
   };
 }
 
-/** Codex subscription (`codex exec`, auth from ~/.codex/auth.json). Gated/unverified — fail-safe. */
+/** Codex subscription (`codex exec`, auth from $CODEX_HOME/auth.json, default ~/.codex). codex needs a WRITABLE
+ *  home for its app-server state, so a brokered self-host points CODEX_HOME at a writable dir. Gated/unverified —
+ *  fail-safe. */
 export function createCodexAi(parentEnv: Record<string, string | undefined>, spawnImpl?: SpawnFn): SelfHostAi {
   return {
     async run(model, options) {
       const env = scrubBillableKeys(parentEnv);
       const prompt = toMessages(options).map((m) => m.content).join("\n\n");
       const spawn = spawnImpl ?? (await defaultSpawn());
-      const codexModel = resolveModel(configuredModel(parentEnv), model, "gpt-5");
-      const { stdout, code } = await spawn("codex", ["exec", "--json", "--sandbox", "read-only", "--ask-for-approval", "never", "--model", codexModel, "--", prompt], { env, timeoutMs: 120_000 });
+      // codex 0.142+: `exec` is non-interactive — the old `--ask-for-approval` flag was REMOVED (passing it errors).
+      // `--skip-git-repo-check` lets it run outside a git repo. Pass `--model` ONLY when one is explicitly
+      // configured: forcing a model (e.g. the old `gpt-5` default) fails on a ChatGPT-account login with "not
+      // supported", whose default model codex selects on its own.
+      const codexModel = resolveModel(configuredModel(parentEnv), model, "");
+      const args = ["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only"];
+      if (codexModel) args.push("--model", codexModel);
+      args.push("--", prompt);
+      const { stdout, code } = await spawn("codex", args, { env, timeoutMs: 120_000 });
       if (code !== 0) throw new Error(`codex_exit_${code ?? "null"}`);
       const text = extractCliText(stdout);
       if (!text) throw new Error("codex_empty_output");

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -296,11 +296,19 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(capturedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe("t");
   });
 
-  it("Codex returns text on success and throws on a non-zero exit", async () => {
-    const ok: StubSpawn = async () => ({ stdout: JSON.stringify({ type: "result", result: "codex review" }), code: 0 });
-    expect((await createCodexAi({}, ok).run("gpt-5", { prompt: "x" })).response).toBe("codex review");
+  it("Codex: 0.142+ exec flags (no --ask-for-approval, has --skip-git-repo-check); --model only when configured", async () => {
+    let seen: string[] = [];
+    const ok: StubSpawn = async (_cmd, args) => { seen = args; return { stdout: JSON.stringify({ type: "result", result: "codex review" }), code: 0 }; };
+    // no configured model + the dual-router's empty model id → OMIT --model (codex picks the account default;
+    // forcing e.g. gpt-5 fails on a ChatGPT-account login). And the removed --ask-for-approval must never appear.
+    expect((await createCodexAi({}, ok).run("", { prompt: "x" })).response).toBe("codex review");
+    expect(seen).toEqual(["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only", "--", "x"]);
+    expect(seen).not.toContain("--ask-for-approval");
+    // an explicit model (AI_MODEL, or a `codex:<model>` reviewer id) IS passed through
+    await createCodexAi({ AI_MODEL: "o4-mini" }, ok).run("", { prompt: "x" });
+    expect(seen.join(" ")).toContain("--model o4-mini");
     const bad: StubSpawn = async () => ({ stdout: "", code: 1 });
-    await expect(createCodexAi({}, bad).run("gpt-5", { prompt: "x" })).rejects.toThrow(/codex_exit_1/);
+    await expect(createCodexAi({}, bad).run("", { prompt: "x" })).rejects.toThrow(/codex_exit_1/);
   });
 
   it("drives the REAL subprocess (defaultSpawn) against a fake `claude` on PATH", async () => {


### PR DESCRIPTION
## Summary

The `codex` review provider was broken on **every call** (found while standing up the self-host dual-AI stack live):

1. **Invalid flag** — passed `--ask-for-approval never`, which codex-cli 0.142's `exec` rejects (`unexpected argument`). Removed (`exec` is non-interactive; `--sandbox read-only` has nothing to approve). Added `--skip-git-repo-check` so it runs outside a git repo.
2. **Wrong model default** — forced `gpt-5`, which a ChatGPT-subscription login rejects with a server-side 400 (*"not supported … with a ChatGPT account"*). Now `--model` is passed **only** when explicitly configured (`AI_MODEL`, or a `codex:<model>` reviewer id); otherwise codex picks the account's entitled default.
3. **Missing CA certs** — the runtime image lacked `ca-certificates`, so codex's native (Rust/rustls) TLS failed with *"no native root CA certificates found"*. Installed under `INSTALL_AI_CLIS` (separate `RUN`).

Docs updated: codex needs a **writable** `CODEX_HOME` with a copied `auth.json` (token refresh rewrites it — a read-only mount fails), and `AI_MODEL` should be left unset for ChatGPT-account codex.

## Validation
- [x] `npm run test:ci` green; **100% branch coverage** on the diff — the codex args test now asserts no `--ask-for-approval`, `--skip-git-repo-check` present, and `--model` omitted unless configured.
- [x] Verified in-container end-to-end: with the corrected command + `ca-certificates` + a writable `CODEX_HOME`, codex auth + TLS + the default model all reached OpenAI (only the account's usage limit, not the code, blocked the final completion).

## Safety
- [x] `claude-code` / other providers unchanged. No secrets. The two CLIs are pinned first-party packages.

Found during the live self-host bring-up; required for the codex half of dual review.