### PR TITLE
fix(github): keep exact page-limit fetches complete instead of capped

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2421,10 +2421,10 @@ async function githubPaged<T>(
     warnings.push(`GitHub sync failed for ${path}: ${errorMessage(error)}`);
   }
 
-  if (status === "complete" && items.length >= limit && limit > 0) {
-    status = "capped";
-    nextCursor = nextCursor ?? String(startPage + Math.max(pageCount, 1));
-    warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path}.`);
+  // A fully drained fetch has no next page: drop the speculative cursor so an exact-`limit` final page
+  // reads as "complete", not "capped". Genuine overflow is already capped with its cursor in the loop.
+  if (status === "complete") {
+    nextCursor = undefined;
   }
   const fetchedCount = priorFetched + items.length;
   const segment = await completeSegment(env, repo, segmentName, sourceKind, mode, startedAt, {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -834,15 +834,17 @@ describe("GitHub backfill", () => {
         });
       }
       if (url.includes("/labels?")) return new Response("label failure", { status: 500 });
+      // Genuine overflow: GitHub advertises a real next page (rel="next"), so fetching only `limit`
+      // item(s) truncates the set and the segment is correctly capped with a live resume cursor.
       if (url.includes("/issues?")) {
-        return Response.json([
-          { number: 1, title: "Open issue", state: "open", user: {}, labels: [{}], body: "body" },
-        ]);
+        return Response.json([{ number: 1, title: "Open issue", state: "open", user: {}, labels: [{}], body: "body" }], {
+          headers: { link: '<https://api.github.com/repositories/1/issues?page=2>; rel="next"' },
+        });
       }
       if (url.includes("/pulls?state=open")) {
-        return Response.json([
-          { number: 10, title: "No head sha PR", state: "open", user: {}, labels: [{}], body: "", head: { sha: "badsha" }, updated_at: "not-a-date" },
-        ]);
+        return Response.json([{ number: 10, title: "No head sha PR", state: "open", user: {}, labels: [{}], body: "", head: { sha: "badsha" }, updated_at: "not-a-date" }], {
+          headers: { link: '<https://api.github.com/repositories/1/pulls?page=2>; rel="next"' },
+        });
       }
       if (url.includes("/pulls?state=closed")) {
         return Response.json([
@@ -864,6 +866,47 @@ describe("GitHub backfill", () => {
         expect.objectContaining({ segment: "open_issues", status: "capped", nextCursor: expect.any(String) }),
         expect.objectContaining({ segment: "open_pull_requests", status: "capped", nextCursor: expect.any(String) }),
         expect.objectContaining({ segment: "labels", status: "partial" }),
+      ]),
+    );
+  });
+
+  it("reports a repo with exactly the page limit and no next page as complete, not capped", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/repos/JSONbored/gittensory")) {
+        return Response.json({
+          name: "gittensory",
+          full_name: "JSONbored/gittensory",
+          private: false,
+          default_branch: "main",
+          language: null,
+          owner: { login: "JSONbored" },
+        });
+      }
+      if (url.includes("/labels?")) return Response.json([]);
+      // Exactly `limit` item(s) returned in a full final page with NO rel="next" link: the entire set
+      // was fetched, so the segment must stay "complete" without a fabricated resume cursor.
+      if (url.includes("/issues?")) {
+        return Response.json([{ number: 1, title: "Only open issue", state: "open", user: { login: "reporter" }, labels: [], body: "" }]);
+      }
+      if (url.includes("/pulls?state=open")) {
+        return Response.json([{ number: 2, title: "Only open PR", state: "open", user: { login: "reporter" }, labels: [], body: "", head: { sha: "sha2" }, updated_at: "2026-05-22T00:00:00.000Z" }]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await backfillRegisteredRepositories(env, { limits: { issues: 1, pullRequests: 1, recentMergedPullRequests: 0, pullRequestDetails: 0 } });
+
+    expect(result.repos[0]?.status).toBe("success");
+    expect(result.repos[0]?.dataQuality).toMatchObject({ capped: false, partial: false });
+    expect(result.repos[0]?.warnings).toEqual([]);
+    expect(await listRepoSyncStates(env)).toMatchObject([{ status: "success", openIssuesCount: 1, openPullRequestsCount: 1 }]);
+    expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ segment: "open_issues", status: "complete", nextCursor: null }),
+        expect.objectContaining({ segment: "open_pull_requests", status: "complete", nextCursor: null }),
       ]),
     );
   });


### PR DESCRIPTION
## Summary

The REST paginator `githubPaged` flagged a sync segment as `capped` whenever a fetch ended with `items.length >= limit`, even when the repository had already returned its entire set in a full final page with no `rel="next"` link. A repo with exactly `limit` open issues or pull requests was reported as truncated: the public `dataQuality.capped` flag was set and a wasteful resume fetch was scheduled against a fabricated cursor that pointed at an empty page.

Genuine overflow is already handled inside the pagination loop, where a real next page sets `status = "capped"` together with its true resume cursor, so the post-loop block could only ever fire on the false positive. The fix drops the speculative cursor on a clean, fully drained fetch so an exact-limit final page stays `complete`. It also prevents a later resume from starting at page two and skipping page one, because `githubPaged` reads the stored cursor without checking the prior status.

No issue is linked: this is a small, self-contained correctness fix confined to the backfill paginator and its tests.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage`
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. The change touches only `src/github/backfill.ts` and its unit tests, so the UI, MCP, and OpenAPI surfaces are unaffected and their checks pass unchanged.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable. This change is backend-only and has no visible UI, frontend, docs, or extension surface.

## Notes

- Added a regression test that a repo returning exactly the page limit with no next page stays `complete` rather than `capped`, and updated the existing cap test to model genuine overflow with a real `rel="next"` link.
- Coverage on the changed lines is 100% for both lines and branches.
