### PR TITLE
fix(review): close trailing dot and *.localhost SSRF host bypasses

### DIFF
--- a/src/review/content-lane/safe-url.ts
+++ b/src/review/content-lane/safe-url.ts
@@ -1,12 +1,14 @@
 // SSRF-safe URL guard (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Ported from reviewbot's
 // core/source-url.ts isSafeHttpUrl + isSafeEndpointUrl (the host/IP guard, including the encoded-IP
-// decoding that a dotted-quad regex misses). PURE — no imports, no I/O.
+// decoding that a dotted-quad regex misses), hardened so a trailing-dot or `*.localhost` host can't
+// dodge the loopback check. PURE — no imports, no I/O.
 //
-// Rejects non-HTTPS (isSafeHttpUrl), localhost/.local/.internal, and private/loopback/link-local
-// IPs in any literal notation (decimal `2130706433`, hex `0x7f000001`, octal, short `127.1`, and the
-// IPv6 forms). isSafeEndpointUrl additionally permits wss:/ws: for base-layer chain endpoints.
+// Rejects non-HTTPS (isSafeHttpUrl), localhost / `*.localhost` / .local / .internal, and private/
+// loopback/link-local IPs in any literal notation (decimal `2130706433`, hex `0x7f000001`, octal,
+// short `127.1`, and the IPv6 forms). isSafeEndpointUrl additionally permits wss:/ws: for base-layer
+// chain endpoints.
 
 function parseIpv4Component(part: string): number | null {
   if (/^0x[0-9a-f]+$/i.test(part)) return parseInt(part, 16);
@@ -29,7 +31,7 @@ function ipv4ToInt(host: string): number | null {
   // isSafe*Url entry points: a host reaches here only after `new URL()`, and the WHATWG parser
   // rejects any all-numeric dotted host whose components overflow (so the >0xff / >lastMax / >2^32
   // cases never arrive), while a host that survives parsing as a domain has a non-numeric label that
-  // makes parseIpv4Component bail (line 24) before these run. Retained for source parity + defense.
+  // makes parseIpv4Component bail (line 26) before these run. Retained for source parity + defense.
   /* v8 ignore start -- @preserve unreachable through new URL() host normalization (see note above) */
   for (let i = 0; i < n - 1; i += 1) if ((vals[i] as number) > 0xff) return null;
   const lastMax = [0xffffffff, 0xffffff, 0xffff, 0xff][n - 1] as number;
@@ -78,8 +80,12 @@ function ipv6IsPrivateOrLocal(host: string): boolean {
 }
 
 function hostIsPrivateOrLocal(host: string): boolean {
-  const h = host.toLowerCase();
-  if (h === "localhost" || h.endsWith(".local") || h.endsWith(".internal")) return true;
+  // Normalize once: lower-case, then strip the FQDN root dot(s) the parser keeps on named hosts
+  // (`localhost.`) but not on IP literals — else `localhost.` / `foo.internal.` would read as public.
+  const h = host.toLowerCase().replace(/\.+$/, "");
+  // localhost + its RFC 6761 `*.localhost` namespace, plus the reserved `.local` (mDNS) / `.internal`.
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h.endsWith(".local") || h.endsWith(".internal")) return true;
   if (h === "0.0.0.0" || h === "::1" || h === "[::1]") return true;
   if (h.includes(":")) return ipv6IsPrivateOrLocal(h);
   return ipv4IsPrivateOrLocal(h);
@@ -94,7 +100,7 @@ export function isSafeHttpUrl(raw: string): boolean {
     return false;
   }
   if (url.protocol !== "https:") return false;
-  return !hostIsPrivateOrLocal(url.hostname.toLowerCase());
+  return !hostIsPrivateOrLocal(url.hostname);
 }
 
 /** Like isSafeHttpUrl but also permits secure WebSocket endpoints (`wss:`, `ws:`) — base-layer chain
@@ -107,5 +113,5 @@ export function isSafeEndpointUrl(raw: string): boolean {
     return false;
   }
   if (!["https:", "wss:", "ws:"].includes(url.protocol)) return false;
-  return !hostIsPrivateOrLocal(url.hostname.toLowerCase());
+  return !hostIsPrivateOrLocal(url.hostname);
 }

--- a/test/unit/content-lane-safe-url.test.ts
+++ b/test/unit/content-lane-safe-url.test.ts
@@ -24,6 +24,25 @@ describe("isSafeHttpUrl", () => {
     expect(isSafeHttpUrl("https://printer.local")).toBe(false);
   });
 
+  it("rejects the RFC 6761 *.localhost loopback namespace (not just bare localhost)", () => {
+    // RFC 6761 makes every `*.localhost` name loopback (systemd-resolved, browsers), so the bare
+    // `=== "localhost"` check leaked sub-labelled forms; `.endsWith(".localhost")` closes them.
+    expect(isSafeHttpUrl("https://test.localhost")).toBe(false);
+    expect(isSafeHttpUrl("https://foo.bar.localhost")).toBe(false);
+    expect(isSafeEndpointUrl("wss://api.localhost")).toBe(false);
+  });
+
+  it("rejects trailing-dot FQDN forms of named loopback hosts (SSRF bypass regression)", () => {
+    // The parser keeps the root dot on named hosts: `new URL("https://localhost./").hostname` ===
+    // "localhost.", which still resolves to loopback — so the guard must strip it before its checks.
+    expect(isSafeHttpUrl("https://localhost./")).toBe(false);
+    expect(isSafeHttpUrl("https://foo.local./")).toBe(false);
+    expect(isSafeHttpUrl("https://bar.internal./")).toBe(false);
+    expect(isSafeHttpUrl("https://localhost../")).toBe(false); // strip the whole run, not one dot
+    expect(isSafeHttpUrl("https://db.localhost./")).toBe(false); // subdomain + trailing dot
+    expect(isSafeEndpointUrl("wss://localhost./")).toBe(false); // shared guard → wss hardened too
+  });
+
   it("rejects encoded-IP SSRF bypasses that a dotted-quad regex misses", () => {
     expect(isSafeHttpUrl("https://2130706433")).toBe(false); // decimal 127.0.0.1
     expect(isSafeHttpUrl("https://0x7f000001")).toBe(false); // hex 127.0.0.1


### PR DESCRIPTION
## Summary

The SSRF host guard in `src/review/content-lane/safe-url.ts` returned a public verdict for several named loopback hosts, because its checks only matched the bare forms. Two gaps let an untrusted URL pass `isSafeHttpUrl` while still resolving to loopback or an internal address:

- Trailing FQDN root dot. `new URL("https://localhost./").hostname` keeps the dot as `localhost.`, which never equals `localhost` and never ends with `.local`, so the guard read it as public. The parser strips the dot for IP literals, so only named hosts leaked. The same held for `foo.local.` and `bar.internal.`.
- The RFC 6761 `*.localhost` namespace. The guard matched bare `localhost` but not `db.localhost` or `foo.bar.localhost`, which systemd-resolved and browsers (including the visual lane headless Chrome) resolve to loopback.

The fix normalizes the host once at the shared chokepoint `hostIsPrivateOrLocal`: lowercase, strip the trailing dot run, then reject `localhost`, the `*.localhost` namespace, `.local`, and `.internal`. Both `isSafeHttpUrl` and `isSafeEndpointUrl` inherit the hardening through that single function, and the duplicate `.toLowerCase()` at both call sites was removed so normalization lives in one place.

Scope note: the trailing dot case was the reported gap. The `*.localhost` case is the same class of named loopback bypass on the same line, so both are closed together. The behavior was confirmed in Node and in the Workers runtime, and public hosts such as `example.com.` stay allowed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked the tracking issue, or this fix is self-contained and the summary explains why a separate issue is not required.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage`
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No checks were skipped. The whole gate ran green through `npm run test:ci` plus `npm audit --audit-level=moderate`. `npm run test:coverage` reports 100% lines and branches on `safe-url.ts`, with every changed line and branch arm exercised. Two negative path regression tests were added (the `*.localhost` namespace and the trailing dot forms); each fails before the fix and passes after.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable. This change is backend only and has no visible UI surface, so no screenshots are required.

## Notes

- The guard feeds server side fetches in `source-evidence.ts` (rechecked per redirect hop) and the screenshot navigation guard in `visual/shot.ts`, so the hardening covers both the HTTPS fetch path and the secure WebSocket endpoint path.
- Normalization was consolidated into `hostIsPrivateOrLocal`, which keeps a single defensive point for the lowercase plus trailing dot strip and avoids the duplicate host normalization that existed at the two call sites.
