### PR TITLE
fix(enrichment): detect quoted workflow `uses` keys

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -4,7 +4,7 @@
 // Official actions/* + github/* are excluded (lowest risk, extremely common) to keep the signal high. Line-cited.
 import type { EnrichRequest, ActionPinFinding } from "../types.js";
 
-const USES_RE = /^\s*-?\s*uses:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
+const USES_RE = /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
 const FULL_SHA = /^[0-9a-f]{40}$/;
 const OFFICIAL = /^(actions|github)\//;
 const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -433,6 +433,24 @@ test("scanWorkflowPins: flags unpinned third-party actions, skips official + SHA
   assert.equal(findings[0].line, 3);
 });
 
+test("scanWorkflowPins: flags unpinned third-party actions with YAML-equivalent uses keys", () => {
+  const patch = [
+    "@@ -1,0 +1,3 @@",
+    "+      - uses : tj-actions/changed-files@v44",
+    "+      - \"uses\": third-party/action@main",
+    "+      - 'uses' : quoted/action@v1",
+  ].join("\n");
+  const findings = scanWorkflowPins(".github/workflows/ci.yml", patch);
+  assert.deepEqual(
+    findings.map(({ action, ref, line }) => ({ action, ref, line })),
+    [
+      { action: "tj-actions/changed-files", ref: "v44", line: 1 },
+      { action: "third-party/action", ref: "main", line: 2 },
+      { action: "quoted/action", ref: "v1", line: 3 },
+    ],
+  );
+});
+
 test("scanActionPins: only scans .github/workflows/* files", async () => {
   const findings = await scanActionPins({
     repoFullName: "o/r",


### PR DESCRIPTION
### Motivation

- The unpinned-action analyzer used a line regex that required an unquoted literal `uses:` token and failed to detect valid YAML variants like `uses :` or quoted keys, allowing bypasses of the unpinned-action check.

### Description

- Relax the `USES_RE` to accept optional key quotes and optional whitespace before the colon so YAML-equivalent `uses`, `uses :`, `"uses":`, and `'uses' :` forms are detected (`review-enrichment/src/analyzers/actions-pin.ts`).
- Add a regression test exercising `uses :`, `"uses":`, and `'uses' :` forms to ensure detection and line-citing remain correct (`review-enrichment/test/enrichment.test.ts`).

### Testing

- Ran the review-enrichment unit suite with `npm --prefix review-enrichment test`, which passed all tests.
- Attempted the full local gate via `git diff --check && npm run test:ci`; earlier checks completed but the `test:coverage` stage hung in this environment and the run was terminated (partial progress observed before termination).
- Ran `npm audit --audit-level=moderate`, which failed due to the npm registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee0688900832cbafbfce8c361668b)