### PR TITLE
docs: contributor policy — anti-gaming ladder, review policy, and system integrity

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,6 +28,16 @@ impact.
 - Evading review boundaries by reopening closed work without addressing the stated reason.
 - Attempting to bypass authentication, rate limits, GitHub App permissions, or Cloudflare Worker
   controls.
+- Manipulating the review bot or automated gate — embedding hidden or misleading instructions in
+  code, comments, PR titles/bodies, file contents, or commit messages to influence the AI review or
+  pass the gate (prompt injection).
+- Circumventing CI or the gate — disabling or weakening tests, faking or gaming coverage,
+  fabricating tests to satisfy Codecov, or editing CI to skip required checks.
+- Submitting malicious or destructive code — malware, backdoors, secret exfiltration, malicious
+  dependencies, destructive migrations, or anything intended to damage the codebase, its data, or
+  production systems.
+- Abusing system resources — webhook floods, deliberately triggering expensive re-reviews or CI
+  runs, or attempts to exhaust the review bot's compute or credits.
 
 ## Enforcement
 
@@ -48,6 +58,15 @@ Enforcement is proportional and escalates with intent and repetition:
 - Plagiarism and ban-evasion — copying another contributor's work, or returning under a new account
   after a block — result in an immediate **permanent block from contributing across all of our
   repositories** (`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
+
+## Contribution Terms
+
+By submitting, you affirm the work is your own original work and that you have the right to contribute
+it under this repository's license. Contributing is not an entitlement: contribution scoring and any
+Gittensor rewards are set by the subnet's on-chain hyperparameters and validators, not by us, and all
+decisions — merge, close, scope, policy, timing, labels, and blocks — are at maintainer discretion and
+final. Report security issues privately (below) rather than exploiting or weaponizing them in a PR;
+good-faith research is welcome through that channel.
 
 For security issues, use GitHub private vulnerability reporting:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,10 +34,20 @@ impact.
 Maintainers may edit or delete comments, close issues or PRs, block users, or report abuse when
 behavior violates this Code of Conduct, the contribution guidelines, or GitHub's terms.
 
-Plagiarism and other deliberate attempts to cheat, copy from other contributors, or farm Gittensor
-rewards through stolen or duplicated PRs are treated as a hard violation: offenders are
-**permanently blocked from contributing**, and the block applies across all of our repositories
-(`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
+Enforcement is proportional and escalates with intent and repetition:
+
+- Opening your own issue and then submitting a PR that resolves it is welcome, and a PR with no
+  linked issue is fine — neither is farming.
+- Off-scope or low-effort work is closed or relabeled, with no further penalty.
+- Reward-farming is against policy: using more than one account under the same person's control
+  (alt / sock-puppet accounts) — for example, one account opening issues for another account to
+  "resolve" — or manufacturing low-value/slop issues and bulk point-chasing PRs to inflate
+  contribution credit. Linked issues from farming are closed so the work earns no bonus credit, and
+  a warning is issued; continuing after a warning, or any confirmed multi-account (sock-puppet)
+  farming, results in submissions being closed and labeled on sight and a block from contributing.
+- Plagiarism and ban-evasion — copying another contributor's work, or returning under a new account
+  after a block — result in an immediate **permanent block from contributing across all of our
+  repositories** (`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
 
 For security issues, use GitHub private vulnerability reporting:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ Do not open PRs for:
   farm Gittensor rewards is a hard violation and results in a **permanent block from contributing
   across all of our repositories**. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
+Filing your own issue and then opening a PR that resolves it is welcome, and a PR with no linked
+issue is fine — neither is farming. What is against policy is **using more than one account you
+control (alt / sock-puppet accounts) — e.g. one account opening issues for another to "resolve" —
+to inflate contribution credit**, along with manufacturing low-value/slop issues and bulk
+point-chasing PRs. Farmed work earns no linked-issue bonus, and repeat or any confirmed
+multi-account farming is closed on sight and blocked. Enforcement is proportional; the full ladder
+is in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Before Opening A PR
 
 - Search existing issues and PRs to avoid duplicate work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,34 @@ branch current with `main` (a conflict closes the PR), and link an eligible issu
 Code or Codex, the `.claude/skills/contributing-to-gittensory` skill (and the root `AGENTS.md`) encode
 the whole procedure step by step.
 
+## How Reviews Work (timing, one-shot, and asking for review)
+
+**Timing is typical, not an SLA.** When the gittensory maintainer agent is operating, most PRs are
+reviewed and auto-merged or auto-closed within **~1 hour of CI finishing**. When the agent is paused or
+under maintenance, manual review **typically takes 24–48 hours, depending on volume**. These are
+observations, not commitments or a service-level guarantee — reviews happen when they happen.
+
+**One-shot, merge-ready as-is.** We do not request changes or iterate on contributor PRs — a PR is
+merged exactly as it stands or it is closed; there is no "changes requested" back-and-forth. Before CI
+we rebase your branch onto `main` with a **merge commit**, then review **after** CI completes — so a
+rebase conflict, or any red CI (including **~97% patch coverage, branch-counted, enforced by Codecov**),
+closes the PR. Recover by opening a **fresh, corrected PR**. PRs touching guarded paths (CI config, the
+review engine, migrations, and similar — the set varies) are held for manual review rather than
+auto-acted.
+
+**If we close your PR by mistake, that's on us.** We may reopen or re-review at our discretion as time
+permits — there is no fixed window, and opening a fresh PR is usually fastest.
+
+**Don't ask for or chase reviews.** The queue is automated and best-effort, and the gate posts its own
+status and reasoning on your PR — read that first. Do **not** DM, @-mention, or comment asking for a
+review or status: it will not speed anything up and **will deprioritize your PR — expect at least 5 days
+added to its place in the manual queue.** Persistent pestering (here, Discord, or elsewhere) is a
+conduct violation and may get the PR closed and the account blocked.
+
+**Scoring and rewards are not ours to grant.** Contribution scoring and any Gittensor rewards are set by
+the subnet's on-chain hyperparameters and validators, not by this repo. Merging a PR is not a promise of
+score, ranking, or compensation, and all review decisions are at maintainer discretion and final.
+
 ## What We Accept
 
 Focused contributions are welcome in these areas:


### PR DESCRIPTION
## What

Consolidates our contributor governance into `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

## Why

Nearly all inflow is Gittensor miners farming for rewards. The on-chain hyperparameters already handle the **economic** levers (max open PRs, issue-spam, credibility, time-decay, duplicate penalties), so these docs cover the **conduct, process, and system-integrity** gaps they do not.

## Adds

**Proportional anti-gaming enforcement ladder** (Code of Conduct + Contributing callout)
- Allowed: opening your own issue and resolving it with the same account; an unlinked PR. Neither is farming.
- Reward-farming (against policy): multiple accounts under one person's control (alt / sock-puppet) opening issues for another to "resolve"; slop issues and bulk point-chasing. Farmed work earns no linked-issue bonus + a warning; repeat or confirmed multi-account farming is closed on sight and blocked.
- Plagiarism / ban-evasion: immediate permanent cross-repo block.

**How reviews work** (Contributing)
- Cadence: ~1h when the maintainer agent runs, 24–48h in maintenance — explicitly **not an SLA**.
- One-shot: merge-ready as-is or closed; rebase via merge commit before CI; review after CI; recover via a fresh PR; guarded paths held for manual review.
- Coverage/gate bar; accidental-closure handling (our mistake, re-review at discretion, no fixed window).
- **No pestering**: chasing reviews deprioritizes the PR (≥5 days) and is a conduct violation.
- Scoring/rewards are set by Gittensor hyperparameters, not us.

**System & bot integrity** (Code of Conduct)
- No review-bot/gate manipulation (prompt injection), CI/gate circumvention, malicious/destructive code, or resource/DoS abuse.
- **Contribution Terms**: originality affirmation, no entitlement, maintainer discretion, responsible disclosure.

Docs-only; no code or schema changes.