### PR TITLE
fix(selfhost): defer user npm bin path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ ENV NODE_ENV=production \
     PORT=8787 \
     DATABASE_PATH=/data/gittensory.sqlite \
     MIGRATIONS_DIR=/app/migrations \
-    NPM_CONFIG_PREFIX=/home/node/.npm-global \
-    PATH=/home/node/.npm-global/bin:$PATH
+    NPM_CONFIG_PREFIX=/home/node/.npm-global
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/migrations ./migrations
 # Optional: bake the Claude Code / Codex CLIs so the `claude-code` / `codex` subscription providers (#979)
@@ -49,6 +48,9 @@ COPY --from=build /app/package*.json ./
 RUN if [ "$INSTALL_VISUAL_REVIEW" = "true" ]; then npm install puppeteer-core@22.13.1 --ignore-scripts; fi
 # Data dir (the SQLite file) — owned by the unprivileged node user; mount a volume here to persist.
 RUN mkdir -p /data && chown -R node:node /data /app
+# Expose the optional user-installed CLIs only after all root build steps have completed, so a
+# lifecycle script cannot poison PATH for later root RUN commands.
+ENV PATH=/home/node/.npm-global/bin:$PATH
 USER node
 EXPOSE 8787
 # Probe /ready (not /health): /health is a liveness stub that returns 200 even when the DB is down,


### PR DESCRIPTION
### Motivation
- Fix a Dockerfile PATH-poisoning vulnerability where a node-writable npm global `bin` directory was prepended to `PATH` before an optional `npm install -g` ran as the unprivileged `node` user, allowing lifecycle scripts to place attacker-controlled executables that later root `RUN` steps could resolve and execute.

### Description
- Remove `/home/node/.npm-global/bin` from the early `ENV PATH` while preserving `NPM_CONFIG_PREFIX=/home/node/.npm-global` so the unprivileged install still writes into the user prefix. 
- Reintroduce `ENV PATH=/home/node/.npm-global/bin:$PATH` only after the final root-owned `RUN` steps (the `mkdir /data && chown -R node:node /data /app` step), ensuring later root `RUN` commands no longer resolve through a node-writable prefix. 
- Keep the optional AI CLI install run as `USER node` into the user-owned prefix so runtime CLI discovery is preserved but cannot poison subsequent root build steps.

### Testing
- Ran `git diff --check` which passed and an ordering check that verifies the `ENV PATH` placement now appears after the final root-owned `mkdir/chown` step, which passed. 
- Executed the full local gate with `npm run test:ci`; the run started but encountered unrelated unit-test timeouts/failures in several suites and did not complete green in this environment. 
- Attempted `npm audit --audit-level=moderate`, but the registry audit endpoint returned `403 Forbidden` in this environment so the dependency audit could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e09e22ce8832caa4af84528a735c9)