### PR TITLE
fix(signals): catch plural private terms in the public-safe comment backstop

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4870,7 +4870,10 @@ function isPrivateBountyLifecycleFinding(code: string): boolean {
 }
 
 function containsPrivatePublicTerm(value: string): boolean {
-  return /\b(reward|payout|farming|wallet|hotkey|trust score|raw trust|estimated score|scoreability|likely_duplicate|reviewability\s*\d)\b/i.test(value);
+  // Plural forms must be caught too: this is the sole public-safe gate at its call sites (no scrub
+  // partner like the unified-comment bridge's), so a bare-singular term would leak "rewards"/"wallets"
+  // onto a public comment. Mirror the `s?` plural-aware sibling denylists (advisory.ts, queue-intelligence.ts).
+  return /\b(rewards?|payouts?|farming|wallets?|hotkeys?|trust scores?|raw trust|estimated scores?|scoreability|likely_duplicate|reviewability\s*\d)\b/i.test(value);
 }
 
 function sanitizePanelText(value: string): string {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -689,6 +689,39 @@ describe("signal coverage edge cases", () => {
     expect(maintainerComment).not.toMatch(/reward|wallet|hotkey|trust score|farming/i);
   });
 
+  it("drops PLURAL private terms from public finding titles, not just singular forms (regression: backstop missed plurals)", () => {
+    const directRepo = repo("owner/plural");
+    const prRecord = pr(directRepo.fullName, 77, "Improve docs", { authorLogin: "miner", linkedIssues: [5], body: "Fixes #5" });
+    const profile = buildContributorProfile("miner", { login: "miner", topLanguages: [], source: "github" }, [], []);
+    const basePreflight = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: "Improve docs", body: "Fixes #5", changedFiles: ["src/docs.ts"], linkedIssues: [5] },
+      directRepo,
+      [],
+      [],
+    );
+    const titlesFor = (title: string): string[] =>
+      buildPublicCommentSignalBundle({
+        repo: directRepo,
+        pr: prRecord,
+        profile,
+        detection: { detected: true, source: "official_gittensor_api", reason: "Confirmed by official API.", priorPullRequests: 1, priorMergedPullRequests: 0, priorIssues: 0 },
+        queueHealth: buildQueueHealth(directRepo, [], [], buildCollisionReport(directRepo.fullName, [], [])),
+        collisions: buildCollisionReport(directRepo.fullName, [], []),
+        preflight: { ...basePreflight, findings: [{ code: "info_note", severity: "warning", title, detail: "n/a", action: "n/a" }, ...basePreflight.findings] },
+        settings: repoSettings(directRepo.fullName),
+      }).publicFindingTitles as string[];
+
+    // The public-safe backstop is the SOLE gate here (unlike the unified-comment bridge, which scrubs
+    // plural-aware terms BEFORE this drop-test), so it must catch plurals exactly like singulars.
+    for (const term of ["rewards", "payouts", "wallets", "hotkeys", "trust scores", "estimated scores"]) {
+      expect(titlesFor(`Quarterly ${term} summary`).some((t) => t.toLowerCase().includes(term))).toBe(false);
+    }
+    // Control: singular forms were already dropped — pins that the plural fix did not regress them.
+    for (const term of ["reward", "payout", "wallet", "hotkey", "trust score", "estimated score"]) {
+      expect(titlesFor(`Quarterly ${term} summary`).some((t) => t.toLowerCase().includes(term))).toBe(false);
+    }
+  });
+
   it("buildPublicPrPanelSignalRows derives the gate conclusion across provided/fallback paths (#1007 unified-panel extraction)", () => {
     const directRepo = repo("owner/panel");
     const collisions = buildCollisionReport(directRepo.fullName, [], []);


### PR DESCRIPTION
## Summary

- `containsPrivatePublicTerm` (`src/signals/engine.ts`) is the fail-safe public-safe backstop that drops a public-comment line if it still names private reward/wallet/trust internals. It is the **sole** gate at four public-surface call sites — `publicSafeNextSteps`, `publicSafePreflightFindings`, the inline next-steps filter in `buildPublicPrIntelligenceComment`, and `buildPublicCommentSignalBundle` — with **no scrub step** before it (unlike `src/review/unified-comment-bridge.ts`, whose byte-identical `PRIVATE_DROP_TERMS` is safe only because `publicSafeNit` first scrubs with the plural-aware `PRIVATE_FORBIDDEN_TERMS`).
- The denylist wrapped **bare-singular** terms in word boundaries, so plural forms slipped through: `reward` matched but `rewards` did not — likewise `payouts`, `wallets`, `hotkeys`, `trust scores`, `estimated scores`. A finding/step whose text used a plural (e.g. a title `"Quarterly rewards summary"`) therefore passed the backstop and could surface on a **public** GitHub PR comment.
- Fix: add the `s?` plural form to the pluralizable terms, matching the intent already established by every sibling denylist — `CHECK_RUN_FORBIDDEN_TERMS` (`src/rules/advisory.ts`), `PRIVATE_FORBIDDEN_TERMS` (`src/review/unified-comment-bridge.ts`), and `FORBIDDEN_PUBLIC_COMMENT_WORDS` (`src/queue-intelligence.ts`), which all use `rewards?` / `wallets?` / `trust\s+scores?`. Purely additive: every input matched before still matches; plurals now match too.
- **No issue linked:** this is a small, self-evident correctness fix to an existing sanitizer boundary, kept narrow (one regex line + a regression test). The repo's `linkedIssuePolicy` is `preferred` (not required) and `issueDiscoveryPolicy` is `discouraged`, so a direct PR with this rationale is the intended path rather than filing a discovery issue.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. (The full suite passes with adequate per-test time; the changed line is covered by the added regression test plus existing public-comment suites.)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This PR strengthens that guarantee — it closes a plural-form leak in the public-comment backstop.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface; this is the public/private sanitizer boundary, covered by the added sanitizer-boundary regression test.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP shape change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — backend-only, no visible change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change to a sanitizer regex; no visible UI, frontend, docs, or extension change.

## Notes

- Regression test (`test/unit/signals-coverage.test.ts`): builds the public comment signal bundle with a finding whose title carries each plural private term and asserts none survive into `publicFindingTitles`; a singular-form control pins that the fix does not regress the cases already caught. Verified the test **fails on the pre-fix regex** (the plural leaks) and **passes after** the fix.
