### PR TITLE
fix(mcp): report real changed line counts for renamed files

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -341,55 +341,81 @@ export function probeLocalScorer(scorerCommand = resolveScorePreviewCommand()) {
   );
 }
 
-export function gitLines(cwd, args) {
+function gitOutput(cwd, args) {
   try {
-    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 })
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
+    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 });
   } catch {
-    return [];
+    return "";
   }
 }
 
+export function gitLines(cwd, args) {
+  return gitOutput(cwd, args)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 function collectChangedFiles(cwd, baseRef) {
-  const statusRows = gitLines(cwd, ["diff", "--name-status", "-M", baseRef, "--"]);
+  // Read both halves with `-z`: the human format quotes non-ASCII/control-char paths, so a quoted
+  // name-status key would never match the verbatim numstat key and the file's stats would be lost.
   const numstat = new Map(parseNumstat(cwd, baseRef).map((entry) => [entry.path, entry]));
-  return statusRows.map((row) => {
-    const fields = row.split(/\t/);
-    const code = fields[0] ?? "";
-    const isRename = code.startsWith("R");
-    const path = isRename ? fields[2] ?? fields[1] ?? "" : fields[1] ?? "";
-    const previousPath = isRename ? fields[1] : undefined;
-    const stats = numstat.get(path) ?? { additions: 0, deletions: 0, binary: false };
+  return parseNameStatus(cwd, baseRef).map((entry) => {
+    const stats = numstat.get(entry.path) ?? { additions: 0, deletions: 0, binary: false };
     return stripUndefined({
-      path,
-      previousPath,
+      path: entry.path,
+      previousPath: entry.previousPath,
       additions: stats.additions,
       deletions: stats.deletions,
-      status: statusFromCode(code),
+      status: statusFromCode(entry.code),
       binary: stats.binary,
     });
   });
 }
 
-function parseNumstat(cwd, baseRef) {
-  return gitLines(cwd, ["diff", "--numstat", "-M", baseRef, "--"]).map((row) => {
-    const fields = row.split(/\t/);
-    const additions = fields[0] === "-" ? 0 : Number(fields[0] ?? 0);
-    const deletions = fields[1] === "-" ? 0 : Number(fields[1] ?? 0);
-    return {
-      path: normalizeNumstatPath(fields.slice(2).join("\t")),
-      additions: Number.isFinite(additions) ? additions : 0,
-      deletions: Number.isFinite(deletions) ? deletions : 0,
-      binary: fields[0] === "-" || fields[1] === "-",
-    };
-  });
+function parseNameStatus(cwd, baseRef) {
+  // `-z`: the status code is its own field and paths are verbatim; a rename is followed by the old
+  // then the new path, any other status by a single path.
+  const records = gitOutput(cwd, ["diff", "--name-status", "-M", "-z", baseRef, "--"]).split("\0");
+  const entries = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const code = records[index];
+    if (!code) continue;
+    const isRename = code.startsWith("R");
+    const previousPath = isRename ? records[index + 1] : undefined;
+    const path = records[index + (isRename ? 2 : 1)];
+    index += isRename ? 2 : 1;
+    entries.push({ code, path, previousPath });
+  }
+  return entries;
 }
 
-function normalizeNumstatPath(path) {
-  const renamed = path.match(/\{.* => (.*)\}/);
-  return renamed?.[1] ? path.replace(/\{.* => (.*)\}/, renamed[1]) : path;
+function parseNumstat(cwd, baseRef) {
+  // `-z`: paths are verbatim and a rename emits old/new as separate fields, not the lossy
+  // "{a => b}" / "a => b" human form that left cross-directory renames keyed by an unmatchable string.
+  const records = gitOutput(cwd, ["diff", "--numstat", "-M", "-z", baseRef, "--"]).split("\0");
+  const entries = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const stat = records[index];
+    if (!stat) continue;
+    const [added, deleted, inlinePath] = splitNumstatStat(stat);
+    // An empty inline path marks a rename: the new path is the second of the two following fields.
+    let path = inlinePath;
+    if (inlinePath === "") {
+      path = records[index + 2];
+      index += 2;
+    }
+    const binary = added === "-";
+    entries.push({ path, additions: binary ? 0 : Number(added), deletions: binary ? 0 : Number(deleted), binary });
+  }
+  return entries;
+}
+
+function splitNumstatStat(stat) {
+  // "<added>\t<deleted>\t<path?>" -- keep the path slice intact even if it contains tabs.
+  const firstTab = stat.indexOf("\t");
+  const secondTab = stat.indexOf("\t", firstTab + 1);
+  return [stat.slice(0, firstTab), stat.slice(firstTab + 1, secondTab), stat.slice(secondTab + 1)];
 }
 
 function collectCommitMessages(cwd, baseRef) {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1500,6 +1500,88 @@ describe("local MCP git metadata collection", () => {
     expect(JSON.stringify(renameMetadata)).not.toMatch(/export const old/);
   });
 
+  it("counts additions and deletions for cross-directory renames that share no prefix or suffix", async () => {
+    // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
+    const { collectLocalBranchMetadata } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));
+    git(tempDir, "init");
+    git(tempDir, "config", "user.email", "test@example.com");
+    git(tempDir, "config", "user.name", "Gittensory Test");
+    git(tempDir, "config", "commit.gpgsign", "false");
+    git(tempDir, "remote", "add", "origin", "git@github.com:entrius/allways-ui.git");
+    writeFileSync(join(tempDir, "README.md"), "fixture\n");
+    git(tempDir, "add", "README.md");
+    git(tempDir, "commit", "-m", "initial commit");
+    git(tempDir, "checkout", "-b", "cross-dir-rename");
+    mkdirSync(join(tempDir, "src/alpha"), { recursive: true });
+    // A large body keeps rename similarity high so git reports a rename, not add + delete.
+    const body = Array.from({ length: 20 }, (_, line) => `line ${line}`).join("\n");
+    writeFileSync(join(tempDir, "src/alpha/foo.js"), `${body}\n`);
+    // A binary blob exercises numstat's "-\t-" path (additions/deletions 0, binary true).
+    writeFileSync(join(tempDir, "logo.bin"), Buffer.from([0, 1, 2, 0, 255, 254]));
+    git(tempDir, "add", "-A");
+    git(tempDir, "commit", "-m", "add foo");
+    // With no shared prefix or suffix git renders this rename as a bare "src/alpha/foo.js =>
+    // docs/beta/bar.js" in --numstat, which the previous brace-only parser never matched -> the
+    // renamed file fell back to +0/-0 and undercounted changedLineCount.
+    mkdirSync(join(tempDir, "docs/beta"), { recursive: true });
+    git(tempDir, "mv", "src/alpha/foo.js", "docs/beta/bar.js");
+    writeFileSync(join(tempDir, "docs/beta/bar.js"), `${body}\nadded one\nadded two\n`);
+    writeFileSync(join(tempDir, "logo.bin"), Buffer.from([3, 0, 4, 0, 5, 0, 6]));
+    git(tempDir, "add", "-A");
+    git(tempDir, "commit", "-m", "rename foo across directories");
+
+    const renameMetadata = collectLocalBranchMetadata({ cwd: tempDir, baseRef: "HEAD~1", login: "oktofeesh1" });
+    expect(renameMetadata.changedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "docs/beta/bar.js", previousPath: "src/alpha/foo.js", status: "renamed", additions: 2, deletions: 0 }),
+        expect.objectContaining({ path: "logo.bin", status: "modified", additions: 0, deletions: 0, binary: true }),
+      ]),
+    );
+  });
+
+  it("returns no lines when the git command fails", async () => {
+    // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
+    const { gitLines } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
+    expect(gitLines(join(tmpdir(), "gittensory-no-such-repo-d8f3"), ["rev-parse", "HEAD"])).toEqual([]);
+  });
+
+  it("counts stats and keeps verbatim paths for non-ASCII filenames at the default core.quotePath", async () => {
+    // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
+    const { collectLocalBranchMetadata } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));
+    git(tempDir, "init");
+    git(tempDir, "config", "user.email", "test@example.com");
+    git(tempDir, "config", "user.name", "Gittensory Test");
+    git(tempDir, "config", "commit.gpgsign", "false");
+    // Deliberately leave core.quotePath at its default (on): git's human --name-status then quotes
+    // accented paths, which would diverge from the verbatim --numstat -z key and zero out the stats.
+    git(tempDir, "remote", "add", "origin", "git@github.com:entrius/allways-ui.git");
+    writeFileSync(join(tempDir, "über.txt"), "a\nb\nc\n");
+    const renameBody = Array.from({ length: 20 }, (_, line) => `line ${line}`).join("\n");
+    mkdirSync(join(tempDir, "café"));
+    writeFileSync(join(tempDir, "café/old.txt"), `${renameBody}\n`);
+    git(tempDir, "add", "-A");
+    git(tempDir, "commit", "-m", "seed non-ascii files");
+    git(tempDir, "checkout", "-b", "non-ascii");
+    writeFileSync(join(tempDir, "über.txt"), "a\nb\nc\nd\ne\n");
+    writeFileSync(join(tempDir, "naïve.txt"), "x\ny\nz\n");
+    mkdirSync(join(tempDir, "docs"));
+    git(tempDir, "mv", "café/old.txt", "docs/résumé.txt");
+    writeFileSync(join(tempDir, "docs/résumé.txt"), `${renameBody}\nextra\n`);
+    git(tempDir, "add", "-A");
+    git(tempDir, "commit", "-m", "edit non-ascii files");
+
+    const metadata = collectLocalBranchMetadata({ cwd: tempDir, baseRef: "HEAD~1", login: "oktofeesh1" });
+    expect(metadata.changedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "über.txt", status: "modified", additions: 2, deletions: 0 }),
+        expect.objectContaining({ path: "naïve.txt", status: "added", additions: 3, deletions: 0 }),
+        expect.objectContaining({ path: "docs/résumé.txt", previousPath: "café/old.txt", status: "renamed", additions: 1, deletions: 0 }),
+      ]),
+    );
+  });
+
   it("parses remotes, changed-file stats, linked issues, and refuses source upload mode", async () => {
     // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
     const { collectLocalBranchMetadata, parseGitRemote } = await import("../../packages/gittensory-mcp/lib/local-branch.js");


### PR DESCRIPTION
## Summary

`collectLocalBranchMetadata` in the MCP package undercounted changed lines whenever a file was renamed across directories. Git renders that kind of rename in `git diff --numstat` as a bare `old => new` line with no braces, and the previous parser only understood the braced `dir/{old => new}/file` form. The renamed file therefore failed the numstat lookup and fell back to 0 additions and 0 deletions, which then skewed `changedLineCount` and the local scorer preview.

The same lookup also broke for filenames containing non-ASCII or control characters: the human diff format quotes those paths, so the numstat key and the name-status key stopped matching and the stats were dropped to zero there too.

The fix reads both `git diff --numstat` and `git diff --name-status` with `-z`. That machine format emits every path verbatim and lists a rename as separate old and new fields, so the numstat key always matches the name-status key. Renamed files, binary renames, and accented or control-character paths now report correct counts, and the brittle brace regex is gone. As a bonus, downstream consumers that read files by path now receive the real path bytes instead of quoted, escaped strings.

No issue is linked: this is a small, self-contained correctness fix in the MCP local diff parser.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full `npm run test:ci` run is clean)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New and changed behavior has unit tests for the rename, binary, git-failure, and non-ASCII branches.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise; this change adds no public-facing text.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Not applicable: no such surface is touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states. (Not applicable: no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (Not applicable: no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; the changelog is not edited in this PR.

## UI Evidence

Not applicable. This change has no visible UI, frontend, docs, or extension surface.

## Notes

- The edited file lives in `packages/gittensory-mcp/lib`, which sits outside Codecov's `src/**` scope, so `codecov/patch` has no changed `src` lines to measure. The changed code was still measured directly with the v8 reporter, and the added tests cover every reachable line and branch.
- Verified against real git repositories on git 2.51.0 for renames within and across directories, binary modifications and binary renames, a mode change, and accented or control-character filenames at the default `core.quotePath` setting.
