### PR TITLE
feat(orb): Orb relay failure queue with periodic retry

### DIFF
--- a/migrations/0070_orb_relay_failures.sql
+++ b/migrations/0070_orb_relay_failures.sql
@@ -1,0 +1,14 @@
+-- Orb relay failure queue (#relay-retry): when forwardOrbEvent fails (container down or returning an error),
+-- the delivery is recorded here for periodic retry. The cron (retry-orb-relay job) re-attempts pending rows,
+-- deletes on success, increments attempts on failure, and prunes expired rows (TTL = 1 hour).
+-- `expires_at` is computed once at insert; `attempts` is bounded by the processor (max 5).
+CREATE TABLE IF NOT EXISTS orb_relay_failures (
+  delivery_id    TEXT    NOT NULL PRIMARY KEY,
+  event_name     TEXT    NOT NULL,
+  installation_id INTEGER NOT NULL,
+  raw_body       TEXT    NOT NULL,
+  attempts       INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at TEXT,
+  created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+  expires_at     TEXT    NOT NULL DEFAULT (datetime('now', '+1 hour'))
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { RateLimiter } from "./auth/rate-limit";
 import { delayUntil, shouldWaitForGitHubRateLimit } from "./github/rate-limit";
 import { processDlqBatch } from "./queue/dlq";
 import { processJob } from "./queue/processors";
+import { isOrbBrokerEnabled } from "./orb/broker";
 import { isOpsEnabled } from "./review/ops-wire";
 import { isRagEnabled } from "./review/rag-wire";
 import { isSelfTuneEnabled } from "./review/selftune-wire";
@@ -60,6 +61,9 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
   // mergeable and only ACTS (merge/close/hold); it never re-runs the AI, so it is cheap enough for this cadence.
   // Previously this was gated by `isHourly`, so an approved PR could wait ~an hour for its merge pass.
   const jobs: JobMessage[] = [{ type: "agent-regate-sweep", requestedBy: "schedule" }];
+  // Orb relay retry: re-attempt failed forwardOrbEvent calls each sweep cycle. Only enqueued when the
+  // broker is enabled — brokered self-hosts register relay URLs; hosted-cloud instances have no relay failures.
+  if (isOrbBrokerEnabled(env)) jobs.push({ type: "retry-orb-relay", requestedBy: "schedule" });
   // The heavier sync/health jobs keep their ~30-minute cadence even though the cron now ticks every ~2 minutes.
   if (minute % 30 === 0) {
     jobs.push({ type: "backfill-registered-repos", requestedBy: "schedule", mode: isFullSyncWindow ? "full" : "light" });

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -82,6 +82,57 @@ export async function registerOrbRelay(env: Env, secret: string, relayUrl: strin
   return { ok: true, installationId: row.installation_id };
 }
 
+const RELAY_RETRY_MAX_ATTEMPTS = 5;
+
+/** Record a failed relay forward in the retry queue. Idempotent on delivery_id — a duplicate insert (e.g. from a
+ *  GitHub redelivery reaching the same event before the retry fires) is silently ignored. */
+export async function storeRelayFailure(
+  env: Env,
+  args: { deliveryId: string; eventName: string; installationId: number; rawBody: string },
+): Promise<void> {
+  await env.DB
+    .prepare(
+      "INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body) VALUES (?, ?, ?, ?) ON CONFLICT(delivery_id) DO NOTHING",
+    )
+    .bind(args.deliveryId, args.eventName, args.installationId, args.rawBody)
+    .run();
+}
+
+/** Re-attempt pending relay failures. Called by the `retry-orb-relay` cron job every sweep cycle (≈2 min).
+ *  Each row gets up to RELAY_RETRY_MAX_ATTEMPTS (5) retries within a 1-hour TTL; on success or expiry the row
+ *  is removed. Never throws — a bad DB row or a persistently-down container is silently dropped after exhaustion. */
+export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fetch }): Promise<void> {
+  // Prune rows whose TTL has elapsed or whose attempt budget is exhausted.
+  await env.DB
+    .prepare("DELETE FROM orb_relay_failures WHERE expires_at < datetime('now') OR attempts >= ?")
+    .bind(RELAY_RETRY_MAX_ATTEMPTS)
+    .run();
+  const { results } = await env.DB
+    .prepare(
+      "SELECT delivery_id, event_name, installation_id, raw_body FROM orb_relay_failures WHERE expires_at >= datetime('now') AND attempts < ?",
+    )
+    .bind(RELAY_RETRY_MAX_ATTEMPTS)
+    .all<{ delivery_id: string; event_name: string; installation_id: number; raw_body: string }>();
+  if (!results.length) return;
+  await Promise.all(
+    results.map(async (row) => {
+      const result = await forwardOrbEvent(
+        env,
+        { eventName: row.event_name, installationId: row.installation_id, deliveryId: row.delivery_id, rawBody: row.raw_body },
+        opts?.fetchImpl,
+      );
+      if (result === "forwarded" || result === "skipped") {
+        await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
+      } else {
+        await env.DB
+          .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
+          .bind(row.delivery_id)
+          .run();
+      }
+    }),
+  );
+}
+
 /** Forward a webhook event to the brokered self-host registered for this installation. BEST-EFFORT + fail-safe:
  *  a non-forwardable event, no registered relay, or ANY error returns without throwing (the Orb's webhook 202
  *  stands; reliability hardening — a retry queue for a down container — is a follow-up). The body is HMAC-signed

--- a/src/orb/webhook.ts
+++ b/src/orb/webhook.ts
@@ -12,7 +12,7 @@ import type { GitHubWebhookPayload } from "../types";
 import { sha256Hex, verifyGitHubSignature } from "../utils/crypto";
 import { upsertOrbInstallation } from "./installations";
 import { recordOrbPrOutcome } from "./outcomes";
-import { forwardOrbEvent } from "./relay";
+import { forwardOrbEvent, storeRelayFailure } from "./relay";
 
 const DEFAULT_MAX_ORB_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
@@ -80,7 +80,13 @@ export async function handleOrbWebhook(c: Context<{ Bindings: Env }>): Promise<R
   await recordOrbWebhookEvent(c.env, { ...eventMeta, status: "received" });
   // Forward the event to a brokered self-host registered for this installation (best-effort, fail-safe — a down
   // container never fails the 202; a non-forwardable event / no registered relay is a fast no-op).
-  await forwardOrbEvent(c.env, { eventName, installationId: payload.installation?.id, deliveryId, rawBody });
+  const installId = payload.installation?.id;
+  const relayResult = await forwardOrbEvent(c.env, { eventName, installationId: installId, deliveryId, rawBody });
+  // Persist failed deliveries so the retry-orb-relay cron can re-attempt them (containers that are temporarily
+  // down recover without losing events; max 5 attempts within a 1-hour TTL).
+  if (relayResult === "failed" && installId !== undefined) {
+    await storeRelayFailure(c.env, { deliveryId, eventName, installationId: installId, rawBody });
+  }
   return c.json({ ok: true, deliveryId, eventName, status: "received" }, 202);
 }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -198,6 +198,7 @@ import { isCloseHoldOnly, isHoldOnly, recordPrOutcome, recordReversalSignals, ru
 import { recordNativeGateDecision } from "../review/parity-wire";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
 import type { AdvisoryFinding, ContributorEvidenceRecord, ContributorRepoStatRecord, DetectedNotificationEvent, GitHubWebhookPayload, IssueRecord, JobMessage, JsonValue, PullRequestFilePathRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../types";
+import { retryFailedRelays } from "../orb/relay";
 import { sha256Hex } from "../utils/crypto";
 import { errorMessage, nowIso } from "../utils/json";
 
@@ -392,6 +393,13 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
     case "submit-draft":
       // Public OAuth draft-submission (GITTENSORY_REVIEW_DRAFT). No-ops internally when the flag is off.
       await processSubmitDraft(env, message.draftId);
+      return;
+    case "retry-orb-relay":
+      // Orb relay retry (#relay-retry): re-attempt events that failed to reach a brokered self-host container
+      // (container was temporarily down). Enqueued by the cron ONLY when ORB_BROKER_ENABLED is set; a stale
+      // in-flight job that arrives after the flag clears is still safe — retryFailedRelays fails open (no-op on
+      // an empty table). Never throws.
+      await retryFailedRelays(env);
       return;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,12 @@ export type JobMessage =
       type: "submit-draft";
       requestedBy: "api" | "test";
       draftId: string;
+    }
+  | {
+      // Orb relay retry (#relay-retry): re-attempt previously-failed forwardOrbEvent calls (container was down).
+      // Enqueued by the cron every sweep cycle (≈2 min) ONLY when ORB_BROKER_ENABLED is set.
+      type: "retry-orb-relay";
+      requestedBy: "schedule" | "test";
     };
 
 export type GitHubWebhookPayload = {

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { issueOrbEnrollment } from "../../src/orb/broker";
-import { forwardOrbEvent, registerOrbRelay, relaySignature, relayVerify } from "../../src/orb/relay";
+import { forwardOrbEvent, registerOrbRelay, relaySignature, relayVerify, retryFailedRelays, storeRelayFailure } from "../../src/orb/relay";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 
 const db = (e: Env) => e.DB as unknown as TestD1Database;
@@ -197,5 +197,80 @@ describe("POST /v1/orb/relay (brokered self-host receiver)", () => {
     const res = await app.request("/v1/orb/relay", { method: "POST", headers: { "x-github-event": "pull_request", "x-github-delivery": "rel-1", "x-orb-signature-256": await sign(PR_BODY) }, body: PR_BODY }, containerEnv());
     expect(res.status).toBe(202);
     expect(await res.json()).toMatchObject({ status: "queued", deliveryId: "rel-1", eventName: "pull_request" });
+  });
+});
+
+describe("storeRelayFailure", () => {
+  it("inserts a pending row; duplicate delivery_id is silently ignored (ON CONFLICT DO NOTHING)", async () => {
+    const e = brokeredEnv();
+    await storeRelayFailure(e, { deliveryId: "fail-1", eventName: "pull_request", installationId: 9001, rawBody: "{}" });
+    const row = await db(e).prepare("SELECT attempts, event_name FROM orb_relay_failures WHERE delivery_id='fail-1'").first<{ attempts: number; event_name: string }>();
+    expect(row?.attempts).toBe(0);
+    expect(row?.event_name).toBe("pull_request");
+    // Second call with same delivery_id must not throw or increment attempts.
+    await storeRelayFailure(e, { deliveryId: "fail-1", eventName: "pull_request", installationId: 9001, rawBody: "{}" });
+    const count = await db(e).prepare("SELECT COUNT(*) AS n FROM orb_relay_failures WHERE delivery_id='fail-1'").first<{ n: number }>();
+    expect(count?.n).toBe(1);
+  });
+});
+
+describe("retryFailedRelays", () => {
+  it("no-op on an empty table", async () => {
+    await expect(retryFailedRelays(brokeredEnv())).resolves.toBeUndefined();
+  });
+
+  it("DELETES a failure row when forwardOrbEvent forwards it successfully", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9100);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    await storeRelayFailure(e, { deliveryId: "retry-ok", eventName: "pull_request", installationId: 9100, rawBody: "{}" });
+    const fetchOk = (() => Promise.resolve(new Response("ok", { status: 200 }))) as typeof fetch;
+    await retryFailedRelays(e, { fetchImpl: fetchOk });
+    const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='retry-ok'").first();
+    expect(row ?? null).toBeNull(); // row removed on success
+  });
+
+  it("INCREMENTS attempts when forwardOrbEvent still fails", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9101);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    await storeRelayFailure(e, { deliveryId: "retry-fail", eventName: "pull_request", installationId: 9101, rawBody: "{}" });
+    const fetchFail = (() => Promise.resolve(new Response("bad", { status: 503 }))) as typeof fetch;
+    await retryFailedRelays(e, { fetchImpl: fetchFail });
+    const row = await db(e).prepare("SELECT attempts FROM orb_relay_failures WHERE delivery_id='retry-fail'").first<{ attempts: number }>();
+    expect(row?.attempts).toBe(1);
+  });
+
+  it("DELETES a row when forwardOrbEvent skips it (event no longer forwardable)", async () => {
+    const e = brokeredEnv();
+    // Store a failure for an event that was later removed from RELAY_FORWARD_EVENTS (e.g. check_run).
+    await storeRelayFailure(e, { deliveryId: "skip-1", eventName: "check_run", installationId: 9200, rawBody: "{}" });
+    // check_run is excluded from RELAY_FORWARD_EVENTS — forwardOrbEvent returns "skipped".
+    await retryFailedRelays(e, { fetchImpl: (() => Promise.resolve(new Response("ok"))) as typeof fetch });
+    const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='skip-1'").first();
+    expect(row ?? null).toBeNull(); // skipped = no longer applicable → cleaned up
+  });
+
+  it("PRUNES rows that have exhausted their attempt budget (attempts >= 5)", async () => {
+    const e = brokeredEnv();
+    // Manually insert a row at the attempt ceiling.
+    await db(e).prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, attempts) VALUES (?, ?, ?, ?, ?)").bind("exhausted-1", "pull_request", 9300, "{}", 5).run();
+    await retryFailedRelays(e);
+    const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='exhausted-1'").first();
+    expect(row ?? null).toBeNull(); // pruned on the DELETE pass before the SELECT
+  });
+
+  it("PRUNES expired rows (expires_at in the past) without attempting to forward", async () => {
+    const e = brokeredEnv();
+    await db(e)
+      .prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, expires_at) VALUES (?, ?, ?, ?, datetime('now', '-1 second'))")
+      .bind("expired-1", "pull_request", 9400, "{}")
+      .run();
+    let fetchCalled = false;
+    const fetchSpy = (() => { fetchCalled = true; return Promise.resolve(new Response("ok")); }) as typeof fetch;
+    await retryFailedRelays(e, { fetchImpl: fetchSpy });
+    expect(fetchCalled).toBe(false); // expired row deleted before SELECT — fetch was never called
+    const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='expired-1'").first();
+    expect(row ?? null).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

When `forwardOrbEvent` fails to reach a brokered self-host container (e.g. it is temporarily unreachable or returning a non-2xx response), the delivery was previously dropped silently. This adds a retry queue so transient failures recover automatically.

**What ships:**

- **Migration 0070** — `orb_relay_failures` table (delivery_id PK, event_name, installation_id, raw_body, attempts, last_attempt_at, created_at, expires_at)
- **`storeRelayFailure`** — idempotent insert (ON CONFLICT DO NOTHING); called from `handleOrbWebhook` when `forwardOrbEvent` returns `"failed"` and the installation_id is known
- **`retryFailedRelays`** — periodic retry worker: deletes rows on success or skip, increments `attempts` on continued failure; prunes rows that have exhausted 5 attempts or exceeded a 1-hour TTL
- **`retry-orb-relay` job type** — added to `src/types.ts` and `src/queue/processors.ts`
- **Cron wiring** — `src/index.ts` enqueues `retry-orb-relay` every sweep cycle (≈2 min) **only when `ORB_BROKER_ENABLED` is set** — the Cloudflare Worker deploy is byte-identical until the broker flag is turned on

**Boundary decisions:**

- Only `"failed"` returns from `forwardOrbEvent` are stored — `"skipped"` events (non-forwardable type, no registered relay) are fast no-ops that don't need retrying
- `retryFailedRelays` never throws; a persistently-down container burns its attempt budget and the row is pruned cleanly
- At-most-5-retries × ≈2-min cadence = up to ~10 min of recovery window before the delivery is abandoned (events older than 1 hour are also pruned regardless of attempt count)
- On retry, `"skipped"` now also deletes the row — if a container deregisters its relay URL between the initial failure and the retry, the failure is cleaned up rather than exhausting attempts

## Scope

- [x] Self-host / Orb / broker path
- [ ] New public API or changed API signature
- [x] DB schema / migration (0070_orb_relay_failures.sql)
- [ ] Auth / session / CORS path
- [ ] UI change
- [ ] Docs change

## Validation

- `npx vitest run test/integration/orb-relay.test.ts` — 26 tests (19 existing + 7 new), all pass
- `npx vitest run test/integration/orb-webhook.test.ts` — 17 tests, all pass
- `npm run test:ci` — exit 0, full gate green

## Safety

- No secrets, tokens, wallets, hotkeys, trust scores, or reward values introduced
- No auth/CORS changes; no public API surface changed
- Self-host only; Cloudflare Worker deploy is byte-identical when `ORB_BROKER_ENABLED` is unset
- `storeRelayFailure` stores the raw webhook body in `raw_body` (same data already stored in `orb_webhook_events.payload_hash`); no new sensitive data is persisted