### PR TITLE
fix(review): predict path-independent pre-merge checks and disclaim diff-dependent gates

### DIFF
--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -18,6 +18,7 @@ const OSS_ANTI_SLOP_FUNNEL = {
   registerUrl: GITTENSOR_HOME_URL,
 } as const;
 import { buildPullRequestAdvisory, evaluateGateCheck, type GateCheckConclusion } from "./advisory";
+import { evaluatePreMergeChecks } from "../review/pre-merge-checks";
 
 /**
  * Pre-submission "will my PR pass the gate?" prediction for a MINER, computed BEFORE a PR exists.
@@ -55,8 +56,11 @@ export type PredictedGateVerdict = {
 const PREDICTED_GATE_NOTE =
   "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have " +
   "private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only " +
-  "evaluated on a real PR. Every author is gated the same: a configured hard blocker fails the gate " +
-  "regardless of confirmed-contributor status (which affects only on-chain scoring).";
+  "evaluated on a real PR. Diff-dependent checks are NOT evaluated pre-submission and may still fail the real " +
+  "gate: the slop score, the focus-manifest path policy, and any pre-merge check scoped to changed paths " +
+  "(path-independent title/description/label pre-merge checks ARE predicted). Every author is gated the same: " +
+  "a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only " +
+  "on-chain scoring).";
 
 export type PredictedGateInput = {
   repoFullName: string;
@@ -148,6 +152,16 @@ export function buildPredictedGateVerdict(args: {
   const issueAuthorByNumber = new Map(issues.filter((issue) => issue.repoFullName === input.repoFullName).map((issue) => [issue.number, issue.authorLogin ?? null]));
   const linkedIssueAuthorLogins = syntheticPr.linkedIssues.map((issueNumber) => issueAuthorByNumber.get(issueNumber) ?? null);
   const advisory = buildPullRequestAdvisory(repo, syntheticPr, { otherOpenPullRequests: pullRequests, requireLinkedIssue, linkedIssueAuthorLogins });
+
+  // Deterministic pre-merge checks parity (#11/#18), partial: the LIVE gate enforces the repo's
+  // `review.pre_merge_checks` (from the SAME public .gittensory.yml the predictor already reads), but the
+  // predictor ignored them — so a PR the gate would auto-close on an enforced title/description rule predicted
+  // "success". Evaluate the PATH-INDEPENDENT checks (empty `whenPaths` — title/description/label assertions) here:
+  // their inputs (title/body/labels) are exactly the real PR's, so the result is identical to live. Path-gated
+  // checks, manifest-policy, and slop need the PR's changed files/diff (not available pre-submission) and are
+  // disclaimed in the note below; they reach parity once the predictor accepts changed paths.
+  const alwaysApplyPreMergeChecks = manifest.review.preMergeChecks.filter((check) => check.whenPaths.length === 0);
+  advisory.findings.push(...evaluatePreMergeChecks(alwaysApplyPreMergeChecks, { title: syntheticPr.title, body: syntheticPr.body, labels: syntheticPr.labels, changedPaths: [] }));
 
   // Pack-aware (#693): under `oss-anti-slop` the gate blocks ANY author, so drop the confirmed-contributor
   // gate entirely (mirrors gateCheckPolicy). `gittensor` keeps it. Pack comes from the PUBLIC .gittensory.yml.

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -21,10 +21,10 @@ const BASE_INPUT: PredictedGateInput = {
   linkedIssues: [7],
 };
 
-function verdict(args: { gate: Record<string, unknown>; input?: Partial<PredictedGateInput>; issues?: IssueRecord[]; pullRequests?: PullRequestRecord[] }) {
+function verdict(args: { gate: Record<string, unknown>; review?: Record<string, unknown>; input?: Partial<PredictedGateInput>; issues?: IssueRecord[]; pullRequests?: PullRequestRecord[] }) {
   return buildPredictedGateVerdict({
     input: { ...BASE_INPUT, ...args.input },
-    manifest: parseFocusManifest({ gate: args.gate }),
+    manifest: parseFocusManifest({ gate: args.gate, ...(args.review ? { review: args.review } : {}) }),
     repo: REPO,
     issues: args.issues ?? [openIssue(7, "Uploads should retry on 5xx")],
     pullRequests: args.pullRequests ?? [],
@@ -173,6 +173,48 @@ describe("buildPredictedGateVerdict", () => {
     });
     expect(result.conclusion).toBe("failure");
     expect(result.blockers.some((b) => b.code === "missing_linked_issue")).toBe(true);
+  });
+
+  it("predicts a BLOCK for an enforced path-INDEPENDENT pre-merge check the title fails (#11/#18)", () => {
+    // The repo's public .gittensory.yml enforces a conventional-style title; the PR title lacks "[FEAT]".
+    const result = verdict({
+      gate: {},
+      review: { pre_merge_checks: [{ name: "Conventional title", title_contains: "[FEAT]", enforce: true }] },
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.some((b) => b.code === "pre_merge_check_required")).toBe(true);
+  });
+
+  it("predicts a PASS once the path-independent pre-merge check is satisfied", () => {
+    const result = verdict({
+      gate: {},
+      input: { title: "[FEAT] Add retry to the upload client" },
+      review: { pre_merge_checks: [{ name: "Conventional title", title_contains: "[FEAT]", enforce: true }] },
+    });
+    expect(result.conclusion).not.toBe("failure");
+    expect(result.blockers.some((b) => b.code === "pre_merge_check_required")).toBe(false);
+  });
+
+  it("surfaces a non-enforced path-independent pre-merge check as a WARNING, not a blocker", () => {
+    const result = verdict({
+      gate: {},
+      review: { pre_merge_checks: [{ name: "Mention testing", description_contains: "tested", enforce: false }] },
+    });
+    expect(result.conclusion).not.toBe("failure");
+    expect(result.warnings.some((w) => w.code === "pre_merge_check_failed")).toBe(true);
+  });
+
+  it("does NOT predict a path-GATED pre-merge check pre-submission (no diff) and discloses the gap in the note (#11/#18)", () => {
+    // A path-gated check whose title assertion the PR fails — but it is scoped to changed paths, which are
+    // unknown pre-submission, so it must be skipped (not falsely block) and called out in the note.
+    const result = verdict({
+      gate: {},
+      review: { pre_merge_checks: [{ name: "Tests for src", title_contains: "ZZZ-never", when_paths: ["src/**"], enforce: true }] },
+    });
+    expect(result.blockers.some((b) => b.code === "pre_merge_check_required")).toBe(false);
+    expect(result.warnings.some((w) => w.code === "pre_merge_check_unresolved")).toBe(false);
+    expect(result.note).toContain("scoped to changed paths");
+    expect(result.note.toLowerCase()).toContain("slop");
   });
 });
 


### PR DESCRIPTION
## Summary

The pre-submit `predict_gate` oracle (`buildPredictedGateVerdict`) ran the advisory + `evaluateGateCheck` but **ignored** the repo's `review.pre_merge_checks`, focus-manifest path policy, and slop score — all of which the LIVE gate enforces. So a PR the gate would auto-close on an enforced title/description rule predicted **"success"**, misleading contributors (audit #11/#18; the slop/manifest arms are #13/#12).

This is **part one** of a two-part fix (scoped this way per maintainer direction — the rest needs a public-contract change):

- **Evaluate the path-INDEPENDENT pre-merge checks now** (empty `whenPaths` — title / description / label assertions), from the same public `.gittensory.yml` the predictor already reads. Their inputs (title/body/labels) are exactly the real PR's, so the predicted result is **identical to live** for those checks — including the enforced → `pre_merge_check_required` block.
- **Honestly disclaim the rest in the note.** Path-gated pre-merge checks, the focus-manifest path policy, and slop all evaluate against the PR's changed files/diff, which doesn't exist pre-submission. The verdict note now states plainly that those are not predicted, so a "success" is not misread as complete.

**Follow-up (part two):** extend the `predict_gate` MCP/API input with the contributor's changed paths so manifest-policy + path-gated pre-merge checks reach full parity (and decide how slop is signalled). That's a public-contract change + OpenAPI regen, kept separate.

No GitHub issue — internal review-subsystem audit finding. The `PredictedGateVerdict` output **shape is unchanged**, so no OpenAPI regen.

## Scope
- [x] Backend (`src/`) only — `src/rules/predicted-gate.ts`
- [x] No API/schema, DB/migration, `wrangler.jsonc`, or UI change (verdict output shape unchanged)
- [x] Narrow, one coherent change

## Validation
- [x] `npm run test:ci` — green (4469 passed | 4 skipped)
- [x] `npm run test:coverage` — every changed line and branch covered (verified against `coverage/lcov.info`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities; `typecheck`/`ui:typecheck`/`ui:openapi:check` clean; `git diff --check` clean
- New tests: enforced path-independent check → predicted `failure` + `pre_merge_check_required`; satisfied check → pass; non-enforced → warning not blocker; a path-gated check is **skipped** pre-submit (no false block, no `pre_merge_check_unresolved` noise) and the note discloses the slop/manifest/path gap.

## Safety
- [x] No secrets / wallets / hotkeys / coldkeys / trust scores / reward values added
- [x] Public-safe: pre-merge findings already run through `publicSafeFinding`/`sanitizePublicComment`; only public `.gittensory.yml` config is read
- [x] Honest-by-construction: path-gated/manifest/slop are skipped (never falsely blocked) and explicitly disclaimed
