### PR TITLE
fix(selfhost): redact exported D1 secret columns

### DIFF
--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -10,14 +10,18 @@ export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_m
 
 // Columns dropped per table on export — cloud-specific secrets/hashes that are dead or unsafe on self-host. A
 // committed credential never crosses the boundary (#selfhost-migration DO-NOT-MIGRATE list):
-//   • auth_sessions.token_hash    — hashed browser session tokens, scoped to the cloud deploy; never migrate.
-//   • webhook_events.payload_hash — per-delivery dedup hash, scoped to the cloud deploy.
-//   • repository_ai_keys.ciphertext — maintainer BYOK provider keys, AES-256-GCM-encrypted with the CLOUD's
-//     TOKEN_ENCRYPTION_SECRET → undecryptable (dead) on self-host, and a secret we must not copy regardless.
+//   • auth_sessions.token_hash                 — hashed browser session tokens, scoped to the cloud deploy.
+//   • webhook_events.payload_hash              — per-delivery dedup hash, scoped to the cloud deploy.
+//   • repository_ai_keys.ciphertext            — maintainer BYOK provider keys, encrypted with the cloud key.
+//   • submission_user_tokens.encrypted_token   — short-lived GitHub OAuth token envelopes, cloud-scoped.
+//   • orb_enrollments.secret_hash              — one-time enrollment secret hashes.
+//   • orb_enrollments.relay_secret_*           — encrypted relay webhook signing secret material.
 export const REDACTED_COLUMNS = {
   auth_sessions: ["token_hash"],
   webhook_events: ["payload_hash"],
   repository_ai_keys: ["ciphertext"],
+  submission_user_tokens: ["encrypted_token"],
+  orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"],
 };
 
 // A table name is only ever interpolated into SQL (`SELECT * FROM "<name>"`) after passing this allowlist, so a

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -32,10 +32,39 @@ describe("export-d1-core redaction (#selfhost-migration)", () => {
     expect(redactRow("repositories", row)).toBe(row);
   });
 
-  it("redacts every DO-NOT-MIGRATE column (token_hash / payload_hash / ciphertext)", () => {
-    expect(REDACTED_COLUMNS).toMatchObject({ auth_sessions: ["token_hash"], webhook_events: ["payload_hash"], repository_ai_keys: ["ciphertext"] });
+  it("redacts every DO-NOT-MIGRATE column", () => {
+    expect(REDACTED_COLUMNS).toMatchObject({
+      auth_sessions: ["token_hash"],
+      webhook_events: ["payload_hash"],
+      repository_ai_keys: ["ciphertext"],
+      submission_user_tokens: ["encrypted_token"],
+      orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"],
+    });
     expect(redactRow("webhook_events", { delivery_id: "d1", payload_hash: "h" })).toEqual({ delivery_id: "d1" });
     expect(redactRow("repository_ai_keys", { repo_full_name: "o/r", ciphertext: "ENCRYPTED" })).toEqual({ repo_full_name: "o/r" });
+  });
+
+  it("redacts draft OAuth and Orb secret material from self-host exports (regression)", () => {
+    const draftExport = buildTableExport("submission_user_tokens", [
+      { draft_id: "d1", encrypted_token: "LEAK_DRAFT_OAUTH_TOKEN_ENVELOPE", expires_at: "2026-01-01T00:00:00Z" },
+    ]);
+    expect(draftExport?.redactedColumns).toEqual(["encrypted_token"]);
+    expect(draftExport?.rows).toEqual([{ draft_id: "d1", expires_at: "2026-01-01T00:00:00Z" }]);
+
+    const orbExport = buildTableExport("orb_enrollments", [
+      {
+        enroll_id: "e1",
+        installation_id: 42,
+        secret_hash: "LEAK_ORB_ENROLLMENT_SECRET_HASH",
+        relay_secret_enc: "LEAK_RELAY_SECRET",
+        relay_secret_iv: "LEAK_RELAY_IV",
+        relay_secret_salt: "LEAK_RELAY_SALT",
+      },
+    ]);
+    expect(orbExport?.redactedColumns).toEqual(["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"]);
+    expect(orbExport?.rows).toEqual([{ enroll_id: "e1", installation_id: 42 }]);
+
+    expect(JSON.stringify([draftExport, orbExport])).not.toMatch(/LEAK_/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The D1 export tool exported additional cloud-scoped secret material (draft OAuth envelopes and Orb enrollment/relay secrets) because the redaction map only covered three columns; this expands the DO-NOT-MIGRATE redaction to match existing migrations and comments.

### Description
- Expand the redaction map in `scripts/export-d1-core.mjs` to include `submission_user_tokens.encrypted_token` and `orb_enrollments` secret/relay fields (`secret_hash`, `relay_secret_enc`, `relay_secret_iv`, `relay_secret_salt`).
- Update the explanatory comment in `scripts/export-d1-core.mjs` to list the newly redacted columns and why they must not be migrated.
- Add a regression unit test in `test/unit/export-d1-core.test.ts` that asserts `buildTableExport` drops the new secret columns and that exported rows do not contain the leaked secret values.
- Preserve existing behavior: excluded tables remain untouched, incremental filtering/ checksumming logic unchanged.

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/export-d1-core.test.ts`, and the file passed (all tests succeeded).
- Attempted the full local gate via `npm run test:ci`, but the run failed due to unrelated long-running coverage tasks and a Vitest coverage remap error (`TypeError: jsTokens is not a function`).
- Ran `npm audit --audit-level=moderate`, which could not complete in this environment due to the registry audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e28a8fca4832c89c088833c16548d)