### PR TITLE
fix(github): redact private score floor blockers

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1435,7 +1435,7 @@ function mentionsRepoOutcomePatternDetail(value: string): boolean {
 
 function publicBlockerLabel(code: string): string {
   const normalized = code.trim().toLowerCase();
-  const privateDecisionBlockers = new Set(["open_pr_pressure", "closed_pr_credibility", "low_credibility", "maintainer_lane", "inactive_or_unknown_lane", "issue_discovery_only"]);
+  const privateDecisionBlockers = new Set(["open_pr_pressure", "closed_pr_credibility", "low_credibility", "maintainer_lane", "inactive_or_unknown_lane", "issue_discovery_only", "merged_pr_history_floor", "issue_discovery_validity_floor"]);
   const labels: Record<string, string> = {
     likely_duplicate: "Possible overlap with existing work",
   };
@@ -1451,7 +1451,7 @@ function publicBlockerDetail(value: string): string {
       value
         .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work")
         .replace(/\bcheck_duplicate_risk\b/gi, "duplicate-risk review")
-        .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only)\b/gi, "private readiness context"),
+        .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only|merged_pr_history_floor|issue_discovery_validity_floor)\b/gi, "private readiness context"),
     ),
   );
 }
@@ -1483,13 +1483,15 @@ export function sanitizePublicComment(value: string): string {
   const sanitized = value
     .replace(/\bopen pr count\s+\d+\s+exceeds threshold\s+\d+\b\.?/gi, "private context")
     .replace(/\bopen pr count is at or below\s+\d+\b/gi, "private context")
+    .replace(/\bmerged pr count\s+\d+\s+is below upstream floor\s+\d+\b\.?/gi, "private context")
+    .replace(/\bissue-discovery history\s*\(\s*\d+\s+valid solved,\s*credibility\s+[-+]?\d+(?:\.\d+)?\s*\)\s+is below upstream floors\s*\(\s*\d+\s+valid solved,\s*[-+]?\d+(?:\.\d+)?\s+credibility\s*\)\.?/gi, "private context")
     .replace(/\bcredibility\s+[-+]?\d+(?:\.\d+)?\s+is below floor\s+[-+]?\d+(?:\.\d+)?\b\.?/gi, "private context")
     .replace(/\b(?:effective|projected|estimated) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
     .replace(/\b(raw trust scores?|trust scores?|wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?)\b/gi, "private context")
     .replace(/\b(public score estimates?|estimated scores?|score estimates?|estimated rewards?|rewards?|reward estimates?|payouts?|farming|scoreability|score previews?|projected score changes?)\b/gi, "private context")
     .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
     .replace(/\b(private rankings?|rankings?)\b/gi, "private context")
-    .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only)\b/gi, "private context")
+    .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only|merged_pr_history_floor|issue_discovery_validity_floor)\b/gi, "private context")
     .replace(/\b(?:credibility(?: updates?)?|closed pr credibility|low credibility|open pr pressure)\b/gi, "private context")
     // Catch-all: a phrase replacement above (e.g. "score estimate"/"score preview") can leave a bare
     // numeric score transition behind ("private context 32.5 -> 41.2"); redact those residual numbers too.

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -168,6 +168,10 @@ describe("GitHub mention commands", () => {
     expect(sanitizePublicComment("Linked issue/no-issue context changes estimated score 18 -> 27.")).not.toMatch(/estimated score|18|27/i);
     expect(sanitizePublicComment("score estimate 5 → 9")).not.toMatch(/score estimate|\b5\b|\b9\b/i);
     expect(sanitizePublicComment("Open PR count 7 exceeds threshold 3.")).not.toMatch(/open PR count|7|threshold|3/i);
+    expect(sanitizePublicComment("Merged PR count 1 is below upstream floor 3.")).not.toMatch(/merged PR count|upstream floor|\b1\b|\b3\b/i);
+    expect(sanitizePublicComment("Issue-discovery history (2 valid solved, credibility 0.42) is below upstream floors (3 valid solved, 0.8 credibility).")).not.toMatch(
+      /issue-discovery history|valid solved|upstream floors|0\.42|0\.8|\b2\b|\b3\b/i,
+    );
     expect(sanitizePublicComment("Credibility 0.12 is below floor 0.4.")).not.toMatch(/credibility|0\.12|floor|0\.4/i);
     expect(sanitizePublicComment("open_pr_pressure closed_pr_credibility low_credibility credibility updates")).not.toMatch(/open_pr_pressure|closed_pr_credibility|low_credibility|credibility/i);
     expect(sanitizePublicComment("Command: @gittensory reviewability")).toContain("@gittensory reviewability");
@@ -391,6 +395,45 @@ describe("GitHub mention commands", () => {
     });
     expect(publicCardFindings(askWithTargets)).toContain("Source: repo focus manifest; freshness: fresh");
     expect(askWithTargets).toContain("owner/repo: Prepare a concise packet and verify linked context.");
+  });
+
+  it("redacts private score floor blockers from public preflight comments", () => {
+    const body = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory preflight")!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 25, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "author",
+      bundle: {
+        run: completedRun("run-private-score-floors"),
+        actions: [
+          {
+            id: "private-score-floors",
+            runId: "run-private-score-floors",
+            actionType: "preflight_branch",
+            status: "blocked",
+            recommendation: "Resolve blockers",
+            why: [],
+            blockedBy: [
+              "Merged PR count 1 is below upstream floor 3.",
+              "Issue-discovery history (2 valid solved, credibility 0.42) is below upstream floors (3 valid solved, 0.8 credibility).",
+              "merged_pr_history_floor",
+              "issue_discovery_validity_floor",
+            ],
+            publicSafeSummary: "Run the public-safe PR packet before posting.",
+            approvalRequired: true,
+            safetyClass: "private",
+            payload: {},
+          },
+        ],
+        contextSnapshots: [],
+        summary: "preflight",
+      },
+    });
+
+    expect(body).toContain("Run the public-safe PR packet before posting.");
+    expect(body).toContain("Private readiness context available in authenticated Gittensory views");
+    expect(body).not.toMatch(/merged PR count|issue-discovery history|valid solved|upstream floors?|0\.42|0\.8/i);
   });
 
   it("does not publish private blocker why details", () => {


### PR DESCRIPTION
### Motivation

- Prevent private contributor-history and issue-discovery floor details (exact merged PR counts, valid-solved counts, credibility and upstream floor values) from being published in public GitHub command comments after those fields were added to score previews.

### Description

- Map the new private blocker codes `merged_pr_history_floor` and `issue_discovery_validity_floor` to the existing authenticated-view readiness label in `src/github/commands.ts` so those codes render as a generic private-context message.
- Extend `sanitizePublicComment` in `src/github/commands.ts` with regexes that redact the newly introduced detail formats (e.g. `Merged PR count ... is below upstream floor ...` and `Issue-discovery history (...) is below upstream floors (...)`) and include the new blocker codes in the private-keys pattern.
- Update `publicBlockerDetail` to fold these codes into the same `private readiness context` phrasing so arbitrary detail strings do not leak sensitive numbers.
- Add unit tests in `test/unit/github-commands.test.ts` that assert the sanitizer removes the new phrases and that a public `@gittensory preflight` comment does not contain raw score floor details.

### Testing

- Ran the focused unit suite `npm test -- --run test/unit/github-commands.test.ts`, and the modified tests passed.
- Ran `tsc --noEmit` (`npm run typecheck`) and `git diff --check`, both of which passed locally.
- Attempted the full gate with `npm run test:ci`; it executed but the environment hit unrelated long-running suites/timeouts and coverage remapping failed with `TypeError: jsTokens is not a function`, so the full CI run did not complete successfully here.
- Attempted `npm audit --audit-level=moderate`, but the registry audit endpoint returned `403 Forbidden` in this environment so the audit could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4fd04694832cb4ffb6aac87f507e)