### PR TITLE
fix(orb): honor air-gap for brokered telemetry

### DIFF
--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -53,10 +53,10 @@ interface OrbExportPayload {
 }
 
 /** Stable instance identifier (hash of the Orb/App ID — no PII). A brokered instance holds no App id, so its
- *  per-install enrollment secret is the stable identity (hashed, so the high-entropy secret never leaks and two
- *  brokered instances never collide on the "unknown" fallback). */
-function instanceId(): string {
-  const seed = process.env.ORB_APP_ID ?? process.env.GITHUB_APP_ID ?? process.env.ORB_ENROLLMENT_SECRET ?? "unknown";
+ *  dedicated anonymization secret becomes the stable identity so ORB_ENROLLMENT_SECRET is never reused as
+ *  a correlatable telemetry identifier. */
+function instanceId(anonSecret: string): string {
+  const seed = process.env.ORB_APP_ID ?? process.env.GITHUB_APP_ID ?? `anon:${anonSecret}`;
   return createHash("sha256").update(seed).digest("hex").slice(0, 16);
 }
 
@@ -153,20 +153,16 @@ function cycleTimeMs(decidedAt: string, outcomeAt: string): number | null {
 
 /**
  * Export newly-resolved PR outcomes (since this instance's watermark) to the central collector. Reads from
- * review_audit (de-noised, reversal-aware), anonymizes, signs, POSTs, then advances the cursor. Always on.
+ * review_audit (de-noised, reversal-aware), anonymizes, signs, POSTs, then advances the cursor.
  * Returns the number of events exported (0 if air-gapped, the App isn't configured, or nothing new).
  */
 export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: typeof fetch = fetch): Promise<number> {
-  // A brokered self-host relies on the central Orb for tokens + webhook relay, so fleet telemetry is part of the
-  // self-hosting contract — air-gap cannot opt it out, and the export is gated on the enrollment (not a local App
-  // key, which a brokered instance never holds).
+  // Air-gapped/offline deployments explicitly suppress every outbound telemetry call, including brokered mode.
+  if ((process.env.ORB_AIR_GAP ?? "").toLowerCase() === "true") return 0;
+
+  // A brokered self-host relies on the central Orb for tokens + webhook relay, so it has review data to export but
+  // no local App key. Otherwise, gate export on the local GitHub App private key being configured.
   const brokered = Boolean((process.env.ORB_ENROLLMENT_SECRET ?? "").trim());
-
-  // Air-gapped/offline deployments may suppress the outbound call — but ONLY a self-managed (non-brokered) instance.
-  if (!brokered && (process.env.ORB_AIR_GAP ?? "").toLowerCase() === "true") return 0;
-
-  // Gate export on the instance being CONFIGURED: a local App private key, OR brokered mode (the Orb holds the App
-  // key and mints tokens on demand, so the instance has review data to export but no local App key).
   if (!brokered && !(process.env.GITHUB_APP_PRIVATE_KEY ?? "")) return 0;
 
   // gittensory's hosted collector. No shared secret is sent: repo/PR identifiers are HMAC'd with this
@@ -176,7 +172,7 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
   const collectorUrl = process.env.ORB_COLLECTOR_URL ?? "https://gittensory-api.aethereal.dev/v1/orb/ingest";
   const secret = await getOrCreateAnonSecret(db);
   const anonymize = (process.env.ORB_ANONYMIZE ?? "true").toLowerCase() !== "false";
-  const instance = instanceId();
+  const instance = instanceId(secret);
 
   // Read this instance's export watermark (resumes where the last run left off).
   const cursorRow = await db

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -1,5 +1,4 @@
 import { DatabaseSync } from "node:sqlite";
-import { createHash } from "node:crypto";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import { bucketReasonCode, exportOrbBatch, getOrCreateAnonSecret } from "../../src/selfhost/orb-collector";
@@ -94,10 +93,7 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     expect(await exportOrbBatch(makeDb(), 200, async () => new Response(null, { status: 200 }))).toBe(0);
   });
 
-  it("brokered mode exports despite air-gap AND without a local App key — telemetry is the fleet contract", async () => {
-    // A brokered self-host (ORB_ENROLLMENT_SECRET set) relies on the Orb for tokens + webhook relay, so it holds
-    // no local App key and air-gap must NOT suppress the export. With no Orb/App id, instanceId derives from the
-    // enrollment secret (stable + unique per install, not the "unknown" collision).
+  it("returns 0 in air-gap mode even when brokered and no local App key is configured", async () => {
     delete (process.env as NodeJS.Dict<string>).GITHUB_APP_PRIVATE_KEY;
     delete (process.env as NodeJS.Dict<string>).ORB_APP_ID;
     process.env.ORB_AIR_GAP = "true";
@@ -105,10 +101,24 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     const db = makeDb();
     await audit(db, "owner/repo", 9, "gate_decision", "merge", "2026-03-01T00:00:00Z");
     await audit(db, "owner/repo", 9, "pr_outcome", "merged", "2026-03-01T01:00:00Z");
+    let called = false;
+    const n = await exportOrbBatch(db, 200, async () => { called = true; return new Response(null, { status: 200 }); });
+    expect(n).toBe(0);
+    expect(called).toBe(false);
+  });
+
+  it("brokered mode exports without a local App key when air-gap is off", async () => {
+    delete (process.env as NodeJS.Dict<string>).GITHUB_APP_PRIVATE_KEY;
+    delete (process.env as NodeJS.Dict<string>).ORB_APP_ID;
+    process.env.ORB_ENROLLMENT_SECRET = "orbsec_test_enrollment";
+    const db = makeDb();
+    await audit(db, "owner/repo", 9, "gate_decision", "merge", "2026-03-01T00:00:00Z");
+    await audit(db, "owner/repo", 9, "pr_outcome", "merged", "2026-03-01T01:00:00Z");
     let captured: { instance_id: string } | undefined;
     const n = await exportOrbBatch(db, 200, async (_u, init) => { captured = JSON.parse(init!.body as string); return new Response(null, { status: 200 }); });
-    expect(n).toBe(1); // exported despite air-gap + no local App key
-    expect(captured!.instance_id).toBe(createHash("sha256").update("orbsec_test_enrollment").digest("hex").slice(0, 16));
+    expect(n).toBe(1);
+    expect(captured!.instance_id).toMatch(/^[a-f0-9]{16}$/);
+    expect(captured!.instance_id).not.toBe("6f2608643da1e0cf");
   });
 
   it("returns 0 when nothing is resolved", async () => {


### PR DESCRIPTION
### Motivation
- A security regression allowed brokered self-hosts to POST fleet telemetry even when `ORB_AIR_GAP=true`, and the fallback `instance_id` was derived from `ORB_ENROLLMENT_SECRET`, creating a correlatable identifier. 

### Description
- Restore `ORB_AIR_GAP` as an unconditional no-outbound-telemetry gate by returning early when `ORB_AIR_GAP=true`. 
- Stop deriving the telemetry `instance_id` from `ORB_ENROLLMENT_SECRET` and instead derive it from the per-instance anonymization secret produced by `getOrCreateAnonSecret`; the instance-hash call site was updated to pass that secret. 
- Keep brokered export behavior (brokered instances may export when not air-gapped) but ensure air-gap suppresses all outbound telemetry regardless of brokered mode. 
- Replace the vulnerable unit test with two tests: one asserting no fetch occurs when `ORB_AIR_GAP=true` (even if brokered) and one asserting brokered export still works without a local App key when air-gap is off. 

### Testing
- Ran `npx vitest run test/unit/selfhost-orb-collector.test.ts`; the suite passed (17 tests). 
- Ran `npm run typecheck` (`tsc --noEmit`); type-check passed. 
- Ran `git diff --check`; it returned clean. 
- Attempted full `npm run test:ci`; the run was started but stopped during the coverage step and did not complete (coverage remapping later failed with `TypeError: jsTokens is not a function`). 
- `npm audit --audit-level=moderate` was attempted but the registry audit endpoint returned `403 Forbidden`, so the dependency-audit step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4fd10ed0832cbd3e87e21b21e9f2)