### PR TITLE
perf(selfhost): default QUEUE_CONCURRENCY to 4 so PR bursts drain in parallel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,7 +151,7 @@ GITTENSORY_REVIEW_DRAFT=false
 # LITESTREAM_REGION=us-east-1
 
 # --- Queue worker (#977/#1201) ---
-# QUEUE_CONCURRENCY=1                        # max concurrent job-processing loops per instance (default 1)
+# QUEUE_CONCURRENCY=4                        # max concurrent (I/O-bound) job loops per instance (default 4; 1 = serial)
 
 # --- Caddy HTTPS terminator (#1203; requires --profile caddy) ---
 # DOMAIN=gittensory.example.com             # fully-qualified domain; Caddy auto-obtains a Let's Encrypt cert

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -117,7 +117,8 @@ the **Orb-brokered** path:
 (You set **no** `GITHUB_APP_*` secrets — the Orb holds the App key and mints tokens for you on demand.)
 
 Runtime knobs: `PORT` (default 8787), `DATABASE_PATH` (default `/data/gittensory.sqlite`), `CRON_INTERVAL_MS`
-(default 120000 ≈ the hosted every-2-minutes cron).
+(default 120000 ≈ the hosted every-2-minutes cron), `QUEUE_CONCURRENCY` (default 4 — how many I/O-bound review
+jobs process at once; raise it to drain bigger PR bursts faster, set `1` for strict serial processing).
 
 **Secrets via files.** Any `FOO_FILE=/run/secrets/foo` is read into `FOO` at startup (Docker/Compose
 secrets, multi-line keys) — an explicit `FOO` always wins.

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -40,7 +40,9 @@ export interface PgQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 1. */
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
+   *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster; FOR UPDATE SKIP LOCKED
+   *  keeps claims race-free across the pool (and across replicas). Set QUEUE_CONCURRENCY=1 to force strict serial. */
   concurrency?: number;
 }
 
@@ -48,7 +50,7 @@ export function createPgQueue(pool: Pool, consume: (message: JobMessage) => Prom
   const maxRetries = opts.maxRetries ?? 5;
   const pollIntervalMs = opts.pollIntervalMs ?? 1000;
   const backoff = opts.backoffMs ?? ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
-  const concurrency = opts.concurrency ?? Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "1"));
+  const concurrency = opts.concurrency ?? Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "4"));
 
   let running = false;
   let active = 0;

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -40,7 +40,9 @@ export interface SqliteQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 1. */
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
+   *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster while SQLite's WAL +
+   *  busy_timeout absorb the short serialized write windows. Set QUEUE_CONCURRENCY=1 to force strict serial. */
   concurrency?: number;
 }
 
@@ -48,7 +50,7 @@ export function createSqliteQueue(driver: SqliteDriver, consume: (message: JobMe
   const maxRetries = opts.maxRetries ?? 5;
   const pollIntervalMs = opts.pollIntervalMs ?? 1000;
   const backoff = opts.backoffMs ?? ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
-  const concurrency = opts.concurrency ?? Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "1"));
+  const concurrency = opts.concurrency ?? Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "4"));
 
   driver.exec(DDL);
   // Recover jobs a crashed previous run left mid-flight → make them claimable again.


### PR DESCRIPTION
## Summary

Review jobs are **I/O-bound** (GitHub API + AI awaits dominate), but the queue defaulted to `QUEUE_CONCURRENCY=1` — strict serial — so a burst of N PRs took N× the slowest review back-to-back. Default to **4** overlapping job loops.

- **SQLite**: WAL + busy_timeout absorb the short serialized write windows; overlapping the I/O waits is the win.
- **Postgres**: `FOR UPDATE SKIP LOCKED` already makes claims race-free across the pool and replicas.
- `QUEUE_CONCURRENCY=1` restores strict serial; documented in `.env.example` + the self-hosting guide.

## Validation
- [x] `npm run typecheck`; `npm run test:coverage` — full suite green, **no changed-line coverage gaps** (existing concurrency=1/2 tests still pass; nothing asserted the old default).

Roadmap item #3 (throughput).