### PR TITLE
feat(selfhost): pin Claude review model and add AI_EFFORT dial

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,7 +97,7 @@ and only the AI **summary** degrades to "unavailable". To enable AI, set `AI_PRO
 | --- | --- | --- |
 | `ollama` / `openai-compatible` / `openai` | any OpenAI-compatible `/chat/completions` endpoint (Ollama, OpenAI, Groq, Together, OpenRouter, vLLM, Gemini's OpenAI-compat endpoint, …) | `AI_BASE_URL`, `AI_API_KEY` (or `OPENAI_API_KEY`), `AI_MODEL` |
 | `anthropic` | **native Anthropic Messages API** (BYOK — bills your API key) | `ANTHROPIC_API_KEY`, `AI_MODEL` (e.g. `claude-sonnet-4-6`) |
-| `claude-code` | your **Claude** subscription via the `claude` CLI (read-only, headless) | `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), `AI_MODEL` (e.g. `sonnet`) |
+| `claude-code` | your **Claude** subscription via the `claude` CLI (read-only, headless) | `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), `AI_MODEL` (default `claude-sonnet-4-6`), `AI_EFFORT` (default `high`) |
 | `codex` | your **Codex** subscription via the `codex` CLI | local `codex` auth, `AI_MODEL` (e.g. `gpt-5`) |
 
 **Fallback chain.** `AI_PROVIDER` accepts a comma-separated list and tries each in order until one succeeds —
@@ -124,7 +124,10 @@ bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. N
 - **Claude Code:** set `CLAUDE_CODE_OAUTH_TOKEN` (a 1-year token from `claude setup-token`, run once in a real
   terminal — it's browser-interactive and prints the token; it has no headless mode). The provider forces the
   subscription token (it scrubs `ANTHROPIC_API_KEY`), so an API key won't be used here — use `AI_PROVIDER=anthropic`
-  for API-key billing.
+  for API-key billing. The model defaults to `claude-sonnet-4-6` and the reasoning **effort** to `high` (a
+  substantive review, not a fast shallow one); override with `AI_MODEL` (any `claude`-CLI model id or alias —
+  `sonnet`, `opus`, `claude-opus-4-8`, …) and `AI_EFFORT` (`low`|`medium`|`high`|`xhigh`|`max`; the CLI clamps a
+  level above the model's own ceiling).
 - **Codex:** codex reads `auth.json` from `$CODEX_HOME` (default `~/.codex`) and **must have a WRITABLE home** — it
   refreshes the token in place, so a read-only mount fails with *"Read-only file system"*. Set `CODEX_HOME` to a
   writable path and **copy** your `~/.codex/auth.json` there (don't bind-mount it read-only). With a ChatGPT-

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -37,11 +37,13 @@ declare global {
     AI_GATEWAY_ID?: string;
     /** Self-host AI provider selection + dual-review config (#dual-ai-combiner). `AI_PROVIDER` is a comma list of
      *  providers (claude-code, codex, anthropic, ollama, …); `AI_COMBINE` picks single|consensus|synthesis (default
-     *  synthesis for two); `AI_ON_MERGE` is the synthesis rule either|both. `AI_REVIEW_PLAN` is the resolved plan
+     *  synthesis for two); `AI_ON_MERGE` is the synthesis rule either|both. `AI_EFFORT` is the Claude Code
+     *  intelligence dial (low|medium|high|xhigh|max, default high). `AI_REVIEW_PLAN` is the resolved plan
      *  (computed from these at boot in server.ts and read at the review call site); undefined on cloud. */
     AI_PROVIDER?: string;
     AI_COMBINE?: string;
     AI_ON_MERGE?: string;
+    AI_EFFORT?: string;
     AI_REVIEW_PLAN?: { reviewers: Array<{ model: string }>; combine: import("./services/ai-review").CombineStrategy; onMerge?: import("./services/ai-review").OnMerge | undefined };
     ADMIN_GITHUB_LOGINS?: string;
     GITHUB_WEBHOOK_SECRET: string;

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -40,6 +40,16 @@ function configuredModel(env: Record<string, string | undefined>): string | unde
   return env.AI_MODEL ?? env.WORKERS_AI_SUMMARY_MODEL;
 }
 
+const VALID_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
+/** Map `AI_EFFORT` (the operator's intelligence dial) to a `claude --effort` level. Defaults to "high" — the
+ *  engine wants a substantive review, not a fast shallow one — and falls back to "high" for any unset or
+ *  unrecognized value so a typo can't silently downgrade reviews. The CLI clamps a level above the model's
+ *  own ceiling (e.g. xhigh on Sonnet) down on its own. */
+export function resolveEffort(configured: string | undefined): string {
+  const level = (configured ?? "").trim().toLowerCase();
+  return VALID_EFFORTS.has(level) ? level : "high";
+}
+
 /** OpenAI-compatible endpoint (Ollama's /v1, OpenAI, vLLM, LM Studio, …) — chat + embeddings. */
 export function createOpenAiCompatibleAi(opts: { baseUrl: string; apiKey?: string | undefined; model?: string | undefined; embedModel?: string | undefined }): SelfHostAi {
   const base = opts.baseUrl.replace(/\/+$/, "");
@@ -194,8 +204,9 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
       env.CLAUDE_CODE_OAUTH_TOKEN = token;
       const prompt = toMessages(options).map((m) => m.content).join("\n\n");
       const spawn = spawnImpl ?? (await defaultSpawn());
-      const claudeModel = resolveModel(configuredModel(parentEnv), model, "sonnet");
-      const { stdout, code } = await spawn("claude", ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "plan", "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"], { env, input: prompt, timeoutMs: 120_000 });
+      const claudeModel = resolveModel(configuredModel(parentEnv), model, "claude-sonnet-4-6");
+      const effort = resolveEffort(parentEnv.AI_EFFORT);
+      const { stdout, code } = await spawn("claude", ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "plan", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"], { env, input: prompt, timeoutMs: 120_000 });
       if (code !== 0) throw new Error(`claude_code_exit_${code ?? "null"}`);
       const errStatus = claudeErrorStatus(stdout);
       if (errStatus) throw new Error(`claude_code_error_${errStatus}`);

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveAiReviewerPlan, resolveModel, resolveProviderNames, routeProviders } from "../../src/selfhost/ai";
+import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveAiReviewerPlan, resolveEffort, resolveModel, resolveProviderNames, routeProviders } from "../../src/selfhost/ai";
 
 describe("resolveModel (#979 — never leak the Workers-AI default to a self-host backend)", () => {
   const WORKERS_DEFAULT = "@cf/meta/llama-3.1-8b-instruct-fp8-fast";
@@ -14,6 +14,19 @@ describe("resolveModel (#979 — never leak the Workers-AI default to a self-hos
   });
   it("passes through a real model the core supplied", () => {
     expect(resolveModel(undefined, "gpt-4o", "sonnet")).toBe("gpt-4o");
+  });
+});
+
+describe("resolveEffort (#selfhost-effort — Claude Code intelligence dial, default high)", () => {
+  it("passes a valid level through, trimmed + lowercased", () => {
+    expect(resolveEffort("low")).toBe("low");
+    expect(resolveEffort("  Medium ")).toBe("medium");
+    expect(resolveEffort("MAX")).toBe("max");
+  });
+  it("defaults to high when unset or unrecognized so a typo can't downgrade reviews", () => {
+    expect(resolveEffort(undefined)).toBe("high"); // ?? right side
+    expect(resolveEffort("")).toBe("high"); // present but not in the valid set
+    expect(resolveEffort("ultra")).toBe("high"); // unrecognized → safe default
   });
 });
 
@@ -294,6 +307,22 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(out.response).toBe("review text");
     expect(capturedEnv.ANTHROPIC_API_KEY).toBeUndefined(); // scrubbed
     expect(capturedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe("t");
+  });
+
+  it("Claude Code pins the default model (claude-sonnet-4-6) + --effort high; AI_MODEL/AI_EFFORT override", async () => {
+    let seen: string[] = [];
+    const cap: StubSpawn = async (_c, a) => {
+      seen = a;
+      return { stdout: JSON.stringify({ type: "result", result: "ok" }), code: 0 };
+    };
+    // empty model id (the dual-router default) + no AI_MODEL → pinned claude-sonnet-4-6; no AI_EFFORT → high
+    await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, cap).run("", { prompt: "x" });
+    expect(seen[seen.indexOf("--model") + 1]).toBe("claude-sonnet-4-6");
+    expect(seen[seen.indexOf("--effort") + 1]).toBe("high");
+    // operator overrides flow through to the argv
+    await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t", AI_MODEL: "claude-opus-4-8", AI_EFFORT: "low" }, cap).run("", { prompt: "x" });
+    expect(seen[seen.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+    expect(seen[seen.indexOf("--effort") + 1]).toBe("low");
   });
 
   it("Codex: 0.142+ exec flags (no --ask-for-approval, has --skip-git-repo-check); --model only when configured", async () => {


### PR DESCRIPTION
## Summary

The self-host Claude Code reviewer was invoked with a bare `sonnet` alias and **no reasoning-effort flag at all** — so reviews ran at the model's lowest thinking budget and read as shallow/advisory. This pins the default and adds an operator intelligence dial.

- **Pin the default model** to `claude-sonnet-4-6` (was the bare `sonnet` alias, a moving target) in `createClaudeCodeAi` — deterministic across CLI/model updates.
- **Add `AI_EFFORT`** — a new `resolveEffort()` maps an operator dial (`low|medium|high|xhigh|max`) to `claude --effort`, **defaulting to `high`** and falling back to `high` for any unset/unrecognized value so a typo can't silently downgrade a review. The CLI clamps a level above the model's own ceiling.
- Both remain per-operator overridable via `AI_MODEL` / `AI_EFFORT`. The `--effort` flag is verified present in the installed `claude` CLI (v2.1.169).

No issue linked — small, self-evident self-host review-quality fix surfaced while bringing the brokered self-host online.

## Scope
- `src/selfhost/ai.ts` — `resolveEffort()` + pinned default + `--effort` in the argv
- `src/env.d.ts` — document `AI_EFFORT`
- `docs/self-hosting.md` — `AI_EFFORT` + default-model docs
- `test/unit/selfhost-ai.test.ts` — `resolveEffort` branch coverage + argv assertions

## Validation
- `npm run test:ci` — green (typecheck, coverage, workers, mcp, ui:*)
- `npx vitest run test/unit/selfhost-ai.test.ts` — 48 passed; `ai.ts` patch lines 100% covered (both `??` arms + both `has` arms of `resolveEffort`, default + override argv)

## Safety
- No secrets/tokens/wallets/scores. Backend + docs only; no API/schema/binding/migration change, so no `ui:openapi`/`cf-typegen`/migration regen needed.
- Child-env billable-key scrubbing is unchanged.