### PR TITLE
fix(review): enforce inline comment gates

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4056,6 +4056,7 @@ async function maybePublishPrPublicSurface(
   let aiReview:
     | { notes: string; reviewerCount: number; inlineFindings?: InlineFinding[] }
     | undefined;
+  let inlineCommentsEnabledForReview = false;
   let gateFinalized = false;
   // The PR's changed files are needed by the slop/manifest gates, the AI review + grounding + RAG, the secret
   // scan, the check-run, and the unified comment. Resolve them AT MOST ONCE per review and share across the
@@ -4322,6 +4323,11 @@ async function maybePublishPrPublicSurface(
           excludePaths: reviewExcludePaths,
         } = resolveReviewPromptOverrides(
           await loadRepoFocusManifest(env, repoFullName).catch(() => null),
+        );
+        inlineCommentsEnabledForReview = shouldRequestInlineFindings(
+          env,
+          repoFullName,
+          reviewInlineComments,
         );
         aiReview = await runAiReviewForAdvisory(env, {
           settings,
@@ -4917,6 +4923,7 @@ async function maybePublishPrPublicSurface(
       commitId: advisory.headSha,
       getFiles: getReviewFiles,
       mode,
+      inlineCommentsEnabled: inlineCommentsEnabledForReview,
     });
   }
   if (decision.willLabel) {

--- a/src/review/inline-comments.ts
+++ b/src/review/inline-comments.ts
@@ -4,9 +4,9 @@
 // without the gate or its verdict ever changing. Default OFF at BOTH layers: the operator flag
 // GITTENSORY_REVIEW_INLINE_COMMENTS (+ the per-repo GITTENSORY_REVIEW_REPOS cutover allowlist) AND the per-repo
 // `.gittensory.yml` review.inline_comments toggle — the caller ANDs all three to decide whether to ASK the model
-// for inline findings, so this module is only reached once findings exist. Fully FAIL-SAFE: a finding whose line
-// is not a commentable line in the PR diff is dropped (GitHub 422s otherwise), and any API error degrades to "no
-// inline comments" — it NEVER throws and NEVER touches the gate.
+// for inline findings AND passes the same resolved gate to the write boundary. Fully FAIL-SAFE: a finding whose
+// line is not a commentable line in the PR diff is dropped (GitHub 422s otherwise), and any API error degrades to
+// "no inline comments" — it NEVER throws and NEVER touches the gate.
 
 import { createPullRequestReviewComments } from "../github/pr-actions";
 import { isConvergenceRepoAllowed } from "./cutover-gate";
@@ -137,8 +137,10 @@ export async function maybePostInlineComments(
     commitId: string | null | undefined;
     getFiles: () => Promise<Pick<PullRequestFileRecord, "path" | "payload">[]>;
     mode: AgentActionMode;
+    inlineCommentsEnabled: boolean;
   },
 ): Promise<void> {
+  if (!args.inlineCommentsEnabled) return;
   const findings = args.aiReview?.inlineFindings;
   if (!findings?.length) return;
   await postInlineReviewComments(env, {

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -973,9 +973,11 @@ export async function runGittensoryAiReview(
   );
   const advisoryNotes =
     reviewsForNotes.length > 0 ? composeAdvisoryNotes(reviewsForNotes) : null;
-  // Line-anchored inline findings (#inline-comments): empty unless the caller asked for them (the prompt suffix
-  // is conditional) AND the model emitted any. Inert until the posting path (PR B) consumes them.
-  const inlineFindings = composeInlineFindings(reviewsForNotes);
+  // Line-anchored inline findings (#inline-comments): only propagate model output when the resolved feature gate
+  // asked for it. AI output is PR-author-influenced, so the prompt suffix is not an authorization boundary.
+  const inlineFindings = input.inlineFindings
+    ? composeInlineFindings(reviewsForNotes)
+    : [];
 
   await record(
     env,

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1217,6 +1217,36 @@ describe("pure helpers", () => {
       ]);
   });
 
+  it("runGittensoryAiReview drops unexpected inline findings when the caller did not ask for them (#inline-comments)", async () => {
+    const json = JSON.stringify({
+      assessment: "Looks fine.",
+      blockers: [],
+      nits: [],
+      suggestions: [],
+      inlineFindings: [
+        {
+          path: "src/a.ts",
+          line: 3,
+          severity: "nit",
+          body: "Guard the empty case.",
+        },
+      ],
+    });
+    const run = vi.fn(async () => ({ response: json }));
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      inlineFindings: false,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.inlineFindings).toEqual([]);
+  });
+
   it("composeAdvisoryNotes renders only the sections that have public-safe content", () => {
     const review = (
       over: Partial<{

--- a/test/unit/inline-comments.test.ts
+++ b/test/unit/inline-comments.test.ts
@@ -132,7 +132,7 @@ describe("maybePostInlineComments (#inline-comments, review-path entry)", () => 
   afterEach(() => vi.unstubAllGlobals());
   const files = [fileWith("src/a.ts", "@@ -1,1 +1,2 @@\n ctx\n+added2")];
   const findings: InlineFinding[] = [{ path: "src/a.ts", line: 2, severity: "nit", body: "guard this" }];
-  const base = { installationId: 7, repoFullName: "acme/widgets", pullNumber: 3, commitId: "headsha", mode: "live" as const };
+  const base = { installationId: 7, repoFullName: "acme/widgets", pullNumber: 3, commitId: "headsha", mode: "live" as const, inlineCommentsEnabled: true };
 
   it("is a no-op — it does not even load the PR files — when the review produced no findings", async () => {
     const getFiles = vi.fn(async () => files);
@@ -144,6 +144,23 @@ describe("maybePostInlineComments (#inline-comments, review-path entry)", () => 
     await maybePostInlineComments(envWithKey(), { ...base, aiReview: undefined, getFiles });
     await maybePostInlineComments(envWithKey(), { ...base, aiReview: { inlineFindings: undefined }, getFiles });
     await maybePostInlineComments(envWithKey(), { ...base, aiReview: { inlineFindings: [] }, getFiles });
+    expect(getFiles).not.toHaveBeenCalled();
+    expect(fetched).toBe(false);
+  });
+
+  it("is a no-op at the write boundary when inline comments are disabled, even with model findings", async () => {
+    const getFiles = vi.fn(async () => files);
+    let fetched = false;
+    vi.stubGlobal("fetch", async () => {
+      fetched = true;
+      return Response.json({});
+    });
+    await maybePostInlineComments(envWithKey(), {
+      ...base,
+      inlineCommentsEnabled: false,
+      aiReview: { inlineFindings: findings },
+      getFiles,
+    });
     expect(getFiles).not.toHaveBeenCalled();
     expect(fetched).toBe(false);
   });


### PR DESCRIPTION
### Motivation
- Prevent AI-provided `inlineFindings` from causing unauthorized GitHub writes when the inline-comments feature is disabled by the operator flag, repo allowlist, or per-repo manifest toggle.
- Close an authorization/configuration boundary: asking the model is not an authorization decision, so the write boundary must re-check the resolved gate.

### Description
- Ensure model-emitted inline findings are only propagated when the caller actually requested them by changing `runGittensoryAiReview` to return `inlineFindings` only when `input.inlineFindings` is truthy (stop propagating unexpected AI output). (`src/services/ai-review.ts`)
- Add an explicit `inlineCommentsEnabled` parameter to the write boundary and make `maybePostInlineComments` return early when disabled, avoiding loading PR files or calling GitHub. (`src/review/inline-comments.ts`)
- Compute and carry the resolved inline-comment decision through the review publish path and pass it into the write boundary when publishing reviews. (`src/queue/processors.ts`)
- Add regression tests covering both layers: the AI-review path drops inline findings when not requested, and the posting path no-ops without loading files when inline comments are disabled. (`test/unit/ai-review.test.ts`, `test/unit/inline-comments.test.ts`)

### Testing
- Ran unit tests for the modified suites with `npx vitest run test/unit/inline-comments.test.ts test/unit/ai-review.test.ts --reporter=verbose`, and all tests in those files passed. 
- Ran `tsc --noEmit` via `npm run typecheck`, which succeeded with no type errors. 
- Verified `git diff --check` returned clean. 
- Started `npm run test:coverage`; the run was initiated but did not complete in this environment before the job was terminated. 
- `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee8aa4c54832c9a34b357bc388b1b)