### PR TITLE
docs(contributing): list the three CI-enforced gates the manual gate omitted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,14 +101,17 @@ checks were skipped and why:
 ```sh
 git diff --check
 npm run actionlint
+npm run db:migrations:check
 npm run typecheck
 npm run test:coverage
 npm run test:workers
 npm run build:mcp
 npm run test:mcp-pack
 npm run ui:openapi:check
+npm run ui:version-audit
 npm run ui:lint
 npm run ui:typecheck
+npm run ui:test
 npm run ui:build
 npm audit --audit-level=moderate
 ```


### PR DESCRIPTION
## Summary

The **Required Gates** code block in `CONTRIBUTING.md` is meant to mirror the combined gate (`npm run test:ci`), but it omitted three commands that `test:ci` runs and that CI enforces. A contributor who followed the documented gate literally would skip them and could still hit CI failures. This adds the missing commands in the same order they appear in `test:ci`.

Added:

| Command | Enforced by (`.github/workflows/ci.yml`) |
| --- | --- |
| `npm run db:migrations:check` | `lint` job — "Check migrations" step |
| `npm run ui:version-audit` | `ui` job — "UI/MCP version audit" step |
| `npm run ui:test` | `ui` job — "UI tests" step |

After this change the documented gate matches the 14-step `test:ci` script in `package.json` (plus the trailing `npm audit`, as before).

## Why no screenshots

Docs-only change to a single Markdown file; there is no visible UI, frontend, or extension surface to capture.

## Validation

```sh
git diff --check
```

Docs-only change: it touches only `CONTRIBUTING.md` (no path matched by the CI `backend`/`ui`/`mcp` filters), so the code/test/build gates are not applicable to this diff. The whitespace gate (`git diff --check`) passes with no errors.

## Linked issue

Fixes #1372

Made with [Cursor](https://cursor.com)