### PR TITLE
fix(github): fail closed when the fold-all check-suites backstop is unreadable

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2001,6 +2001,10 @@ export async function fetchLiveCiAggregate(
   // where a transient fetch failure plus one green check could otherwise read as "passed".
   let checkRunsIncomplete = false;
   let statusIncomplete = false;
+  // Whether a FIRST-PARTY (GitHub Actions) check-run was observed at all. Used by the fold-all suites backstop:
+  // if the suites read is unreadable AND we never saw a first-party run, we cannot confirm the workflow ran, so
+  // we must fail CLOSED rather than certify "passed" off only always-on third-party checks (#review-audit, #1799).
+  let sawFirstPartyCheckRun = false;
   // Track which required context names actually appear in any API result. An absent required context
   // (never queued, in-progress, or complete) has no entry to push anyPending — without this guard it
   // would be silently ignored and ciState could become "passed" while it never ran.
@@ -2008,7 +2012,7 @@ export async function fetchLiveCiAggregate(
 
   // 1) Check-runs (GitHub Actions jobs, CodeQL, app checks).
   for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
-    const result = await githubJsonWithHeaders<{ check_runs?: Array<GitHubCheckRunPayload & { output?: { title?: unknown; summary?: unknown } }> }>(
+    const result = await githubJsonWithHeaders<{ check_runs?: Array<GitHubCheckRunPayload & { output?: { title?: unknown; summary?: unknown }; app?: { slug?: string | null } | null }> }>(
       env,
       repoFullName,
       `/commits/${headSha}/check-runs?per_page=100&page=${page}`,
@@ -2021,6 +2025,7 @@ export async function fetchLiveCiAggregate(
     }
     for (const run of result.data.check_runs ?? []) {
       seenContextNames?.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
+      if ((run.app?.slug ?? "").toLowerCase() === "github-actions") sawFirstPartyCheckRun = true;
       if (isOwnGitHubAppCheckRun(env, run)) continue; // never wait on the bot's own Gate/Context check-runs (see above)
       total += 1;
       const conclusion = (run.conclusion ?? "").toLowerCase();
@@ -2098,10 +2103,16 @@ export async function fetchLiveCiAggregate(
       `/commits/${headSha}/check-suites?per_page=100`,
       token,
     ).catch(() => undefined);
-    // ONLY downgrade on an AFFIRMATIVE signal — a GitHub-Actions suite that has not completed. The check-suites read
-    // is a bonus hardening, not a primary CI source, so an unreadable/absent result is left as-is (the original
-    // check-run/status verdict stands) rather than fail-closed, which would wrongly pend every fold-all-passing PR.
-    if (suitesResult && (suitesResult.data.check_suites ?? []).some((suite) => (suite.app?.slug ?? "").toLowerCase() === "github-actions" && (suite.status ?? "").toLowerCase() !== "completed")) {
+    // Downgrade on an AFFIRMATIVE incomplete suite. AND: if the suites read itself is UNREADABLE (it 403s under the
+    // very same missing administration:read that forced fold-all, or rate-limits) we can no longer rely on it — so
+    // fail CLOSED (pending) when we ALSO never saw a first-party GitHub Actions check-run, i.e. we cannot confirm the
+    // required workflow ran at all (the #1799 false-green: a fork PR awaiting approval with only an always-on
+    // third-party status). A readable, all-completed suites result still certifies "passed" (no mass false-pending).
+    if (!suitesResult) {
+      // total === 0 means the commit has NO checks at all → genuinely unverified (no CI), not a missing first-party
+      // run, so leave it; only pend when checks DO exist but none of them is a confirmed first-party run.
+      if (!sawFirstPartyCheckRun && total > 0) anyPending = true;
+    } else if ((suitesResult.data.check_suites ?? []).some((suite) => (suite.app?.slug ?? "").toLowerCase() === "github-actions" && (suite.status ?? "").toLowerCase() !== "completed")) {
       anyPending = true; // a first-party GitHub Actions workflow has not completed (e.g. a fork PR awaiting approval)
     }
   }

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -2971,6 +2971,35 @@ describe("GitHub backfill", () => {
       expect(aggregate.ciState).toBe("passed");
     });
 
+    it("fold-all: an UNREADABLE check-suites read with NO first-party check-run reads PENDING, not passed (#review-audit / #1799)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        // Fork PR awaiting approval: only an always-on third-party status; NO first-party GitHub-Actions check-run.
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "license/cla", status: "completed", conclusion: "success", app: { slug: "cla-bot" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [{ context: "license/cla", state: "success" }] });
+        if (url.includes("/check-suites?")) return new Response("forbidden", { status: 403 }); // same missing admin:read that forced fold-all
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/metagraphed", "forksha", "public-token", null);
+      // The suites backstop is unreadable AND no first-party run was seen → cannot confirm CI ran → fail closed.
+      expect(aggregate.ciState).toBe("pending");
+    });
+
+    it("fold-all: an UNREADABLE check-suites read still reads PASSED when a first-party check-run was seen (no over-pending)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        // A real (non-fork) PR: the GitHub-Actions workflow ran and passed (a first-party check-run is present).
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return new Response("forbidden", { status: 403 });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("passed"); // a first-party run was observed and passed; do not over-pend
+    });
+
     it("fold-all: a non-completed THIRD-PARTY suite is ignored (only first-party GitHub-Actions suites gate)", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -3057,8 +3086,9 @@ describe("GitHub backfill", () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
-        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "build", status: "completed", conclusion: "success" }] });
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "build", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
         if (url.includes("/status?")) return Response.json({}); // no `statuses` key → exercises `?? []`
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
         return new Response("not found", { status: 404 });
       });
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);


### PR DESCRIPTION
## Summary
Adversarial-audit finding (high, 3/3 verifiers; the #1799 false-green class). In fold-all mode (branch protection unreadable — the missing `administration:read`), the check-suites backstop is the only signal that a first-party GitHub Actions workflow hasn't run. Its fetch was `.catch(() => undefined)` and only downgraded `if (suitesResult && …)`, so when that fetch **also** fails (a 403/rate-limit), `anyPending` stayed false and an awaiting-approval fork PR — whose only signal is an always-on third-party status — certified `ciState="passed"` → a false-green auto-merge.

## Changes
- Track whether any first-party `github-actions` check-run was observed.
- In the fold-all block, when the suites read is **unreadable AND no first-party run was seen AND checks exist (`total > 0`)**, fail **closed** (`pending`). A readable+completed suites result still certifies `passed` (no mass false-pending); a commit with no checks at all stays `unverified`; a confirmed first-party run is trusted.

## Validation
- [x] `npm run test:ci` exit 0 (4405 tests); `npm audit` clean; all changed lines+branches covered
- [x] New tests: unreadable suites + no first-party → `pending`; unreadable suites + a first-party run → `passed`; existing `unverified` (no checks) and readable-suites cases preserved