### PR TITLE
fix(db): scrub /root/ and /var/ paths from product-usage metadata

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5251,7 +5251,7 @@ const PRODUCT_USAGE_SENSITIVE_KEY =
   /authorization|cookie|token|secret|password|private[_-]?key|source|body|diff|patch|prompt|raw[_-]?trust|trust[_-]?score|wallet|hotkey|coldkey|seed|mnemonic|local[_-]?path|repo[_-]?root|cwd|scoreability|reviewability|farming/i;
 const PRODUCT_USAGE_SENSITIVE_VALUE =
   /\b(seed phrase|mnemonic|private key|raw trust|trust score|wallet|hotkey|coldkey|scoreability|reviewability|farming|reward estimate|payout)\b/i;
-const PRODUCT_USAGE_LOCAL_PATH = /(?:\/Users|\/home|\/tmp)\/[^\s"',;)]*|[A-Za-z]:\\Users\\[^\s"',;)]*/g;
+const PRODUCT_USAGE_LOCAL_PATH = /(?:\/Users|\/home|\/root|\/var|\/tmp)\/[^\s"',;)]*|[A-Za-z]:\\Users\\[^\s"',;)]*/g;
 const PRODUCT_USAGE_TOKEN_VALUE = /\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
 const PRODUCT_USAGE_BEARER_VALUE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi;
 

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -153,6 +153,8 @@ describe("product usage events", () => {
         cwd: "/Users/example/private/project",
         nested: {
           localPath: "/Users/example/private/project/file.ts",
+          rootPath: "/root/work/private/project/file.ts",
+          varPath: "/var/log/private/app.log",
           values: ["see /Users/example/private/file.ts", "github_pat_1234567890abcdef"],
           safe: "kept",
         },
@@ -174,7 +176,7 @@ describe("product usage events", () => {
     expect(row.metadata).not.toHaveProperty("body");
     expect(row.metadata).not.toHaveProperty("diff");
     expect(row.metadata).not.toHaveProperty("cwd");
-    expect(JSON.stringify(row.metadata)).not.toMatch(/\/Users|github_pat|ghp_|source code|private patch|trustScore|wallet/i);
+    expect(JSON.stringify(row.metadata)).not.toMatch(/\/Users|\/root\/|\/var\/|github_pat|ghp_|source code|private patch|trustScore|wallet/i);
   });
 
   it("persists normalized role on the event row and strips private scoreability metadata", async () => {


### PR DESCRIPTION
## Summary
- Extends `PRODUCT_USAGE_LOCAL_PATH` in `repositories.ts` to redact `/root/` and `/var/` absolute paths before product-usage events are persisted.
- Aligns the telemetry scrubber with the canonical public boundary (`/root/` already redacted elsewhere; `/var/` was missing here).

Related: #1418 (single-surface slice)

## Test plan
- [x] `npx vitest run test/unit/product-usage.test.ts -t "redacts sensitive metadata"`
- [x] Metadata fixture includes `/root/work/...` and `/var/log/...` paths; persisted JSON must not contain them


