### PR TITLE
fix(review): publish the authoritative surface-lane verdict on the gate check-run

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -4,7 +4,7 @@ import { makeInstallationOctokit } from "./client";
 import { maintainerControlPanelUrl } from "./footer";
 import type { AgentActionMode } from "../settings/agent-execution";
 import { signRs256Jwt } from "../utils/crypto";
-import { evaluateGateCheck, formatCheckRunOutput, formatGateCheckOutput, type CheckRunAnnotationContext, type CheckRunOutput, type GateCheckConclusion, type GateCheckPolicy } from "../rules/advisory";
+import { evaluateGateCheck, formatCheckRunOutput, formatGateCheckOutput, type CheckRunAnnotationContext, type CheckRunOutput, type GateCheckConclusion, type GateCheckEvaluation, type GateCheckPolicy } from "../rules/advisory";
 
 type CheckRunResponse = {
   id: number;
@@ -159,10 +159,14 @@ export async function createOrUpdateGateCheckRun(
   repoFullName: string,
   advisory: Advisory,
   policy: GateCheckPolicy = {},
-  options: { checkRunId?: number | undefined } = {},
+  options: { checkRunId?: number | undefined; gate?: GateCheckEvaluation | undefined } = {},
   mode: AgentActionMode = "live",
 ): Promise<CheckRunOutcome | null> {
-  const gate = evaluateGateCheck(advisory, policy);
+  // Prefer the AUTHORITATIVE pre-computed evaluation when the caller has one (#5 / audit): the surface/content
+  // lane can OVERRIDE the generic verdict (surface_lane_reject → failure, surface_lane_manual → action_required),
+  // and re-deriving here via evaluateGateCheck would discard that override — publishing a GREEN check while the
+  // PR is actually auto-closed/held. Callers without a surface lane omit `gate` and re-derive as before (identical).
+  const gate = options.gate ?? evaluateGateCheck(advisory, policy);
   return createOrUpdateNamedCheckRun(env, installationId, repoFullName, advisory, {
     name: GITTENSORY_GATE_CHECK_NAME,
     status: "completed",

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2720,6 +2720,10 @@ async function maybePublishPrPublicSurface(
           gatePolicy,
           {
             checkRunId: pendingGateCheckRunId,
+            // #5 (audit): publish the AUTHORITATIVE surface-lane-merged verdict so the check-run conclusion matches
+            // the disposition; without this the check re-derives the generic verdict and shows green on a surface-
+            // lane reject/manual PR that is actually auto-closed/held. Undefined (gate off) ⇒ re-derive (identical).
+            gate: gateEvaluation,
           },
           mode,
         );

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -378,6 +378,38 @@ describe("GitHub check runs", () => {
     });
   });
 
+  it("publishes the precomputed authoritative gate (surface-lane override) instead of re-deriving (#5)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let capturedBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs")) {
+        capturedBody = JSON.parse(String(init?.body)) as typeof capturedBody;
+        return Response.json({ id: 91 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    // The advisory is CLEAN (re-deriving via evaluateGateCheck would publish "success"), but the surface lane
+    // REJECTED the PR. The published check must reflect the authoritative override, not the generic re-derivation.
+    const surfaceGate = {
+      enabled: true,
+      conclusion: "failure" as const,
+      title: "Metagraphed surface review",
+      summary: "Surface payload rejected.",
+      blockers: [{ code: "surface_lane_reject", title: "Surface rejected", severity: "critical" as const, detail: "Registry payload failed validation." }],
+      warnings: [],
+    };
+    const result = await createOrUpdateGateCheckRun(env, 123, "JSONbored/gittensory", gateAdvisory("surface-sha"), {}, { gate: surfaceGate });
+
+    expect(result).toEqual({ kind: "published", id: 91 });
+    expect(capturedBody.conclusion).toBe("failure"); // the surface override, NOT the clean re-derivation
+    expect(capturedBody.output?.title).toBe("Metagraphed surface review");
+  });
+
   it("updates an existing pending Gate check without adding a conclusion", async () => {
     const privateKey = await generatePrivateKeyPem();
     let capturedBody: { status?: string; conclusion?: string } = {};


### PR DESCRIPTION
## Summary

The published `Gittensory Gate` check **re-derived** its verdict (`evaluateGateCheck` inside `createOrUpdateGateCheckRun`, `app.ts:165`), ignoring the surface/content-lane override already merged into the authoritative `gateEvaluation` (`processors.ts`, via `evaluateWithSurfaceLane`). The surface codes — `surface_lane_reject` / `surface_lane_manual` — are unknown to that generic path (`isConfiguredGateBlocker`), so a content-lane PR that was **rejected** or routed to **manual** review published a **GREEN required check** while the disposition auto-closed / held it. The check disagreed with the action (audit #5).

The fix threads the authoritative `gateEvaluation` into the check-run via an optional precomputed `gate`:

- `createOrUpdateGateCheckRun` now uses `options.gate ?? evaluateGateCheck(advisory, policy)` — when the caller supplies the merged evaluation, the check-run conclusion **and** output (`formatGateCheckOutput`) match the disposition exactly.
- `applySurfaceGate` already produces a fully-formed `GateCheckEvaluation` (reject → `failure` + a `surface_lane_reject` blocker; manual → `action_required` + a `surface_lane_manual` warning), so no new code path is needed in `isConfiguredGateBlocker`.
- Callers without a surface lane omit `gate` and re-derive exactly as before — **byte-identical** when the content lane is off (which is also the default).

No GitHub issue — internal review-subsystem audit finding (#5). Narrow: only the flag-gated, per-repo-allowlisted content lane changes behavior.

## Scope
- [x] Backend (`src/`) only — `src/github/app.ts`, `src/queue/processors.ts`
- [x] No API/schema, DB/migration, `wrangler.jsonc`, or UI change
- [x] Narrow, one coherent change

## Validation
- [x] `npm run test:ci` — green (4465 passed | 4 skipped)
- [x] `npm run test:coverage` — every changed line and branch covered (verified against `coverage/lcov.info`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities; `typecheck`/`ui:typecheck` clean; `git diff --check` clean
- New test: `github-app.test.ts` — a CLEAN advisory (would re-derive to `success`) with a precomputed surface-lane `failure` gate publishes `failure` + the surface title, proving the override is honored (the omitted-`gate` re-derivation path stays covered by the existing gate-check tests).

## Safety
- [x] No secrets / wallets / hotkeys / coldkeys / trust scores / reward values added
- [x] Backward-compatible (omitted `gate` ⇒ identical re-derivation); content-lane off ⇒ byte-identical
- [x] No public-surface term leakage (surface summaries already sanitized upstream)
