### PR TITLE
fix(planner): authorize the plan command via per-repo policy and don't swallow PR-thread plans

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -91,7 +91,6 @@ import {
   buildPublicAgentCommandComment,
   type GittensoryMentionCommandName,
   isAuthorizedCommandActor,
-  isMaintainerAssociation,
   isMaintainerQueueDigestCommand,
   parseAgentCommandFeedbackContext,
   parseGittensoryMentionCommand,
@@ -114,7 +113,7 @@ import {
 } from "../services/contributor-evidence-graph";
 import { executeAgentRun, explainBlockersWithAgent, planNextWork, preflightBranchWithAgent, preparePrPacketWithAgent } from "../services/agent-orchestrator";
 import { isAuthorizedGitHubSessionLogin, parseGitHubLoginList } from "../auth/security";
-import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetection } from "../settings/command-authorization";
+import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetection, evaluateCommandAuthorization } from "../settings/command-authorization";
 import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
 import { SWEEP_FANOUT_DEDUP_MS, isRegateSweepDraining, selectRegateCandidates } from "../settings/agent-sweep";
@@ -3289,6 +3288,10 @@ async function recordGateOverrideSkip(
 async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
   if (!isPlannerEnabled(env)) return false; // flag-OFF → not handled here; the worker is byte-identical to today
   if (!isPlanCommand(payload.comment?.body)) return false;
+  // #22: planning is ISSUE-only. A `@gittensory plan` on a PR is not a plan request, so DON'T consume it — fall
+  // through to the generic mention handler so it posts the help card, exactly as the flag-OFF path does. Without
+  // this the flag-ON worker swallowed a PR-thread `plan` mention and the contributor saw nothing.
+  if (payload.issue?.pull_request) return false;
   // All eligibility guards live in the PURE classifier (exhaustively unit-tested); here we carry one ok branch.
   const req = classifyPlanCommandRequest(payload, getInstallationId(payload));
   if (!req.ok) {
@@ -3296,11 +3299,21 @@ async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: Gi
     return true;
   }
   const targetKey = `${req.repoFullName}#${req.issue.number}`;
-  // Issue-level authorization: planning spends Workers AI + posts publicly, so restrict it to maintainers
-  // (the REAL repo permission, not the comment's spoofable author_association).
+  // Issue-level authorization: planning spends Workers AI + posts publicly. Honor the repo's per-repo
+  // commandAuthorization policy for `plan` (#21) — the SAME policy every other command respects — over the REAL
+  // repo permission (resolveRealRepoPermissionAssociation), never the comment's spoofable author_association.
+  // `plan` defaults to maintainer/collaborator (DEFAULT_COMMAND_AUTHORIZATION_POLICY), so the default behavior is
+  // unchanged; a maintainer can now widen/narrow it like any other command.
+  const settings = await resolveRepositorySettings(env, req.repoFullName);
   const association = await resolveRealRepoPermissionAssociation(env, req.installationId, req.repoFullName, req.actor);
-  if (!isMaintainerAssociation(association)) {
-    await recordPlanSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, "actor_not_maintainer");
+  const authorization = evaluateCommandAuthorization({
+    policy: settings.commandAuthorization,
+    commandName: "plan",
+    commenterLogin: req.actor,
+    commenterAssociation: association,
+  });
+  if (!authorization.authorized) {
+    await recordPlanSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, authorization.reason);
     return true;
   }
   if (await isPlanCommandCoolingDown(env, req.repoFullName, req.actor, ISSUE_PLAN_COOLDOWN_MS)) {

--- a/src/settings/command-authorization.ts
+++ b/src/settings/command-authorization.ts
@@ -13,6 +13,7 @@ export const DEFAULT_COMMAND_AUTHORIZATION_POLICY: RepositoryCommandAuthorizatio
     "outcome-patterns": ["maintainer", "collaborator"],
     "noise-report": ["maintainer", "collaborator"],
     "gate-override": ["maintainer", "collaborator"],
+    plan: ["maintainer", "collaborator"],
   },
 };
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1640,8 +1640,29 @@ describe("queue processors", () => {
     await processJob(env, plannerWebhook("@gittensory plan", "outsider"));
     expect(run).not.toHaveBeenCalled();
     const denied = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.issue_plan_skipped").first<{ detail: string }>();
-    expect(denied?.detail).toBe("actor_not_maintainer");
+    // Authorization now flows through the per-repo commandAuthorization policy (#21), so the skip reason is the
+    // policy's verdict (not the old bespoke "actor_not_maintainer").
+    expect(denied?.detail).toBe("not_maintainer_or_pr_author");
   });
+
+  it("planner (#21): honors a per-repo commandAuthorization override that restricts `plan` to maintainers", async () => {
+    const run = vi.fn(async () => ({ response: "should not run" }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
+    await setupPlannerRepo(env);
+    // Override: `plan` is maintainer-ONLY (drop the default collaborator role).
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commandAuthorization: { default: ["maintainer", "collaborator", "confirmed_miner"], commands: { plan: ["maintainer"] } } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "write" }); // collaborator, not maintainer
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory plan", "collab1"));
+    expect(run).not.toHaveBeenCalled();
+    const denied = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.issue_plan_skipped").first<{ detail: string }>();
+    expect(denied?.detail).toBe("not_maintainer_or_pr_author");
+  });
+
 
   it("planner: a flag-ON non-plan comment is not intercepted (the handler declines)", async () => {
     const run = vi.fn(async () => ({ response: "nope" }));
@@ -1652,15 +1673,40 @@ describe("queue processors", () => {
     expect(run).not.toHaveBeenCalled(); // not a plan command → maybeProcessPlanCommand returns false, no AI spend
   });
 
-  it("planner: @gittensory plan on a PR (not an issue) is skipped via the classifier", async () => {
+  it("planner (#22): @gittensory plan on a PR is NOT consumed — it falls through (no plan, no skip audit)", async () => {
     const run = vi.fn(async () => ({ response: "nope" }));
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
     await setupPlannerRepo(env);
-    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+    vi.stubGlobal("fetch", async () => Response.json({}));
     await processJob(env, plannerWebhook("@gittensory plan", "maintainer1", { number: 77, title: "PR not issue", state: "open", user: { login: "x" }, body: "b", pull_request: { url: "https://api.github.com/x" } }));
     expect(run).not.toHaveBeenCalled();
+    // Planning is issue-only; a PR-thread `plan` falls through to the mention/help path (flag-ON now matches
+    // flag-OFF) instead of being swallowed as a plan skip.
+    const planAudits = await env.DB.prepare("select count(*) as n from audit_events where event_type in (?, ?)").bind("github_app.issue_plan_skipped", "github_app.issue_plan_generated").first<{ n: number }>();
+    expect(planAudits?.n).toBe(0);
+  });
+
+  it("planner: a bot-authored @gittensory plan on an issue is recorded as a classifier skip", async () => {
+    const run = vi.fn(async () => ({ response: "nope" }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
+    await setupPlannerRepo(env);
+    vi.stubGlobal("fetch", async () => Response.json({}));
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "plan-bot",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 77, title: "Issue", state: "open", user: { login: "reporter" }, body: "b" },
+        comment: { body: "@gittensory plan", user: { login: "some-bot[bot]", type: "Bot" } },
+        sender: { login: "some-bot[bot]", type: "Bot" },
+      },
+    } as unknown as Parameters<typeof processJob>[1]);
+    expect(run).not.toHaveBeenCalled();
     const skip = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.issue_plan_skipped").first<{ detail: string }>();
-    expect(skip?.detail).toBe("missing_repo_issue_installation_or_actor");
+    expect(skip?.detail).toBe("unsupported_comment_action_or_bot");
   });
 
   it("planner: a maintainer request that yields no plan is recorded as a skip (fail-safe)", async () => {


### PR DESCRIPTION
## Summary

Two fixes to the `@gittensory plan` command (audit #21/#22; my own feature):

- **#21 — authorization bypassed the per-repo policy.** `maybeProcessPlanCommand` gated on a bare `isMaintainerAssociation` check, ignoring the per-repo `commandAuthorization` policy every *other* command honors. It now routes through `evaluateCommandAuthorization` with `commandName: "plan"`, over the REAL repo permission (`resolveRealRepoPermissionAssociation`, never the spoofable `author_association`). `plan` is added to the maintainer-only command defaults, so the **default behavior is unchanged** (maintainer/collaborator) while a maintainer can now widen or narrow it like any other command.

- **#22 — flag-ON swallowed a PR-thread plan.** Planning is issue-only. With the planner flag ON, a `@gittensory plan` on a **PR** thread was consumed (classifier skip + `return true`), which suppressed the help card the flag-OFF worker posts via the mention path — so the contributor saw nothing. It now **falls through** (`return false`) for a PR thread, so flag-ON matches flag-OFF exactly.

No GitHub issue — internal review-subsystem audit finding (#21/#22). Closes the audit campaign's last actionable bug.

## Scope
- [x] Backend (`src/`) only — `src/queue/processors.ts`, `src/settings/command-authorization.ts`
- [x] No API/schema, DB/migration, `wrangler.jsonc`, or UI change (the `commandAuthorization` default gains a `plan` entry — config-as-code, backward-compatible)
- [x] Narrow, one coherent change

## Validation
- [x] `npm run test:ci` — green
- [x] `npm run test:coverage` — every changed line and branch covered (verified against `coverage/lcov.info`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities; `typecheck`/`ui:typecheck` clean; `git diff --check` clean
- Tests: a per-repo override restricting `plan` to maintainers denies a collaborator; the denial reason is now the policy verdict (`not_maintainer_or_pr_author`, not the old bespoke `actor_not_maintainer`); a PR-thread `plan` is not consumed (no plan audit); a bot-authored `plan` is a classifier skip. The maintainer happy-path + flag-OFF byte-identical tests still pass through the new auth path.

## Safety
- [x] No secrets / wallets / hotkeys / coldkeys / trust scores / reward values added
- [x] Authorization hardened (per-repo policy + real permission), not weakened; default stays maintainer-only
- [x] No public-surface term leakage
