### PR TITLE
fix(signals): redact /root/ local paths on the public-safe boundary (…

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1228,7 +1228,7 @@ function firstCommitTitle(messages: string[] | undefined): string | undefined {
 
 function safeRepoPath(path: string): string {
   /* v8 ignore next -- Empty path fallback protects malformed local-git adapters; path redaction is covered by local branch tests. */
-  return /^(\/Users\/|\/home\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
+  return /^(\/Users\/|\/home\/|\/root\/|\/tmp\/|[A-Z]:\/Users\/)/i.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
 }
 
 export function isTestFile(file: string): boolean {

--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -19,7 +19,7 @@
 // intentionally NOT collapsed onto `PUBLIC_UNSAFE_TERMS`.
 export const PUBLIC_UNSAFE_TERMS = String.raw`reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
 
-export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
+export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/root/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
 
 /** True iff `text` contains nothing that must stay private — i.e. it is safe to surface on a public GitHub surface. */
 export function isPublicSafeText(text: string): boolean {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1122,6 +1122,28 @@ describe("local branch analysis", () => {
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score|\/Users\/example/i);
   });
 
+  it("hides a /root/ changed-file path from the public PR packet (regression for #1375)", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "/root/work/src/cache.ts", additions: 12, deletions: 2, status: "modified" }],
+        validation: [{ command: "npm test -- cache", status: "passed" }],
+      },
+      repo,
+      issues: [],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.prPacket.markdown).toContain("[local path hidden]");
+    expect(analysis.prPacket.markdown).not.toContain("/root/work");
+    expect(JSON.stringify(analysis.prPacket)).not.toContain("/root/work");
+  });
+
   it("removes Windows home paths from public PR packet title and validation lines", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {

--- a/test/unit/redaction.test.ts
+++ b/test/unit/redaction.test.ts
@@ -32,9 +32,16 @@ describe("isPublicSafeText (#542 shared public/private boundary)", () => {
   it("rejects local filesystem paths (posix and Windows)", () => {
     expect(isPublicSafeText("/Users/alice/project")).toBe(false);
     expect(isPublicSafeText("/home/bob/repo")).toBe(false);
+    expect(isPublicSafeText("/root/repo")).toBe(false);
     expect(isPublicSafeText("/tmp/scratch")).toBe(false);
     expect(isPublicSafeText("C:\\Users\\carol\\repo")).toBe(false);
     expect(isPublicSafeText("C:/Users/carol/repo")).toBe(false);
+  });
+
+  it("rejects /root/ home paths so a container/CI working tree cannot leak (regression for #1375)", () => {
+    // The root user's home was the one local-path family the canonical boundary omitted, even though
+    // miner-dashboard-recommendations.ts already treats /root/ as local. Repro from the issue:
+    expect(isPublicSafeText("/root/project/src/index.ts")).toBe(false);
   });
 
   it("is case-insensitive", () => {


### PR DESCRIPTION
## Summary

**Closes #1375.**

- The canonical public/private boundary in `src/signals/redaction.ts` (`PUBLIC_UNSAFE_PATTERN` / `isPublicSafeText`, the `#542` primitive) treated `/Users/`, `/home/`, and `/tmp/` as local filesystem paths that must never reach a public GitHub surface, but omitted `/root/` — the root user's home. A contributor running local branch analysis from a `/root/...` working tree (common in containers, CI, and devcontainers) could leak that absolute local path onto public surfaces (PR/issue comments, check annotations, notifications, badge, extension payloads).
- `safeRepoPath` in `src/signals/local-branch.ts` — which redacts changed **file paths** rendered into the public PR packet's `Changed Paths` — carried the same denylist and the same `/root/` gap, the most likely place a real `/root/...` path appears.
- Fix: add `/root/` to both denylists, matching the intent already established in `src/services/miner-dashboard-recommendations.ts` (`/(?:Users|home|root|tmp|var)/`). Behavior-preserving for every existing input — it only adds `/root/` detection. Closes #1375.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched; this hardens an existing public-safe redaction boundary, covered by sanitizer-boundary tests below.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP shape change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — backend-only, no visible change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change to the redaction boundary; no visible UI, frontend, docs, or extension change.

## Notes

- Tests: `test/unit/redaction.test.ts` adds `/root/` to the canonical local-path rejection set plus a dedicated regression test using the issue's exact repro (`/root/project/src/index.ts`); `test/unit/local-branch.test.ts` adds a regression test asserting a `/root/work/src/cache.ts` changed-file path renders as `[local path hidden]` and never appears in the public PR packet.
- Out of scope (per the issue): other surfaces with their own context-specific path denylists (`control-panel-roles.ts`, `weekly-value-report.ts`, `db/repositories.ts`, `agent-action-explanation-card.ts`, `focus-manifest.ts`) can be aligned in a follow-up.
