### PR TITLE
fix(mcp): restore the stale compatibility status for supported-but-behind clients

### DIFF
--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -59,7 +59,10 @@ export function classifyMcpClientVersion(version: string | null | undefined): Mc
   const minimumComparison = compareMcpSemver(version, MINIMUM_SUPPORTED_MCP_VERSION);
   if (minimumComparison === null) return "unknown";
   if (minimumComparison < 0) return "incompatible";
-  return "current";
+  // A version at/above the minimum but below the latest recommended is supported-but-behind → "stale".
+  // (The flat "current" was correct only while MINIMUM === LATEST_RECOMMENDED; #745 reopened the gap.)
+  const latestComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION)!;
+  return latestComparison < 0 ? "stale" : "current";
 }
 
 function parseSemver(version: string) {

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -8,7 +8,12 @@ describe("MCP compatibility telemetry", () => {
     expect(classifyMcpClientVersion("0.2.1")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.3.0")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.4.0")).toBe("incompatible");
-    expect(classifyMcpClientVersion("0.5.0")).toBe("current");
+    // >= minimum (0.5.0) but < latest recommended (0.6.0) → supported-but-behind → "stale".
+    expect(classifyMcpClientVersion("0.5.0")).toBe("stale");
+    expect(classifyMcpClientVersion("0.5.9")).toBe("stale");
+    // At/above the latest recommended → "current".
+    expect(classifyMcpClientVersion("0.6.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.7.1")).toBe("current");
     expect(classifyMcpClientVersion("not-a-version")).toBe("unknown");
     expect(classifyMcpClientVersion(undefined)).toBe("unknown");
   });
@@ -50,7 +55,7 @@ describe("MCP compatibility telemetry", () => {
       clientVersion: "0.5.0",
       metadata: {
         packageName: "@example/custom-mcp",
-        compatibilityStatus: "current",
+        compatibilityStatus: "stale",
       },
     });
   });

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -57,7 +57,7 @@ describe("MCP server telemetry", () => {
         clientVersion: "0.5.0",
         metadata: expect.objectContaining({
           toolName: "gittensory_local_status",
-          compatibilityStatus: "current",
+          compatibilityStatus: "stale",
         }),
       }),
     ]);


### PR DESCRIPTION
## What & why

`classifyMcpClientVersion` can return `"stale"`, and `LATEST_RECOMMENDED_MCP_VERSION`
(0.6.0) exists precisely to mark a client that is **at/above the minimum (0.5.0) but
behind the latest recommended**. That arm was lost in the 0.4.0 release (#265), which
collapsed the classifier to a flat `"current"`. That was only safe because #265 also set
`MINIMUM_SUPPORTED === LATEST_RECOMMENDED`, so the `[minimum, latest)` stale band was
empty and unreachable.

#745 later bumped `LATEST_RECOMMENDED_MCP_VERSION` to 0.6.0 and **reopened the
`[0.5.0, 0.6.0)` band without restoring the stale arm**. As a result, every
supported-but-behind client (e.g. any `0.5.x`) is misclassified as `"current"`.

### Impact
This silently **under-reports the `staleEvents` MCP-adoption counter** (`src/types.ts`,
surfaced on the operator dashboard): auto-classified telemetry events could never land in
the `stale` bucket, so the dashboard reports zero stale adoption even when behind-version
clients are actively connecting. It's a metrics-correctness regression, not a
user-facing crash — which is why it went unnoticed.

## The fix

Restore the original comparison against `LATEST_RECOMMENDED_MCP_VERSION` in
`src/services/mcp-compatibility.ts`. After the existing `minimum` checks pass, a version
in `[minimum, latest)` classifies as `"stale"`; `>= latest` stays `"current"`:

```ts
const latestComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION)!;
return latestComparison < 0 ? "stale" : "current";

The ! is sound here: compareMcpSemver only returns null for an unparseable
version, and any such version already returned "unknown" at the minimumComparison
guard above, so by this line version is known-parseable.

Tests
Both arms covered in test/unit/mcp-compatibility.test.ts:
0.5.0 and 0.5.9 → "stale" (>= minimum, < latest)
0.6.0 and 0.7.1 → "current" (>= latest)
existing incompatible / unknown cases unchanged
Updated three pre-existing assertions that had encoded the buggy "current" output for a 0.5.0 client (the classifier unit test + two telemetry-event tests in mcp-compatibility.test.ts and mcp-server-telemetry.test.ts).

Risk
Behavioral change: 0.5.x clients now classify as stale instead of current. This is
the intended pre-#265 behavior and the reason LATEST_RECOMMENDED_MCP_VERSION exists.
No schema, migration, or generated-artifact changes.

---

A couple of things worth flagging before this goes up:

1. **No linked issue.** This is a regression-fix rationale PR. Per your gate rules, contributor PRs need a *valid linked issue* to auto-merge — confirm the repo accepts the rationale path for fixes, or this could auto-close one-shot.
2. The description references `#265`, `#745`, and `staleEvents`/`src/types.ts` — those came from the commit message. Want me to **verify those references are accurate** (that `staleEvents` exists in `src/types.ts` and the PR numbers are real) before you post, so nothing in the description is wrong?

Want me to tighten/shorten it, or run that verification?