### PR TITLE
fix(orb): validate ORB_BROKER_URL to prevent enrollment-secret leakage

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -11,6 +11,31 @@
 const DEFAULT_BROKER_URL = "https://gittensory-api.aethereal.dev";
 const BROKER_TIMEOUT_MS = 10_000;
 
+function isLocalBrokerHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || (hostname === "::1" || hostname === "[::1]");
+}
+
+function orbBrokerBaseUrl(env: { ORB_BROKER_URL?: string | undefined }): string {
+  const raw = env.ORB_BROKER_URL ?? DEFAULT_BROKER_URL;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("ORB_BROKER_URL must be a valid URL.");
+  }
+  if (url.username || url.password) {
+    throw new Error("ORB_BROKER_URL must not include userinfo.");
+  }
+  if (url.search || url.hash) {
+    throw new Error("ORB_BROKER_URL must not include a query string or fragment.");
+  }
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalBrokerHost(url.hostname))) {
+    throw new Error("ORB_BROKER_URL must use https unless it targets localhost development.");
+  }
+  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${path}`;
+}
+
 /** True when GitHub tokens should be sourced from the central Orb broker (a brokered self-host) rather than minted
  *  locally from an App key — i.e. an enrollment secret is configured. Cloud never sets it ⇒ false there. */
 export function isOrbBrokerMode(env: { ORB_ENROLLMENT_SECRET?: string | undefined }): boolean {
@@ -27,7 +52,7 @@ export async function fetchBrokeredInstallationToken(
   env: { ORB_ENROLLMENT_SECRET?: string | undefined; ORB_BROKER_URL?: string | undefined },
   fetchImpl: typeof fetch = fetch,
 ): Promise<BrokeredInstallationToken> {
-  const base = (env.ORB_BROKER_URL ?? DEFAULT_BROKER_URL).replace(/\/+$/, "");
+  const base = orbBrokerBaseUrl(env);
   const response = await fetchImpl(`${base}/v1/orb/token`, {
     method: "POST",
     headers: { authorization: `Bearer ${env.ORB_ENROLLMENT_SECRET ?? ""}` },
@@ -54,9 +79,9 @@ export async function registerOrbRelayTarget(
   fetchImpl: typeof fetch = fetch,
 ): Promise<"registered" | "skipped" | "failed"> {
   if (!isOrbBrokerMode(env) || !env.PUBLIC_API_ORIGIN) return "skipped";
-  const base = (env.ORB_BROKER_URL ?? DEFAULT_BROKER_URL).replace(/\/+$/, "");
   const relayUrl = `${env.PUBLIC_API_ORIGIN.replace(/\/+$/, "")}/v1/orb/relay`;
   try {
+    const base = orbBrokerBaseUrl(env);
     const res = await fetchImpl(`${base}/v1/orb/relay/register`, {
       method: "POST",
       headers: { authorization: `Bearer ${env.ORB_ENROLLMENT_SECRET}`, "content-type": "application/json" }, // present — isOrbBrokerMode required it

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -43,6 +43,38 @@ describe("fetchBrokeredInstallationToken", () => {
     expect((calls[0]?.init?.headers as Record<string, string>).authorization).toBe("Bearer ");
   });
 
+  it("rejects broker URLs that would send the enrollment secret to unsafe origins", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("fetch should not be called for an unsafe broker URL");
+    }) as typeof fetch;
+
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://broker.example" }, fetchImpl)).rejects.toThrow(/must use https/);
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "https://user:pass@broker.example" }, fetchImpl)).rejects.toThrow(/userinfo/);
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "https://:pass@broker.example" }, fetchImpl)).rejects.toThrow(/userinfo/);
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "https://broker.example?redirect=evil" }, fetchImpl)).rejects.toThrow(/query string or fragment/);
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "https://broker.example#token" }, fetchImpl)).rejects.toThrow(/query string or fragment/);
+    await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "not a url" }, fetchImpl)).rejects.toThrow(/valid URL/);
+  });
+
+  it("allows explicit localhost HTTP broker URLs for development only", async () => {
+    const calls: { url: string; init?: RequestInit | undefined }[] = [];
+    const fetchImpl = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return Response.json({ token: "ghs_local" });
+    }) as typeof fetch;
+
+    await fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://127.0.0.1:8787" }, fetchImpl);
+    await fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://[::1]:8787" }, fetchImpl);
+    const out = await fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://localhost:8787/orb/" }, fetchImpl);
+
+    expect(out.token).toBe("ghs_local");
+    expect(calls.map((call) => call.url)).toEqual([
+      "http://127.0.0.1:8787/v1/orb/token",
+      "http://[::1]:8787/v1/orb/token",
+      "http://localhost:8787/orb/v1/orb/token",
+    ]);
+  });
+
   it("throws on a non-OK broker response (e.g. 403 installation_not_eligible)", async () => {
     const fetchImpl = (async () => new Response("nope", { status: 403 })) as typeof fetch;
     await expect(fetchBrokeredInstallationToken({ ORB_ENROLLMENT_SECRET: "s" }, fetchImpl)).rejects.toThrow(/403/);
@@ -72,6 +104,14 @@ describe("registerOrbRelayTarget", () => {
     const { fetchImpl, calls } = captureFetch(new Response("ok"));
     await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" }, fetchImpl);
     expect(calls[0]?.url).toBe("https://gittensory-api.aethereal.dev/v1/orb/relay/register");
+  });
+
+  it("fails closed without registering when the broker URL is unsafe", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("fetch should not be called for an unsafe broker URL");
+    }) as typeof fetch;
+
+    await expect(registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example", ORB_BROKER_URL: "http://broker.example" }, fetchImpl)).resolves.toBe("failed");
   });
 
   it("returns failed on a non-ok response or a thrown fetch (never blocks boot)", async () => {


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of the long-lived ORB_ENROLLMENT_SECRET when an operator overrides `ORB_BROKER_URL` with an unsafe destination.
- Enforce a fail-closed policy: require valid URLs, reject userinfo/query/fragment, and require `https:` except for explicit localhost development hosts.

### Description
- Add `orbBrokerBaseUrl()` which parses `ORB_BROKER_URL`, rejects invalid URLs, userinfo, query/fragment, and disallows plaintext `http:` except for `localhost`, `127.0.0.1`, and `[::1]` development hosts.
- Replace raw string normalization with `orbBrokerBaseUrl()` in `fetchBrokeredInstallationToken` and `registerOrbRelayTarget` so the enrollment secret is never sent to an unvalidated origin.
- Add unit tests in `test/unit/orb-broker-client.test.ts` covering unsafe URL errors (invalid URL, userinfo, query/fragment, non-HTTPS), localhost HTTP allowance, and relay-registration fail-closed behavior.
- Small host handling tweak to accept IPv6 loopback string form for localhost development (`[::1]`).

### Testing
- Ran unit tests with `npx vitest run test/unit/orb-broker-client.test.ts test/unit/github-app.test.ts` and observed both test files pass (39 tests passed).
- Ran static checks with `npm run typecheck` and `git diff --check`, both of which succeeded locally and showed no type or diff issues.
- Ran repository-wide coverage (`npm run test:coverage`) which started but failed during coverage remapping due to an upstream dependency mismatch (`TypeError: jsTokens is not a function`) unrelated to the PR logic; `vitest` unit runs themselves passed.
- Attempted `npm audit`/`npm ci` which hit registry access errors in this environment (403), so dependency-audit and full CI audit steps could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db6e247b0832c9eab8b1aa3513c2b)