### PR TITLE
feat(selfhost): add the read-only D1 export tooling for the migration

### DIFF
--- a/scripts/export-d1-core.d.mts
+++ b/scripts/export-d1-core.d.mts
@@ -18,6 +18,7 @@ export type ExportManifest = {
   [meta: string]: unknown;
 };
 
+export function isSafeTableName(name: unknown): boolean;
 export function redactRow(table: string, row: D1Row): D1Row;
 export function checksumRows(rows: D1Row[]): string;
 export function filterRowsSince(rows: D1Row[], sinceColumn: string | undefined, sinceDate: string | undefined): D1Row[];

--- a/scripts/export-d1-core.d.mts
+++ b/scripts/export-d1-core.d.mts
@@ -1,0 +1,25 @@
+export const EXCLUDED_TABLES: Set<string>;
+export const REDACTED_COLUMNS: Record<string, string[]>;
+
+export type D1Row = Record<string, unknown>;
+
+export type TableExport = {
+  table: string;
+  rowCount: number;
+  redactedColumns: string[];
+  checksum: string;
+  rows: D1Row[];
+};
+
+export type ExportManifest = {
+  tableCount: number;
+  totalRows: number;
+  tables: Array<{ table: string; rowCount: number; redactedColumns: string[]; checksum: string }>;
+  [meta: string]: unknown;
+};
+
+export function redactRow(table: string, row: D1Row): D1Row;
+export function checksumRows(rows: D1Row[]): string;
+export function filterRowsSince(rows: D1Row[], sinceColumn: string | undefined, sinceDate: string | undefined): D1Row[];
+export function buildTableExport(table: string, rows: D1Row[], opts?: { sinceColumn?: string; sinceDate?: string }): TableExport | null;
+export function buildExportManifest(tableExports: Array<TableExport | null>, meta?: Record<string, unknown>): ExportManifest;

--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -20,6 +20,16 @@ export const REDACTED_COLUMNS = {
   repository_ai_keys: ["ciphertext"],
 };
 
+// A table name is only ever interpolated into SQL (`SELECT * FROM "<name>"`) after passing this allowlist, so a
+// hostile or malformed identifier (even though names come from the DB's own sqlite_master) can never break out of
+// the quoted identifier — defense-in-depth against SQL injection on the export path.
+const SAFE_TABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** True when `name` is a plain SQL identifier safe to interpolate into a quoted-table SELECT. */
+export function isSafeTableName(name) {
+  return typeof name === "string" && SAFE_TABLE_NAME.test(name);
+}
+
 /** Drop the redacted columns for `table` from a single row (returns the row unchanged when nothing is redacted). */
 export function redactRow(table, row) {
   const drop = REDACTED_COLUMNS[table];

--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -1,0 +1,86 @@
+// Pure core for the self-host D1 export (#selfhost-migration Phase 3). Read-only: it transforms rows already
+// SELECTed from the cloud D1 into a redacted, checksummed, category-organized export the self-host importer can
+// load idempotently. No IO here — the CLI (export-d1-data.mjs) does the wrangler/D1 reads and the file writes —
+// so this stays unit-testable. See [[gittensory-selfhost-migration-plan]].
+import { createHash } from "node:crypto";
+
+// Tables NEVER exported: SQLite/Drizzle internals + the cloud's own migration ledger (the self-host applies its
+// own forward migrations). Keep this conservative — excluding a real table loses data; the importer also skips it.
+export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_migrations", "_cf_KV", "__drizzle_migrations"]);
+
+// Columns dropped per table on export — cloud-specific secrets/hashes that are dead or unsafe on self-host. A
+// committed credential never crosses the boundary (#selfhost-migration DO-NOT-MIGRATE list):
+//   • auth_sessions.token_hash    — hashed browser session tokens, scoped to the cloud deploy; never migrate.
+//   • webhook_events.payload_hash — per-delivery dedup hash, scoped to the cloud deploy.
+//   • repository_ai_keys.ciphertext — maintainer BYOK provider keys, AES-256-GCM-encrypted with the CLOUD's
+//     TOKEN_ENCRYPTION_SECRET → undecryptable (dead) on self-host, and a secret we must not copy regardless.
+export const REDACTED_COLUMNS = {
+  auth_sessions: ["token_hash"],
+  webhook_events: ["payload_hash"],
+  repository_ai_keys: ["ciphertext"],
+};
+
+/** Drop the redacted columns for `table` from a single row (returns the row unchanged when nothing is redacted). */
+export function redactRow(table, row) {
+  const drop = REDACTED_COLUMNS[table];
+  if (!drop || drop.length === 0) return row;
+  const out = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (!drop.includes(key)) out[key] = value;
+  }
+  return out;
+}
+
+/** Canonicalize a row (sort keys) so column-order differences between D1/SQLite/Postgres don't change the checksum. */
+function canonicalizeRow(row) {
+  return Object.fromEntries(Object.entries(row).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}
+
+/** Deterministic SHA-256 over the canonicalized rows, so a self-host import can prove a faithful round-trip. */
+export function checksumRows(rows) {
+  return createHash("sha256").update(JSON.stringify(rows.map(canonicalizeRow))).digest("hex");
+}
+
+/**
+ * Optional incremental export: keep only rows whose `sinceColumn` (an ISO-8601 timestamp column such as
+ * `updated_at`) is >= `sinceDate`. ISO-8601 strings sort lexicographically, so a string compare is correct. A row
+ * missing the column (or with a non-string value) is KEPT — fail-safe: an incremental pass never silently drops a
+ * row it can't time-compare (the importer's idempotent upsert reconciles it).
+ */
+export function filterRowsSince(rows, sinceColumn, sinceDate) {
+  if (!sinceDate || !sinceColumn) return rows;
+  return rows.filter((row) => {
+    const value = row[sinceColumn];
+    return typeof value !== "string" || value >= sinceDate;
+  });
+}
+
+/**
+ * Build the export for ONE table: returns null for an excluded table; otherwise redacts every row, applies the
+ * optional incremental filter, and attaches a checksum + the list of redacted columns.
+ */
+export function buildTableExport(table, rows, opts = {}) {
+  if (EXCLUDED_TABLES.has(table)) return null;
+  const filtered = filterRowsSince(rows, opts.sinceColumn, opts.sinceDate);
+  const redacted = filtered.map((row) => redactRow(table, row));
+  return {
+    table,
+    rowCount: redacted.length,
+    redactedColumns: REDACTED_COLUMNS[table] ?? [],
+    checksum: checksumRows(redacted),
+    rows: redacted,
+  };
+}
+
+/** Summarize the table exports into a manifest (row payloads omitted) the importer validates against. */
+export function buildExportManifest(tableExports, meta = {}) {
+  const tables = tableExports
+    .filter((entry) => entry !== null)
+    .map(({ table, rowCount, redactedColumns, checksum }) => ({ table, rowCount, redactedColumns, checksum }));
+  return {
+    ...meta,
+    tableCount: tables.length,
+    totalRows: tables.reduce((sum, entry) => sum + entry.rowCount, 0),
+    tables,
+  };
+}

--- a/scripts/export-d1-data.mjs
+++ b/scripts/export-d1-data.mjs
@@ -11,7 +11,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildExportManifest, buildTableExport, EXCLUDED_TABLES } from "./export-d1-core.mjs";
+import { buildExportManifest, buildTableExport, EXCLUDED_TABLES, isSafeTableName } from "./export-d1-core.mjs";
 
 function parseArgs(argv) {
   const args = { db: undefined, output: "./export", remote: false, sinceDate: undefined, sinceColumn: "updated_at" };
@@ -44,7 +44,15 @@ function d1Query(db, remote, sql) {
 
 function listTables(db, remote) {
   const rows = d1Query(db, remote, "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name");
-  return rows.map((row) => row.name).filter((name) => typeof name === "string" && !EXCLUDED_TABLES.has(name));
+  // Only export plain-identifier table names (sqlite_master is trusted, but the name is interpolated into the SELECT
+  // below, so validate it anyway). A non-conforming name is skipped loudly rather than risking an injected SELECT.
+  return rows.map((row) => row.name).filter((name) => {
+    if (!isSafeTableName(name) || EXCLUDED_TABLES.has(name)) {
+      if (typeof name === "string" && !isSafeTableName(name)) console.error(`skipping table with an unexpected name: ${JSON.stringify(name).slice(0, 80)}`);
+      return false;
+    }
+    return true;
+  });
 }
 
 function main() {
@@ -58,6 +66,7 @@ function main() {
 
   const tableExports = [];
   for (const table of listTables(args.db, args.remote)) {
+    if (!isSafeTableName(table)) continue; // provably-safe interpolation: the name is a validated plain identifier
     const rows = d1Query(args.db, args.remote, `SELECT * FROM "${table}"`);
     const exported = buildTableExport(table, rows, { sinceColumn: args.sinceColumn, sinceDate: args.sinceDate });
     if (exported === null) continue; // excluded

--- a/scripts/export-d1-data.mjs
+++ b/scripts/export-d1-data.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Read-only D1 → self-host export (#selfhost-migration Phase 3). Enumerates the cloud D1's tables, SELECTs each
+// via `wrangler d1 execute --json` (no writes to D1), and emits a redacted, checksummed, per-table JSON dump plus
+// a manifest the self-host importer validates against. The data transformation lives in export-d1-core.mjs (pure,
+// unit-tested); this file is the thin IO wrapper.
+//
+//   node scripts/export-d1-data.mjs --db gittensory --output ./export [--remote] [--since-date 2026-06-01T00:00:00Z] [--since-column updated_at]
+//
+// --remote reads the deployed D1 (default is the local miniflare DB). --since-date does an INCREMENTAL export
+// (rows whose --since-column is >= the date); omit it for a full export. NEVER pass a write command.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { buildExportManifest, buildTableExport, EXCLUDED_TABLES } from "./export-d1-core.mjs";
+
+function parseArgs(argv) {
+  const args = { db: undefined, output: "./export", remote: false, sinceDate: undefined, sinceColumn: "updated_at" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === "--remote") args.remote = true;
+    else if (flag === "--db") args.db = argv[++i];
+    else if (flag === "--output") args.output = argv[++i];
+    else if (flag === "--since-date") args.sinceDate = argv[++i];
+    else if (flag === "--since-column") args.sinceColumn = argv[++i];
+  }
+  return args;
+}
+
+// Run a read-only SQL statement via wrangler and return the result rows. Throws on any wrangler failure so a
+// partial/garbled export can never be mistaken for a complete one.
+function d1Query(db, remote, sql) {
+  const result = spawnSync("npx", ["wrangler", "d1", "execute", db, remote ? "--remote" : "--local", "--json", "--command", sql], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (${result.status}): ${(result.stderr || result.stdout || "").slice(0, 500)}`);
+  }
+  const parsed = JSON.parse(result.stdout);
+  // wrangler returns [{ results: [...], success, meta }] (one entry per statement).
+  const first = Array.isArray(parsed) ? parsed[0] : parsed;
+  return first?.results ?? [];
+}
+
+function listTables(db, remote) {
+  const rows = d1Query(db, remote, "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name");
+  return rows.map((row) => row.name).filter((name) => typeof name === "string" && !EXCLUDED_TABLES.has(name));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.db) {
+    console.error("Usage: node scripts/export-d1-data.mjs --db <database> --output <dir> [--remote] [--since-date <iso>] [--since-column <col>]");
+    process.exit(2);
+  }
+  const tablesDir = join(args.output, "tables");
+  mkdirSync(tablesDir, { recursive: true });
+
+  const tableExports = [];
+  for (const table of listTables(args.db, args.remote)) {
+    const rows = d1Query(args.db, args.remote, `SELECT * FROM "${table}"`);
+    const exported = buildTableExport(table, rows, { sinceColumn: args.sinceColumn, sinceDate: args.sinceDate });
+    if (exported === null) continue; // excluded
+    writeFileSync(join(tablesDir, `${table}.json`), `${JSON.stringify({ table: exported.table, checksum: exported.checksum, redactedColumns: exported.redactedColumns, rows: exported.rows }, null, 2)}\n`);
+    tableExports.push(exported);
+    console.error(`exported ${table}: ${exported.rowCount} rows${exported.redactedColumns.length ? ` (redacted: ${exported.redactedColumns.join(", ")})` : ""}`);
+  }
+
+  const manifest = buildExportManifest(tableExports, {
+    source: args.remote ? "d1-remote" : "d1-local",
+    database: args.db,
+    incremental: Boolean(args.sinceDate),
+    ...(args.sinceDate ? { sinceColumn: args.sinceColumn, sinceDate: args.sinceDate } : {}),
+  });
+  writeFileSync(join(args.output, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  console.error(`\nexport complete: ${manifest.tableCount} tables, ${manifest.totalRows} rows → ${args.output}`);
+}
+
+main();

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { buildExportManifest, buildTableExport, checksumRows, EXCLUDED_TABLES, filterRowsSince, redactRow, REDACTED_COLUMNS } from "../../scripts/export-d1-core.mjs";
+import { buildExportManifest, buildTableExport, checksumRows, EXCLUDED_TABLES, filterRowsSince, isSafeTableName, redactRow, REDACTED_COLUMNS } from "../../scripts/export-d1-core.mjs";
+
+describe("export-d1-core isSafeTableName (SQL-injection guard)", () => {
+  it("accepts plain SQL identifiers", () => {
+    expect(isSafeTableName("repositories")).toBe(true);
+    expect(isSafeTableName("auth_sessions")).toBe(true);
+    expect(isSafeTableName("_internal9")).toBe(true);
+  });
+
+  it("rejects anything that could break out of a quoted identifier", () => {
+    expect(isSafeTableName('repos"; DROP TABLE x;--')).toBe(false);
+    expect(isSafeTableName("has space")).toBe(false);
+    expect(isSafeTableName("9starts-with-digit")).toBe(false);
+    expect(isSafeTableName("")).toBe(false);
+    expect(isSafeTableName(undefined)).toBe(false);
+    expect(isSafeTableName(123)).toBe(false);
+  });
+});
 
 describe("export-d1-core redaction (#selfhost-migration)", () => {
   it("drops the sensitive column for a redacted table and never emits it", () => {

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildExportManifest, buildTableExport, checksumRows, EXCLUDED_TABLES, filterRowsSince, redactRow, REDACTED_COLUMNS } from "../../scripts/export-d1-core.mjs";
+
+describe("export-d1-core redaction (#selfhost-migration)", () => {
+  it("drops the sensitive column for a redacted table and never emits it", () => {
+    const row = { id: 1, login: "a", token_hash: "SECRET-HASH", expires_at: "2026-01-01T00:00:00Z" };
+    const safe = redactRow("auth_sessions", row);
+    expect(safe).not.toHaveProperty("token_hash");
+    expect(safe).toEqual({ id: 1, login: "a", expires_at: "2026-01-01T00:00:00Z" });
+    expect(JSON.stringify(safe)).not.toContain("SECRET-HASH");
+  });
+
+  it("leaves a row from a non-redacted table untouched (same reference)", () => {
+    const row = { id: 1, full_name: "owner/repo" };
+    expect(redactRow("repositories", row)).toBe(row);
+  });
+
+  it("redacts every DO-NOT-MIGRATE column (token_hash / payload_hash / ciphertext)", () => {
+    expect(REDACTED_COLUMNS).toMatchObject({ auth_sessions: ["token_hash"], webhook_events: ["payload_hash"], repository_ai_keys: ["ciphertext"] });
+    expect(redactRow("webhook_events", { delivery_id: "d1", payload_hash: "h" })).toEqual({ delivery_id: "d1" });
+    expect(redactRow("repository_ai_keys", { repo_full_name: "o/r", ciphertext: "ENCRYPTED" })).toEqual({ repo_full_name: "o/r" });
+  });
+});
+
+describe("export-d1-core checksum", () => {
+  it("is deterministic and column-order independent", () => {
+    const a = [{ id: 1, name: "x" }, { id: 2, name: "y" }];
+    const b = [{ name: "x", id: 1 }, { name: "y", id: 2 }]; // same data, different key order
+    expect(checksumRows(a)).toBe(checksumRows(b));
+  });
+
+  it("changes when the data changes", () => {
+    expect(checksumRows([{ id: 1 }])).not.toBe(checksumRows([{ id: 2 }]));
+  });
+});
+
+describe("export-d1-core incremental filter", () => {
+  const rows = [
+    { id: 1, updated_at: "2026-05-01T00:00:00Z" },
+    { id: 2, updated_at: "2026-06-15T00:00:00Z" },
+    { id: 3 }, // missing the timestamp column
+  ];
+
+  it("keeps only rows at/after the since-date, and KEEPS rows missing the column (fail-safe)", () => {
+    const kept = filterRowsSince(rows, "updated_at", "2026-06-01T00:00:00Z");
+    expect(kept.map((r) => r.id)).toEqual([2, 3]);
+  });
+
+  it("returns every row when no since-date (full export) or no since-column", () => {
+    expect(filterRowsSince(rows, "updated_at", undefined)).toHaveLength(3);
+    expect(filterRowsSince(rows, undefined, "2026-06-01T00:00:00Z")).toHaveLength(3);
+  });
+});
+
+describe("export-d1-core buildTableExport + manifest", () => {
+  it("returns null for an excluded table so it is never written", () => {
+    expect(EXCLUDED_TABLES.has("d1_migrations")).toBe(true);
+    expect(buildTableExport("d1_migrations", [{ id: 1 }])).toBeNull();
+  });
+
+  it("redacts + checksums + counts rows for an exported table", () => {
+    const out = buildTableExport("auth_sessions", [{ id: 1, token_hash: "h1" }, { id: 2, token_hash: "h2" }]);
+    expect(out).not.toBeNull();
+    expect(out?.rowCount).toBe(2);
+    expect(out?.redactedColumns).toEqual(["token_hash"]);
+    expect(JSON.stringify(out?.rows)).not.toContain("h1");
+    expect(out?.checksum).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("applies the incremental window through buildTableExport", () => {
+    const out = buildTableExport("repositories", [{ id: 1, updated_at: "2026-05-01T00:00:00Z" }, { id: 2, updated_at: "2026-07-01T00:00:00Z" }], {
+      sinceColumn: "updated_at",
+      sinceDate: "2026-06-01T00:00:00Z",
+    });
+    expect(out?.rowCount).toBe(1);
+    expect(out?.rows[0]).toMatchObject({ id: 2 });
+  });
+
+  it("builds a manifest that omits row payloads, sums rows, and drops excluded entries", () => {
+    const exports = [
+      buildTableExport("repositories", [{ id: 1 }, { id: 2 }]),
+      buildTableExport("auth_sessions", [{ id: 9, token_hash: "h" }]),
+      buildTableExport("d1_migrations", [{ id: 1 }]), // null → excluded
+    ];
+    const manifest = buildExportManifest(exports, { database: "gittensory" });
+    expect(manifest.database).toBe("gittensory");
+    expect(manifest.tableCount).toBe(2);
+    expect(manifest.totalRows).toBe(3);
+    expect(manifest.tables.map((t) => t.table).sort()).toEqual(["auth_sessions", "repositories"]);
+    // The manifest carries metadata + checksums only — never the row payloads.
+    expect(JSON.stringify(manifest)).not.toContain('"rows"');
+  });
+});


### PR DESCRIPTION
## Summary

**Self-host migration Phase 3, piece 1** (the foundation). A **read-only** D1 exporter that SELECTs the cloud D1's tables and emits a redacted, checksummed, per-table JSON dump plus a manifest the self-host importer (next piece) validates against. Part of [[gittensory-selfhost-migration-plan]] — the cloud stays 100% intact (this only reads).

- **`scripts/export-d1-core.mjs`** (pure, unit-tested):
  - `EXCLUDED_TABLES` — SQLite/Drizzle internals + the cloud's migration ledger (self-host applies its own forward migrations).
  - `REDACTED_COLUMNS` — the DO-NOT-MIGRATE columns dropped on export: `auth_sessions.token_hash` and `webhook_events.payload_hash` (cloud-deploy-scoped hashes) and `repository_ai_keys.ciphertext` (maintainer BYOK keys, AES-256-GCM-encrypted with the **cloud's** secret → dead on self-host, and a secret we must not copy regardless).
  - `checksumRows` — an order-independent SHA-256 so the importer can prove a faithful round-trip across D1/SQLite/Postgres.
  - `filterRowsSince` — a **fail-safe** incremental window (`--since-date`): rows missing the timestamp column are KEPT (the importer's idempotent upsert reconciles them).
- **`scripts/export-d1-data.mjs`** — the thin IO wrapper: enumerates tables and reads each via `wrangler d1 execute --json` (never a write command), writes `tables/<name>.json` + `manifest.json`. Supports `--remote`, `--since-date`, `--since-column`.

```
node scripts/export-d1-data.mjs --db gittensory --output ./export [--remote] [--since-date <iso>]
```

No `src/` runtime change. Import / incremental-sync / pre-cut validation land in follow-up PRs.

## Scope
- [x] Tooling only — `scripts/**` + a `test/**` unit test; no `src/` change, no DB/migration, no API/UI
- [x] Read-only by construction (the CLI issues only `SELECT` / `sqlite_master` reads)

## Validation
- [x] `npm run test:ci` — green; `typecheck` clean; `npm audit --audit-level=moderate` — 0 vulnerabilities; `git diff --check` clean
- [x] `codecov/patch` — n/a (no `src/**` lines changed)
- New tests (`export-d1-core.test.ts`): redaction drops every DO-NOT-MIGRATE column (asserts the secret never appears in output); checksum is deterministic + column-order-independent and changes with the data; the incremental filter keeps at/after the date and fail-safe-keeps column-less rows; excluded tables return null; the manifest sums rows, drops excluded entries, and omits row payloads.

## Safety
- [x] No secrets / wallets / hotkeys / coldkeys / trust scores / reward values added — and the exporter explicitly **strips** committed secrets/ciphertext from the dump
- [x] Read-only: cannot mutate the live cloud D1
