### PR TITLE
fix(db): persist webhook payload marker on conflict

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3788,6 +3788,7 @@ export async function recordWebhookEvent(
     .onConflictDoUpdate({
       target: webhookEvents.deliveryId,
       set: {
+        payloadHash: args.payloadHash,
         status: args.status,
         errorSummary: args.errorSummary,
         processedAt: args.status === "processed" || args.status === "error" ? nowIso() : undefined,

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -127,6 +127,18 @@ describe("database row parser hardening", () => {
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:01:40.000Z", W)).toBe(false); // back inside the new window → loses
   });
 
+  it("REGRESSION: recordWebhookEvent updates payload_hash when processing an existing queued delivery", async () => {
+    const env = createTestEnv();
+    await recordWebhookEvent(env, { deliveryId: "foreign-app-queued", eventName: "pull_request", payloadHash: "raw-sha", status: "queued" });
+
+    await recordWebhookEvent(env, { deliveryId: "foreign-app-queued", eventName: "pull_request", payloadHash: "foreign_app", status: "processed" });
+
+    const row = await env.DB.prepare("select payload_hash, status from webhook_events where delivery_id = ?")
+      .bind("foreign-app-queued")
+      .first<{ payload_hash: string; status: string }>();
+    expect(row).toEqual({ payload_hash: "foreign_app", status: "processed" });
+  });
+
   it("REGRESSION: webhook_events.received_at is always a real ISO timestamp, never the 'CURRENT_TIMESTAMP' literal (#audit-ts-literal)", async () => {
     const env = createTestEnv();
     // Real path: recordWebhookEvent always passes nowIso().


### PR DESCRIPTION
### Motivation
- The queued webhook entry path inserts a `webhook_events` row with the raw payload hash, and a later queue processor may want to mark the same delivery as `foreign_app` for audit/observability.
- The existing conflict update path did not overwrite `payload_hash`, so the `foreign_app` marker was not persisted for real webhooks that had a pre-existing queued row.
- This is an audit/observability correctness fix that preserves the intended marker when a queued row is updated to `processed`.

### Description
- Update `recordWebhookEvent` to include `payloadHash: args.payloadHash` in the `.onConflictDoUpdate(... set: {...})` clause so a conflicting insert overwrites the stored `payload_hash` as intended.
- Add a regression test in `test/unit/db-parsers.test.ts` that seeds a `queued` row and then calls `recordWebhookEvent` with `payloadHash: "foreign_app"` and `status: "processed"`, asserting the row is updated to `{ payload_hash: "foreign_app", status: "processed" }`.
- No schema, migration, OpenAPI, UI, or dependency changes are included.

### Testing
- Ran typecheck with `npm run typecheck` and it completed successfully.
- Ran the focused unit tests with `npx vitest run test/unit/db-parsers.test.ts` and the file's tests passed.
- Ran the targeted pattern run `npx vitest run test/unit/db-parsers.test.ts test/unit/queue.test.ts -t "recordWebhookEvent updates payload_hash|DIFFERENT app"` and the invoked tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e28a8e350832c9f0200c72fe46303)