### PR TITLE
fix(review): require maintainer self-tune outcomes

### DIFF
--- a/src/review/selftune-wire.ts
+++ b/src/review/selftune-wire.ts
@@ -17,8 +17,10 @@
 // advisor consumes a GateEvalReport (per-project confusion matrix). We build that report from gittensory's
 // NATIVE outcome sources via the SAME aggregation services ops-wire already reuses (no new queries / schema):
 //   • agent_recommendation_outcomes (#543) — the positive/negative resolved split (buildRepoOutcomeCalibration).
-//     A NEGATIVE outcome (gittensory recommended "proceed", the human CLOSED) is the gittensory-native analogue
-//     of reviewbot's "would-merge BUT human closed" (mergeFalse) — the dangerous error a TIGHTENING fixes.
+//     Only maintainer-lane outcomes are authoritative enough for live self-tune policy changes; contributor-lane
+//     closures can be self-authored and stay reporting-only. A maintainer-lane NEGATIVE outcome (gittensory
+//     recommended "proceed", the human CLOSED) is the gittensory-native analogue of reviewbot's "would-merge
+//     BUT human closed" (mergeFalse) — the dangerous error a TIGHTENING fixes.
 // The mapping is deliberately conservative: it only ever populates the would-MERGE side of the matrix, so the
 // advisor can only ever recommend a TIGHTENING (raise the floor) or a no-op — never a loosening.
 //
@@ -81,7 +83,7 @@ export function evalRowFromCalibration(project: string, positive: number, negati
 
 /** Build the per-project GateEvalReport from gittensory's recommendation-outcome calibration for one repo. */
 async function buildEvalRow(env: Env, repoFullName: string): Promise<GateEvalRow> {
-  const calibration = await buildRepoOutcomeCalibration(env, repoFullName);
+  const calibration = await buildRepoOutcomeCalibration(env, repoFullName, undefined, { maintainerOnly: true });
   return evalRowFromCalibration(repoFullName, calibration.recommendations.positive, calibration.recommendations.negative);
 }
 

--- a/src/services/outcome-calibration.ts
+++ b/src/services/outcome-calibration.ts
@@ -31,6 +31,11 @@ export type SlopOutcomeCalibration = {
 
 export type RecommendationOutcomeCalibration = { total: number; positive: number; negative: number; pending: number; positiveRate: number | null };
 
+export type RecommendationOutcomeCalibrationOptions = {
+  /** Only maintainer-lane outcomes are authoritative enough for live self-tune policy changes. */
+  maintainerOnly?: boolean | undefined;
+};
+
 export type OutcomeCalibration = {
   repoFullName: string;
   generatedAt: string;
@@ -100,8 +105,13 @@ function computeDiscriminates(bands: SlopBandCalibration[]): boolean | null {
  * Positive (accepted/merged/improved) vs negative (rejected/closed) vs pending (stale/ignored) split. Pure.
  * When `repoFullName` is given, only outcomes targeting that repo are counted (by outcome/target repo).
  */
-export function buildRecommendationOutcomeCalibration(outcomes: AgentRecommendationOutcomeRecord[], repoFullName?: string): RecommendationOutcomeCalibration {
-  const scoped = repoFullName ? outcomes.filter((o) => sameRepo(o.outcomeRepoFullName ?? o.targetRepoFullName, repoFullName)) : outcomes;
+export function buildRecommendationOutcomeCalibration(
+  outcomes: AgentRecommendationOutcomeRecord[],
+  repoFullName?: string,
+  options: RecommendationOutcomeCalibrationOptions = {},
+): RecommendationOutcomeCalibration {
+  const repoScoped = repoFullName ? outcomes.filter((o) => sameRepo(o.outcomeRepoFullName ?? o.targetRepoFullName, repoFullName)) : outcomes;
+  const scoped = options.maintainerOnly ? repoScoped.filter((o) => o.maintainerLane) : repoScoped;
   const positive = scoped.filter((o) => o.outcomeState === "accepted" || o.outcomeState === "merged" || o.outcomeState === "improved").length;
   const negative = scoped.filter((o) => o.outcomeState === "rejected" || o.outcomeState === "closed").length;
   const pending = scoped.filter((o) => o.outcomeState === "stale" || o.outcomeState === "ignored").length;
@@ -138,12 +148,17 @@ export function outcomeCalibrationSummary(fullName: string, slop: SlopOutcomeCal
 }
 
 /** Load a repo's PRs + recommendation outcomes and assemble the calibration report. */
-export async function buildRepoOutcomeCalibration(env: Env, repoFullName: string, windowDays?: number): Promise<OutcomeCalibration> {
+export async function buildRepoOutcomeCalibration(
+  env: Env,
+  repoFullName: string,
+  windowDays?: number,
+  options: RecommendationOutcomeCalibrationOptions = {},
+): Promise<OutcomeCalibration> {
   const [pullRequests, outcomes] = await Promise.all([
     listPullRequests(env, repoFullName),
     listAgentRecommendationOutcomes(env, windowDays !== undefined ? { repoFullName, windowDays } : { repoFullName }),
   ]);
   const slop = buildSlopOutcomeCalibration(pullRequests);
-  const recommendations = buildRecommendationOutcomeCalibration(outcomes, repoFullName);
+  const recommendations = buildRecommendationOutcomeCalibration(outcomes, repoFullName, options);
   return { repoFullName, generatedAt: nowIso(), windowDays: windowDays ?? null, slop, recommendations, signals: buildOutcomeCalibrationSignals(slop, recommendations) };
 }

--- a/test/unit/outcome-calibration.test.ts
+++ b/test/unit/outcome-calibration.test.ts
@@ -63,8 +63,8 @@ describe("buildSlopOutcomeCalibration", () => {
 });
 
 describe("buildRecommendationOutcomeCalibration", () => {
-  function outcome(state: AgentRecommendationOutcomeState): AgentRecommendationOutcomeRecord {
-    return { actionId: `a-${state}`, runId: "r", actorLogin: "miner", actionType: "choose_next_work", source: "explicit", outcomeState: state, outcomeTargetType: "pull_request", maintainerLane: false, confidence: "high", reason: "x", metadata: {} };
+  function outcome(state: AgentRecommendationOutcomeState, maintainerLane = false): AgentRecommendationOutcomeRecord {
+    return { actionId: `a-${state}-${maintainerLane}`, runId: "r", actorLogin: "miner", actionType: "choose_next_work", source: "explicit", outcomeState: state, outcomeTargetType: "pull_request", maintainerLane, confidence: "high", reason: "x", metadata: {} };
   }
   it("splits positive / negative / pending and computes a positive rate over resolved", () => {
     const result = buildRecommendationOutcomeCalibration([outcome("merged"), outcome("improved"), outcome("accepted"), outcome("closed"), outcome("stale"), outcome("ignored")]);
@@ -73,6 +73,10 @@ describe("buildRecommendationOutcomeCalibration", () => {
   it("reports a null rate when nothing is resolved", () => {
     expect(buildRecommendationOutcomeCalibration([outcome("stale")]).positiveRate).toBeNull();
     expect(buildRecommendationOutcomeCalibration([]).positiveRate).toBeNull();
+  });
+  it("can restrict calibration to maintainer-lane outcomes for live self-tune policy", () => {
+    const outcomes = [outcome("closed"), outcome("rejected"), outcome("accepted", true), outcome("closed", true), outcome("ignored", true)];
+    expect(buildRecommendationOutcomeCalibration(outcomes, undefined, { maintainerOnly: true })).toMatchObject({ total: 3, positive: 1, negative: 1, pending: 1, positiveRate: 0.5 });
   });
   it("scopes to a repo (case-insensitive, by outcome repo then target repo) when repoFullName is given", () => {
     const outcomes: AgentRecommendationOutcomeRecord[] = [

--- a/test/unit/selftune-wiring.test.ts
+++ b/test/unit/selftune-wiring.test.ts
@@ -41,7 +41,7 @@ async function seedRegisteredRepo(env: Env, fullName: string, autonomyJson: stri
 // Seed N resolved recommendation outcomes for a repo: `negative` rejected/closed (the dangerous error a
 // tightening fixes) + `positive` accepted. Inserted directly (FKs off) — buildRepoOutcomeCalibration reads
 // the outcome_state split, which is all the eval mapping needs.
-async function seedRecommendationOutcomes(env: Env, repoFullName: string, positive: number, negative: number): Promise<void> {
+async function seedRecommendationOutcomes(env: Env, repoFullName: string, positive: number, negative: number, maintainerLane = true): Promise<void> {
   await env.DB.prepare("PRAGMA foreign_keys=OFF").run();
   let i = 0;
   const insert = async (state: string) => {
@@ -50,9 +50,9 @@ async function seedRecommendationOutcomes(env: Env, repoFullName: string, positi
       `INSERT INTO agent_recommendation_outcomes
         (id, action_id, run_id, actor_login, action_type, outcome_state, outcome_target_type, outcome_repo_full_name,
          maintainer_lane, confidence, reason, source, updated_at)
-       VALUES (?, ?, ?, ?, 'review', ?, 'pull_request', ?, 0, 'medium', 'seed', 'inferred', CURRENT_TIMESTAMP)`,
+       VALUES (?, ?, ?, ?, 'review', ?, 'pull_request', ?, ?, 'medium', 'seed', 'inferred', CURRENT_TIMESTAMP)`,
     )
-      .bind(`o${i}`, `a${i}`, `r${i}`, "bot", state, repoFullName)
+      .bind(`o${i}`, `a${i}`, `r${i}`, "bot", state, repoFullName, maintainerLane ? 1 : 0)
       .run();
   };
   for (let n = 0; n < positive; n += 1) await insert("accepted");
@@ -152,6 +152,18 @@ describe("runSelfTune — shadow-soak over gittensory's own outcome data", () =>
     expect(shadow?.override.confidenceFloor).toBeGreaterThan(0);
     expect(await loadOverride(env as never, "owner/repo")).toBeNull(); // not promoted within one tick (still soaking)
     expect((await listOverrideAudit(env as never, "owner/repo")).some((a) => a.eventType === "override_shadowed")).toBe(true);
+  });
+
+  it("ignores contributor-lane closures when building live self-tune policy", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
+    await seedRegisteredRepo(env, "owner/repo", ACTING_AUTONOMY);
+    await seedRecommendationOutcomes(env, "owner/repo", 0, 10, false);
+
+    await runSelfTune(env);
+
+    expect(await loadShadowOverride(env as never, "owner/repo")).toBeNull();
+    expect(await loadOverride(env as never, "owner/repo")).toBeNull();
+    expect((await listOverrideAudit(env as never, "owner/repo")).length).toBe(0);
   });
 
   it("FLAG-ON: promotes a SOAKED tightening shadow override to live on a later tick (tightening + evidence + soaked)", async () => {


### PR DESCRIPTION
### Motivation
- Prevent maintainer-unverified contributor actions from poisoning self-tune live policy by ensuring only maintainer-lane outcomes feed live tuning decisions.

### Description
- Add `RecommendationOutcomeCalibrationOptions` and an optional `maintainerOnly` flag to `buildRecommendationOutcomeCalibration` and `buildRepoOutcomeCalibration` and default to the existing behavior.
- Filter recommendation outcomes when `maintainerOnly: true` so only outcomes with `maintainerLane` are counted for live self-tune wiring.
- Wire the self-tune evaluator to call `buildRepoOutcomeCalibration(..., { maintainerOnly: true })` so live gate-evaluation rows are built only from maintainer-lane outcomes.
- Add regression tests and test helpers: a maintainer-only calibration unit test and a self-tune wiring test that verifies contributor-lane closures do not create shadow or live overrides, and update the seeding helper to set `maintainer_lane` when inserting outcomes.

### Testing
- `git diff --check` ran and passed locally.
- `npm run typecheck` completed successfully.
- Targeted unit tests `npx vitest run test/unit/outcome-calibration.test.ts test/unit/selftune-wiring.test.ts --pool forks` passed (both test files succeeded).
- Full `npm run test:ci` was started but did not complete in this environment due to unrelated `queue` tests timing out; this did not block the focused regression verification.
- Coverage remapping during a coverage-enabled run surfaced `TypeError: jsTokens is not a function` in this environment; the focused unit test runs without coverage completed successfully, and `npm audit --audit-level=moderate` returned `403 Forbidden` from the registry in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e7a3b12bc832c9a7e3f03d0e28ef7)