### PR TITLE
fix(api): include blacklistLabel in settings-preview

### DIFF
--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -195,6 +195,7 @@ export type RepoSettingsPreview = {
     slopGateMinScore?: number | null | undefined;
     autoLabelEnabled: boolean;
     gittensorLabel: string;
+    blacklistLabel: string;
     createMissingLabel: boolean;
     includeMaintainerAuthors: boolean;
     requireLinkedIssue: boolean;
@@ -318,6 +319,7 @@ export function buildRepoSettingsPreview(args: {
       slopGateMinScore: settings.slopGateMinScore ?? null,
       autoLabelEnabled: settings.autoLabelEnabled,
       gittensorLabel: settings.gittensorLabel,
+      blacklistLabel: settings.blacklistLabel ?? "slop",
       createMissingLabel: settings.createMissingLabel,
       includeMaintainerAuthors: settings.includeMaintainerAuthors,
       requireLinkedIssue: settings.requireLinkedIssue,

--- a/test/unit/settings-preview.test.ts
+++ b/test/unit/settings-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildRepoSettingsPreview, decidePublicSurface, type InstallationHealthSummary } from "../../src/signals/settings-preview";
 import { REQUIRED_INSTALLATION_PERMISSIONS } from "../../src/github/backfill";
+import { RepoSettingsPreviewSchema } from "../../src/openapi/schemas";
 import type { IssueRecord, PullRequestRecord, RepositoryRecord, RepositorySettings } from "../../src/types";
 
 const FORBIDDEN_INSTALL_PREVIEW_PUBLIC_LANGUAGE =
@@ -120,6 +121,8 @@ describe("buildRepoSettingsPreview", () => {
     const preview = buildRepoSettingsPreview({ ...base, settings: settings(), installation: healthyInstall, sample: { authorLogin: "miner", minerStatus: "confirmed" } });
     expect(preview.decision.willComment).toBe(true);
     expect(preview.appliedLabel).toBe("gittensor");
+    expect(preview.settings.blacklistLabel).toBe("slop");
+    expect(() => RepoSettingsPreviewSchema.parse(preview)).not.toThrow();
     expect(preview.previewComment).toContain("<!-- gittensory-pr-panel:v1 -->");
     expect(preview.previewComment).toContain("Gittensory");
     expect(preview.previewComment).toContain("Confirmed Gittensor contributor");
@@ -152,6 +155,18 @@ describe("buildRepoSettingsPreview", () => {
         preview.installPreview.checklist.map((item) => [item.summary, item.action]),
       ]),
     ).not.toMatch(FORBIDDEN_INSTALL_PREVIEW_PUBLIC_LANGUAGE);
+  });
+
+  it("includes the configured blacklist label required by the OpenAPI contract", () => {
+    const preview = buildRepoSettingsPreview({
+      ...base,
+      settings: settings({ blacklistLabel: "abuse" }),
+      installation: healthyInstall,
+      sample: { authorLogin: "miner", minerStatus: "confirmed" },
+    });
+
+    expect(preview.settings.blacklistLabel).toBe("abuse");
+    expect(() => RepoSettingsPreviewSchema.parse(preview)).not.toThrow();
   });
 
   it("uses safe defaults for an empty sample preview", () => {


### PR DESCRIPTION
### Motivation
- The published OpenAPI/Zod contract declares `settings.blacklistLabel` as required in the `RepoSettingsPreview` response but the `buildRepoSettingsPreview()` implementation omitted that field, causing schema validation failures for generated clients and tests.

### Description
- Add `blacklistLabel: string` to the `RepoSettingsPreview` type so the response shape includes the field. 
- Return `blacklistLabel` from `buildRepoSettingsPreview()`, defaulting to `"slop"` when the repository settings omit it to preserve backward compatibility. 
- Add regression tests that assert both the default and a configured `blacklistLabel` produce `RepoSettingsPreview` objects that parse successfully with `RepoSettingsPreviewSchema`.

### Testing
- Ran the unit file covering these changes with `npx vitest run test/unit/settings-preview.test.ts` and it passed. 
- Verified type checking with `npm run typecheck`, which completed successfully. 
- Attempted the full local gate `npm run test:ci`; the run reached the coverage stage but failed due to an unrelated coverage remapping error (`TypeError: jsTokens is not a function`) in the environment rather than this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e47aef97c832cbf0c6fbc7bc95471)