### PR TITLE
fix(queue): webhook-handler correctness — reopen autonomy floor + delivery stamp + mention action guard

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1664,6 +1664,17 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       // was by the bot / repo owner / admin, re-close it and skip the re-review. Self-closes (the contributor
       // closed their own PR) stay reopenable; the bot's own nightly-re-review reopens are exempt.
       if (payload.action === "reopened" && installationId && (await maybeRecloseDisallowedReopen(env, deliveryId, installationId, repoFullName, pr, payload).catch(() => false))) {
+        // Stamp the delivery processed like every other owning path — the early return otherwise leaves the
+        // webhook_events row stuck at "queued"/its body hash, mis-reporting the delivery as un-acked (#review-audit).
+        await recordWebhookEvent(env, {
+          deliveryId,
+          eventName,
+          action: payload.action,
+          installationId: payload.installation?.id,
+          repositoryFullName: payload.repository?.full_name,
+          payloadHash: "processed",
+          status: "processed",
+        });
         return;
       }
       // Resolve settings first so the self-authored live-fetch fallback only fires when its gate is in block mode.
@@ -3462,6 +3473,12 @@ async function maybeRecloseDisallowedReopen(
   // NOT touch GitHub, and dry-run records the would-be re-close without acting — so a dry-run is truly inert and
   // the global kill-switch is a COMPLETE stop. This close path previously bypassed pause/freeze/dry-run entirely.
   const reopenSettings = await resolveRepositorySettings(env, repoFullName);
+  // Honor the autonomy floor like every other write path (sweepRepoRegate / the live-action handler / the
+  // draft-dodge sibling all gate on isAgentConfigured): on an OBSERVE-only / un-opted-in repo (autonomy {} =
+  // deny-by-default) the agent must take NO action, so do not re-close. resolveAgentActionMode is orthogonal to
+  // autonomy (it only reflects pause/freeze/dry-run) and returns "live" for an unconfigured repo, so without this
+  // the re-close would genuinely reach GitHub on a repo that never authorized any action (#review-audit).
+  if (!isAgentConfigured(reopenSettings.autonomy)) return false;
   const reopenMode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: reopenSettings.agentPaused, agentDryRun: reopenSettings.agentDryRun });
   if (reopenMode !== "live") {
     await recordAuditEvent(env, {
@@ -3497,6 +3514,10 @@ async function maybeRecloseDisallowedReopen(
 }
 
 async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+  // Only act on a NEWLY-created comment (mirrors maybeProcessGateOverrideCommand / maybeProcessPlanCommand). Without
+  // this an `edited` comment re-runs the agent + rewrites the card, and a `deleted` command still posts an answer
+  // card for a command that no longer exists (#review-audit).
+  if (payload.action !== "created") return false;
   const command = parseGittensoryMentionCommand(payload.comment?.body);
   if (!command) return false;
   // Action commands (e.g. gate-override) are handled by their own dispatch earlier in processGitHubWebhook;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6527,6 +6527,7 @@ describe("one-shot reopen prevention", () => {
     });
 
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } }); // opted into acting autonomy
 
     await processJob(env, {
       type: "github-webhook",
@@ -6541,6 +6542,28 @@ describe("one-shot reopen prevention", () => {
     expect(calls.some((call) => call.method === "PATCH" && call.url.endsWith("/pulls/42"))).toBe(true);
     const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ detail: string }>();
     expect(audit?.detail).toContain("originally closed by maintainer");
+    // #review-audit: the early return after a re-close stamps the delivery processed (was left "queued").
+    const webhookRow = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("reopen-write-collab-close").first<{ status: string }>();
+    expect(webhookRow?.status).toBe("processed");
+  });
+
+  it("does NOT re-close a disallowed reopen on an OBSERVE-only / un-opted-in repo (autonomy floor, #review-audit)", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
+      if (url.endsWith("/collaborators/maintainer/permission")) return Response.json({ permission: "write" });
+      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    // NO autonomy configured (observe-only / un-opted-in): the agent must take NO destructive action.
+    await processJob(env, { type: "github-webhook", deliveryId: "reopen-observe-only", eventName: "pull_request", payload: reopenedPayload("contributor") });
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
+    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/issues/42/comments"))).toBe(false); // never commented
   });
 
   it("does NOT re-close a disallowed reopen while the global freeze is on — records a skip instead (#killswitch-gap)", async () => {
@@ -6556,6 +6579,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } }); // opted into acting autonomy
     await repositoriesModule.setGlobalAgentFrozen(env, true); // emergency brake on
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-frozen", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
@@ -6577,7 +6601,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
-    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true, autonomy: { merge: "auto", request_changes: "auto" } });
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-dryrun", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false); // never closed
     const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string }>();
@@ -6637,6 +6661,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } }); // opted into acting autonomy
     await processJob(env, { type: "github-webhook", deliveryId: "window-evasion-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
     const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ detail: string }>();
@@ -6657,6 +6682,7 @@ describe("one-shot reopen prevention", () => {
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } }); // opted into acting autonomy
     await processJob(env, { type: "github-webhook", deliveryId: "bot-closer-reclose", eventName: "pull_request", payload: reopenedPayload("contributor") });
     expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
   });
@@ -7131,6 +7157,27 @@ describe("recordAgentCommandUsage (signal-snapshot fail-safe)", () => {
     await expect(
       processJob(env, { type: "github-webhook", deliveryId: "bot-mention-signal-fail", eventName: "issue_comment", payload }),
     ).resolves.toBeUndefined();
+  });
+
+  it("ignores a @gittensory mention on an EDITED comment — only newly-created comments are answered (#review-audit)", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if ((init?.method ?? "GET") === "POST" && url.includes("/comments")) posts.push(url);
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const payload: any = {
+      action: "edited", // an edit re-fires issue_comment with a NEW delivery id — the handler must NOT re-answer
+      installation: { id: 123 },
+      repository: { id: 1, name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", owner: { login: "JSONbored" } },
+      sender: { login: "maintainer", type: "User" },
+      comment: { id: 999, body: "@gittensory ask is this mergeable?", user: { login: "maintainer", type: "User" } },
+      issue: { id: 1, number: 77, title: "some issue", pull_request: { url: "https://api.github.com/repos/JSONbored/gittensory/pulls/77" } },
+    };
+    await processJob(env, { type: "github-webhook", deliveryId: "mention-edited", eventName: "issue_comment", payload });
+    expect(posts).toEqual([]); // the action guard returns false → no answer card posted
   });
 });
 


### PR DESCRIPTION
## Summary
Three adversarial-audit findings (high + med + low) in the issue/PR webhook handlers:

1. **Reopen-reclose ignored the autonomy floor (high).** `maybeRecloseDisallowedReopen` gated only on `resolveAgentActionMode` (pause/freeze/dry-run), never on `isAgentConfigured(autonomy)`. On an **observe-only / un-opted-in** repo (`autonomy {}`) the mode resolves `"live"`, so the agent **force-closed a contributor's reopen on a repo that never authorized any action** — every other write path (sweep / live-action / the draft-dodge sibling) checks `isAgentConfigured`. Fix: add the autonomy-floor check before the close.
2. **Stuck webhook row (low).** The reopen-reclose early return skipped the terminal `recordWebhookEvent`, leaving `webhook_events` at `"queued"` (mis-reported as un-acked). Stamp it `"processed"` like every other owning path.
3. **Mention command had no action guard (med).** `maybeProcessGittensoryMentionCommand` lacked the `payload.action === "created"` guard its siblings have, so it re-ran the agent + rewrote the answer card on an `edited` comment and answered a `deleted` command. Bail unless `created`.

## Validation
- [x] `npm run test:ci` exit 0 (4411 tests); `npm audit` clean; all changed lines+branches covered
- [x] New tests: observe-only repo → **no** re-close; the re-close path stamps the delivery `processed`; a `@gittensory` mention on an `edited` comment posts no answer. Existing re-close tests updated to opt into acting autonomy (they previously relied on the bypassed check).