### PR TITLE
fix(scoring): harden label glob translation

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -921,10 +921,20 @@ function labelPatternToRegExp(pattern: string): RegExp {
         // No closing bracket: fnmatch treats the `[` as a literal character.
         regex += "\\[";
       } else {
-        let body = pattern.slice(i, close).replace(/\\/g, "\\\\");
-        // `[!seq]` is fnmatch's negated class; RegExp spells negation as `[^seq]`.
-        if (body.startsWith("!")) body = `^${body.slice(1)}`;
-        regex += `[${body}]`;
+        const rawBody = pattern.slice(i, close);
+        if (rawBody === "" || rawBody === "!") {
+          // Empty classes and bare `[!]` stay literal in Python fnmatch instead of compiling as classes.
+          regex += `\\[${escapeRegExpLiteral(rawBody)}\\]`;
+        } else if (hasDescendingCharacterRange(rawBody)) {
+          // Python fnmatch treats invalid ranges like `[z-a]` as a never-match pattern; RegExp throws.
+          regex += "(?!)";
+        } else {
+          let body = rawBody.replace(/\\/g, "\\\\");
+          // `[!seq]` is fnmatch's negated class; RegExp spells negation as `[^seq]`.
+          if (body.startsWith("!")) body = `^${body.slice(1)}`;
+          else if (body.startsWith("^")) body = `\\${body}`;
+          regex += `[${body}]`;
+        }
         i = close + 1;
       }
     } else if (/[.+^${}()|\]\\]/.test(char)) {
@@ -934,6 +944,18 @@ function labelPatternToRegExp(pattern: string): RegExp {
     }
   }
   return new RegExp(`^${regex}$`, "i");
+}
+
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasDescendingCharacterRange(body: string): boolean {
+  const start = body.startsWith("!") ? 1 : 0;
+  for (let i = start + 1; i < body.length - 1; i += 1) {
+    if (body.charAt(i) === "-" && body.charCodeAt(i - 1) > body.charCodeAt(i + 1)) return true;
+  }
+  return false;
 }
 
 function decideLinkedIssueMultiplier(

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -836,6 +836,9 @@ NOVELTY_BONUS_SCALAR = 3
     expect(labelMultiplierFor({ "[!]": 2 }, ["!"])).toBe(1);
     // An empty `[]` class stays literal too (the `rawBody === ""` arm): pattern `[]` matches only the label `[]`.
     expect(labelMultiplierFor({ "[]": 2 }, ["[]"])).toBe(2);
+    // An ASCENDING range (`[a-c]`) has a `-` but is NOT descending, so it compiles as a real class (the other
+    // arm of the descending-range check): `b` is in `[a-c]`, so `[a-c]ug` matches `bug`.
+    expect(labelMultiplierFor({ "[a-c]ug": 1.5 }, ["bug"])).toBe(1.5);
     // A `[` with no closing bracket is a literal, not a class.
     expect(labelMultiplierFor({ "a[b": 0.7 }, ["a[b"])).toBe(0.7);
     // Regex metacharacters in a literal key stay literal: `.` matches only a dot, not any char.

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -829,6 +829,11 @@ NOVELTY_BONUS_SCALAR = 3
     // `[seq]` / `[!seq]` character classes.
     expect(labelMultiplierFor({ "[bf]ug": 1.4 }, ["bug"])).toBe(1.4);
     expect(labelMultiplierFor({ "[!x]ug": 1.3 }, ["bug"])).toBe(1.3);
+    expect(labelMultiplierFor({ "[^x]ug": 1.3 }, ["bug"])).toBe(1);
+    expect(labelMultiplierFor({ "[^x]ug": 1.3 }, ["^ug"])).toBe(1.3);
+    // Malformed or empty bracket classes mirror Python fnmatch: they never throw or over-match.
+    expect(labelMultiplierFor({ "[z-a]": 2 }, ["a"])).toBe(1);
+    expect(labelMultiplierFor({ "[!]": 2 }, ["!"])).toBe(1);
     // A `[` with no closing bracket is a literal, not a class.
     expect(labelMultiplierFor({ "a[b": 0.7 }, ["a[b"])).toBe(0.7);
     // Regex metacharacters in a literal key stay literal: `.` matches only a dot, not any char.

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -834,6 +834,8 @@ NOVELTY_BONUS_SCALAR = 3
     // Malformed or empty bracket classes mirror Python fnmatch: they never throw or over-match.
     expect(labelMultiplierFor({ "[z-a]": 2 }, ["a"])).toBe(1);
     expect(labelMultiplierFor({ "[!]": 2 }, ["!"])).toBe(1);
+    // An empty `[]` class stays literal too (the `rawBody === ""` arm): pattern `[]` matches only the label `[]`.
+    expect(labelMultiplierFor({ "[]": 2 }, ["[]"])).toBe(2);
     // A `[` with no closing bracket is a literal, not a class.
     expect(labelMultiplierFor({ "a[b": 0.7 }, ["a[b"])).toBe(0.7);
     // Regex metacharacters in a literal key stay literal: `.` matches only a dot, not any char.


### PR DESCRIPTION
### Motivation
- Translating repo-configured label multiplier keys to JavaScript `RegExp` could throw or mis-match for certain fnmatch-style bracket expressions (e.g. `[z-a]`, `[!]`, `[^x]`) and thereby crash the scoring preview or produce incorrect multiplier matches.
- The upstream/validator uses Python `fnmatch` semantics which tolerate these cases; the preview must preserve parity and fail-safe behavior for untrusted registry keys.

### Description
- Harden `labelPatternToRegExp` to mirror Python `fnmatch` edge-case behavior by treating empty/bare bracket classes (like `[]` or `[!]`) as literals and by emitting a never-match fragment (`(?!)`) for descending/invalid ranges instead of compiling a throwing `RegExp`.
- Preserve negation semantics for `[^x]`/`[!x]` while avoiding accidental RegExp caret-interpretation for literal leading `^` in classes.
- Add small helpers `escapeRegExpLiteral` and `hasDescendingCharacterRange` to support safe translation and range validation.
- Add unit test coverage in `test/unit/scoring.test.ts` for `[^x]`, `[z-a]`, and `[!]` patterns and other bracket-class edge cases to guard against regressions.

### Testing
- Ran the focused unit test: `npx vitest run test/unit/scoring.test.ts -t "matches configured label keys"` and the full file: both completed and passed (`72 tests` passed).
- `npm run typecheck` completed with no type errors.
- `npm run test:coverage` and `npm run test:ci` were started during validation but did not complete in this environment (coverage run was terminated due to local runtime constraints and `test:ci` was interrupted during coverage); the unit-level tests validating the fix passed.
- `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e409b5750832c9361a9d8631c0515)