### PR TITLE
docs(selfhost): make Orb-brokered the canonical self-host path + document telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,9 @@ GITTENSORY_REVIEW_DRAFT=false
 # the worker reads.
 
 # --- Core (required for the worker to run) -----------------------------------
+# SELF-HOST (Orb-brokered, the recommended path): leave the GITHUB_APP_* below UNSET and instead set
+# ORB_ENROLLMENT_SECRET + ORB_BROKER_URL + PUBLIC_API_ORIGIN (see the Orb section near the bottom). The
+# GITHUB_APP_* keys are for the cloud worker and the self-managed-App path (no Orb) only.
 # GITHUB_WEBHOOK_SECRET=
 # GITHUB_APP_ID=
 # GITHUB_APP_PRIVATE_KEY=
@@ -213,7 +216,8 @@ GITTENSORY_REVIEW_DRAFT=false
 # ORB_ANONYMIZE=true                         # HMAC-hash repo/PR before export (default true; false = raw names)
 # ORB_COLLECTOR_URL=https://gittensory-api.aethereal.dev/v1/orb/ingest  # gittensory's hosted collector (default; override for your own)
 #
-# Token broker (optional): get GitHub tokens from the central Orb (you installed the Orb App) instead of running
-# your own GitHub App. Set the enrollment secret the operator issued for your install; unset = use your own App key.
+# Token broker — the RECOMMENDED self-host path (gittensor-Mirror model): get GitHub tokens from the central Orb
+# (you installed the Orb App) instead of running your own GitHub App. Set the enrollment secret the operator issued
+# for your install + PUBLIC_API_ORIGIN (so the Orb can relay your repos' events). Unset = self-managed App (GITHUB_APP_* above).
 # ORB_ENROLLMENT_SECRET=                      # one-time enrollment secret (a secret — keep it out of version control)
 # ORB_BROKER_URL=https://gittensory-api.aethereal.dev  # the Orb broker base (default; override for a private deployment)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,9 +1,17 @@
 # Self-hosting Gittensory
 
 Gittensory ships as a Cloudflare Worker, but the **same** review engine runs unchanged on a plain Node
-container so you can self-host it next to your own GitHub App. `docker compose up` gives you the full
-reviewer — webhooks, the deterministic gate, AI summaries, the maintain/sweep cron, and (optionally) full
-maintainer autonomy — backed by a local SQLite database.
+container so you can self-host it on your own infrastructure (Docker, Railway, Fly, a VM …). `docker
+compose up` gives you the full reviewer — webhooks, the deterministic gate, AI summaries, the
+maintain/sweep cron, and (optionally) full maintainer autonomy — backed by a local SQLite database.
+
+Self-host connects to the **Gittensory Orb** — our central GitHub App that brokers GitHub access and
+collects anonymized fleet calibration. This is the **gittensor-Mirror model**: you install the **Orb App**
+on your repos and run the container; you **do not create your own GitHub App or manage a private key**, the
+Orb relays your repos' events to your container and mints short-lived GitHub tokens on demand, and your
+instance contributes anonymized review outcomes that keep the gate calibrated across the whole fleet (and
+power the public stats on gittensory.aethereal.dev). A fully self-managed App with no Orb is possible but
+unsupported for now — see [Advanced: self-managed App](#9-advanced--self-managed-github-app-no-orb).
 
 > **How it works (one paragraph).** The Worker's Cloudflare bindings are swapped for self-host adapters and
 > nothing else changes: **D1 → `node:sqlite`** (a faithful `D1Database` shim, so Drizzle + every raw query +
@@ -13,17 +21,32 @@ maintainer autonomy — backed by a local SQLite database.
 
 ---
 
-## 1. Quick start
+## 1. Quick start (Orb-brokered)
+
+You need three things from the Orb: the **Orb App installed** on your repos, an **enrollment secret**
+(`ORB_ENROLLMENT_SECRET`, issued to you by the Gittensory operator for that install — self-service
+enrollment is coming), and a **public URL the Orb can reach** to deliver your repos' events.
+
+1. **Install the Gittensory Orb App** on the repositories you want reviewed.
+2. **Get your enrollment secret** from the operator for that install.
+3. **Configure `.env` and run:**
 
 ```bash
-cp .env.example .env          # then edit .env — see §3
+cp .env.example .env
+# set in .env:
+#   ORB_ENROLLMENT_SECRET=<your enrollment secret>
+#   ORB_BROKER_URL=https://gittensory-api.aethereal.dev   # default — the Orb broker + collector
+#   PUBLIC_API_ORIGIN=https://<your-host>                 # MUST be reachable by the Orb relay
 docker compose up --build
 curl localhost:8787/health    # {"status":"ok"}
 ```
 
-On first boot the container creates the SQLite database on the `gittensory-data` volume and applies all 56
-migrations automatically (`{"event":"selfhost_migrations_applied","count":56}` in the logs). Point your
-GitHub App's webhook at `https://<your-host>/v1/github/webhook` (expose port 8787 behind your own TLS).
+On boot the container creates the SQLite database on the `gittensory-data` volume, applies all migrations
+automatically (`{"event":"selfhost_migrations_applied",…}` in the logs), then **registers its relay URL**
+(`PUBLIC_API_ORIGIN` + `/v1/orb/relay`) with the Orb. From there the Orb **forwards your install's
+webhooks** to the container, HMAC-signed with your enrollment secret — there is **no GitHub webhook to
+configure**. GitHub API actions (comment, label, merge, close) use **short-lived installation tokens
+brokered from the Orb on demand**, so the container never holds a GitHub App private key.
 
 **Or use the published image** (multi-arch, ~254 MB) instead of building:
 
@@ -46,39 +69,38 @@ GitHub Release.
 
 ---
 
-## 2. Create the GitHub App
+## 2. Telemetry — Orb fleet calibration
 
-**One-click (recommended):** before setting any GitHub secrets, set `PUBLIC_API_ORIGIN` and a long random
-`SELFHOST_SETUP_TOKEN`, boot the container, then visit **`/setup`** and enter your `SELFHOST_SETUP_TOKEN`
-in the form (the token is sent in the POST body, never the URL, so it can't leak to logs or browser history).
-It creates the App for you via GitHub's App-manifest flow (correct permissions/events + webhook URL), then
-writes the credentials to `/data/gittensory-app.env`. Add those to your `.env`, install the App on your repos,
-and restart. `/setup` requires the setup token and is disabled once `GITHUB_APP_ID` is set, so it can't rebind
-a live install. (Scripted setups can pass the token via an `x-setup-token` header instead.)
+Self-hosting is a **fleet-telemetry contract**: each instance exports an anonymized, reversal-aware
+review-outcome signal to the Orb collector (`ORB_COLLECTOR_URL`, default the hosted collector). This is
+what calibrates the gate across the whole self-host fleet and produces the accurate aggregate numbers on
+gittensory.aethereal.dev — it is **on by default** once your App is configured.
 
-**Or manually**, create a GitHub App (the hosted gittensory[bot] is separate) with:
-
-- **Webhook URL** `https://<your-host>/v1/github/webhook`, and a **webhook secret** (→ `GITHUB_WEBHOOK_SECRET`).
-- **Permissions**: Pull requests (read/write), Contents (read; read/write if you want merge), Issues
-  (read/write), Checks (read), Metadata (read). Commit statuses (read).
-- **Events**: Pull request, Pull request review, Push, Issues, Check suite, Check run, Status.
-- Generate a **private key** (→ `GITHUB_APP_PRIVATE_KEY`), and note the **App ID** (→ `GITHUB_APP_ID`) and the
-  app **slug** (→ `GITHUB_APP_SLUG`). Install the app on the repos you want reviewed.
+- **Anonymized.** Repo/PR identifiers are HMAC-hashed with a per-instance secret the collector **never
+  holds**, so it can't de-anonymize you. The payload is only `verdict + outcome + reversal + a bucketed
+  reason category + cycle time` — **no diffs, no code, no comments, no logins, no commit SHAs**.
+- **Knobs** (`.env`): `ORB_ANONYMIZE` (default `true`), `ORB_COLLECTOR_URL` (repoint at your own
+  collector), and `ORB_AIR_GAP=true` for **offline/air-gapped** deployments — computes locally and never
+  sends. Air-gap also implies running a self-managed App (no broker); see §9.
 
 ---
 
 ## 3. Configuration
 
 Everything is environment variables — see [`.env.example`](../.env.example) for the annotated list (it holds
-**sample placeholders only; never commit a real `.env`** — it is gitignored). The required core secrets:
+**sample placeholders only; never commit a real `.env`** — it is gitignored). The required core secrets for
+the **Orb-brokered** path:
 
 | Variable | What it is |
 | --- | --- |
-| `GITHUB_APP_ID` / `GITHUB_APP_SLUG` | your GitHub App's id + slug |
-| `GITHUB_APP_PRIVATE_KEY` | the App's PKCS#8 private key (or mount `GITHUB_APP_PRIVATE_KEY_FILE`) |
-| `GITHUB_WEBHOOK_SECRET` | the webhook secret you set on the App |
+| `ORB_ENROLLMENT_SECRET` | your one-time enrollment secret, issued by the operator for your Orb install |
+| `ORB_BROKER_URL` | the Orb broker + collector base (default `https://gittensory-api.aethereal.dev`) |
+| `PUBLIC_API_ORIGIN` | your container's public base URL — **must be reachable by the Orb relay** |
 | `GITTENSOR_REGISTRY_URL` | registry endpoint (or any reachable placeholder if you don't use the registry) |
 | `GITTENSORY_API_TOKEN` / `GITTENSORY_MCP_TOKEN` / `INTERNAL_JOB_TOKEN` | bearer tokens — generate your own (`openssl rand -hex 32`) |
+
+(In broker mode you set **no** `GITHUB_APP_*` secrets — the Orb holds the App key and mints tokens for you.
+The `GITHUB_APP_*` path is only for the self-managed App in §9.)
 
 Runtime knobs: `PORT` (default 8787), `DATABASE_PATH` (default `/data/gittensory.sqlite`), `CRON_INTERVAL_MS`
 (default 120000 ≈ the hosted every-2-minutes cron).
@@ -236,3 +258,33 @@ These are Cloudflare-platform features; they degrade cleanly and the core review
 - **Distributed rate limiting** (RateLimiter Durable Object) — off by default; set `REDIS_URL` for a
   Redis-backed fixed-window limiter (see §7). Otherwise put a reverse proxy / WAF in front.
 - **Vectorize-backed RAG** and **R2 audit storage** — inert unless you wire equivalent backends.
+
+---
+
+## 9. Advanced — self-managed GitHub App (no Orb)
+
+> The **Orb-brokered path (§1) is the supported model.** This self-managed path — bring your own GitHub
+> App, hold your own private key, opt out of the broker — exists only for **air-gapped / fully-independent**
+> deployments (`ORB_AIR_GAP=true`, no `ORB_ENROLLMENT_SECRET`). It does not contribute fleet calibration.
+> If you need it, file an issue so we can support your case properly.
+
+In this mode you create and run your own GitHub App instead of installing the Orb App:
+
+**One-click:** set `PUBLIC_API_ORIGIN` and a long random `SELFHOST_SETUP_TOKEN`, boot the container, then
+visit **`/setup`** and enter your `SELFHOST_SETUP_TOKEN` in the form (sent in the POST body, never the URL).
+It creates the App via GitHub's App-manifest flow (correct permissions/events + webhook URL) and writes the
+credentials to `/data/gittensory-app.env`. Add those to your `.env`, install the App on your repos, and
+restart. `/setup` is disabled once `GITHUB_APP_ID` is set, so it can't rebind a live install.
+
+**Or manually**, create a GitHub App (the hosted gittensory[bot] is separate) with:
+
+- **Webhook URL** `https://<your-host>/v1/github/webhook`, and a **webhook secret** (→ `GITHUB_WEBHOOK_SECRET`).
+- **Permissions**: Pull requests (read/write), Contents (read; read/write if you want merge), Issues
+  (read/write), Checks (read), Metadata (read). Commit statuses (read).
+- **Events**: Pull request, Pull request review, Push, Issues, Check suite, Check run, Status.
+- Generate a **private key** (→ `GITHUB_APP_PRIVATE_KEY`), and note the **App ID** (→ `GITHUB_APP_ID`) and the
+  app **slug** (→ `GITHUB_APP_SLUG`). Install the app on the repos you want reviewed.
+
+The required core secrets here are `GITHUB_APP_ID` / `GITHUB_APP_SLUG` / `GITHUB_APP_PRIVATE_KEY` /
+`GITHUB_WEBHOOK_SECRET` (in place of the `ORB_*` variables from §3), and GitHub webhooks are delivered
+**directly** to `/v1/github/webhook` rather than relayed by the Orb.


### PR DESCRIPTION
## Summary

The self-hosting guide was built entirely around the **self-managed-App** model (create your own GitHub App,
hold a private key, point a webhook at the container) and **never mentioned the Gittensory Orb broker or the
fleet-telemetry exporter** — even though both are fully built in the code. That's backwards from the intended
deployment model. This rewrites the guide around the **gittensor-Mirror model**, where self-hosters rely on
the central Orb App.

### Changes
- **Lead with the Orb-brokered quick start** ([self-hosting.md](docs/self-hosting.md) §1): install the Orb App → set `ORB_ENROLLMENT_SECRET` + `ORB_BROKER_URL` + `PUBLIC_API_ORIGIN` → run. The Orb relays the install's webhooks to the container (HMAC-signed) and brokers short-lived GitHub tokens on demand — **no own App, no private key, no webhook to configure**.
- **New §2 "Telemetry — Orb fleet calibration"**: documents the anonymized export honestly — `verdict + outcome + reversal + bucketed reason + cycle time`, HMAC'd with a per-instance secret the collector never holds, **on by default** (the fleet-telemetry contract).
- **§3 core-secrets table** now lists the `ORB_*` variables; notes that broker mode sets **no** `GITHUB_APP_*`.
- **Demote** the bring-your-own-App flow to an **"Advanced — self-managed App (no Orb)"** appendix (§9) for air-gapped/independent deployments only.
- **`.env.example`**: present `ORB_*` as the recommended self-host path; `GITHUB_APP_*` for the cloud worker + self-managed path.

## Scope
- [x] Docs + `.env.example` only — no code change, no `src/**` touched (no coverage obligation).
- [x] No secrets / private values; telemetry description matches the code (anonymized, no code/diffs/logins/SHAs).

## Validation
- [x] Reviewed every remaining `GITHUB_APP_*` / `/v1/github/webhook` reference — all now scoped to the §9 self-managed appendix or explicitly negated in the intro.

No issue (docs alignment surfaced while squaring away the self-host deployment model).
