### PR TITLE
docs: prohibit PR plagiarism and reward-farming with a permanent cross-repo block

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,6 +18,9 @@ impact.
 
 - Harassment, threats, personal attacks, slurs, or sexualized language.
 - Spam, reward-farming noise, generated bulk submissions, or intentionally low-effort PRs.
+- Plagiarism — copying another contributor's PR, diff, commits, or work and submitting it as your
+  own, including lightly reworded or re-tested copies filed under a different account to claim
+  credit or farm Gittensor rewards.
 - Posting secrets, private contributor evidence, private maintainer evidence, wallet details,
   hotkeys, coldkeys, raw trust scores, or private rankings publicly.
 - Misrepresenting Gittensory output as guaranteed compensation, guaranteed ranking, or financial
@@ -30,6 +33,11 @@ impact.
 
 Maintainers may edit or delete comments, close issues or PRs, block users, or report abuse when
 behavior violates this Code of Conduct, the contribution guidelines, or GitHub's terms.
+
+Plagiarism and other deliberate attempts to cheat, copy from other contributors, or farm Gittensor
+rewards through stolen or duplicated PRs are treated as a hard violation: offenders are
+**permanently blocked from contributing**, and the block applies across all of our repositories
+(`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
 
 For security issues, use GitHub private vulnerability reporting:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,10 @@ Do not open PRs for:
 - Changelog edits in ordinary feature/fix PRs. Changelogs are updated during release prep.
 - Low-effort reward-farming changes, spam, generated bulk edits, or PRs that do not explain the
   product impact.
+- Plagiarized PRs — copying another contributor's PR, diff, or work and submitting it as your own,
+  including lightly reworded or re-tested copies filed under a different account. Copying others to
+  farm Gittensor rewards is a hard violation and results in a **permanent block from contributing
+  across all of our repositories**. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## Before Opening A PR
 


### PR DESCRIPTION
## What

Adds an explicit, enforceable anti-plagiarism policy to both `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

## Why

Copying another contributor's PR, diff, or work and submitting it as your own — including lightly reworded or re-tested copies filed under a different account — to farm Gittensor rewards is gaming, not contribution. This makes the consequence explicit and uniform across our repos.

## Policy

- **Code of Conduct** — plagiarism added to the unacceptable-behavior list; enforcement clause states offenders are **permanently blocked from contributing**, across `JSONbored/gittensory`, `JSONbored/metagraphed`, and `JSONbored/awesome-claude`.
- **Contributing** — a visible callout in the submission rules cross-referencing the Code of Conduct.

Docs-only; no code or schema changes.