### PR TITLE
fix(orb): prevent OAuth self-enrollment from re-enabling operator-disabled installs

### DIFF
--- a/migrations/0074_orb_self_enrollment_disabled.sql
+++ b/migrations/0074_orb_self_enrollment_disabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orb_github_installations ADD COLUMN self_enrollment_disabled INTEGER NOT NULL DEFAULT 0;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3001,8 +3001,9 @@ export function createApp() {
   });
 
   // Opt an installation into (or out of) the registry. Body: { installationId, registered? } (registered defaults
-  // true). 404 when the installation isn't recorded yet — an install MUST arrive via the webhook first (unlike the
-  // fleet instances there's no account context to upsert a never-seen installation from).
+  // true). Opting out also blocks OAuth self-enrollment until an operator opts back in. 404 when the installation
+  // isn't recorded yet — an install MUST arrive via the webhook first (unlike the fleet instances there's no account
+  // context to upsert a never-seen installation from).
   app.post("/v1/internal/orb/installations/register", async (c) => {
     const payload = (await c.req.json().catch(() => null)) as { installationId?: unknown; registered?: unknown } | null;
     const installationId = Number(payload?.installationId);
@@ -3010,7 +3011,7 @@ export function createApp() {
     const existing = await c.env.DB.prepare("SELECT installation_id FROM orb_github_installations WHERE installation_id = ?").bind(installationId).first();
     if (!existing) return c.json({ error: "installation_not_found" }, 404);
     const registered = payload?.registered === false ? 0 : 1;
-    await c.env.DB.prepare("UPDATE orb_github_installations SET registered = ? WHERE installation_id = ?").bind(registered, installationId).run();
+    await c.env.DB.prepare("UPDATE orb_github_installations SET registered = ?, self_enrollment_disabled = ? WHERE installation_id = ?").bind(registered, registered === 1 ? 0 : 1, installationId).run();
     return c.json({ installationId, registered: registered === 1 });
   });
 

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -8,9 +8,10 @@
 // attacker-controllable query param, so a stolen OAuth code paired with a VICTIM's installation_id must NEVER
 // enroll the victim's install. We require: a valid OAuth code (single-use, GitHub-issued) → the authenticated
 // user → that user is an admin of the install's account (org admin, or the user account owner) → the install is
-// active (not suspended/removed). A verified admin AUTO-REGISTERS the install (registered=1) — zero-touch, no
-// operator step — and installation_id is then bound server-side in the enrollment (read back at token-exchange,
-// never from a request). No request input is echoed into the markup (no injection surface).
+// active (not suspended/removed) and not operator-disabled. A verified admin AUTO-REGISTERS the install
+// (registered=1) — zero-touch, no operator step — and installation_id is then bound server-side in the enrollment
+// (read back at token-exchange, never from a request). No request input is echoed into the markup (no injection
+// surface).
 import type { Context } from "hono";
 import { isOrbBrokerEnabled, issueOrbEnrollment } from "./broker";
 
@@ -66,17 +67,18 @@ async function handleOrbEnrollment(c: Context<{ Bindings: Env }>, code: string, 
   if (!token) return c.html(landingPage("Couldn't verify your GitHub identity", "The authorization didn't complete — re-run the install from GitHub and try again."), 400);
   const user = await fetchOrbOAuthUser(token);
   if (!user) return c.html(landingPage("Couldn't verify your GitHub identity", "We couldn't read your GitHub account — try the install again."), 400);
-  const install = await c.env.DB.prepare("SELECT account_login, account_type, registered, suspended_at, removed_at FROM orb_github_installations WHERE installation_id = ?")
+  const install = await c.env.DB.prepare("SELECT account_login, account_type, registered, self_enrollment_disabled, suspended_at, removed_at FROM orb_github_installations WHERE installation_id = ?")
     .bind(installationId)
-    .first<{ account_login: string | null; account_type: string | null; registered: number; suspended_at: string | null; removed_at: string | null }>();
+    .first<{ account_login: string | null; account_type: string | null; registered: number; self_enrollment_disabled: number; suspended_at: string | null; removed_at: string | null }>();
   if (!install) return c.html(landingPage("Installation not recognized", "We haven't recorded this installation yet — give it a moment after installing, then retry."), 404);
   // The admin-of-installation check is the authorization gate — it runs BEFORE we reveal or change any state, so a
   // non-admin learns nothing about the install and can never enroll someone else's.
   const isAdmin = await verifyInstallationAdmin(token, user.login, install.account_login, install.account_type);
   if (!isAdmin) return c.html(landingPage("Admin access required", "You must be an admin of this installation's account to enroll it for self-host."), 403);
   if (install.removed_at !== null || install.suspended_at !== null) return c.html(landingPage("Installation not active", "This installation is suspended or uninstalled — re-install the Orb App, then retry."), 403);
-  // Zero-touch self-service: a verified admin of an ACTIVE install self-registers it (registered=1) with no operator
-  // step. installation_id stays bound server-side in the enrollment, so brokered tokens remain scoped to this install.
+  if (install.self_enrollment_disabled === 1) return c.html(landingPage("Installation disabled", "This installation was disabled by the operator — contact the operator to re-enable self-host enrollment."), 403);
+  // Zero-touch self-service: a verified admin of an ACTIVE, non-disabled install self-registers it (registered=1).
+  // installation_id stays bound server-side in the enrollment, so brokered tokens remain scoped to this install.
   if (install.registered !== 1) {
     await c.env.DB.prepare("UPDATE orb_github_installations SET registered = 1, last_event_at = CURRENT_TIMESTAMP WHERE installation_id = ?").bind(installationId).run();
   }

--- a/test/integration/orb-broker.test.ts
+++ b/test/integration/orb-broker.test.ts
@@ -105,6 +105,12 @@ describe("broker endpoints", () => {
   it("/v1/internal/orb/enrollments: 400 missing id, 409 unregistered, 404 unknown", async () => {
     const e = await brokerEnv();
     await seedInstall(e, 402, { registered: 0 });
+    expect((await db(e).prepare("SELECT self_enrollment_disabled FROM orb_github_installations WHERE installation_id=402").first<{ self_enrollment_disabled: number }>())?.self_enrollment_disabled).toBe(0);
+    expect((await app.request("/v1/internal/orb/installations/register", { method: "POST", headers: auth, body: JSON.stringify({ installationId: 402, registered: false }) }, e)).status).toBe(200);
+    expect((await db(e).prepare("SELECT registered, self_enrollment_disabled FROM orb_github_installations WHERE installation_id=402").first<{ registered: number; self_enrollment_disabled: number }>())).toMatchObject({ registered: 0, self_enrollment_disabled: 1 });
+    expect((await app.request("/v1/internal/orb/installations/register", { method: "POST", headers: auth, body: JSON.stringify({ installationId: 402 }) }, e)).status).toBe(200);
+    expect((await db(e).prepare("SELECT registered, self_enrollment_disabled FROM orb_github_installations WHERE installation_id=402").first<{ registered: number; self_enrollment_disabled: number }>())).toMatchObject({ registered: 1, self_enrollment_disabled: 0 });
+    await db(e).prepare("UPDATE orb_github_installations SET registered=0 WHERE installation_id=402").run();
     expect((await app.request("/v1/internal/orb/enrollments", { method: "POST", headers: auth, body: "{}" }, e)).status).toBe(400);
     expect((await app.request("/v1/internal/orb/enrollments", { method: "POST", headers: auth, body: "{bad" }, e)).status).toBe(400); // unparseable JSON → catch → null
     expect((await app.request("/v1/internal/orb/enrollments", { method: "POST", headers: auth, body: JSON.stringify({ installationId: 402 }) }, e)).status).toBe(409);

--- a/test/integration/orb-oauth.test.ts
+++ b/test/integration/orb-oauth.test.ts
@@ -121,6 +121,18 @@ describe("maintainer self-enrollment via the OAuth callback", () => {
     expect(row?.registered).toBe(1); // self-registered, no operator step
   });
 
+  it("an operator-disabled install cannot be self-reenabled through OAuth", async () => {
+    const e = brokeredEnv();
+    await seedInstall(e, { installation_id: 503, account_login: "acme", account_type: "Organization", registered: 0, self_enrollment_disabled: 1 });
+    stubGitHub();
+    const res = await app.request("/v1/orb/oauth/callback?code=abc&installation_id=503", {}, e);
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain("Installation disabled");
+    expect(await db(e).prepare("SELECT 1 AS x FROM orb_enrollments WHERE installation_id=503").first()).toBeUndefined();
+    const row = await db(e).prepare("SELECT registered FROM orb_github_installations WHERE installation_id=503").first<{ registered: number }>();
+    expect(row?.registered).toBe(0);
+  });
+
   it("a SUSPENDED or UNINSTALLED install is refused (403 not active), even for an admin", async () => {
     const e = brokeredEnv();
     await seedInstall(e, { installation_id: 507, account_login: "acme", account_type: "Organization", registered: 1, suspended_at: "2026-01-01T00:00:00Z" });


### PR DESCRIPTION
### Motivation
- Prevent a privilege/authorization bypass where a verified installation admin could revisit the OAuth callback and clear an operator opt-out by flipping `registered` back to `1` and obtaining a new enrollment secret.
- Ensure operator-controlled revocation/disable remains authoritative and cannot be undone via the OAuth self-enrollment flow.

### Description
- Add a new installation column `self_enrollment_disabled` (migration `0074_orb_self_enrollment_disabled.sql`) to separate operator disables from pending/unregistered installs.
- Read `self_enrollment_disabled` in the Orb OAuth callback and block self-enrollment when it is set, returning a 403 and an explanatory landing page instead of auto-registering. (`src/orb/oauth.ts`)
- Update the internal operator `POST /v1/internal/orb/installations/register` endpoint to set `self_enrollment_disabled = 1` when opting out and clear it when opting back in, so operator actions persist as a distinct state. (`src/api/routes.ts`)
- Add integration regression tests that cover: (a) operator-disable prevents OAuth re-enablement, and (b) the operator register endpoint toggles `self_enrollment_disabled` correctly while preserving the zero-touch flow for non-disabled pending installs. (`test/integration/orb-oauth.test.ts`, `test/integration/orb-broker.test.ts`)

### Testing
- Ran the relevant integration suites with `npx vitest run test/integration/orb-oauth.test.ts test/integration/orb-broker.test.ts` and they passed (`2 files, 28 tests, 28 passed`).
- Ran migration sanity with `npm run db:migrations:check` and TypeScript typecheck with `npm run typecheck`, both succeeded.
- Ran `npm run ui:openapi:check`, which succeeded on the committed spec check step; `npm audit --audit-level=moderate` failed due to the npm audit endpoint returning `403 Forbidden` from the environment and is thus inconclusive.
- Attempted the full coverage run `npm run test:coverage` but it failed outside the changed area due to long-running test timeouts and a coverage remapping error (`TypeError: jsTokens is not a function`), so full repo coverage could not be verified in this environment; the added integration tests exercise the new branches introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4fd047b0832cad92fd0709e0f965)