### PR TITLE
test(selfhost): cover the null-value branch of the fs blob store put

### DIFF
--- a/test/unit/selfhost-blob-store.test.ts
+++ b/test/unit/selfhost-blob-store.test.ts
@@ -28,6 +28,12 @@ describe("createFsBlobStore (#10 — self-host visual screenshot persistence)", 
     expect(await new Response((await store.get("gittensory/shots/s.png"))!.body).text()).toBe("hello");
   });
 
+  it("accepts a null value (stores an empty object), satisfying the R2 put body type", async () => {
+    const store = createFsBlobStore(dir);
+    await store.put("gittensory/shots/empty.png", null);
+    expect((await new Response((await store.get("gittensory/shots/empty.png"))!.body).arrayBuffer()).byteLength).toBe(0);
+  });
+
   it("rejects a key that escapes the base dir — put throws, get is a safe miss (no traversal)", async () => {
     const store = createFsBlobStore(dir);
     await expect(store.put("../escape.png", new Uint8Array([1]))).rejects.toThrow(/escapes base dir/);


### PR DESCRIPTION
Follow-up to #1490, which merged with a failing `codecov/patch` (the admin override let it through): the `value ?? ""` null-value arm of `createFsBlobStore.put` was untested. Adds a null-value put test, restoring the blob store to **100% branch coverage**. No production change.