### PR TITLE
feat(scoring): explain the open-issue spam gate in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -77,6 +77,28 @@ function openPrBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown 
   };
 }
 
+// Sibling of openPrBreakdown for the issue-discovery channel: the open-issue spam gate (#808) zeroes the
+// score once a contributor's concurrent open-issue count exceeds their earned allowance. Explained here so a
+// miner in the issue-discovery lane sees the same actionable breakdown the open-PR gate already provides.
+function openIssueBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { openIssueMultiplier } = preview.scoreEstimate;
+  const { openIssueCount, openIssueThreshold } = preview.gates;
+  const band = bandForMultiplier(openIssueMultiplier);
+  return {
+    component: "openIssueMultiplier",
+    band,
+    summary:
+      openIssueMultiplier >= 1
+        ? `Open issue count (${openIssueCount}) is within the current allowance (${openIssueThreshold}).`
+        : `Open issue count (${openIssueCount}) exceeds the current allowance (${openIssueThreshold}), so the open-issue spam gate blocks scoring.`,
+    lever:
+      openIssueMultiplier >= 1
+        ? "Keep concurrent open issues within the allowance to stay clear of the open-issue spam gate."
+        : "Close or resolve excess open issues to drop back within the open-issue spam threshold.",
+    leverageScore: openIssueMultiplier >= 1 ? 5 : 100,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -216,6 +238,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     credibilityBreakdown(preview),
     reviewPenaltyBreakdown(preview),
     openPrBreakdown(preview),
+    openIssueBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -82,6 +82,7 @@ describe("explainScoreBreakdown", () => {
         "credibilityMultiplier",
         "reviewPenaltyMultiplier",
         "openPrMultiplier",
+        "openIssueMultiplier",
       ]),
     );
     for (const component of breakdown.components) {
@@ -91,6 +92,31 @@ describe("explainScoreBreakdown", () => {
     }
     expect(breakdown.highestLeverageLever.component).toBeTruthy();
     expect(breakdown.highestLeverageLever.lever).toMatch(/merge|close|credibility|open PR|linked issue|density|review/i);
+    expect(JSON.stringify(breakdown)).not.toMatch(FORBIDDEN);
+    // No open issues → within the allowance → full band on the open-issue gate.
+    expect(breakdown.components.find((entry) => entry.component === "openIssueMultiplier")).toMatchObject({ band: "full" });
+  });
+
+  it("explains an over-threshold open-issue count as a blocked open-issue spam gate", () => {
+    const preview = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: repo.fullName,
+        contributorLogin: "miner",
+        sourceTokenScore: 40,
+        totalTokenScore: 60,
+        sourceLines: 80,
+        openIssueCount: 50,
+        linkedIssueMode: "standard",
+      },
+    });
+
+    const breakdown = explainScoreBreakdown(preview);
+    const openIssue = breakdown.components.find((entry) => entry.component === "openIssueMultiplier");
+    expect(openIssue).toMatchObject({ band: "blocked" });
+    expect(openIssue?.summary).toMatch(/exceeds the current allowance/i);
+    expect(openIssue?.lever).toMatch(/close or resolve/i);
     expect(JSON.stringify(breakdown)).not.toMatch(FORBIDDEN);
   });
 


### PR DESCRIPTION
## What

`explainScoreBreakdown` produces an improvement lever for every score multiplier — density, contribution bonus, label, issue, credibility, review penalty, open-PR — **except** the open-issue spam gate (#808). That gate is the issue-discovery-lane sibling of the open-PR gate (which already has `openPrBreakdown`), so the breakdown is asymmetric: a miner whose score is zeroed by too many concurrent open issues gets no row explaining why or how to recover.

## How

Adds `openIssueBreakdown`, a direct mirror of `openPrBreakdown`. It reads values the preview **already computes** — `scoreEstimate.openIssueMultiplier` and the `gates.openIssueCount`/`openIssueThreshold` fields — and emits a full/blocked band with a concrete lever (close or resolve excess open issues). No new inputs, no score-math change, no schema change: purely an explanation for a dimension that already exists in the preview.

## Tests / coverage

- Within-allowance path asserts a `full` band (existing fixture, no open issues).
- New over-threshold case (50 open issues) asserts a `blocked` band, the 'exceeds the current allowance' summary, and the close/resolve lever.
- Full branch coverage on every added line; output stays public-safe (sanitized, no forbidden terms). OpenAPI unchanged.