### PR TITLE
fix(review): fall back to the generic slop detail when the rationale neutralizes to empty

### DIFF
--- a/src/services/ai-slop.ts
+++ b/src/services/ai-slop.ts
@@ -120,7 +120,10 @@ export function slopFindingFromOpinion(opinion: SlopOpinion): SignalFinding | nu
   const safeSignals = opinion.signals.map((s) => toPublicSafe(s)).filter((s): s is string => Boolean(s));
   // Nothing publishable survived sanitization → drop the advisory entirely (fail-safe, never publish).
   if (!safeRationale && safeSignals.length === 0) return null;
-  const detailBody = safeRationale ?? "An AI maintainer-assist pass flagged possible low-effort patterns in this change.";
+  // `||` not `??`: toPublicSafe can return "" (not only null) when a non-empty rationale neutralizes away
+  // (e.g. control-char-only text), and an empty body must still take the generic fallback — matching the
+  // `!safeRationale` drop-guard above, which already treats "" and null alike.
+  const detailBody = safeRationale || "An AI maintainer-assist pass flagged possible low-effort patterns in this change.";
   const detail = safeSignals.length > 0 ? `${detailBody} Observations: ${safeSignals.join("; ")}.` : detailBody;
   const publicText = `AI maintainer-assist (advisory): ${detail}`;
   return {

--- a/test/unit/ai-slop.test.ts
+++ b/test/unit/ai-slop.test.ts
@@ -116,6 +116,15 @@ describe("slopFindingFromOpinion", () => {
     expect(finding?.detail).toContain("An AI maintainer-assist pass flagged");
     expect(finding?.detail).toContain("mostly reformatting");
   });
+
+  it("uses the generic fallback when a non-empty rationale neutralizes to an empty string, not just null", () => {
+    // A rationale of only control characters survives parseSlopOpinion's trim() but neutralizes to "" (not
+    // null) in toPublicSafe, so a `??` fallback was skipped and the detail began with a malformed " Observations: …".
+    const finding = slopFindingFromOpinion({ band: "high", rationale: String.fromCharCode(1), signals: ["mostly reformatting"] });
+    expect(finding?.detail).toContain("An AI maintainer-assist pass flagged");
+    expect(finding?.detail).not.toMatch(/^\s/);
+    expect(finding?.detail).toContain("mostly reformatting");
+  });
 });
 
 describe("buildUserPrompt", () => {


### PR DESCRIPTION
## Summary

**No issue linked** — this is a small, self-evident correctness fix to an existing sanitizer path, kept to one operator plus a regression test. The repo's `linkedIssuePolicy` is `preferred` (not required) and `issueDiscoveryPolicy` is `discouraged`, so a direct PR with this rationale is the intended path rather than filing a discovery issue.

- `slopFindingFromOpinion` (`src/services/ai-slop.ts`) built the public advisory detail with `const detailBody = safeRationale ?? "An AI maintainer-assist pass flagged…"`.
- `toPublicSafe` (`src/services/ai-review.ts`) is typed `string | null`, and it returns the **empty string `""` (not only `null`)** when a *non-empty* rationale neutralizes away: a control-character-only rationale survives `parseSlopOpinion`'s `.trim()` (JS `trim()` does not strip C0/C1 control chars) but `neutralizePublicMarkdown` collapses it to `""`. Since `"" ?? fallback` evaluates to `""`, the generic fallback sentence was skipped and the public advisory `detail` began with a malformed `" Observations: …"` — a leading space and no explanatory body.
- The drop-guard immediately above (`if (!safeRationale && safeSignals.length === 0) return null;`) already treats `""` and `null` alike via `!safeRationale`; only the `detailBody` line used `??`, so it was the inconsistent one.
- Fix: use `||` so an empty body also takes the fallback. Purely additive — `safeRationale` is `string | null`, whose only falsy values (`""`, `null`) should both fall back; any real rationale is truthy and still used verbatim.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. The changed line is 100% statement- and branch-covered (both `||` arms), and the full suite passes with adequate per-test time.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This PR keeps the public advisory well-formed — it restores the explanatory fallback sentence instead of emitting a malformed `" Observations: …"` fragment.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface; this is the AI-advisory public-text path, covered by the added regression test.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP shape change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — backend-only, no visible change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change to the AI-slop advisory builder; no visible UI, frontend, docs, or extension change.

## Notes

- Regression test (`test/unit/ai-slop.test.ts`): drives `slopFindingFromOpinion` with a control-character rationale (`String.fromCharCode(1)`) that neutralizes to `""`, plus one surviving signal, and asserts the detail contains the generic fallback sentence, has no leading space, and still includes the signal. Verified it **fails on the pre-fix `??`** (detail is `" Observations: mostly reformatting."`) and **passes after** the `||` fix. The pre-existing `rationale: ""` test continues to pass via the `null` path, confirming no regression.
