### PR TITLE
feat(signals): recognize deno.lock, bun.lock, pubspec.lock, and Podfile.lock

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -29,6 +29,7 @@ const LOCKFILE_NAMES: ReadonlySet<string> = new Set([
   "npm-shrinkwrap.json",
   "yarn.lock",
   "pnpm-lock.yaml",
+  "bun.lock",
   "bun.lockb",
   "cargo.lock",
   "poetry.lock",
@@ -39,6 +40,9 @@ const LOCKFILE_NAMES: ReadonlySet<string> = new Set([
   "uv.lock",
   "packages.lock.json",
   "flake.lock",
+  "deno.lock",
+  "pubspec.lock",
+  "podfile.lock",
 ]);
 
 const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -63,6 +63,10 @@ describe("isLockfile", () => {
       "go.sum",
       "uv.lock",
       "poetry.lock",
+      "bun.lock",
+      "deno.lock",
+      "pubspec.lock",
+      "Podfile.lock",
     ]) {
       expect(isLockfile(path)).toBe(true);
     }
@@ -233,6 +237,10 @@ describe("classifyChangedFile", () => {
       ["src/api.generated.ts", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
+      ["bun.lock", "lockfile"],
+      ["deno.lock", "lockfile"],
+      ["pubspec.lock", "lockfile"],
+      ["ios/Podfile.lock", "lockfile"],
       ["package.json", "dependency_manifest"],
       ["tsconfig.json", "config"],
       ["vitest.config.ts", "config"],


### PR DESCRIPTION
## Summary
- Adds `bun.lock`, `deno.lock`, `pubspec.lock`, and `podfile.lock` to slop `LOCKFILE_NAMES` so they classify as `lockfile` instead of `other`.
- Small slice of #1421 (lockfile coverage only; no CI/toolchain classifier overlap with closed #1422).

## Test plan
- [x] `npx vitest run test/unit/path-matchers.test.ts`
- [x] `isLockfile` and `classifyChangedFile` cases for each new lockfile name


