### PR TITLE
feat(orb): zero-touch self-enrollment — a verified admin auto-registers their install

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -34,13 +34,12 @@ events to your container and mint short-lived GitHub tokens for it on demand.
 
 ### Step 2 — Get your enrollment secret (self-service)
 
-When the install is authorized, GitHub returns you to a Gittensory page that — once we've verified you're an
-**admin of the installed account** — shows your **`ORB_ENROLLMENT_SECRET` once**. Copy it (it isn't shown
-again). This is a per-install secret; treat it like a password.
+When the install is authorized, GitHub returns you to a Gittensory page that — once we've verified server-side
+that you're an **admin of the installed account** — shows your **`ORB_ENROLLMENT_SECRET` once**. Copy it (it
+isn't shown again). This is a per-install secret; treat it like a password.
 
-> First-time installs are reviewed by the operator before the secret is issued (a one-time approval; you'll see
-> "not enabled yet" until it's done, then re-open the install to get your secret). The secret is **self-issued —
-> the operator never sees or hands you a credential.**
+> The secret is **self-issued — zero-touch.** There's no operator step and no credential hand-off: a verified
+> admin enrolls their own install on the spot. (Lose it? Re-open the install from GitHub to issue a new one.)
 
 ### Step 3 — Configure `.env` and run
 

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -8,8 +8,9 @@
 // attacker-controllable query param, so a stolen OAuth code paired with a VICTIM's installation_id must NEVER
 // enroll the victim's install. We require: a valid OAuth code (single-use, GitHub-issued) → the authenticated
 // user → that user is an admin of the install's account (org admin, or the user account owner) → the install is
-// registered=1. installation_id is then bound server-side in the enrollment (read back at token-exchange, never
-// from a request). No request input is echoed into the markup (no injection surface).
+// active (not suspended/removed). A verified admin AUTO-REGISTERS the install (registered=1) — zero-touch, no
+// operator step — and installation_id is then bound server-side in the enrollment (read back at token-exchange,
+// never from a request). No request input is echoed into the markup (no injection surface).
 import type { Context } from "hono";
 import { isOrbBrokerEnabled, issueOrbEnrollment } from "./broker";
 
@@ -65,16 +66,23 @@ async function handleOrbEnrollment(c: Context<{ Bindings: Env }>, code: string, 
   if (!token) return c.html(landingPage("Couldn't verify your GitHub identity", "The authorization didn't complete — re-run the install from GitHub and try again."), 400);
   const user = await fetchOrbOAuthUser(token);
   if (!user) return c.html(landingPage("Couldn't verify your GitHub identity", "We couldn't read your GitHub account — try the install again."), 400);
-  const install = await c.env.DB.prepare("SELECT account_login, account_type, registered FROM orb_github_installations WHERE installation_id = ?")
+  const install = await c.env.DB.prepare("SELECT account_login, account_type, registered, suspended_at, removed_at FROM orb_github_installations WHERE installation_id = ?")
     .bind(installationId)
-    .first<{ account_login: string | null; account_type: string | null; registered: number }>();
+    .first<{ account_login: string | null; account_type: string | null; registered: number; suspended_at: string | null; removed_at: string | null }>();
   if (!install) return c.html(landingPage("Installation not recognized", "We haven't recorded this installation yet — give it a moment after installing, then retry."), 404);
-  if (install.registered !== 1) return c.html(landingPage("Not enabled yet", "This installation isn't enabled for brokered self-host yet — ask the operator to register it, then retry."), 403);
+  // The admin-of-installation check is the authorization gate — it runs BEFORE we reveal or change any state, so a
+  // non-admin learns nothing about the install and can never enroll someone else's.
   const isAdmin = await verifyInstallationAdmin(token, user.login, install.account_login, install.account_type);
   if (!isAdmin) return c.html(landingPage("Admin access required", "You must be an admin of this installation's account to enroll it for self-host."), 403);
+  if (install.removed_at !== null || install.suspended_at !== null) return c.html(landingPage("Installation not active", "This installation is suspended or uninstalled — re-install the Orb App, then retry."), 403);
+  // Zero-touch self-service: a verified admin of an ACTIVE install self-registers it (registered=1) with no operator
+  // step. installation_id stays bound server-side in the enrollment, so brokered tokens remain scoped to this install.
+  if (install.registered !== 1) {
+    await c.env.DB.prepare("UPDATE orb_github_installations SET registered = 1, last_event_at = CURRENT_TIMESTAMP WHERE installation_id = ?").bind(installationId).run();
+  }
   const result = await issueOrbEnrollment(c.env, installationId, { login: user.login, githubId: user.id ?? null });
-  /* v8 ignore next -- defensive: the existence + registered=1 checks above already passed, so issueOrbEnrollment
-     (which re-checks the same) cannot return an error here; kept so a future refactor degrades safely. */
+  /* v8 ignore next -- defensive: the existence + admin + active checks above passed and we just set registered=1, so
+     issueOrbEnrollment (which re-checks existence + registered) cannot return an error here; kept to degrade safely. */
   if ("error" in result) return c.html(landingPage("Couldn't issue an enrollment", "Please retry, or contact the operator."), 409);
   return c.html(secretPage(result.secret));
 }

--- a/test/integration/orb-oauth.test.ts
+++ b/test/integration/orb-oauth.test.ts
@@ -98,23 +98,38 @@ describe("maintainer self-enrollment via the OAuth callback", () => {
     expect(row).toMatchObject({ maintainer_login: "alice", maintainer_github_id: 7 });
   });
 
-  it("a NON-admin is refused (403) and NO enrollment is created — the escalation gate", async () => {
+  it("a NON-admin is refused (403), NO enrollment created, and the install is NOT auto-registered — the escalation gate", async () => {
     const e = brokeredEnv();
-    await seedInstall(e, { installation_id: 501, account_login: "acme", account_type: "Organization", registered: 1 });
+    await seedInstall(e, { installation_id: 501, account_login: "acme", account_type: "Organization", registered: 0 });
     stubGitHub({ membership: { role: "member", state: "active" } });
     const res = await app.request("/v1/orb/oauth/callback?code=abc&installation_id=501", {}, e);
     expect(res.status).toBe(403);
     expect(await res.text()).toContain("Admin access required");
     expect(await db(e).prepare("SELECT 1 AS x FROM orb_enrollments WHERE installation_id=501").first()).toBeUndefined();
+    const row = await db(e).prepare("SELECT registered FROM orb_github_installations WHERE installation_id=501").first<{ registered: number }>();
+    expect(row?.registered).toBe(0); // a non-admin never auto-registers
   });
 
-  it("an UNREGISTERED install is refused (403)", async () => {
+  it("a verified admin AUTO-REGISTERS an unregistered install (zero-touch) and gets a secret", async () => {
     const e = brokeredEnv();
     await seedInstall(e, { installation_id: 502, account_login: "acme", account_type: "Organization", registered: 0 });
     stubGitHub();
     const res = await app.request("/v1/orb/oauth/callback?code=abc&installation_id=502", {}, e);
-    expect(res.status).toBe(403);
-    expect(await res.text()).toContain("Not enabled yet");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Your enrollment secret");
+    const row = await db(e).prepare("SELECT registered FROM orb_github_installations WHERE installation_id=502").first<{ registered: number }>();
+    expect(row?.registered).toBe(1); // self-registered, no operator step
+  });
+
+  it("a SUSPENDED or UNINSTALLED install is refused (403 not active), even for an admin", async () => {
+    const e = brokeredEnv();
+    await seedInstall(e, { installation_id: 507, account_login: "acme", account_type: "Organization", registered: 1, suspended_at: "2026-01-01T00:00:00Z" });
+    await seedInstall(e, { installation_id: 508, account_login: "acme", account_type: "Organization", registered: 0, removed_at: "2026-01-01T00:00:00Z" });
+    stubGitHub();
+    expect((await app.request("/v1/orb/oauth/callback?code=abc&installation_id=507", {}, e)).status).toBe(403); // suspended (removed_at null → right arm)
+    const removed = await app.request("/v1/orb/oauth/callback?code=abc&installation_id=508", {}, e);
+    expect(removed.status).toBe(403); // removed (left arm)
+    expect(await removed.text()).toContain("not active");
   });
 
   it("an UNKNOWN install is 404", async () => {


### PR DESCRIPTION
## Summary

Makes Orb self-enrollment **zero-touch** — the model you asked for. A maintainer who installs the Gittensory
Orb App now onboards with **no operator step**: on the OAuth landing, once we verify server-side that they're
an **admin of the installed account**, their install is **auto-registered** and the `ORB_ENROLLMENT_SECRET` is
issued on the spot.

Previously a first-time install landed `registered=0` and the maintainer saw "not enabled yet — ask the
operator." Now a verified admin self-registers their own install.

### Security is unchanged at the gate ([src/orb/oauth.ts](src/orb/oauth.ts))
- The **admin-of-installation check** (`verifyInstallationAdmin`: user-account owner, or active org admin) runs
  **before any state is revealed or changed** — a non-admin learns nothing and never enrolls *or* auto-registers.
- Only an install **GitHub already recorded** (via the verified `installation` webhook) that is **active**
  (not suspended/uninstalled) can be enrolled — a fabricated `installation_id` → 404; a suspended/removed one → 403.
- `installation_id` stays **bound server-side** in the enrollment (read back at token-exchange), so brokered
  tokens remain scoped to that install. The trade-off you accepted: any admin who installs the App can broker
  tokens for **their own** repos (resource cost, not a breach).
- The operator-issued internal endpoints remain for **revocation / override**.

## Scope
- [x] `src/orb/oauth.ts` + its integration test + the one-line docs note; the operator path is untouched.
- [x] No secrets echoed; no request input bound to the token (installation_id read from the recorded row).

## Validation
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full suite green; **100% of changed lines and branches** (new tests: admin auto-registers an unregistered install; non-admin neither enrolls nor auto-registers; suspended + uninstalled both refused).

Follow-up to #1436.
