### PR TITLE
fix(engine): keep blacklist reasons out of close comments

### DIFF
--- a/docs/review-configuration.md
+++ b/docs/review-configuration.md
@@ -159,12 +159,12 @@ Everything a maintainer can toggle in the dashboard can be set as code under `se
 
 The **contributor blacklist** is layered like every other setting (`.gittensory.yml`
 `settings.contributorBlacklist` > database) and is unioned with the shared/global list. Logins are
-public data, so entries carry only public-safe metadata (a `reason`, `evidence` URLs, an `addedAt`
-date) — never wallets, hotkeys, trust scores, or private values. `blacklistLabel` (default `slop`) is
-the label the engine applies to a blacklisted author's PR.
+public data, but the optional `reason`, `evidence`, and `addedAt` fields are maintainer metadata
+for configuration/audit context and are not echoed in automated public close comments. `blacklistLabel`
+(default `slop`) is the label the engine applies to a blacklisted author's PR.
 
 A PR from a **blacklisted login** is labeled (`blacklistLabel`) and **closed deterministically** —
-ahead of any merit/CI/AI analysis, with a sanitized close comment and **no AI call**. The close
+ahead of any merit/CI/AI analysis, with a static public close comment and **no AI call**. The close
 short-circuits and **wins over the normal gate disposition**; it honors the autonomy dial and
 `agentPaused` / `agentDryRun` exactly like any other agent action, and the owner and automation bots
 are never auto-closed.

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -827,7 +827,7 @@ async function maybeRunAgentMaintenance(
 
   // Contributor blacklist (#1425): resolve whether the PR author is on the repo's blacklist (the shared/global
   // list unions in once its table lands). A match short-circuits the planner to a deterministic label + close
-  // ahead of merit/CI/AI; the configured label (default "slop") and the entry's public-safe reason drive it.
+  // ahead of merit/CI/AI; only the configured label (default "slop") reaches public actions.
   const blacklistEntry = findBlacklistEntry(pr.authorLogin, settings.contributorBlacklist);
 
   const planned = planAgentMaintenanceActions({

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -118,8 +118,8 @@ export type AgentActionPlanInput = {
   // global), the disposition SHORT-CIRCUITS to a deterministic close ahead of ALL merit/CI/AI analysis — the
   // banned account never gets merit-reviewed or auto-merged. Zero-hallucination (not an AI judgment), so its
   // close is EXEMPT from the AI-refutation breaker (closeKind "blacklist"). Fires for a CONTRIBUTOR only
-  // (owner/automation bots are never auto-closed). `reason` is the entry's public-safe reason (or null). Absent /
-  // not-matched ⇒ no effect. The close comment is sanitized through the public-safe sanitizer before posting.
+  // (owner/automation bots are never auto-closed). `reason` is private maintainer metadata used only for matching
+  // context; the public close comment intentionally uses static copy. Absent / not-matched ⇒ no effect.
   blacklistMatch?: { matched: boolean; reason: string | null | undefined } | undefined;
   // The repo-configured label applied to a blacklisted author's PR (#1425), resolved from `.gittensory.yml`.
   // Absent ⇒ the default (`DEFAULT_BLACKLIST_LABEL` = "slop"), so the disposition works regardless of the label set.
@@ -230,10 +230,10 @@ function closeMessage(reasons: string[]): string {
   return `Gittensory is closing this pull request on the maintainer's behalf (${reasons.join("; ")}). This is an automated maintenance action — to pursue this change, please open a new pull request with the issues resolved. Closed PRs are re-reviewed automatically, so an inaccurate close may be reopened, but that does not guarantee it can merge (e.g. if conflicts or failing CI remain).`;
 }
 
-// The close comment for a blacklisted author (#1425). The maintainer-supplied `reason` is sanitized by the caller
-// through the public-safe sanitizer, so this never leaks a private term into the public PR thread.
-function blacklistCloseMessage(reason: string): string {
-  return `Gittensory is closing this pull request on the maintainer's behalf: ${reason}. This account is blocked from contributing to this repository, so the change was not reviewed on its merits. This is an automated maintenance action.`;
+// The close comment for a blacklisted author (#1425). Do not interpolate maintainer-supplied blacklist metadata:
+// reasons/evidence may come from private configuration, and this string is posted to the public PR thread.
+function blacklistCloseMessage(): string {
+  return "Gittensory is closing this pull request on the maintainer's behalf. This account is blocked from contributing to this repository, so the change was not reviewed on its merits. This is an automated maintenance action.";
 }
 
 /**
@@ -259,14 +259,13 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // the standing rule). Zero-hallucination, so its close is `closeKind: "blacklist"` — exempt from the AI-refutation
   // breaker like the linked-issue hard rule. The `acting`/`approval` gates here + the executor's pause/dry-run/
   // kill-switch gate make it dry-run-able and approval-gated exactly like every other action. The close comment is
-  // run through the public-safe sanitizer so a maintainer's reason can never leak a private term.
+  // static by construction so private maintainer metadata from the blacklist entry cannot leak.
   const blacklistContributor = !input.authorIsOwner && !input.authorIsAutomationBot;
   if (input.blacklistMatch?.matched === true && blacklistContributor) {
     const label = input.blacklistLabel ?? DEFAULT_BLACKLIST_LABEL;
     if (acting("label")) actions.push({ actionClass: "label", requiresApproval: approval("label"), reason: "blacklisted contributor", label, labelOp: "add" });
     if (acting("close")) {
-      const reason = input.blacklistMatch.reason ?? "this account is blocked from contributing to this repository";
-      actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: "blacklisted contributor", closeComment: sanitizePublicComment(blacklistCloseMessage(reason)), closeKind: "blacklist" });
+      actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: "blacklisted contributor", closeComment: sanitizePublicComment(blacklistCloseMessage()), closeKind: "blacklist" });
     }
     return actions;
   }

--- a/src/settings/contributor-blacklist.ts
+++ b/src/settings/contributor-blacklist.ts
@@ -1,7 +1,7 @@
 // Contributor blacklist (#1425, anti-abuse). Pure resolution + matching for the banned-login list the converged
 // engine acts on. Config-driven and layered the same as other settings (`.gittensory.yml` > DB) and unioned with
 // the shared/global list at the point of use — NEVER hard-coded for any repo. Logins are public data; entries
-// carry only public-safe metadata (no wallets/hotkeys/trust-scores/private values). Mirrors the shape of
+// may carry private maintainer metadata, so public surfaces must not echo it. Mirrors the shape of
 // command-authorization.ts (normalize → typed policy + warnings).
 import type { ContributorBlacklistEntry } from "../types";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -588,14 +588,14 @@ export type RepositoryCommandAuthorizationPolicy = {
   commands: Record<string, CommandAuthorizationRole[]>;
 };
 
-/** A blocked contributor (#1425, anti-abuse): a GitHub `login` plus optional PUBLIC metadata. The converged
+/** A blocked contributor (#1425, anti-abuse): a GitHub `login` plus optional maintainer metadata. The converged
  *  engine short-circuits a blacklisted author's PR/issue to a deterministic close ahead of any merit/CI/AI
- *  analysis. `login` is public data — entries NEVER carry wallets/hotkeys/trust-scores/private values. */
+ *  analysis. Metadata can come from private configuration and must not be echoed to public surfaces. */
 export type ContributorBlacklistEntry = {
   login: string;
-  /** Why the account is blocked, e.g. `plagiarism` / `farming`. Free-text, public-safe. */
+  /** Why the account is blocked. Free-text maintainer metadata; not published in automated close comments. */
   reason?: string | undefined;
-  /** Public PR/issue URLs (or other public refs) evidencing the block. */
+  /** PR/issue URLs (or other maintainer refs) evidencing the block. */
   evidence?: string[] | undefined;
   /** ISO-8601 date the entry was added. */
   addedAt?: string | undefined;

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -695,7 +695,7 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     expect(classes(plan)).toEqual(["label", "close"]); // short-circuit: no approve/merge despite a SUCCESS gate
     expect(plan[0]).toMatchObject({ actionClass: "label", label: DEFAULT_BLACKLIST_LABEL, labelOp: "add" });
     expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "blacklist" });
-    expect(plan[1]?.closeComment).toContain("plagiarism");
+    expect(plan[1]?.closeComment).not.toContain("plagiarism");
     expect(plan[1]?.closeComment).toContain("blocked from contributing");
   });
 
@@ -705,9 +705,11 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     expect(planAgentMaintenanceActions(blacklisted())[0]).toMatchObject({ label: "slop" });
   });
 
-  it("uses a default reason when the entry has none", () => {
-    const plan = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: null } }));
-    expect(plan[1]?.closeComment).toContain("blocked from contributing");
+  it("uses the same static public close comment when the entry has no reason", () => {
+    const withReason = planAgentMaintenanceActions(blacklisted());
+    const withoutReason = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: null } }));
+    expect(withoutReason[1]?.closeComment).toBe(withReason[1]?.closeComment);
+    expect(withoutReason[1]?.closeComment).toContain("blocked from contributing");
   });
 
   it("fires AHEAD of CI — closes even while CI is still pending (not the pending early-return)", () => {
@@ -728,8 +730,10 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     expect(classes(planAgentMaintenanceActions(blacklisted({ autonomy: { label: "auto" } })))).toEqual(["label"]);
   });
 
-  it("sanitizes the close comment — a forbidden term in the reason never reaches the public thread", () => {
-    const plan = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: "leaked a wallet address" } }));
-    expect(plan[1]?.closeComment).not.toMatch(/wallet/i);
+  it("never publishes blacklist reason text in the public close comment", () => {
+    const privateReason = "internal-case-7421-do-not-publish";
+    const plan = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: privateReason } }));
+    expect(plan[1]?.closeComment).not.toContain(privateReason);
+    expect(plan[1]?.closeComment).toContain("blocked from contributing");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent accidental public disclosure of maintainer-supplied blacklist metadata by the auto-close path when a blacklisted contributor opens a PR.
- The previous implementation interpolated `blacklistMatch.reason` into a public issue comment after only keyword sanitization, which can leak private maintainer notes or identifiers.

### Description
- Stop interpolating maintainer `reason` into the public close comment by replacing the templated `blacklistCloseMessage(reason)` with a static `blacklistCloseMessage()` that contains no maintainer-supplied text.  
- Update the planner callsite to post the static sanitized close comment (no per-entry reason) while preserving deterministic label+close behavior.  
- Clarify types/docs/comments to treat `ContributorBlacklistEntry.reason` / `evidence` as maintainer metadata that must not be echoed to public surfaces.  
- Update unit tests in `agent-actions.test.ts` to assert that configured blacklist reason text is never present in the public `closeComment` while keeping the label+close short-circuit semantics intact.

### Testing
- Ran `git diff --check` and `npm run typecheck` successfully.  
- Ran targeted unit tests with `npx vitest` for the blacklist-focused suites (`test/unit/agent-actions.test.ts`, `test/unit/contributor-blacklist.test.ts`, `test/unit/queue.test.ts -t "blacklist"`) and the relevant tests passed.  
- Attempted the full gate (`npm run test:ci`), but the coverage/CI run encountered unrelated long-running test timeouts and was terminated before completion.  
- Attempted `npm audit --audit-level=moderate`, but the registry audit endpoint returned HTTP 403 (external environmental failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3a98aebc832cae3703867dcde518)