### PR TITLE
docs(contributing): list the three CI-enforced gates omitted from Req…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,14 +101,17 @@ checks were skipped and why:
 ```sh
 git diff --check
 npm run actionlint
+npm run db:migrations:check
 npm run typecheck
 npm run test:coverage
 npm run test:workers
 npm run build:mcp
 npm run test:mcp-pack
 npm run ui:openapi:check
+npm run ui:version-audit
 npm run ui:lint
 npm run ui:typecheck
+npm run ui:test
 npm run ui:build
 npm audit --audit-level=moderate
 ```


### PR DESCRIPTION
## Summary

**Closes #1372.**

- The `## Required Gates` code block in `CONTRIBUTING.md` listed 10 of the commands `npm run test:ci` actually runs but omitted three CI-enforced ones, so a contributor who ran only the documented list could pass it yet still fail CI on a gate they were never told to run.
- The three omissions, now added in their real `test:ci` order: **`npm run db:migrations:check`** (after `actionlint`), **`npm run ui:version-audit`** (after `ui:openapi:check`), and **`npm run ui:test`** (after `ui:typecheck`).
- Verified against `package.json`'s `test:ci` script: the documented list now matches the enforced command set exactly, in order. Docs-only; no code, behavior, or generated artifact changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Docs-only change to `CONTRIBUTING.md` (one code fence, three added lines). It touches no `src/**`, test, build, OpenAPI, migration, or workflow file, so the code/test/build/coverage gates have nothing to exercise — `CONTRIBUTING.md` is outside Codecov's `src/**` scope (no `codecov/patch` obligation) and outside every lint/typecheck path. `git diff --check` was run and is clean. The change was validated by diffing the documented list against `package.json`'s `test:ci` script (now an exact, in-order match). Per the Required Gates note, docs-only PRs may skip the gate with the skipped checks named here.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — Markdown docs change, no rendered UI/screenshot surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (This updates contributor docs only; `CHANGELOG.md` is untouched.)

## UI Evidence

N/A — documentation-only change to `CONTRIBUTING.md`; no UI, frontend, extension, or rendered-page surface.

## Notes

- One-line-per-command additions inside the existing `## Required Gates` fenced block; no surrounding prose changed.
