### PR TITLE
chore(enrichment): pin Serverless-off + teardown timings in railway.json (config-as-code)

### DIFF
--- a/review-enrichment/railway.json
+++ b/review-enrichment/railway.json
@@ -6,10 +6,13 @@
     "watchPatterns": ["review-enrichment/**"]
   },
   "deploy": {
+    "numReplicas": 1,
     "healthcheckPath": "/health",
     "healthcheckTimeout": 60,
+    "sleepApplication": false,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
-    "numReplicas": 1
+    "overlapSeconds": 0,
+    "drainingSeconds": 15
   }
 }


### PR DESCRIPTION
Moves every Railway setting the schema supports into `review-enrichment/railway.json` so the REES is fully config-as-code:
- `numReplicas`, `healthcheckPath`/`healthcheckTimeout`, `restartPolicyType`/`restartPolicyMaxRetries` (existing)
- **`sleepApplication: false`** — keep always-on; `/v1/enrich` is called synchronously during reviews, so scale-to-zero cold starts would add latency / risk timeouts
- **`overlapSeconds: 0`, `drainingSeconds: 15`** — zero-downtime teardown

Root Directory, the custom domain, `REES_SHARED_SECRET`, and Skipped Builds stay UI-only (not expressible in railway.json).

Follow-up to #1485.