### PR TITLE
feat(selfhost): review-enrichment engine seam — POST the PR to the REES + splice the brief

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -84,10 +84,36 @@ import {
   refreshInstallationHealth,
   refreshPullRequestDetails,
 } from "../github/backfill";
-import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot, fetchOfficialGittensorMiner, type GittensorContributorSnapshot, type OfficialGittensorMinerDetection } from "../gittensor/api";
-import { createInstallationToken, createOrUpdateCheckRun, createOrUpdateErroredGateCheckRun, createOrUpdateGateCheckRun, createOrUpdateOverriddenGateCheckRun, createOrUpdatePendingGateCheckRun, createOrUpdateSkippedGateCheckRun, getInstallationId, getRepositoryCollaboratorPermission, isForeignAppInstallation } from "../github/app";
-import { AGENT_COMMAND_COMMENT_MARKER, createOrUpdateAgentCommandComment, createOrUpdatePrIntelligenceComment, PR_PANEL_COMMENT_MARKER } from "../github/comments";
-import { gittensoryFooter, gittensorRepoEarnUrl, maintainerControlPanelUrl } from "../github/footer";
+import {
+  contributorRepoStatsFromGittensor,
+  fetchGittensorContributorSnapshot,
+  fetchOfficialGittensorMiner,
+  type GittensorContributorSnapshot,
+  type OfficialGittensorMinerDetection,
+} from "../gittensor/api";
+import {
+  createInstallationToken,
+  createOrUpdateCheckRun,
+  createOrUpdateErroredGateCheckRun,
+  createOrUpdateGateCheckRun,
+  createOrUpdateOverriddenGateCheckRun,
+  createOrUpdatePendingGateCheckRun,
+  createOrUpdateSkippedGateCheckRun,
+  getInstallationId,
+  getRepositoryCollaboratorPermission,
+  isForeignAppInstallation,
+} from "../github/app";
+import {
+  AGENT_COMMAND_COMMENT_MARKER,
+  createOrUpdateAgentCommandComment,
+  createOrUpdatePrIntelligenceComment,
+  PR_PANEL_COMMENT_MARKER,
+} from "../github/comments";
+import {
+  gittensoryFooter,
+  gittensorRepoEarnUrl,
+  maintainerControlPanelUrl,
+} from "../github/footer";
 import {
   buildMaintainerQueueDigest,
   buildPublicAgentCommandComment,
@@ -98,36 +124,101 @@ import {
   parseGittensoryMentionCommand,
   sanitizePublicComment,
 } from "../github/commands";
-import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
+import {
+  ensurePullRequestLabel,
+  removePullRequestLabel,
+} from "../github/labels";
 import { resolveRepoActionMode } from "../github/client";
 import { ALL_TYPE_LABELS, resolvePrTypeLabel } from "../settings/pr-type-label";
 import { fetchPublicContributorProfile } from "../github/public";
 import { refreshRegistry } from "../registry/sync";
-import { buildIssueAdvisory, buildPullRequestAdvisory, evaluateGateCheck, isTestPath, reconcileGateEvaluationForGreenCi } from "../rules/advisory";
+import {
+  buildIssueAdvisory,
+  buildPullRequestAdvisory,
+  evaluateGateCheck,
+  isTestPath,
+  reconcileGateEvaluationForGreenCi,
+} from "../rules/advisory";
 import { detectNotificationEvents } from "../notifications/events";
-import { deliverNotification, detectIssueWatchEvents, evaluateNotificationEvent } from "../notifications/service";
-import { getOrCreateScoringModelSnapshot, refreshScoringModelSnapshot } from "../scoring/model";
-import { buildAndPersistContributorDecisionPack, loadDecisionPackSharedInputs } from "../services/decision-pack";
+import {
+  deliverNotification,
+  detectIssueWatchEvents,
+  evaluateNotificationEvent,
+} from "../notifications/service";
+import {
+  getOrCreateScoringModelSnapshot,
+  refreshScoringModelSnapshot,
+} from "../scoring/model";
+import {
+  buildAndPersistContributorDecisionPack,
+  loadDecisionPackSharedInputs,
+} from "../services/decision-pack";
 import {
   buildContributorEvidenceGraph,
   CONTRIBUTOR_EVIDENCE_GRAPH_SIGNAL,
   evidenceGraphTouchedRepoFullNames,
 } from "../services/contributor-evidence-graph";
-import { executeAgentRun, explainBlockersWithAgent, planNextWork, preflightBranchWithAgent, preparePrPacketWithAgent } from "../services/agent-orchestrator";
-import { isAuthorizedGitHubSessionLogin, parseGitHubLoginList } from "../auth/security";
-import { commandAuthorizationAllowedRoles, commandAuthorizationNeedsMinerDetection, evaluateCommandAuthorization } from "../settings/command-authorization";
-import { findBlacklistEntry, isAuthorBlacklisted } from "../settings/contributor-blacklist";
-import { autonomyRequiresApproval, isAgentConfigured, resolveAutonomy } from "../settings/autonomy";
-import { isGlobalAgentPause, resolveAgentActionMode } from "../settings/agent-execution";
-import { SWEEP_FANOUT_DEDUP_MS, isRegateSweepDraining, selectRegateCandidates } from "../settings/agent-sweep";
-import { MAINTENANCE_RESERVED_HEADROOM, delayUntil, shouldWaitForGitHubRateLimit } from "../github/rate-limit";
-import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type PlannedAgentAction } from "../settings/agent-actions";
-import { executeAgentMaintenanceActions, pendingClosureLabelApplied } from "../services/agent-action-executor";
+import {
+  executeAgentRun,
+  explainBlockersWithAgent,
+  planNextWork,
+  preflightBranchWithAgent,
+  preparePrPacketWithAgent,
+} from "../services/agent-orchestrator";
+import {
+  isAuthorizedGitHubSessionLogin,
+  parseGitHubLoginList,
+} from "../auth/security";
+import {
+  commandAuthorizationAllowedRoles,
+  commandAuthorizationNeedsMinerDetection,
+  evaluateCommandAuthorization,
+} from "../settings/command-authorization";
+import {
+  findBlacklistEntry,
+  isAuthorBlacklisted,
+} from "../settings/contributor-blacklist";
+import {
+  autonomyRequiresApproval,
+  isAgentConfigured,
+  resolveAutonomy,
+} from "../settings/autonomy";
+import {
+  isGlobalAgentPause,
+  resolveAgentActionMode,
+} from "../settings/agent-execution";
+import {
+  SWEEP_FANOUT_DEDUP_MS,
+  isRegateSweepDraining,
+  selectRegateCandidates,
+} from "../settings/agent-sweep";
+import {
+  MAINTENANCE_RESERVED_HEADROOM,
+  delayUntil,
+  shouldWaitForGitHubRateLimit,
+} from "../github/rate-limit";
+import {
+  downgradeCloseToHold,
+  downgradeMergeToHold,
+  isProtectedAutomationAuthor,
+  planAgentMaintenanceActions,
+  type PlannedAgentAction,
+} from "../settings/agent-actions";
+import {
+  executeAgentMaintenanceActions,
+  pendingClosureLabelApplied,
+} from "../services/agent-action-executor";
 import { processSubmitDraft } from "../services/draft";
 import { loadIssueQualityReportMap } from "../services/issue-quality";
 import { generateWeeklyValueReport } from "../services/weekly-value-report";
-import { REPO_OUTCOME_PATTERNS_SIGNAL, computeRepoOutcomePatterns } from "../services/repo-outcome-patterns";
-import { buildQueueTrendReport, QUEUE_TREND_HISTORY_DAYS } from "../services/queue-trends";
+import {
+  REPO_OUTCOME_PATTERNS_SIGNAL,
+  computeRepoOutcomePatterns,
+} from "../services/repo-outcome-patterns";
+import {
+  buildQueueTrendReport,
+  QUEUE_TREND_HISTORY_DAYS,
+} from "../services/queue-trends";
 import {
   buildUpstreamRulesetSnapshot,
   detectAndPersistUpstreamDrift,
@@ -169,47 +260,128 @@ import {
 } from "../signals/engine";
 import { isDuplicateClusterWinner } from "../signals/duplicate-winner";
 import { buildUnifiedReviewDiff } from "../review/review-diff";
-import { buildUnifiedCommentBody, isUnifiedReviewCommentEnabled } from "../review/unified-comment-bridge";
+import {
+  buildUnifiedCommentBody,
+  isUnifiedReviewCommentEnabled,
+} from "../review/unified-comment-bridge";
 import { screenshotsAllowed } from "../review/visual-wire";
 import { isVisualPath } from "../review/visual/paths";
 import { buildCapture, type CaptureRoute } from "../review/visual/capture";
-import { renderReviewingPlaceholder, shouldPostReviewingPlaceholder, type CheckFailureDetail, type MergeReadiness } from "../review/unified-comment";
-import { buildIssueSlopAssessment, buildSlopAssessment, type SlopBand } from "../signals/slop";
+import {
+  renderReviewingPlaceholder,
+  shouldPostReviewingPlaceholder,
+  type CheckFailureDetail,
+  type MergeReadiness,
+} from "../review/unified-comment";
+import {
+  buildIssueSlopAssessment,
+  buildSlopAssessment,
+  type SlopBand,
+} from "../signals/slop";
 import { runGittensoryAiSlopAdvisory } from "../services/ai-slop";
 import { decidePublicSurface } from "../signals/settings-preview";
-import { buildFocusManifestGuidance, excludeReviewPaths, resolveReviewPathInstructions, resolveReviewPreMergeChecks, resolveReviewPromptOverrides, type FocusManifestFinding, type ReviewPathInstruction, type ReviewProfile } from "../signals/focus-manifest";
+import {
+  buildFocusManifestGuidance,
+  excludeReviewPaths,
+  resolveReviewPathInstructions,
+  resolveReviewPreMergeChecks,
+  resolveReviewPromptOverrides,
+  type FocusManifestFinding,
+  type ReviewPathInstruction,
+  type ReviewProfile,
+} from "../signals/focus-manifest";
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import type { LocalBranchAnalysisInput } from "../signals/local-branch";
-import { runGittensoryAiReview, type InlineFinding } from "../services/ai-review";
-import { maybePostInlineComments, shouldRequestInlineFindings } from "../review/inline-comments";
+import {
+  runGittensoryAiReview,
+  type InlineFinding,
+} from "../services/ai-review";
+import {
+  maybePostInlineComments,
+  shouldRequestInlineFindings,
+} from "../review/inline-comments";
 import { evaluatePreMergeChecks } from "../review/pre-merge-checks";
 import { secretLeakFinding } from "../review/safety";
-import { buildIssuePlanComment, classifyPlanCommandRequest, generateIssuePlan, isPlanCommand, isPlannerEnabled } from "../review/planner";
-import { aiCiRefutationActive, buildReviewGroundingText, checkSummaryText as checkFailureSummaryText, isGroundingEnabled } from "../review/grounding-wire";
+import {
+  buildIssuePlanComment,
+  classifyPlanCommandRequest,
+  generateIssuePlan,
+  isPlanCommand,
+  isPlannerEnabled,
+} from "../review/planner";
+import {
+  aiCiRefutationActive,
+  buildReviewGroundingText,
+  checkSummaryText as checkFailureSummaryText,
+  isGroundingEnabled,
+} from "../review/grounding-wire";
 import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
+import {
+  buildReviewEnrichment,
+  isEnrichmentEnabled,
+} from "../review/enrichment-wire";
 import { evaluateWithSurfaceLane } from "../review/content-lane-wire";
 import { indexRepo, reindexChangedPaths } from "../review/rag-index";
-import { isReputationEnabled, recordReputationOutcome, shouldSkipAiForReputation } from "../review/reputation-wire";
+import {
+  isReputationEnabled,
+  recordReputationOutcome,
+  shouldSkipAiForReputation,
+} from "../review/reputation-wire";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
-import { deploymentStatusToPreview, type DeploymentStatusPayload } from "../review/visual/preview-url";
+import {
+  deploymentStatusToPreview,
+  type DeploymentStatusPayload,
+} from "../review/visual/preview-url";
 import { loadHardGuardrailGlobs } from "../review/guardrail-config";
 import { isGuardrailHit } from "../signals/change-guardrail";
-import { closePullRequest, createIssueComment, getLastCloserLogin } from "../github/pr-actions";
-import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
+import {
+  closePullRequest,
+  createIssueComment,
+  getLastCloserLogin,
+} from "../github/pr-actions";
+import {
+  loadLinkedIssueHardRules,
+  resolveLinkedIssueHardRule,
+} from "../review/linked-issue-hard-rules";
 import { isOpsEnabled, runOpsAlerts } from "../review/ops-wire";
 import { isSelfTuneEnabled, runSelfTune } from "../review/selftune-wire";
-import { isCloseHoldOnly, isHoldOnly, recordPrOutcome, recordReversalSignals, runSelfTuneBreaker } from "../review/outcomes-wire";
+import {
+  isCloseHoldOnly,
+  isHoldOnly,
+  recordPrOutcome,
+  recordReversalSignals,
+  runSelfTuneBreaker,
+} from "../review/outcomes-wire";
 import { recordNativeGateDecision } from "../review/parity-wire";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
-import type { AdvisoryFinding, ContributorEvidenceRecord, ContributorRepoStatRecord, DetectedNotificationEvent, GitHubWebhookPayload, IssueRecord, JobMessage, JsonValue, PullRequestFilePathRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../types";
+import type {
+  AdvisoryFinding,
+  ContributorEvidenceRecord,
+  ContributorRepoStatRecord,
+  DetectedNotificationEvent,
+  GitHubWebhookPayload,
+  IssueRecord,
+  JobMessage,
+  JsonValue,
+  PullRequestFilePathRecord,
+  PullRequestRecord,
+  RepositoryRecord,
+  RepositorySettings,
+} from "../types";
 import { retryFailedRelays } from "../orb/relay";
 import { sha256Hex } from "../utils/crypto";
 import { errorMessage, nowIso } from "../utils/json";
 
 const OFFICIAL_MINER_DETECTION_TTL_MS = 5 * 60 * 1000;
 const OFFICIAL_MINER_DETECTION_UNAVAILABLE_TTL_MS = 60 * 1000;
-const PR_PUBLIC_SURFACE_ACTIONS = new Set(["opened", "reopened", "synchronize", "ready_for_review", "edited"]);
+const PR_PUBLIC_SURFACE_ACTIONS = new Set([
+  "opened",
+  "reopened",
+  "synchronize",
+  "ready_for_review",
+  "edited",
+]);
 const PR_GATE_CLOSED_ACTIONS = new Set(["closed"]);
 const ISSUE_PLAN_COOLDOWN_MS = 10 * 60 * 1000;
 
@@ -217,30 +389,49 @@ const ISSUE_PLAN_COOLDOWN_MS = 10 * 60 * 1000;
  * Run (or dry-run) the data-retention prune across the configured log/snapshot tables and audit the
  * outcome. The per-table windows live in RETENTION_POLICY; only append-only/superseded tables are pruned.
  */
-export async function runRetentionPrune(env: Env, requestedBy: string, dryRun: boolean): Promise<void> {
+export async function runRetentionPrune(
+  env: Env,
+  requestedBy: string,
+  dryRun: boolean,
+): Promise<void> {
   const results = await pruneExpiredRecords(env, { dryRun });
   const totalDeleted = results.reduce((sum, result) => sum + result.deleted, 0);
   await recordAuditEvent(env, {
     eventType: "retention.prune",
     actor: requestedBy,
     outcome: dryRun ? "completed" : "success",
-    detail: dryRun ? `dry-run: ${totalDeleted} row(s) eligible` : `pruned ${totalDeleted} row(s)`,
-    metadata: { dryRun, totalDeleted, perTable: Object.fromEntries(results.map((r) => [r.table, r.deleted])) },
+    detail: dryRun
+      ? `dry-run: ${totalDeleted} row(s) eligible`
+      : `pruned ${totalDeleted} row(s)`,
+    metadata: {
+      dryRun,
+      totalDeleted,
+      perTable: Object.fromEntries(results.map((r) => [r.table, r.deleted])),
+    },
   });
 }
 
-const PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES: Partial<Record<FocusManifestFinding["code"], Pick<AdvisoryFinding, "detail" | "action">>> = {
+const PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES: Partial<
+  Record<
+    FocusManifestFinding["code"],
+    Pick<AdvisoryFinding, "detail" | "action">
+  >
+> = {
   manifest_blocked_path: {
     detail: "Changed paths match maintainer-blocked areas.",
-    action: "Move this work out of the maintainer-blocked area or confirm with the maintainer before opening a PR.",
+    action:
+      "Move this work out of the maintainer-blocked area or confirm with the maintainer before opening a PR.",
   },
   manifest_missing_tests: {
     detail: "Maintainer test expectations are not satisfied by this PR.",
-    action: "Add or update tests, or attach passing validation output that satisfies the maintainer's test expectations.",
+    action:
+      "Add or update tests, or attach passing validation output that satisfies the maintainer's test expectations.",
   },
 };
 
-export function publicSafeManifestPolicyFinding(finding: FocusManifestFinding): AdvisoryFinding {
+export function publicSafeManifestPolicyFinding(
+  finding: FocusManifestFinding,
+): AdvisoryFinding {
   return {
     code: finding.code,
     severity: finding.severity,
@@ -261,20 +452,27 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       return;
     case "backfill-registered-repos":
       if (!message.repoFullName && message.requestedBy !== "test") {
-        const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered);
+        const repositories = (await listRepositories(env)).filter(
+          (repo) => repo.isRegistered,
+        );
         if (repositories.length > 0) {
-          const delayStepSeconds = message.mode === "full" || message.mode === "resume" ? 45 : 15;
+          const delayStepSeconds =
+            message.mode === "full" || message.mode === "resume" ? 45 : 15;
           await Promise.all(
             repositories.map((repo, index) => {
               const repoMessage: JobMessage = {
                 type: "backfill-registered-repos",
                 requestedBy: message.requestedBy,
                 repoFullName: repo.fullName,
-                ...(message.force === undefined ? {} : { force: message.force }),
+                ...(message.force === undefined
+                  ? {}
+                  : { force: message.force }),
                 ...(message.mode === undefined ? {} : { mode: message.mode }),
               };
               const delaySeconds = Math.min(index * delayStepSeconds, 900);
-              return delaySeconds > 0 ? env.JOBS.send(repoMessage, { delaySeconds }) : env.JOBS.send(repoMessage);
+              return delaySeconds > 0
+                ? env.JOBS.send(repoMessage, { delaySeconds })
+                : env.JOBS.send(repoMessage);
             }),
           );
           return;
@@ -348,7 +546,11 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       await buildContributorDecisionPacks(env, message.login);
       return;
     case "refresh-contributor-activity":
-      await refreshContributorActivity(env, message.login, message.repoFullName ? { repoFullName: message.repoFullName } : {});
+      await refreshContributorActivity(
+        env,
+        message.login,
+        message.repoFullName ? { repoFullName: message.repoFullName } : {},
+      );
       return;
     case "build-burden-forecasts":
       await buildBurdenForecasts(env, message.repoFullName);
@@ -357,13 +559,23 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       await repairDataFidelity(env, message.requestedBy);
       return;
     case "rollup-product-usage":
-      await rollupProductUsageDaily(env, { ...(message.day ? { day: message.day } : {}), ...(message.days === undefined ? {} : { days: message.days }) });
+      await rollupProductUsageDaily(env, {
+        ...(message.day ? { day: message.day } : {}),
+        ...(message.days === undefined ? {} : { days: message.days }),
+      });
       return;
     case "prune-retention":
-      await runRetentionPrune(env, message.requestedBy, message.dryRun ?? false);
+      await runRetentionPrune(
+        env,
+        message.requestedBy,
+        message.dryRun ?? false,
+      );
       return;
     case "generate-weekly-value-report":
-      await generateWeeklyValueReport(env, { variant: message.variant ?? "operator", ...(message.days === undefined ? {} : { days: message.days }) });
+      await generateWeeklyValueReport(env, {
+        variant: message.variant ?? "operator",
+        ...(message.days === undefined ? {} : { days: message.days }),
+      });
       return;
     case "agent-regate-sweep":
       if (!message.repoFullName && message.requestedBy !== "test") {
@@ -374,14 +586,28 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       return;
     case "agent-regate-pr":
       // One bounded re-gate unit fanned out by the sweep (#audit-sweep-fanout): re-review + stamp a single PR.
-      await regatePullRequest(env, message.repoFullName, message.prNumber, message.installationId, message.deliveryId);
+      await regatePullRequest(
+        env,
+        message.repoFullName,
+        message.prNumber,
+        message.installationId,
+        message.deliveryId,
+      );
       return;
     case "run-agent":
       await executeAgentRun(env, message.runId);
       return;
     case "notify-evaluate": {
       const deliveries = await evaluateNotificationEvent(env, message.event);
-      await Promise.all(deliveries.map((delivery) => env.JOBS.send({ type: "notify-deliver", requestedBy: "notify-evaluate", deliveryId: delivery.id })));
+      await Promise.all(
+        deliveries.map((delivery) =>
+          env.JOBS.send({
+            type: "notify-deliver",
+            requestedBy: "notify-evaluate",
+            deliveryId: delivery.id,
+          }),
+        ),
+      );
       return;
     }
     case "notify-deliver":
@@ -412,14 +638,32 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // Convergence (RAG / codebase index, flag GITTENSORY_REVIEW_RAG). Defense-in-depth: the cron + webhook only
       // ENQUEUE this when the flag is ON, but a stale in-flight job that lands after a flag-flip must still no-op,
       // so flag-OFF does zero work here too. indexRepo / reindexChangedPaths are fully fail-safe (never throw).
-      if (isRagEnabled(env)) await runRagIndexJob(env, message.requestedBy, message.repoFullName, message.paths);
+      if (isRagEnabled(env))
+        await runRagIndexJob(
+          env,
+          message.requestedBy,
+          message.repoFullName,
+          message.paths,
+        );
       return;
     case "recapture-preview":
       // Delayed visual self-poll: re-review the PR to re-capture the AFTER preview shot once its deploy is live.
-      await reReviewStoredPullRequest(env, message.deliveryId, message.installationId, message.repoFullName, message.prNumber, message.attempt);
+      await reReviewStoredPullRequest(
+        env,
+        message.deliveryId,
+        message.installationId,
+        message.repoFullName,
+        message.prNumber,
+        message.attempt,
+      );
       break;
     case "github-webhook":
-      await processGitHubWebhook(env, message.deliveryId, message.eventName, message.payload);
+      await processGitHubWebhook(
+        env,
+        message.deliveryId,
+        message.eventName,
+        message.payload,
+      );
       return;
     case "submit-draft":
       // Public OAuth draft-submission (GITTENSORY_REVIEW_DRAFT). No-ops internally when the flag is off.
@@ -435,24 +679,43 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
   }
 }
 
-async function buildContributorDecisionPacks(env: Env, login?: string): Promise<void> {
+async function buildContributorDecisionPacks(
+  env: Env,
+  login?: string,
+): Promise<void> {
   const logins = login ? [login] : await discoverContributorLogins(env);
   // Load the login-independent full-table datasets once, then reuse across every login instead of re-scanning per contributor.
   const shared = await loadDecisionPackSharedInputs(env);
   for (const contributorLogin of logins) {
     try {
-      await buildAndPersistContributorDecisionPack(env, contributorLogin, shared);
+      await buildAndPersistContributorDecisionPack(
+        env,
+        contributorLogin,
+        shared,
+      );
     } catch (error) {
       // Isolate per-login failures so one bad login can't fail the whole batch (which would re-run
       // from the first login on retry and poison-pill the queue) (#787).
       /* v8 ignore next -- defensive per-login isolation; the log-and-continue path is not exercised in tests */
-      console.error(JSON.stringify({ level: "warn", event: "decision_pack_login_failed", login: contributorLogin, error: errorMessage(error) }));
+      console.error(
+        JSON.stringify({
+          level: "warn",
+          event: "decision_pack_login_failed",
+          login: contributorLogin,
+          error: errorMessage(error),
+        }),
+      );
     }
   }
 }
 
-async function fanOutRepoSignalSnapshotJobs(env: Env, requestedBy: "schedule" | "api" | "test"): Promise<void> {
-  const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered);
+async function fanOutRepoSignalSnapshotJobs(
+  env: Env,
+  requestedBy: "schedule" | "api" | "test",
+): Promise<void> {
+  const repositories = (await listRepositories(env)).filter(
+    (repo) => repo.isRegistered,
+  );
   await Promise.all(
     repositories.map((repo, index) => {
       const message: JobMessage = {
@@ -461,7 +724,9 @@ async function fanOutRepoSignalSnapshotJobs(env: Env, requestedBy: "schedule" | 
         repoFullName: repo.fullName,
       };
       const delaySeconds = Math.min(index * 10, 600);
-      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
     }),
   );
   await recordAuditEvent(env, {
@@ -474,7 +739,10 @@ async function fanOutRepoSignalSnapshotJobs(env: Env, requestedBy: "schedule" | 
 // #777 scheduled re-gate sweep. The cron (index.ts) enqueues one fan-out job hourly; this enqueues a per-repo
 // sweep job for every repo that opted the agent in (an acting autonomy level). Mirrors the signal-snapshot
 // fan-out so each repo's sweep runs as its own bounded, retryable queue message.
-async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "api" | "test"): Promise<void> {
+async function fanOutAgentRegateSweepJobs(
+  env: Env,
+  requestedBy: "schedule" | "api" | "test",
+): Promise<void> {
   const now = nowIso();
   // Atomic fan-out dedup (#audit-fanout-dedup): collapse a BURST of fan-out jobs to a SINGLE effective fan-out per
   // window, so a deploy-restart cron catch-up (or fan-out jobs delayed behind a per-PR backlog then drained
@@ -483,7 +751,8 @@ async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "a
     await recordAuditEvent(env, {
       eventType: "agent.sweep.fanout",
       outcome: "denied",
-      detail: "re-gate fan-out deduped: another fan-out already claimed this window",
+      detail:
+        "re-gate fan-out deduped: another fan-out already claimed this window",
       metadata: { requestedBy, deduped: true },
     });
     return;
@@ -498,7 +767,9 @@ async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "a
     // mid-flight and stamping last_regated_at as they run, so the freshest stamp being within the sweep window
     // means a sweep is active. Re-arming now would enqueue duplicate per-PR jobs for the not-yet-drained
     // candidates, so this is what finally stops the 2-min cron piling a second full sweep on an unfinished one.
-    if (isRegateSweepDraining(await getLatestRegatedAt(env, repo.fullName), now)) {
+    if (
+      isRegateSweepDraining(await getLatestRegatedAt(env, repo.fullName), now)
+    ) {
       skippedDraining += 1;
       continue;
     }
@@ -506,9 +777,15 @@ async function fanOutAgentRegateSweepJobs(env: Env, requestedBy: "schedule" | "a
   }
   await Promise.all(
     configured.map((repoFullName, index) => {
-      const message: JobMessage = { type: "agent-regate-sweep", requestedBy, repoFullName };
+      const message: JobMessage = {
+        type: "agent-regate-sweep",
+        requestedBy,
+        repoFullName,
+      };
       const delaySeconds = Math.min(index * 10, 600);
-      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
     }),
   );
   await recordAuditEvent(env, {
@@ -552,13 +829,24 @@ async function runRagIndexJob(
 // signal-snapshot / agent-regate fan-out: a delayed per-repo queue message so each repo's index runs as its own
 // bounded, retryable job rather than one giant tick). Only allowlisted repos are indexed — retrieval is gated the
 // same way, so indexing a non-converged repo would only burn the free-tier vector budget for no benefit.
-async function fanOutRagIndexJobs(env: Env, requestedBy: "schedule" | "api" | "webhook" | "test"): Promise<void> {
-  const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered && isConvergenceRepoAllowed(env, repo.fullName));
+async function fanOutRagIndexJobs(
+  env: Env,
+  requestedBy: "schedule" | "api" | "webhook" | "test",
+): Promise<void> {
+  const repositories = (await listRepositories(env)).filter(
+    (repo) => repo.isRegistered && isConvergenceRepoAllowed(env, repo.fullName),
+  );
   await Promise.all(
     repositories.map((repo, index) => {
-      const message: JobMessage = { type: "rag-index-repo", requestedBy, repoFullName: repo.fullName };
+      const message: JobMessage = {
+        type: "rag-index-repo",
+        requestedBy,
+        repoFullName: repo.fullName,
+      };
       const delaySeconds = Math.min(index * 30, 900);
-      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
     }),
   );
   await recordAuditEvent(env, {
@@ -590,20 +878,32 @@ async function maybeEnqueueRagReindexForMergedPr(
   action: string | undefined,
   mergedAt: string | null | undefined,
 ): Promise<void> {
-  if (!isRagEnabled(env) || !isConvergenceRepoAllowed(env, repoFullName)) return;
+  if (!isRagEnabled(env) || !isConvergenceRepoAllowed(env, repoFullName))
+    return;
   // A PR that merged: closed action + a merged_at timestamp. (A closed-unmerged PR changed nothing on the base.)
   if (!PR_GATE_CLOSED_ACTIONS.has(action ?? "") || !mergedAt) return;
   const files = await listPullRequestFiles(env, repoFullName, pullNumber);
-  const paths = files.map((file) => file.path).filter((path) => path.length > 0).slice(0, RAG_REINDEX_MAX_PATHS);
+  const paths = files
+    .map((file) => file.path)
+    .filter((path) => path.length > 0)
+    .slice(0, RAG_REINDEX_MAX_PATHS);
   if (paths.length === 0) return;
-  await env.JOBS.send({ type: "rag-index-repo", requestedBy: "webhook", repoFullName, paths });
+  await env.JOBS.send({
+    type: "rag-index-repo",
+    requestedBy: "webhook",
+    repoFullName,
+    paths,
+  });
 }
 
 // Recompute the DETERMINISTIC gate verdict for a repo's stalest open PRs and record it as an audit event —
 // ADVISORY ONLY: nothing is published to GitHub (no check, comment, or label) and no PR is mutated. This is
 // the Phase-0 scheduling rail; the action layer (#778) is what will later turn a flagged verdict into a real
 // action. Respects the #776 safety gate: a global or per-repo pause records a skip and recomputes nothing.
-async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Promise<void> {
+async function sweepRepoRegate(
+  env: Env,
+  repoFullName: string | undefined,
+): Promise<void> {
   if (!repoFullName) return;
   const settings = await resolveRepositorySettings(env, repoFullName);
   // Defensive: a repo can lose its acting autonomy between fan-out and processing.
@@ -624,23 +924,40 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     });
     return;
   }
-  const [repo, openPullRequests] = await Promise.all([getRepository(env, repoFullName), listOpenPullRequests(env, repoFullName)]);
-  const candidates = selectRegateCandidates({ pulls: openPullRequests, now: nowIso() });
+  const [repo, openPullRequests] = await Promise.all([
+    getRepository(env, repoFullName),
+    listOpenPullRequests(env, repoFullName),
+  ]);
+  const candidates = selectRegateCandidates({
+    pulls: openPullRequests,
+    now: nowIso(),
+  });
   // No stale PRs this tick — stay quiet rather than writing an empty heartbeat to the audit feed.
   if (candidates.length === 0) return;
   // Reserve installation rate-limit headroom for real webhook traffic (#audit-rate-headroom): with the shared REST
   // budget at/below the maintenance floor, defer the WHOLE sweep until the reset rather than fanning out per-PR
   // jobs that would each have to defer. Webhooks never pre-yield, so this hands the remaining budget to them.
-  const sweepRateResetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM);
+  const sweepRateResetAt = await shouldWaitForGitHubRateLimit(
+    env,
+    MAINTENANCE_RESERVED_HEADROOM,
+  );
   if (sweepRateResetAt) {
-    await env.JOBS.send({ type: "agent-regate-sweep", requestedBy: "schedule", repoFullName }, { delaySeconds: delayUntil(sweepRateResetAt) });
+    await env.JOBS.send(
+      { type: "agent-regate-sweep", requestedBy: "schedule", repoFullName },
+      { delaySeconds: delayUntil(sweepRateResetAt) },
+    );
     await recordAuditEvent(env, {
       eventType: "agent.sweep.regate",
       actor: "gittensory",
       targetKey: repoFullName,
       outcome: "queued",
       detail: `re-gate sweep deferred: shared GitHub REST budget below the maintenance headroom floor; re-queued after ${sweepRateResetAt}`,
-      metadata: { repoFullName, mode, deferred: true, rateResetAt: sweepRateResetAt },
+      metadata: {
+        repoFullName,
+        mode,
+        deferred: true,
+        rateResetAt: sweepRateResetAt,
+      },
     });
     return;
   }
@@ -650,23 +967,52 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
   // rate-deferred per-PR re-reviews finish. Stamping in the per-PR job lagged minutes behind under load, so the
   // guard never engaged and overlapping sweeps stacked up (the metagraphed dry-run runaway). It also advances
   // selectRegateCandidates so the NEXT sweep picks the next-stalest 25. A plain D1 write → dry-run stays inert.
-  await markPullRequestsRegated(env, repoFullName, candidates.map((pr) => pr.number)).catch((error) => {
-    console.error(JSON.stringify({ level: "warn", event: "sweep_mark_regated_failed", repository: repoFullName, error: errorMessage(error) }));
+  await markPullRequestsRegated(
+    env,
+    repoFullName,
+    candidates.map((pr) => pr.number),
+  ).catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "sweep_mark_regated_failed",
+        repository: repoFullName,
+        error: errorMessage(error),
+      }),
+    );
   });
-  const requireLinkedIssue = settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off";
+  const requireLinkedIssue =
+    settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off";
   const verdicts: Record<string, string> = {};
   const flaggedPulls: number[] = [];
   const sweepInstallationId = repo?.installationId ?? null;
   const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
   for (const [index, pr] of candidates.entries()) {
-    const others = openPullRequests.filter((other) => other.number !== pr.number);
+    const others = openPullRequests.filter(
+      (other) => other.number !== pr.number,
+    );
     // Thread linked-issue authors so the re-gate sweep applies the self-authored-linked-issue block too — without
     // this a self-authored PR re-gated by the sweep escapes a block the main webhook path applies. (#self-authored-parity)
-    const linkedIssueAuthorLogins = await resolveLinkedIssueAuthorLogins(env, sweepInstallationId, repoFullName, pr.linkedIssues, settings.selfAuthoredLinkedIssueGateMode === "block");
-    const advisory = buildPullRequestAdvisory(repo, pr, { otherOpenPullRequests: others, requireLinkedIssue, duplicateWinnerEnabled, linkedIssueAuthorLogins });
-    const gate = evaluateGateCheck(advisory, gateCheckPolicy(settings, null, undefined, pr.slopRisk ?? null));
+    const linkedIssueAuthorLogins = await resolveLinkedIssueAuthorLogins(
+      env,
+      sweepInstallationId,
+      repoFullName,
+      pr.linkedIssues,
+      settings.selfAuthoredLinkedIssueGateMode === "block",
+    );
+    const advisory = buildPullRequestAdvisory(repo, pr, {
+      otherOpenPullRequests: others,
+      requireLinkedIssue,
+      duplicateWinnerEnabled,
+      linkedIssueAuthorLogins,
+    });
+    const gate = evaluateGateCheck(
+      advisory,
+      gateCheckPolicy(settings, null, undefined, pr.slopRisk ?? null),
+    );
     verdicts[String(pr.number)] = gate.conclusion;
-    if (gate.conclusion === "failure" || gate.conclusion === "action_required") flaggedPulls.push(pr.number);
+    if (gate.conclusion === "failure" || gate.conclusion === "action_required")
+      flaggedPulls.push(pr.number);
     // Fan the HEAVY re-review (rebuild advisory → re-publish the unified comment with the current head/CI →
     // re-run auto-maintain) into its own bounded, individually-retryable per-PR job, staggered like the repo
     // fan-out, so it interleaves with other work instead of monopolizing the consumer for all SWEEP_MAX_PRS
@@ -674,9 +1020,17 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     // below, preserving the advisory audit. The convergence marker was already stamped for every candidate at
     // dispatch (above); with no installation to act with there is simply no re-review to fan out (audit-only).
     if (sweepInstallationId != null) {
-      const job: JobMessage = { type: "agent-regate-pr", deliveryId: `regate-sweep:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId: sweepInstallationId };
+      const job: JobMessage = {
+        type: "agent-regate-pr",
+        deliveryId: `regate-sweep:${repoFullName}#${pr.number}`,
+        repoFullName,
+        prNumber: pr.number,
+        installationId: sweepInstallationId,
+      };
       const delaySeconds = Math.min(index * 10, 600);
-      await (delaySeconds > 0 ? env.JOBS.send(job, { delaySeconds }) : env.JOBS.send(job));
+      await (delaySeconds > 0
+        ? env.JOBS.send(job, { delaySeconds })
+        : env.JOBS.send(job));
     }
   }
   await recordAuditEvent(env, {
@@ -685,7 +1039,15 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
     targetKey: repoFullName,
     outcome: "completed",
     detail: `scheduled re-gate recomputed ${candidates.length} stale open PR verdict(s); ${flaggedPulls.length} flagged; fanned out per-PR re-review`,
-    metadata: { repoFullName, mode, openCount: openPullRequests.length, examined: candidates.length, flagged: flaggedPulls.length, flaggedPulls, verdicts },
+    metadata: {
+      repoFullName,
+      mode,
+      openCount: openPullRequests.length,
+      examined: candidates.length,
+      flagged: flaggedPulls.length,
+      flaggedPulls,
+      verdicts,
+    },
   });
 }
 
@@ -695,27 +1057,65 @@ async function sweepRepoRegate(env: Env, repoFullName: string | undefined): Prom
 // sweep's skipAiReview policy. The convergence marker is NOT stamped here — the sweep already stamped every
 // candidate at dispatch (#audit-sweep-dispatch-stamp), so the in-flight guard does not wait on this job and a
 // deferred/failed re-review never stalls convergence (the next sweep after the window re-claims the PR).
-async function regatePullRequest(env: Env, repoFullName: string, prNumber: number, installationId: number, deliveryId: string): Promise<void> {
+async function regatePullRequest(
+  env: Env,
+  repoFullName: string,
+  prNumber: number,
+  installationId: number,
+  deliveryId: string,
+): Promise<void> {
   // Reserve installation rate-limit headroom for real webhooks (#audit-rate-headroom): all repos share ONE GitHub
   // App installation = ONE REST bucket, so when the shared budget is at/below the maintenance floor, DEFER this
   // re-review until the reset instead of burning budget a webhook's re-review needs. Re-enqueue with the reset
   // delay so the PR is still eventually re-reviewed.
-  const rateResetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM);
+  const rateResetAt = await shouldWaitForGitHubRateLimit(
+    env,
+    MAINTENANCE_RESERVED_HEADROOM,
+  );
   if (rateResetAt) {
-    await env.JOBS.send({ type: "agent-regate-pr", deliveryId, repoFullName, prNumber, installationId }, { delaySeconds: delayUntil(rateResetAt) });
+    await env.JOBS.send(
+      {
+        type: "agent-regate-pr",
+        deliveryId,
+        repoFullName,
+        prNumber,
+        installationId,
+      },
+      { delaySeconds: delayUntil(rateResetAt) },
+    );
     return;
   }
   const settings = await resolveRepositorySettings(env, repoFullName);
-  await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, prNumber, undefined, { skipAiReview: settings.aiReviewMode !== "block" }).catch((error) => {
-    console.error(JSON.stringify({ level: "warn", event: "sweep_rereview_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
+  await reReviewStoredPullRequest(
+    env,
+    deliveryId,
+    installationId,
+    repoFullName,
+    prNumber,
+    undefined,
+    { skipAiReview: settings.aiReviewMode !== "block" },
+  ).catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "sweep_rereview_failed",
+        deliveryId,
+        repository: repoFullName,
+        pullNumber: prNumber,
+        error: errorMessage(error),
+      }),
+    );
   });
 }
 
-export function changedPathsForGuardrail(files: Awaited<ReturnType<typeof listPullRequestFiles>>): string[] {
+export function changedPathsForGuardrail(
+  files: Awaited<ReturnType<typeof listPullRequestFiles>>,
+): string[] {
   const paths = new Set<string>();
   for (const file of files) {
     if (file.path.length > 0) paths.add(file.path);
-    if (file.previousFilename && file.previousFilename.length > 0) paths.add(file.previousFilename);
+    if (file.previousFilename && file.previousFilename.length > 0)
+      paths.add(file.previousFilename);
   }
   return [...paths];
 }
@@ -729,7 +1129,11 @@ export function changedPathsForGuardrail(files: Awaited<ReturnType<typeof listPu
  * Both off (the common path) returns the plan byte-identically. The breakers don't interfere: the merge
  * downgrade only touches `merge`/ready-label, the close downgrade only touches a heuristic `close`.
  */
-export function applyPrecisionBreakers(planned: PlannedAgentAction[], holdOnly: boolean, closeHoldOnly: boolean): PlannedAgentAction[] {
+export function applyPrecisionBreakers(
+  planned: PlannedAgentAction[],
+  holdOnly: boolean,
+  closeHoldOnly: boolean,
+): PlannedAgentAction[] {
   const afterMerge = holdOnly ? downgradeMergeToHold(planned, true) : planned;
   return closeHoldOnly ? downgradeCloseToHold(afterMerge, true) : afterMerge;
 }
@@ -740,7 +1144,9 @@ export function applyPrecisionBreakers(planned: PlannedAgentAction[], holdOnly: 
  * EMPTY required set means `fetchLiveCiAggregate` may have folded an optional / third-party red into `failed`,
  * which must keep a guarded PR held for a human rather than auto-close it.
  */
-export function hasVerifiedRequiredContexts(requiredContexts: Set<string> | null): boolean {
+export function hasVerifiedRequiredContexts(
+  requiredContexts: Set<string> | null,
+): boolean {
   return requiredContexts != null && requiredContexts.size > 0;
 }
 
@@ -766,7 +1172,13 @@ async function maybeRunAgentMaintenance(
     gate: ReturnType<typeof evaluateGateCheck> | undefined;
   },
 ): Promise<void> {
-  const { installationId, repoFullName, settings, otherOpenPullRequests, gate } = args;
+  const {
+    installationId,
+    repoFullName,
+    settings,
+    otherOpenPullRequests,
+    gate,
+  } = args;
   if (!isAgentConfigured(settings.autonomy)) return;
   // Re-read the stored PR so we act on the persisted slop score the gate just wrote, not the pre-gate payload.
   const pr = await getPullRequest(env, repoFullName, args.pr.number);
@@ -789,27 +1201,64 @@ async function maybeRunAgentMaintenance(
   // commit-statuses (codecov posts a commit-status, NOT a check-run — the stored check_summaries miss it). The
   // planner uses this to NEVER approve/merge a PR whose CI isn't green, to CLOSE a red-CI non-owner PR (citing
   // the failing checks) / HOLD the owner's, and to DEFER entirely while CI is still pending.
-  const ciToken = await createInstallationToken(env, installationId).catch(() => undefined);
-  const [changedFiles, hardGuardrailGlobs, requiredContexts, liveMergeState, liveReviewDecision] = await Promise.all([
-    resolvePullRequestFilesForReview(env, { installationId, repoFullName, pullNumber: pr.number }),
+  const ciToken = await createInstallationToken(env, installationId).catch(
+    () => undefined,
+  );
+  const [
+    changedFiles,
+    hardGuardrailGlobs,
+    requiredContexts,
+    liveMergeState,
+    liveReviewDecision,
+  ] = await Promise.all([
+    resolvePullRequestFilesForReview(env, {
+      installationId,
+      repoFullName,
+      pullNumber: pr.number,
+    }),
     loadHardGuardrailGlobs(env, repoFullName),
     // RC2: branch-protection REQUIRED status contexts, so only a required red check gates the PR (a red
     // codecov/* is surfaced but never blocks merge/approve or forces request_changes). null ⇒ fold all red.
-    fetchRequiredStatusContexts(env, repoFullName, pr.baseRef ?? args.repo?.defaultBranch, ciToken ?? env.GITHUB_PUBLIC_TOKEN),
+    fetchRequiredStatusContexts(
+      env,
+      repoFullName,
+      pr.baseRef ?? args.repo?.defaultBranch,
+      ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+    ),
     // Live mergeable_state — the stored one lags GitHub's async recompute after the bot's own approve, which
     // otherwise leaves a green+approved PR stuck OPEN at mergeState=CLEAN (never auto-merged).
-    fetchLivePullRequestMergeState(env, repoFullName, pr.number, ciToken ?? env.GITHUB_PUBLIC_TOKEN),
+    fetchLivePullRequestMergeState(
+      env,
+      repoFullName,
+      pr.number,
+      ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+    ),
     // RC1: live reviewDecision so the approve/request-changes dedup is accurate. The STORED reviewDecision is
     // only written by the open-PR backfill and goes stale → the planner re-posted a review every cycle (the
     // re-review loop with 14-23 stacked reviews). With the live value, an already-approved/changes-requested PR
     // is not re-reviewed for the same state.
-    fetchLivePullRequestReviewDecision(env, repoFullName, pr.number, ciToken ?? env.GITHUB_PUBLIC_TOKEN),
+    fetchLivePullRequestReviewDecision(
+      env,
+      repoFullName,
+      pr.number,
+      ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+    ),
   ]);
-  const ciAggregate = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, ciToken ?? env.GITHUB_PUBLIC_TOKEN, requiredContexts);
+  const ciAggregate = await fetchLiveCiAggregate(
+    env,
+    repoFullName,
+    pr.headSha,
+    ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+    requiredContexts,
+  );
   const changedPaths = changedPathsForGuardrail(changedFiles);
-  const repoOwner = repoFullName.includes("/") ? repoFullName.slice(0, repoFullName.indexOf("/")) : "";
+  const repoOwner = repoFullName.includes("/")
+    ? repoFullName.slice(0, repoFullName.indexOf("/"))
+    : "";
   const authorLogin = pr.authorLogin ?? "";
-  const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
+  const authorIsOwner =
+    authorLogin.length > 0 &&
+    authorLogin.toLowerCase() === repoOwner.toLowerCase();
   const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
 
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules): when the repo enabled any rule, a body that links
@@ -817,7 +1266,10 @@ async function maybeRunAgentMaintenance(
   // linked issues' facts (fail-open per issue). The decision is extracted into resolveLinkedIssueHardRule (pure,
   // dependency-injected) so it is unit-tested directly rather than only through this orchestrator. Config load is
   // FAIL-SAFE (a KV fault yields all-off, never a surprise close).
-  const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, repoFullName);
+  const linkedIssueRulesConfig = await loadLinkedIssueHardRules(
+    env,
+    repoFullName,
+  );
   const linkedIssueHardRule = await resolveLinkedIssueHardRule({
     env,
     repoFullName,
@@ -855,13 +1307,18 @@ async function maybeRunAgentMaintenance(
     ciState: ciAggregate.ciState,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),
-    ...(blacklistEntry !== null ? { blacklistMatch: { matched: true, reason: blacklistEntry.reason } } : {}),
+    ...(blacklistEntry !== null
+      ? { blacklistMatch: { matched: true, reason: blacklistEntry.reason } }
+      : {}),
     // Always threaded (the DB layer populates it, default "slop"); the planner applies its own fallback.
     blacklistLabel: settings.blacklistLabel,
     ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
     // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
     // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).
-    linkedIssueVerify: { verifyBeforeClose: linkedIssueRulesConfig.verifyBeforeClose, closeDelaySeconds: linkedIssueRulesConfig.closeDelaySeconds },
+    linkedIssueVerify: {
+      verifyBeforeClose: linkedIssueRulesConfig.verifyBeforeClose,
+      closeDelaySeconds: linkedIssueRulesConfig.closeDelaySeconds,
+    },
     pr: {
       mergeableState: liveMergeState ?? pr.mergeableState,
       reviewDecision: liveReviewDecision ?? pr.reviewDecision,
@@ -872,7 +1329,11 @@ async function maybeRunAgentMaintenance(
       // PR is the cluster winner, force the count to 0 so the winner's close reason OMITS the duplicate cause
       // (it can still close on its own merits — CI/conflict/blockers). Flag-OFF short-circuits ⇒ the real
       // count is used (byte-identical). The sibling numbers are open-only, so the lowest is the open winner.
-      linkedDuplicateCount: dupWinnerLinkedDuplicateCount(linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests), pr.number, env.GITTENSORY_DUPLICATE_WINNER === "true"),
+      linkedDuplicateCount: dupWinnerLinkedDuplicateCount(
+        linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests),
+        pr.number,
+        env.GITTENSORY_DUPLICATE_WINNER === "true",
+      ),
       headSha: pr.headSha,
       mergeBlockedSha: pr.mergeBlockedSha,
       approvedHeadSha: pr.approvedHeadSha,
@@ -885,7 +1346,11 @@ async function maybeRunAgentMaintenance(
   // Each read is independent and fail-open (isHoldOnly / isCloseHoldOnly read false until a breaker actually
   // engages), so the common path is byte-identical (both downgrades return the plan unchanged). The chaining is
   // extracted into the pure applyPrecisionBreakers below so it is unit-tested directly.
-  const breakerOnPlan = applyPrecisionBreakers(planned, await isHoldOnly(env, repoFullName), await isCloseHoldOnly(env, repoFullName));
+  const breakerOnPlan = applyPrecisionBreakers(
+    planned,
+    await isHoldOnly(env, repoFullName),
+    await isCloseHoldOnly(env, repoFullName),
+  );
   if (breakerOnPlan.length === 0) return;
 
   const installation = await getInstallation(env, installationId);
@@ -911,11 +1376,25 @@ async function maybeRunAgentMaintenance(
   // completed. Queued/failed/dry-run label actions do not establish the label-backed state that Pass 2 requires,
   // so scheduling off the plan alone can create a verification loop. Best-effort — if the enqueue fails, the next
   // sweep / CI event is the backstop Pass 2. Reuses the existing `recapture-preview` delayed-re-review job.
-  const flaggedForLinkedIssue = pendingClosureLabelApplied(breakerOnPlan, actionOutcomes);
+  const flaggedForLinkedIssue = pendingClosureLabelApplied(
+    breakerOnPlan,
+    actionOutcomes,
+  );
   if (flaggedForLinkedIssue) {
     const delaySeconds = Math.max(0, linkedIssueRulesConfig.closeDelaySeconds);
-    const verifyJob = { type: "recapture-preview" as const, deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`, repoFullName, prNumber: pr.number, installationId, attempt: 0 };
-    await (delaySeconds > 0 ? env.JOBS.send(verifyJob, { delaySeconds }) : env.JOBS.send(verifyJob)).catch(() => undefined);
+    const verifyJob = {
+      type: "recapture-preview" as const,
+      deliveryId: `linked-issue-verify:${repoFullName}#${pr.number}`,
+      repoFullName,
+      prNumber: pr.number,
+      installationId,
+      attempt: 0,
+    };
+    await (
+      delaySeconds > 0
+        ? env.JOBS.send(verifyJob, { delaySeconds })
+        : env.JOBS.send(verifyJob)
+    ).catch(() => undefined);
   }
 }
 
@@ -934,20 +1413,46 @@ async function reReviewStoredPullRequest(
   previewPollAttempt?: number,
   options: { skipAiReview?: boolean } = {},
 ): Promise<void> {
-  const [repo, settings] = await Promise.all([getRepository(env, repoFullName), resolveRepositorySettings(env, repoFullName)]);
+  const [repo, settings] = await Promise.all([
+    getRepository(env, repoFullName),
+    resolveRepositorySettings(env, repoFullName),
+  ]);
   const pr = await getPullRequest(env, repoFullName, prNumber);
   if (!pr || pr.state !== "open") return;
   // Operator review flow: rebase-if-behind → wait for ALL CI to finish → only THEN review. Defers (returns) when
   // a rebase fired a synchronize, or CI is still running — the synchronize / CI-completion webhook re-triggers
   // once the head is current and CI has settled (the sweep backstops a missed event).
-  if (!(await prReadyForReview(env, installationId, repoFullName, pr, settings, deliveryId))) return;
-  const [cachedOtherOpenPullRequests, linkedIssueAuthorLogins] = await Promise.all([
-    listOtherOpenPullRequests(env, repoFullName, prNumber),
-    resolveLinkedIssueAuthorLogins(env, installationId, repoFullName, pr.linkedIssues, settings.selfAuthoredLinkedIssueGateMode === "block"),
-  ]);
+  if (
+    !(await prReadyForReview(
+      env,
+      installationId,
+      repoFullName,
+      pr,
+      settings,
+      deliveryId,
+    ))
+  )
+    return;
+  const [cachedOtherOpenPullRequests, linkedIssueAuthorLogins] =
+    await Promise.all([
+      listOtherOpenPullRequests(env, repoFullName, prNumber),
+      resolveLinkedIssueAuthorLogins(
+        env,
+        installationId,
+        repoFullName,
+        pr.linkedIssues,
+        settings.selfAuthoredLinkedIssueGateMode === "block",
+      ),
+    ]);
   // #dup-winner / audit #15: drop any cached-open duplicate sibling already closed on GitHub before the advisory
   // (and the disposition below) elect the cluster winner, so the real lowest-OPEN PR is never demoted+auto-closed.
-  const otherOpenPullRequests = await reconcileLiveDuplicateSiblings(env, installationId, repoFullName, pr, cachedOtherOpenPullRequests);
+  const otherOpenPullRequests = await reconcileLiveDuplicateSiblings(
+    env,
+    installationId,
+    repoFullName,
+    pr,
+    cachedOtherOpenPullRequests,
+  );
   const advisory = buildPullRequestAdvisory(repo, pr, {
     otherOpenPullRequests,
     requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
@@ -955,19 +1460,60 @@ async function reReviewStoredPullRequest(
     linkedIssueAuthorLogins,
   });
   await persistAdvisory(env, advisory);
-  if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
-    await refreshPullRequestDetails(env, repoFullName, prNumber).catch(() => undefined);
+  if (
+    shouldCollectSlopEvidence(settings) ||
+    settings.manifestPolicyGateMode !== "off"
+  ) {
+    await refreshPullRequestDetails(env, repoFullName, prNumber).catch(
+      () => undefined,
+    );
   }
-  const gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
-    deliveryId,
-    ...(previewPollAttempt !== undefined ? { previewPollAttempt } : {}),
-    ...(options.skipAiReview ? { skipAiReview: true } : {}),
-  }).catch((error) => {
-    console.error(JSON.stringify({ level: "warn", event: "pr_public_surface_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
+  const gate = await maybePublishPrPublicSurface(
+    env,
+    installationId,
+    repoFullName,
+    pr,
+    repo,
+    settings,
+    advisory,
+    {
+      deliveryId,
+      ...(previewPollAttempt !== undefined ? { previewPollAttempt } : {}),
+      ...(options.skipAiReview ? { skipAiReview: true } : {}),
+    },
+  ).catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "pr_public_surface_failed",
+        deliveryId,
+        repository: repoFullName,
+        pullNumber: prNumber,
+        error: errorMessage(error),
+      }),
+    );
     return undefined;
   });
-  await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
-    console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: prNumber, error: errorMessage(error) }));
+  await maybeRunAgentMaintenance(env, {
+    installationId,
+    repoFullName,
+    repo,
+    pr,
+    settings,
+    otherOpenPullRequests,
+    deliveryId,
+    gate,
+  }).catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "agent_maintenance_failed",
+        deliveryId,
+        repository: repoFullName,
+        pullNumber: prNumber,
+        error: errorMessage(error),
+      }),
+    );
   });
 }
 
@@ -982,14 +1528,35 @@ async function reReviewStoredPullRequest(
  * Agent-OFF / draft / no-head PRs are never gated (reviewed as before). Fail-OPEN on a token/API hiccup (review
  * rather than stall a PR forever).
  */
-async function prReadyForReview(env: Env, installationId: number, repoFullName: string, pr: PullRequestRecord, settings: RepositorySettings, deliveryId: string): Promise<boolean> {
+async function prReadyForReview(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  pr: PullRequestRecord,
+  settings: RepositorySettings,
+  deliveryId: string,
+): Promise<boolean> {
   // Only gate an OPEN, non-draft, agent-configured PR. A closed PR (the live path also runs on `closed` to
   // finalize / record reputation) must NOT be rebased or CI-waited — proceed so finalization runs.
-  if (!isAgentConfigured(settings.autonomy) || pr.isDraft || !pr.headSha || pr.state !== "open") return true;
-  const token = (await createInstallationToken(env, installationId).catch(() => undefined)) ?? env.GITHUB_PUBLIC_TOKEN;
+  if (
+    !isAgentConfigured(settings.autonomy) ||
+    pr.isDraft ||
+    !pr.headSha ||
+    pr.state !== "open"
+  )
+    return true;
+  const token =
+    (await createInstallationToken(env, installationId).catch(
+      () => undefined,
+    )) ?? env.GITHUB_PUBLIC_TOKEN;
   if (!token) return true;
   // 1) rebase if BEHIND base — the synchronize on the new head re-triggers this flow on the merged result.
-  const liveMergeState = await fetchLivePullRequestMergeState(env, repoFullName, pr.number, token).catch(() => undefined);
+  const liveMergeState = await fetchLivePullRequestMergeState(
+    env,
+    repoFullName,
+    pr.number,
+    token,
+  ).catch(() => undefined);
   if (liveMergeState === "behind") {
     const autonomyLevel = resolveAutonomy(settings.autonomy, "update_branch");
     const installation = await getInstallation(env, installationId);
@@ -1021,8 +1588,19 @@ async function prReadyForReview(env: Env, installationId: number, repoFullName: 
     // Not authorized, staged, dry-run, or failed (conflict/transient) → fall through and review without mutating.
   }
   // 2) wait for trusted required CI to finish. Non-required checks are advisory and must not stall review.
-  const requiredContexts = await fetchRequiredStatusContexts(env, repoFullName, pr.baseRef, token).catch(() => null);
-  const ci = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, token, requiredContexts).catch(() => undefined);
+  const requiredContexts = await fetchRequiredStatusContexts(
+    env,
+    repoFullName,
+    pr.baseRef,
+    token,
+  ).catch(() => null);
+  const ci = await fetchLiveCiAggregate(
+    env,
+    repoFullName,
+    pr.headSha,
+    token,
+    requiredContexts,
+  ).catch(() => undefined);
   if (ci?.ciState === "pending") {
     // Staleness cap: genuinely-running CI settles in minutes. A required check that stays pending far longer
     // (an orphaned / never-completing check — e.g. a fork check that never reports back) would otherwise make us
@@ -1030,11 +1608,28 @@ async function prReadyForReview(env: Env, installationId: number, repoFullName: 
     // STUCK_CI_DEFER_MS we stop deferring and let the gate FINALIZE, so the PR is surfaced (held / needs-human),
     // or disposed if a verdict is reachable — never silently deferred. first-seen is KV-tracked per PR+headSha (a
     // new push = new SHA = fresh window); a KV miss degrades to the old defer (safe — never acts early). (#ci-stuck-finalize)
-    if (!(await ciPendingDeferStuck(env, repoFullName, pr.number, pr.headSha))) {
-      await recordAuditEvent(env, { eventType: "github_app.review_deferred_ci_pending", actor: "gittensory", targetKey: `${repoFullName}#${pr.number}`, outcome: "queued", detail: "CI still running — review deferred until all checks finish", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
+    if (
+      !(await ciPendingDeferStuck(env, repoFullName, pr.number, pr.headSha))
+    ) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.review_deferred_ci_pending",
+        actor: "gittensory",
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "queued",
+        detail: "CI still running — review deferred until all checks finish",
+        metadata: { deliveryId, repoFullName },
+      }).catch(() => undefined);
       return false;
     }
-    await recordAuditEvent(env, { eventType: "github_app.review_finalized_ci_stuck", actor: "gittensory", targetKey: `${repoFullName}#${pr.number}`, outcome: "completed", detail: "required CI stuck pending past the staleness cap — finalizing so the PR is surfaced, not silently deferred forever", metadata: { deliveryId, repoFullName } }).catch(() => undefined);
+    await recordAuditEvent(env, {
+      eventType: "github_app.review_finalized_ci_stuck",
+      actor: "gittensory",
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail:
+        "required CI stuck pending past the staleness cap — finalizing so the PR is surfaced, not silently deferred forever",
+      metadata: { deliveryId, repoFullName },
+    }).catch(() => undefined);
     // fall through → return true → the gate finalizes + the PR is disposed/held, never silently stuck.
   }
   return true;
@@ -1050,13 +1645,20 @@ const STUCK_CI_DEFER_MS = 30 * 60 * 1000;
  * (REVIEW_CONFIG) keyed by repo#pr:headSha — a new push is a new SHA, so the window resets per commit. A missing
  * KV / KV hiccup degrades to `false` (never force-finalize → keeps the safe old defer rather than acting early).
  */
-async function ciPendingDeferStuck(env: Env, repoFullName: string, prNumber: number, headSha: string | null | undefined): Promise<boolean> {
+async function ciPendingDeferStuck(
+  env: Env,
+  repoFullName: string,
+  prNumber: number,
+  headSha: string | null | undefined,
+): Promise<boolean> {
   if (!env.REVIEW_CONFIG || !headSha) return false;
   const key = `ci-pending-first-seen:${repoFullName.toLowerCase()}#${prNumber}:${headSha}`;
   try {
     const first = await env.REVIEW_CONFIG.get(key);
     if (!first) {
-      await env.REVIEW_CONFIG.put(key, String(Date.now()), { expirationTtl: 7 * 24 * 3600 });
+      await env.REVIEW_CONFIG.put(key, String(Date.now()), {
+        expirationTtl: 7 * 24 * 3600,
+      });
       return false;
     }
     const firstMs = Number(first);
@@ -1088,26 +1690,50 @@ async function ciCompletionCoalesced(env: Env, key: string): Promise<boolean> {
   if (!env.REVIEW_CONFIG) return false;
   try {
     if (await env.REVIEW_CONFIG.get(key)) return true; // already handled within the window → skip this event
-    await env.REVIEW_CONFIG.put(key, "1", { expirationTtl: CI_COALESCE_WINDOW_SECONDS }); // claim the window
+    await env.REVIEW_CONFIG.put(key, "1", {
+      expirationTtl: CI_COALESCE_WINDOW_SECONDS,
+    }); // claim the window
     return false;
   } catch {
     return false;
   }
 }
 
-async function ciReReviewCoalesced(env: Env, repoFullName: string, prNumber: number): Promise<boolean> {
-  return ciCompletionCoalesced(env, `ci-coalesce:${repoFullName.toLowerCase()}#${prNumber}`);
+async function ciReReviewCoalesced(
+  env: Env,
+  repoFullName: string,
+  prNumber: number,
+): Promise<boolean> {
+  return ciCompletionCoalesced(
+    env,
+    `ci-coalesce:${repoFullName.toLowerCase()}#${prNumber}`,
+  );
 }
 
-async function ciHeadShaResolutionCoalesced(env: Env, repoFullName: string, headSha: string): Promise<boolean> {
-  return ciCompletionCoalesced(env, `ci-head-sha-resolve:${repoFullName.toLowerCase()}@${headSha.toLowerCase()}`);
+async function ciHeadShaResolutionCoalesced(
+  env: Env,
+  repoFullName: string,
+  headSha: string,
+): Promise<boolean> {
+  return ciCompletionCoalesced(
+    env,
+    `ci-head-sha-resolve:${repoFullName.toLowerCase()}@${headSha.toLowerCase()}`,
+  );
 }
 
 /** Read the CI head SHA off a `check_suite`/`check_run` `completed` payload (the event node carries `head_sha`;
  *  `check_run` also nests it under `check_suite.head_sha`). Returns "" when absent. The payload type doesn't model
  *  these events, so we narrow off `Record<string, unknown>` the same way the `pull_requests[]` read does. */
-export function ciCompletionHeadSha(eventName: string, payload: GitHubWebhookPayload): string {
-  const node = (payload as Record<string, unknown>)[eventName] as { head_sha?: string | null; check_suite?: { head_sha?: string | null } | null } | undefined;
+export function ciCompletionHeadSha(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): string {
+  const node = (payload as Record<string, unknown>)[eventName] as
+    | {
+        head_sha?: string | null;
+        check_suite?: { head_sha?: string | null } | null;
+      }
+    | undefined;
   return (node?.head_sha ?? node?.check_suite?.head_sha ?? "").trim();
 }
 
@@ -1126,7 +1752,8 @@ export async function resolveCiCompletionPrNumbers(
   populatedPrNumbers: number[],
   headSha: string,
 ): Promise<{ numbers: number[]; viaHeadShaFallback: boolean }> {
-  if (populatedPrNumbers.length > 0) return { numbers: populatedPrNumbers, viaHeadShaFallback: false };
+  if (populatedPrNumbers.length > 0)
+    return { numbers: populatedPrNumbers, viaHeadShaFallback: false };
   if (!headSha) return { numbers: [], viaHeadShaFallback: false };
   const resolved = new Set<number>();
   // 1) Fast path: a stored open PR row whose head SHA matches the completed CI (no GitHub round-trip).
@@ -1138,9 +1765,17 @@ export async function resolveCiCompletionPrNumbers(
   }
   // 2) Fork fallback: GitHub's commit→PRs association, the only resolution that works for cross-repo PRs.
   if (resolved.size === 0) {
-    const token = (await createInstallationToken(env, installationId).catch(() => undefined)) ?? env.GITHUB_PUBLIC_TOKEN;
+    const token =
+      (await createInstallationToken(env, installationId).catch(
+        () => undefined,
+      )) ?? env.GITHUB_PUBLIC_TOKEN;
     if (token) {
-      const apiNumbers = await fetchOpenPullRequestNumbersForCommit(env, repoFullName, headSha, token).catch(() => []);
+      const apiNumbers = await fetchOpenPullRequestNumbersForCommit(
+        env,
+        repoFullName,
+        headSha,
+        token,
+      ).catch(() => []);
       for (const number of apiNumbers) resolved.add(number);
     }
   }
@@ -1156,43 +1791,90 @@ export async function resolveCiCompletionPrNumbers(
  * — without this fork PRs deferred at open-time never get their required gate posted and are BLOCKED forever.
  * COALESCED so one CI run's ~20 completions collapse to one re-review. Returns true (handled).
  */
-async function maybeReReviewOnCiCompletion(env: Env, deliveryId: string, eventName: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeReReviewOnCiCompletion(
+  env: Env,
+  deliveryId: string,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   if (eventName !== "check_run" && eventName !== "check_suite") return false;
   if (payload.action !== "completed") return false;
   const repoFullName = payload.repository?.full_name;
   const installationId = getInstallationId(payload);
   if (!repoFullName || !installationId) return false;
-  const node = (payload as Record<string, unknown>)[eventName] as { pull_requests?: Array<{ number?: number | null }> } | undefined;
-  const populatedPrNumbers = [...new Set((node?.pull_requests ?? []).map((entry) => entry?.number).filter((value): value is number => typeof value === "number"))];
+  const node = (payload as Record<string, unknown>)[eventName] as
+    | { pull_requests?: Array<{ number?: number | null }> }
+    | undefined;
+  const populatedPrNumbers = [
+    ...new Set(
+      (node?.pull_requests ?? [])
+        .map((entry) => entry?.number)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+  ];
   const headSha = ciCompletionHeadSha(eventName, payload);
   if (isConvergenceRepoAllowed(env, repoFullName)) {
     // GitHub can emit many empty-pull_requests CI completions for the same fork head SHA. Claim a head-SHA
     // window before the fallback resolver so duplicate events do not repeat DB scans or commits/{sha}/pulls calls.
-    if (populatedPrNumbers.length === 0 && headSha && (await ciHeadShaResolutionCoalesced(env, repoFullName, headSha))) {
-      await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId, repositoryFullName: repoFullName, payloadHash: "processed", status: "processed" });
+    if (
+      populatedPrNumbers.length === 0 &&
+      headSha &&
+      (await ciHeadShaResolutionCoalesced(env, repoFullName, headSha))
+    ) {
+      await recordWebhookEvent(env, {
+        deliveryId,
+        eventName,
+        action: payload.action,
+        installationId,
+        repositoryFullName: repoFullName,
+        payloadHash: "processed",
+        status: "processed",
+      });
       return true;
     }
-    const { numbers: prNumbers, viaHeadShaFallback } = await resolveCiCompletionPrNumbers(env, installationId, repoFullName, populatedPrNumbers, headSha).catch(() => ({
-      numbers: populatedPrNumbers,
-      viaHeadShaFallback: false,
-    }));
+    const { numbers: prNumbers, viaHeadShaFallback } =
+      await resolveCiCompletionPrNumbers(
+        env,
+        installationId,
+        repoFullName,
+        populatedPrNumbers,
+        headSha,
+      ).catch(() => ({
+        numbers: populatedPrNumbers,
+        viaHeadShaFallback: false,
+      }));
     if (viaHeadShaFallback && prNumbers.length > 0) {
       await recordAuditEvent(env, {
         eventType: "github_app.ci_completion_fork_resume",
         actor: "gittensory",
         targetKey: `${repoFullName}#${prNumbers.join(",")}`,
         outcome: "queued",
-        detail: "resumed fork PR via head-SHA fallback (empty check pull_requests[])",
+        detail:
+          "resumed fork PR via head-SHA fallback (empty check pull_requests[])",
         metadata: { deliveryId, repoFullName, eventName, prNumbers },
       }).catch(() => undefined);
     }
     for (const prNumber of prNumbers) {
       // Coalesce the CI-completion storm: skip if this PR was re-reviewed within the window.
       if (await ciReReviewCoalesced(env, repoFullName, prNumber)) continue;
-      await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, prNumber);
+      await reReviewStoredPullRequest(
+        env,
+        deliveryId,
+        installationId,
+        repoFullName,
+        prNumber,
+      );
     }
   }
-  await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId, repositoryFullName: repoFullName, payloadHash: "processed", status: "processed" });
+  await recordWebhookEvent(env, {
+    deliveryId,
+    eventName,
+    action: payload.action,
+    installationId,
+    repositoryFullName: repoFullName,
+    payloadHash: "processed",
+    status: "processed",
+  });
   return true;
 }
 
@@ -1201,37 +1883,79 @@ async function maybeReReviewOnCiCompletion(env: Env, deliveryId: string, eventNa
  * "after" cell once the preview deploy finishes (or flips to a deploy-failed note). Mirrors reviewbot's
  * deployment_status routing; the capture itself runs inside the re-published review (visual-capture path).
  */
-async function maybeCaptureOnDeploymentStatus(env: Env, deliveryId: string, eventName: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeCaptureOnDeploymentStatus(
+  env: Env,
+  deliveryId: string,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   if (eventName !== "deployment_status") return false;
   const repoFullName = payload.repository?.full_name;
   const installationId = getInstallationId(payload);
   if (!repoFullName || !installationId) return false;
-  const preview = deploymentStatusToPreview(payload as unknown as DeploymentStatusPayload);
+  const preview = deploymentStatusToPreview(
+    payload as unknown as DeploymentStatusPayload,
+  );
   if (preview && isConvergenceRepoAllowed(env, repoFullName)) {
-    await reReviewStoredPullRequest(env, deliveryId, installationId, repoFullName, preview.prNumber);
+    await reReviewStoredPullRequest(
+      env,
+      deliveryId,
+      installationId,
+      repoFullName,
+      preview.prNumber,
+    );
   }
-  await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId, repositoryFullName: repoFullName, payloadHash: "processed", status: "processed" });
+  await recordWebhookEvent(env, {
+    deliveryId,
+    eventName,
+    action: payload.action,
+    installationId,
+    repositoryFullName: repoFullName,
+    payloadHash: "processed",
+    status: "processed",
+  });
   return true;
 }
 
-async function repairDataFidelity(env: Env, requestedBy: "schedule" | "api" | "test"): Promise<void> {
-  const [repositories, segments, signalSnapshots] = await Promise.all([listRepositories(env), listRepoSyncSegments(env), listLatestSignalSnapshotsByTarget(env)]);
-  const requiredSegments = new Set(["labels", "open_issues", "open_pull_requests"]);
+async function repairDataFidelity(
+  env: Env,
+  requestedBy: "schedule" | "api" | "test",
+): Promise<void> {
+  const [repositories, segments, signalSnapshots] = await Promise.all([
+    listRepositories(env),
+    listRepoSyncSegments(env),
+    listLatestSignalSnapshotsByTarget(env),
+  ]);
+  const requiredSegments = new Set([
+    "labels",
+    "open_issues",
+    "open_pull_requests",
+  ]);
   const segmentsByRepo = new Map<string, Set<string>>();
   for (const segment of segments) {
-    if (requiredSegments.has(segment.segment) && segment.status === "complete") {
-      const complete = segmentsByRepo.get(segment.repoFullName) ?? new Set<string>();
+    if (
+      requiredSegments.has(segment.segment) &&
+      segment.status === "complete"
+    ) {
+      const complete =
+        segmentsByRepo.get(segment.repoFullName) ?? new Set<string>();
       complete.add(segment.segment);
       segmentsByRepo.set(segment.repoFullName, complete);
     }
   }
   const registeredRepos = repositories.filter((repo) => repo.isRegistered);
-  const freshnessSlo = buildFreshnessSloReport({ repoCount: registeredRepos.length, segments, signalSnapshots });
+  const freshnessSlo = buildFreshnessSloReport({
+    repoCount: registeredRepos.length,
+    segments,
+    signalSnapshots,
+  });
   const repairs = [];
   const signalRefreshes = [];
   for (const repo of registeredRepos) {
     const complete = segmentsByRepo.get(repo.fullName) ?? new Set<string>();
-    const missing = [...requiredSegments].filter((segment) => !complete.has(segment));
+    const missing = [...requiredSegments].filter(
+      (segment) => !complete.has(segment),
+    );
     if (missing.length > 0) {
       repairs.push({ repoFullName: repo.fullName, missing });
       continue;
@@ -1247,7 +1971,9 @@ async function repairDataFidelity(env: Env, requestedBy: "schedule" | "api" | "t
         mode: "resume",
       };
       const delaySeconds = Math.min(index * 30, 900);
-      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
     }),
     ...signalRefreshes.slice(0, 50).map((repoFullName, index) => {
       const message: JobMessage = {
@@ -1255,14 +1981,26 @@ async function repairDataFidelity(env: Env, requestedBy: "schedule" | "api" | "t
         requestedBy,
         repoFullName,
       };
-      const delaySeconds = repairs.length > 0 || index > 0 ? Math.min(60 + index * 10, 900) : 0;
-      return delaySeconds > 0 ? env.JOBS.send(message, { delaySeconds }) : env.JOBS.send(message);
+      const delaySeconds =
+        repairs.length > 0 || index > 0 ? Math.min(60 + index * 10, 900) : 0;
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
     }),
   ]);
   await recordAuditEvent(env, {
     eventType: "sync.fidelity_repair",
-    outcome: repairs.length > 0 || freshnessSlo.repairRecommended ? "queued" : "completed",
-    metadata: { requestedBy, repairCount: repairs.length, signalRefreshCount: signalRefreshes.length, repairs: repairs.slice(0, 25), freshnessSlo: freshnessAuditMetadata(freshnessSlo) },
+    outcome:
+      repairs.length > 0 || freshnessSlo.repairRecommended
+        ? "queued"
+        : "completed",
+    metadata: {
+      requestedBy,
+      repairCount: repairs.length,
+      signalRefreshCount: signalRefreshes.length,
+      repairs: repairs.slice(0, 25),
+      freshnessSlo: freshnessAuditMetadata(freshnessSlo),
+    },
   });
   await recordAuditEvent(env, {
     eventType: "signals.freshness_slo",
@@ -1273,8 +2011,17 @@ async function repairDataFidelity(env: Env, requestedBy: "schedule" | "api" | "t
 }
 
 async function discoverContributorLogins(env: Env): Promise<string[]> {
-  const [pullRequests, issues] = await Promise.all([listAllPullRequests(env), listAllIssues(env)]);
-  return [...new Set([...pullRequests, ...issues].flatMap((record) => (record.authorLogin ? [record.authorLogin] : [])))].slice(0, 200);
+  const [pullRequests, issues] = await Promise.all([
+    listAllPullRequests(env),
+    listAllIssues(env),
+  ]);
+  return [
+    ...new Set(
+      [...pullRequests, ...issues].flatMap((record) =>
+        record.authorLogin ? [record.authorLogin] : [],
+      ),
+    ),
+  ].slice(0, 200);
 }
 
 const CONTRIBUTOR_EVIDENCE_MAX_PR_FILE_PATHS = 2000;
@@ -1304,7 +2051,9 @@ async function loadContributorPullRequestFilePaths(
     if (files.length >= CONTRIBUTOR_EVIDENCE_MAX_PR_FILE_PATHS) break;
     const remaining = CONTRIBUTOR_EVIDENCE_MAX_PR_FILE_PATHS - files.length;
     const repoFiles = await listRepoPullRequestFilePaths(env, repoFullName, {
-      pullNumbers: [...(pullNumbersByRepo.get(repoFullName.toLowerCase()) ?? [])],
+      pullNumbers: [
+        ...(pullNumbersByRepo.get(repoFullName.toLowerCase()) ?? []),
+      ],
       limit: Math.min(CONTRIBUTOR_EVIDENCE_PR_FILE_PATHS_PER_REPO, remaining),
     });
     files.push(...repoFiles);
@@ -1312,8 +2061,18 @@ async function loadContributorPullRequestFilePaths(
   return files;
 }
 
-async function buildContributorEvidence(env: Env, login?: string): Promise<void> {
-  const [allPullRequests, allIssues, repositories, syncStates, allBounties, snapshot] = await Promise.all([
+async function buildContributorEvidence(
+  env: Env,
+  login?: string,
+): Promise<void> {
+  const [
+    allPullRequests,
+    allIssues,
+    repositories,
+    syncStates,
+    allBounties,
+    snapshot,
+  ] = await Promise.all([
     listAllPullRequests(env),
     listAllIssues(env),
     listRepositories(env),
@@ -1321,118 +2080,195 @@ async function buildContributorEvidence(env: Env, login?: string): Promise<void>
     listBounties(env),
     getOrCreateScoringModelSnapshot(env),
   ]);
-  const logins = login ? [login] : [...new Set([...allPullRequests, ...allIssues].flatMap((record) => (record.authorLogin ? [record.authorLogin] : [])))].slice(0, 500);
+  const logins = login
+    ? [login]
+    : [
+        ...new Set(
+          [...allPullRequests, ...allIssues].flatMap((record) =>
+            record.authorLogin ? [record.authorLogin] : [],
+          ),
+        ),
+      ].slice(0, 500);
   const issueQualityByRepo = await loadIssueQualityReportMap(env, repositories);
   for (const contributorLogin of logins) {
     // Isolate each login so one failure (transient GitHub/D1 error) doesn't abort the whole
     // 500-login batch and poison-pill the queue on retry (#787).
     try {
-    const [github, contributorPullRequests, contributorIssues, cachedRepoStats, gittensorSnapshot] = await Promise.all([
-      fetchPublicContributorProfile(contributorLogin, env),
-      listContributorPullRequests(env, contributorLogin),
-      listContributorIssues(env, contributorLogin),
-      listContributorRepoStats(env, contributorLogin),
-      fetchGittensorContributorSnapshot(contributorLogin),
-    ]);
-    const repoStats = authoritativeContributorRepoStats(gittensorSnapshot, cachedRepoStats);
-    const profile = buildContributorProfile(contributorLogin, github, contributorPullRequests, contributorIssues, repoStats, gittensorSnapshot);
-    const pullRequestFiles = await loadContributorPullRequestFilePaths(env, {
-      login: contributorLogin,
-      profile,
-      pullRequests: contributorPullRequests,
-      issues: contributorIssues,
-      repoStats,
-      repositories,
-    });
-    const fit = buildContributorFit(profile, repositories, allIssues, allPullRequests, syncStates, repoStats, allBounties, issueQualityByRepo);
-    const scoringProfile = buildContributorScoringProfile({ login: contributorLogin, fit, scoringSnapshot: snapshot });
-    const outcomeHistory = buildContributorOutcomeHistory({ login: contributorLogin, profile, repositories, pullRequests: allPullRequests, issues: allIssues, repoStats, cachedRepoStats });
-    const strategy = buildContributorStrategy({ login: contributorLogin, fit, scoringProfile, scoringSnapshot: snapshot, outcomeHistory });
-    const roleContexts = repositories
-      .filter((repo) => repo.isRegistered)
-      .map((repo) =>
-        buildRoleContext({
-          login: contributorLogin,
-          repo,
-          repoFullName: repo.fullName,
-          pullRequests: contributorPullRequests,
-          issues: contributorIssues,
-          profile,
-        }),
+      const [
+        github,
+        contributorPullRequests,
+        contributorIssues,
+        cachedRepoStats,
+        gittensorSnapshot,
+      ] = await Promise.all([
+        fetchPublicContributorProfile(contributorLogin, env),
+        listContributorPullRequests(env, contributorLogin),
+        listContributorIssues(env, contributorLogin),
+        listContributorRepoStats(env, contributorLogin),
+        fetchGittensorContributorSnapshot(contributorLogin),
+      ]);
+      const repoStats = authoritativeContributorRepoStats(
+        gittensorSnapshot,
+        cachedRepoStats,
       );
-    const evidenceGraph = buildContributorEvidenceGraph({
-      login: contributorLogin,
-      profile,
-      outcomeHistory,
-      roleContexts,
-      repositories,
-      pullRequests: contributorPullRequests,
-      issues: contributorIssues,
-      repoStats,
-      syncStates,
-      pullRequestFiles,
-      gittensorSnapshot,
-    });
-    const evidence: ContributorEvidenceRecord = {
-      login: contributorLogin,
-      generatedAt: scoringProfile.generatedAt,
-      payload: {
-        pullRequests: scoringProfile.evidence.registeredRepoPullRequests,
-        mergedPullRequests: scoringProfile.evidence.mergedPullRequests,
-        openPullRequests: scoringProfile.evidence.openPullRequests,
-        stalePullRequests: scoringProfile.evidence.stalePullRequests,
-        unlinkedPullRequests: scoringProfile.evidence.unlinkedPullRequests,
-        issueDiscoveryReports: scoringProfile.evidence.issueDiscoveryReports,
-        languageMatches: scoringProfile.evidence.languageMatches,
-        credibilityAssumption: scoringProfile.evidence.credibilityAssumption,
-        evidenceGraph: evidenceGraph as unknown as JsonValue,
-      },
-    };
-    await upsertContributorEvidence(env, evidence);
-    await upsertContributorScoringProfile(env, {
-      login: contributorLogin,
-      scoringModelSnapshotId: snapshot.id,
-      payload: scoringProfile as unknown as Record<string, JsonValue>,
-      generatedAt: scoringProfile.generatedAt,
-    });
-    await persistSignalSnapshot(env, {
-      id: crypto.randomUUID(),
-      signalType: "contributor-outcome-history",
-      targetKey: contributorLogin,
-      payload: outcomeHistory as unknown as Record<string, JsonValue>,
-      generatedAt: outcomeHistory.generatedAt,
-    });
-    await persistSignalSnapshot(env, {
-      id: crypto.randomUUID(),
-      signalType: "contributor-strategy",
-      targetKey: contributorLogin,
-      payload: strategy as unknown as Record<string, JsonValue>,
-      generatedAt: strategy.generatedAt,
-    });
-    await persistSignalSnapshot(env, {
-      id: crypto.randomUUID(),
-      signalType: CONTRIBUTOR_EVIDENCE_GRAPH_SIGNAL,
-      targetKey: contributorLogin,
-      payload: evidenceGraph as unknown as Record<string, JsonValue>,
-      generatedAt: evidenceGraph.generatedAt,
-    });
+      const profile = buildContributorProfile(
+        contributorLogin,
+        github,
+        contributorPullRequests,
+        contributorIssues,
+        repoStats,
+        gittensorSnapshot,
+      );
+      const pullRequestFiles = await loadContributorPullRequestFilePaths(env, {
+        login: contributorLogin,
+        profile,
+        pullRequests: contributorPullRequests,
+        issues: contributorIssues,
+        repoStats,
+        repositories,
+      });
+      const fit = buildContributorFit(
+        profile,
+        repositories,
+        allIssues,
+        allPullRequests,
+        syncStates,
+        repoStats,
+        allBounties,
+        issueQualityByRepo,
+      );
+      const scoringProfile = buildContributorScoringProfile({
+        login: contributorLogin,
+        fit,
+        scoringSnapshot: snapshot,
+      });
+      const outcomeHistory = buildContributorOutcomeHistory({
+        login: contributorLogin,
+        profile,
+        repositories,
+        pullRequests: allPullRequests,
+        issues: allIssues,
+        repoStats,
+        cachedRepoStats,
+      });
+      const strategy = buildContributorStrategy({
+        login: contributorLogin,
+        fit,
+        scoringProfile,
+        scoringSnapshot: snapshot,
+        outcomeHistory,
+      });
+      const roleContexts = repositories
+        .filter((repo) => repo.isRegistered)
+        .map((repo) =>
+          buildRoleContext({
+            login: contributorLogin,
+            repo,
+            repoFullName: repo.fullName,
+            pullRequests: contributorPullRequests,
+            issues: contributorIssues,
+            profile,
+          }),
+        );
+      const evidenceGraph = buildContributorEvidenceGraph({
+        login: contributorLogin,
+        profile,
+        outcomeHistory,
+        roleContexts,
+        repositories,
+        pullRequests: contributorPullRequests,
+        issues: contributorIssues,
+        repoStats,
+        syncStates,
+        pullRequestFiles,
+        gittensorSnapshot,
+      });
+      const evidence: ContributorEvidenceRecord = {
+        login: contributorLogin,
+        generatedAt: scoringProfile.generatedAt,
+        payload: {
+          pullRequests: scoringProfile.evidence.registeredRepoPullRequests,
+          mergedPullRequests: scoringProfile.evidence.mergedPullRequests,
+          openPullRequests: scoringProfile.evidence.openPullRequests,
+          stalePullRequests: scoringProfile.evidence.stalePullRequests,
+          unlinkedPullRequests: scoringProfile.evidence.unlinkedPullRequests,
+          issueDiscoveryReports: scoringProfile.evidence.issueDiscoveryReports,
+          languageMatches: scoringProfile.evidence.languageMatches,
+          credibilityAssumption: scoringProfile.evidence.credibilityAssumption,
+          evidenceGraph: evidenceGraph as unknown as JsonValue,
+        },
+      };
+      await upsertContributorEvidence(env, evidence);
+      await upsertContributorScoringProfile(env, {
+        login: contributorLogin,
+        scoringModelSnapshotId: snapshot.id,
+        payload: scoringProfile as unknown as Record<string, JsonValue>,
+        generatedAt: scoringProfile.generatedAt,
+      });
+      await persistSignalSnapshot(env, {
+        id: crypto.randomUUID(),
+        signalType: "contributor-outcome-history",
+        targetKey: contributorLogin,
+        payload: outcomeHistory as unknown as Record<string, JsonValue>,
+        generatedAt: outcomeHistory.generatedAt,
+      });
+      await persistSignalSnapshot(env, {
+        id: crypto.randomUUID(),
+        signalType: "contributor-strategy",
+        targetKey: contributorLogin,
+        payload: strategy as unknown as Record<string, JsonValue>,
+        generatedAt: strategy.generatedAt,
+      });
+      await persistSignalSnapshot(env, {
+        id: crypto.randomUUID(),
+        signalType: CONTRIBUTOR_EVIDENCE_GRAPH_SIGNAL,
+        targetKey: contributorLogin,
+        payload: evidenceGraph as unknown as Record<string, JsonValue>,
+        generatedAt: evidenceGraph.generatedAt,
+      });
     } catch (error) {
       /* v8 ignore next -- defensive per-login isolation; the log-and-continue path is not exercised in tests */
-      console.error(JSON.stringify({ level: "warn", event: "contributor_evidence_login_failed", login: contributorLogin, error: errorMessage(error) }));
+      console.error(
+        JSON.stringify({
+          level: "warn",
+          event: "contributor_evidence_login_failed",
+          login: contributorLogin,
+          error: errorMessage(error),
+        }),
+      );
     }
   }
 }
 
-async function buildBurdenForecasts(env: Env, repoFullName?: string): Promise<void> {
-  const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered && (!repoFullName || repo.fullName === repoFullName));
+async function buildBurdenForecasts(
+  env: Env,
+  repoFullName?: string,
+): Promise<void> {
+  const repositories = (await listRepositories(env)).filter(
+    (repo) =>
+      repo.isRegistered && (!repoFullName || repo.fullName === repoFullName),
+  );
   for (const repo of repositories) {
-    const [issues, pullRequests, recentMergedPullRequests, queueCounts] = await Promise.all([
-      listIssueSignalSample(env, repo.fullName),
-      listOpenPullRequests(env, repo.fullName),
-      listRecentMergedPullRequests(env, repo.fullName),
-      loadOpenQueueCounts(env, repo.fullName),
-    ]);
-    const forecast = buildBurdenForecast(repo, issues, pullRequests, buildCollisionReport(repo.fullName, issues, pullRequests, recentMergedPullRequests), 30, queueCounts);
+    const [issues, pullRequests, recentMergedPullRequests, queueCounts] =
+      await Promise.all([
+        listIssueSignalSample(env, repo.fullName),
+        listOpenPullRequests(env, repo.fullName),
+        listRecentMergedPullRequests(env, repo.fullName),
+        loadOpenQueueCounts(env, repo.fullName),
+      ]);
+    const forecast = buildBurdenForecast(
+      repo,
+      issues,
+      pullRequests,
+      buildCollisionReport(
+        repo.fullName,
+        issues,
+        pullRequests,
+        recentMergedPullRequests,
+      ),
+      30,
+      queueCounts,
+    );
     await upsertBurdenForecast(env, {
       repoFullName: repo.fullName,
       payload: forecast as unknown as Record<string, JsonValue>,
@@ -1441,29 +2277,104 @@ async function buildBurdenForecasts(env: Env, repoFullName?: string): Promise<vo
   }
 }
 
-export async function generateSignalSnapshots(env: Env, repoFullName?: string): Promise<void> {
-  const repositories = (await listRepositories(env)).filter((repo) => repo.isRegistered && (!repoFullName || repo.fullName === repoFullName));
+export async function generateSignalSnapshots(
+  env: Env,
+  repoFullName?: string,
+): Promise<void> {
+  const repositories = (await listRepositories(env)).filter(
+    (repo) =>
+      repo.isRegistered && (!repoFullName || repo.fullName === repoFullName),
+  );
   for (const repo of repositories) {
-    const trendSince = new Date(Date.now() - QUEUE_TREND_HISTORY_DAYS * 24 * 60 * 60 * 1000).toISOString();
-    const [issues, pullRequests, recentMergedPullRequests, labels, queueCounts, bounties, totalsHistory, queueHealthHistory] = await Promise.all([
+    const trendSince = new Date(
+      Date.now() - QUEUE_TREND_HISTORY_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const [
+      issues,
+      pullRequests,
+      recentMergedPullRequests,
+      labels,
+      queueCounts,
+      bounties,
+      totalsHistory,
+      queueHealthHistory,
+    ] = await Promise.all([
       listIssueSignalSample(env, repo.fullName),
       listOpenPullRequests(env, repo.fullName),
       listRecentMergedPullRequests(env, repo.fullName),
       listRepoLabels(env, repo.fullName),
       loadOpenQueueCounts(env, repo.fullName),
       listBountiesByRepo(env, repo.fullName),
-      listRepoGithubTotalsSnapshotHistory(env, repo.fullName, { sinceIso: trendSince, limit: 120 }),
+      listRepoGithubTotalsSnapshotHistory(env, repo.fullName, {
+        sinceIso: trendSince,
+        limit: 120,
+      }),
       listSignalSnapshots(env, "queue-health", repo.fullName),
     ]);
-    const collisions = buildCollisionReport(repo.fullName, issues, pullRequests, recentMergedPullRequests);
-    const queueHealth = buildQueueHealth(repo, issues, pullRequests, collisions, queueCounts);
-    const configQuality = buildConfigQuality(repo, issues, pullRequests, repo.fullName);
-    const labelAudit = buildLabelAudit(repo, labels, issues, pullRequests, repo.fullName);
-    const maintainerLane = buildMaintainerLaneReport(repo, issues, pullRequests, repo.fullName, collisions, queueCounts);
-    const maintainerCutReadiness = buildMaintainerCutReadiness(repo, issues, pullRequests, repo.fullName, queueCounts, collisions);
-    const contributorIntakeHealth = buildContributorIntakeHealth(repo, issues, pullRequests, repo.fullName, collisions, queueCounts);
-    const issueQuality = buildIssueQualityReport(repo, issues, pullRequests, repo.fullName, bounties, collisions, recentMergedPullRequests);
-    await replaceCollisionEdges(env, repo.fullName, buildCollisionEdges(collisions));
+    const collisions = buildCollisionReport(
+      repo.fullName,
+      issues,
+      pullRequests,
+      recentMergedPullRequests,
+    );
+    const queueHealth = buildQueueHealth(
+      repo,
+      issues,
+      pullRequests,
+      collisions,
+      queueCounts,
+    );
+    const configQuality = buildConfigQuality(
+      repo,
+      issues,
+      pullRequests,
+      repo.fullName,
+    );
+    const labelAudit = buildLabelAudit(
+      repo,
+      labels,
+      issues,
+      pullRequests,
+      repo.fullName,
+    );
+    const maintainerLane = buildMaintainerLaneReport(
+      repo,
+      issues,
+      pullRequests,
+      repo.fullName,
+      collisions,
+      queueCounts,
+    );
+    const maintainerCutReadiness = buildMaintainerCutReadiness(
+      repo,
+      issues,
+      pullRequests,
+      repo.fullName,
+      queueCounts,
+      collisions,
+    );
+    const contributorIntakeHealth = buildContributorIntakeHealth(
+      repo,
+      issues,
+      pullRequests,
+      repo.fullName,
+      collisions,
+      queueCounts,
+    );
+    const issueQuality = buildIssueQualityReport(
+      repo,
+      issues,
+      pullRequests,
+      repo.fullName,
+      bounties,
+      collisions,
+      recentMergedPullRequests,
+    );
+    await replaceCollisionEdges(
+      env,
+      repo.fullName,
+      buildCollisionEdges(collisions),
+    );
     const generatedAt = new Date().toISOString();
     await persistSignalSnapshot(env, {
       id: crypto.randomUUID(),
@@ -1532,7 +2443,11 @@ export async function generateSignalSnapshots(env: Env, repoFullName?: string): 
       payload: issueQuality as unknown as Record<string, never>,
       generatedAt,
     });
-    const repoOutcomePatterns = await computeRepoOutcomePatterns(env, repo.fullName, repo);
+    const repoOutcomePatterns = await computeRepoOutcomePatterns(
+      env,
+      repo.fullName,
+      repo,
+    );
     await persistSignalSnapshot(env, {
       id: crypto.randomUUID(),
       signalType: REPO_OUTCOME_PATTERNS_SIGNAL,
@@ -1544,17 +2459,33 @@ export async function generateSignalSnapshots(env: Env, repoFullName?: string): 
   }
 }
 
-async function loadOpenQueueCounts(env: Env, repoFullName: string): Promise<{ openIssues: number; openPullRequests: number }> {
-  const [totals, openIssues, openPullRequests] = await Promise.all([getLatestRepoGithubTotalsSnapshot(env, repoFullName), countOpenIssues(env, repoFullName), countOpenPullRequests(env, repoFullName)]);
+async function loadOpenQueueCounts(
+  env: Env,
+  repoFullName: string,
+): Promise<{ openIssues: number; openPullRequests: number }> {
+  const [totals, openIssues, openPullRequests] = await Promise.all([
+    getLatestRepoGithubTotalsSnapshot(env, repoFullName),
+    countOpenIssues(env, repoFullName),
+    countOpenPullRequests(env, repoFullName),
+  ]);
   return {
     openIssues: totals?.openIssuesTotal ?? openIssues,
     openPullRequests: totals?.openPullRequestsTotal ?? openPullRequests,
   };
 }
 
-async function processGitHubWebhook(env: Env, deliveryId: string, eventName: string, payload: GitHubWebhookPayload): Promise<void> {
+async function processGitHubWebhook(
+  env: Env,
+  deliveryId: string,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): Promise<void> {
   try {
-    if (eventName === "installation" && payload.action === "deleted" && payload.installation?.id) {
+    if (
+      eventName === "installation" &&
+      payload.action === "deleted" &&
+      payload.installation?.id
+    ) {
       await markInstallationDeleted(env, payload.installation.id);
       await recordWebhookEvent(env, {
         deliveryId,
@@ -1588,44 +2519,85 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
     }
     const installationActor =
       payload.installation?.account?.login ??
-      (payload.installation?.id ? (await getInstallation(env, payload.installation.id))?.accountLogin : undefined);
+      (payload.installation?.id
+        ? (await getInstallation(env, payload.installation.id))?.accountLogin
+        : undefined);
     if (eventName === "installation_repositories" && payload.installation?.id) {
-      const addedRepos = payload.repositories_added?.map((repo) => repo.full_name).filter(Boolean) ?? [];
-      const removedRepos = payload.repositories_removed?.map((repo) => repo.full_name).filter(Boolean) ?? [];
-      for (const repo of payload.repositories_added ?? []) await upsertRepositoryFromGitHub(env, repo, payload.installation.id);
-      await markRepositoriesRemovedFromInstallation(env, payload.installation.id, removedRepos);
+      const addedRepos =
+        payload.repositories_added
+          ?.map((repo) => repo.full_name)
+          .filter(Boolean) ?? [];
+      const removedRepos =
+        payload.repositories_removed
+          ?.map((repo) => repo.full_name)
+          .filter(Boolean) ?? [];
+      for (const repo of payload.repositories_added ?? [])
+        await upsertRepositoryFromGitHub(env, repo, payload.installation.id);
+      await markRepositoriesRemovedFromInstallation(
+        env,
+        payload.installation.id,
+        removedRepos,
+      );
       await Promise.all([
         ...addedRepos.slice(0, 50).map((repoFullName) =>
-          recordGithubProductUsage(env, "github_installation_repository_added", {
-            actor: installationActor,
-            repoFullName,
-            targetKey: payload.installation?.id ? `installation:${payload.installation.id}` : repoFullName,
-            outcome: "completed",
-            metadata: { action: payload.action, repoCount: addedRepos.length, truncatedRepos: Math.max(addedRepos.length - 50, 0) },
-          }),
+          recordGithubProductUsage(
+            env,
+            "github_installation_repository_added",
+            {
+              actor: installationActor,
+              repoFullName,
+              targetKey: payload.installation?.id
+                ? `installation:${payload.installation.id}`
+                : repoFullName,
+              outcome: "completed",
+              metadata: {
+                action: payload.action,
+                repoCount: addedRepos.length,
+                truncatedRepos: Math.max(addedRepos.length - 50, 0),
+              },
+            },
+          ),
         ),
         ...removedRepos.slice(0, 50).map((repoFullName) =>
-          recordGithubProductUsage(env, "github_installation_repository_removed", {
-            actor: installationActor,
-            repoFullName,
-            targetKey: payload.installation?.id ? `installation:${payload.installation.id}` : repoFullName,
-            outcome: "completed",
-            metadata: { action: payload.action, repoCount: removedRepos.length, truncatedRepos: Math.max(removedRepos.length - 50, 0) },
-          }),
+          recordGithubProductUsage(
+            env,
+            "github_installation_repository_removed",
+            {
+              actor: installationActor,
+              repoFullName,
+              targetKey: payload.installation?.id
+                ? `installation:${payload.installation.id}`
+                : repoFullName,
+              outcome: "completed",
+              metadata: {
+                action: payload.action,
+                repoCount: removedRepos.length,
+                truncatedRepos: Math.max(removedRepos.length - 50, 0),
+              },
+            },
+          ),
         ),
       ]);
     }
 
     if (eventName === "installation" && payload.action === "created") {
-      const installedRepos = payload.repositories?.map((repo) => repo.full_name).filter(Boolean) ?? (payload.repository?.full_name ? [payload.repository.full_name] : []);
+      const installedRepos =
+        payload.repositories?.map((repo) => repo.full_name).filter(Boolean) ??
+        (payload.repository?.full_name ? [payload.repository.full_name] : []);
       await Promise.all(
         installedRepos.slice(0, 50).map((repoFullName) =>
           recordGithubProductUsage(env, "github_installation_created", {
             actor: installationActor,
             repoFullName,
-            targetKey: payload.installation?.id ? `installation:${payload.installation.id}` : repoFullName,
+            targetKey: payload.installation?.id
+              ? `installation:${payload.installation.id}`
+              : repoFullName,
             outcome: "completed",
-            metadata: { action: payload.action, repoCount: installedRepos.length, truncatedRepos: Math.max(installedRepos.length - 50, 0) },
+            metadata: {
+              action: payload.action,
+              repoCount: installedRepos.length,
+              truncatedRepos: Math.max(installedRepos.length - 50, 0),
+            },
           }),
         ),
       );
@@ -1633,11 +2605,24 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
 
     const installationId = getInstallationId(payload);
     if (payload.repositories) {
-      for (const repo of payload.repositories) await upsertRepositoryFromGitHub(env, repo, installationId ?? undefined);
+      for (const repo of payload.repositories)
+        await upsertRepositoryFromGitHub(
+          env,
+          repo,
+          installationId ?? undefined,
+        );
     }
-    if (payload.repository) await upsertRepositoryFromGitHub(env, payload.repository, installationId ?? undefined);
+    if (payload.repository)
+      await upsertRepositoryFromGitHub(
+        env,
+        payload.repository,
+        installationId ?? undefined,
+      );
 
-    if (eventName === "reaction" && (await maybeProcessAgentCommandFeedbackReaction(env, deliveryId, payload))) {
+    if (
+      eventName === "reaction" &&
+      (await maybeProcessAgentCommandFeedbackReaction(env, deliveryId, payload))
+    ) {
       await recordWebhookEvent(env, {
         deliveryId,
         eventName,
@@ -1650,7 +2635,10 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       return;
     }
 
-    if (eventName === "issue_comment" && (await maybeProcessPrPanelRetrigger(env, deliveryId, payload))) {
+    if (
+      eventName === "issue_comment" &&
+      (await maybeProcessPrPanelRetrigger(env, deliveryId, payload))
+    ) {
       await recordWebhookEvent(env, {
         deliveryId,
         eventName,
@@ -1663,7 +2651,10 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       return;
     }
 
-    if (eventName === "issue_comment" && (await maybeProcessGateOverrideCommand(env, deliveryId, payload))) {
+    if (
+      eventName === "issue_comment" &&
+      (await maybeProcessGateOverrideCommand(env, deliveryId, payload))
+    ) {
       await recordWebhookEvent(env, {
         deliveryId,
         eventName,
@@ -1676,7 +2667,10 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       return;
     }
 
-    if (eventName === "issue_comment" && (await maybeProcessPlanCommand(env, deliveryId, payload))) {
+    if (
+      eventName === "issue_comment" &&
+      (await maybeProcessPlanCommand(env, deliveryId, payload))
+    ) {
       await recordWebhookEvent(env, {
         deliveryId,
         eventName,
@@ -1689,7 +2683,10 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       return;
     }
 
-    if (eventName === "issue_comment" && (await maybeProcessGittensoryMentionCommand(env, deliveryId, payload))) {
+    if (
+      eventName === "issue_comment" &&
+      (await maybeProcessGittensoryMentionCommand(env, deliveryId, payload))
+    ) {
       await recordWebhookEvent(env, {
         deliveryId,
         eventName,
@@ -1706,9 +2703,13 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
     // carries no `payload.pull_request`, so it must be handled BEFORE the pull_request block: it wakes the
     // stored PR row and re-reviews it now that CI has settled (merge on green, close-non-owner / hold-owner on
     // red). Without this a PR that goes green/red AFTER its open-time review is never re-evaluated.
-    if (await maybeReReviewOnCiCompletion(env, deliveryId, eventName, payload)) return;
+    if (await maybeReReviewOnCiCompletion(env, deliveryId, eventName, payload))
+      return;
     // deployment_status (preview deploy finished) → re-review so the visual before/after capture fills in.
-    if (await maybeCaptureOnDeploymentStatus(env, deliveryId, eventName, payload)) return;
+    if (
+      await maybeCaptureOnDeploymentStatus(env, deliveryId, eventName, payload)
+    )
+      return;
 
     if (payload.repository?.full_name && payload.pull_request) {
       const repoFullName = payload.repository.full_name;
@@ -1719,18 +2720,49 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       //     record the human override so reversalRate/calibration are no longer blind. Both fail safe.
       await recordPrOutcome(env, eventName, payload).catch((error) => {
         /* v8 ignore next -- best-effort: outcome recording never blocks the webhook. */
-        console.warn(JSON.stringify({ level: "warn", event: "pr_outcome_record_failed", deliveryId, repository: repoFullName, error: errorMessage(error) }));
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "pr_outcome_record_failed",
+            deliveryId,
+            repository: repoFullName,
+            error: errorMessage(error),
+          }),
+        );
       });
       await recordReversalSignals(env, eventName, payload).catch((error) => {
         /* v8 ignore next -- best-effort: reversal recording never blocks the webhook. */
-        console.warn(JSON.stringify({ level: "warn", event: "reversal_record_failed", deliveryId, repository: repoFullName, error: errorMessage(error) }));
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            event: "reversal_record_failed",
+            deliveryId,
+            repository: repoFullName,
+            error: errorMessage(error),
+          }),
+        );
       });
-      const pr = await upsertPullRequestFromGitHub(env, repoFullName, payload.pull_request);
+      const pr = await upsertPullRequestFromGitHub(
+        env,
+        repoFullName,
+        payload.pull_request,
+      );
       // Reopen-prevention (#one-shot-reopen): a CONTRIBUTOR may not reopen a PR that gittensory or a maintainer
       // closed — closes are one-shot (resubmit, don't reopen). If a non-maintainer reopened a PR whose last close
       // was by the bot / repo owner / admin, re-close it and skip the re-review. Self-closes (the contributor
       // closed their own PR) stay reopenable; the bot's own nightly-re-review reopens are exempt.
-      if (payload.action === "reopened" && installationId && (await maybeRecloseDisallowedReopen(env, deliveryId, installationId, repoFullName, pr, payload).catch(() => false))) {
+      if (
+        payload.action === "reopened" &&
+        installationId &&
+        (await maybeRecloseDisallowedReopen(
+          env,
+          deliveryId,
+          installationId,
+          repoFullName,
+          pr,
+          payload,
+        ).catch(() => false))
+      ) {
         // Stamp the delivery processed like every other owning path — the early return otherwise leaves the
         // webhook_events row stuck at "queued"/its body hash, mis-reporting the delivery as un-acked (#review-audit).
         await recordWebhookEvent(env, {
@@ -1746,14 +2778,27 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
       }
       // Resolve settings first so the self-authored live-fetch fallback only fires when its gate is in block mode.
       const settings = await resolveRepositorySettings(env, repoFullName);
-      const [repo, cachedOtherOpenPullRequests, linkedIssueAuthorLogins] = await Promise.all([
-        getRepository(env, repoFullName),
-        listOtherOpenPullRequests(env, repoFullName, pr.number),
-        resolveLinkedIssueAuthorLogins(env, installationId, repoFullName, pr.linkedIssues, settings.selfAuthoredLinkedIssueGateMode === "block"),
-      ]);
+      const [repo, cachedOtherOpenPullRequests, linkedIssueAuthorLogins] =
+        await Promise.all([
+          getRepository(env, repoFullName),
+          listOtherOpenPullRequests(env, repoFullName, pr.number),
+          resolveLinkedIssueAuthorLogins(
+            env,
+            installationId,
+            repoFullName,
+            pr.linkedIssues,
+            settings.selfAuthoredLinkedIssueGateMode === "block",
+          ),
+        ]);
       // #dup-winner / audit #15: drop any cached-open duplicate sibling already closed on GitHub before the
       // advisory (and the disposition) elect the cluster winner, so the real lowest-OPEN PR is never auto-closed.
-      const otherOpenPullRequests = await reconcileLiveDuplicateSiblings(env, installationId, repoFullName, pr, cachedOtherOpenPullRequests);
+      const otherOpenPullRequests = await reconcileLiveDuplicateSiblings(
+        env,
+        installationId,
+        repoFullName,
+        pr,
+        cachedOtherOpenPullRequests,
+      );
       const advisory = buildPullRequestAdvisory(repo, pr, {
         otherOpenPullRequests,
         requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
@@ -1775,14 +2820,32 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
         !settings.agentPaused &&
         !isProtectedAutomationAuthor(pr.authorLogin)
       ) {
-        const block = await getGateBlockOutcome(env, repoFullName, pr.number).catch(() => undefined);
-        const repoOwner = repoFullName.includes("/") ? repoFullName.slice(0, repoFullName.indexOf("/")).toLowerCase() : "";
-        const authorIsOwner = (pr.authorLogin ?? "").toLowerCase() === repoOwner && repoOwner.length > 0;
-        if (block && block.headSha === pr.headSha && !block.overridden && !authorIsOwner) {
+        const block = await getGateBlockOutcome(
+          env,
+          repoFullName,
+          pr.number,
+        ).catch(() => undefined);
+        const repoOwner = repoFullName.includes("/")
+          ? repoFullName.slice(0, repoFullName.indexOf("/")).toLowerCase()
+          : "";
+        const authorIsOwner =
+          (pr.authorLogin ?? "").toLowerCase() === repoOwner &&
+          repoOwner.length > 0;
+        if (
+          block &&
+          block.headSha === pr.headSha &&
+          !block.overridden &&
+          !authorIsOwner
+        ) {
           // Respect the agent action mode (#killswitch-gap): the outer guard already excludes a per-repo pause,
           // but this close path must also honor the global freeze and dry-run — so a freeze is a COMPLETE stop
           // and a dry-run records the would-be close without touching GitHub.
-          const draftMode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: settings.agentPaused, agentDryRun: settings.agentDryRun });
+          const draftMode = resolveAgentActionMode({
+            globalPaused:
+              isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+            agentPaused: settings.agentPaused,
+            agentDryRun: settings.agentDryRun,
+          });
           if (draftMode === "live") {
             const codes = block.blockerCodes.join(", ");
             await createIssueComment(
@@ -1792,14 +2855,24 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
               pr.number,
               `Gate verdict stands for this commit — converting to draft does not reset the review. Re-submit a new PR with the issues addressed${codes ? ` (${codes})` : ""}.`,
             ).catch(() => undefined);
-            await closePullRequest(env, installationId, repoFullName, pr.number).catch(() => undefined);
+            await closePullRequest(
+              env,
+              installationId,
+              repoFullName,
+              pr.number,
+            ).catch(() => undefined);
             await recordAuditEvent(env, {
               eventType: "github_app.draft_dodge_closed",
               actor: "gittensory",
               targetKey: `${repoFullName}#${pr.number}`,
               outcome: "completed",
               detail: `closed draft-dodge attempt by ${pr.authorLogin ?? "unknown"} — prior gate failure on headSha ${pr.headSha} stands`,
-              metadata: { deliveryId, repoFullName, headSha: pr.headSha, blockerCodes: block.blockerCodes },
+              metadata: {
+                deliveryId,
+                repoFullName,
+                headSha: pr.headSha,
+                blockerCodes: block.blockerCodes,
+              },
             }).catch(() => undefined);
           } else if (draftMode === "dry_run") {
             /* v8 ignore next -- a deleted-account PR yields a null author login; the fallback is defensive */
@@ -1810,7 +2883,13 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
               targetKey: `${repoFullName}#${pr.number}`,
               outcome: "completed",
               detail: `dry-run: would close draft-dodge attempt by ${draftAuthor} — prior gate failure on headSha ${pr.headSha} stands`,
-              metadata: { deliveryId, repoFullName, headSha: pr.headSha, blockerCodes: block.blockerCodes, mode: "dry_run" },
+              metadata: {
+                deliveryId,
+                repoFullName,
+                headSha: pr.headSha,
+                blockerCodes: block.blockerCodes,
+                mode: "dry_run",
+              },
             }).catch(
               /* v8 ignore next -- fail-safe: an audit write failure never blocks the handler */
               () => undefined,
@@ -1818,21 +2897,48 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
           }
         }
       }
-      if (installationId && shouldProcessPullRequestPublicSurface(payload.action)) {
-        if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off" || isAgentConfigured(settings.autonomy)) {
+      if (
+        installationId &&
+        shouldProcessPullRequestPublicSurface(payload.action)
+      ) {
+        if (
+          shouldCollectSlopEvidence(settings) ||
+          settings.manifestPolicyGateMode !== "off" ||
+          isAgentConfigured(settings.autonomy)
+        ) {
           await refreshPullRequestDetails(env, repoFullName, pr.number);
         }
         // Operator review flow: rebase-if-behind → wait for ALL CI → only THEN review/act. When deferred (a
         // rebase fired a synchronize, or CI is still running) skip the review+maintain now; the synchronize /
         // CI-completion webhook (sweep backstop) re-runs this once the head is current and CI has settled. gate
         // stays undefined so the reputation/RAG steps below no-op until the terminal decision.
-        let gate: Awaited<ReturnType<typeof maybePublishPrPublicSurface>> | undefined;
-        if (await prReadyForReview(env, installationId, repoFullName, pr, settings, deliveryId)) {
-          gate = await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
+        let gate:
+          | Awaited<ReturnType<typeof maybePublishPrPublicSurface>>
+          | undefined;
+        if (
+          await prReadyForReview(
+            env,
+            installationId,
+            repoFullName,
+            pr,
+            settings,
             deliveryId,
-            authorType: payload.pull_request.user?.type,
-            action: payload.action,
-          }).catch((error) => {
+          )
+        ) {
+          gate = await maybePublishPrPublicSurface(
+            env,
+            installationId,
+            repoFullName,
+            pr,
+            repo,
+            settings,
+            advisory,
+            {
+              deliveryId,
+              authorType: payload.pull_request.user?.type,
+              action: payload.action,
+            },
+          ).catch((error) => {
             console.error(
               JSON.stringify({
                 level: "warn",
@@ -1848,9 +2954,27 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
           // #778 maintainer auto-maintain: act on the PR's state (label/review/merge/close) per the repo's
           // autonomy config, after the gate has run. The function self-guards on agent config; best-effort here
           // so it never blocks the gate or public surface.
-          await maybeRunAgentMaintenance(env, { installationId, repoFullName, repo, pr, settings, otherOpenPullRequests, deliveryId, gate }).catch((error) => {
+          await maybeRunAgentMaintenance(env, {
+            installationId,
+            repoFullName,
+            repo,
+            pr,
+            settings,
+            otherOpenPullRequests,
+            deliveryId,
+            gate,
+          }).catch((error) => {
             /* v8 ignore next -- best-effort: auto-maintain failures are logged, never surfaced to the gate. */
-            console.error(JSON.stringify({ level: "warn", event: "agent_maintenance_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+            console.error(
+              JSON.stringify({
+                level: "warn",
+                event: "agent_maintenance_failed",
+                deliveryId,
+                repository: repoFullName,
+                pullNumber: pr.number,
+                error: errorMessage(error),
+              }),
+            );
           });
         }
         // Reputation (convergence, flag-gated by GITTENSORY_REVIEW_REPUTATION). After the gate decides, record this
@@ -1859,11 +2983,27 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
         // nothing is ever surfaced publicly. Flag-OFF (default) is an immediate no-op (nothing recorded), so the
         // path is byte-identical. Best-effort: a record failure must never affect the gate or the public surface.
         const reputationOutcome =
-          isReputationEnabled(env) && isConvergenceRepoAllowed(env, repoFullName) ? reputationOutcomeFromTerminalState(pr, payload.pull_request, gate) : undefined;
+          isReputationEnabled(env) &&
+          isConvergenceRepoAllowed(env, repoFullName)
+            ? reputationOutcomeFromTerminalState(pr, payload.pull_request, gate)
+            : undefined;
         if (reputationOutcome) {
-          await recordReputationOutcome(env, { project: repoFullName, submitter: pr.authorLogin ?? null, outcome: reputationOutcome }).catch((error) => {
+          await recordReputationOutcome(env, {
+            project: repoFullName,
+            submitter: pr.authorLogin ?? null,
+            outcome: reputationOutcome,
+          }).catch((error) => {
             /* v8 ignore next -- best-effort: a reputation-record failure is logged, never surfaced to the gate. */
-            console.error(JSON.stringify({ level: "warn", event: "reputation_record_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+            console.error(
+              JSON.stringify({
+                level: "warn",
+                event: "reputation_record_failed",
+                deliveryId,
+                repository: repoFullName,
+                pullNumber: pr.number,
+                error: errorMessage(error),
+              }),
+            );
           });
         }
         // RAG incremental index (convergence, flag-gated by GITTENSORY_REVIEW_RAG + the per-repo cutover allowlist).
@@ -1871,32 +3011,73 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
         // incremental re-index of just the changed files (reindexChangedPaths) so the index stays fresh without a
         // full re-crawl. Enqueued (not run inline) so the webhook stays fast + the index work is its own retryable
         // job. Flag-OFF (default) is a no-op (the job is never enqueued AND the processor no-ops). Best-effort.
-        await maybeEnqueueRagReindexForMergedPr(env, repoFullName, pr.number, payload.action, payload.pull_request.merged_at).catch((error) => {
+        await maybeEnqueueRagReindexForMergedPr(
+          env,
+          repoFullName,
+          pr.number,
+          payload.action,
+          payload.pull_request.merged_at,
+        ).catch((error) => {
           /* v8 ignore next -- best-effort: a RAG re-index enqueue failure is logged, never surfaced to the gate. */
-          console.error(JSON.stringify({ level: "warn", event: "rag_reindex_enqueue_failed", deliveryId, repository: repoFullName, pullNumber: pr.number, error: errorMessage(error) }));
+          console.error(
+            JSON.stringify({
+              level: "warn",
+              event: "rag_reindex_enqueue_failed",
+              deliveryId,
+              repository: repoFullName,
+              pullNumber: pr.number,
+              error: errorMessage(error),
+            }),
+          );
         });
       }
     }
 
     let issueWatchEvents: DetectedNotificationEvent[] = [];
-    if (payload.repository?.full_name && payload.issue && !payload.issue.pull_request) {
-      const issue = await upsertIssueFromGitHub(env, payload.repository.full_name, payload.issue);
+    if (
+      payload.repository?.full_name &&
+      payload.issue &&
+      !payload.issue.pull_request
+    ) {
+      const issue = await upsertIssueFromGitHub(
+        env,
+        payload.repository.full_name,
+        payload.issue,
+      );
       const repo = await getRepository(env, payload.repository.full_name);
       const advisory = buildIssueAdvisory(repo, issue);
       // Issue-side slop triage (#533): opt-in via slopGateMode, advisory-only (issues have no gate, and
       // the issue advisory is maintainer-facing — never a public comment). Flags clearly low-effort issues.
-      const issueSettings = await resolveRepositorySettings(env, payload.repository.full_name);
+      const issueSettings = await resolveRepositorySettings(
+        env,
+        payload.repository.full_name,
+      );
       if (issueSettings.slopGateMode !== "off") {
-        advisory.findings.push(...buildIssueSlopAssessment({ title: issue.title, body: issue.body }).findings);
+        advisory.findings.push(
+          ...buildIssueSlopAssessment({ title: issue.title, body: issue.body })
+            .findings,
+        );
       }
       await persistAdvisory(env, advisory);
       // #699 path B: a newly opened grabbable, high-multiplier issue notifies the miners watching this repo
       // (fanned out through the same #535 pipeline below).
-      if (payload.action === "opened") issueWatchEvents = await detectIssueWatchEvents(env, payload.repository.full_name, issue);
+      if (payload.action === "opened")
+        issueWatchEvents = await detectIssueWatchEvents(
+          env,
+          payload.repository.full_name,
+          issue,
+        );
     }
 
-    const trustedReviewEvents = await filterTrustedReviewNotificationEvents(env, payload.installation?.id, detectNotificationEvents(eventName, payload));
-    for (const notificationEvent of [...trustedReviewEvents, ...issueWatchEvents]) {
+    const trustedReviewEvents = await filterTrustedReviewNotificationEvents(
+      env,
+      payload.installation?.id,
+      detectNotificationEvents(eventName, payload),
+    );
+    for (const notificationEvent of [
+      ...trustedReviewEvents,
+      ...issueWatchEvents,
+    ]) {
       await recordAuditEvent(env, {
         eventType: "notification.event_detected",
         actor: notificationEvent.actorLogin,
@@ -1913,7 +3094,11 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
           deeplink: notificationEvent.deeplink,
         },
       });
-      await env.JOBS.send({ type: "notify-evaluate", requestedBy: "webhook", event: notificationEvent });
+      await env.JOBS.send({
+        type: "notify-evaluate",
+        requestedBy: "webhook",
+        event: notificationEvent,
+      });
     }
 
     await recordWebhookEvent(env, {
@@ -1941,14 +3126,28 @@ async function processGitHubWebhook(env: Env, deliveryId: string, eventName: str
 }
 
 type PublicSurfaceOutput = "comment" | "label" | "check_run";
-type PublicSurfaceOutputFailure = { output: PublicSurfaceOutput; error: string };
+type PublicSurfaceOutputFailure = {
+  output: PublicSurfaceOutput;
+  error: string;
+};
 
-function mergeReadinessGateEnabled(settings: Pick<RepositorySettings, "mergeReadinessGateMode">): boolean {
+function mergeReadinessGateEnabled(
+  settings: Pick<RepositorySettings, "mergeReadinessGateMode">,
+): boolean {
   return settings.mergeReadinessGateMode !== "off";
 }
 
-export function shouldCollectLinkedIssueEvidence(settings: Pick<RepositorySettings, "requireLinkedIssue" | "linkedIssueGateMode" | "mergeReadinessGateMode">): boolean {
-  return settings.requireLinkedIssue || settings.linkedIssueGateMode !== "off" || mergeReadinessGateEnabled(settings);
+export function shouldCollectLinkedIssueEvidence(
+  settings: Pick<
+    RepositorySettings,
+    "requireLinkedIssue" | "linkedIssueGateMode" | "mergeReadinessGateMode"
+  >,
+): boolean {
+  return (
+    settings.requireLinkedIssue ||
+    settings.linkedIssueGateMode !== "off" ||
+    mergeReadinessGateEnabled(settings)
+  );
 }
 
 // Resolve the author login for each linked issue number. Prefers the local DB cache; on a cache MISS (issue not
@@ -1956,32 +3155,64 @@ export function shouldCollectLinkedIssueEvidence(settings: Pick<RepositorySettin
 // the self_authored_linked_issue anti-farming detection (#audit-3.11). The live token is minted lazily — only
 // when at least one issue misses the cache — so the common (fully-cached) path adds no fetch. Each lookup is
 // fail-safe: a per-issue error yields null (the detection stays fail-open only on a genuine inability to resolve).
-export async function resolveLinkedIssueAuthorLogins(env: Env, installationId: number | null | undefined, repoFullName: string, linkedIssues: number[], liveFallback = false): Promise<(string | null)[]> {
+export async function resolveLinkedIssueAuthorLogins(
+  env: Env,
+  installationId: number | null | undefined,
+  repoFullName: string,
+  linkedIssues: number[],
+  liveFallback = false,
+): Promise<(string | null)[]> {
   if (linkedIssues.length === 0) return [];
-  const cached = await Promise.all(linkedIssues.map((n) => getIssue(env, repoFullName, n).then((i) => i?.authorLogin ?? null).catch(() => null)));
+  const cached = await Promise.all(
+    linkedIssues.map((n) =>
+      getIssue(env, repoFullName, n)
+        .then((i) => i?.authorLogin ?? null)
+        .catch(() => null),
+    ),
+  );
   // The live-fetch fallback only fires when the self-authored gate can actually BLOCK (caller passes
   // liveFallback) — so quiet/advisory paths add no API calls, and we pay the fetch only where a cache miss
   // could otherwise void a hard block.
-  if (!liveFallback || !installationId || cached.every((login) => login != null)) return cached;
-  const token = await createInstallationToken(env, installationId).catch(() => undefined);
+  if (
+    !liveFallback ||
+    !installationId ||
+    cached.every((login) => login != null)
+  )
+    return cached;
+  const token = await createInstallationToken(env, installationId).catch(
+    () => undefined,
+  );
   if (!token) return cached;
   return Promise.all(
     cached.map((login, index) =>
-      login != null ? Promise.resolve(login) : fetchLinkedIssueFacts(env, repoFullName, linkedIssues[index]!, token).then((facts) => facts?.authorLogin ?? null).catch(() => null),
+      login != null
+        ? Promise.resolve(login)
+        : fetchLinkedIssueFacts(env, repoFullName, linkedIssues[index]!, token)
+            .then((facts) => facts?.authorLogin ?? null)
+            .catch(() => null),
     ),
   );
 }
 
-export function shouldCollectSlopEvidence(settings: Pick<RepositorySettings, "slopGateMode" | "mergeReadinessGateMode">): boolean {
+export function shouldCollectSlopEvidence(
+  settings: Pick<RepositorySettings, "slopGateMode" | "mergeReadinessGateMode">,
+): boolean {
   return settings.slopGateMode !== "off" || mergeReadinessGateEnabled(settings);
 }
 
-export function shouldRunSlopAiAdvisory(settings: Pick<RepositorySettings, "slopAiAdvisory" | "slopGateMode">): boolean {
+export function shouldRunSlopAiAdvisory(
+  settings: Pick<RepositorySettings, "slopAiAdvisory" | "slopGateMode">,
+): boolean {
   return settings.slopAiAdvisory && settings.slopGateMode !== "off";
 }
 
-function shouldProcessPullRequestPublicSurface(action: string | undefined): boolean {
-  return PR_PUBLIC_SURFACE_ACTIONS.has(action ?? "") || PR_GATE_CLOSED_ACTIONS.has(action ?? "");
+function shouldProcessPullRequestPublicSurface(
+  action: string | undefined,
+): boolean {
+  return (
+    PR_PUBLIC_SURFACE_ACTIONS.has(action ?? "") ||
+    PR_GATE_CLOSED_ACTIONS.has(action ?? "")
+  );
 }
 
 export function gateCheckPolicy(
@@ -1996,7 +3227,8 @@ export function gateCheckPolicy(
   // The `oss-anti-slop` pack (#692) is repo-agnostic and carries no confirmed-contributor field at all (no
   // Gittensor coupling). The `gittensor` pack still threads confirmedContributor for context/telemetry, but
   // it no longer changes the verdict — every author is gated identically. (#gate-nonconfirmed)
-  const confirmedContributorForPack = settings.gatePack === "oss-anti-slop" ? undefined : confirmedContributor;
+  const confirmedContributorForPack =
+    settings.gatePack === "oss-anti-slop" ? undefined : confirmedContributor;
   return {
     linkedIssueGateMode: settings.linkedIssueGateMode,
     duplicatePrGateMode: settings.duplicatePrGateMode,
@@ -2017,10 +3249,20 @@ export function gateCheckPolicy(
   };
 }
 
-async function loadGateAuthorHistory(env: Env, repoFullName: string, author: string | null, pullNumber: number): Promise<{ mergedPrCount: number; closedUnmergedPrCount: number }> {
+async function loadGateAuthorHistory(
+  env: Env,
+  repoFullName: string,
+  author: string | null,
+  pullNumber: number,
+): Promise<{ mergedPrCount: number; closedUnmergedPrCount: number }> {
   if (!author) return { mergedPrCount: 1, closedUnmergedPrCount: 3 };
   try {
-    return await getRepoAuthorPullRequestHistory(env, repoFullName, author, pullNumber);
+    return await getRepoAuthorPullRequestHistory(
+      env,
+      repoFullName,
+      author,
+      pullNumber,
+    );
   } catch {
     // Fail closed for firstTimeContributorGrace: if complete author history cannot be determined,
     // make the author ineligible for grace rather than publishing a would-be blocking gate as neutral.
@@ -2043,19 +3285,45 @@ async function resolvePullRequestFilesForReview(
   env: Env,
   args: { installationId: number; repoFullName: string; pullNumber: number },
 ): Promise<Awaited<ReturnType<typeof listPullRequestFiles>>> {
-  const stored = await listPullRequestFiles(env, args.repoFullName, args.pullNumber);
+  const stored = await listPullRequestFiles(
+    env,
+    args.repoFullName,
+    args.pullNumber,
+  );
   if (stored.length > 0) return stored;
   // Stored files are empty (the review fired before detail-sync). Fetch + persist inline from GitHub.
   try {
-    const token = await createInstallationToken(env, args.installationId).catch(() => undefined);
-    const fetched = await fetchAndStorePullRequestFilesForReview(env, args.repoFullName, args.pullNumber, token ?? env.GITHUB_PUBLIC_TOKEN);
+    const token = await createInstallationToken(env, args.installationId).catch(
+      () => undefined,
+    );
+    const fetched = await fetchAndStorePullRequestFilesForReview(
+      env,
+      args.repoFullName,
+      args.pullNumber,
+      token ?? env.GITHUB_PUBLIC_TOKEN,
+    );
     if (fetched.length > 0) {
-      console.log(JSON.stringify({ ev: "review_files_fetched_inline", repository: args.repoFullName, pullNumber: args.pullNumber, files: fetched.length }));
+      console.log(
+        JSON.stringify({
+          ev: "review_files_fetched_inline",
+          repository: args.repoFullName,
+          pullNumber: args.pullNumber,
+          files: fetched.length,
+        }),
+      );
       return fetched;
     }
   } catch (error) {
     /* v8 ignore next -- fail-safe: an inline fetch failure degrades to the empty stored rows (byte-identical to pre-fix). */
-    console.error(JSON.stringify({ level: "warn", event: "review_files_inline_fetch_failed", repository: args.repoFullName, pullNumber: args.pullNumber, error: errorMessage(error) }));
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "review_files_inline_fetch_failed",
+        repository: args.repoFullName,
+        pullNumber: args.pullNumber,
+        error: errorMessage(error),
+      }),
+    );
   }
   return stored;
 }
@@ -2063,7 +3331,9 @@ async function resolvePullRequestFilesForReview(
 /** Build a bounded unified-diff string from cached PR files for the AI reviewer. Caps total size so a
  *  huge PR cannot blow the model context or the neuron budget; each file's patch is taken from the raw
  *  GitHub file payload when present. */
-export function buildAiReviewDiff(files: Awaited<ReturnType<typeof listPullRequestFiles>>): string {
+export function buildAiReviewDiff(
+  files: Awaited<ReturnType<typeof listPullRequestFiles>>,
+): string {
   // Source-first + hunk-aware + always-list-dropped-files (ported from reviewbot). The old blind 60k
   // head-slice `break`-dropped whole files in stored order, so the file DEFINING a symbol could vanish
   // while another referenced it → the model hallucinated "missing import / undefined symbol" (the #1528
@@ -2071,7 +3341,10 @@ export function buildAiReviewDiff(files: Awaited<ReturnType<typeof listPullReque
   return buildUnifiedReviewDiff(
     files.map((file) => ({
       path: file.path,
-      patch: typeof file.payload?.patch === "string" ? file.payload.patch : undefined,
+      patch:
+        typeof file.payload?.patch === "string"
+          ? file.payload.patch
+          : undefined,
       status: file.status,
       additions: file.additions,
       deletions: file.deletions,
@@ -2084,12 +3357,15 @@ export function buildAiReviewDiff(files: Awaited<ReturnType<typeof listPullReque
  * this is intentionally unbudgeted and does not reorder files or drop hunks: security controls must inspect
  * every raw patch GitHub returned instead of the lossy AI-review prompt view.
  */
-export function buildSecretScanDiff(files: Awaited<ReturnType<typeof listPullRequestFiles>>): string {
+export function buildSecretScanDiff(
+  files: Awaited<ReturnType<typeof listPullRequestFiles>>,
+): string {
   return files
     .map((file) => {
       const status = file.status ?? "modified";
       const header = `### ${file.path} (${status}) +${file.additions ?? 0}/-${file.deletions ?? 0}`;
-      const patch = typeof file.payload?.patch === "string" ? file.payload.patch : "";
+      const patch =
+        typeof file.payload?.patch === "string" ? file.payload.patch : "";
       return patch ? `${header}\n${patch}` : header;
     })
     .join("\n\n")
@@ -2135,9 +3411,19 @@ export async function runAiReviewForAdvisory(
     // model for line-anchored inline findings. Absent/false ⇒ the reviewer prompt is byte-identical (no findings).
     reviewInlineComments?: boolean | undefined;
   },
-): Promise<{ notes: string; reviewerCount: number; inlineFindings: InlineFinding[] } | undefined> {
-  const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
-  if (args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha) return undefined;
+): Promise<
+  | { notes: string; reviewerCount: number; inlineFindings: InlineFinding[] }
+  | undefined
+> {
+  const packAllowsAnyAuthorBlockingReview =
+    args.settings.gatePack === "oss-anti-slop" &&
+    args.settings.aiReviewMode === "block";
+  if (
+    args.settings.aiReviewMode === "off" ||
+    (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) ||
+    !args.advisory.headSha
+  )
+    return undefined;
   // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the converged review features (reputation AI-skip,
   // grounding, RAG) activate for THIS repo only when it is allowlisted. Computed once and ANDed into each
   // feature's global flag below. Empty/unset allowlist → false → every converged branch here is unreachable
@@ -2150,62 +3436,119 @@ export async function runAiReviewForAdvisory(
   // surfaced — this only routes the private AI-spend decision. Flag-OFF (default) is an immediate no-op (no DB
   // read, no new branch) → the AI-spend gate is byte-identical to today. Fail-safe (the read degrades to
   // neutral → false on any error).
-  if (isReputationEnabled(env) && convergedRepoAllowed && (await shouldSkipAiForReputation(env, { project: args.repoFullName, submitter: args.author }))) return undefined;
+  if (
+    isReputationEnabled(env) &&
+    convergedRepoAllowed &&
+    (await shouldSkipAiForReputation(env, {
+      project: args.repoFullName,
+      submitter: args.author,
+    }))
+  )
+    return undefined;
   try {
     // BYOK: decrypt the maintainer's provider key only for confirmed contributors when opted in. Falls back to free Workers AI when
     // no key is configured or the encryption secret is unavailable (getDecryptedRepositoryAiKey → null).
     // Apply config-as-code provider/model: a declared provider must match the stored key's provider (else
     // skip BYOK → Workers-AI fallback); a declared model overrides the stored/default model.
-    const storedKey = args.confirmedContributor && args.settings.aiReviewByok ? await getDecryptedRepositoryAiKey(env, args.repoFullName) : null;
+    const storedKey =
+      args.confirmedContributor && args.settings.aiReviewByok
+        ? await getDecryptedRepositoryAiKey(env, args.repoFullName)
+        : null;
     const providerKey =
-      storedKey && (!args.settings.aiReviewProvider || args.settings.aiReviewProvider === storedKey.provider)
-        ? { provider: storedKey.provider, key: storedKey.key, model: args.settings.aiReviewModel ?? storedKey.model }
+      storedKey &&
+      (!args.settings.aiReviewProvider ||
+        args.settings.aiReviewProvider === storedKey.provider)
+        ? {
+            provider: storedKey.provider,
+            key: storedKey.key,
+            model: args.settings.aiReviewModel ?? storedKey.model,
+          }
         : null;
     // FIX B: prefer the caller's pre-resolved files (real diff even on a pre-sync first review); fall back to
     // the stored read when the caller didn't pass them (e.g. unit tests calling this function directly).
     // review.exclude_paths (#review-exclude-paths): advisory-mode prose can skip generated/lockfiles, but block
     // mode is gate-relevant and must review the full diff so excluded paths cannot bypass AI consensus blockers.
-    const allFiles = args.files ?? (await listPullRequestFiles(env, args.repoFullName, args.pr.number));
-    const files = args.settings.aiReviewMode === "block" ? allFiles : excludeReviewPaths(allFiles, args.reviewExcludePaths ?? []);
+    const allFiles =
+      args.files ??
+      (await listPullRequestFiles(env, args.repoFullName, args.pr.number));
+    const files =
+      args.settings.aiReviewMode === "block"
+        ? allFiles
+        : excludeReviewPaths(allFiles, args.reviewExcludePaths ?? []);
     // Grounding (convergence, flag-gated by GITTENSORY_REVIEW_GROUNDING). Build the FINISHED CI status + the full
     // content of the changed files so the reviewer verifies its claims against reality instead of guessing.
     // Flag-OFF (default) → we take no new branch at all: NO check/repo load, NO file fetch, and `grounding`
     // is left undefined so the prompt handed to the model is byte-identical to today. Fully fail-safe.
-    const grounding = isGroundingEnabled(env) && convergedRepoAllowed
-      ? await buildReviewGroundingText(env, {
-          repoFullName: args.repoFullName,
-          headSha: args.advisory.headSha,
-          files,
-          checks: await listCheckSummaries(env, args.repoFullName, args.pr.number),
-          installationId: (await getRepository(env, args.repoFullName))?.installationId ?? null,
-        })
-      : undefined;
+    const grounding =
+      isGroundingEnabled(env) && convergedRepoAllowed
+        ? await buildReviewGroundingText(env, {
+            repoFullName: args.repoFullName,
+            headSha: args.advisory.headSha,
+            files,
+            checks: await listCheckSummaries(
+              env,
+              args.repoFullName,
+              args.pr.number,
+            ),
+            installationId:
+              (await getRepository(env, args.repoFullName))?.installationId ??
+              null,
+          })
+        : undefined;
     // RAG retrieval (convergence, flag-gated by GITTENSORY_REVIEW_RAG). Query the codebase vector index for code/docs
     // semantically related to the changed files and append them as additive reference context — exactly like
     // grounding. Flag-OFF (default) → NO new branch: no adapter use, no vector query, and `ragContext` is left
     // undefined so the prompt is byte-identical to today. Fully fail-safe (a missing/cold index degrades to "").
-    const ragContext = isRagEnabled(env) && convergedRepoAllowed
-      ? await buildReviewRagContext(env, {
-          repoFullName: args.repoFullName,
-          title: args.pr.title,
-          files: files.map((file) => ({ path: file.path, patch: typeof file.payload?.patch === "string" ? file.payload.patch : undefined })),
-        })
-      : undefined;
+    const ragContext =
+      isRagEnabled(env) && convergedRepoAllowed
+        ? await buildReviewRagContext(env, {
+            repoFullName: args.repoFullName,
+            title: args.pr.title,
+            files: files.map((file) => ({
+              path: file.path,
+              patch:
+                typeof file.payload?.patch === "string"
+                  ? file.payload.patch
+                  : undefined,
+            })),
+          })
+        : undefined;
+    // Review-enrichment (#1472, flag-gated by GITTENSORY_REVIEW_ENRICHMENT + REES_URL). POST the PR to the external
+    // REES for the heavy/external analysis the reviewer can't run (dependency CVEs, secrets, license/EOL/supply-chain);
+    // its public-safe brief splices into the prompt next to grounding + RAG. Flag-OFF (default) → no call, no branch,
+    // byte-identical prompt. Fully fail-safe (any timeout/error/empty → undefined → review proceeds).
+    const enrichmentDiff = buildAiReviewDiff(files);
+    const enrichment =
+      isEnrichmentEnabled(env) && convergedRepoAllowed
+        ? await buildReviewEnrichment(env, {
+            repoFullName: args.repoFullName,
+            prNumber: args.pr.number,
+            headSha: args.advisory.headSha,
+            title: args.pr.title,
+            files,
+            diff: enrichmentDiff,
+          })
+        : undefined;
     const result = await runGittensoryAiReview(env, {
       repoFullName: args.repoFullName,
       prNumber: args.pr.number,
       title: args.pr.title,
       body: args.pr.body ?? undefined,
-      diff: buildAiReviewDiff(files),
+      diff: enrichmentDiff,
       actor: args.author,
       mode: args.settings.aiReviewMode === "block" ? "block" : "advisory",
       providerKey,
       grounding,
       ragContext,
+      enrichment,
       profile: args.reviewProfile ?? null,
       // Inline comments (#inline-comments): ask the model for line-anchored findings only when the operator flag,
       // the cutover allowlist, AND the per-repo manifest toggle all pass. Otherwise the prompt is byte-identical.
-      inlineFindings: shouldRequestInlineFindings(env, args.repoFullName, args.reviewInlineComments),
+      inlineFindings: shouldRequestInlineFindings(
+        env,
+        args.repoFullName,
+        args.reviewInlineComments,
+      ),
       pathGuidance: resolveReviewPathInstructions(
         args.reviewPathInstructions ?? [],
         files.map((file) => file.path),
@@ -2218,7 +3561,8 @@ export async function runAiReviewForAdvisory(
         severity: "critical",
         title: `AI reviewers agree on a likely critical defect: ${result.consensusDefect.title}`,
         detail: result.consensusDefect.detail,
-        action: "Resolve the flagged defect, or override if the AI reviewers are mistaken, then re-run the gate.",
+        action:
+          "Resolve the flagged defect, or override if the AI reviewers are mistaken, then re-run the gate.",
       };
       args.advisory.findings.push(defect);
     } else if (result.split) {
@@ -2229,8 +3573,10 @@ export async function runAiReviewForAdvisory(
         code: "ai_review_split",
         severity: "critical",
         title: "An AI reviewer flagged a likely blocking defect",
-        detail: "One AI reviewer independently flagged a concrete must-fix defect in this change (the other did not). Under the quorum rule, a single rejection closes the PR; see the review notes for specifics.",
-        action: "Resolve the flagged defect and open a new pull request, or override if the reviewers are mistaken.",
+        detail:
+          "One AI reviewer independently flagged a concrete must-fix defect in this change (the other did not). Under the quorum rule, a single rejection closes the PR; see the review notes for specifics.",
+        action:
+          "Resolve the flagged defect and open a new pull request, or override if the reviewers are mistaken.",
       });
     } else if (result.inconclusive) {
       // Fail-CLOSED (#ai-fail-closed): block-mode AI could not return a usable verdict. Hold the PR for a human
@@ -2239,13 +3585,29 @@ export async function runAiReviewForAdvisory(
         code: "ai_review_inconclusive",
         severity: "warning",
         title: "AI review could not be completed",
-        detail: "The dual-model AI review did not return a usable verdict for this change.",
-        action: "The gate is held for a human reviewer rather than passed automatically; it re-evaluates on the next update.",
+        detail:
+          "The dual-model AI review did not return a usable verdict for this change.",
+        action:
+          "The gate is held for a human reviewer rather than passed automatically; it re-evaluates on the next update.",
       });
     }
-    return result.advisoryNotes ? { notes: result.advisoryNotes, reviewerCount: result.reviewerCount, inlineFindings: result.inlineFindings } : undefined;
+    return result.advisoryNotes
+      ? {
+          notes: result.advisoryNotes,
+          reviewerCount: result.reviewerCount,
+          inlineFindings: result.inlineFindings,
+        }
+      : undefined;
   } catch (error) {
-    console.error(JSON.stringify({ level: "warn", event: "ai_review_failed", repository: args.repoFullName, pullNumber: args.pr.number, error: errorMessage(error) }));
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "ai_review_failed",
+        repository: args.repoFullName,
+        pullNumber: args.pr.number,
+        error: errorMessage(error),
+      }),
+    );
     return undefined;
   }
 }
@@ -2272,12 +3634,22 @@ export async function maybeAddSecretLeakFinding(
   // repo — NOT only the safety-flag-on / allowlisted ones. secretLeakFinding already filters to HARD_SECRET_KINDS
   // (the weak heuristics that false-positive on config/workflow content are dropped), so this never mis-fires.
   try {
-    const files = args.files ?? (await listPullRequestFiles(env, args.repoFullName, args.pullNumber));
+    const files =
+      args.files ??
+      (await listPullRequestFiles(env, args.repoFullName, args.pullNumber));
     const finding = secretLeakFinding(buildSecretScanDiff(files));
     if (finding) args.advisory.findings.push(finding);
   } catch (error) {
     /* v8 ignore next -- fail-safe: a file-load error never destabilizes the gate. */
-    console.error(JSON.stringify({ level: "warn", event: "secret_scan_failed", repository: args.repoFullName, pullNumber: args.pullNumber, error: errorMessage(error) }));
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "secret_scan_failed",
+        repository: args.repoFullName,
+        pullNumber: args.pullNumber,
+        error: errorMessage(error),
+      }),
+    );
   }
 }
 
@@ -2310,10 +3682,18 @@ export async function runAiSlopForAdvisory(
     // features. A declared provider must match the stored key's provider, else skip BYOK (Workers-AI
     // fallback). The contributor is already confirmed (early return above), so BYOK billing is authorized.
     // The slop advisory stays advisory-only regardless of which model writes it.
-    const storedKey = args.settings.aiReviewByok ? await getDecryptedRepositoryAiKey(env, args.repoFullName) : null;
+    const storedKey = args.settings.aiReviewByok
+      ? await getDecryptedRepositoryAiKey(env, args.repoFullName)
+      : null;
     const providerKey =
-      storedKey && (!args.settings.aiReviewProvider || args.settings.aiReviewProvider === storedKey.provider)
-        ? { provider: storedKey.provider, key: storedKey.key, model: args.settings.aiReviewModel ?? storedKey.model }
+      storedKey &&
+      (!args.settings.aiReviewProvider ||
+        args.settings.aiReviewProvider === storedKey.provider)
+        ? {
+            provider: storedKey.provider,
+            key: storedKey.key,
+            model: args.settings.aiReviewModel ?? storedKey.model,
+          }
         : null;
     const result = await runGittensoryAiSlopAdvisory(env, {
       repoFullName: args.repoFullName,
@@ -2325,9 +3705,18 @@ export async function runAiSlopForAdvisory(
       deterministicBand: args.deterministicBand,
       providerKey,
     });
-    if (result.status === "ok" && result.finding) args.advisory.findings.push(result.finding);
+    if (result.status === "ok" && result.finding)
+      args.advisory.findings.push(result.finding);
   } catch (error) {
-    console.error(JSON.stringify({ level: "warn", event: "ai_slop_failed", repository: args.repoFullName, pullNumber: args.pr.number, error: errorMessage(error) }));
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "ai_slop_failed",
+        repository: args.repoFullName,
+        pullNumber: args.pr.number,
+        error: errorMessage(error),
+      }),
+    );
   }
 }
 
@@ -2338,8 +3727,16 @@ export async function runAiSlopForAdvisory(
  * 0 so the winner's close reason OMITS the "duplicate of another open PR" cause (agent-actions only adds it
  * when count > 0). Flag-OFF (default) returns the real sibling count — byte-identical to today.
  */
-export function dupWinnerLinkedDuplicateCount(openSiblingNumbers: number[], prNumber: number, duplicateWinnerEnabled: boolean): number {
-  if (duplicateWinnerEnabled && isDuplicateClusterWinner(prNumber, openSiblingNumbers)) return 0;
+export function dupWinnerLinkedDuplicateCount(
+  openSiblingNumbers: number[],
+  prNumber: number,
+  duplicateWinnerEnabled: boolean,
+): number {
+  if (
+    duplicateWinnerEnabled &&
+    isDuplicateClusterWinner(prNumber, openSiblingNumbers)
+  )
+    return 0;
   return openSiblingNumbers.length;
 }
 
@@ -2367,30 +3764,51 @@ export async function reconcileLiveDuplicateSiblings(
   const linkedIssues = new Set(pr.linkedIssues);
   if (linkedIssues.size === 0) return otherOpenPullRequests;
   const lowerOverlapping = otherOpenPullRequests.filter(
-    (other) => other.number < pr.number && other.state === "open" && other.linkedIssues.some((issue) => linkedIssues.has(issue)),
+    (other) =>
+      other.number < pr.number &&
+      other.state === "open" &&
+      other.linkedIssues.some((issue) => linkedIssues.has(issue)),
   );
   if (lowerOverlapping.length === 0) return otherOpenPullRequests;
-  const installationToken = installationId === null ? undefined : await createInstallationToken(env, installationId).catch(() => undefined);
+  const installationToken =
+    installationId === null
+      ? undefined
+      : await createInstallationToken(env, installationId).catch(
+          () => undefined,
+        );
   const token = installationToken ?? env.GITHUB_PUBLIC_TOKEN;
   const staleClosed = new Set<number>();
   await Promise.all(
     lowerOverlapping.map(async (sibling) => {
-      const liveState = await fetchLivePullRequestState(env, repoFullName, sibling.number, token).catch(() => undefined);
-      if (liveState !== undefined && liveState !== "open") staleClosed.add(sibling.number);
+      const liveState = await fetchLivePullRequestState(
+        env,
+        repoFullName,
+        sibling.number,
+        token,
+      ).catch(() => undefined);
+      if (liveState !== undefined && liveState !== "open")
+        staleClosed.add(sibling.number);
     }),
   );
   if (staleClosed.size === 0) return otherOpenPullRequests;
-  return otherOpenPullRequests.filter((other) => !staleClosed.has(other.number));
+  return otherOpenPullRequests.filter(
+    (other) => !staleClosed.has(other.number),
+  );
 }
 
-export function linkedIssueDuplicatePullRequestsForGate(pr: PullRequestRecord, pullRequests: PullRequestRecord[]): number[] {
+export function linkedIssueDuplicatePullRequestsForGate(
+  pr: PullRequestRecord,
+  pullRequests: PullRequestRecord[],
+): number[] {
   const linkedIssues = new Set(pr.linkedIssues);
   if (linkedIssues.size === 0) return [];
   return [
     ...new Set(
       pullRequests.flatMap((otherPr) => {
         if (otherPr.number === pr.number || otherPr.state !== "open") return [];
-        return otherPr.linkedIssues.some((issue) => linkedIssues.has(issue)) ? [otherPr.number] : [];
+        return otherPr.linkedIssues.some((issue) => linkedIssues.has(issue))
+          ? [otherPr.number]
+          : [];
       }),
     ),
   ].sort((left, right) => left - right);
@@ -2431,7 +3849,11 @@ export function reputationOutcomeFromTerminalState(
 ): SubmissionOutcome | undefined {
   const merged = Boolean(payload?.merged_at) || Boolean(pr.mergedAt);
   if (pr.state !== "open") return merged ? "merged" : "closed";
-  if (gate && (gate.conclusion === "failure" || gate.conclusion === "action_required")) return "manual";
+  if (
+    gate &&
+    (gate.conclusion === "failure" || gate.conclusion === "action_required")
+  )
+    return "manual";
   return undefined;
 }
 
@@ -2443,7 +3865,13 @@ async function maybePublishPrPublicSurface(
   repo: Awaited<ReturnType<typeof getRepository>>,
   settings: Awaited<ReturnType<typeof getRepositorySettings>>,
   advisory: Awaited<ReturnType<typeof buildPullRequestAdvisory>>,
-  webhook: { deliveryId: string; authorType?: string | undefined; action?: string | undefined; previewPollAttempt?: number | undefined; skipAiReview?: boolean | undefined },
+  webhook: {
+    deliveryId: string;
+    authorType?: string | undefined;
+    action?: string | undefined;
+    previewPollAttempt?: number | undefined;
+    skipAiReview?: boolean | undefined;
+  },
 ): Promise<ReturnType<typeof evaluateGateCheck> | undefined> {
   const author = pr.authorLogin ?? null;
   // Resolve the repo's action mode ONCE for the whole publish pass and thread it into every GitHub write below, so
@@ -2454,11 +3882,14 @@ async function maybePublishPrPublicSurface(
   // only when it is allowlisted AND the global GITTENSORY_REVIEW_UNIFIED_COMMENT flag is ON. Computed once and ANDed into
   // both unified-comment sites below (closed/skipped + open). Empty/unset allowlist → false → both sites keep
   // the LEGACY panel byte-identical for every repo regardless of GITTENSORY_REVIEW_UNIFIED_COMMENT.
-  const unifiedCommentAllowed = isUnifiedReviewCommentEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
+  const unifiedCommentAllowed =
+    isUnifiedReviewCommentEnabled(env) &&
+    isConvergenceRepoAllowed(env, repoFullName);
   // `settings` is the EFFECTIVE config (`.gittensory.yml` > DB > defaults), resolved by the caller via
   // resolveRepositorySettings — so gate on/off and every blocker mode already reflect the repo's config
   // file. The gate verdict is the same for every author; confirmedContributor feeds only on-chain scoring.
-  const gateEnabled = settings.gateCheckMode === "enabled" && Boolean(advisory.headSha);
+  const gateEnabled =
+    settings.gateCheckMode === "enabled" && Boolean(advisory.headSha);
   // Cheap, network-free skip checks (also avoids the miner lookup when it would be wasted).
   const prelim = decidePublicSurface({
     settings,
@@ -2469,14 +3900,29 @@ async function maybePublishPrPublicSurface(
   });
   let publicSurfaceSkipped = false;
   if (prelim.skipped) {
-    await auditPrVisibilitySkip(env, repoFullName, pr.number, author, prelim.skipReason ?? "skipped", webhook.deliveryId);
+    await auditPrVisibilitySkip(
+      env,
+      repoFullName,
+      pr.number,
+      author,
+      prelim.skipReason ?? "skipped",
+      webhook.deliveryId,
+    );
     publicSurfaceSkipped = true;
   }
   const needsMinerCheckForDetectedComment =
     !publicSurfaceSkipped &&
     settings.commentMode === "detected_contributors_only" &&
-    (settings.publicSurface === "comment_and_label" || settings.publicSurface === "comment_only");
-  if (!gateEnabled && (publicSurfaceSkipped || (prelim.actions.length === 1 && prelim.actions[0] === "none" && !needsMinerCheckForDetectedComment))) return undefined;
+    (settings.publicSurface === "comment_and_label" ||
+      settings.publicSurface === "comment_only");
+  if (
+    !gateEnabled &&
+    (publicSurfaceSkipped ||
+      (prelim.actions.length === 1 &&
+        prelim.actions[0] === "none" &&
+        !needsMinerCheckForDetectedComment))
+  )
+    return undefined;
   if (!author && !gateEnabled) return undefined;
 
   if (gateEnabled && (pr.state !== "open" || webhook.action === "closed")) {
@@ -2485,28 +3931,64 @@ async function maybePublishPrPublicSurface(
     // the actual diff + verdict) with an empty "advisory only — 0 files — no longer open" skip card — so a
     // freshly MERGED PR ended up showing a contentless review. The real review must survive the merge/close.
     // (#preserve-review-on-close) A bot-CLOSED PR still gets its close reasoning from the executor's close comment.
-    const gateCheckResult = await createOrUpdateSkippedGateCheckRun(env, installationId, repoFullName, advisory, "PR closed before full evaluation.", mode);
+    const gateCheckResult = await createOrUpdateSkippedGateCheckRun(
+      env,
+      installationId,
+      repoFullName,
+      advisory,
+      "PR closed before full evaluation.",
+      mode,
+    );
     if (gateCheckResult?.kind === "permission_missing") {
-      await auditGateCheckPermissionMissing(env, author, repoFullName, pr.number, webhook.deliveryId, gateCheckResult.warning);
+      await auditGateCheckPermissionMissing(
+        env,
+        author,
+        repoFullName,
+        pr.number,
+        webhook.deliveryId,
+        gateCheckResult.warning,
+      );
     }
     return undefined;
   }
   const prelimHasPublicOutput =
-    !publicSurfaceSkipped && (needsMinerCheckForDetectedComment || prelim.actions.some((action) => action === "comment" || action === "label" || action === "check_run"));
-  let official: Awaited<ReturnType<typeof getCachedOfficialMinerDetection>> | null = null;
+    !publicSurfaceSkipped &&
+    (needsMinerCheckForDetectedComment ||
+      prelim.actions.some(
+        (action) =>
+          action === "comment" || action === "label" || action === "check_run",
+      ));
+  let official: Awaited<
+    ReturnType<typeof getCachedOfficialMinerDetection>
+  > | null = null;
   let decision = prelim;
   if (prelimHasPublicOutput && author) {
-    const requireOfficialMiner = settings.publicAudienceMode === "gittensor_only";
+    const requireOfficialMiner =
+      settings.publicAudienceMode === "gittensor_only";
     official = await getCachedOfficialMinerDetection(env, author, {
       targetKey: `${repoFullName}#${pr.number}`,
       deliveryId: webhook.deliveryId,
     });
     if (requireOfficialMiner && official.status === "unavailable") {
-      await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "miner_detection_unavailable", webhook.deliveryId);
+      await auditPrVisibilitySkip(
+        env,
+        repoFullName,
+        pr.number,
+        author,
+        "miner_detection_unavailable",
+        webhook.deliveryId,
+      );
       if (!gateEnabled) return undefined;
       publicSurfaceSkipped = true;
     } else if (requireOfficialMiner && official.status !== "confirmed") {
-      await auditPrVisibilitySkip(env, repoFullName, pr.number, author, "not_official_gittensor_miner", webhook.deliveryId);
+      await auditPrVisibilitySkip(
+        env,
+        repoFullName,
+        pr.number,
+        author,
+        "not_official_gittensor_miner",
+        webhook.deliveryId,
+      );
       if (!gateEnabled) return undefined;
       publicSurfaceSkipped = true;
     }
@@ -2518,20 +4000,45 @@ async function maybePublishPrPublicSurface(
       minerStatus: official.status,
     });
 
-    if (!gateEnabled && decision.actions.length === 1 && decision.actions[0] === "none") return undefined;
+    if (
+      !gateEnabled &&
+      decision.actions.length === 1 &&
+      decision.actions[0] === "none"
+    )
+      return undefined;
   }
 
   // Respect the per-repo agent pause: suppress all public surface mutations (label, comment, context
   // check run) so a paused repo sees no gittensory-authored GitHub content. The Gittensory Gate check
   // run still posts so the required-check status is not broken (#agent-pause).
-  if (settings.agentPaused) decision = { ...decision, willLabel: false, willComment: false, willCheckRun: false };
+  if (settings.agentPaused)
+    decision = {
+      ...decision,
+      willLabel: false,
+      willComment: false,
+      willCheckRun: false,
+    };
 
   let pendingGateCheckRunId: number | undefined;
   if (gateEnabled) {
-    const pendingGateResult = await createOrUpdatePendingGateCheckRun(env, installationId, repoFullName, advisory, mode);
-    if (pendingGateResult?.kind === "published") pendingGateCheckRunId = pendingGateResult.id;
+    const pendingGateResult = await createOrUpdatePendingGateCheckRun(
+      env,
+      installationId,
+      repoFullName,
+      advisory,
+      mode,
+    );
+    if (pendingGateResult?.kind === "published")
+      pendingGateCheckRunId = pendingGateResult.id;
     if (pendingGateResult?.kind === "permission_missing") {
-      await auditGateCheckPermissionMissing(env, author, repoFullName, pr.number, webhook.deliveryId, pendingGateResult.warning);
+      await auditGateCheckPermissionMissing(
+        env,
+        author,
+        repoFullName,
+        pr.number,
+        webhook.deliveryId,
+        pendingGateResult.warning,
+      );
     }
   }
 
@@ -2546,7 +4053,9 @@ async function maybePublishPrPublicSurface(
   let gateEvaluation: ReturnType<typeof evaluateGateCheck> | undefined;
   // inlineFindings is present ONLY on a FRESH review (cache miss) with inline comments enabled; the AI cache
   // round-trips just notes + reviewerCount, so a cache hit carries no findings and never re-posts (#inline-comments).
-  let aiReview: { notes: string; reviewerCount: number; inlineFindings?: InlineFinding[] } | undefined;
+  let aiReview:
+    | { notes: string; reviewerCount: number; inlineFindings?: InlineFinding[] }
+    | undefined;
   let gateFinalized = false;
   // The PR's changed files are needed by the slop/manifest gates, the AI review + grounding + RAG, the secret
   // scan, the check-run, and the unified comment. Resolve them AT MOST ONCE per review and share across the
@@ -2555,9 +4064,17 @@ async function maybePublishPrPublicSurface(
   // them pays nothing. resolvePullRequestFilesForReview prefers the stored rows and, when they are empty at
   // review time (the webhook beat detail-sync), fetches + persists them inline — so the FIRST review sees the
   // real diff instead of "0 files / No diff provided" (FIX B). Fail-safe by construction.
-  let reviewFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null = null;
-  const getReviewFiles = async (): Promise<Awaited<ReturnType<typeof listPullRequestFiles>>> => {
-    if (reviewFiles === null) reviewFiles = await resolvePullRequestFilesForReview(env, { installationId, repoFullName, pullNumber: pr.number });
+  let reviewFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null =
+    null;
+  const getReviewFiles = async (): Promise<
+    Awaited<ReturnType<typeof listPullRequestFiles>>
+  > => {
+    if (reviewFiles === null)
+      reviewFiles = await resolvePullRequestFilesForReview(env, {
+        installationId,
+        repoFullName,
+        pullNumber: pr.number,
+      });
     return reviewFiles;
   };
   try {
@@ -2566,8 +4083,17 @@ async function maybePublishPrPublicSurface(
       listPullRequests(env, repoFullName),
       listBountiesByRepo(env, repoFullName),
     ]);
-    collisions = buildCollisionReport(repoFullName, repoIssues, repoPullRequests);
-    queueHealth = buildQueueHealth(repo, repoIssues, repoPullRequests, collisions);
+    collisions = buildCollisionReport(
+      repoFullName,
+      repoIssues,
+      repoPullRequests,
+    );
+    queueHealth = buildQueueHealth(
+      repo,
+      repoIssues,
+      repoPullRequests,
+      collisions,
+    );
     preflight = buildPreflightResult(
       {
         repoFullName,
@@ -2588,15 +4114,24 @@ async function maybePublishPrPublicSurface(
     // penalty (below), and the public panel builders (further down) so they agree by construction. Flag-OFF
     // (default) ⇒ duplicateWinnerEnabled is false and isDupWinner is false ⇒ every guard short-circuits
     // (byte-identical).
-    const linkedDuplicatePrsForGate = linkedIssueDuplicatePullRequestsForGate(pr, repoPullRequests);
+    const linkedDuplicatePrsForGate = linkedIssueDuplicatePullRequestsForGate(
+      pr,
+      repoPullRequests,
+    );
     const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
-    const isDupWinner = duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, linkedDuplicatePrsForGate);
+    const isDupWinner =
+      duplicateWinnerEnabled &&
+      isDuplicateClusterWinner(pr.number, linkedDuplicatePrsForGate);
     const readiness = buildPublicReadinessScore({
       pr,
       preflight,
       queueHealth,
       linkedDuplicatePrs: isDupWinner ? [] : linkedDuplicatePrsForGate,
-      scopedOverlapCount: unionScopedOverlapClusters(collisions, pr, preflight.collisions).length,
+      scopedOverlapCount: unionScopedOverlapClusters(
+        collisions,
+        pr,
+        preflight.collisions,
+      ).length,
     });
 
     if (gateEnabled && author && !publicSurfaceSkipped && !official) {
@@ -2617,31 +4152,58 @@ async function maybePublishPrPublicSurface(
     let slopRisk: number | null = null;
     // Slop (#530) and focus-manifest-policy (#555) gates both need the PR's changed files; load via the shared
     // resolver (lazy — a repo with both off pays nothing; see getReviewFiles above).
-    let gateFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null = null;
-    if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
+    let gateFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null =
+      null;
+    if (
+      shouldCollectSlopEvidence(settings) ||
+      settings.manifestPolicyGateMode !== "off"
+    ) {
       gateFiles = await getReviewFiles();
     }
     if (shouldCollectSlopEvidence(settings)) {
       const slopFiles = gateFiles ?? [];
       const slop = buildSlopAssessment({
-        changedFiles: slopFiles.map((file) => ({ path: file.path, additions: file.additions, deletions: file.deletions })),
+        changedFiles: slopFiles.map((file) => ({
+          path: file.path,
+          additions: file.additions,
+          deletions: file.deletions,
+        })),
         description: pr.body,
         // Reuse the collision report already built for this gate run so a duplicate-cluster PR is flagged (#563).
         // Duplicate-winner adjudication (#dup-winner): the winner is judged on its OWN merits, so it is NOT
         // penalized for the cluster. Flag-OFF ⇒ isDupWinner is false ⇒ byte-identical to today.
-        inDuplicateCluster: !isDupWinner && isPullRequestInDuplicateCluster(collisions, pr.number),
+        inDuplicateCluster:
+          !isDupWinner &&
+          isPullRequestInDuplicateCluster(collisions, pr.number),
       });
       slopRisk = slop.slopRisk;
       advisory.findings.push(...slop.findings);
       // Persist dashboard-visible slop only when the repo opted into the slop gate. Merge-readiness may
       // still use the live score above, but disabling slop should clear any previously cached dashboard row.
       // Best-effort: a write hiccup must not abort gate evaluation.
-      const persistedSlop = settings.slopGateMode === "off" ? { slopRisk: null, slopBand: null } : { slopRisk: slop.slopRisk, slopBand: slop.band };
-      await updatePullRequestSlopAssessment(env, repoFullName, pr.number, persistedSlop).catch(() => undefined);
+      const persistedSlop =
+        settings.slopGateMode === "off"
+          ? { slopRisk: null, slopBand: null }
+          : { slopRisk: slop.slopRisk, slopBand: slop.band };
+      await updatePullRequestSlopAssessment(
+        env,
+        repoFullName,
+        pr.number,
+        persistedSlop,
+      ).catch(() => undefined);
       // AI-assisted slop advisory (#533, opt-in). Reuses the already-fetched files; appends at most one
       // advisory-only finding. Deliberately does NOT update slopRisk — only the deterministic core blocks.
       if (shouldRunSlopAiAdvisory(settings)) {
-        await runAiSlopForAdvisory(env, { settings, advisory, repoFullName, pr, author, files: slopFiles, deterministicBand: slop.band, confirmedContributor });
+        await runAiSlopForAdvisory(env, {
+          settings,
+          advisory,
+          repoFullName,
+          pr,
+          author,
+          files: slopFiles,
+          deterministicBand: slop.band,
+          confirmedContributor,
+        });
       }
     }
     // Focus-manifest policy (#555, opt-in via manifestPolicyGateMode). Reload the CACHED manifest (the
@@ -2656,10 +4218,15 @@ async function maybePublishPrPublicSurface(
         changedPaths: manifestFiles.map((file) => file.path),
         labels: pr.labels,
         linkedIssueCount: pr.linkedIssues.length,
-        testFileCount: manifestFiles.filter((file) => isTestPath(file.path)).length,
+        testFileCount: manifestFiles.filter((file) => isTestPath(file.path))
+          .length,
         passedValidationCount: 0,
       });
-      const policyCodes = new Set(["manifest_blocked_path", "manifest_linked_issue_required", "manifest_missing_tests"]);
+      const policyCodes = new Set([
+        "manifest_blocked_path",
+        "manifest_linked_issue_required",
+        "manifest_missing_tests",
+      ]);
       for (const finding of guidance.findings) {
         if (!policyCodes.has(finding.code)) continue;
         advisory.findings.push(publicSafeManifestPolicyFinding(finding));
@@ -2671,7 +4238,9 @@ async function maybePublishPrPublicSurface(
     // one when the maintainer set enforce: true — BEFORE the gate evaluates. No AI judgment, so this can never cause
     // an AI false-close. The manifest is cached (settings resolution loaded it), so this is a cheap hit;
     // resolveReviewPreMergeChecks fail-safes to [] on a load error. Empty (default) ⇒ no finding (byte-identical).
-    const preMergeChecks = resolveReviewPreMergeChecks(await loadRepoFocusManifest(env, repoFullName).catch(() => null));
+    const preMergeChecks = resolveReviewPreMergeChecks(
+      await loadRepoFocusManifest(env, repoFullName).catch(() => null),
+    );
     if (preMergeChecks.length > 0) {
       const checkFiles = await getReviewFiles(); // memoized — reuses the gate/slop diff when already resolved
       // An empty resolved file set means the changed paths could not be resolved (a PR always touches >=1 file),
@@ -2697,21 +4266,47 @@ async function maybePublishPrPublicSurface(
     // Contributor blacklist (#1425): a blocked author's PR is closed by the deterministic disposition, so it must
     // NEVER spend an AI call — skip the AI review entirely when the author is blacklisted (the gate + disposition
     // still run; the close fires there). Per-repo list now; the shared/global list unions in once its table lands.
-    const authorBlacklisted = isAuthorBlacklisted(author, settings.contributorBlacklist);
-    const aiReviewWillRun = !webhook.skipAiReview && settings.aiReviewMode !== "off" && Boolean(advisory.headSha) && !authorBlacklisted;
+    const authorBlacklisted = isAuthorBlacklisted(
+      author,
+      settings.contributorBlacklist,
+    );
+    const aiReviewWillRun =
+      !webhook.skipAiReview &&
+      settings.aiReviewMode !== "off" &&
+      Boolean(advisory.headSha) &&
+      !authorBlacklisted;
     // Post a transient "🟪 reviewing…" placeholder BEFORE the AI runs so contributors see the bot
     // is actively working rather than silent. In-place upsert: once the final verdict is ready it
     // overwrites this comment. Best-effort — a failed post never aborts the review. (#reviewing-placeholder)
-    if (shouldPostReviewingPlaceholder({ aiReviewWillRun, mode, willComment: decision.willComment })) {
+    if (
+      shouldPostReviewingPlaceholder({
+        aiReviewWillRun,
+        mode,
+        willComment: decision.willComment,
+      })
+    ) {
       const placeholderBody = `${PR_PANEL_COMMENT_MARKER}\n\n${renderReviewingPlaceholder()}`;
-      await createOrUpdatePrIntelligenceComment(env, installationId, repoFullName, pr.number, placeholderBody, { mode }).catch(() => undefined);
+      await createOrUpdatePrIntelligenceComment(
+        env,
+        installationId,
+        repoFullName,
+        pr.number,
+        placeholderBody,
+        { mode },
+      ).catch(() => undefined);
     }
     if (aiReviewWillRun) {
       // #1 self-host AI-review cache: the LLM output for a PR changes only when the code (head SHA) or the review
       // mode changes, so reuse a prior review for this exact (repo, pr, head SHA, mode) — a re-delivered webhook or
       // the block-mode ~2-min re-gate sweep (which re-runs the AI for every open PR) need not re-spend the call. On
       // self-host there is no AI gateway, so this is the only AI cache. The deterministic gate below still runs.
-      const cachedReview = await getCachedAiReview(env, repoFullName, pr.number, advisory.headSha, settings.aiReviewMode).catch(() => null);
+      const cachedReview = await getCachedAiReview(
+        env,
+        repoFullName,
+        pr.number,
+        advisory.headSha,
+        settings.aiReviewMode,
+      ).catch(() => null);
       if (cachedReview) {
         aiReview = cachedReview;
       } else {
@@ -2720,7 +4315,14 @@ async function maybePublishPrPublicSurface(
         // resolution, so a cheap cache hit — no extra fetch) and thread them into the AI review. Profile shapes
         // nitpickiness; path-instructions add per-path guidance; exclude-paths drop files from review. Absent ⇒
         // byte-identical prompt. Fail-safe to defaults on any read error (resolveReviewPromptOverrides).
-        const { profile: reviewProfile, inlineComments: reviewInlineComments, pathInstructions: reviewPathInstructions, excludePaths: reviewExcludePaths } = resolveReviewPromptOverrides(await loadRepoFocusManifest(env, repoFullName).catch(() => null));
+        const {
+          profile: reviewProfile,
+          inlineComments: reviewInlineComments,
+          pathInstructions: reviewPathInstructions,
+          excludePaths: reviewExcludePaths,
+        } = resolveReviewPromptOverrides(
+          await loadRepoFocusManifest(env, repoFullName).catch(() => null),
+        );
         aiReview = await runAiReviewForAdvisory(env, {
           settings,
           advisory,
@@ -2734,7 +4336,15 @@ async function maybePublishPrPublicSurface(
           reviewExcludePaths,
           reviewInlineComments,
         });
-        if (aiReview) await putCachedAiReview(env, repoFullName, pr.number, advisory.headSha, settings.aiReviewMode, aiReview).catch(() => undefined);
+        if (aiReview)
+          await putCachedAiReview(
+            env,
+            repoFullName,
+            pr.number,
+            advisory.headSha,
+            settings.aiReviewMode,
+            aiReview,
+          ).catch(() => undefined);
       }
     }
 
@@ -2751,28 +4361,54 @@ async function maybePublishPrPublicSurface(
     // First-time-contributor grace (#552): compute the author's complete per-repo PR history
     // (excluding this PR) with an aggregate DB query. Do not derive policy-enforcement history from
     // the bounded repoPullRequests sample; missing or case-mismatched history could soften a block.
-    const authorHistory = await loadGateAuthorHistory(env, repoFullName, author, pr.number);
+    const authorHistory = await loadGateAuthorHistory(
+      env,
+      repoFullName,
+      author,
+      pr.number,
+    );
 
-    const gatePolicy = gateCheckPolicy(settings, readiness.total, confirmedContributor, slopRisk, authorHistory);
-    gateEvaluation = gateEnabled ? evaluateGateCheck(advisory, gatePolicy) : undefined;
+    const gatePolicy = gateCheckPolicy(
+      settings,
+      readiness.total,
+      confirmedContributor,
+      slopRisk,
+      authorHistory,
+    );
+    gateEvaluation = gateEnabled
+      ? evaluateGateCheck(advisory, gatePolicy)
+      : undefined;
     // Deterministic content/registry surface lane (#1255) — flag-gated + per-repo allowlist, byte-identical when
     // off (evaluateWithSurfaceLane returns the generic evaluation unchanged and resolves no files). A metagraphed
     // registry-submission PR's surface verdict OVERRIDES the generic gate; the helper preserves a generic HARD
     // blocker (e.g. a committed secret) and an unreadable head defers. AI-free → independent of the AI reviewer.
-    gateEvaluation = await evaluateWithSurfaceLane(env, repoFullName, gateEnabled, gateEvaluation, {
-      installationId,
-      pr,
-      repo,
-      advisory,
-      getChangedFiles: getReviewFiles,
-    });
+    gateEvaluation = await evaluateWithSurfaceLane(
+      env,
+      repoFullName,
+      gateEnabled,
+      gateEvaluation,
+      {
+        installationId,
+        pr,
+        repo,
+        advisory,
+        getChangedFiles: getReviewFiles,
+      },
+    );
     // #554 gate false-positive telemetry: when the gate BLOCKS, record the block (one latest row per PR) so a
     // maintainer can later compute a per-gate-type false-positive rate (blocked-then-merged / blocked).
     // MEASUREMENT only — never adjusts the gate. Best-effort: a write failure must NOT abort finalization
     // (mirrors the slop-assessment persist above). Privacy: codes + PR number only, no actor/trust fields.
     if (gateEvaluation?.conclusion === "failure") {
-      const blockerCodes = gateEvaluation.blockers.map((blocker) => blocker.code);
-      await recordGateBlockOutcome(env, { repoFullName, pullNumber: pr.number, headSha: pr.headSha, blockerCodes }).catch(() => undefined);
+      const blockerCodes = gateEvaluation.blockers.map(
+        (blocker) => blocker.code,
+      );
+      await recordGateBlockOutcome(env, {
+        repoFullName,
+        pullNumber: pr.number,
+        headSha: pr.headSha,
+        blockerCodes,
+      }).catch(() => undefined);
       await recordGithubProductUsage(env, "gate_blocked", {
         repoFullName,
         targetKey: `${repoFullName}#${pr.number}`,
@@ -2787,8 +4423,17 @@ async function maybePublishPrPublicSurface(
     // authoritative 'reviewbot' rows it is later compared against are written by reviewbot's deploy-time dual-
     // run, not here (see src/review/parity-wire.ts). Only a finalized gate evaluation (not skipped) is recorded.
     if (gateEvaluation) {
-      const reasonCode = gateEvaluation.conclusion === "failure" ? (gateEvaluation.blockers[0]?.code ?? gateEvaluation.conclusion) : gateEvaluation.conclusion;
-      await recordNativeGateDecision(env, { project: repoFullName, pullNumber: pr.number, headSha: pr.headSha, conclusion: gateEvaluation.conclusion, reasonCode });
+      const reasonCode =
+        gateEvaluation.conclusion === "failure"
+          ? (gateEvaluation.blockers[0]?.code ?? gateEvaluation.conclusion)
+          : gateEvaluation.conclusion;
+      await recordNativeGateDecision(env, {
+        project: repoFullName,
+        pullNumber: pr.number,
+        headSha: pr.headSha,
+        conclusion: gateEvaluation.conclusion,
+        reasonCode,
+      });
     }
     if (gateEnabled) {
       try {
@@ -2809,14 +4454,28 @@ async function maybePublishPrPublicSurface(
         );
         if (gateCheckResult?.kind === "published") gateFinalized = true;
         if (gateCheckResult?.kind === "permission_missing") {
-          await auditGateCheckPermissionMissing(env, author, repoFullName, pr.number, webhook.deliveryId, gateCheckResult.warning);
+          await auditGateCheckPermissionMissing(
+            env,
+            author,
+            repoFullName,
+            pr.number,
+            webhook.deliveryId,
+            gateCheckResult.warning,
+          );
           // A 403 on the COMPLETION call is classified as permission_missing and does NOT throw, so the catch
           // below never runs and the pending in_progress check would be orphaned. But the pending check already
           // posted (pendingGateCheckRunId is set), proving the App had Checks:write — so a 403 here is almost
           // always a transient secondary-rate-limit, not a real revocation. Finalize the pending check to
           // neutral (mirrors the catch); if it were a genuine revocation this PATCH also 403s and is swallowed.
           if (pendingGateCheckRunId !== undefined && !gateFinalized) {
-            await createOrUpdateErroredGateCheckRun(env, installationId, repoFullName, advisory, { checkRunId: pendingGateCheckRunId }, mode).catch(() => undefined);
+            await createOrUpdateErroredGateCheckRun(
+              env,
+              installationId,
+              repoFullName,
+              advisory,
+              { checkRunId: pendingGateCheckRunId },
+              mode,
+            ).catch(() => undefined);
             gateFinalized = true;
           }
         }
@@ -2827,7 +4486,14 @@ async function maybePublishPrPublicSurface(
         // grew long with failing-check names) were silently never reviewed or closed. Finalize the pending
         // check to a neutral terminal state so it doesn't hang, log, and CONTINUE — do not re-throw.
         if (pendingGateCheckRunId !== undefined && !gateFinalized) {
-          await createOrUpdateErroredGateCheckRun(env, installationId, repoFullName, advisory, { checkRunId: pendingGateCheckRunId }, mode).catch(() => undefined);
+          await createOrUpdateErroredGateCheckRun(
+            env,
+            installationId,
+            repoFullName,
+            advisory,
+            { checkRunId: pendingGateCheckRunId },
+            mode,
+          ).catch(() => undefined);
           gateFinalized = true;
         }
         await recordAuditEvent(env, {
@@ -2846,7 +4512,14 @@ async function maybePublishPrPublicSurface(
     // the gate was enabled, a pending check id exists, and a real conclusion was not already published.
     if (gateEnabled && pendingGateCheckRunId !== undefined && !gateFinalized) {
       /* v8 ignore next -- outer-catch recovery for a mid-evaluation throw; the mode-threaded errored-finalize is exercised by its inner-catch twin above */
-      await createOrUpdateErroredGateCheckRun(env, installationId, repoFullName, advisory, { checkRunId: pendingGateCheckRunId }, mode).catch(() => undefined);
+      await createOrUpdateErroredGateCheckRun(
+        env,
+        installationId,
+        repoFullName,
+        advisory,
+        { checkRunId: pendingGateCheckRunId },
+        mode,
+      ).catch(() => undefined);
       await recordAuditEvent(env, {
         eventType: "github_app.gate_finalized_on_error",
         actor: author,
@@ -2862,16 +4535,43 @@ async function maybePublishPrPublicSurface(
   if (!prelimHasPublicOutput) return gateEvaluation;
   if (publicSurfaceSkipped || !official || !author) return gateEvaluation;
 
-  const [github] = await Promise.all([fetchPublicContributorProfile(author, env)]);
-  const contributorPullRequests: Awaited<ReturnType<typeof listContributorPullRequests>> = [];
-  const contributorIssues: Awaited<ReturnType<typeof listContributorIssues>> = [];
-  const repoStats: Awaited<ReturnType<typeof listContributorRepoStats>> = official.status === "confirmed" ? contributorRepoStatsFromGittensor(official.snapshot) : [];
+  const [github] = await Promise.all([
+    fetchPublicContributorProfile(author, env),
+  ]);
+  const contributorPullRequests: Awaited<
+    ReturnType<typeof listContributorPullRequests>
+  > = [];
+  const contributorIssues: Awaited<ReturnType<typeof listContributorIssues>> =
+    [];
+  const repoStats: Awaited<ReturnType<typeof listContributorRepoStats>> =
+    official.status === "confirmed"
+      ? contributorRepoStatsFromGittensor(official.snapshot)
+      : [];
   const detection =
     official.status === "confirmed"
-      ? officialGittensorContributorDetection(official.snapshot, pr, contributorPullRequests, contributorIssues, repoStats)
-      : { detected: false, reason: "Official Gittensor API did not confirm this GitHub user.", priorPullRequests: 0, priorMergedPullRequests: 0, priorIssues: 0 };
+      ? officialGittensorContributorDetection(
+          official.snapshot,
+          pr,
+          contributorPullRequests,
+          contributorIssues,
+          repoStats,
+        )
+      : {
+          detected: false,
+          reason: "Official Gittensor API did not confirm this GitHub user.",
+          priorPullRequests: 0,
+          priorMergedPullRequests: 0,
+          priorIssues: 0,
+        };
 
-  const profile = buildContributorProfile(author, github, contributorPullRequests, contributorIssues, repoStats, official.status === "confirmed" ? official.snapshot : null);
+  const profile = buildContributorProfile(
+    author,
+    github,
+    contributorPullRequests,
+    contributorIssues,
+    repoStats,
+    official.status === "confirmed" ? official.snapshot : null,
+  );
   const publishedOutputs: PublicSurfaceOutput[] = [];
   const failedOutputs: PublicSurfaceOutputFailure[] = [];
 
@@ -2894,7 +4594,10 @@ async function maybePublishPrPublicSurface(
         mode,
       );
       if (checkRunResult?.kind === "permission_missing") {
-        failedOutputs.push({ output: "check_run", error: checkRunResult.warning });
+        failedOutputs.push({
+          output: "check_run",
+          error: checkRunResult.warning,
+        });
         await recordAuditEvent(env, {
           eventType: "github_app.check_run_permission_missing",
           actor: author,
@@ -2909,19 +4612,41 @@ async function maybePublishPrPublicSurface(
     } catch (error) {
       const message = errorMessage(error);
       failedOutputs.push({ output: "check_run", error: message });
-      await recordPublicSurfaceOutputFailure(env, "check_run", author, repoFullName, pr.number, webhook.deliveryId, message);
+      await recordPublicSurfaceOutputFailure(
+        env,
+        "check_run",
+        author,
+        repoFullName,
+        pr.number,
+        webhook.deliveryId,
+        message,
+      );
     }
   }
 
   if (decision.willComment) {
     // Maintainer review-content overrides from `.gittensory.yml` (footer text, row toggles, intro note).
     // Cached, so this is a DB read after the settings resolution already loaded the manifest.
-    const reviewConfig = (await loadRepoFocusManifest(env, repoFullName)).review;
+    const reviewConfig = (await loadRepoFocusManifest(env, repoFullName))
+      .review;
     // Duplicate-winner adjudication (#dup-winner): thread the flag into the public panel builders so the
     // winner's hard-duplicate block is suppressed (they recompute the winner from their own open-only sibling
     // list). Flag-OFF (default) ⇒ false ⇒ the panels are byte-identical to today.
     const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
-    const commentArgs = { repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: gateEvaluation, review: reviewConfig, aiReview, duplicateWinnerEnabled };
+    const commentArgs = {
+      repo,
+      pr,
+      profile,
+      detection,
+      queueHealth,
+      collisions,
+      preflight,
+      settings,
+      gate: gateEvaluation,
+      review: reviewConfig,
+      aiReview,
+      duplicateWinnerEnabled,
+    };
     let deterministicBody: string;
     // Convergence (Stage D): when the unified-review-comment flag is ON, render the single converged comment
     // (gittensory shape + reviewbot's review folded in). The gate stays authoritative (passed as `decision`),
@@ -2954,28 +4679,55 @@ async function maybePublishPrPublicSurface(
       // never captured, which is why a red codecov was shown as "CI green". Use the SAME live fetch the
       // auto-maintain planner uses so the public chip and the disposition can never disagree. "pending" folds to
       // the "unverified" bucket for the 3-state comment chip (renders "CI pending").
-      const ciToken = await createInstallationToken(env, installationId).catch(() => undefined);
+      const ciToken = await createInstallationToken(env, installationId).catch(
+        () => undefined,
+      );
       // RC2: only branch-protection-required checks gate the PR; a red codecov/* is surfaced but never blocks.
-      const requiredContexts = await fetchRequiredStatusContexts(env, repoFullName, pr.baseRef ?? repo?.defaultBranch, ciToken ?? env.GITHUB_PUBLIC_TOKEN);
-      const liveCi = await fetchLiveCiAggregate(env, repoFullName, pr.headSha, ciToken ?? env.GITHUB_PUBLIC_TOKEN, requiredContexts);
+      const requiredContexts = await fetchRequiredStatusContexts(
+        env,
+        repoFullName,
+        pr.baseRef ?? repo?.defaultBranch,
+        ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+      );
+      const liveCi = await fetchLiveCiAggregate(
+        env,
+        repoFullName,
+        pr.headSha,
+        ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+        requiredContexts,
+      );
       // Live merge-state too — the SAME source the disposition uses (planAgentMaintenanceActions reads liveMergeState).
       // The stored pr.mergeableState lags GitHub's async recompute, so a base-conflicting PR could read `clean` here
       // ("✅ safe to merge") while the disposition reads the live `dirty` and auto-CLOSES it — the exact #4220
       // contradiction. (#review-audit / #ready-needs-mergeable)
-      const liveMergeState = await fetchLivePullRequestMergeState(env, repoFullName, pr.number, ciToken ?? env.GITHUB_PUBLIC_TOKEN).catch(() => undefined);
+      const liveMergeState = await fetchLivePullRequestMergeState(
+        env,
+        repoFullName,
+        pr.number,
+        ciToken ?? env.GITHUB_PUBLIC_TOKEN,
+      ).catch(() => undefined);
       const mergeStateLabel = liveMergeState ?? pr.mergeableState; // fail-safe to the stored value
-      const ciState: MergeReadiness["ciState"] = liveCi.ciState === "passed" ? "passed" : liveCi.ciState === "failed" ? "failed" : "unverified";
+      const ciState: MergeReadiness["ciState"] =
+        liveCi.ciState === "passed"
+          ? "passed"
+          : liveCi.ciState === "failed"
+            ? "failed"
+            : "unverified";
       // Per-failed-check WHY (codecov %/test/lint reason) from each check-run output or commit-status
       // description — capped + public-safe (name + short reason only). The renderer lists these under the CI chip.
-      const failingDetails: CheckFailureDetail[] = liveCi.failingDetails.map((detail) => ({
-        name: detail.name,
-        ...(detail.summary ? { summary: detail.summary } : {}),
-        ...(detail.detailsUrl ? { detailsUrl: detail.detailsUrl } : {}),
-      }));
+      const failingDetails: CheckFailureDetail[] = liveCi.failingDetails.map(
+        (detail) => ({
+          name: detail.name,
+          ...(detail.summary ? { summary: detail.summary } : {}),
+          ...(detail.detailsUrl ? { detailsUrl: detail.detailsUrl } : {}),
+        }),
+      );
       const mergeReadiness: MergeReadiness = {
         ciState,
         ...(mergeStateLabel ? { mergeStateLabel } : {}),
-        ...(failingDetails.length > 0 ? { failingChecks: failingDetails.map((detail) => detail.name) } : {}),
+        ...(failingDetails.length > 0
+          ? { failingChecks: failingDetails.map((detail) => detail.name) }
+          : {}),
         ...(failingDetails.length > 0 ? { failingDetails } : {}),
       };
       // CI-refutation for the PUBLIC comment (#ai-ci-refutation): when the gate FAILED solely on an AI-judgment
@@ -2984,7 +4736,11 @@ async function maybePublishPrPublicSurface(
       // SAME grounding+convergence gate as the disposition refutation (a single `aiCiRefutationActive` call so this
       // site carries no branch), built AFTER the live CI is resolved and used for BOTH the panel rows and the
       // comment body so the two never disagree. Gate OFF ⇒ commentGate === gateEvaluation (byte-identical comment).
-      const commentGate = reconcileGateEvaluationForGreenCi(gateEvaluation, ciState, aiCiRefutationActive(env, repoFullName));
+      const commentGate = reconcileGateEvaluationForGreenCi(
+        gateEvaluation,
+        ciState,
+        aiCiRefutationActive(env, repoFullName),
+      );
       // Guarded-hold (#guarded-hold-comment): a clean+green PR whose diff touches a hard-guardrail path is HELD
       // for owner review by the disposition (planAgentMaintenanceActions), never auto-merged — so the comment
       // must render "held for review", not "✅ safe to merge". Compute the SAME guardrail-hit the disposition uses
@@ -2996,11 +4752,27 @@ async function maybePublishPrPublicSurface(
       // Held-vs-closed parity (#8/#9): the disposition NEVER auto-closes an owner / automation-bot PR, so a gate
       // "close" verdict on one must headline "held", not "Closed". Compute the same author classification the
       // planner uses (repo-owner login match + protected automation author) and thread it to the comment.
-      const commentRepoOwner = repoFullName.includes("/") ? repoFullName.slice(0, repoFullName.indexOf("/")) : "";
+      const commentRepoOwner = repoFullName.includes("/")
+        ? repoFullName.slice(0, repoFullName.indexOf("/"))
+        : "";
       const commentAuthorLogin = pr.authorLogin ?? "";
       const neverClosed =
-        (commentAuthorLogin.length > 0 && commentAuthorLogin.toLowerCase() === commentRepoOwner.toLowerCase()) || isProtectedAutomationAuthor(pr.authorLogin);
-      const { rows, readinessTotal } = buildPublicPrPanelSignalRows({ repo, pr, profile, detection, queueHealth, collisions, preflight, settings, gate: commentGate, duplicateWinnerEnabled });
+        (commentAuthorLogin.length > 0 &&
+          commentAuthorLogin.toLowerCase() ===
+            commentRepoOwner.toLowerCase()) ||
+        isProtectedAutomationAuthor(pr.authorLogin);
+      const { rows, readinessTotal } = buildPublicPrPanelSignalRows({
+        repo,
+        pr,
+        profile,
+        detection,
+        queueHealth,
+        collisions,
+        preflight,
+        settings,
+        gate: commentGate,
+        duplicateWinnerEnabled,
+      });
       // Visual before/after capture (visual-capture port). Fires ONLY when (1) the global flag + per-repo
       // cutover gate both allow it (screenshotsAllowed) AND (2) the PR touches WEB-VISIBLE files (isVisualPath
       // — frontend pages / public OG images; backend .ts/.md/.json PRs never qualify). Fully wrapped in
@@ -3008,31 +4780,64 @@ async function maybePublishPrPublicSurface(
       // NEVER sink the review — it just omits the "Visual preview" section. Flag-OFF (default) ⇒ this block is
       // skipped entirely and the unified comment is byte-identical.
       let beforeAfter: CaptureRoute[] = [];
-      const visualFiles = unifiedFiles.map((file) => file.path).filter(isVisualPath);
+      const visualFiles = unifiedFiles
+        .map((file) => file.path)
+        .filter(isVisualPath);
       if (screenshotsAllowed(env, repoFullName) && visualFiles.length > 0) {
         try {
           const token = await createInstallationToken(env, installationId);
-          const capture = await buildCapture(env, token, {
-            repoFullName,
-            prNumber: pr.number,
-            ...(pr.headSha ? { headSha: pr.headSha } : {}),
-            ...(pr.headRef ? { headRef: pr.headRef } : {}),
-            previewFromChecks: true,
-          }, visualFiles);
+          const capture = await buildCapture(
+            env,
+            token,
+            {
+              repoFullName,
+              prNumber: pr.number,
+              ...(pr.headSha ? { headSha: pr.headSha } : {}),
+              ...(pr.headRef ? { headRef: pr.headRef } : {}),
+              previewFromChecks: true,
+            },
+            visualFiles,
+          );
           beforeAfter = capture.routes;
           // Visual self-poll: the FIRST capture returns a "loading" placeholder for the AFTER shot when the
           // preview deploy isn't live yet (capture.previewPending). Schedule a delayed re-review to re-capture
           // the now-ready shot — bounded by `attempt` so a never-resolving preview can't loop (the deployment_status
           // webhook also refills it; this is the backstop when that event is missed/late).
           const previewPollAttempt = webhook.previewPollAttempt ?? 0;
-          if (capture.previewPending && previewPollAttempt < MAX_PREVIEW_POLLS) {
+          if (
+            capture.previewPending &&
+            previewPollAttempt < MAX_PREVIEW_POLLS
+          ) {
             await env.JOBS.send(
-              { type: "recapture-preview", deliveryId: webhook.deliveryId, repoFullName, prNumber: pr.number, installationId, attempt: previewPollAttempt + 1 },
+              {
+                type: "recapture-preview",
+                deliveryId: webhook.deliveryId,
+                repoFullName,
+                prNumber: pr.number,
+                installationId,
+                attempt: previewPollAttempt + 1,
+              },
               { delaySeconds: PREVIEW_POLL_SECONDS },
-            ).catch((error) => console.log(JSON.stringify({ ev: "recapture_enqueue_failed", repoFullName, pull: pr.number, message: errorMessage(error).slice(0, 120) })));
+            ).catch((error) =>
+              console.log(
+                JSON.stringify({
+                  ev: "recapture_enqueue_failed",
+                  repoFullName,
+                  pull: pr.number,
+                  message: errorMessage(error).slice(0, 120),
+                }),
+              ),
+            );
           }
         } catch (error) {
-          console.log(JSON.stringify({ ev: "visual_capture_error", repoFullName, pull: pr.number, message: errorMessage(error).slice(0, 200) }));
+          console.log(
+            JSON.stringify({
+              ev: "visual_capture_error",
+              repoFullName,
+              pull: pr.number,
+              message: errorMessage(error).slice(0, 200),
+            }),
+          );
         }
       }
       deterministicBody = buildUnifiedCommentBody({
@@ -3040,10 +4845,14 @@ async function maybePublishPrPublicSurface(
         ...(aiReview !== undefined ? { aiReview } : {}),
         advisoryFindings: advisory.findings,
         panelRows: rows,
-        ...(reviewConfig?.fields !== undefined ? { reviewFields: reviewConfig.fields } : {}),
+        ...(reviewConfig?.fields !== undefined
+          ? { reviewFields: reviewConfig.fields }
+          : {}),
         readinessTotal,
         changedFiles: unifiedFiles.length,
-        ...(aiReview?.reviewerCount !== undefined ? { reviewerCount: aiReview.reviewerCount } : {}),
+        ...(aiReview?.reviewerCount !== undefined
+          ? { reviewerCount: aiReview.reviewerCount }
+          : {}),
         mergeReadiness,
         heldForReview,
         neverClosed,
@@ -3060,8 +4869,12 @@ async function maybePublishPrPublicSurface(
           ...(aiReview !== undefined ? { aiReview } : {}),
         }),
         footerMarkdown: gittensoryFooter({
-          earnUrl: repo?.isRegistered ? gittensorRepoEarnUrl(repoFullName) : undefined,
-          ...(reviewConfig?.footerText ? { customText: reviewConfig.footerText } : {}),
+          earnUrl: repo?.isRegistered
+            ? gittensorRepoEarnUrl(repoFullName)
+            : undefined,
+          ...(reviewConfig?.footerText
+            ? { customText: reviewConfig.footerText }
+            : {}),
         }),
         reRunLabel: `${PR_PANEL_RETRIGGER_MARKER} Re-run Gittensory review`,
         ...(beforeAfter.length > 0 ? { beforeAfter } : {}),
@@ -3070,12 +4883,27 @@ async function maybePublishPrPublicSurface(
       deterministicBody = buildPublicPrIntelligenceComment(commentArgs);
     }
     try {
-      await createOrUpdatePrIntelligenceComment(env, installationId, repoFullName, pr.number, deterministicBody, { mode });
+      await createOrUpdatePrIntelligenceComment(
+        env,
+        installationId,
+        repoFullName,
+        pr.number,
+        deterministicBody,
+        { mode },
+      );
       publishedOutputs.push("comment");
     } catch (error) {
       const message = errorMessage(error);
       failedOutputs.push({ output: "comment", error: message });
-      await recordPublicSurfaceOutputFailure(env, "comment", author, repoFullName, pr.number, webhook.deliveryId, message);
+      await recordPublicSurfaceOutputFailure(
+        env,
+        "comment",
+        author,
+        repoFullName,
+        pr.number,
+        webhook.deliveryId,
+        message,
+      );
     }
     // Quiet inline review comments (#inline-comments): layer the AI's line-anchored findings on top of the
     // summary just posted, as a NON-BLOCKING COMMENT review. A no-op (no extra work) unless this is a fresh
@@ -3093,15 +4921,30 @@ async function maybePublishPrPublicSurface(
   }
   if (decision.willLabel) {
     try {
-      await ensurePullRequestLabel(env, installationId, repoFullName, pr.number, settings.gittensorLabel, {
-        createMissingLabel: settings.createMissingLabel,
-        mode,
-      });
+      await ensurePullRequestLabel(
+        env,
+        installationId,
+        repoFullName,
+        pr.number,
+        settings.gittensorLabel,
+        {
+          createMissingLabel: settings.createMissingLabel,
+          mode,
+        },
+      );
       publishedOutputs.push("label");
     } catch (error) {
       const message = errorMessage(error);
       failedOutputs.push({ output: "label", error: message });
-      await recordPublicSurfaceOutputFailure(env, "label", author, repoFullName, pr.number, webhook.deliveryId, message);
+      await recordPublicSurfaceOutputFailure(
+        env,
+        "label",
+        author,
+        repoFullName,
+        pr.number,
+        webhook.deliveryId,
+        message,
+      );
     }
     // Per-PR TYPE label (reviewbot auto-label parity): exactly ONE of gittensor:bug/feature/priority by the PR
     // title + changed paths. Review-time + neutral, BEST-EFFORT + independent of the context label above so a
@@ -3109,15 +4952,48 @@ async function maybePublishPrPublicSurface(
     // (otherwise the label is title-derived). The status labels (ready-to-merge etc.) remain the autonomy layer's.
     if (settings.autoLabelEnabled) {
       try {
-        const contentGlobs = (settings as { contentGlobs?: string[] }).contentGlobs ?? [];
-        const typeFiles = contentGlobs.length > 0 ? await getReviewFiles().catch(() => [] as Awaited<ReturnType<typeof getReviewFiles>>) : [];
-        const chosenType = resolvePrTypeLabel({ title: pr.title, changedPaths: typeFiles.map((file) => file.path), contentGlobs });
-        await ensurePullRequestLabel(env, installationId, repoFullName, pr.number, chosenType, { createMissingLabel: true, mode });
-        for (const other of ALL_TYPE_LABELS.filter((label) => label !== chosenType)) {
-          await removePullRequestLabel(env, installationId, repoFullName, pr.number, other, mode);
+        const contentGlobs =
+          (settings as { contentGlobs?: string[] }).contentGlobs ?? [];
+        const typeFiles =
+          contentGlobs.length > 0
+            ? await getReviewFiles().catch(
+                () => [] as Awaited<ReturnType<typeof getReviewFiles>>,
+              )
+            : [];
+        const chosenType = resolvePrTypeLabel({
+          title: pr.title,
+          changedPaths: typeFiles.map((file) => file.path),
+          contentGlobs,
+        });
+        await ensurePullRequestLabel(
+          env,
+          installationId,
+          repoFullName,
+          pr.number,
+          chosenType,
+          { createMissingLabel: true, mode },
+        );
+        for (const other of ALL_TYPE_LABELS.filter(
+          (label) => label !== chosenType,
+        )) {
+          await removePullRequestLabel(
+            env,
+            installationId,
+            repoFullName,
+            pr.number,
+            other,
+            mode,
+          );
         }
       } catch (error) {
-        console.log(JSON.stringify({ ev: "type_label_error", repoFullName, pull: pr.number, message: errorMessage(error).slice(0, 150) }));
+        console.log(
+          JSON.stringify({
+            ev: "type_label_error",
+            repoFullName,
+            pull: pr.number,
+            message: errorMessage(error).slice(0, 150),
+          }),
+        );
       }
     }
   }
@@ -3129,7 +5005,11 @@ async function maybePublishPrPublicSurface(
         targetKey: `${repoFullName}#${pr.number}`,
         outcome: "error",
         detail: failedOutputs.map((failure) => failure.output).join(","),
-        metadata: { deliveryId: webhook.deliveryId, repoFullName, failedOutputs },
+        metadata: {
+          deliveryId: webhook.deliveryId,
+          repoFullName,
+          failedOutputs,
+        },
       });
     }
     return gateEvaluation;
@@ -3194,11 +5074,22 @@ async function recordGithubProductUsage(
     actor?: string | null | undefined;
     repoFullName?: string | null | undefined;
     targetKey?: string | null | undefined;
-    outcome?: "success" | "denied" | "error" | "queued" | "completed" | "skipped";
+    outcome?:
+      | "success"
+      | "denied"
+      | "error"
+      | "queued"
+      | "completed"
+      | "skipped";
     metadata?: Record<string, unknown>;
   },
 ): Promise<void> {
-  const actorRole = typeof event.metadata?.actorKind === "string" ? event.metadata.actorKind : typeof event.metadata?.role === "string" ? event.metadata.role : undefined;
+  const actorRole =
+    typeof event.metadata?.actorKind === "string"
+      ? event.metadata.actorKind
+      : typeof event.metadata?.role === "string"
+        ? event.metadata.role
+        : undefined;
   await recordProductUsageEvent(env, {
     surface: "github_app",
     eventName,
@@ -3219,9 +5110,22 @@ async function recordGithubProductUsage(
  * cached head, so a transient GitHub hiccup never strands the override — it just targets the stored SHA as before.
  * Mirrors the rebase path's live re-fetch (prReadyForReview) and the dup-winner live reconcile.
  */
-export async function resolveOverrideHeadSha(env: Env, installationId: number, repoFullName: string, pr: PullRequestRecord): Promise<string | null | undefined> {
-  const token = (await createInstallationToken(env, installationId).catch(() => undefined)) ?? env.GITHUB_PUBLIC_TOKEN;
-  const liveHeadSha = await fetchLivePullRequestHeadSha(env, repoFullName, pr.number, token);
+export async function resolveOverrideHeadSha(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  pr: PullRequestRecord,
+): Promise<string | null | undefined> {
+  const token =
+    (await createInstallationToken(env, installationId).catch(
+      () => undefined,
+    )) ?? env.GITHUB_PUBLIC_TOKEN;
+  const liveHeadSha = await fetchLivePullRequestHeadSha(
+    env,
+    repoFullName,
+    pr.number,
+    token,
+  );
   return liveHeadSha ?? pr.headSha;
 }
 
@@ -3232,7 +5136,11 @@ export async function resolveOverrideHeadSha(env: Env, installationId: number, r
  * payload.comment.author_association. The override is intentionally NOT persisted: a follow-up push
  * re-evaluates the Gate from scratch (no permanent bypass).
  */
-async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeProcessGateOverrideCommand(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   const comment = payload.comment;
   const command = parseGittensoryMentionCommand(comment?.body);
   if (!command || command.name !== "gate-override") return false;
@@ -3241,22 +5149,58 @@ async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, pay
   const issue = payload.issue;
   const installationId = getInstallationId(payload);
   const actor = payload.sender?.login ?? comment?.user?.login ?? null;
-  const targetKey = repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
+  const targetKey =
+    repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
   if (payload.action !== "created") {
-    await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "unsupported_comment_action");
+    await recordGateOverrideSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "unsupported_comment_action",
+    );
     return true;
   }
-  if (comment?.user?.type === "Bot" || payload.sender?.type === "Bot" || /\[bot\]$/i.test(actor ?? "")) {
-    await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "bot_author");
+  if (
+    comment?.user?.type === "Bot" ||
+    payload.sender?.type === "Bot" ||
+    /\[bot\]$/i.test(actor ?? "")
+  ) {
+    await recordGateOverrideSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "bot_author",
+    );
     return true;
   }
   if (!repoFullName || !issue?.pull_request || !installationId || !actor) {
-    await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "missing_repo_pr_installation_or_actor");
+    await recordGateOverrideSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "missing_repo_pr_installation_or_actor",
+    );
     return true;
   }
-  const [pr, settings] = await Promise.all([getPullRequest(env, repoFullName, issue.number), resolveRepositorySettings(env, repoFullName)]);
+  const [pr, settings] = await Promise.all([
+    getPullRequest(env, repoFullName, issue.number),
+    resolveRepositorySettings(env, repoFullName),
+  ]);
   if (!pr) {
-    await recordGateOverrideSkip(env, deliveryId, repoFullName, targetKey, actor, "cached_pr_missing");
+    await recordGateOverrideSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "cached_pr_missing",
+    );
     return true;
   }
 
@@ -3278,14 +5222,28 @@ async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, pay
       targetKey: `${repoFullName}#${pr.number}`,
       outcome: "denied",
       detail: authorization.reason,
-      metadata: { deliveryId, repoFullName, allowedRoles: commandAuthorizationAllowedRoles(settings.commandAuthorization, "gate-override") },
+      metadata: {
+        deliveryId,
+        repoFullName,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          "gate-override",
+        ),
+      },
     });
     await recordGithubProductUsage(env, "gate_override_denied", {
       actor,
       repoFullName,
       targetKey: `${repoFullName}#${pr.number}`,
       outcome: "denied",
-      metadata: { reason: authorization.reason, actorKind: authorization.actorKind, allowedRoles: commandAuthorizationAllowedRoles(settings.commandAuthorization, "gate-override") },
+      metadata: {
+        reason: authorization.reason,
+        actorKind: authorization.actorKind,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          "gate-override",
+        ),
+      },
     });
     return true;
   }
@@ -3294,18 +5252,42 @@ async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, pay
   // The override is a per-commit neutral check-run, so posting it on the cached SHA is a silent no-op on the LIVE
   // head (whose Gate check stays blocking). Re-fetch the live head and override THAT commit (fail-open to the
   // cached head), then thread it through the advisory so the check-run + audit target the right SHA.
-  const headForOverride = await resolveOverrideHeadSha(env, installationId, repoFullName, pr);
-  const prAtLiveHead = headForOverride === pr.headSha ? pr : { ...pr, headSha: headForOverride };
-  const { advisory } = await buildAuthorizedPrActionAdvisory(env, repoFullName, prAtLiveHead, settings);
-  const safeReason = sanitizePublicComment((command.reason ?? "").trim() || "No reason provided.");
-  await createOrUpdateOverriddenGateCheckRun(env, installationId, repoFullName, advisory, { actor, reason: safeReason });
+  const headForOverride = await resolveOverrideHeadSha(
+    env,
+    installationId,
+    repoFullName,
+    pr,
+  );
+  const prAtLiveHead =
+    headForOverride === pr.headSha ? pr : { ...pr, headSha: headForOverride };
+  const { advisory } = await buildAuthorizedPrActionAdvisory(
+    env,
+    repoFullName,
+    prAtLiveHead,
+    settings,
+  );
+  const safeReason = sanitizePublicComment(
+    (command.reason ?? "").trim() || "No reason provided.",
+  );
+  await createOrUpdateOverriddenGateCheckRun(
+    env,
+    installationId,
+    repoFullName,
+    advisory,
+    { actor, reason: safeReason },
+  );
   await recordAuditEvent(env, {
     eventType: "github_app.gate_overridden",
     actor,
     targetKey: `${repoFullName}#${pr.number}`,
     outcome: "completed",
     detail: safeReason,
-    metadata: { deliveryId, repoFullName, headSha: advisory.headSha ?? null, cachedHeadSha: pr.headSha ?? null },
+    metadata: {
+      deliveryId,
+      repoFullName,
+      headSha: advisory.headSha ?? null,
+      cachedHeadSha: pr.headSha ?? null,
+    },
   });
   const confirmation = sanitizePublicComment(
     [
@@ -3321,18 +5303,29 @@ async function maybeProcessGateOverrideCommand(env: Env, deliveryId: string, pay
       gittensoryFooter(),
     ].join("\n"),
   );
-  await createOrUpdateAgentCommandComment(env, installationId, repoFullName, issue.number, confirmation);
+  await createOrUpdateAgentCommandComment(
+    env,
+    installationId,
+    repoFullName,
+    issue.number,
+    confirmation,
+  );
   await recordGithubProductUsage(env, "gate_overridden", {
     actor,
     repoFullName,
     targetKey: `${repoFullName}#${pr.number}`,
     outcome: "completed",
-    metadata: { actorKind: authorization.actorKind, headSha: advisory.headSha ?? null },
+    metadata: {
+      actorKind: authorization.actorKind,
+      headSha: advisory.headSha ?? null,
+    },
   });
   // #554 gate false-positive telemetry: flag the gate-block row as maintainer-overridden — the strongest
   // false-positive signal (a human explicitly judged the block wrong). Best-effort + no-op if no block was
   // recorded; never affects the override outcome above.
-  await markGateOutcomeOverridden(env, repoFullName, pr.number).catch(() => undefined);
+  await markGateOutcomeOverridden(env, repoFullName, pr.number).catch(
+    () => undefined,
+  );
   return true;
 }
 
@@ -3370,7 +5363,11 @@ async function recordGateOverrideSkip(
  * recorded as a skip and never throws into the webhook loop. A per-actor/per-repo cooldown prevents repeated
  * maintainer comments from spending shared AI quota in a burst.
  */
-async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeProcessPlanCommand(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   if (!isPlannerEnabled(env)) return false; // flag-OFF → not handled here; the worker is byte-identical to today
   if (!isPlanCommand(payload.comment?.body)) return false;
   // #22: planning is ISSUE-only. A `@gittensory plan` on a PR is not a plan request, so DON'T consume it — fall
@@ -3380,7 +5377,14 @@ async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: Gi
   // All eligibility guards live in the PURE classifier (exhaustively unit-tested); here we carry one ok branch.
   const req = classifyPlanCommandRequest(payload, getInstallationId(payload));
   if (!req.ok) {
-    await recordPlanSkip(env, deliveryId, req.repoFullName, req.targetKey, req.actor, req.reason);
+    await recordPlanSkip(
+      env,
+      deliveryId,
+      req.repoFullName,
+      req.targetKey,
+      req.actor,
+      req.reason,
+    );
     return true;
   }
   const targetKey = `${req.repoFullName}#${req.issue.number}`;
@@ -3390,7 +5394,12 @@ async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: Gi
   // `plan` defaults to maintainer/collaborator (DEFAULT_COMMAND_AUTHORIZATION_POLICY), so the default behavior is
   // unchanged; a maintainer can now widen/narrow it like any other command.
   const settings = await resolveRepositorySettings(env, req.repoFullName);
-  const association = await resolveRealRepoPermissionAssociation(env, req.installationId, req.repoFullName, req.actor);
+  const association = await resolveRealRepoPermissionAssociation(
+    env,
+    req.installationId,
+    req.repoFullName,
+    req.actor,
+  );
   const authorization = evaluateCommandAuthorization({
     policy: settings.commandAuthorization,
     commandName: "plan",
@@ -3398,19 +5407,65 @@ async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: Gi
     commenterAssociation: association,
   });
   if (!authorization.authorized) {
-    await recordPlanSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, authorization.reason);
+    await recordPlanSkip(
+      env,
+      deliveryId,
+      req.repoFullName,
+      targetKey,
+      req.actor,
+      authorization.reason,
+    );
     return true;
   }
-  if (await isPlanCommandCoolingDown(env, req.repoFullName, req.actor, ISSUE_PLAN_COOLDOWN_MS)) {
-    await recordPlanSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, "cooldown_active");
+  if (
+    await isPlanCommandCoolingDown(
+      env,
+      req.repoFullName,
+      req.actor,
+      ISSUE_PLAN_COOLDOWN_MS,
+    )
+  ) {
+    await recordPlanSkip(
+      env,
+      deliveryId,
+      req.repoFullName,
+      targetKey,
+      req.actor,
+      "cooldown_active",
+    );
     return true;
   }
-  const plan = await generateIssuePlan(env, { title: req.issue.title, body: req.issue.body }, { actor: req.actor, repoFullName: req.repoFullName, issueNumber: req.issue.number });
+  const plan = await generateIssuePlan(
+    env,
+    { title: req.issue.title, body: req.issue.body },
+    {
+      actor: req.actor,
+      repoFullName: req.repoFullName,
+      issueNumber: req.issue.number,
+    },
+  );
   if (!plan) {
-    await recordPlanSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, "no_plan_generated");
+    await recordPlanSkip(
+      env,
+      deliveryId,
+      req.repoFullName,
+      targetKey,
+      req.actor,
+      "no_plan_generated",
+    );
     return true;
   }
-  await createIssueComment(env, req.installationId, req.repoFullName, req.issue.number, buildIssuePlanComment(plan, { actor: req.actor, repoFullName: req.repoFullName, issueNumber: req.issue.number }));
+  await createIssueComment(
+    env,
+    req.installationId,
+    req.repoFullName,
+    req.issue.number,
+    buildIssuePlanComment(plan, {
+      actor: req.actor,
+      repoFullName: req.repoFullName,
+      issueNumber: req.issue.number,
+    }),
+  );
   await recordAuditEvent(env, {
     eventType: "github_app.issue_plan_generated",
     actor: req.actor,
@@ -3419,11 +5474,22 @@ async function maybeProcessPlanCommand(env: Env, deliveryId: string, payload: Gi
     detail: `Implementation plan posted for ${targetKey}.`,
     metadata: { deliveryId, repoFullName: req.repoFullName },
   });
-  await recordGithubProductUsage(env, "issue_plan_generated", { actor: req.actor, repoFullName: req.repoFullName, targetKey, outcome: "completed", metadata: {} });
+  await recordGithubProductUsage(env, "issue_plan_generated", {
+    actor: req.actor,
+    repoFullName: req.repoFullName,
+    targetKey,
+    outcome: "completed",
+    metadata: {},
+  });
   return true;
 }
 
-async function isPlanCommandCoolingDown(env: Env, repoFullName: string, actor: string, cooldownMs: number): Promise<boolean> {
+async function isPlanCommandCoolingDown(
+  env: Env,
+  repoFullName: string,
+  actor: string,
+  cooldownMs: number,
+): Promise<boolean> {
   const since = new Date(Date.now() - cooldownMs).toISOString();
   const row = await env.DB.prepare(
     `select 1 as active
@@ -3440,7 +5506,14 @@ async function isPlanCommandCoolingDown(env: Env, repoFullName: string, actor: s
   return Boolean(row);
 }
 
-async function recordPlanSkip(env: Env, deliveryId: string, repoFullName: string | null, targetKey: string | null, actor: string | null, reason: string): Promise<void> {
+async function recordPlanSkip(
+  env: Env,
+  deliveryId: string,
+  repoFullName: string | null,
+  targetKey: string | null,
+  actor: string | null,
+  reason: string,
+): Promise<void> {
   await recordAuditEvent(env, {
     eventType: "github_app.issue_plan_skipped",
     actor,
@@ -3449,30 +5522,70 @@ async function recordPlanSkip(env: Env, deliveryId: string, repoFullName: string
     detail: reason,
     metadata: { deliveryId, repoFullName, reason },
   });
-  await recordGithubProductUsage(env, "issue_plan_skipped", { actor, repoFullName, targetKey, outcome: "skipped", metadata: { reason } });
+  await recordGithubProductUsage(env, "issue_plan_skipped", {
+    actor,
+    repoFullName,
+    targetKey,
+    outcome: "skipped",
+    metadata: { reason },
+  });
 }
 
-async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeProcessPrPanelRetrigger(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   const comment = payload.comment;
-  if (payload.action !== "edited" || !comment || !isCheckedPrPanelRetrigger(comment.body)) return false;
+  if (
+    payload.action !== "edited" ||
+    !comment ||
+    !isCheckedPrPanelRetrigger(comment.body)
+  )
+    return false;
   if (!isGittensoryPanelBotComment(env, comment.user)) return false;
 
   const repoFullName = payload.repository?.full_name;
   const issue = payload.issue;
   const installationId = getInstallationId(payload);
   const actor = payload.sender?.login ?? null;
-  const targetKey = repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
+  const targetKey =
+    repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
   if (payload.sender?.type === "Bot" || /\[bot\]$/i.test(actor ?? "")) {
-    await recordPrPanelRetriggerSkip(env, deliveryId, repoFullName, targetKey, actor, "bot_author");
+    await recordPrPanelRetriggerSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "bot_author",
+    );
     return true;
   }
   if (!repoFullName || !issue?.pull_request || !installationId) {
-    await recordPrPanelRetriggerSkip(env, deliveryId, repoFullName, targetKey, actor, "missing_repo_pr_or_installation");
+    await recordPrPanelRetriggerSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "missing_repo_pr_or_installation",
+    );
     return true;
   }
-  const [pr, settings] = await Promise.all([getPullRequest(env, repoFullName, issue.number), resolveRepositorySettings(env, repoFullName)]);
+  const [pr, settings] = await Promise.all([
+    getPullRequest(env, repoFullName, issue.number),
+    resolveRepositorySettings(env, repoFullName),
+  ]);
   if (!pr) {
-    await recordPrPanelRetriggerSkip(env, deliveryId, repoFullName, targetKey, actor, "cached_pr_missing");
+    await recordPrPanelRetriggerSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "cached_pr_missing",
+    );
     return true;
   }
 
@@ -3489,18 +5602,40 @@ async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payloa
     needsMinerDetection: true,
   });
   if (!authorization.authorized) {
-    await recordPrPanelRetriggerSkip(env, deliveryId, repoFullName, `${repoFullName}#${pr.number}`, actor, authorization.reason);
+    await recordPrPanelRetriggerSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      `${repoFullName}#${pr.number}`,
+      actor,
+      authorization.reason,
+    );
     await recordGithubProductUsage(env, "pr_panel_retrigger_skipped", {
       actor,
       repoFullName,
       targetKey: `${repoFullName}#${pr.number}`,
-      outcome: authorization.reason === "miner_detection_unavailable" ? "error" : "skipped",
-      metadata: { reason: authorization.reason, actorKind: authorization.actorKind, allowedRoles: commandAuthorizationAllowedRoles(settings.commandAuthorization, "review-now") },
+      outcome:
+        authorization.reason === "miner_detection_unavailable"
+          ? "error"
+          : "skipped",
+      metadata: {
+        reason: authorization.reason,
+        actorKind: authorization.actorKind,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          "review-now",
+        ),
+      },
     });
     return true;
   }
 
-  const { repo, advisory } = await buildAuthorizedPrActionAdvisory(env, repoFullName, pr, settings);
+  const { repo, advisory } = await buildAuthorizedPrActionAdvisory(
+    env,
+    repoFullName,
+    pr,
+    settings,
+  );
   await persistAdvisory(env, advisory);
   await recordAuditEvent(env, {
     eventType: "github_app.pr_panel_retriggered",
@@ -3512,13 +5647,25 @@ async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payloa
   // A manual re-run is a re-evaluation surface — the user clicks it AFTER the PR changed — so the slop and
   // manifest-policy gates must see the PR's current files, not whatever is cached. Mirror the webhook path
   // (#866/#925): refresh before publishing so the re-published Gate check reflects the latest file set.
-  if (shouldCollectSlopEvidence(settings) || settings.manifestPolicyGateMode !== "off") {
+  if (
+    shouldCollectSlopEvidence(settings) ||
+    settings.manifestPolicyGateMode !== "off"
+  ) {
     await refreshPullRequestDetails(env, repoFullName, pr.number);
   }
-  await maybePublishPrPublicSurface(env, installationId, repoFullName, pr, repo, settings, advisory, {
-    deliveryId,
-    action: "manual_retrigger",
-  });
+  await maybePublishPrPublicSurface(
+    env,
+    installationId,
+    repoFullName,
+    pr,
+    repo,
+    settings,
+    advisory,
+    {
+      deliveryId,
+      action: "manual_retrigger",
+    },
+  );
   await recordGithubProductUsage(env, "pr_panel_retriggered", {
     actor,
     repoFullName,
@@ -3529,9 +5676,19 @@ async function maybeProcessPrPanelRetrigger(env: Env, deliveryId: string, payloa
   return true;
 }
 
-async function resolveRealRepoPermissionAssociation(env: Env, installationId: number, repoFullName: string, actor: string | null): Promise<string | null> {
+async function resolveRealRepoPermissionAssociation(
+  env: Env,
+  installationId: number,
+  repoFullName: string,
+  actor: string | null,
+): Promise<string | null> {
   if (!actor) return null;
-  const permission = await getRepositoryCollaboratorPermission(env, installationId, repoFullName, actor).catch(() => null);
+  const permission = await getRepositoryCollaboratorPermission(
+    env,
+    installationId,
+    repoFullName,
+    actor,
+  ).catch(() => null);
   if (permission === "admin" || permission === "maintain") return "MEMBER";
   if (permission === "write") return "COLLABORATOR";
   return null;
@@ -3549,8 +5706,18 @@ async function filterTrustedReviewNotificationEvents(
       continue;
     }
     if (!installationId || event.actorLogin === "unknown") continue;
-    const permission = await getRepositoryCollaboratorPermission(env, installationId, event.repoFullName, event.actorLogin).catch(() => null);
-    if (permission === "admin" || permission === "maintain" || permission === "write") trustedEvents.push(event);
+    const permission = await getRepositoryCollaboratorPermission(
+      env,
+      installationId,
+      event.repoFullName,
+      event.actorLogin,
+    ).catch(() => null);
+    if (
+      permission === "admin" ||
+      permission === "maintain" ||
+      permission === "write"
+    )
+      trustedEvents.push(event);
   }
   return trustedEvents;
 }
@@ -3572,9 +5739,19 @@ async function authorizePrActionActor(args: {
   settings: RepositorySettings;
   pr: PullRequestRecord;
   needsMinerDetection?: boolean;
-}): Promise<{ authorization: ReturnType<typeof isAuthorizedCommandActor>; actorAssociation: string | null; pullRequestAuthor: string | null }> {
-  const actorAssociation = await resolveRealRepoPermissionAssociation(args.env, args.installationId, args.repoFullName, args.actor);
-  const pullRequestAuthor = args.pr.authorLogin ?? args.issue.user?.login ?? null;
+}): Promise<{
+  authorization: ReturnType<typeof isAuthorizedCommandActor>;
+  actorAssociation: string | null;
+  pullRequestAuthor: string | null;
+}> {
+  const actorAssociation = await resolveRealRepoPermissionAssociation(
+    args.env,
+    args.installationId,
+    args.repoFullName,
+    args.actor,
+  );
+  const pullRequestAuthor =
+    args.pr.authorLogin ?? args.issue.user?.login ?? null;
   const official =
     args.needsMinerDetection &&
     pullRequestAuthor &&
@@ -3585,7 +5762,10 @@ async function authorizePrActionActor(args: {
       commenterAssociation: actorAssociation,
       pullRequestAuthorLogin: pullRequestAuthor,
     })
-      ? await getCachedOfficialMinerDetection(args.env, pullRequestAuthor, { targetKey: `${args.repoFullName}#${args.issue.number}`, deliveryId: args.deliveryId })
+      ? await getCachedOfficialMinerDetection(args.env, pullRequestAuthor, {
+          targetKey: `${args.repoFullName}#${args.issue.number}`,
+          deliveryId: args.deliveryId,
+        })
       : undefined;
   const authorization = isAuthorizedCommandActor({
     commandName: args.commandName,
@@ -3605,11 +5785,23 @@ export async function buildAuthorizedPrActionAdvisory(
   repoFullName: string,
   pr: PullRequestRecord,
   settings: RepositorySettings,
-): Promise<{ repo: Awaited<ReturnType<typeof getRepository>>; advisory: ReturnType<typeof buildPullRequestAdvisory> }> {
-  const [repo, otherOpenPullRequests] = await Promise.all([getRepository(env, repoFullName), listOtherOpenPullRequests(env, repoFullName, pr.number)]);
+): Promise<{
+  repo: Awaited<ReturnType<typeof getRepository>>;
+  advisory: ReturnType<typeof buildPullRequestAdvisory>;
+}> {
+  const [repo, otherOpenPullRequests] = await Promise.all([
+    getRepository(env, repoFullName),
+    listOtherOpenPullRequests(env, repoFullName, pr.number),
+  ]);
   // Mirror the main webhook path: thread linked-issue authors so an authorized PR action (gate-override / panel
   // retrigger) honors the self-authored-linked-issue block too. installationId comes from the repo record. (#self-authored-parity)
-  const linkedIssueAuthorLogins = await resolveLinkedIssueAuthorLogins(env, repo?.installationId ?? null, repoFullName, pr.linkedIssues, settings.selfAuthoredLinkedIssueGateMode === "block");
+  const linkedIssueAuthorLogins = await resolveLinkedIssueAuthorLogins(
+    env,
+    repo?.installationId ?? null,
+    repoFullName,
+    pr.linkedIssues,
+    settings.selfAuthoredLinkedIssueGateMode === "block",
+  );
   const advisory = buildPullRequestAdvisory(repo, pr, {
     otherOpenPullRequests,
     requireLinkedIssue: shouldCollectLinkedIssueEvidence(settings),
@@ -3620,20 +5812,32 @@ export async function buildAuthorizedPrActionAdvisory(
 }
 
 function isCheckedPrPanelRetrigger(body: string | null | undefined): boolean {
-  if (!body?.includes(PR_PANEL_COMMENT_MARKER) || !body.includes(PR_PANEL_RETRIGGER_MARKER)) return false;
+  if (
+    !body?.includes(PR_PANEL_COMMENT_MARKER) ||
+    !body.includes(PR_PANEL_RETRIGGER_MARKER)
+  )
+    return false;
   return checkedMarkerRegex(PR_PANEL_RETRIGGER_MARKER).test(body);
 }
 
 function checkedMarkerRegex(marker: string): RegExp {
-  return new RegExp(`(?:^|\\n)\\s*[-*]\\s*\\[[xX]\\]\\s*${escapeRegExp(marker)}`);
+  return new RegExp(
+    `(?:^|\\n)\\s*[-*]\\s*\\[[xX]\\]\\s*${escapeRegExp(marker)}`,
+  );
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function isGittensoryPanelBotComment(env: Env, user: NonNullable<GitHubWebhookPayload["comment"]>["user"] | undefined): boolean {
-  return user?.type === "Bot" && user.login?.toLowerCase() === `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase();
+function isGittensoryPanelBotComment(
+  env: Env,
+  user: NonNullable<GitHubWebhookPayload["comment"]>["user"] | undefined,
+): boolean {
+  return (
+    user?.type === "Bot" &&
+    user.login?.toLowerCase() === `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase()
+  );
 }
 
 async function recordPrPanelRetriggerSkip(
@@ -3676,24 +5880,43 @@ async function maybeRecloseDisallowedReopen(
   if (!reopener) return false;
   const botLogin = `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase();
   if (reopener === botLogin) return false; // the bot's own nightly re-review reopen is allowed
-  const repoOwner = repoFullName.includes("/") ? repoFullName.slice(0, repoFullName.indexOf("/")).toLowerCase() : "";
+  const repoOwner = repoFullName.includes("/")
+    ? repoFullName.slice(0, repoFullName.indexOf("/")).toLowerCase()
+    : "";
   const admins = parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS); // unified parse: whitespace OR comma (#audit-3.13)
   const hasMaintainerPermission = async (login: string): Promise<boolean> => {
     if (login === repoOwner || admins.has(login)) return true;
-    const permission = await getRepositoryCollaboratorPermission(env, installationId, repoFullName, login).catch(() => null);
-    return permission === "admin" || permission === "maintain" || permission === "write";
+    const permission = await getRepositoryCollaboratorPermission(
+      env,
+      installationId,
+      repoFullName,
+      login,
+    ).catch(() => null);
+    return (
+      permission === "admin" ||
+      permission === "maintain" ||
+      permission === "write"
+    );
   };
   if (await hasMaintainerPermission(reopener)) return false; // owner / admin / write collaborators may reopen
   // A non-maintainer reopened: re-close ONLY if gittensory or a maintainer closed it (one-shot). A contributor
   // reopening a PR they closed themselves is allowed (fail-open on an unknown closer).
-  const closerResult = await getLastCloserLogin(env, installationId, repoFullName, pr.number);
+  const closerResult = await getLastCloserLogin(
+    env,
+    installationId,
+    repoFullName,
+    pr.number,
+  );
   const closer = closerResult.login?.toLowerCase() ?? null;
-  const closerIsBotOrMaintainer = closer != null && (closer === botLogin || (await hasMaintainerPermission(closer)));
+  const closerIsBotOrMaintainer =
+    closer != null &&
+    (closer === botLogin || (await hasMaintainerPermission(closer)));
   // #audit-2.4: getLastCloserLogin inspects only a bounded newest-events window, so a contributor who appends
   // >1000 timeline events can push the real close out of view → null closer → bypass. When we could NOT inspect
   // the whole timeline AND found no qualifying closer, fail CLOSED — a one-shot close stands. A genuine
   // self-close sits at the timeline end and is found in-window, so legitimate self-close reopens stay allowed.
-  const windowEvasionSuspected = closer == null && !closerResult.coveredAllPages;
+  const windowEvasionSuspected =
+    closer == null && !closerResult.coveredAllPages;
   if (!closerIsBotOrMaintainer && !windowEvasionSuspected) return false;
   // Respect the agent action mode like every other write action (#killswitch-gap): a paused/frozen repo must
   // NOT touch GitHub, and dry-run records the would-be re-close without acting — so a dry-run is truly inert and
@@ -3705,7 +5928,11 @@ async function maybeRecloseDisallowedReopen(
   // autonomy (it only reflects pause/freeze/dry-run) and returns "live" for an unconfigured repo, so without this
   // the re-close would genuinely reach GitHub on a repo that never authorized any action (#review-audit).
   if (!isAgentConfigured(reopenSettings.autonomy)) return false;
-  const reopenMode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: reopenSettings.agentPaused, agentDryRun: reopenSettings.agentDryRun });
+  const reopenMode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: reopenSettings.agentPaused,
+    agentDryRun: reopenSettings.agentDryRun,
+  });
   if (reopenMode !== "live") {
     await recordAuditEvent(env, {
       eventType: "github_app.reopen_reclosed",
@@ -3727,7 +5954,9 @@ async function maybeRecloseDisallowedReopen(
     pr.number,
     "This pull request was closed by Gittensory and can't be reopened — reviews are one-shot. Please open a new pull request with the issues resolved.",
   ).catch(() => undefined);
-  await closePullRequest(env, installationId, repoFullName, pr.number).catch(() => undefined);
+  await closePullRequest(env, installationId, repoFullName, pr.number).catch(
+    () => undefined,
+  );
   await recordAuditEvent(env, {
     eventType: "github_app.reopen_reclosed",
     actor: "gittensory",
@@ -3739,7 +5968,11 @@ async function maybeRecloseDisallowedReopen(
   return true;
 }
 
-async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeProcessGittensoryMentionCommand(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   // Only act on a NEWLY-created comment (mirrors maybeProcessGateOverrideCommand / maybeProcessPlanCommand). Without
   // this an `edited` comment re-runs the agent + rewrites the card, and a `deleted` command still posts an answer
   // card for a command that no longer exists (#review-audit).
@@ -3753,7 +5986,8 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
   const issue = payload.issue;
   const installationId = getInstallationId(payload);
   const commenter = payload.comment?.user?.login;
-  const targetKey = repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
+  const targetKey =
+    repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
   if (!repoFullName || !issue || !installationId || !commenter) {
     await recordAuditEvent(env, {
       eventType: "github_app.agent_command_skipped",
@@ -3777,7 +6011,10 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
       repoFullName,
       targetKey: repoFullName,
       outcome: "skipped",
-      metadata: { command: command.name, reason: "missing_repo_issue_installation_or_actor" },
+      metadata: {
+        command: command.name,
+        reason: "missing_repo_issue_installation_or_actor",
+      },
     });
     return true;
   }
@@ -3790,7 +6027,15 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
       detail: "bot_author",
       metadata: { deliveryId, command: command.name },
     });
-    await recordAgentCommandUsage(env, { repoFullName, targetKey, actor: commenter, command: command.name, actorKind: "none", outcome: "skipped", detail: "bot_author" });
+    await recordAgentCommandUsage(env, {
+      repoFullName,
+      targetKey,
+      actor: commenter,
+      command: command.name,
+      actorKind: "none",
+      outcome: "skipped",
+      detail: "bot_author",
+    });
     await recordGithubProductUsage(env, "agent_command_skipped", {
       actor: commenter,
       repoFullName,
@@ -3809,7 +6054,15 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
       detail: "not_a_pull_request_thread",
       metadata: { deliveryId, command: command.name },
     });
-    await recordAgentCommandUsage(env, { repoFullName, targetKey, actor: commenter, command: command.name, actorKind: "none", outcome: "skipped", detail: "not_a_pull_request_thread" });
+    await recordAgentCommandUsage(env, {
+      repoFullName,
+      targetKey,
+      actor: commenter,
+      command: command.name,
+      actorKind: "none",
+      outcome: "skipped",
+      detail: "not_a_pull_request_thread",
+    });
     await recordGithubProductUsage(env, "agent_command_skipped", {
       actor: commenter,
       repoFullName,
@@ -3824,13 +6077,20 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
   // (getRepositoryCollaboratorPermission via resolveRealRepoPermissionAssociation), NOT the spoofable
   // payload.comment.author_association — an org `MEMBER` is not a maintainer of THIS repo. This matches the
   // action-command path (#538) and closes the privilege-escalation hole before write-capable commands (#778).
-  const [repo, cachedPullRequest, settings, commenterAssociation] = await Promise.all([
-    getRepository(env, repoFullName),
-    getPullRequest(env, repoFullName, issue.number),
-    resolveRepositorySettings(env, repoFullName),
-    resolveRealRepoPermissionAssociation(env, installationId, repoFullName, commenter),
-  ]);
-  const pullRequestAuthor = cachedPullRequest?.authorLogin ?? issue.user?.login ?? null;
+  const [repo, cachedPullRequest, settings, commenterAssociation] =
+    await Promise.all([
+      getRepository(env, repoFullName),
+      getPullRequest(env, repoFullName, issue.number),
+      resolveRepositorySettings(env, repoFullName),
+      resolveRealRepoPermissionAssociation(
+        env,
+        installationId,
+        repoFullName,
+        commenter,
+      ),
+    ]);
+  const pullRequestAuthor =
+    cachedPullRequest?.authorLogin ?? issue.user?.login ?? null;
   const needsMinerDetection = commandAuthorizationNeedsMinerDetection({
     policy: settings.commandAuthorization,
     commandName: command.name,
@@ -3838,9 +6098,14 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     commenterAssociation,
     pullRequestAuthorLogin: pullRequestAuthor,
   });
-  const official = pullRequestAuthor && (needsMinerDetection || command.name === "miner-context")
-    ? await getCachedOfficialMinerDetection(env, pullRequestAuthor, { targetKey: `${repoFullName}#${issue.number}`, deliveryId })
-    : undefined;
+  const official =
+    pullRequestAuthor &&
+    (needsMinerDetection || command.name === "miner-context")
+      ? await getCachedOfficialMinerDetection(env, pullRequestAuthor, {
+          targetKey: `${repoFullName}#${issue.number}`,
+          deliveryId,
+        })
+      : undefined;
   const authorization = isAuthorizedCommandActor({
     commandName: command.name,
     commenterLogin: commenter,
@@ -3854,9 +6119,19 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
       eventType: "github_app.agent_command_skipped",
       actor: commenter,
       targetKey: `${repoFullName}#${issue.number}`,
-      outcome: authorization.reason === "miner_detection_unavailable" ? "error" : "completed",
+      outcome:
+        authorization.reason === "miner_detection_unavailable"
+          ? "error"
+          : "completed",
       detail: authorization.reason,
-      metadata: { deliveryId, command: command.name, allowedRoles: commandAuthorizationAllowedRoles(settings.commandAuthorization, command.name) },
+      metadata: {
+        deliveryId,
+        command: command.name,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          command.name,
+        ),
+      },
     });
     await recordAgentCommandUsage(env, {
       repoFullName,
@@ -3864,14 +6139,20 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
       actor: commenter,
       command: command.name,
       actorKind: authorization.actorKind,
-      outcome: authorization.reason === "miner_detection_unavailable" ? "error" : "skipped",
+      outcome:
+        authorization.reason === "miner_detection_unavailable"
+          ? "error"
+          : "skipped",
       detail: authorization.reason,
     });
     await recordGithubProductUsage(env, "agent_command_skipped", {
       actor: commenter,
       repoFullName,
       targetKey: `${repoFullName}#${issue.number}`,
-      outcome: authorization.reason === "miner_detection_unavailable" ? "error" : "skipped",
+      outcome:
+        authorization.reason === "miner_detection_unavailable"
+          ? "error"
+          : "skipped",
       metadata: { command: command.name, reason: authorization.reason },
     });
     return true;
@@ -3884,24 +6165,36 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     : null;
   const bundle = maintainerDigest
     ? null
-    : await buildMentionCommandBundle(env, command.name, {
-        login,
-        repoFullName,
-        issue,
-        pullRequest: cachedPullRequest,
-      }, command.question);
+    : await buildMentionCommandBundle(
+        env,
+        command.name,
+        {
+          login,
+          repoFullName,
+          issue,
+          pullRequest: cachedPullRequest,
+        },
+        command.question,
+      );
   const body = buildPublicAgentCommandComment({
     command,
     repo,
     issue,
     pullRequest: cachedPullRequest,
-    actorKind: authorization.actorKind === "maintainer" ? "maintainer" : "author",
+    actorKind:
+      authorization.actorKind === "maintainer" ? "maintainer" : "author",
     answerId,
     officialMiner: official?.status === "confirmed" ? official.snapshot : null,
     bundle,
     maintainerDigest,
   });
-  const responseComment = await createOrUpdateAgentCommandComment(env, installationId, repoFullName, issue.number, body);
+  const responseComment = await createOrUpdateAgentCommandComment(
+    env,
+    installationId,
+    repoFullName,
+    issue.number,
+    body,
+  );
   await upsertAgentCommandAnswer(env, {
     id: answerId,
     repoFullName,
@@ -3910,7 +6203,8 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     requestCommentId: payload.comment?.id ?? null,
     responseCommentId: responseComment?.id ?? null,
     responseUrl: responseComment?.html_url ?? null,
-    actorKind: authorization.actorKind === "maintainer" ? "maintainer" : "author",
+    actorKind:
+      authorization.actorKind === "maintainer" ? "maintainer" : "author",
     metadata: {
       publicSurface: "github_comment",
       responseCommentStored: Boolean(responseComment?.id),
@@ -3921,7 +6215,13 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     actor: commenter,
     targetKey: `${repoFullName}#${issue.number}`,
     outcome: "completed",
-    metadata: { deliveryId, command: command.name, actorKind: authorization.actorKind, runId: bundle?.run.id ?? null, answerId },
+    metadata: {
+      deliveryId,
+      command: command.name,
+      actorKind: authorization.actorKind,
+      runId: bundle?.run.id ?? null,
+      answerId,
+    },
   });
   await recordAgentCommandUsage(env, {
     repoFullName,
@@ -3930,7 +6230,8 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     command: command.name,
     actorKind: authorization.actorKind,
     outcome: "replied",
-    detail: bundle?.run.status ?? (maintainerDigest ? "maintainer_digest" : "no_run"),
+    detail:
+      bundle?.run.status ?? (maintainerDigest ? "maintainer_digest" : "no_run"),
     family: maintainerDigest ? "maintainer_digest" : "agent_command",
     runId: bundle?.run.id ?? null,
   });
@@ -3939,14 +6240,20 @@ async function maybeProcessGittensoryMentionCommand(env: Env, deliveryId: string
     repoFullName,
     targetKey: `${repoFullName}#${issue.number}`,
     outcome: "completed",
-    metadata: { command: command.name, actorKind: authorization.actorKind, hasAgentRun: Boolean(bundle), family: maintainerDigest ? "queue_digest" : "agent_command" },
+    metadata: {
+      command: command.name,
+      actorKind: authorization.actorKind,
+      hasAgentRun: Boolean(bundle),
+      family: maintainerDigest ? "queue_digest" : "agent_command",
+    },
   });
   await recordAgentCommandFeedbackPrompt(env, {
     deliveryId,
     command: command.name,
     actor: commenter,
     targetKey: `${repoFullName}#${issue.number}`,
-    actorKind: authorization.actorKind === "maintainer" ? "maintainer" : "author",
+    actorKind:
+      authorization.actorKind === "maintainer" ? "maintainer" : "author",
     family: maintainerDigest ? "maintainer_digest" : "agent_command",
   });
   return true;
@@ -3964,9 +6271,24 @@ async function buildMentionCommandBundle(
   question?: string | undefined,
 ) {
   if (commandName === "help" || commandName === "miner-context") return null;
-  if (commandName === "blockers") return explainBlockersWithAgent(env, { login: context.login, repoFullName: context.repoFullName, surface: "github_comment" });
-  if (commandName === "preflight" || commandName === "reviewability") return preflightBranchWithAgent(env, buildMentionBranchInput(context), "github_comment");
-  if (commandName === "packet") return preparePrPacketWithAgent(env, buildMentionBranchInput(context), "github_comment");
+  if (commandName === "blockers")
+    return explainBlockersWithAgent(env, {
+      login: context.login,
+      repoFullName: context.repoFullName,
+      surface: "github_comment",
+    });
+  if (commandName === "preflight" || commandName === "reviewability")
+    return preflightBranchWithAgent(
+      env,
+      buildMentionBranchInput(context),
+      "github_comment",
+    );
+  if (commandName === "packet")
+    return preparePrPacketWithAgent(
+      env,
+      buildMentionBranchInput(context),
+      "github_comment",
+    );
   return planNextWork(env, {
     login: context.login,
     repoFullName: context.repoFullName,
@@ -4012,7 +6334,9 @@ async function recordAgentCommandUsage(
   },
 ): Promise<void> {
   try {
-    const actorHash = args.actor ? await sha256Hex(`github:${args.actor.toLowerCase()}`) : null;
+    const actorHash = args.actor
+      ? await sha256Hex(`github:${args.actor.toLowerCase()}`)
+      : null;
     await persistSignalSnapshot(env, {
       id: crypto.randomUUID(),
       signalType: "github-agent-command-usage",
@@ -4030,7 +6354,11 @@ async function recordAgentCommandUsage(
       generatedAt: nowIso(),
     });
   } catch (error) {
-    console.warn("Failed to record GitHub agent command usage", { command: args.command, outcome: args.outcome, error: errorMessage(error) });
+    console.warn("Failed to record GitHub agent command usage", {
+      command: args.command,
+      outcome: args.outcome,
+      error: errorMessage(error),
+    });
   }
 }
 
@@ -4059,7 +6387,10 @@ async function buildMaintainerQueueDigestForCommand(
   });
 }
 
-async function loadCachedConfirmedMinerLogins(env: Env, pullRequests: Awaited<ReturnType<typeof listPullRequests>>): Promise<string[]> {
+async function loadCachedConfirmedMinerLogins(
+  env: Env,
+  pullRequests: Awaited<ReturnType<typeof listPullRequests>>,
+): Promise<string[]> {
   const logins = [
     ...new Set(
       pullRequests
@@ -4068,8 +6399,15 @@ async function loadCachedConfirmedMinerLogins(env: Env, pullRequests: Awaited<Re
         .map((login) => login.toLowerCase()),
     ),
   ].slice(0, 50);
-  const detections = await Promise.all(logins.map(async (login) => [login, await getFreshOfficialMinerDetection(env, login)] as const));
-  return detections.flatMap(([login, detection]) => (detection?.status === "confirmed" ? [login] : []));
+  const detections = await Promise.all(
+    logins.map(
+      async (login) =>
+        [login, await getFreshOfficialMinerDetection(env, login)] as const,
+    ),
+  );
+  return detections.flatMap(([login, detection]) =>
+    detection?.status === "confirmed" ? [login] : [],
+  );
 }
 
 async function loadQueueCheckSummariesByPullNumber(
@@ -4077,8 +6415,18 @@ async function loadQueueCheckSummariesByPullNumber(
   repoFullName: string,
   pullRequests: Awaited<ReturnType<typeof listPullRequests>>,
 ): Promise<Record<number, Awaited<ReturnType<typeof listCheckSummaries>>>> {
-  const openPullRequests = pullRequests.filter((pr) => pr.state === "open").slice(0, 50);
-  const entries = await Promise.all(openPullRequests.map(async (pr) => [pr.number, await listCheckSummaries(env, repoFullName, pr.number)] as const));
+  const openPullRequests = pullRequests
+    .filter((pr) => pr.state === "open")
+    .slice(0, 50);
+  const entries = await Promise.all(
+    openPullRequests.map(
+      async (pr) =>
+        [
+          pr.number,
+          await listCheckSummaries(env, repoFullName, pr.number),
+        ] as const,
+    ),
+  );
   return Object.fromEntries(entries);
 }
 
@@ -4109,7 +6457,11 @@ async function recordAgentCommandFeedbackPrompt(
   });
 }
 
-async function maybeProcessAgentCommandFeedbackReaction(env: Env, deliveryId: string, payload: GitHubWebhookPayload): Promise<boolean> {
+async function maybeProcessAgentCommandFeedbackReaction(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
   const repoFullName = payload.repository?.full_name;
   const issue = payload.issue;
   const actor = payload.reaction?.user?.login ?? payload.sender?.login;
@@ -4125,7 +6477,11 @@ async function maybeProcessAgentCommandFeedbackReaction(env: Env, deliveryId: st
       targetKey,
       outcome: "completed",
       detail: "unsupported_reaction_action",
-      metadata: { deliveryId, action: payload.action ?? null, answerId: feedback.answerId },
+      metadata: {
+        deliveryId,
+        action: payload.action ?? null,
+        answerId: feedback.answerId,
+      },
     });
     return true;
   }
@@ -4156,7 +6512,9 @@ async function maybeProcessAgentCommandFeedbackReaction(env: Env, deliveryId: st
     });
     return true;
   }
-  const contextMismatch = answer.repoFullName.toLowerCase() !== repoFullName.toLowerCase() || answer.issueNumber !== issue.number;
+  const contextMismatch =
+    answer.repoFullName.toLowerCase() !== repoFullName.toLowerCase() ||
+    answer.issueNumber !== issue.number;
   if (contextMismatch) {
     await recordAuditEvent(env, {
       eventType: "github_app.agent_command_feedback_skipped",
@@ -4168,21 +6526,35 @@ async function maybeProcessAgentCommandFeedbackReaction(env: Env, deliveryId: st
     });
     return true;
   }
-  if (!answer.responseCommentId || answer.responseCommentId !== payload.comment?.id) {
+  if (
+    !answer.responseCommentId ||
+    answer.responseCommentId !== payload.comment?.id
+  ) {
     await recordAuditEvent(env, {
       eventType: "github_app.agent_command_feedback_skipped",
       actor,
       targetKey,
       outcome: "completed",
       detail: "answer_comment_mismatch",
-      metadata: { deliveryId, answerId: feedback.answerId, command, vote, commentId: payload.comment?.id ?? null },
+      metadata: {
+        deliveryId,
+        answerId: feedback.answerId,
+        command,
+        vote,
+        commentId: payload.comment?.id ?? null,
+      },
     });
     return true;
   }
-  const pullRequestAuthor = cachedPullRequest?.authorLogin ?? issue.user?.login ?? null;
-  const official = pullRequestAuthor && actor.toLowerCase() === pullRequestAuthor.toLowerCase()
-    ? await getCachedOfficialMinerDetection(env, actor, { targetKey, deliveryId })
-    : undefined;
+  const pullRequestAuthor =
+    cachedPullRequest?.authorLogin ?? issue.user?.login ?? null;
+  const official =
+    pullRequestAuthor && actor.toLowerCase() === pullRequestAuthor.toLowerCase()
+      ? await getCachedOfficialMinerDetection(env, actor, {
+          targetKey,
+          deliveryId,
+        })
+      : undefined;
   const authorization = authorizeFeedbackActor(env, {
     actor,
     repoFullName,
@@ -4220,12 +6592,21 @@ async function maybeProcessAgentCommandFeedbackReaction(env: Env, deliveryId: st
     actor,
     targetKey,
     outcome: "completed",
-    metadata: { deliveryId, answerId: feedback.answerId, command, vote, source: "github_reaction", actorKind: authorization.actorKind },
+    metadata: {
+      deliveryId,
+      answerId: feedback.answerId,
+      command,
+      vote,
+      source: "github_reaction",
+      actorKind: authorization.actorKind,
+    },
   });
   return true;
 }
 
-function reactionVote(content: string | null | undefined): "useful" | "not_useful" | null {
+function reactionVote(
+  content: string | null | undefined,
+): "useful" | "not_useful" | null {
   if (content === "+1") return "useful";
   if (content === "-1") return "not_useful";
   return null;
@@ -4242,10 +6623,18 @@ function authorizeFeedbackActor(
 ): { authorized: boolean; reason: string; actorKind: "maintainer" | "author" } {
   const [owner] = args.repoFullName.split("/");
   if (owner && owner.toLowerCase() === args.actor.toLowerCase()) {
-    return { authorized: true, reason: "repo_owner_feedback", actorKind: "maintainer" };
+    return {
+      authorized: true,
+      reason: "repo_owner_feedback",
+      actorKind: "maintainer",
+    };
   }
   if (isAuthorizedGitHubSessionLogin(env, args.actor)) {
-    return { authorized: true, reason: "operator_feedback", actorKind: "maintainer" };
+    return {
+      authorized: true,
+      reason: "operator_feedback",
+      actorKind: "maintainer",
+    };
   }
   const authorAuthorization = isAuthorizedCommandActor({
     commenterLogin: args.actor,
@@ -4285,26 +6674,83 @@ async function auditPrVisibilitySkip(
   });
 }
 
-async function getCachedOfficialMinerDetection(env: Env, login: string, context: { targetKey: string; deliveryId: string }): Promise<OfficialGittensorMinerDetection> {
+async function getCachedOfficialMinerDetection(
+  env: Env,
+  login: string,
+  context: { targetKey: string; deliveryId: string },
+): Promise<OfficialGittensorMinerDetection> {
   const cached = await getFreshOfficialMinerDetection(env, login);
   if (cached) {
-    await auditMinerDetectionCache(env, "github_app.miner_detection_cache_hit", login, context, cached.status);
-    if (cached.status === "unavailable") await auditMinerDetectionUnavailable(env, login, context, cached.error);
+    await auditMinerDetectionCache(
+      env,
+      "github_app.miner_detection_cache_hit",
+      login,
+      context,
+      cached.status,
+    );
+    if (cached.status === "unavailable")
+      await auditMinerDetectionUnavailable(env, login, context, cached.error);
     return cached;
   }
-  await auditMinerDetectionCache(env, "github_app.miner_detection_cache_miss", login, context, "miss");
+  await auditMinerDetectionCache(
+    env,
+    "github_app.miner_detection_cache_miss",
+    login,
+    context,
+    "miss",
+  );
   const detection = await fetchOfficialGittensorMiner(login);
-  const cacheableDetection = await upsertOfficialMinerDetection(env, login, detection, detection.status === "unavailable" ? OFFICIAL_MINER_DETECTION_UNAVAILABLE_TTL_MS : OFFICIAL_MINER_DETECTION_TTL_MS);
-  if (cacheableDetection.status === "unavailable") await auditMinerDetectionUnavailable(env, login, context, cacheableDetection.error);
+  const cacheableDetection = await upsertOfficialMinerDetection(
+    env,
+    login,
+    detection,
+    detection.status === "unavailable"
+      ? OFFICIAL_MINER_DETECTION_UNAVAILABLE_TTL_MS
+      : OFFICIAL_MINER_DETECTION_TTL_MS,
+  );
+  if (cacheableDetection.status === "unavailable")
+    await auditMinerDetectionUnavailable(
+      env,
+      login,
+      context,
+      cacheableDetection.error,
+    );
   return cacheableDetection;
 }
 
-async function auditMinerDetectionUnavailable(env: Env, actor: string, context: { targetKey: string; deliveryId: string }, detail: string): Promise<void> {
-  await recordAuditEvent(env, { eventType: "github_app.miner_detection_unavailable", actor, targetKey: context.targetKey, outcome: "error", detail, metadata: { deliveryId: context.deliveryId } });
+async function auditMinerDetectionUnavailable(
+  env: Env,
+  actor: string,
+  context: { targetKey: string; deliveryId: string },
+  detail: string,
+): Promise<void> {
+  await recordAuditEvent(env, {
+    eventType: "github_app.miner_detection_unavailable",
+    actor,
+    targetKey: context.targetKey,
+    outcome: "error",
+    detail,
+    metadata: { deliveryId: context.deliveryId },
+  });
 }
 
-async function auditMinerDetectionCache(env: Env, eventType: "github_app.miner_detection_cache_hit" | "github_app.miner_detection_cache_miss", actor: string, context: { targetKey: string; deliveryId: string }, detail: string): Promise<void> {
-  await recordAuditEvent(env, { eventType, actor, targetKey: context.targetKey, outcome: "completed", detail, metadata: { deliveryId: context.deliveryId } });
+async function auditMinerDetectionCache(
+  env: Env,
+  eventType:
+    | "github_app.miner_detection_cache_hit"
+    | "github_app.miner_detection_cache_miss",
+  actor: string,
+  context: { targetKey: string; deliveryId: string },
+  detail: string,
+): Promise<void> {
+  await recordAuditEvent(env, {
+    eventType,
+    actor,
+    targetKey: context.targetKey,
+    outcome: "completed",
+    detail,
+    metadata: { deliveryId: context.deliveryId },
+  });
 }
 
 function officialGittensorContributorDetection(
@@ -4314,28 +6760,48 @@ function officialGittensorContributorDetection(
   issues: Awaited<ReturnType<typeof listContributorIssues>>,
   repoStats: Awaited<ReturnType<typeof listContributorRepoStats>>,
 ) {
-  const cached = detectGittensorContributor(snapshot.githubUsername, currentPr, pullRequests, issues, repoStats);
+  const cached = detectGittensorContributor(
+    snapshot.githubUsername,
+    currentPr,
+    pullRequests,
+    issues,
+    repoStats,
+  );
   return {
     ...cached,
     detected: true,
     source: "official_gittensor_api" as const,
     reason: "Official Gittensor API confirms this GitHub user.",
-    priorPullRequests: Math.max(cached.priorPullRequests, snapshot.totals.pullRequests),
-    priorMergedPullRequests: Math.max(cached.priorMergedPullRequests, snapshot.totals.mergedPullRequests),
-    priorIssues: Math.max(cached.priorIssues, snapshot.totals.openIssues + snapshot.totals.closedIssues),
+    priorPullRequests: Math.max(
+      cached.priorPullRequests,
+      snapshot.totals.pullRequests,
+    ),
+    priorMergedPullRequests: Math.max(
+      cached.priorMergedPullRequests,
+      snapshot.totals.mergedPullRequests,
+    ),
+    priorIssues: Math.max(
+      cached.priorIssues,
+      snapshot.totals.openIssues + snapshot.totals.closedIssues,
+    ),
   };
 }
 
 function authoritativeContributorRepoStats(
-  gittensorSnapshot: Awaited<ReturnType<typeof fetchGittensorContributorSnapshot>>,
+  gittensorSnapshot: Awaited<
+    ReturnType<typeof fetchGittensorContributorSnapshot>
+  >,
   cachedRepoStats: Awaited<ReturnType<typeof listContributorRepoStats>>,
 ) {
-  const officialRepoStats = contributorRepoStatsFromGittensor(gittensorSnapshot);
+  const officialRepoStats =
+    contributorRepoStatsFromGittensor(gittensorSnapshot);
   return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
 /** Split `owner/name` into the project/repo key shape shared by RAG indexing and retrieval. */
 export function splitRepoForRag(repoFullName: string): [string, string] {
   const slash = repoFullName.indexOf("/");
-  return slash === -1 ? ["", repoFullName] : [repoFullName.slice(0, slash), repoFullName.slice(slash + 1)];
+  return slash === -1
+    ? ["", repoFullName]
+    : [repoFullName.slice(0, slash), repoFullName.slice(slash + 1)];
 }

--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -1,0 +1,89 @@
+// Review-enrichment service (REES) wiring (#1472). POSTs the PR to the external REES, which runs the heavy/
+// external/historical analysis the no-checkout `claude --print` reviewer can't (dependency CVEs, leaked secrets,
+// license/EOL/supply-chain), and returns a pre-rendered, public-safe brief the engine splices into the review
+// prompt next to grounding + RAG (same { promptSection, systemSuffix } shape, same splice points in ai-review.ts).
+//
+// Single env switch: GITTENSORY_REVIEW_ENRICHMENT (+ REES_URL must be set, so the hosted Worker — which sets neither
+// — is unaffected). Default OFF → gathers nothing, prompt byte-identical. FULLY FAIL-SAFE: any timeout / non-200 /
+// network / parse error, or an empty brief, returns undefined and the review proceeds on diff + grounding + RAG.
+import type { PullRequestFileRecord } from "../types";
+
+interface EnrichmentEnv {
+  GITTENSORY_REVIEW_ENRICHMENT?: string | undefined;
+  REES_URL?: string | undefined;
+  REES_SHARED_SECRET?: string | undefined;
+  REES_TIMEOUT_MS?: string | undefined;
+}
+
+// The REES vars are self-host-only runtime env (process.env), not declared on the Worker Env type — read them via
+// this cast. The hosted Worker simply has none set, so isEnrichmentEnabled is false there.
+function reesConfig(env: Env): EnrichmentEnv {
+  return env as unknown as EnrichmentEnv;
+}
+
+/** True when enrichment is enabled: the flag is on AND the REES URL is configured. OFF ⇒ no call, prompt unchanged. */
+export function isEnrichmentEnabled(env: Env): boolean {
+  const cfg = reesConfig(env);
+  return (
+    /^(1|true|yes|on)$/i.test(cfg.GITTENSORY_REVIEW_ENRICHMENT ?? "") &&
+    Boolean(cfg.REES_URL?.trim())
+  );
+}
+
+interface EnrichmentInput {
+  repoFullName: string;
+  prNumber: number;
+  headSha: string | null;
+  baseSha?: string | null;
+  title?: string | undefined;
+  files: PullRequestFileRecord[];
+  diff: string;
+}
+
+/** POST the PR to the REES and return the spliceable brief, or undefined on any error/timeout/empty (fail-safe). */
+export async function buildReviewEnrichment(
+  env: Env,
+  input: EnrichmentInput,
+): Promise<{ promptSection: string; systemSuffix: string } | undefined> {
+  const cfg = reesConfig(env);
+  const base = cfg.REES_URL?.trim();
+  if (!base) return undefined;
+  const timeoutMs = Math.max(1000, Number(cfg.REES_TIMEOUT_MS ?? "8000"));
+  try {
+    const response = await fetch(`${base.replace(/\/+$/, "")}/v1/enrich`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(cfg.REES_SHARED_SECRET
+          ? { authorization: `Bearer ${cfg.REES_SHARED_SECRET}` }
+          : {}),
+      },
+      body: JSON.stringify({
+        repoFullName: input.repoFullName,
+        prNumber: input.prNumber,
+        headSha: input.headSha,
+        baseSha: input.baseSha ?? null,
+        title: input.title,
+        files: input.files.map((file) => ({
+          path: file.path,
+          patch:
+            typeof file.payload?.patch === "string"
+              ? file.payload.patch
+              : undefined,
+        })),
+        diff: input.diff,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return undefined;
+    const brief = (await response.json()) as {
+      promptSection?: string;
+      systemSuffix?: string;
+    };
+    const promptSection = brief.promptSection?.trim();
+    if (!promptSection) return undefined; // no findings ⇒ no section ⇒ byte-identical prompt
+    return { promptSection, systemSuffix: brief.systemSuffix ?? "" };
+  } catch {
+    return undefined; // timeout / network / parse ⇒ fail-safe; review proceeds without the brief
+  }
+}

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -16,7 +16,11 @@
 // that trips the public/private boundary is dropped, not published. Free Workers-AI calls are metered against
 // the shared daily neuron budget; maintainer-paid BYOK calls have a separate repo/day cap. All calls
 // are audited via `recordAiUsageEvent`.
-import { countByokAiEventsForRepoSince, recordAiUsageEvent, sumAiEstimatedNeuronsSince } from "../db/repositories";
+import {
+  countByokAiEventsForRepoSince,
+  recordAiUsageEvent,
+  sumAiEstimatedNeuronsSince,
+} from "../db/repositories";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { defangReviewInput, isSafetyEnabled } from "../review/safety";
 import { isConvergenceRepoAllowed } from "../review/cutover-gate";
@@ -26,14 +30,16 @@ import type { ReviewProfile } from "../signals/focus-manifest";
  * The best free Workers-AI model pair for review accuracy — two different families for independence,
  * both probe-verified in reviewbot to emit clean JSON. The consensus blocker always uses this pair.
  */
-export const BEST_REVIEW_MODELS: readonly [string, string] = ["@cf/openai/gpt-oss-120b", "@cf/nvidia/nemotron-3-120b-a12b"];
+export const BEST_REVIEW_MODELS: readonly [string, string] = [
+  "@cf/openai/gpt-oss-120b",
+  "@cf/nvidia/nemotron-3-120b-a12b",
+];
 
 /** Reliable per-slot fallbacks (non-reasoning, clean JSON) so a slot never comes back empty. */
 export const RELIABLE_FALLBACK_MODELS: readonly [string, string] = [
   "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
   "@cf/mistralai/mistral-small-3.1-24b-instruct",
 ];
-
 
 const REVIEW_SYSTEM_PROMPT = [
   "You are a senior open-source maintainer giving a FOCUSED, high-signal code review of a single pull request diff.",
@@ -95,7 +101,10 @@ export type GittensoryAiReviewInput = {
    * `{ model: "codex" }` — addressed by the self-host AI router; `fallback` is Workers-AI-only (a self-host
    * provider has none). `single` (or a single entry) runs reviewer[0]; consensus/synthesis run [0] and [1].
    */
-  reviewers?: ReadonlyArray<{ model: string; fallback?: string | null | undefined }> | null | undefined;
+  reviewers?:
+    | ReadonlyArray<{ model: string; fallback?: string | null | undefined }>
+    | null
+    | undefined;
   /** Present only when the repo has BYOK on AND a key configured; drives the advisory write-up. */
   providerKey?: AiReviewProviderKey | null | undefined;
   /**
@@ -105,7 +114,10 @@ export type GittensoryAiReviewInput = {
    * appended. `systemSuffix` carries the grounding-discipline rules; `promptSection` carries the CI STATUS
    * + FULL FILE CONTENT blocks. Empty strings behave the same as absent.
    */
-  grounding?: { systemSuffix?: string | undefined; promptSection?: string | undefined } | null | undefined;
+  grounding?:
+    | { systemSuffix?: string | undefined; promptSection?: string | undefined }
+    | null
+    | undefined;
   /**
    * Convergence (RAG retrieval, flag-gated by GITTENSORY_REVIEW_RAG). The caller builds this by querying the
    * codebase vector index for code/docs semantically related to the PR's changed files (see
@@ -115,6 +127,17 @@ export type GittensoryAiReviewInput = {
    * to today — no section is appended.
    */
   ragContext?: string | null | undefined;
+  /**
+   * Review-enrichment service brief (#1472, flag-gated by GITTENSORY_REVIEW_ENRICHMENT). The caller POSTs the PR
+   * to the external REES (see `review/enrichment-wire`), which runs heavy/external/historical analysis the
+   * no-checkout reviewer can't (dependency CVEs, leaked secrets, license/EOL/supply-chain) and returns a
+   * pre-rendered, public-safe brief. Same shape + splice point as grounding: `promptSection` appends to the USER
+   * prompt, `systemSuffix` to the SYSTEM prompt. ABSENT (default, flag-OFF) or empty ⇒ the prompt is byte-identical.
+   */
+  enrichment?:
+    | { systemSuffix?: string | undefined; promptSection?: string | undefined }
+    | null
+    | undefined;
   /**
    * `.gittensory.yml` `review.profile` (#review-profile): adjusts how nitpicky the maintainer review write-up is.
    * `chill` → surface only blocking defects; `assertive` → also raise minor improvements & nits; absent/`balanced`
@@ -139,18 +162,40 @@ export type GittensoryAiReviewInput = {
 };
 
 /** A consensus critical defect, already public-safe, ready to become a gate blocker finding. */
-export type AiConsensusDefect = { title: string; detail: string; confidence: number };
+export type AiConsensusDefect = {
+  title: string;
+  detail: string;
+  confidence: number;
+};
 
 export type GittensoryAiReviewResult =
   | { status: "disabled"; reason: string }
   | { status: "unavailable"; reason: string }
-  | { status: "quota_exceeded"; estimatedNeurons: number; remainingBudget: number }
-  | { status: "ok"; advisoryNotes: string | null; consensusDefect: AiConsensusDefect | null; split: boolean; inconclusive: boolean; estimatedNeurons: number; reviewerCount: number; inlineFindings: InlineFinding[] };
+  | {
+      status: "quota_exceeded";
+      estimatedNeurons: number;
+      remainingBudget: number;
+    }
+  | {
+      status: "ok";
+      advisoryNotes: string | null;
+      consensusDefect: AiConsensusDefect | null;
+      split: boolean;
+      inconclusive: boolean;
+      estimatedNeurons: number;
+      reviewerCount: number;
+      inlineFindings: InlineFinding[];
+    };
 
 /** A line-anchored review finding the model can emit for quiet inline PR comments (#inline-comments). `line` is
  *  the 1-based line number in the NEW (post-change) file; `severity` separates a must-fix from a nit. The body
  *  is made public-safe before it ever leaves the engine (see {@link composeInlineFindings}). */
-export type InlineFinding = { path: string; line: number; severity: "blocker" | "nit"; body: string };
+export type InlineFinding = {
+  path: string;
+  line: number;
+  severity: "blocker" | "nit";
+  body: string;
+};
 
 export type ModelReview = {
   assessment: string;
@@ -165,7 +210,13 @@ export type ModelReview = {
 };
 
 type AiGatewayOptions = { gateway?: { id: string } };
-type AiRunner = { run?: (model: string, options: Record<string, unknown>, extra?: AiGatewayOptions) => Promise<unknown> };
+type AiRunner = {
+  run?: (
+    model: string,
+    options: Record<string, unknown>,
+    extra?: AiGatewayOptions,
+  ) => Promise<unknown>;
+};
 
 // Exported so the sibling AI-advisory features (e.g. the slop advisory in `./ai-slop`) share ONE budget
 // window + neuron estimator and never drift from the review path's accounting.
@@ -180,12 +231,21 @@ export function clampNumber(value: number, min: number, max: number): number {
 
 export function utcDayStartIso(): string {
   const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  ).toISOString();
 }
 
-export function estimateNeurons(promptChars: number, maxOutputTokens: number, calls: number): number {
+export function estimateNeurons(
+  promptChars: number,
+  maxOutputTokens: number,
+  calls: number,
+): number {
   const inputTokens = Math.ceil(promptChars / 4);
-  return Math.max(1, Math.ceil((inputTokens + maxOutputTokens) * 0.035) * Math.max(1, calls));
+  return Math.max(
+    1,
+    Math.ceil((inputTokens + maxOutputTokens) * 0.035) * Math.max(1, calls),
+  );
 }
 
 function neutralizePublicMarkdown(text: string): string {
@@ -216,10 +276,14 @@ export function coerceAiText(result: unknown): string {
     const obj = result as Record<string, unknown>;
     const response = obj.response;
     if (typeof response === "string" && response.trim()) return response;
-    if (response && typeof response === "object") return JSON.stringify(response);
+    if (response && typeof response === "object")
+      return JSON.stringify(response);
     const choices = obj.choices;
     if (Array.isArray(choices) && choices.length > 0) {
-      const first = choices[0] as { message?: { content?: unknown }; text?: unknown };
+      const first = choices[0] as {
+        message?: { content?: unknown };
+        text?: unknown;
+      };
       const content = first?.message?.content ?? first?.text;
       if (typeof content === "string" && content.trim()) return content;
     }
@@ -227,11 +291,18 @@ export function coerceAiText(result: unknown): string {
     const content = obj.content;
     if (Array.isArray(content) && content.length > 0) {
       const parts = content
-        .map((part) => (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string" ? (part as { text: string }).text : ""))
+        .map((part) =>
+          part &&
+          typeof part === "object" &&
+          typeof (part as { text?: unknown }).text === "string"
+            ? (part as { text: string }).text
+            : "",
+        )
         .filter(Boolean);
       if (parts.length > 0) return parts.join("\n");
     }
-    if (typeof obj.output_text === "string" && obj.output_text.trim()) return obj.output_text;
+    if (typeof obj.output_text === "string" && obj.output_text.trim())
+      return obj.output_text;
   }
   return "";
 }
@@ -276,7 +347,13 @@ export function parseModelReview(text: string): ModelReview | null {
   try {
     const obj = JSON.parse(jsonText) as Record<string, unknown>;
     const toList = (value: unknown): string[] =>
-      Array.isArray(value) ? value.filter((x): x is string => typeof x === "string").map((x) => x.trim()).filter(Boolean).slice(0, 6) : [];
+      Array.isArray(value)
+        ? value
+            .filter((x): x is string => typeof x === "string")
+            .map((x) => x.trim())
+            .filter(Boolean)
+            .slice(0, 6)
+        : [];
     // Fail-safe: a malformed/absent inlineFindings field degrades to []; each item missing a usable path / a
     // positive line / a body is skipped, never partial. Severity defaults to "nit" unless it's exactly "blocker".
     const toInlineFindings = (value: unknown): InlineFinding[] =>
@@ -290,17 +367,27 @@ export function parseModelReview(text: string): ModelReview | null {
               // float, and the `line > 0` guard below drops 0/negative anchors.
               const line = typeof o.line === "number" ? Math.trunc(o.line) : 0;
               const body = typeof o.body === "string" ? o.body.trim() : "";
-              const severity: "blocker" | "nit" = o.severity === "blocker" ? "blocker" : "nit";
-              return path && line > 0 && body ? [{ path, line, severity, body }] : [];
+              const severity: "blocker" | "nit" =
+                o.severity === "blocker" ? "blocker" : "nit";
+              return path && line > 0 && body
+                ? [{ path, line, severity, body }]
+                : [];
             })
             .slice(0, 20)
         : [];
-    const assessment = typeof obj.assessment === "string" ? obj.assessment.trim() : "";
+    const assessment =
+      typeof obj.assessment === "string" ? obj.assessment.trim() : "";
     const blockers = toList(obj.blockers);
     const nits = toList(obj.nits);
     const suggestions = toList(obj.suggestions);
     const inlineFindings = toInlineFindings(obj.inlineFindings);
-    if (!assessment && blockers.length === 0 && nits.length === 0 && suggestions.length === 0) return null;
+    if (
+      !assessment &&
+      blockers.length === 0 &&
+      nits.length === 0 &&
+      suggestions.length === 0
+    )
+      return null;
     return { assessment, blockers, nits, suggestions, inlineFindings };
   } catch {
     return null;
@@ -311,7 +398,9 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
   const lines = [
     `Repository: ${input.repoFullName}`,
     `Pull request #${input.prNumber}: ${input.title}`,
-    input.body ? `Description:\n${input.body.slice(0, 2000)}` : "Description: (none)",
+    input.body
+      ? `Description:\n${input.body.slice(0, 2000)}`
+      : "Description: (none)",
     "",
     "Unified diff (truncated if large):",
     // Widened 60k→120k so a large multi-file PR is actually reviewed in full (the 120B Workers-AI models have a
@@ -326,6 +415,10 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
   // supplied one (flag GITTENSORY_REVIEW_RAG on AND an index exists). Absent/empty (the default) → byte-identical.
   const ragSection = input.ragContext;
   if (ragSection) lines.push("", ragSection);
+  // Review-enrichment brief (#1472): append the external REES analysis block when the caller supplied one (flag
+  // GITTENSORY_REVIEW_ENRICHMENT on AND REES_URL set). Absent/empty (the default) → the prompt is byte-identical.
+  const enrichmentSection = input.enrichment?.promptSection;
+  if (enrichmentSection) lines.push("", enrichmentSection);
   return lines.join("\n");
 }
 
@@ -349,24 +442,41 @@ const INLINE_FINDINGS_SUFFIX =
  *  instruction when the caller asked for them; all absent (default) → the base prompt, byte-identical to today. */
 function buildSystemPrompt(input: GittensoryAiReviewInput): string {
   const groundingSuffix = input.grounding?.systemSuffix ?? "";
-  const profileSuffix = input.profile === "chill" || input.profile === "assertive" ? REVIEW_PROFILE_SUFFIX[input.profile] : "";
+  // Review-enrichment brief (#1472): the REES supplies a one-line discipline suffix ("treat a listed CVE/secret as
+  // verified ground truth"). Absent (default) ⇒ "" ⇒ byte-identical.
+  const enrichmentSuffix = input.enrichment?.systemSuffix ?? "";
+  const profileSuffix =
+    input.profile === "chill" || input.profile === "assertive"
+      ? REVIEW_PROFILE_SUFFIX[input.profile]
+      : "";
   // `.gittensory.yml` review.path_instructions (#review-path-instructions): the caller pre-resolved the entries
   // matching this PR's files into a prompt section; empty ⇒ nothing appended (byte-identical).
   const pathSuffix = input.pathGuidance?.trim() ? input.pathGuidance : "";
   const inlineSuffix = input.inlineFindings ? INLINE_FINDINGS_SUFFIX : "";
-  return `${REVIEW_SYSTEM_PROMPT}${groundingSuffix}${profileSuffix}${pathSuffix}${inlineSuffix}`;
+  return `${REVIEW_SYSTEM_PROMPT}${groundingSuffix}${enrichmentSuffix}${profileSuffix}${pathSuffix}${inlineSuffix}`;
 }
 
 /** One Workers-AI opinion with a per-slot reliable fallback and a 3× retry on the primary. */
-async function runWorkersOpinion(env: Env, primary: string, fallback: string, system: string, user: string, maxTokens: number): Promise<ModelReview | null> {
+async function runWorkersOpinion(
+  env: Env,
+  primary: string,
+  fallback: string,
+  system: string,
+  user: string,
+  maxTokens: number,
+): Promise<ModelReview | null> {
   const ai = env.AI as unknown as AiRunner | undefined;
   if (!ai || typeof ai.run !== "function") return null;
   // Route through Cloudflare AI Gateway when configured (caching, rate-limiting, logging, fallback). The
   // diff/prompt is the cache key input, scoped per model + content, so distinct PRs never share a cached
   // review. Unset → direct binding call (unchanged behavior).
   const gatewayId = env.AI_GATEWAY_ID?.trim();
-  const extra: AiGatewayOptions | undefined = gatewayId ? { gateway: { id: gatewayId } } : undefined;
-  for (const model of fallback && fallback !== primary ? [primary, fallback] : [primary]) {
+  const extra: AiGatewayOptions | undefined = gatewayId
+    ? { gateway: { id: gatewayId } }
+    : undefined;
+  for (const model of fallback && fallback !== primary
+    ? [primary, fallback]
+    : [primary]) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
         const result = await ai.run(
@@ -391,10 +501,11 @@ async function runWorkersOpinion(env: Env, primary: string, fallback: string, sy
   return null;
 }
 
-const PROVIDER_DEFAULT_MODEL: Record<AiReviewProviderKey["provider"], string> = {
-  anthropic: "claude-3-5-sonnet-latest",
-  openai: "gpt-4o",
-};
+const PROVIDER_DEFAULT_MODEL: Record<AiReviewProviderKey["provider"], string> =
+  {
+    anthropic: "claude-3-5-sonnet-latest",
+    openai: "gpt-4o",
+  };
 
 /** Hard cap on a single BYOK provider request. Without it a slow/half-open Anthropic/OpenAI connection
  *  would stall the queue worker for as long as the platform allows; a bounded timeout turns the hang into
@@ -406,7 +517,10 @@ export const DEFAULT_BYOK_DAILY_REPO_LIMIT = 25;
 
 /** Why a BYOK call produced no usable output — surfaced in the audit event for observability (never a key). */
 export type ProviderFailure = "timeout" | "http_error" | "exception";
-type ProviderReviewOutcome = { review: ModelReview | null; failure?: ProviderFailure };
+type ProviderReviewOutcome = {
+  review: ModelReview | null;
+  failure?: ProviderFailure;
+};
 
 /**
  * POST to the maintainer's BYOK provider and return the raw response text (or null + a failure reason).
@@ -419,20 +533,33 @@ export async function callAiProvider(
   user: string,
   maxTokens: number,
 ): Promise<{ text: string | null; failure?: ProviderFailure }> {
-  const model = providerKey.model || PROVIDER_DEFAULT_MODEL[providerKey.provider];
+  const model =
+    providerKey.model || PROVIDER_DEFAULT_MODEL[providerKey.provider];
   try {
     let response: Response;
     if (providerKey.provider === "anthropic") {
       response = await fetch("https://api.anthropic.com/v1/messages", {
         method: "POST",
-        headers: { "content-type": "application/json", "x-api-key": providerKey.key, "anthropic-version": "2023-06-01" },
-        body: JSON.stringify({ model, max_tokens: maxTokens, system, messages: [{ role: "user", content: user }] }),
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": providerKey.key,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: maxTokens,
+          system,
+          messages: [{ role: "user", content: user }],
+        }),
         signal: AbortSignal.timeout(AI_PROVIDER_TIMEOUT_MS),
       });
     } else {
       response = await fetch("https://api.openai.com/v1/chat/completions", {
         method: "POST",
-        headers: { "content-type": "application/json", authorization: `Bearer ${providerKey.key}` },
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${providerKey.key}`,
+        },
         body: JSON.stringify({
           model,
           max_tokens: maxTokens,
@@ -448,16 +575,32 @@ export async function callAiProvider(
     return { text: coerceAiText(await response.json()) };
   } catch (error) {
     // AbortSignal.timeout rejects with a TimeoutError; everything else is a network/parse exception.
-    const failure: ProviderFailure = (error as { name?: string } | null)?.name === "TimeoutError" ? "timeout" : "exception";
+    const failure: ProviderFailure =
+      (error as { name?: string } | null)?.name === "TimeoutError"
+        ? "timeout"
+        : "exception";
     return { text: null, failure };
   }
 }
 
 /** Run the maintainer's BYOK frontier model for the advisory write-up. Never throws; the review is null on
  *  any error and `failure` names the reason (timeout/http_error/exception) for the audit trail. */
-async function runProviderReview(providerKey: AiReviewProviderKey, system: string, user: string, maxTokens: number): Promise<ProviderReviewOutcome> {
-  const { text, failure } = await callAiProvider(providerKey, system, user, maxTokens);
-  return { review: text ? parseModelReview(text) : null, ...(failure ? { failure } : {}) };
+async function runProviderReview(
+  providerKey: AiReviewProviderKey,
+  system: string,
+  user: string,
+  maxTokens: number,
+): Promise<ProviderReviewOutcome> {
+  const { text, failure } = await callAiProvider(
+    providerKey,
+    system,
+    user,
+    maxTokens,
+  );
+  return {
+    review: text ? parseModelReview(text) : null,
+    ...(failure ? { failure } : {}),
+  };
 }
 
 /** Compose a public-safe markdown advisory blurb from one or two model reviews. Null if nothing safe. */
@@ -467,11 +610,18 @@ export function composeAdvisoryNotes(reviews: ModelReview[]): string | null {
   // model to be selective + deduplicate). Keep the core blockers and a handful of nits. (#focused-reviews)
   const blockers = [...new Set(reviews.flatMap((r) => r.blockers))].slice(0, 3);
   // nits + suggestions are both non-blocking — merge + dedupe for the write-up.
-  const nits = [...new Set(reviews.flatMap((r) => [...r.nits, ...r.suggestions]))].slice(0, 5);
+  const nits = [
+    ...new Set(reviews.flatMap((r) => [...r.nits, ...r.suggestions])),
+  ].slice(0, 5);
   const assessment = toPublicSafe(assessments[0] ?? "");
-  const safeBlockers = blockers.map((s) => toPublicSafe(s)).filter((s): s is string => Boolean(s));
-  const safeNits = nits.map((s) => toPublicSafe(s)).filter((s): s is string => Boolean(s));
-  if (!assessment && safeBlockers.length === 0 && safeNits.length === 0) return null;
+  const safeBlockers = blockers
+    .map((s) => toPublicSafe(s))
+    .filter((s): s is string => Boolean(s));
+  const safeNits = nits
+    .map((s) => toPublicSafe(s))
+    .filter((s): s is string => Boolean(s));
+  if (!assessment && safeBlockers.length === 0 && safeNits.length === 0)
+    return null;
   const lines: string[] = [];
   if (assessment) lines.push(assessment, "");
   if (safeBlockers.length > 0) {
@@ -515,21 +665,35 @@ export function composeInlineFindings(reviews: ModelReview[]): InlineFinding[] {
  *  reviewbot model: a lone blocker in a dual review is a split, not a hard block). Requiring two independent
  *  models to AGREE is itself the precision mechanism — the free Workers-AI models emit no calibrated confidence
  *  score, so there is no numeric floor to enforce; agreement is the signal. */
-export function consensusDefectOf(a: ModelReview, b: ModelReview): AiConsensusDefect | null {
+export function consensusDefectOf(
+  a: ModelReview,
+  b: ModelReview,
+): AiConsensusDefect | null {
   if (a.blockers.length === 0 || b.blockers.length === 0) return null;
-  const title = toPublicSafe(a.blockers[0] || b.blockers[0] || "AI reviewers agree on a likely blocking defect");
+  const title = toPublicSafe(
+    a.blockers[0] ||
+      b.blockers[0] ||
+      "AI reviewers agree on a likely blocking defect",
+  );
   if (!title) return null; // unsafe title → drop the block entirely (fail-safe)
   // Cite ONLY the primary blocker (not every finding joined together) so the Gate's "why blocked" reason
   // stays focused on the single core defect instead of repeating the whole blockers list. (#focused-reviews)
-  const detail = toPublicSafe(a.blockers[0] || b.blockers[0] || "") ?? "Both AI reviewers independently flagged a concrete must-fix defect in this change.";
+  const detail =
+    toPublicSafe(a.blockers[0] || b.blockers[0] || "") ??
+    "Both AI reviewers independently flagged a concrete must-fix defect in this change.";
   return { title, detail, confidence: 1 };
 }
 
 /** Deterministic SYNTHESIS of one public-safe defect from the reviews that named a blocker — same public-safe
  *  discipline as `consensusDefectOf` (cite the primary blocker; an unsafe title drops the whole block, fail-safe).
  *  Used by the `synthesis` and `single` combine strategies. */
-function synthesizeDefect(reviews: ReadonlyArray<ModelReview>): AiConsensusDefect | null {
-  const primary = reviews.flatMap((r) => r.blockers).map((b) => b.trim()).find((b) => b.length > 0);
+function synthesizeDefect(
+  reviews: ReadonlyArray<ModelReview>,
+): AiConsensusDefect | null {
+  const primary = reviews
+    .flatMap((r) => r.blockers)
+    .map((b) => b.trim())
+    .find((b) => b.length > 0);
   if (!primary) return null;
   const title = toPublicSafe(primary);
   if (!title) return null; // unsafe title → drop the block entirely (fail-safe)
@@ -554,7 +718,11 @@ export function combineReviews(
     // missing review can't certify the change → hold.
     const r = present[0];
     if (!r) return { defect: null, split: false, inconclusive: true };
-    return { defect: r.blockers.length > 0 ? synthesizeDefect([r]) : null, split: false, inconclusive: false };
+    return {
+      defect: r.blockers.length > 0 ? synthesizeDefect([r]) : null,
+      split: false,
+      inconclusive: false,
+    };
   }
 
   if (opts.strategy === "synthesis") {
@@ -562,13 +730,23 @@ export function combineReviews(
     const flagged = present.filter((r) => r.blockers.length > 0);
     if ((opts.onMerge ?? "either") === "both") {
       // Block only when EVERY expected reviewer is present AND each named a blocker.
-      if (missing > 0) return { defect: null, split: false, inconclusive: true };
+      if (missing > 0)
+        return { defect: null, split: false, inconclusive: true };
       const all = present.length > 0 && flagged.length === present.length;
-      return { defect: all ? synthesizeDefect(present) : null, split: false, inconclusive: false };
+      return {
+        defect: all ? synthesizeDefect(present) : null,
+        split: false,
+        inconclusive: false,
+      };
     }
     // `either`: any present reviewer's blocker blocks. With no present blocker but a missing opinion we cannot
     // certify the change is clean → hold (fail-closed).
-    if (flagged.length > 0) return { defect: synthesizeDefect(flagged), split: false, inconclusive: false };
+    if (flagged.length > 0)
+      return {
+        defect: synthesizeDefect(flagged),
+        split: false,
+        inconclusive: false,
+      };
     return { defect: null, split: false, inconclusive: missing > 0 };
   }
 
@@ -576,7 +754,7 @@ export function combineReviews(
   const [a, b] = reviews;
   if (a && b) {
     const defect = consensusDefectOf(a, b);
-    const split = !defect && (a.blockers.length > 0) !== (b.blockers.length > 0);
+    const split = !defect && a.blockers.length > 0 !== b.blockers.length > 0;
     return { defect, split, inconclusive: false };
   }
   return { defect: null, split: false, inconclusive: true };
@@ -587,15 +765,28 @@ export function combineReviews(
  * a consensus defect when the free Workers-AI pair agrees with high confidence. Fail-safe on every error
  * path: no notes, no defect, never a thrown error reaching the webhook.
  */
-export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewInput): Promise<GittensoryAiReviewResult> {
-  if (!isEnabled(env.AI_SUMMARIES_ENABLED)) return { status: "disabled", reason: "AI summaries are disabled." };
-  if (!isEnabled(env.AI_PUBLIC_COMMENTS_ENABLED)) return { status: "disabled", reason: "Public AI comments are disabled." };
-  if (!env.AI) return { status: "unavailable", reason: "Workers AI binding is not configured." };
+export async function runGittensoryAiReview(
+  env: Env,
+  input: GittensoryAiReviewInput,
+): Promise<GittensoryAiReviewResult> {
+  if (!isEnabled(env.AI_SUMMARIES_ENABLED))
+    return { status: "disabled", reason: "AI summaries are disabled." };
+  if (!isEnabled(env.AI_PUBLIC_COMMENTS_ENABLED))
+    return { status: "disabled", reason: "Public AI comments are disabled." };
+  if (!env.AI)
+    return {
+      status: "unavailable",
+      reason: "Workers AI binding is not configured.",
+    };
 
   // Output ceiling for the review. The old 1024 cap forced a shallow "no blockers" scorecard across large diffs;
   // a thorough finding-by-finding review needs real room. Default 4096, max 8192 (the free Workers-AI 120B models
   // support it); an explicit env value still wins, clamped. (#extensive-reviews)
-  const maxTokens = clampNumber(Number(env.AI_MAX_OUTPUT_TOKENS) || 4096, 512, 8192);
+  const maxTokens = clampNumber(
+    Number(env.AI_MAX_OUTPUT_TOKENS) || 4096,
+    512,
+    8192,
+  );
   // Safety (convergence, flag-gated): defang the UNTRUSTED, author-controlled title/body/diff so a
   // prompt-injection payload never reaches the model verbatim. Flag-OFF (default) passes `input` through
   // unchanged → the prompt is byte-identical to today. Only the title/body/diff fed to buildUserPrompt are
@@ -603,7 +794,10 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   // Per-repo cutover gate (GITTENSORY_REVIEW_REPOS): the defang activates for THIS PR's repo only when it
   // is allowlisted AND the global safety flag is ON. Empty/unset allowlist → `input` passes through unchanged
   // for every repo (the prompt is byte-identical to today) regardless of GITTENSORY_REVIEW_SAFETY.
-  const promptInput = isSafetyEnabled(env) && isConvergenceRepoAllowed(env, input.repoFullName) ? { ...input, ...defangReviewInput(input) } : input;
+  const promptInput =
+    isSafetyEnabled(env) && isConvergenceRepoAllowed(env, input.repoFullName)
+      ? { ...input, ...defangReviewInput(input) }
+      : input;
   const user = buildUserPrompt(promptInput);
   // Grounding-discipline SYSTEM suffix (convergence, flag-gated). When the caller supplied grounding, the
   // reviewers are told to verify claims against the attached CI/files; otherwise this is REVIEW_SYSTEM_PROMPT
@@ -618,39 +812,80 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   // named providers (e.g. claude-code + codex) and a strategy; an explicit `input` field overrides it. `single`
   // (or a single configured reviewer) runs ONE opinion; consensus/synthesis run two.
   const plan = env.AI_REVIEW_PLAN;
-  const configured: ReadonlyArray<{ model: string; fallback?: string | null | undefined }> | null = (input.reviewers?.length ? input.reviewers : plan?.reviewers) ?? null;
-  const primary = configured?.[0] ?? { model: BEST_REVIEW_MODELS[0], fallback: RELIABLE_FALLBACK_MODELS[0] as string | null };
-  const secondary = configured?.[1] ?? { model: BEST_REVIEW_MODELS[1], fallback: RELIABLE_FALLBACK_MODELS[1] as string | null };
+  const configured: ReadonlyArray<{
+    model: string;
+    fallback?: string | null | undefined;
+  }> | null =
+    (input.reviewers?.length ? input.reviewers : plan?.reviewers) ?? null;
+  const primary = configured?.[0] ?? {
+    model: BEST_REVIEW_MODELS[0],
+    fallback: RELIABLE_FALLBACK_MODELS[0] as string | null,
+  };
+  const secondary = configured?.[1] ?? {
+    model: BEST_REVIEW_MODELS[1],
+    fallback: RELIABLE_FALLBACK_MODELS[1] as string | null,
+  };
   // Per-slot fallback model (Workers-AI default pair has one; a self-host provider has none → reuse its own model,
   // i.e. runWorkersOpinion's single-model path).
   const primaryFallback = primary.fallback ?? primary.model;
   const secondaryFallback = secondary.fallback ?? secondary.model;
-  const combine: CombineStrategy = input.combine ?? plan?.combine ?? "consensus";
+  const combine: CombineStrategy =
+    input.combine ?? plan?.combine ?? "consensus";
   const onMerge: OnMerge | null | undefined = input.onMerge ?? plan?.onMerge;
   const dual = combine !== "single" && (!configured || configured.length > 1);
-  const freeAiCalls = (input.mode === "block" ? (dual ? 2 : 1) : 0) + (input.providerKey ? 0 : 1);
+  const freeAiCalls =
+    (input.mode === "block" ? (dual ? 2 : 1) : 0) + (input.providerKey ? 0 : 1);
   // Estimate against the EFFECTIVE system prompt (`system`) so grounding's extra context is billed against the
   // budget. Flag-OFF, `system === REVIEW_SYSTEM_PROMPT`, so the estimate is byte-identical to today.
-  const estimatedNeurons = freeAiCalls === 0 ? 0 : estimateNeurons(system.length + user.length, maxTokens, freeAiCalls);
+  const estimatedNeurons =
+    freeAiCalls === 0
+      ? 0
+      : estimateNeurons(system.length + user.length, maxTokens, freeAiCalls);
   // FAIL-SAFE default (#budget-no-starve): the daily neuron budget is a runaway-LOOP backstop, not a normal-
   // operation gate. An absent/empty/non-numeric env var must default HIGH (the clamp max), never to a tiny value
   // that silently starves every dual-AI review into quota_exceeded — that exact misconfig (the deployed worker
   // read the 10k free-tier default off `main` while this branch said 2M) blocked all reviews. An EXPLICIT value
   // (including "0" to deliberately disable) still wins; only unset/empty/NaN falls back to the safe maximum.
   const rawNeuronBudget = Number(env.AI_DAILY_NEURON_BUDGET);
-  const budget = clampNumber(env.AI_DAILY_NEURON_BUDGET && Number.isFinite(rawNeuronBudget) ? rawNeuronBudget : 10_000_000, 0, 10_000_000);
+  const budget = clampNumber(
+    env.AI_DAILY_NEURON_BUDGET && Number.isFinite(rawNeuronBudget)
+      ? rawNeuronBudget
+      : 10_000_000,
+    0,
+    10_000_000,
+  );
   const used = await sumAiEstimatedNeuronsSince(env, utcDayStartIso());
   const remainingBudget = Math.max(0, budget - used);
   if (estimatedNeurons > remainingBudget) {
-    await record(env, input, "quota_exceeded", 0, `estimated ${estimatedNeurons} neurons exceeds remaining ${remainingBudget}`);
+    await record(
+      env,
+      input,
+      "quota_exceeded",
+      0,
+      `estimated ${estimatedNeurons} neurons exceeds remaining ${remainingBudget}`,
+    );
     return { status: "quota_exceeded", estimatedNeurons, remainingBudget };
   }
 
   if (input.providerKey) {
-    const byokDailyLimit = clampNumber(Number(env.AI_BYOK_DAILY_REPO_LIMIT || DEFAULT_BYOK_DAILY_REPO_LIMIT), 0, 10_000);
-    const byokUsed = await countByokAiEventsForRepoSince(env, input.repoFullName, utcDayStartIso());
+    const byokDailyLimit = clampNumber(
+      Number(env.AI_BYOK_DAILY_REPO_LIMIT || DEFAULT_BYOK_DAILY_REPO_LIMIT),
+      0,
+      10_000,
+    );
+    const byokUsed = await countByokAiEventsForRepoSince(
+      env,
+      input.repoFullName,
+      utcDayStartIso(),
+    );
     if (byokUsed >= byokDailyLimit) {
-      await record(env, input, "quota_exceeded", 0, `BYOK daily repo limit ${byokDailyLimit} reached`);
+      await record(
+        env,
+        input,
+        "quota_exceeded",
+        0,
+        `BYOK daily repo limit ${byokDailyLimit} reached`,
+      );
       return { status: "quota_exceeded", estimatedNeurons, remainingBudget };
     }
   }
@@ -659,11 +894,23 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
   let byokFailure: ProviderFailure | undefined;
   let advisoryReview: ModelReview | null;
   if (input.providerKey) {
-    const outcome = await runProviderReview(input.providerKey, system, user, maxTokens);
+    const outcome = await runProviderReview(
+      input.providerKey,
+      system,
+      user,
+      maxTokens,
+    );
     advisoryReview = outcome.review;
     byokFailure = outcome.failure;
   } else {
-    advisoryReview = await runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens);
+    advisoryReview = await runWorkersOpinion(
+      env,
+      primary.model,
+      primaryFallback,
+      system,
+      user,
+      maxTokens,
+    );
   }
 
   let consensusDefect: AiConsensusDefect | null = null;
@@ -676,8 +923,24 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
       // configured provider pair on self-host). Reuse the advisory leg's review as the first opinion when it
       // already ran it (non-BYOK), instead of paying for it twice.
       const [a, b] = await Promise.all([
-        input.providerKey ? runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens) : Promise.resolve(advisoryReview),
-        runWorkersOpinion(env, secondary.model, secondaryFallback, system, user, maxTokens),
+        input.providerKey
+          ? runWorkersOpinion(
+              env,
+              primary.model,
+              primaryFallback,
+              system,
+              user,
+              maxTokens,
+            )
+          : Promise.resolve(advisoryReview),
+        runWorkersOpinion(
+          env,
+          secondary.model,
+          secondaryFallback,
+          system,
+          user,
+          maxTokens,
+        ),
       ]);
       secondReview = b;
       // Combine per the configured strategy (#dual-ai-combiner). Default `consensus` is byte-identical to the
@@ -689,28 +952,64 @@ export async function runGittensoryAiReview(env: Env, input: GittensoryAiReviewI
       inconclusive = combined.inconclusive;
     } else {
       // Single reviewer: its verdict IS the decision. Reuse the advisory leg (non-BYOK) or run the one reviewer.
-      const a = input.providerKey ? await runWorkersOpinion(env, primary.model, primaryFallback, system, user, maxTokens) : advisoryReview;
+      const a = input.providerKey
+        ? await runWorkersOpinion(
+            env,
+            primary.model,
+            primaryFallback,
+            system,
+            user,
+            maxTokens,
+          )
+        : advisoryReview;
       const combined = combineReviews([a], { strategy: "single" });
       consensusDefect = combined.defect;
       inconclusive = combined.inconclusive;
     }
   }
 
-  const reviewsForNotes = [advisoryReview, secondReview].filter((r): r is ModelReview => Boolean(r));
-  const advisoryNotes = reviewsForNotes.length > 0 ? composeAdvisoryNotes(reviewsForNotes) : null;
+  const reviewsForNotes = [advisoryReview, secondReview].filter(
+    (r): r is ModelReview => Boolean(r),
+  );
+  const advisoryNotes =
+    reviewsForNotes.length > 0 ? composeAdvisoryNotes(reviewsForNotes) : null;
   // Line-anchored inline findings (#inline-comments): empty unless the caller asked for them (the prompt suffix
   // is conditional) AND the model emitted any. Inert until the posting path (PR B) consumes them.
   const inlineFindings = composeInlineFindings(reviewsForNotes);
 
-  await record(env, input, "ok", estimatedNeurons, consensusDefect ? "consensus defect" : aiReviewSplit ? "split" : inconclusive ? "inconclusive — held" : advisoryNotes ? "advisory notes" : "no usable output", {
-    mode: input.mode,
-    byok: Boolean(input.providerKey),
-    consensus: Boolean(consensusDefect),
+  await record(
+    env,
+    input,
+    "ok",
+    estimatedNeurons,
+    consensusDefect
+      ? "consensus defect"
+      : aiReviewSplit
+        ? "split"
+        : inconclusive
+          ? "inconclusive — held"
+          : advisoryNotes
+            ? "advisory notes"
+            : "no usable output",
+    {
+      mode: input.mode,
+      byok: Boolean(input.providerKey),
+      consensus: Boolean(consensusDefect),
+      split: aiReviewSplit,
+      inconclusive,
+      ...(byokFailure ? { byokFailure } : {}),
+    },
+  );
+  return {
+    status: "ok",
+    advisoryNotes,
+    consensusDefect,
     split: aiReviewSplit,
     inconclusive,
-    ...(byokFailure ? { byokFailure } : {}),
-  });
-  return { status: "ok", advisoryNotes, consensusDefect, split: aiReviewSplit, inconclusive, estimatedNeurons, reviewerCount: reviewsForNotes.length, inlineFindings };
+    estimatedNeurons,
+    reviewerCount: reviewsForNotes.length,
+    inlineFindings,
+  };
 }
 
 async function record(
@@ -726,11 +1025,17 @@ async function record(
     feature: "ai_review_pr",
     actor: input.actor ?? null,
     route: "github_app.ai_review",
-    model: input.providerKey ? `byok:${input.providerKey.provider}` : BEST_REVIEW_MODELS.join("+"),
+    model: input.providerKey
+      ? `byok:${input.providerKey.provider}`
+      : BEST_REVIEW_MODELS.join("+"),
     status,
     estimatedNeurons,
     detail,
-    metadata: { repoFullName: input.repoFullName, pullNumber: input.prNumber, ...(metadata ?? {}) },
+    metadata: {
+      repoFullName: input.repoFullName,
+      pullNumber: input.prNumber,
+      ...(metadata ?? {}),
+    },
   });
 }
 

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -7,17 +7,64 @@ import {
 } from "../../src/services/ai-review";
 import { createTestEnv } from "../helpers/d1";
 
-const { parseModelReview, coerceAiText, composeAdvisoryNotes, composeInlineFindings, consensusDefectOf, combineReviews, toPublicSafe, runWorkersOpinion } = __aiReviewInternals;
+const {
+  parseModelReview,
+  coerceAiText,
+  composeAdvisoryNotes,
+  composeInlineFindings,
+  consensusDefectOf,
+  combineReviews,
+  toPublicSafe,
+  runWorkersOpinion,
+} = __aiReviewInternals;
 
-type InlineFinding = { path: string; line: number; severity: "blocker" | "nit"; body: string };
-type ModelReviewShape = { assessment: string; blockers: string[]; nits: string[]; suggestions: string[]; inlineFindings: InlineFinding[] };
-const reviewWithFindings = (inlineFindings: InlineFinding[]): ModelReviewShape => ({ assessment: "", blockers: [], nits: [], suggestions: [], inlineFindings });
+type InlineFinding = {
+  path: string;
+  line: number;
+  severity: "blocker" | "nit";
+  body: string;
+};
+type ModelReviewShape = {
+  assessment: string;
+  blockers: string[];
+  nits: string[];
+  suggestions: string[];
+  inlineFindings: InlineFinding[];
+};
+const reviewWithFindings = (
+  inlineFindings: InlineFinding[],
+): ModelReviewShape => ({
+  assessment: "",
+  blockers: [],
+  nits: [],
+  suggestions: [],
+  inlineFindings,
+});
 
-function reviewJson(over: Partial<{ assessment: string; suggestions: string[]; nits: string[]; blockers: string[]; present: boolean; confidence: number; title: string; detail: string }> = {}): string {
+function reviewJson(
+  over: Partial<{
+    assessment: string;
+    suggestions: string[];
+    nits: string[];
+    blockers: string[];
+    present: boolean;
+    confidence: number;
+    title: string;
+    detail: string;
+  }> = {},
+): string {
   return JSON.stringify({
     assessment: over.assessment ?? "The change looks reasonable and focused.",
     // `present`/`title` retained for call-site compat: a "present" critical defect maps to one blocker.
-    blockers: over.blockers ?? (over.present ? [over.title || over.detail || "Unhandled null dereference in src/a.ts."] : []),
+    blockers:
+      over.blockers ??
+      (over.present
+        ? [
+            over.title ||
+              over.detail ||
+              "Unhandled null dereference in src/a.ts.",
+          ]
+        : []),
     nits: over.nits ?? ["Edge case on empty input is untested."],
     suggestions: over.suggestions ?? ["Add a unit test for the new branch."],
   });
@@ -40,54 +87,127 @@ afterEach(() => {
 describe("runGittensoryAiReview gating", () => {
   it("is disabled until both AI flags are on", async () => {
     const run = vi.fn();
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true" });
-    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({ status: "disabled" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+    });
+    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({
+      status: "disabled",
+    });
     expect(run).not.toHaveBeenCalled();
   });
 
   it("reports unavailable when the Workers AI binding is missing", async () => {
-    const env = createTestEnv({ AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
-    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({ status: "unavailable" });
+    const env = createTestEnv({
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+    });
+    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({
+      status: "unavailable",
+    });
   });
 
   it("enforces the shared daily neuron budget before calling the model", async () => {
     const run = vi.fn();
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "1" });
-    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({ status: "quota_exceeded" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "1",
+    });
+    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({
+      status: "quota_exceeded",
+    });
     expect(run).not.toHaveBeenCalled();
   });
 
   it("clamps a non-numeric AI_MAX_OUTPUT_TOKENS back to the default", async () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000", AI_MAX_OUTPUT_TOKENS: "not-a-number" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+      AI_MAX_OUTPUT_TOKENS: "not-a-number",
+    });
     const result = await runGittensoryAiReview(env, baseInput);
     expect(result.status).toBe("ok"); // NaN → clamped to the 256 floor, review still runs
   });
 
   it("does NOT count a BYOK advisory against the free neuron budget (it bills the maintainer)", async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "BYOK advisory." }) }] }), { status: 200 }));
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: reviewJson({ assessment: "BYOK advisory." }),
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
     vi.stubGlobal("fetch", fetchMock);
     const run = vi.fn();
     // Free budget is exhausted (1 neuron), but a BYOK advisory bills the maintainer's account, so it still runs
     // while the separate BYOK repo/day quota has capacity.
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "1", AI_BYOK_DAILY_REPO_LIMIT: "1" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, providerKey: { provider: "anthropic", key: "sk-ant-secret" } });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "1",
+      AI_BYOK_DAILY_REPO_LIMIT: "1",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: { provider: "anthropic", key: "sk-ant-secret" },
+    });
     expect(result.status).toBe("ok");
-    expect(result.status === "ok" && result.advisoryNotes).toContain("BYOK advisory.");
+    expect(result.status === "ok" && result.advisoryNotes).toContain(
+      "BYOK advisory.",
+    );
     expect(result.status === "ok" && result.estimatedNeurons).toBe(0); // advisory-only BYOK consumes no free budget
     expect(fetchMock).toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
   });
 
   it("enforces a separate per-repo daily quota before BYOK provider calls", async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "BYOK advisory." }) }] }), { status: 200 }));
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: reviewJson({ assessment: "BYOK advisory." }),
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
     vi.stubGlobal("fetch", fetchMock);
     const run = vi.fn();
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "0", AI_BYOK_DAILY_REPO_LIMIT: "1" });
-    const providerKey = { provider: "anthropic" as const, key: "sk-ant-secret" };
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "0",
+      AI_BYOK_DAILY_REPO_LIMIT: "1",
+    });
+    const providerKey = {
+      provider: "anthropic" as const,
+      key: "sk-ant-secret",
+    };
 
-    await expect(runGittensoryAiReview(env, { ...baseInput, providerKey })).resolves.toMatchObject({ status: "ok" });
-    await expect(runGittensoryAiReview(env, { ...baseInput, prNumber: 8, providerKey })).resolves.toMatchObject({ status: "quota_exceeded" });
+    await expect(
+      runGittensoryAiReview(env, { ...baseInput, providerKey }),
+    ).resolves.toMatchObject({ status: "ok" });
+    await expect(
+      runGittensoryAiReview(env, { ...baseInput, prNumber: 8, providerKey }),
+    ).resolves.toMatchObject({ status: "quota_exceeded" });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(run).not.toHaveBeenCalled();
@@ -97,15 +217,28 @@ describe("runGittensoryAiReview gating", () => {
 describe("AI Gateway routing for free Workers-AI calls", () => {
   it("routes through the gateway when AI_GATEWAY_ID is set", async () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000", AI_GATEWAY_ID: "gtsy-gw" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+      AI_GATEWAY_ID: "gtsy-gw",
+    });
     await runGittensoryAiReview(env, baseInput);
     expect(run).toHaveBeenCalled();
-    expect((run.mock.calls[0] as unknown[] | undefined)?.[2]).toEqual({ gateway: { id: "gtsy-gw" } });
+    expect((run.mock.calls[0] as unknown[] | undefined)?.[2]).toEqual({
+      gateway: { id: "gtsy-gw" },
+    });
   });
 
   it("calls the binding directly (no gateway arg) when AI_GATEWAY_ID is unset", async () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
     await runGittensoryAiReview(env, baseInput);
     expect((run.mock.calls[0] as unknown[] | undefined)?.[2]).toBeUndefined();
   });
@@ -114,7 +247,12 @@ describe("AI Gateway routing for free Workers-AI calls", () => {
 describe("runGittensoryAiReview advisory mode", () => {
   it("produces public-safe advisory notes from one Workers-AI opinion and no defect", async () => {
     const run = vi.fn(async (_model: string) => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
     const result = await runGittensoryAiReview(env, baseInput);
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
@@ -128,10 +266,17 @@ describe("runGittensoryAiReview advisory mode", () => {
 });
 
 describe("review.profile shapes the reviewer system prompt (#review-profile)", () => {
-  const systemPromptOf = (run: ReturnType<typeof vi.fn>): string => ((run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })?.messages?.[0]?.content ?? "");
+  const systemPromptOf = (run: ReturnType<typeof vi.fn>): string =>
+    (run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })
+      ?.messages?.[0]?.content ?? "";
   const runProfile = async (profile: GittensoryAiReviewInput["profile"]) => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
     await runGittensoryAiReview(env, { ...baseInput, profile });
     return systemPromptOf(run);
   };
@@ -157,24 +302,46 @@ describe("review.profile shapes the reviewer system prompt (#review-profile)", (
   });
 
   it("pathGuidance is appended to the system prompt; empty/absent leaves it byte-identical (#review-path-instructions)", async () => {
-    const systemPromptOf = (run: ReturnType<typeof vi.fn>): string => ((run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })?.messages?.[0]?.content ?? "");
+    const systemPromptOf = (run: ReturnType<typeof vi.fn>): string =>
+      (run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })
+        ?.messages?.[0]?.content ?? "";
     const runGuidance = async (pathGuidance: string | undefined) => {
       const run = vi.fn(async () => ({ response: reviewJson() }));
-      const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+      const env = createTestEnv({
+        AI: { run } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
       await runGittensoryAiReview(env, { ...baseInput, pathGuidance });
       return systemPromptOf(run);
     };
-    expect(await runGuidance("\n\nPath-specific review instructions:\n- `src/**`: Enforce null checks.")).toContain("Enforce null checks.");
+    expect(
+      await runGuidance(
+        "\n\nPath-specific review instructions:\n- `src/**`: Enforce null checks.",
+      ),
+    ).toContain("Enforce null checks.");
     // Absent or whitespace-only → no append.
-    expect(await runGuidance(undefined)).not.toContain("Path-specific review instructions");
-    expect(await runGuidance("   ")).not.toContain("Path-specific review instructions");
+    expect(await runGuidance(undefined)).not.toContain(
+      "Path-specific review instructions",
+    );
+    expect(await runGuidance("   ")).not.toContain(
+      "Path-specific review instructions",
+    );
   });
 
   it("the inline-findings instruction is appended to the system prompt ONLY when requested (#inline-comments)", async () => {
-    const systemPromptOf = (run: ReturnType<typeof vi.fn>): string => ((run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })?.messages?.[0]?.content ?? "");
+    const systemPromptOf = (run: ReturnType<typeof vi.fn>): string =>
+      (run.mock.calls[0]?.[1] as { messages?: Array<{ content?: string }> })
+        ?.messages?.[0]?.content ?? "";
     const runInline = async (inlineFindings: boolean | undefined) => {
       const run = vi.fn(async () => ({ response: reviewJson() }));
-      const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+      const env = createTestEnv({
+        AI: { run } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
       await runGittensoryAiReview(env, { ...baseInput, inlineFindings });
       return systemPromptOf(run);
     };
@@ -187,12 +354,27 @@ describe("review.profile shapes the reviewer system prompt (#review-profile)", (
 
 describe("runGittensoryAiReview block mode (consensus)", () => {
   function envWith(run: (model: string) => Promise<unknown>) {
-    return createTestEnv({ AI: { run: vi.fn(run) } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    return createTestEnv({
+      AI: { run: vi.fn(run) } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
   }
 
   it("reports a consensus defect only when BOTH models name a concrete blocker", async () => {
-    const env = envWith(async () => ({ response: reviewJson({ present: true, confidence: 0.95, title: "Unhandled null", detail: "Crashes on empty list." }) }));
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    const env = envWith(async () => ({
+      response: reviewJson({
+        present: true,
+        confidence: 0.95,
+        title: "Unhandled null",
+        detail: "Crashes on empty list.",
+      }),
+    }));
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+    });
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.consensusDefect).not.toBeNull();
@@ -203,25 +385,56 @@ describe("runGittensoryAiReview block mode (consensus)", () => {
     const env = envWith(async (model) =>
       model === BEST_REVIEW_MODELS[1]
         ? { response: reviewJson({ present: false }) }
-        : { response: reviewJson({ present: true, confidence: 0.99, title: "Race", detail: "Concurrent write." }) },
+        : {
+            response: reviewJson({
+              present: true,
+              confidence: 0.99,
+              title: "Race",
+              detail: "Concurrent write.",
+            }),
+          },
     );
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+    });
     expect(result.status === "ok" && result.consensusDefect).toBeNull();
   });
 
   it("does NOT report a defect when both models flag only nits (no blocker)", async () => {
     // Severity discipline: nits never block. Both reviewers return nits but zero blockers → no consensus defect.
-    const env = envWith(async () => ({ response: reviewJson({ present: false, nits: ["Consider renaming the helper."] }) }));
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    const env = envWith(async () => ({
+      response: reviewJson({
+        present: false,
+        nits: ["Consider renaming the helper."],
+      }),
+    }));
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+    });
     expect(result.status === "ok" && result.consensusDefect).toBeNull();
   });
 
   it("does NOT report a defect when one model's verdict is unparseable (null opinion)", async () => {
     // Only the first slot's primary parses; the second slot's primary AND its reliable fallback fail.
     const env = envWith(async (model) =>
-      model === BEST_REVIEW_MODELS[0] ? { response: reviewJson({ present: true, confidence: 0.99, title: "Null deref", detail: "boom" }) } : { response: "garbage" },
+      model === BEST_REVIEW_MODELS[0]
+        ? {
+            response: reviewJson({
+              present: true,
+              confidence: 0.99,
+              title: "Null deref",
+              detail: "boom",
+            }),
+          }
+        : { response: "garbage" },
     );
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block", actor: undefined });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+      actor: undefined,
+    });
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.consensusDefect).toBeNull();
@@ -230,17 +443,54 @@ describe("runGittensoryAiReview block mode (consensus)", () => {
   });
 
   it("a clean dual review is NOT inconclusive (both models parsed, neither blocks → passes)", async () => {
-    const env = envWith(async () => ({ response: reviewJson({ present: false }) }));
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
+    const env = envWith(async () => ({
+      response: reviewJson({ present: false }),
+    }));
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+    });
     expect(result.status === "ok" && result.consensusDefect).toBeNull();
     expect(result.status === "ok" && result.inconclusive).toBe(false);
   });
 
   it("block mode with BYOK: provider writes the advisory, the free Workers-AI pair drives consensus", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "Frontier advisory." }) }] }), { status: 200 })));
-    const run = vi.fn(async (_model: string) => ({ response: reviewJson({ present: true, confidence: 0.96, title: "Off-by-one", detail: "Loop bound." }) }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block", providerKey: { provider: "anthropic", key: "sk-ant" } });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              content: [
+                {
+                  type: "text",
+                  text: reviewJson({ assessment: "Frontier advisory." }),
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    const run = vi.fn(async (_model: string) => ({
+      response: reviewJson({
+        present: true,
+        confidence: 0.96,
+        title: "Off-by-one",
+        detail: "Loop bound.",
+      }),
+    }));
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+      providerKey: { provider: "anthropic", key: "sk-ant" },
+    });
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.consensusDefect?.title).toContain("Off-by-one"); // consensus from Workers AI, not the provider
@@ -251,26 +501,70 @@ describe("runGittensoryAiReview block mode (consensus)", () => {
 
 describe("BYOK provider dispatch", () => {
   it("uses the Anthropic API for the advisory write-up when a key is supplied", async () => {
-    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "BYOK review." }) }] }), { status: 200 }));
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: reviewJson({ assessment: "BYOK review." }),
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
     vi.stubGlobal("fetch", fetchMock);
     const run = vi.fn();
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, providerKey: { provider: "anthropic", key: "sk-ant-secret" } });
-    expect(result.status === "ok" && result.advisoryNotes).toContain("BYOK review.");
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.anthropic.com/v1/messages");
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: { provider: "anthropic", key: "sk-ant-secret" },
+    });
+    expect(result.status === "ok" && result.advisoryNotes).toContain(
+      "BYOK review.",
+    );
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
     // The provider fetch must carry a timeout signal so a hung provider can't stall the queue worker.
-    expect((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal,
+    ).toBeInstanceOf(AbortSignal);
     expect(run).not.toHaveBeenCalled(); // advisory mode + BYOK → no Workers AI call
   });
 
   it("falls back to no notes when the provider returns a non-200 and records the failure reason", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 401 })));
-    const env = createTestEnv({ AI: { run: vi.fn() } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, providerKey: { provider: "openai", key: "sk-secret" } });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 401 })),
+    );
+    const env = createTestEnv({
+      AI: { run: vi.fn() } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: { provider: "openai", key: "sk-secret" },
+    });
     expect(result.status === "ok" && result.advisoryNotes).toBeNull();
     // The audit event names the failure (observability) and NEVER includes key material.
-    const row = await env.DB.prepare("select metadata_json from ai_usage_events where feature = ? order by rowid desc limit 1").bind("ai_review_pr").first<{ metadata_json: string }>();
-    expect(JSON.parse(row?.metadata_json ?? "{}").byokFailure).toBe("http_error");
+    const row = await env.DB.prepare(
+      "select metadata_json from ai_usage_events where feature = ? order by rowid desc limit 1",
+    )
+      .bind("ai_review_pr")
+      .first<{ metadata_json: string }>();
+    expect(JSON.parse(row?.metadata_json ?? "{}").byokFailure).toBe(
+      "http_error",
+    );
     expect(row?.metadata_json ?? "").not.toContain("sk-secret");
   });
 
@@ -279,32 +573,74 @@ describe("BYOK provider dispatch", () => {
       "fetch",
       vi.fn(async () => {
         // Mirror AbortSignal.timeout's rejection (a TimeoutError DOMException-shaped error).
-        throw Object.assign(new Error("The operation timed out."), { name: "TimeoutError" });
+        throw Object.assign(new Error("The operation timed out."), {
+          name: "TimeoutError",
+        });
       }),
     );
-    const env = createTestEnv({ AI: { run: vi.fn() } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, providerKey: { provider: "anthropic", key: "sk-ant-secret" } });
+    const env = createTestEnv({
+      AI: { run: vi.fn() } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: { provider: "anthropic", key: "sk-ant-secret" },
+    });
     expect(result.status === "ok" && result.advisoryNotes).toBeNull();
-    const row = await env.DB.prepare("select metadata_json from ai_usage_events where feature = ? order by rowid desc limit 1").bind("ai_review_pr").first<{ metadata_json: string }>();
+    const row = await env.DB.prepare(
+      "select metadata_json from ai_usage_events where feature = ? order by rowid desc limit 1",
+    )
+      .bind("ai_review_pr")
+      .first<{ metadata_json: string }>();
     expect(JSON.parse(row?.metadata_json ?? "{}").byokFailure).toBe("timeout");
   });
 
   it("falls back to no notes when the provider fetch throws, and honors a model override", async () => {
-    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) => {
-      throw new Error("network down");
-    });
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, _init?: RequestInit) => {
+        throw new Error("network down");
+      },
+    );
     vi.stubGlobal("fetch", fetchMock);
-    const env = createTestEnv({ AI: { run: vi.fn() } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, providerKey: { provider: "anthropic", key: "sk-ant", model: "claude-custom" } });
+    const env = createTestEnv({
+      AI: { run: vi.fn() } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: {
+        provider: "anthropic",
+        key: "sk-ant",
+        model: "claude-custom",
+      },
+    });
     expect(result.status === "ok" && result.advisoryNotes).toBeNull();
-    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1] && (fetchMock.mock.calls[0][1] as RequestInit).body)).model).toBe("claude-custom");
+    expect(
+      JSON.parse(
+        String(
+          fetchMock.mock.calls[0]?.[1] &&
+            (fetchMock.mock.calls[0][1] as RequestInit).body,
+        ),
+      ).model,
+    ).toBe("claude-custom");
   });
 });
 
 describe("Workers AI fallback + degraded output", () => {
   it("tries the per-slot fallback model then returns no notes when every opinion is unparseable", async () => {
-    const run = vi.fn(async (_model: string) => ({ response: "this is not json at all" }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
+    const run = vi.fn(async (_model: string) => ({
+      response: "this is not json at all",
+    }));
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
     const result = await runGittensoryAiReview(env, baseInput);
     expect(result.status === "ok" && result.advisoryNotes).toBeNull();
     // primary 3× + fallback 3× retries, all unparseable.
@@ -313,27 +649,70 @@ describe("Workers AI fallback + degraded output", () => {
 });
 
 describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () => {
-  const planEnv = (plan: { reviewers: Array<{ model: string }>; combine: string; onMerge?: string }, run: (model: string) => Promise<unknown>) =>
-    createTestEnv({ AI: { run: vi.fn(run) } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000", AI_REVIEW_PLAN: plan as never });
+  const planEnv = (
+    plan: {
+      reviewers: Array<{ model: string }>;
+      combine: string;
+      onMerge?: string;
+    },
+    run: (model: string) => Promise<unknown>,
+  ) =>
+    createTestEnv({
+      AI: { run: vi.fn(run) } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+      AI_REVIEW_PLAN: plan as never,
+    });
 
   it("single provider: runs ONE named reviewer and its blocker IS the decision", async () => {
     const seen: string[] = [];
-    const env = planEnv({ reviewers: [{ model: "claude-code" }], combine: "single" }, async (model) => {
-      seen.push(model);
-      return { response: reviewJson({ present: true, title: "Null deref in src/a.ts" }) };
+    const env = planEnv(
+      { reviewers: [{ model: "claude-code" }], combine: "single" },
+      async (model) => {
+        seen.push(model);
+        return {
+          response: reviewJson({
+            present: true,
+            title: "Null deref in src/a.ts",
+          }),
+        };
+      },
+    );
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
     });
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
-    expect(result.status === "ok" && result.consensusDefect?.title).toContain("Null deref");
+    expect(result.status === "ok" && result.consensusDefect?.title).toContain(
+      "Null deref",
+    );
     expect(seen).toEqual(["claude-code"]); // exactly one reviewer, addressed by name
   });
 
   it("dual synthesis (either): runs claude-code AND codex; EITHER blocker decides, never a split", async () => {
     const seen: string[] = [];
-    const env = planEnv({ reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis", onMerge: "either" }, async (model) => {
-      seen.push(model);
-      return model === "codex" ? { response: reviewJson({ present: true, title: "Race condition in src/x.ts" }) } : { response: reviewJson({ present: false }) };
+    const env = planEnv(
+      {
+        reviewers: [{ model: "claude-code" }, { model: "codex" }],
+        combine: "synthesis",
+        onMerge: "either",
+      },
+      async (model) => {
+        seen.push(model);
+        return model === "codex"
+          ? {
+              response: reviewJson({
+                present: true,
+                title: "Race condition in src/x.ts",
+              }),
+            }
+          : { response: reviewJson({ present: false }) };
+      },
+    );
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
     });
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block" });
     if (result.status !== "ok") throw new Error("expected ok");
     expect(result.consensusDefect?.title).toContain("Race condition"); // codex's lone blocker decides under synthesis/either
     expect(result.split).toBe(false); // synthesis never splits
@@ -341,13 +720,38 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
   });
 
   it("single + BYOK: the provider writes the advisory; the one decision reviewer runs via the router", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ content: [{ type: "text", text: reviewJson({ assessment: "Frontier advisory." }) }] }), { status: 200 })));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              content: [
+                {
+                  type: "text",
+                  text: reviewJson({ assessment: "Frontier advisory." }),
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
     const seen: string[] = [];
-    const env = planEnv({ reviewers: [{ model: "claude-code" }], combine: "single" }, async (model) => {
-      seen.push(model);
-      return { response: reviewJson({ present: true, title: "Bug in src/a.ts" }) };
+    const env = planEnv(
+      { reviewers: [{ model: "claude-code" }], combine: "single" },
+      async (model) => {
+        seen.push(model);
+        return {
+          response: reviewJson({ present: true, title: "Bug in src/a.ts" }),
+        };
+      },
+    );
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+      providerKey: { provider: "anthropic", key: "sk-ant" },
     });
-    const result = await runGittensoryAiReview(env, { ...baseInput, mode: "block", providerKey: { provider: "anthropic", key: "sk-ant" } });
     if (result.status !== "ok") throw new Error("expected ok");
     expect(result.consensusDefect?.title).toContain("Bug"); // the single Workers-AI/router reviewer's blocker decides
     expect(seen).toEqual(["claude-code"]); // the decision reviewer ran once; the advisory came from BYOK (fetch)
@@ -355,11 +759,23 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
 
   it("explicit input.reviewers/combine/onMerge override the env plan", async () => {
     const seen: string[] = [];
-    const env = planEnv({ reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis" }, async (model) => {
-      seen.push(model);
-      return { response: reviewJson({ present: false }) };
+    const env = planEnv(
+      {
+        reviewers: [{ model: "claude-code" }, { model: "codex" }],
+        combine: "synthesis",
+      },
+      async (model) => {
+        seen.push(model);
+        return { response: reviewJson({ present: false }) };
+      },
+    );
+    await runGittensoryAiReview(env, {
+      ...baseInput,
+      mode: "block",
+      reviewers: [{ model: "ollama" }, { model: "groq" }],
+      combine: "synthesis",
+      onMerge: "both",
     });
-    await runGittensoryAiReview(env, { ...baseInput, mode: "block", reviewers: [{ model: "ollama" }, { model: "groq" }], combine: "synthesis", onMerge: "both" });
     expect([...seen].sort()).toEqual(["groq", "ollama"]); // input reviewers win over the env plan
   });
 });
@@ -368,7 +784,11 @@ describe("pure helpers", () => {
   it("toPublicSafe drops forbidden public text and neutralizes markdown, mentions, links, and control characters", () => {
     expect(toPublicSafe("This change is solid.")).toBe("This change is solid.");
     expect(toPublicSafe("Boost your reward payout")).toBeNull();
-    expect(toPublicSafe("Ping @octo-team about [urgent update](https://evil.example/p) ![pixel](https://evil.example/i.png)\n- injected")).toBe(
+    expect(
+      toPublicSafe(
+        "Ping @octo-team about [urgent update](https://evil.example/p) ![pixel](https://evil.example/i.png)\n- injected",
+      ),
+    ).toBe(
       "Ping @\u200Bocto-team about \\[urgent update\\]\\(https:\u200B//evil.example/p\\) \\!\\[pixel\\]\\(https:\u200B//evil.example/i.png\\) - injected",
     );
     expect(toPublicSafe("")).toBeNull();
@@ -379,10 +799,14 @@ describe("pure helpers", () => {
   it("coerceAiText handles string, {response}, OpenAI choices, Anthropic content, and output_text shapes", () => {
     expect(coerceAiText("raw")).toBe("raw");
     expect(coerceAiText({ response: "r" })).toBe("r");
-    expect(coerceAiText({ choices: [{ message: { content: "c" } }] })).toBe("c");
+    expect(coerceAiText({ choices: [{ message: { content: "c" } }] })).toBe(
+      "c",
+    );
     expect(coerceAiText({ content: [{ type: "text", text: "a" }] })).toBe("a");
     expect(coerceAiText({ content: [] })).toBe(""); // empty content array
-    expect(coerceAiText({ content: [{ type: "image" }], output_text: "fallback" })).toBe("fallback"); // non-text parts → fall through
+    expect(
+      coerceAiText({ content: [{ type: "image" }], output_text: "fallback" }),
+    ).toBe("fallback"); // non-text parts → fall through
     expect(coerceAiText({ response: {} })).toBe("{}"); // object response → JSON.stringify
     expect(coerceAiText({ response: "" })).toBe(""); // empty-string response → fall through
     expect(coerceAiText({ choices: [{ text: "t" }] })).toBe("t"); // content via first.text fallback
@@ -394,12 +818,16 @@ describe("pure helpers", () => {
     expect(parseModelReview("not json")).toBeNull();
     expect(parseModelReview("{ not: valid json }")).toBeNull(); // matches the brace regex but JSON.parse throws
     expect(parseModelReview('{"foo":1}')).toBeNull(); // no assessment, no blockers/nits/suggestions
-    const parsed = parseModelReview(reviewJson({ present: true, title: "Null deref in src/a.ts" }));
+    const parsed = parseModelReview(
+      reviewJson({ present: true, title: "Null deref in src/a.ts" }),
+    );
     expect(parsed?.blockers).toContain("Null deref in src/a.ts");
   });
 
   it("parseModelReview coerces non-string/non-array fields to safe defaults", () => {
-    const parsed = parseModelReview('{"assessment":"ok","suggestions":"not-an-array","blockers":7,"nits":null}');
+    const parsed = parseModelReview(
+      '{"assessment":"ok","suggestions":"not-an-array","blockers":7,"nits":null}',
+    );
     expect(parsed).not.toBeNull();
     expect(parsed?.suggestions).toEqual([]); // non-array → []
     expect(parsed?.blockers).toEqual([]);
@@ -418,98 +846,241 @@ describe("pure helpers", () => {
   });
 
   it("parseModelReview parses a verdict wrapped in ```json fences without a regex strip (#accuracy-gap-3)", () => {
-    const fenced = '```json\n{"assessment":"ok","blockers":["X in src/a.ts"],"nits":[],"suggestions":[]}\n```';
+    const fenced =
+      '```json\n{"assessment":"ok","blockers":["X in src/a.ts"],"nits":[],"suggestions":[]}\n```';
     const parsed = parseModelReview(fenced);
     expect(parsed?.blockers).toEqual(["X in src/a.ts"]);
   });
 
   describe("combineReviews (#dual-ai-combiner)", () => {
-    const r = (blockers: string[]) => ({ assessment: "", suggestions: [], nits: [], blockers, inlineFindings: [] });
+    const r = (blockers: string[]) => ({
+      assessment: "",
+      suggestions: [],
+      nits: [],
+      blockers,
+      inlineFindings: [],
+    });
     const clean = r([]);
     const blocked = r(["Null deref in src/a.ts"]);
 
     it("single: the lone reviewer's blocker IS the decision; a clean review passes; a missing review holds", () => {
-      expect(combineReviews([blocked], { strategy: "single" }).defect?.title).toContain("Null deref");
-      expect(combineReviews([clean], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: false });
-      expect(combineReviews([null], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: true });
+      expect(
+        combineReviews([blocked], { strategy: "single" }).defect?.title,
+      ).toContain("Null deref");
+      expect(combineReviews([clean], { strategy: "single" })).toEqual({
+        defect: null,
+        split: false,
+        inconclusive: false,
+      });
+      expect(combineReviews([null], { strategy: "single" })).toEqual({
+        defect: null,
+        split: false,
+        inconclusive: true,
+      });
     });
 
     it("consensus (default): blocks only when BOTH name a blocker; lone blocker → split; a missing opinion → inconclusive (byte-identical to the historical logic)", () => {
-      expect(combineReviews([blocked, blocked], { strategy: "consensus" }).defect).not.toBeNull();
-      expect(combineReviews([blocked, clean], { strategy: "consensus" })).toMatchObject({ defect: null, split: true, inconclusive: false });
-      expect(combineReviews([clean, clean], { strategy: "consensus" })).toEqual({ defect: null, split: false, inconclusive: false });
-      expect(combineReviews([blocked, null], { strategy: "consensus" })).toEqual({ defect: null, split: false, inconclusive: true });
+      expect(
+        combineReviews([blocked, blocked], { strategy: "consensus" }).defect,
+      ).not.toBeNull();
+      expect(
+        combineReviews([blocked, clean], { strategy: "consensus" }),
+      ).toMatchObject({ defect: null, split: true, inconclusive: false });
+      expect(combineReviews([clean, clean], { strategy: "consensus" })).toEqual(
+        { defect: null, split: false, inconclusive: false },
+      );
+      expect(
+        combineReviews([blocked, null], { strategy: "consensus" }),
+      ).toEqual({ defect: null, split: false, inconclusive: true });
     });
 
     it("synthesis/either: ANY reviewer's blocker blocks (one decision, never a split); a missing opinion holds only when nothing present blocked", () => {
-      expect(combineReviews([clean, blocked], { strategy: "synthesis", onMerge: "either" })).toMatchObject({ split: false, inconclusive: false });
-      expect(combineReviews([clean, blocked], { strategy: "synthesis", onMerge: "either" }).defect).not.toBeNull();
-      expect(combineReviews([clean, clean], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: false });
-      expect(combineReviews([blocked, null], { strategy: "synthesis", onMerge: "either" }).defect).not.toBeNull(); // a present blocker decides despite the missing one
-      expect(combineReviews([clean, null], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: true }); // can't certify clean
-      expect(combineReviews([clean, blocked], { strategy: "synthesis" }).defect).not.toBeNull(); // onMerge defaults to either
+      expect(
+        combineReviews([clean, blocked], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }),
+      ).toMatchObject({ split: false, inconclusive: false });
+      expect(
+        combineReviews([clean, blocked], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }).defect,
+      ).not.toBeNull();
+      expect(
+        combineReviews([clean, clean], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }),
+      ).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(
+        combineReviews([blocked, null], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }).defect,
+      ).not.toBeNull(); // a present blocker decides despite the missing one
+      expect(
+        combineReviews([clean, null], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }),
+      ).toEqual({ defect: null, split: false, inconclusive: true }); // can't certify clean
+      expect(
+        combineReviews([clean, blocked], { strategy: "synthesis" }).defect,
+      ).not.toBeNull(); // onMerge defaults to either
     });
 
     it("synthesis/both: blocks only when EVERY present reviewer flags; disagreement passes (never a hold); a missing opinion holds; empty set passes", () => {
-      expect(combineReviews([blocked, blocked], { strategy: "synthesis", onMerge: "both" }).defect).not.toBeNull();
-      expect(combineReviews([blocked, clean], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: false });
-      expect(combineReviews([blocked, null], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: true });
-      expect(combineReviews([], { strategy: "synthesis", onMerge: "both" })).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(
+        combineReviews([blocked, blocked], {
+          strategy: "synthesis",
+          onMerge: "both",
+        }).defect,
+      ).not.toBeNull();
+      expect(
+        combineReviews([blocked, clean], {
+          strategy: "synthesis",
+          onMerge: "both",
+        }),
+      ).toEqual({ defect: null, split: false, inconclusive: false });
+      expect(
+        combineReviews([blocked, null], {
+          strategy: "synthesis",
+          onMerge: "both",
+        }),
+      ).toEqual({ defect: null, split: false, inconclusive: true });
+      expect(
+        combineReviews([], { strategy: "synthesis", onMerge: "both" }),
+      ).toEqual({ defect: null, split: false, inconclusive: false });
     });
 
     it("synthesized defect drops a blocker whose only finding is blank or unsafe (fail-safe, same discipline as consensus)", () => {
-      expect(combineReviews([r(["   "])], { strategy: "single" })).toEqual({ defect: null, split: false, inconclusive: false }); // whitespace-only → no primary
-      expect(combineReviews([r(["Boost your reward payout"]), clean], { strategy: "synthesis", onMerge: "either" })).toEqual({ defect: null, split: false, inconclusive: false }); // unsafe title dropped
+      expect(combineReviews([r(["   "])], { strategy: "single" })).toEqual({
+        defect: null,
+        split: false,
+        inconclusive: false,
+      }); // whitespace-only → no primary
+      expect(
+        combineReviews([r(["Boost your reward payout"]), clean], {
+          strategy: "synthesis",
+          onMerge: "either",
+        }),
+      ).toEqual({ defect: null, split: false, inconclusive: false }); // unsafe title dropped
     });
   });
 
   it("consensusDefectOf requires a concrete blocker in BOTH reviews and drops unsafe titles", () => {
-    const r = (blockers: string[]) => ({ assessment: "", suggestions: [], nits: [], blockers, inlineFindings: [] });
-    expect(consensusDefectOf(r(["Null deref in src/a.ts"]), r(["Null deref in src/a.ts"]))).not.toBeNull();
+    const r = (blockers: string[]) => ({
+      assessment: "",
+      suggestions: [],
+      nits: [],
+      blockers,
+      inlineFindings: [],
+    });
+    expect(
+      consensusDefectOf(
+        r(["Null deref in src/a.ts"]),
+        r(["Null deref in src/a.ts"]),
+      ),
+    ).not.toBeNull();
     expect(consensusDefectOf(r([]), r(["Null deref"]))).toBeNull(); // one has no blocker → split, not consensus
     expect(consensusDefectOf(r(["Null deref"]), r([]))).toBeNull();
-    expect(consensusDefectOf(r(["Boost your reward payout"]), r(["Boost your reward payout"]))).toBeNull(); // unsafe → dropped
+    expect(
+      consensusDefectOf(
+        r(["Boost your reward payout"]),
+        r(["Boost your reward payout"]),
+      ),
+    ).toBeNull(); // unsafe → dropped
   });
 
   it("consensusDefectOf falls back to b's blocker when a's is blank", () => {
-    const a = { assessment: "", suggestions: [], nits: [], blockers: [""], inlineFindings: [] };
-    const b = { assessment: "", suggestions: [], nits: [], blockers: ["Race condition in src/x.ts"], inlineFindings: [] };
+    const a = {
+      assessment: "",
+      suggestions: [],
+      nits: [],
+      blockers: [""],
+      inlineFindings: [],
+    };
+    const b = {
+      assessment: "",
+      suggestions: [],
+      nits: [],
+      blockers: ["Race condition in src/x.ts"],
+      inlineFindings: [],
+    };
     expect(consensusDefectOf(a, b)?.title).toBe("Race condition in src/x.ts");
   });
 
   it("consensusDefectOf uses the default title + detail when BOTH reviewers' blockers are blank", () => {
-    const blank = { assessment: "", suggestions: [], nits: [], blockers: [""], inlineFindings: [] };
+    const blank = {
+      assessment: "",
+      suggestions: [],
+      nits: [],
+      blockers: [""],
+      inlineFindings: [],
+    };
     const out = consensusDefectOf(blank, { ...blank, blockers: [""] });
     expect(out?.title).toContain("AI reviewers agree"); // both blockers[0] falsy → default title
     expect(out?.detail).toContain("independently flagged"); // joined detail empty → default detail
   });
 
   it("runWorkersOpinion returns null without a binding and handles a single-model (no distinct fallback) list", async () => {
-    expect(await runWorkersOpinion(createTestEnv({}), "m", "f", "sys", "user", 256)).toBeNull();
+    expect(
+      await runWorkersOpinion(createTestEnv({}), "m", "f", "sys", "user", 256),
+    ).toBeNull();
     const run = vi.fn(async (_model: string) => ({ response: reviewJson() }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     // fallback === primary exercises the single-element model list branch.
-    const parsed = await runWorkersOpinion(env, "@cf/x/model", "@cf/x/model", "sys", "user", 256);
+    const parsed = await runWorkersOpinion(
+      env,
+      "@cf/x/model",
+      "@cf/x/model",
+      "sys",
+      "user",
+      256,
+    );
     expect(parsed?.assessment).toContain("reasonable");
     expect(run).toHaveBeenCalledTimes(1);
   });
 
   it("applies the default daily neuron budget when none is configured", async () => {
     const run = vi.fn(async (_model: string) => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true" });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+    });
     const result = await runGittensoryAiReview(env, baseInput);
     expect(result.status).toBe("ok");
   });
 
   it("composeAdvisoryNotes returns null when nothing is public-safe", () => {
-    expect(composeAdvisoryNotes([{ assessment: "reward payout farming", suggestions: ["payout"], nits: ["reward"], blockers: [], inlineFindings: [] }])).toBeNull();
+    expect(
+      composeAdvisoryNotes([
+        {
+          assessment: "reward payout farming",
+          suggestions: ["payout"],
+          nits: ["reward"],
+          blockers: [],
+          inlineFindings: [],
+        },
+      ]),
+    ).toBeNull();
   });
 
   it("parseModelReview parses well-formed inline findings; severity defaults to nit unless exactly 'blocker' (#inline-comments)", () => {
     const json = JSON.stringify({
-      assessment: "ok", blockers: [], nits: [], suggestions: [],
+      assessment: "ok",
+      blockers: [],
+      nits: [],
+      suggestions: [],
       inlineFindings: [
-        { path: "src/a.ts", line: 12, severity: "blocker", body: "Null deref." },
+        {
+          path: "src/a.ts",
+          line: 12,
+          severity: "blocker",
+          body: "Null deref.",
+        },
         { path: "src/b.ts", line: 3, severity: "whatever", body: "Rename x." },
       ],
     });
@@ -521,7 +1092,10 @@ describe("pure helpers", () => {
 
   it("parseModelReview drops malformed inline findings (non-object / missing path|line|body / non-positive line), never partial", () => {
     const json = JSON.stringify({
-      assessment: "ok", blockers: [], nits: [], suggestions: [],
+      assessment: "ok",
+      blockers: [],
+      nits: [],
+      suggestions: [],
       inlineFindings: [
         null,
         "nope",
@@ -529,23 +1103,59 @@ describe("pure helpers", () => {
         { path: "src/a.ts", body: "no line" },
         { path: "src/c.ts", line: 7 },
         { path: "src/a.ts", line: 0, body: "zero line" },
-        { path: "src/a.ts", line: 2.9, severity: "nit", body: "kept (truncated)" },
+        {
+          path: "src/a.ts",
+          line: 2.9,
+          severity: "nit",
+          body: "kept (truncated)",
+        },
       ],
     });
-    expect(parseModelReview(json)?.inlineFindings).toEqual([{ path: "src/a.ts", line: 2, severity: "nit", body: "kept (truncated)" }]);
+    expect(parseModelReview(json)?.inlineFindings).toEqual([
+      { path: "src/a.ts", line: 2, severity: "nit", body: "kept (truncated)" },
+    ]);
   });
 
   it("parseModelReview defaults inline findings to [] when absent or not an array", () => {
-    expect(parseModelReview(JSON.stringify({ assessment: "ok", blockers: [], nits: [], suggestions: [] }))?.inlineFindings).toEqual([]);
-    expect(parseModelReview(JSON.stringify({ assessment: "ok", blockers: [], nits: [], suggestions: [], inlineFindings: "nope" }))?.inlineFindings).toEqual([]);
+    expect(
+      parseModelReview(
+        JSON.stringify({
+          assessment: "ok",
+          blockers: [],
+          nits: [],
+          suggestions: [],
+        }),
+      )?.inlineFindings,
+    ).toEqual([]);
+    expect(
+      parseModelReview(
+        JSON.stringify({
+          assessment: "ok",
+          blockers: [],
+          nits: [],
+          suggestions: [],
+          inlineFindings: "nope",
+        }),
+      )?.inlineFindings,
+    ).toEqual([]);
   });
 
   it("composeInlineFindings dedupes by path+line (first wins) and drops public-unsafe bodies (#inline-comments)", () => {
     const out = composeInlineFindings([
       reviewWithFindings([
         { path: "src/a.ts", line: 1, severity: "nit", body: "First." },
-        { path: "src/a.ts", line: 1, severity: "blocker", body: "Duplicate line — dropped." },
-        { path: "src/a.ts", line: 2, severity: "nit", body: "reward payout farming" },
+        {
+          path: "src/a.ts",
+          line: 1,
+          severity: "blocker",
+          body: "Duplicate line — dropped.",
+        },
+        {
+          path: "src/a.ts",
+          line: 2,
+          severity: "nit",
+          body: "reward payout farming",
+        },
         { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." },
       ]),
     ]);
@@ -556,36 +1166,102 @@ describe("pure helpers", () => {
   });
 
   it("composeInlineFindings caps the total at 10 across reviewers, and returns [] for no reviews", () => {
-    const many = Array.from({ length: 14 }, (_, i): InlineFinding => ({ path: `src/f${i}.ts`, line: i + 1, severity: "nit", body: `Body ${i}` }));
+    const many = Array.from(
+      { length: 14 },
+      (_, i): InlineFinding => ({
+        path: `src/f${i}.ts`,
+        line: i + 1,
+        severity: "nit",
+        body: `Body ${i}`,
+      }),
+    );
     expect(composeInlineFindings([reviewWithFindings(many)])).toHaveLength(10);
     expect(composeInlineFindings([])).toEqual([]);
   });
 
   it("runGittensoryAiReview emits composed inline findings only when the caller asks for them (#inline-comments)", async () => {
-    const json = JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [], inlineFindings: [{ path: "src/a.ts", line: 3, severity: "nit", body: "Guard the empty case." }] });
+    const json = JSON.stringify({
+      assessment: "Looks fine.",
+      blockers: [],
+      nits: [],
+      suggestions: [],
+      inlineFindings: [
+        {
+          path: "src/a.ts",
+          line: 3,
+          severity: "nit",
+          body: "Guard the empty case.",
+        },
+      ],
+    });
     const run = vi.fn(async () => ({ response: json }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, inlineFindings: true });
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      inlineFindings: true,
+    });
     expect(result.status).toBe("ok");
-    if (result.status === "ok") expect(result.inlineFindings).toEqual([{ path: "src/a.ts", line: 3, severity: "nit", body: "Guard the empty case." }]);
+    if (result.status === "ok")
+      expect(result.inlineFindings).toEqual([
+        {
+          path: "src/a.ts",
+          line: 3,
+          severity: "nit",
+          body: "Guard the empty case.",
+        },
+      ]);
   });
 
   it("composeAdvisoryNotes renders only the sections that have public-safe content", () => {
-    const review = (over: Partial<{ assessment: string; suggestions: string[]; nits: string[]; blockers: string[] }>) => ({ assessment: over.assessment ?? "", suggestions: over.suggestions ?? [], nits: over.nits ?? [], blockers: over.blockers ?? [], inlineFindings: [] });
-    const assessmentOnly = composeAdvisoryNotes([review({ assessment: "Looks good." })]);
+    const review = (
+      over: Partial<{
+        assessment: string;
+        suggestions: string[];
+        nits: string[];
+        blockers: string[];
+      }>,
+    ) => ({
+      assessment: over.assessment ?? "",
+      suggestions: over.suggestions ?? [],
+      nits: over.nits ?? [],
+      blockers: over.blockers ?? [],
+      inlineFindings: [],
+    });
+    const assessmentOnly = composeAdvisoryNotes([
+      review({ assessment: "Looks good." }),
+    ]);
     expect(assessmentOnly).toBe("Looks good.");
     const nitsOnly = composeAdvisoryNotes([review({ nits: ["Add a test."] })]);
     expect(nitsOnly).toContain("**Nits (1)**");
     expect(nitsOnly).not.toContain("<details>");
     expect(nitsOnly).not.toContain("**Blockers**");
-    const blockersOnly = composeAdvisoryNotes([review({ blockers: ["Null deref in src/a.ts."] })]);
+    const blockersOnly = composeAdvisoryNotes([
+      review({ blockers: ["Null deref in src/a.ts."] }),
+    ]);
     expect(blockersOnly).toContain("**Blockers**");
     expect(blockersOnly).not.toContain("**Nits");
   });
 
   it("composeAdvisoryNotes merges + dedupes blockers/nits across two reviewers and renders both sections", () => {
-    const a = { assessment: "Solid change.", suggestions: ["Add a test."], nits: ["Rename x."], blockers: ["Null deref in src/a.ts."], inlineFindings: [] };
-    const b = { assessment: "Second look.", suggestions: ["Add a test."], nits: ["Rename x.", "Tighten the type."], blockers: ["Null deref in src/a.ts.", "Off-by-one in the loop bound."], inlineFindings: [] };
+    const a = {
+      assessment: "Solid change.",
+      suggestions: ["Add a test."],
+      nits: ["Rename x."],
+      blockers: ["Null deref in src/a.ts."],
+      inlineFindings: [],
+    };
+    const b = {
+      assessment: "Second look.",
+      suggestions: ["Add a test."],
+      nits: ["Rename x.", "Tighten the type."],
+      blockers: ["Null deref in src/a.ts.", "Off-by-one in the loop bound."],
+      inlineFindings: [],
+    };
     const out = composeAdvisoryNotes([a, b]) ?? "";
     expect(out).toContain("Solid change."); // first reviewer's assessment wins
     expect(out).toContain("**Blockers**");
@@ -600,14 +1276,70 @@ describe("pure helpers", () => {
 
   it("runGittensoryAiReview is disabled when neither flag is set", async () => {
     const env = createTestEnv({ AI: { run: vi.fn() } as unknown as Ai });
-    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({ status: "disabled", reason: "AI summaries are disabled." });
+    await expect(runGittensoryAiReview(env, baseInput)).resolves.toMatchObject({
+      status: "disabled",
+      reason: "AI summaries are disabled.",
+    });
   });
 
   it("handles a review input with no PR body", async () => {
-    const run = vi.fn(async (_model: string, _options: { messages: Array<{ content: string }> }) => ({ response: reviewJson() }));
-    const env = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
-    const result = await runGittensoryAiReview(env, { ...baseInput, body: undefined });
+    const run = vi.fn(
+      async (
+        _model: string,
+        _options: { messages: Array<{ content: string }> },
+      ) => ({ response: reviewJson() }),
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      body: undefined,
+    });
     expect(result.status).toBe("ok");
-    expect(String(run.mock.calls[0]?.[1] && (run.mock.calls[0][1] as { messages: Array<{ content: string }> }).messages[1]?.content)).toContain("Description: (none)");
+    expect(
+      String(
+        run.mock.calls[0]?.[1] &&
+          (run.mock.calls[0][1] as { messages: Array<{ content: string }> })
+            .messages[1]?.content,
+      ),
+    ).toContain("Description: (none)");
+  });
+
+  it("splices the review-enrichment brief into the user + system prompts (#1472)", async () => {
+    const run = vi.fn(
+      async (
+        _model: string,
+        _options: { messages: Array<{ content: string }> },
+      ) => ({ response: reviewJson() }),
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      enrichment: {
+        promptSection: "## EXTERNAL REVIEW BRIEF\n- CVE-1 in lodash",
+        systemSuffix: "Treat the brief as verified ground truth.",
+      },
+    });
+    expect(result.status).toBe("ok");
+    const opts = run.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content: string }>;
+    };
+    const user =
+      opts.messages.find((m) => m.role === "user")?.content ??
+      String(opts.messages[1]?.content);
+    const system =
+      opts.messages.find((m) => m.role === "system")?.content ??
+      String(opts.messages[0]?.content);
+    expect(user).toContain("## EXTERNAL REVIEW BRIEF");
+    expect(system).toContain("Treat the brief as verified ground truth.");
   });
 });

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isEnrichmentEnabled,
+  buildReviewEnrichment,
+} from "../../src/review/enrichment-wire";
+
+const env = (o: Record<string, string>) => o as unknown as Env;
+const input = {
+  repoFullName: "o/r",
+  prNumber: 5,
+  headSha: "abc",
+  title: "t",
+  files: [
+    { path: "a.ts", payload: { patch: "@@ +1 @@" } },
+    { path: "b.ts" },
+  ] as never,
+  diff: "the diff",
+};
+
+describe("isEnrichmentEnabled", () => {
+  it("true only when the flag is on AND REES_URL is set", () => {
+    expect(
+      isEnrichmentEnabled(
+        env({ GITTENSORY_REVIEW_ENRICHMENT: "on", REES_URL: "https://r" }),
+      ),
+    ).toBe(true);
+    expect(
+      isEnrichmentEnabled(
+        env({ GITTENSORY_REVIEW_ENRICHMENT: "true", REES_URL: "https://r" }),
+      ),
+    ).toBe(true);
+    expect(
+      isEnrichmentEnabled(env({ GITTENSORY_REVIEW_ENRICHMENT: "on" })),
+    ).toBe(false); // no URL
+    expect(isEnrichmentEnabled(env({ REES_URL: "https://r" }))).toBe(false); // flag off
+    expect(
+      isEnrichmentEnabled(
+        env({ GITTENSORY_REVIEW_ENRICHMENT: "false", REES_URL: "https://r" }),
+      ),
+    ).toBe(false);
+    expect(isEnrichmentEnabled(env({}))).toBe(false);
+  });
+});
+
+describe("buildReviewEnrichment", () => {
+  let realFetch: typeof fetch;
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("returns the trimmed brief, sends the bearer + mapped files, honors REES_TIMEOUT_MS", async () => {
+    const calls: Array<{ url: unknown; init: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init: RequestInit) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => ({
+          promptSection: "  BRIEF  ",
+          systemSuffix: "suffix",
+        }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const r = await buildReviewEnrichment(
+      env({
+        REES_URL: "https://rees/",
+        REES_SHARED_SECRET: "sek",
+        REES_TIMEOUT_MS: "12000",
+      }),
+      input,
+    );
+    expect(r).toEqual({ promptSection: "BRIEF", systemSuffix: "suffix" });
+    expect(calls[0]!.url).toBe("https://rees/v1/enrich");
+    expect(
+      (calls[0]!.init.headers as Record<string, string>).authorization,
+    ).toBe("Bearer sek");
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.repoFullName).toBe("o/r");
+    expect(body.files).toEqual([
+      { path: "a.ts", patch: "@@ +1 @@" },
+      { path: "b.ts", patch: undefined },
+    ]);
+  });
+
+  it("undefined when REES_URL is unset", async () => {
+    expect(await buildReviewEnrichment(env({}), input)).toBeUndefined();
+  });
+
+  it("undefined on a non-200 response", async () => {
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: false, json: async () => ({}) }) as Response,
+    ) as unknown as typeof fetch;
+    expect(
+      await buildReviewEnrichment(env({ REES_URL: "https://r" }), input),
+    ).toBeUndefined();
+  });
+
+  it("undefined on an empty promptSection (no findings)", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({ promptSection: "", systemSuffix: "x" }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+    expect(
+      await buildReviewEnrichment(env({ REES_URL: "https://r" }), input),
+    ).toBeUndefined();
+  });
+
+  it("undefined on a fetch throw (timeout/network) — fail-safe", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("timeout");
+    }) as unknown as typeof fetch;
+    expect(
+      await buildReviewEnrichment(env({ REES_URL: "https://r" }), input),
+    ).toBeUndefined();
+  });
+
+  it("omits the bearer header when no secret, and defaults systemSuffix to empty", async () => {
+    const calls: RequestInit[] = [];
+    globalThis.fetch = vi.fn(async (_url: unknown, init: RequestInit) => {
+      calls.push(init);
+      return {
+        ok: true,
+        json: async () => ({ promptSection: "x" }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const r = await buildReviewEnrichment(
+      env({ REES_URL: "https://r" }),
+      input,
+    );
+    expect(r).toEqual({ promptSection: "x", systemSuffix: "" });
+    expect(
+      (calls[0]!.headers as Record<string, string>).authorization,
+    ).toBeUndefined();
+  });
+});

--- a/test/unit/enrichment-wiring.test.ts
+++ b/test/unit/enrichment-wiring.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { runAiReviewForAdvisory } from "../../src/queue/processors";
+import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import type { Advisory, RepositorySettings } from "../../src/types";
+import { createTestEnv } from "../helpers/d1";
+
+const notesJson = JSON.stringify({
+  assessment: "Looks fine.",
+  suggestions: [],
+  risks: [],
+  criticalDefect: { present: false, confidence: 0, title: "", detail: "" },
+});
+
+const adv = (repo: string): Advisory => ({
+  id: "adv-e",
+  targetType: "pull_request",
+  targetKey: `${repo}#7`,
+  repoFullName: repo,
+  pullNumber: 7,
+  headSha: "sha7",
+  conclusion: "neutral",
+  severity: "info",
+  title: "Gittensory advisory available",
+  summary: "ok",
+  findings: [],
+  generatedAt: "2026-06-20T00:00:00.000Z",
+});
+
+async function seedRepoFile(env: Env, repo: string) {
+  await upsertRepositoryFromGitHub(
+    env,
+    {
+      name: repo.split("/")[1]!,
+      full_name: repo,
+      private: true,
+      owner: { login: repo.split("/")[0]! },
+    },
+    4242,
+  );
+  await env.DB.prepare(
+    "INSERT INTO pull_request_files (repo_full_name, pull_number, path, status, additions, deletions, changes, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  )
+    .bind(
+      repo,
+      7,
+      "src/a.ts",
+      "modified",
+      1,
+      0,
+      1,
+      JSON.stringify({ patch: "@@\n+export const A = 1;" }),
+    )
+    .run();
+}
+
+describe("review-enrichment wired into the processors review (flag GITTENSORY_REVIEW_ENRICHMENT + REES_URL)", () => {
+  it("FLAG-ON via runAiReviewForAdvisory: POSTs the PR to the REES (with bearer) and splices the brief into the prompts", async () => {
+    const seenUser: string[] = [];
+    const seenSystem: string[] = [];
+    const run = vi.fn(
+      async (
+        _m: string,
+        opts: { messages: Array<{ role: string; content: string }> },
+      ) => {
+        const u = opts.messages.find((m) => m.role === "user");
+        const s = opts.messages.find((m) => m.role === "system");
+        if (u) seenUser.push(u.content);
+        if (s) seenSystem.push(s.content);
+        return { response: notesJson };
+      },
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    // The REES vars are self-host runtime env (not declared on the Worker Env type) — set them as the self-host does.
+    Object.assign(env, {
+      GITTENSORY_REVIEW_ENRICHMENT: "true",
+      REES_URL: "https://rees.example",
+      REES_SHARED_SECRET: "sek",
+    });
+    await seedRepoFile(env, "acme/widgets");
+    let reesUrl = "";
+    let reesAuth: string | null = null;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (url, init) => {
+        if (String(url).includes("/v1/enrich")) {
+          reesUrl = String(url);
+          reesAuth = new Headers(init?.headers).get("authorization");
+          return new Response(
+            JSON.stringify({
+              promptSection: "## EXTERNAL REVIEW BRIEF\n- CVE-1 in lodash",
+              systemSuffix: "Treat the brief as verified ground truth.",
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("nope", { status: 404 });
+      });
+    try {
+      await runAiReviewForAdvisory(env, {
+        settings: { aiReviewMode: "advisory" } as RepositorySettings,
+        repoFullName: "acme/widgets",
+        pr: {
+          number: 7,
+          title: "Add a feature",
+          body: "Implements the thing.",
+        },
+        author: "alice",
+        confirmedContributor: true,
+        advisory: adv("acme/widgets"),
+      });
+      // The enrichment build branch executed: the REES was POSTed at /v1/enrich with the shared-secret bearer.
+      expect(reesUrl).toBe("https://rees.example/v1/enrich");
+      expect(reesAuth).toBe("Bearer sek");
+      // The returned brief flowed into both prompts (splice in ai-review.ts).
+      expect(seenUser[0] ?? "").toContain("## EXTERNAL REVIEW BRIEF");
+      expect(seenSystem[0] ?? "").toContain(
+        "Treat the brief as verified ground truth.",
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("FLAG-OFF (default): the REES is never called", async () => {
+    const run = vi.fn(async () => ({ response: notesJson }));
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await seedRepoFile(env, "acme/off");
+    let reesCalled = false;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (url) => {
+        if (String(url).includes("/v1/enrich")) reesCalled = true;
+        return new Response("nope", { status: 404 });
+      });
+    try {
+      await runAiReviewForAdvisory(env, {
+        settings: { aiReviewMode: "advisory" } as RepositorySettings,
+        repoFullName: "acme/off",
+        pr: { number: 7, title: "t", body: "b" },
+        author: "alice",
+        confirmedContributor: true,
+        advisory: adv("acme/off"),
+      });
+      expect(reesCalled).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Wires the engine to the external review-enrichment service (REES, #1472) — **the seam that makes the six live REES analyzers actually consumed by reviews.**

During a review, flag-gated by `GITTENSORY_REVIEW_ENRICHMENT` + `REES_URL` (self-host only — the hosted Worker sets neither, so it's inert + byte-identical), the engine POSTs the PR (repo/pr/headSha/files/diff) with a shared-secret bearer to `/v1/enrich` and splices the returned public-safe brief into the review prompt **next to grounding + RAG** (same `{promptSection, systemSuffix}` shape + splice points). **Fully fail-safe:** any timeout / non-200 / error / empty brief → undefined → the review proceeds unchanged.

- `src/review/enrichment-wire.ts` — `isEnrichmentEnabled` + `buildReviewEnrichment` (injectable, fail-safe)
- `ai-review.ts` — enrichment input + user/system prompt splice (mirrors grounding)
- `processors.ts` — flag-gated build at the `runGittensoryAiReview` call site
- tests — enrichment-wire unit + enrichment-wiring integration (asserts the REES POST + the splice) + ai-review splice

Closes #1472. (Note: #1530 was a contributor PR on a maintainer-only issue → correctly closed; this is the maintainer-authored seam.)