### PR TITLE
fix(queue): guard computeDaysSince so a malformed timestamp can't make the ranking non-deterministic

### DIFF
--- a/src/queue-intelligence.ts
+++ b/src/queue-intelligence.ts
@@ -71,7 +71,13 @@ export const FORBIDDEN_PUBLIC_COMMENT_WORDS = [
 ] as const;
 
 function computeDaysSince(isoDateString: string, now: Date): number {
-  return (now.getTime() - new Date(isoDateString).getTime()) / MILLISECONDS_PER_DAY;
+  // A malformed/empty timestamp -> NaN, which flows into computePrivateBurdenReductionScore and then the
+  // analyzePRQueue sort comparator (`b.score - a.score`). NaN makes Array.sort non-deterministic, and even
+  // Infinity would reintroduce that (`Infinity - Infinity = NaN` when two PRs share a bad timestamp), so the
+  // fallback must be finite. 0 degrades a bad timestamp to "just-created" (lowest burden priority); mirrors the
+  // issueAgeDays guard in signals/reward-risk.ts.
+  const parsed = Date.parse(isoDateString);
+  return Number.isFinite(parsed) ? (now.getTime() - parsed) / MILLISECONDS_PER_DAY : 0;
 }
 
 function isPRVeryLarge(pr: PullRequestInput): boolean {

--- a/test/unit/queue-intelligence.test.ts
+++ b/test/unit/queue-intelligence.test.ts
@@ -183,6 +183,43 @@ describe("analyzePRQueue — ranking (reviewability + burden reduction)", () => 
   });
 });
 
+describe("analyzePRQueue — malformed timestamp robustness", () => {
+  it("keeps the ranking deterministic when a PR has an unparseable createdAt", async () => {
+    const now = Date.now();
+    const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const recent = new Date(now - 60 * 60 * 1000).toISOString();
+    // All three are confirmed miners with passing checks + good issue -> tie on reviewability, so the
+    // ranking is decided by privateBurdenReductionScore, which must stay finite.
+    const validOld = makePR({ number: 1, createdAt: tenDaysAgo, lastUpdatedAt: tenDaysAgo });
+    const validRecent = makePR({ number: 2, createdAt: recent, lastUpdatedAt: recent });
+    const badTimestamp = makePR({ number: 3, createdAt: "not-a-date", lastUpdatedAt: "not-a-date" });
+
+    const { rankedPRs } = await analyzePRQueue([badTimestamp, validRecent, validOld], defaultContext);
+
+    // Pre-fix the bad timestamp NaN-poisoned the comparator and the order of #2/#3 was non-deterministic;
+    // now the bad timestamp degrades to a finite 0-day age and the whole set is stable.
+    expect(rankedPRs.map((pr) => pr.number)).toEqual([1, 2, 3]);
+  });
+
+  it("degrades an empty createdAt to a finite age instead of NaN", async () => {
+    const now = Date.now();
+    const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const validOld = makePR({ number: 1, createdAt: tenDaysAgo });
+    const emptyTimestamp = makePR({ number: 2, createdAt: "" });
+
+    const { rankedPRs } = await analyzePRQueue([emptyTimestamp, validOld], defaultContext);
+
+    expect(rankedPRs.map((pr) => pr.number)).toEqual([1, 2]);
+  });
+
+  it("does not flag a PR as pending-too-long when its lastUpdatedAt is unparseable", async () => {
+    const pr = makePR({ number: 1, checksStatus: "pending", lastUpdatedAt: "not-a-date" });
+    const { recommendations } = await analyzePRQueue([pr], defaultContext);
+    // A bad timestamp degrades to 0 days, so it is not treated as stale-pending -> review_now.
+    expect(recommendations.get(1)).toBe("review_now");
+  });
+});
+
 describe("analyzePRQueue — performance", () => {
   it("ranks 120 PRs in under 50ms", async () => {
     const prs: PullRequestInput[] = Array.from({ length: 120 }, (_, i) =>


### PR DESCRIPTION
## Summary

`computeDaysSince` in `src/queue-intelligence.ts` parsed a PR timestamp with `new Date(isoDateString).getTime()` and divided by the day constant with no guard against a non-finite result. A malformed or empty `createdAt` / `lastUpdatedAt` yields `NaN`, which flows into `computePrivateBurdenReductionScore` (`daysSinceCreated * 2 + ...`) and then into the `analyzePRQueue` ranking comparator `b.privateBurdenReductionScore - a.privateBurdenReductionScore`. An `Array.sort` comparator that returns `NaN` is implementation-defined, so the ranked PR list for a repo reorders run-to-run whenever one PR in the set carries a bad timestamp.

The two directly-analogous helpers already guard this case -- `daysSince` (`src/scoring/pending-pr-scenarios.ts`) and `issueAgeDays` (`src/signals/reward-risk.ts`). `computeDaysSince` was the lone sibling without the guard.

## Fix

Mirror the `issueAgeDays` guard: when `Date.parse` is not finite, return `0` (treated as just-created, lowest burden-reduction priority) instead of `NaN`. The fallback is **finite** rather than `Infinity` because `Infinity - Infinity` is still `NaN` when two PRs share a bad timestamp -- the sort comparator must stay deterministic for any input, so a finite fallback is required. `0` is also conservative on the recommendation path: a bad `lastUpdatedAt` is not flagged as pending-too-long. No behavior change for any well-formed input.

Reachability note: live GitHub webhooks carry valid ISO timestamps, but a backfilled / partially-migrated / manually-inserted `pull_requests` row can carry a malformed or empty value -- the same dirty-data state the rest of the codebase defends against.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1541).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/queue-intelligence.test.ts` 33/33 pass; scoped coverage on `src/queue-intelligence.ts` is 100% statements / branches / functions / lines.
- [x] New behavior has regression tests: a malformed `createdAt` keeps the ranking deterministic; an empty `createdAt` degrades to a finite age; a malformed `lastUpdatedAt` does not trigger the pending-too-long branch.

Targeted run:

```sh
npx vitest run test/unit/queue-intelligence.test.ts --coverage --coverage.include='src/queue-intelligence.ts'
# 33/33 passed; src/queue-intelligence.ts 100% statements/branches/functions/lines
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- pure-function guard, no I/O.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend pure-function guard with no visible UI, frontend, docs, or extension surface.

Closes #1541