### PR TITLE
fix(signals): redact /root/ local paths on the public-safety boundary

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1228,7 +1228,7 @@ function firstCommitTitle(messages: string[] | undefined): string | undefined {
 
 function safeRepoPath(path: string): string {
   /* v8 ignore next -- Empty path fallback protects malformed local-git adapters; path redaction is covered by local branch tests. */
-  return /^(\/Users\/|\/home\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
+  return /^(\/Users\/|\/home\/|\/root\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
 }
 
 export function isTestFile(file: string): boolean {

--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -19,7 +19,7 @@
 // intentionally NOT collapsed onto `PUBLIC_UNSAFE_TERMS`.
 export const PUBLIC_UNSAFE_TERMS = String.raw`reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
 
-export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
+export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/root/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
 
 /** True iff `text` contains nothing that must stay private — i.e. it is safe to surface on a public GitHub surface. */
 export function isPublicSafeText(text: string): boolean {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1147,6 +1147,29 @@ describe("local branch analysis", () => {
     expect(analysis.prPacket.markdown).not.toMatch(/C:\\Users\\alice/i);
   });
 
+  it("hides root-user home paths from public PR packet changed paths", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        body: "Fixes #7",
+        changedFiles: [{ path: "/root/work/src/cache.ts", additions: 12, deletions: 2, status: "modified" }],
+        validation: [{ command: "npm test -- cache", status: "passed" }],
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Cache refresh fails", state: "open", labels: ["bug"], linkedPrs: [] }],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.prPacket.markdown).toContain("## Changed Paths");
+    expect(analysis.prPacket.markdown).toContain("[local path hidden]");
+    expect(analysis.prPacket.markdown).not.toContain("/root/work");
+  });
+
   it("removes snake_case private signals from public PR packet markdown", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {

--- a/test/unit/redaction.test.ts
+++ b/test/unit/redaction.test.ts
@@ -32,6 +32,8 @@ describe("isPublicSafeText (#542 shared public/private boundary)", () => {
   it("rejects local filesystem paths (posix and Windows)", () => {
     expect(isPublicSafeText("/Users/alice/project")).toBe(false);
     expect(isPublicSafeText("/home/bob/repo")).toBe(false);
+    expect(isPublicSafeText("/root/project/src")).toBe(false);
+    expect(isPublicSafeText("clone failed at /root/work/repo")).toBe(false);
     expect(isPublicSafeText("/tmp/scratch")).toBe(false);
     expect(isPublicSafeText("C:\\Users\\carol\\repo")).toBe(false);
     expect(isPublicSafeText("C:/Users/carol/repo")).toBe(false);


### PR DESCRIPTION
## Summary

The signals public/private boundary treats `/Users/`, `/home/`, and `/tmp/` (and Windows `…\Users\…`) as local filesystem paths that must never reach a public GitHub surface, but it missed `/root/` — the root user's home directory. A contributor running local branch analysis from a `/root/...` working tree (common in containers, CI, and devcontainers) could leak that absolute local path onto public surfaces.

The project already treats `/root/` as a local path to redact in `src/services/miner-dashboard-recommendations.ts`:

```ts
const LOCAL_PATH = /(?:\/(?:Users|home|root|tmp|var)\/[^\s,;:)]+|[A-Za-z]:\\Users\\[^\s,;:)]+)/g;
```

This PR aligns the canonical boundary primitive and the changed-file-path redactor with that established intent.

## Changes

- `src/signals/redaction.ts` — add `/root/` to `PUBLIC_UNSAFE_PATTERN`, the canonical `isPublicSafeText` boundary governing PR/issue comments, check annotations, notifications, badge, and extension payloads.
- `src/signals/local-branch.ts` — add `/root/` to `safeRepoPath`, which redacts changed **file paths** rendered into the public PR packet's `Changed Paths` section (the most likely place a `/root/...` path appears).
- Tests for the new case in `test/unit/redaction.test.ts` and `test/unit/local-branch.test.ts`.

Behavior-preserving for every existing input — it only adds `/root/` detection.

## Security / privacy notes

This strengthens the public/private boundary: an absolute `/root/...` path is now redacted (`isPublicSafeText` returns `false`; changed-file paths render as `[local path hidden]`) before reaching any public GitHub surface, consistent with the existing `/Users/`, `/home/`, `/tmp/` handling. No public output that was previously sanitized changes; only previously-leaking `/root/...` paths are now caught.

## Scope

Narrow, scoped to the canonical `signals` boundary primitive plus the changed-file-path redactor. Other surfaces that keep their own context-specific path denylists (`control-panel-roles.ts`, `weekly-value-report.ts`, `db/repositories.ts`, `agent-action-explanation-card.ts`, `focus-manifest.ts`) can be aligned in a follow-up.

## Validation

Run from the repo root (Node 22, after `npm ci`):

```sh
git diff --check
npm run actionlint
npm run db:migrations:check
npm run typecheck
npm run test:coverage
npm run test:workers
npm run ui:openapi:check
```

All pass locally. `npm ci` reports `found 0 vulnerabilities`. New behavior is covered by the added unit tests (changed source lines are exercised; `safeRepoPath`'s changed line is additionally covered behaviorally via the PR-packet test).

## Linked issue

Fixes #1375
