### PR TITLE
fix(mcp): gate maintainer-noise behind maintainer approval/write access

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1821,7 +1821,7 @@ export class GittensoryMcp {
 
   private async getMaintainerNoise(input: { owner: string; repo: string }): Promise<ToolPayload> {
     const fullName = `${input.owner}/${input.repo}`;
-    await this.requireRepoAccess(fullName);
+    await this.requireRepoApprovalQueueAccess(fullName);
     const report = await loadMaintainerNoiseReport(this.env, fullName);
     return {
       summary: maintainerNoiseSummary(report),

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
 import { persistSignalSnapshot, upsertBounty, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub, updatePullRequestSlopAssessment } from "../../src/db/repositories";
+import type { AuthIdentity } from "../../src/auth/security";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
@@ -30,8 +31,8 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_explain_score_breakdown",
 ];
 
-async function connectTestClient(env: Env = createTestEnv()) {
-  const mcpServer = new GittensoryMcp(env).createServer();
+async function connectTestClient(env: Env = createTestEnv(), identity?: AuthIdentity) {
+  const mcpServer = new GittensoryMcp(env, identity).createServer();
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await mcpServer.connect(serverTransport);
   const client = new Client({ name: "gittensory-output-schema-test", version: "0.1.0" }, { capabilities: {} });
@@ -198,6 +199,38 @@ describe("MCP tool calls return schema-valid structured content", () => {
     expect(typeof data.level).toBe("string");
     expect(Array.isArray(data.noiseSources)).toBe(true);
     expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+  });
+
+  it("gittensory_get_maintainer_noise denies cached member-only session access", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "private-repo", full_name: "victim-org/private-repo", private: true, owner: { login: "victim-org" }, default_branch: "main" });
+    await upsertPullRequestFromGitHub(env, "victim-org/private-repo", {
+      number: 7,
+      title: "cached member evidence",
+      state: "open",
+      user: { login: "read-only-member" },
+      author_association: "MEMBER",
+      body: "",
+    });
+    const { client } = await connectTestClient(env, {
+      kind: "session",
+      actor: "read-only-member",
+      session: {
+        id: "session-read-only-member",
+        tokenHash: "hash",
+        login: "read-only-member",
+        scopes: [],
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        metadata: {},
+      },
+    });
+
+    const result = await client.callTool({ name: "gittensory_get_maintainer_noise", arguments: { owner: "victim-org", repo: "private-repo" } });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain("maintainer access is required");
+    expect(result.structuredContent).toBeUndefined();
   });
 
   it("gittensory_validate_linked_issue reports multiplier eligibility for an uncached issue", async () => {


### PR DESCRIPTION
### Motivation
- Close an authorization gap where the `gittensory_get_maintainer_noise` MCP tool used the cached `requireRepoAccess` gate and could return maintainer-only queue-noise analytics to a session with stale/cached MEMBER/COLLABORATOR evidence instead of requiring live maintainer/write permission.

### Description
- Replace the read/cached gate call with the stricter maintainer/write gate by changing `await this.requireRepoAccess(fullName)` to `await this.requireRepoApprovalQueueAccess(fullName)` in `src/mcp/server.ts` for `getMaintainerNoise`.
- Allow test harness instantiation with an explicit session identity by adding an optional `identity` parameter to `connectTestClient` in `test/unit/mcp-output-schemas.test.ts` so MCP server tests can simulate session identities.
- Add a regression test that asserts a session whose only cached evidence is an authored PR with `author_association: "MEMBER"` is denied access to `gittensory_get_maintainer_noise` (the test checks the returned error and that no structured content is exposed).

### Testing
- Ran `git diff --check` which produced no whitespace or conflict errors and passed locally.
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully with no type errors.
- Ran the focused test suite `npx vitest run test/unit/mcp-output-schemas.test.ts -t "maintainer_noise" --reporter=verbose` and the added regression plus the maintainer-noise validation tests passed; an earlier attempt to run the entire file experienced timeouts on unrelated, pre-existing tests, but the targeted regression and schema checks for this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e56cbedb8832c954e553bb783d312)