### PR TITLE
fix(orb): drop check_run from relay forward set

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -11,11 +11,14 @@ import { decryptSecret, encryptSecret } from "../utils/crypto";
 // The events a brokered container needs to review/act on. Installation-lifecycle + other Orb-internal events are
 // deliberately NOT forwarded (the container runs under the CENTRAL Orb App, not its own, so it must not treat
 // those as its own installation state).
+// check_run is intentionally excluded: CI emits one per job per repo (thousands/day), making it a firehose that
+// would flood self-host containers. check_suite fires once per push/PR sync and is sufficient — the engine
+// re-reviews on suite completion (#1371: processors.ts handles both check_run and check_suite for that trigger,
+// so dropping check_run here is lossless for brokered containers).
 const RELAY_FORWARD_EVENTS = new Set([
   "pull_request",
   "pull_request_review",
   "pull_request_review_comment",
-  "check_run",
   "check_suite",
   "issue_comment",
   "issues",

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -115,6 +115,7 @@ describe("forwardOrbEvent", () => {
   it("SKIPS a non-forwardable event, a missing installation, and an enrolled install with no relay registered", async () => {
     const e = brokeredEnv();
     expect(await forwardOrbEvent(e, { eventName: "installation", installationId: 1, deliveryId: "d", rawBody: "{}" })).toBe("skipped");
+    expect(await forwardOrbEvent(e, { eventName: "check_run", installationId: 1, deliveryId: "d", rawBody: "{}" })).toBe("skipped"); // excluded: CI firehose
     expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: null, deliveryId: "d", rawBody: "{}" })).toBe("skipped");
     await enroll(e, 801);
     expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 801, deliveryId: "d", rawBody: "{}" })).toBe("skipped"); // enrolled, no relay


### PR DESCRIPTION
## Summary

`check_run` events are fired once per CI job per repo — at the scale of a
busy monorepo that's thousands of events per day. Forwarding them to
brokered self-host containers creates a CI firehose: the container receives
events it can't meaningfully act on and burns queue capacity.

`check_suite` is sufficient: it fires once per push/PR sync, and the
re-review trigger in `processors.ts` (`eventName !== "check_run" &&
eventName !== "check_suite"`) handles both. Dropping `check_run` from
`RELAY_FORWARD_EVENTS` is therefore lossless for all brokered containers.

A regression assertion added to the existing skip-test pins `check_run` as
intentionally excluded with an explanatory comment so no future refactor
accidentally re-adds it.

## Scope

- [ ] New public API or changed API signature
- [ ] DB schema / migration
- [x] Self-host / Orb / broker path
- [ ] Auth / session / CORS path
- [ ] UI change
- [ ] Docs change

## Validation

- `npx vitest run test/integration/orb-relay.test.ts` — 19 tests, all pass
- `npm run test:ci` — 258 test files passed, 0 failed

## Safety

- No secrets, tokens, wallets, hotkeys, trust scores, or reward values introduced
- No auth/CORS changes
- No UI changes
- Change is backward-compatible: brokered containers simply stop receiving the CI firehose; no new required config