### PR TITLE
fix(notify): escape Slack mrkdwn in action notifications

### DIFF
--- a/src/services/notify-discord.ts
+++ b/src/services/notify-discord.ts
@@ -89,6 +89,10 @@ function isValidSlackWebhook(url: string): boolean {
   }
 }
 
+function escapeSlackMrkdwnText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 /** Post a per-action Slack message (merged/closed/manual) to `SLACK_WEBHOOK_URL` as a Block Kit section. Best-effort:
  *  never throws. The modular self-host default — ANY repo notifies the operator's single Slack channel when
  *  `SLACK_WEBHOOK_URL` is set; unset → no-op, byte-identical to today. Sibling of {@link notifyActionToDiscord}. */
@@ -100,8 +104,9 @@ export async function notifyActionToSlack(
   if (typeof webhookUrl !== "string" || !isValidSlackWebhook(webhookUrl)) return;
   const meta = OUTCOME_META[params.outcome];
   const prUrl = `https://github.com/${params.repoFullName}/pull/${params.pullNumber}`;
-  const lines = [`*<${prUrl}|${params.repoFullName}#${params.pullNumber}>* · ${meta.word}`, (params.summary || meta.word).slice(0, 1800)];
-  if (params.submitter) lines.push(`Submitter: @${params.submitter}`);
+  const prLabel = escapeSlackMrkdwnText(`${params.repoFullName}#${params.pullNumber}`);
+  const lines = [`*<${prUrl}|${prLabel}>* · ${meta.word}`, escapeSlackMrkdwnText(params.summary || meta.word).slice(0, 1800)];
+  if (params.submitter) lines.push(`Submitter: @${escapeSlackMrkdwnText(params.submitter)}`);
   const body = {
     text: `${params.repoFullName}#${params.pullNumber} ${meta.word}`,
     blocks: [{ type: "section", text: { type: "mrkdwn", text: lines.join("\n") } }],

--- a/test/unit/notify-discord.test.ts
+++ b/test/unit/notify-discord.test.ts
@@ -69,6 +69,22 @@ describe("notifyActionToSlack (#11 — modular self-host Slack channel)", () => 
     expect(calls[0]?.body.blocks[0]?.text.text).toContain("Submitter: @octocat");
   });
 
+  it("escapes untrusted Slack mrkdwn in the summary and submitter", async () => {
+    const calls = slackStub();
+    await notifyActionToSlack(withEnv({ SLACK_WEBHOOK_URL: SLACK }), {
+      repoFullName: "acme/widgets",
+      pullNumber: 7,
+      outcome: "closed",
+      summary: "failed <!channel> & <https://evil.example|trusted check>",
+      submitter: "octo<cat>&co",
+    });
+    const text = calls[0]?.body.blocks[0]?.text.text ?? "";
+    expect(text).toContain("failed &lt;!channel&gt; &amp; &lt;https://evil.example|trusted check&gt;");
+    expect(text).toContain("Submitter: @octo&lt;cat&gt;&amp;co");
+    expect(text).not.toContain("<!channel>");
+    expect(text).not.toContain("<https://evil.example|trusted check>");
+  });
+
   it("omits the submitter line when absent (and falls back to the outcome word for an empty summary)", async () => {
     const calls = slackStub();
     await notifyActionToSlack(withEnv({ SLACK_WEBHOOK_URL: SLACK }), { repoFullName: "acme/widgets", pullNumber: 7, outcome: "closed", summary: "" });


### PR DESCRIPTION
### Motivation
- The Slack notifier rendered action summaries and submitter text as `mrkdwn` and directly interpolated untrusted strings, which allows attacker-controlled content (e.g. `<!channel>` or `<https://evil|text>`) to produce unwanted mentions or deceptive links in operator channels.

### Description
- Add `escapeSlackMrkdwnText` and apply it to the PR label, summary, and submitter before composing the Block Kit section in `notifyActionToSlack` (`src/services/notify-discord.ts`).
- Add a regression unit test that proves channel-mention and deceptive-link payloads are escaped in Slack notifications (`test/unit/notify-discord.test.ts`).

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/notify-discord.test.ts` and the Slack/Discord notifier tests passed.
- Ran `npm run typecheck` which completed successfully with no TypeScript errors.
- Attempted coverage and full gate (`npm run test:coverage` / `npm run test:ci`) but the local environment failed during coverage remapping with `TypeError: jsTokens is not a function`, and `npm audit` returned a registry `403` — these are environment/dependency issues unrelated to the introduced sanitizer logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e6e31b59c832ca0345ceb1c1964f2)