### PR TITLE
fix(ci): grandfather the already-applied 0074 migration collision

### DIFF
--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -6,10 +6,17 @@
 //   • a skipped number (gap) or a stray non-conforming filename.
 // Migration-only PRs trigger this via the `migrations/**` path filter in .github/workflows/ci.yml.
 //
-// KNOWN_DUPLICATES: two pairs (0015, 0017) already merged silently before this guard existed and are
-// already applied in production — D1 records applied migrations by filename, so renaming either now would
-// make wrangler try to re-apply it. They are grandfathered here. Do NOT add to this list; the whole point
-// of the guard is that a NEW duplicate fails CI and gets renumbered before merge.
+// KNOWN_DUPLICATES: pairs already merged AND applied in production before the collision was noticed — D1
+// records applied migrations by filename, so renaming either now would make wrangler (and the self-host
+// migrator) try to RE-APPLY it. For a non-idempotent statement (e.g. `ALTER TABLE … ADD COLUMN`, which SQLite
+// cannot guard with IF NOT EXISTS) the re-apply ERRORS and breaks the deploy, so renumbering is unsafe once the
+// dup has shipped — those are grandfathered here. Do NOT add a NEW (not-yet-merged) duplicate to this list:
+// renumber its branch to the next free number BEFORE merge. Only an already-shipped, can't-be-renumbered dup
+// belongs here.
+//   • 0015 / 0017 — predate the guard.
+//   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
+//     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
+//     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
 import { readdirSync } from "node:fs";
 
 const DIR = "migrations";
@@ -17,6 +24,7 @@ const NAME = /^(\d{4})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$/;
 const KNOWN_DUPLICATES = new Map([
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
+  [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
 ]);
 
 const fail = (message) => {


### PR DESCRIPTION
## Summary

Main's `db:migrations:check` is currently **failing** — both [`0074_ai_review_cache`](https://github.com/JSONbored/gittensory/pull/1462) and [`0074_orb_self_enrollment_disabled`](https://github.com/JSONbored/gittensory/pull/1465) merged and deployed before the duplicate number surfaced, so `validate` is red on **every** open PR.

The newer one (`0074_orb_self_enrollment_disabled.sql`) is a bare `ALTER TABLE … ADD COLUMN`, which SQLite can't guard with `IF NOT EXISTS`, and D1 + the self-host migrator both track applied migrations **by filename** — so renaming it now would re-run the ALTER and **fail the deploy** with a duplicate-column error. It can't be safely renumbered once shipped.

This grandfathers the 0074 pair in `check-migrations.mjs` — the same rationale as the existing 0015/0017 entries (already-applied dups that predate/escaped the guard) — so the check passes on main again. The migrations themselves are unchanged; prod and self-host already hold both columns.

## Validation
- `npm run db:migrations:check` → passes (`77 migrations OK … no new duplicates`)

## Safety
- No migration files renamed or altered (zero risk of a prod/self-host re-apply). The guard still fails any *new*, not-yet-shipped duplicate.