### PR TITLE
fix(mcp): bound predict-gate changedPaths

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -677,7 +677,7 @@ const predictGateShape = {
   linkedIssues: z.array(z.number().int().positive()).optional(),
   // The PR's changed file PATHS (metadata only — paths, never source content). Supplying them lets the predictor
   // also evaluate the focus-manifest path policy + path-gated pre-merge checks, matching the live gate (#11-13/#18).
-  changedPaths: z.array(z.string().min(1)).max(500).optional(),
+  changedPaths: z.array(z.string().min(1).max(PREFLIGHT_LIMITS.changedFileChars)).max(500).optional(),
 };
 
 // Pure local-metadata computation (no repo data, no secrets) — the agent supplies its own diff metadata

--- a/test/unit/mcp-predict-gate.test.ts
+++ b/test/unit/mcp-predict-gate.test.ts
@@ -47,6 +47,19 @@ describe("MCP gittensory_predict_gate", () => {
     expect((minimal.structuredContent as { pack: string }).pack).toBe("oss-anti-slop");
   });
 
+  it("rejects changedPaths entries above the path metadata size cap", async () => {
+    const env = createTestEnv();
+    const client = await connect(env);
+
+    const result = await client.callTool({
+      name: "gittensory_predict_gate",
+      arguments: { login: "miner1", owner: "acme", repo: "widgets", title: "Huge path", changedPaths: [`src/${"a".repeat(301)}.ts`] },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain("Too big");
+  });
+
   it("predicts the focus-manifest path policy when changedPaths are supplied (#11-13/#18)", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets" });


### PR DESCRIPTION
### Motivation
- Prevent unbounded caller-controlled path strings in the MCP `gittensory_predict_gate` input from driving large allocations and CPU during path-glob matching by applying the same per-path metadata size cap used elsewhere.

### Description
- Constrain `changedPaths` elements in the MCP `predictGateShape` to `PREFLIGHT_LIMITS.changedFileChars` (using `z.string().min(1).max(PREFLIGHT_LIMITS.changedFileChars)`), keeping the existing array cap of 500.
- Add a regression unit test that submits an oversized `changedPaths` entry to `gittensory_predict_gate` and asserts the call is rejected before prediction processing.

### Testing
- Ran the focused unit test file with `npx vitest run test/unit/mcp-predict-gate.test.ts`, and all tests in that file passed.
- Ran `git diff --check` and `npm run typecheck` and they succeeded (no typing or diff issues).
- Ran the full local gate with `npm run test:ci`; the targeted change passed, but the full suite aborted on unrelated long-running coverage remap work with `TypeError: jsTokens is not a function` and therefore did not complete end-to-end.
- `npm audit --audit-level=moderate` could not complete due to a registry audit endpoint error (network/403) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e28a936ac832cad216827021e7347)