### PR TITLE
fix(signals): redact plural economic and identity terms

### DIFF
--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -12,12 +12,15 @@
 // flags, no `\b` anchors), so a surface that redacts/gates with these terms can compose from one source
 // instead of re-typing the list and drifting. `pr-body-draft.ts` builds its scrubber + final guard from it.
 //
+// The pluralizable signal nouns share one trailing `\w*`: callers wrap this in `\b(…)\b`, where a bare
+// term's closing boundary would land before its "s" and leak the plural ("wallets", "payouts").
+//
 // NOTE: two other public surfaces — `agent-action-explanation-card.ts` and `miner-dashboard-recommendations.ts`
 // — keep their own context-specific, phrase-tuned vocabularies (they redact whole phrases like "public score
 // estimate" and extra terms like "seed phrase"/"private key" for cleaner output, and deliberately do not
 // redact a bare "score"/"reward"). Those are curated for their surface, not drift of this core, so they are
 // intentionally NOT collapsed onto `PUBLIC_UNSAFE_TERMS`.
-export const PUBLIC_UNSAFE_TERMS = String.raw`reward\w*|score\w*|wallet|hotkey|coldkey|mnemonic|farming|payout|ranking|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
+export const PUBLIC_UNSAFE_TERMS = String.raw`(?:reward|score|wallet|hotkey|coldkey|mnemonic|payout|ranking)\w*|farming|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
 
 export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
 

--- a/test/unit/redaction.test.ts
+++ b/test/unit/redaction.test.ts
@@ -29,6 +29,12 @@ describe("isPublicSafeText (#542 shared public/private boundary)", () => {
     }
   });
 
+  it("rejects plural economic / identity signals (the closing \\b must not let the 's' slip past a bare term)", () => {
+    for (const text of ["your wallets here", "hotkeys", "coldkeys", "mnemonics", "payouts", "rankings"]) {
+      expect(isPublicSafeText(text)).toBe(false);
+    }
+  });
+
   it("rejects local filesystem paths (posix and Windows)", () => {
     expect(isPublicSafeText("/Users/alice/project")).toBe(false);
     expect(isPublicSafeText("/home/bob/repo")).toBe(false);


### PR DESCRIPTION
## Summary

- `PUBLIC_UNSAFE_TERMS` is the canonical public/private boundary behind `isPublicSafeText`, yet several singular nouns (`wallet`, `hotkey`, `coldkey`, `mnemonic`, `payout`, `ranking`) carried no wildcard suffix. Callers wrap the alternation in `\b(...)\b`, so the closing boundary landed before a trailing "s" and plural forms passed as public safe: `isPublicSafeText("your wallets here")`, `"hotkeys"`, `"coldkeys"`, `"payouts"`, `"rankings"`, and `"mnemonics"` all returned `true`. Every surface that gates on this primitive (PR and issue comments, check annotations, notifications, badge, extension payloads, slop and advisory reasons) could leak those plural tokens.
- The fix groups the pluralizable signal nouns under one shared `\w*`, matching the existing `reward\w*` and `score\w*` and the plural handling already present in the parallel `sanitizePublicComment`. `pr-body-draft.ts` builds its scrubber and final guard from the same constant, so all public surfaces tighten from this single change.
- A focused regression test pins the six newly covered plurals; coverage on the changed file stays at 100% of lines and branches.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches one backend file (`src/signals/redaction.ts`) plus its unit test, with no UI, MCP, OpenAPI, worker, or migration surface. The unchecked steps run as part of `npm run test:ci` and pass green before push; they are listed here for completeness.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable. This is a backend redaction fix with no visible UI, frontend, docs, or extension change.

## Notes

- The grouped form `(?:reward|score|wallet|hotkey|coldkey|mnemonic|payout|ranking)\w*` is exactly equivalent to repeating `\w*` per term, verified across the issue examples, singulars, filesystem paths, and the existing test corpus. No caller depends on capture groups (each uses `.test()` or a literal replacement), so grouping the terms is safe.
- `farming`, `raw[-_\s]?trust`, `trust[-_\s]?score`, and `reviewability` keep no suffix on purpose: "trust scores" is already caught by `score\w*`, and the rest have no plural that leaks.
- The Safety boxes left unchecked are not applicable, since this PR changes no auth, session, CORS, API, MCP, or UI surface.
