### PR TITLE
fix(review): enforce surface lane gate verdicts

### DIFF
--- a/src/review/content-lane-wire.ts
+++ b/src/review/content-lane-wire.ts
@@ -63,16 +63,16 @@ export function surfaceVerdictToGate(result: SurfaceReviewResult): {
   return { evaluation: { enabled: true, conclusion: "failure", title: SURFACE_TITLE, summary, blockers: [finding], warnings: [] }, finding };
 }
 
-/** Merge the surface override onto the generic gate while PRESERVING the generic gate's hard blockers. A surface
- *  "merge" must NOT clear a real critical (e.g. a committed secret) the generic gate already raised — so when the
- *  generic gate carries blockers, they survive and the conclusion stays a failure. `null` surface ⇒ defer (the
- *  generic gate is returned unchanged). PURE. */
+/** Merge the surface override onto the generic gate while PRESERVING generic holds/blockers. A surface "merge"
+ *  must NOT clear either a real critical (e.g. a committed secret) or a deliberate generic neutral/action-required
+ *  hold (e.g. first-contribution grace). `null` surface ⇒ defer (the generic gate is returned unchanged). PURE. */
 export function applySurfaceGate(
   generic: GateCheckEvaluation | undefined,
   surface: GateCheckEvaluation | null,
 ): GateCheckEvaluation | undefined {
   if (surface === null) return generic;
-  if (!generic || generic.blockers.length === 0) return surface; // gate off, or generic was clean → surface stands
+  if (!generic || generic.conclusion === "success") return surface; // gate off, or generic was clean → surface stands
+  if (generic.blockers.length === 0) return surface.conclusion === "success" ? generic : surface; // preserve generic holds
   return {
     enabled: true,
     conclusion: "failure",

--- a/test/unit/content-lane-wire.test.ts
+++ b/test/unit/content-lane-wire.test.ts
@@ -78,6 +78,15 @@ describe("applySurfaceGate", () => {
     expect(out?.conclusion).toBe("failure"); // the secret still blocks the merge
     expect(out?.blockers).toEqual([secret]); // the generic blocker survives the override
   });
+  it("preserves a generic neutral hold over a surface merge", () => {
+    const generic = gate({ conclusion: "neutral", title: "First-contribution grace", blockers: [], warnings: [] });
+    const surfaceMerge = gate({ conclusion: "success", title: "Surface", summary: "valid entry" });
+    expect(applySurfaceGate(generic, surfaceMerge)).toBe(generic);
+  });
+  it("lets a surface rejection override a generic neutral hold", () => {
+    const generic = gate({ conclusion: "neutral", title: "First-contribution grace", blockers: [], warnings: [] });
+    expect(applySurfaceGate(generic, surfaceClose)).toBe(surfaceClose);
+  });
 });
 
 describe("runMetagraphedSurfaceGate (injected loader — adapter logic)", () => {


### PR DESCRIPTION
### Motivation
- The deterministic content/registry surface lane computed an authoritative `GateCheckEvaluation` but the published GitHub Gate check was being recomputed from `advisory` + `policy`, which could drop the surface-lane override and display a green Gate despite a surface `failure`/`action_required` verdict.
- `applySurfaceGate` treated a generic evaluation with an empty `blockers` array as permissive, which could convert deliberate generic `neutral`/hold states (e.g. first-time-contributor grace) into `success` when a surface lane returned `merge`.

### Description
- Allow `createOrUpdateGateCheckRun` to accept an optional `gateEvaluation` and prefer it over recomputing the gate from `advisory`/`policy` so the finalized surface-lane verdict is published intact (`src/github/app.ts`).
- Thread the finalized `gateEvaluation` from the processor into the Gate completion call so the published check run matches the already-overridden evaluation (`src/queue/processors.ts`).
- Adjust `applySurfaceGate` so generic `neutral`/`action_required` holds are preserved when the surface lane returns `success`, while still preserving generic hard blockers and allowing surface `failure` to enforce a blocking conclusion (`src/review/content-lane-wire.ts`).
- Add unit tests that assert (1) a supplied `gateEvaluation` is published instead of being recomputed and (2) a generic neutral hold is preserved over a surface `merge`, and that surface rejections still override neutral holds (`test/unit/github-app.test.ts`, `test/unit/content-lane-wire.test.ts`).
- Add the required `type` import and small test/fixture adjustments to cover the new paths.

### Testing
- Ran targeted unit tests: `npx vitest run test/unit/content-lane-wire.test.ts test/unit/github-app.test.ts`, all tests in those files passed.
- Type-check succeeded with `tsc --noEmit`.
- Attempted full CI/local coverage with `npm run test:coverage` / `npm run test:ci`, but coverage finalization in this environment failed due to an unrelated tooling/runtime issue (`TypeError: jsTokens is not a function`) during coverage remapping; this is an environment/tooling failure and not a regression in the changes here.
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry audit endpoint returning `403 Forbidden` (external to the code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d052e3474832cb014a4bbeac34e48)