### PR TITLE
fix(selfhost): sandbox optional AI CLI install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ ENV NODE_ENV=production \
     PLATFORM=self-hosted \
     PORT=8787 \
     DATABASE_PATH=/data/gittensory.sqlite \
-    MIGRATIONS_DIR=/app/migrations
+    MIGRATIONS_DIR=/app/migrations \
+    NPM_CONFIG_PREFIX=/home/node/.npm-global \
+    PATH=/home/node/.npm-global/bin:$PATH
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/migrations ./migrations
 # Optional: bake the Claude Code / Codex CLIs so the `claude-code` / `codex` subscription providers (#979)
@@ -33,10 +35,13 @@ ARG INSTALL_AI_CLIS=false
 # codex's native (Rust) binary loads the SYSTEM CA trust store (rustls-native-certs); node:slim ships none, so the
 # `codex` provider fails every call with "no native root CA certificates found" without ca-certificates.
 RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*; fi
-# NB: NO --ignore-scripts here. claude-code's postinstall downloads its platform-native binary; skipping it makes
-# `claude` fail at runtime with "native binary not installed". These are trusted first-party CLIs, so their
-# install scripts are allowed to run.
+# claude-code's postinstall downloads its platform-native binary, so scripts must run. Install the optional
+# CLIs as the unprivileged user into a user-owned prefix while /app is still root-owned, keeping lifecycle
+# hooks from mutating the already-copied application bundle during the image build.
+RUN mkdir -p /home/node/.npm-global /home/node/.npm && chown -R node:node /home/node/.npm-global /home/node/.npm
+USER node
 RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g @anthropic-ai/claude-code@2.1.187 @openai/codex@0.142.0; fi
+USER root
 # Optional: enable visual review via an external Chrome sidecar (e.g. `browserless/chrome:latest`).
 # Build with `--build-arg INSTALL_VISUAL_REVIEW=true` then set BROWSER_WS_ENDPOINT=<ws-url> at runtime.
 ARG INSTALL_VISUAL_REVIEW=false


### PR DESCRIPTION
### Motivation
- The Dockerfile previously ran an optional global `npm install -g` for AI CLIs as root after copying the application bundle, which allows npm lifecycle scripts to execute as root and potentially mutate `/app` during image build, creating a supply-chain risk.
- The change aims to preserve the in-image convenience of installing the CLIs while removing the ability for their lifecycle hooks to modify the already-copied application bundle as root.

### Description
- Modified `Dockerfile` to set a user-owned npm prefix via `NPM_CONFIG_PREFIX=/home/node/.npm-global` and add it to `PATH` so global installs can be performed without root-owned global state.
- Create and `chown` `/home/node/.npm-global` and `/home/node/.npm`, switch to `USER node` to run the optional `npm install -g @anthropic-ai/claude-code ... @openai/codex ...` so lifecycle scripts run as the unprivileged user and cannot mutate `/app` during build, then restore `USER root` to continue remaining build steps unchanged.
- Kept the application bundle copy behavior the same (copy `dist` and `migrations` from build stage) and preserved the final `USER node` at runtime and the data-dir ownership setup.
- Change is limited to `Dockerfile` and does not modify application code or tests.

### Testing
- `git diff --check` succeeded locally.
- `npm run test:ci` started and progressed through `actionlint` (fell back to WASM setup due to network), `db:migrations:check` (72 migrations OK), and `typecheck` successfully, then reached `test:coverage` which hung in this environment and was interrupted, so the full gate did not complete here.
- `npm audit --audit-level=moderate` failed in this environment due to the npm registry audit endpoint returning `403 Forbidden` (environmental limitation), and Docker was unavailable for a local image build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db6e38f0c832ca17d10c5173753b7)