### PR TITLE
fix(enrichment): harden install-script package rendering

### DIFF
--- a/review-enrichment/src/analyzers/install-scripts.ts
+++ b/review-enrichment/src/analyzers/install-scripts.ts
@@ -7,6 +7,14 @@ import type { EnrichRequest, InstallScriptFinding } from "../types.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
 
 const INSTALL_HOOKS = ["preinstall", "install", "postinstall"];
+const NPM_PACKAGE_RE =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
+const SEMVER_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function isSafeNpmChange(name: string, version: string): boolean {
+  return NPM_PACKAGE_RE.test(name) && SEMVER_RE.test(version);
+}
 
 /** Analyzer entrypoint: changed npm deps → registry packument → only the versions that run install scripts. */
 export async function scanInstallScripts(
@@ -15,10 +23,13 @@ export async function scanInstallScripts(
 ): Promise<InstallScriptFinding[]> {
   const findings: InstallScriptFinding[] = [];
   for (const change of extractDependencyChanges(req.files ?? [])) {
-    if (change.ecosystem !== "npm") continue;
-    // Scoped packages (@scope/name) encode only the slash in the registry path; the @ stays literal.
+    if (
+      change.ecosystem !== "npm" ||
+      !isSafeNpmChange(change.package, change.to)
+    )
+      continue;
     const response = await fetchImpl(
-      `https://registry.npmjs.org/${change.package.replace("/", "%2F")}`,
+      `https://registry.npmjs.org/${encodeURIComponent(change.package)}`,
     );
     if (!response.ok) continue;
     const data = (await response.json()) as {

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -10,6 +10,14 @@ const SEVERITY_RANK: Record<string, number> = {
   unknown: 4,
 };
 
+function promptText(value: string): string {
+  return value
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/([*_{}[\]()#+.!|-])/g, "\\$1");
+}
+
 /** Build the `promptSection` (verbatim splice) + a one-line `systemSuffix` from the findings. Empty when nothing found. */
 export function renderBrief(
   findings: BriefFindings,
@@ -67,7 +75,7 @@ export function renderBrief(
         ? ` (published ${dep.publishedAt.slice(0, 10)})`
         : "";
       lines.push(
-        `- \`${dep.package}@${dep.version}\` runs ${dep.hooks.join("/")} on install${when}`,
+        `- \`${promptText(dep.package)}@${promptText(dep.version)}\` runs ${promptText(dep.hooks.join("/"))} on install${when}`,
       );
     }
   }

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -402,6 +402,56 @@ test("scanInstallScripts: flags npm deps with install hooks, skips clean + non-n
   assert.equal(fail.length, 0);
 });
 
+test("scanInstallScripts: validates npm names and encodes the full registry path", async () => {
+  const calls: string[] = [];
+  const fetchImpl = async (url) => {
+    calls.push(String(url));
+    return {
+      ok: true,
+      json: async () => ({
+        versions: { "1.0.0": { scripts: { install: "x" } } },
+      }),
+    };
+  };
+  const findings = await scanInstallScripts(
+    {
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [
+        {
+          path: "package.json",
+          patch: [
+            '+    "@scope/pkg": "1.0.0",',
+            '+    "core-js#` **inject** `": "1.0.0",',
+            '+    "bad-version": "1.0.0 || 2.0.0",',
+          ].join("\n"),
+        },
+      ],
+    },
+    fetchImpl,
+  );
+  assert.deepEqual(calls, ["https://registry.npmjs.org/%40scope%2Fpkg"]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].package, "@scope/pkg");
+});
+
+test("renderBrief: escapes install-script markdown and control characters", () => {
+  const r = renderBrief({
+    installScript: [
+      {
+        package: "core-js` **inject**\nnext",
+        version: "1.0.0",
+        hooks: ["postinstall"],
+        publishedAt: null,
+      },
+    ],
+  });
+  assert.ok(
+    r.promptSection.includes("core\\-js\\` \\*\\*inject\\*\\* next@1\\.0\\.0"),
+  );
+  assert.doesNotMatch(r.promptSection, /core-js` \*\*inject\*\*/);
+});
+
 test("renderBrief: renders the install-script block", () => {
   const r = renderBrief({
     installScript: [
@@ -416,7 +466,7 @@ test("renderBrief: renders the install-script block", () => {
   assert.match(r.promptSection, /install scripts \(supply-chain risk/);
   assert.match(
     r.promptSection,
-    /`evil@1.0.0` runs preinstall\/postinstall on install \(published 2026-06-01\)/,
+    /`evil@1\\.0\\.0` runs preinstall\/postinstall on install \(published 2026-06-01\)/,
   );
 });
 


### PR DESCRIPTION
### Motivation
- The install-script analyzer accepted arbitrary package keys and built a registry URL without fully validating or encoding the name, and then rendered the original key verbatim into the external review brief, which allowed prompt-injection via characters like `#` or backticks.

### Description
- Add npm package-name and semver validation using `NPM_PACKAGE_RE` and `SEMVER_RE` and skip changes that do not validate to avoid fetching/recording attacker-controlled keys (file: `review-enrichment/src/analyzers/install-scripts.ts`).
- Encode the full package name with `encodeURIComponent` when fetching the registry packument so fragments and query delimiters cannot alias a different package (file: `review-enrichment/src/analyzers/install-scripts.ts`).
- Add a `promptText` helper that escapes control and Markdown characters and apply it to rendered brief fields so findings are safe to include in the EXTERNAL REVIEW BRIEF (file: `review-enrichment/src/render.ts`).
- Add regression unit tests that cover malicious package keys, scoped package URL encoding, invalid/unsupported versions, and escaping of install-script brief output (file: `review-enrichment/test/enrichment.test.ts`).

### Testing
- Ran the TypeScript build with `npm --prefix review-enrichment run build` and it completed successfully.
- Ran the package's unit tests with `npm --prefix review-enrichment test` and all tests passed (31 passed, 0 failed).
- Attempted the full local CI via `npm run test:ci`, but the run could not complete due to external/setup issues: `actionlint` network setup retried and a repository migration-number conflict (duplicate `0074`) stopped the CI job (automated failure unrelated to these code changes).
- Ran `npm audit --audit-level=moderate`, which failed due to the npm audit endpoint returning `403 Forbidden`, blocking the dependency-audit step (automated failure external to the patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee8aa2c4c832c8f7621219d2ac5f4)