### PR TITLE
feat(signals): redact /var/ paths on the public-safety boundary

### DIFF
--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -22,7 +22,7 @@
 // intentionally NOT collapsed onto `PUBLIC_UNSAFE_TERMS`.
 export const PUBLIC_UNSAFE_TERMS = String.raw`(?:reward|score|wallet|hotkey|coldkey|mnemonic|payout|ranking)\w*|farming|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;
 
-export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/root/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
+export const PUBLIC_UNSAFE_PATTERN = new RegExp(String.raw`\b(${PUBLIC_UNSAFE_TERMS})\b|/Users/|/home/|/root/|/var/|/tmp/|[A-Z]:[\\/]Users[\\/]`, "i");
 
 /** True iff `text` contains nothing that must stay private — i.e. it is safe to surface on a public GitHub surface. */
 export function isPublicSafeText(text: string): boolean {

--- a/test/unit/redaction.test.ts
+++ b/test/unit/redaction.test.ts
@@ -40,6 +40,8 @@ describe("isPublicSafeText (#542 shared public/private boundary)", () => {
     expect(isPublicSafeText("/home/bob/repo")).toBe(false);
     expect(isPublicSafeText("/root/project/src")).toBe(false);
     expect(isPublicSafeText("clone failed at /root/work/repo")).toBe(false);
+    expect(isPublicSafeText("/var/log/app.log")).toBe(false);
+    expect(isPublicSafeText("/var/folders/alice/work/private-repo/cache.ts")).toBe(false);
     expect(isPublicSafeText("/tmp/scratch")).toBe(false);
     expect(isPublicSafeText("C:\\Users\\carol\\repo")).toBe(false);
     expect(isPublicSafeText("C:/Users/carol/repo")).toBe(false);


### PR DESCRIPTION
## Summary
- Extends the canonical `PUBLIC_UNSAFE_PATTERN` in `redaction.ts` to treat `/var/` local paths as unsafe on public GitHub surfaces.
- Closes the gap where `/root/` was already redacted but macOS/Linux `/var/folders/...` and `/var/log/...` paths could leak through `isPublicSafeText`.

Related: #1307 (slice), #1418

## Test plan
- [x] `npx vitest run test/unit/redaction.test.ts`
- [x] Assert `/var/log/...` and `/var/folders/...` are rejected


