### PR TITLE
fix(enrichment): bound license analyzer lookups

### DIFF
--- a/review-enrichment/src/analyzers/license-check.ts
+++ b/review-enrichment/src/analyzers/license-check.ts
@@ -10,6 +10,8 @@ const SYSTEM: Record<string, string> = { npm: "npm", PyPI: "pypi", Go: "go" };
 
 // Strong/weak copyleft families worth a compatibility check against a permissive project.
 const COPYLEFT = /^(A?GPL|LGPL|MPL|EPL|CDDL|EUPL|OSL|SSPL|CPAL|CECILL)/i;
+const MAX_LICENSE_LOOKUPS = 25;
+const LICENSE_LOOKUP_TIMEOUT_MS = 1500;
 
 function classify(licenses: string[]): LicenseFinding["classification"] | null {
   const resolved = licenses.filter(
@@ -28,10 +30,18 @@ async function fetchLicenses(
   fetchImpl: typeof fetch,
 ): Promise<string[] | null> {
   const url = `https://api.deps.dev/v3/systems/${system}/packages/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`;
-  const response = await fetchImpl(url);
-  if (!response.ok) return null;
-  const data = (await response.json()) as { licenses?: string[] };
-  return Array.isArray(data.licenses) ? data.licenses : [];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LICENSE_LOOKUP_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { licenses?: string[] };
+    return Array.isArray(data.licenses) ? data.licenses : [];
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** Analyzer entrypoint: changed deps → deps.dev license → only the copyleft/unknown ones. */
@@ -40,7 +50,11 @@ export async function scanLicenses(
   fetchImpl: typeof fetch = fetch,
 ): Promise<LicenseFinding[]> {
   const findings: LicenseFinding[] = [];
-  for (const change of extractDependencyChanges(req.files ?? [])) {
+  const changes = extractDependencyChanges(req.files ?? []).slice(
+    0,
+    MAX_LICENSE_LOOKUPS,
+  );
+  for (const change of changes) {
     const system = SYSTEM[change.ecosystem];
     if (!system) continue;
     const licenses = await fetchLicenses(

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -293,6 +293,35 @@ test("scanLicenses: flags copyleft + unknown, skips permissive + fetch-fail", as
   assert.equal(failed.length, 0);
 });
 
+test("scanLicenses: caps deps.dev lookups from large manifest diffs", async () => {
+  const patch = Array.from(
+    { length: 40 },
+    (_, i) => `+    "pkg-${i}": "1.0.0",`,
+  ).join("\n");
+  let calls = 0;
+  const findings = await scanLicenses(
+    {
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [{ path: "package.json", patch }],
+    },
+    async () => {
+      calls += 1;
+      return { ok: true, json: async () => ({ licenses: ["MIT"] }) };
+    },
+  );
+  assert.equal(findings.length, 0);
+  assert.equal(calls, 25);
+});
+
+test("scanLicenses: passes an abort signal and degrades failed lookups", async () => {
+  const findings = await scanLicenses(pkgPatch("slow"), async (_url, init) => {
+    assert.ok(init?.signal instanceof AbortSignal);
+    throw new Error("network down");
+  });
+  assert.equal(findings.length, 0);
+});
+
 test("renderBrief: renders the license block", () => {
   const r = renderBrief({
     license: [


### PR DESCRIPTION
### Motivation

- The new license analyzer issued one deps.dev lookup per extracted dependency with no cap or abort, allowing a maliciously large manifest diff to sustain outbound requests and exhaust REES resources.

### Description

- Limit license lookups to the first 25 extracted dependency changes using `MAX_LICENSE_LOOKUPS` to prevent unbounded fan-out.
- Add an abortable per-request timeout (`AbortController` + `LICENSE_LOOKUP_TIMEOUT_MS = 1500ms`) and fail-safe degradation so slow/failed deps.dev requests are cancelled or return `null` instead of blocking resources.
- Add regression tests that assert the lookup cap and that timed-out/failed lookups degrade without producing findings.
- Modified files: `review-enrichment/src/analyzers/license-check.ts`, `review-enrichment/test/enrichment.test.ts`.

### Testing

- Ran `npm test` inside `review-enrichment` (local package test suite) and all tests passed (21 passed, 0 failed).
- Attempted the full local gate via `npm run test:ci`; the run began but the root Vitest coverage remapping hit an unrelated `TypeError: jsTokens is not a function` during coverage conversion (failure unrelated to this change).
- `git diff --check` (preflight) passed locally; `npm audit --audit-level=moderate` was blocked by the registry returning HTTP 403 so the audit step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e75eaa9f0832c9dc53a357afd626c)