### PR TITLE
feat(enrichment): unpinned GitHub Actions analyzer

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -1,0 +1,54 @@
+// Unpinned GitHub Actions analyzer (#1500). Scans changed .github/workflows/* for third-party actions referenced by
+// a MUTABLE tag/branch (@v3, @main) instead of a full commit SHA — the tj-actions/changed-files supply-chain class,
+// where a compromised upstream tag silently re-points and runs in your CI with your secrets. Pure compute, no network.
+// Official actions/* + github/* are excluded (lowest risk, extremely common) to keep the signal high. Line-cited.
+import type { EnrichRequest, ActionPinFinding } from "../types.js";
+
+const USES_RE = /^\s*-?\s*uses:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
+const FULL_SHA = /^[0-9a-f]{40}$/;
+const OFFICIAL = /^(actions|github)\//;
+const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
+
+/** Scan one workflow patch's added lines for unpinned third-party `uses:` refs, line-cited via hunk headers. Pure. */
+export function scanWorkflowPins(
+  path: string,
+  patch: string,
+): ActionPinFinding[] {
+  const findings: ActionPinFinding[] = [];
+  let newLine = 0;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (line.startsWith("+")) {
+      const match = USES_RE.exec(line.slice(1));
+      if (match) {
+        const action = match[1]!;
+        const ref = match[2]!;
+        if (!OFFICIAL.test(action) && !FULL_SHA.test(ref)) {
+          findings.push({ file: path, line: newLine, action, ref });
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-")) {
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed workflow file for unpinned third-party actions. */
+export async function scanActionPins(
+  req: EnrichRequest,
+): Promise<ActionPinFinding[]> {
+  const findings: ActionPinFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (WORKFLOW_PATH.test(file.path) && file.patch) {
+      findings.push(...scanWorkflowPins(file.path, file.patch));
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -11,6 +11,7 @@ import { scanDependencies } from "./analyzers/dependency-scan.js";
 import { scanSecrets } from "./analyzers/secret-scan.js";
 import { scanLicenses } from "./analyzers/license-check.js";
 import { scanInstallScripts } from "./analyzers/install-scripts.js";
+import { scanActionPins } from "./analyzers/actions-pin.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest) => Promise<unknown>;
@@ -21,6 +22,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   secret: (req) => scanSecrets(req),
   license: (req) => scanLicenses(req),
   installScript: (req) => scanInstallScripts(req),
+  actionPin: (req) => scanActionPins(req),
 };
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -72,6 +72,16 @@ export function renderBrief(
     }
   }
 
+  const actionPins = findings.actionPin ?? [];
+  if (actionPins.length) {
+    lines.push("### Unpinned GitHub Actions (pin to a commit SHA)");
+    for (const pin of actionPins) {
+      lines.push(
+        `- \`${pin.file}:${pin.line}\` — \`${pin.action}@${pin.ref}\` is a mutable ref; pin to a full commit SHA`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -67,11 +67,20 @@ export interface InstallScriptFinding {
   publishedAt: string | null;
 }
 
+/** A third-party GitHub Action referenced by a mutable tag/branch instead of a pinned commit SHA. */
+export interface ActionPinFinding {
+  file: string;
+  line: number;
+  action: string;
+  ref: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
   secret?: SecretFinding[];
   license?: LicenseFinding[];
+  actionPin?: ActionPinFinding[];
   installScript?: InstallScriptFinding[];
 }
 

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -10,6 +10,10 @@ import { buildBrief } from "../dist/brief.js";
 import { scanPatch, scanSecrets } from "../dist/analyzers/secret-scan.js";
 import { scanLicenses } from "../dist/analyzers/license-check.js";
 import { scanInstallScripts } from "../dist/analyzers/install-scripts.js";
+import {
+  scanWorkflowPins,
+  scanActionPins,
+} from "../dist/analyzers/actions-pin.js";
 
 const npmFetch =
   (scripts, time = {}) =>
@@ -397,6 +401,70 @@ test("buildBrief: install-script analyzer runs alongside the others", async () =
     assert.equal(brief.analyzerStatus.installScript, "ok");
     assert.equal(brief.findings.installScript.length, 1);
     assert.match(brief.promptSection, /supply-chain risk/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("scanWorkflowPins: flags unpinned third-party actions, skips official + SHA-pinned + local, line-cited", () => {
+  const patch = [
+    "@@ -1,1 +1,5 @@",
+    " jobs:",
+    "+      - uses: actions/checkout@v4",
+    "+      - uses: tj-actions/changed-files@v44",
+    "+      - uses: pinned/action@1234567890123456789012345678901234567890",
+    "+      - uses: ./local-action",
+  ].join("\n");
+  const findings = scanWorkflowPins(".github/workflows/ci.yml", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].action, "tj-actions/changed-files");
+  assert.equal(findings[0].ref, "v44");
+  assert.equal(findings[0].line, 3);
+});
+
+test("scanActionPins: only scans .github/workflows/* files", async () => {
+  const findings = await scanActionPins({
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      {
+        path: ".github/workflows/ci.yml",
+        patch: "@@ -1,0 +1,1 @@\n+  uses: foo/bar@main",
+      },
+      { path: "src/x.ts", patch: "@@ -1,0 +1,1 @@\n+  uses: foo/bar@main" },
+    ],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].action, "foo/bar");
+});
+
+test("renderBrief: renders the unpinned-actions block", () => {
+  const r = renderBrief({
+    actionPin: [
+      { file: ".github/workflows/ci.yml", line: 5, action: "tj/x", ref: "v1" },
+    ],
+  });
+  assert.match(r.promptSection, /Unpinned GitHub Actions/);
+  assert.match(r.promptSection, /`tj\/x@v1` is a mutable ref/);
+});
+
+test("buildBrief: action-pin analyzer runs (pure, no network)", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [
+        {
+          path: ".github/workflows/ci.yml",
+          patch: "@@ -1,0 +1,1 @@\n+  uses: evil/action@main",
+        },
+      ],
+    });
+    assert.equal(brief.analyzerStatus.actionPin, "ok");
+    assert.equal(brief.findings.actionPin.length, 1);
+    assert.match(brief.promptSection, /Unpinned GitHub Actions/);
   } finally {
     globalThis.fetch = realFetch;
   }


### PR DESCRIPTION
Fifth REES analyzer (high-value brainstorm pick). Scans changed `.github/workflows/*` for third-party actions pinned to a mutable **tag/branch** instead of a **commit SHA** — the tj-actions/changed-files supply-chain class. Pure compute, no network; official `actions/*`+`github/*` excluded; line-cited. 4 new `node:test` units (23 total). Closes #1500.