### PR TITLE
feat(selfhost): observability stack + dashboards + docs (Grafana/OTEL/Tempo/Prometheus/Alertmanager/backups)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,11 +55,6 @@ GITTENSORY_REVIEW_REPUTATION=false
 # legacy multi-panel comment. OFF keeps the legacy comment byte-identical.
 GITTENSORY_REVIEW_UNIFIED_COMMENT=false
 
-# Quiet inline review comments (CodeRabbit-style): on top of the decision summary, leave
-# NON-BLOCKING inline comments on changed lines. Also requires the repo in GITTENSORY_REVIEW_REPOS
-# AND review.inline_comments: true in its .gittensory.yml. OFF the model is never asked for them.
-GITTENSORY_REVIEW_INLINE_COMMENTS=false
-
 # --- Global capabilities (NOT scoped by GITTENSORY_REVIEW_REPOS) -------------
 
 # Observability (read-only): cron anomaly scan over the gate-block ledger emits
@@ -89,10 +84,7 @@ GITTENSORY_REVIEW_DRAFT=false
 # or in `.dev.vars` (local, git-ignored). Listed by name so operators know what
 # the worker reads.
 
-# --- Core -------------------------------------------------------------------
-# SELF-HOST: leave the GITHUB_APP_* below UNSET — set ORB_ENROLLMENT_SECRET + ORB_BROKER_URL + PUBLIC_API_ORIGIN
-# instead (see the Orb section near the bottom; you get the enrollment secret from the install flow). The
-# GITHUB_APP_* keys below are for the central cloud worker only.
+# --- Core (required for the worker to run) -----------------------------------
 # GITHUB_WEBHOOK_SECRET=
 # GITHUB_APP_ID=
 # GITHUB_APP_PRIVATE_KEY=
@@ -135,23 +127,13 @@ GITTENSORY_REVIEW_DRAFT=false
 # DATABASE_PATH=/data/gittensory.sqlite     # SQLite file on the mounted data volume; all migrations auto-apply
 # DATABASE_URL=                              # set to postgres://user:pw@host:5432/db to use Postgres instead of
 #                                            #   SQLite (shared DB → multi-instance). Overrides DATABASE_PATH.
-# BACKUP_ACKNOWLEDGED=                       # set to "true" to silence the boot warning that a single SQLite file
-#                                            #   has no backup — only after you've wired Litestream (docs §6) or
-#                                            #   equivalent. Unset on SQLite ⇒ a loud data-loss warning at boot.
 # REDIS_URL=                                 # set to redis://host:6379 for distributed rate limiting + webhook dedup
 #                                            #   cache (prevents double-processing of GitHub retries). Off when unset.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
-# BROWSER_WS_ENDPOINT=                        # ws:// endpoint of a browserless/chrome sidecar → enables visual
-#                                            #   (before/after screenshot) review. Unset = visual review off.
-# REVIEW_AUDIT_DIR=/data/shots               # dir to persist captured screenshots (fs-backed blob store) so they
-#                                            #   cache + serve from /gittensory/shot instead of re-rendering. Unset
-#                                            #   = on-demand only (no persistence). Pair with BROWSER_WS_ENDPOINT.
 # DISCORD_WEBHOOK_URL=                        # one Discord channel for per-action notifications (merged/closed/
 #                                            #   manual) on ANY repo you review. Unset = no Discord notifications.
 #                                            #   Collection and schema are auto-created at startup. Off when unset.
-# SLACK_WEBHOOK_URL=                          # a Slack incoming webhook (https://hooks.slack.com/services/…) for the
-#                                            #   same per-action notifications. Set either, both, or neither.
 # QDRANT_API_KEY=                            # Bearer token for an authenticated Qdrant (cloud / on-prem). Omit for
 #                                            #   the local --profile qdrant container (unauthenticated).
 # QDRANT_DIM=1024                            # vector dimension of the collection (default 1024 = bge-m3); set to
@@ -166,7 +148,7 @@ GITTENSORY_REVIEW_DRAFT=false
 # LITESTREAM_REGION=us-east-1
 
 # --- Queue worker (#977/#1201) ---
-# QUEUE_CONCURRENCY=4                        # max concurrent (I/O-bound) job loops per instance (default 4; 1 = serial)
+# QUEUE_CONCURRENCY=1                        # max concurrent job-processing loops per instance (default 1)
 
 # --- Caddy HTTPS terminator (#1203; requires --profile caddy) ---
 # DOMAIN=gittensory.example.com             # fully-qualified domain; Caddy auto-obtains a Let's Encrypt cert
@@ -188,6 +170,25 @@ GITTENSORY_REVIEW_DRAFT=false
 # prometheus/rules/, routing in alertmanager/alertmanager.yml — silent until you fill in a receiver) +
 # Loki + Promtail (ship every container's logs to Loki) + Grafana (dashboards for metrics AND logs).
 # GRAFANA_ADMIN_PASSWORD=changeme            # REQUIRED when using --profile observability; compose fails if unset
+#
+# Maintainer dashboards (in addition to the infra dashboard):
+#   • "Reviews & PRs (maintainer)" — per-repo + combined PR/review analytics (SQLite data source over the app DB).
+#   • "Claude usage (OTEL)" — cost/tokens/model/effort from the review CLI's OpenTelemetry export (see below).
+#   • "Resource hub" — links to every integrated service.
+#
+# Claude usage telemetry → OTEL collector → Prometheus → the Claude usage dashboard. OFF by default.
+# CLAUDE_CODE_ENABLE_TELEMETRY=1             # enable; needs --profile observability (starts the otel-collector)
+# OTEL_METRIC_EXPORT_INTERVAL=10000          # ms between metric exports (default 10s here; CLI default is 60s)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318   # override only for an external collector
+#
+# Live upstream PR/issue census (the GitHub data source). Install is automatic (GF_INSTALL_PLUGINS); add the
+# data source after Grafana is up with: ./scripts/setup-github-datasource.sh  (reads GITHUB_TOKEN below).
+# GITHUB_TOKEN=github_pat_xxx                # read-only fine-grained PAT: Pull requests:read, Issues:read, Contents:read
+#
+# Discord notifications. Alertmanager → Discord (system/stack alerts) is configured in alertmanager/alertmanager.yml.
+# The ENGINE posts a per-repo review summary when it publishes a review — set a per-repo map and/or a global fallback:
+# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...           # global fallback for any repo without its own
+# DISCORD_REPO_WEBHOOKS={"owner/repoA":"https://discord.com/api/webhooks/...","owner/repoB":"https://..."}  # per-repo
 
 # --- AI review backend (optional; without it reviews run deterministically) ---
 # AI_SUMMARIES_ENABLED=true
@@ -227,11 +228,11 @@ GITTENSORY_REVIEW_DRAFT=false
 # webhook secret) — and the collector never holds it, so even gittensory (running the collector) can never
 # de-anonymize them.
 # The export carries no shared key; the collector treats it as untrusted, rate-limited, aggregate-only data.
+# ORB_AIR_GAP=false                          # air-gapped/OFFLINE deployments only: compute locally, never send
 # ORB_ANONYMIZE=true                         # HMAC-hash repo/PR before export (default true; false = raw names)
 # ORB_COLLECTOR_URL=https://gittensory-api.aethereal.dev/v1/orb/ingest  # gittensory's hosted collector (default; override for your own)
 #
-# Token broker (the self-host path, gittensor-Mirror model): get GitHub tokens + relayed webhooks from the central
-# Orb (you installed the Orb App). Set the enrollment secret from your install flow + PUBLIC_API_ORIGIN (so the Orb
-# can relay your repos' events). A brokered instance always exports telemetry (the fleet contract).
+# Token broker (optional): get GitHub tokens from the central Orb (you installed the Orb App) instead of running
+# your own GitHub App. Set the enrollment secret the operator issued for your install; unset = use your own App key.
 # ORB_ENROLLMENT_SECRET=                      # one-time enrollment secret (a secret — keep it out of version control)
 # ORB_BROKER_URL=https://gittensory-api.aethereal.dev  # the Orb broker base (default; override for a private deployment)

--- a/.github/workflows/self-host-nightly.yml
+++ b/.github/workflows/self-host-nightly.yml
@@ -1,0 +1,44 @@
+# Nightly maintenance on the self-hosted runner (gittensory channel). Deliberately NOT wired into PR CI: this
+# repo's gate auto-closes PRs with red required checks, so a self-hosted runner being offline must never be able
+# to fail-close a PR. This runs on a schedule + on demand only, and keeps the local RAG index fresh.
+#
+# Setup: this repo needs a self-hosted runner labelled `gittensory` (the self-host stack provides one), and
+# optionally an INTERNAL_JOB_TOKEN repo secret (Settings → Secrets → Actions) to trigger the RAG re-index.
+name: self-host nightly
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: self-host-nightly
+  cancel-in-progress: false
+
+jobs:
+  maintenance:
+    runs-on: [self-hosted, gittensory]
+    timeout-minutes: 30
+    env:
+      # The runner shares the stack's Docker network, so it reaches the engine by service name. Override with a
+      # repo variable SELF_HOST_URL if your runner is elsewhere (e.g. a published port / Tailscale address).
+      SELF_HOST_URL: ${{ vars.SELF_HOST_URL || 'http://gittensory:8787' }}
+      INTERNAL_JOB_TOKEN: ${{ secrets.INTERNAL_JOB_TOKEN }}
+    steps:
+      - name: Self-host health
+        run: |
+          curl -fsS "$SELF_HOST_URL/ready" >/dev/null && echo "✓ self-host ready" || { echo "✗ self-host not ready"; exit 1; }
+
+      - name: Refresh the RAG index (fan out over configured repos)
+        run: |
+          if [ -z "$INTERNAL_JOB_TOKEN" ]; then
+            echo "INTERNAL_JOB_TOKEN not set — skipping RAG refresh (set it as a repo secret to enable)."
+            exit 0
+          fi
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$SELF_HOST_URL/v1/internal/jobs/rag-index" \
+            -H "authorization: Bearer $INTERNAL_JOB_TOKEN" -H "content-type: application/json" -d '{}')
+          echo "RAG re-index request → HTTP $code"
+          [ "$code" = "202" ] || [ "$code" = "200" ]

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -33,13 +33,13 @@ global:
 # real receivers.
 # ─────────────────────────────────────────────────────────────────────────────
 route:
-  receiver: "null"               # default sink: discards alerts until you change it
+  receiver: "null" # default sink: discards alerts until you change it
 
   # Group alerts that share these labels into a single notification.
   group_by: ["alertname", "severity"]
-  group_wait: 30s                # wait this long to batch the first notification in a group
-  group_interval: 5m             # wait this long before sending an updated batch for a group
-  repeat_interval: 4h            # re-send an unresolved alert at most this often
+  group_wait: 30s # wait this long to batch the first notification in a group
+  group_interval: 5m # wait this long before sending an updated batch for a group
+  repeat_interval: 4h # re-send an unresolved alert at most this often
 
   # routes:
   #   # Page-worthy: send critical alerts to the on-call integration.
@@ -78,6 +78,20 @@ receivers:
   #         {{ range .Alerts }}*{{ .Annotations.summary }}*
   #         {{ .Annotations.description }}
   #         _runbook:_ {{ .Annotations.runbook }}
+  #         {{ end }}
+
+  # ── Discord ───────────────────────────────────────────────────────────────────
+  # Create a channel webhook (Discord → Edit Channel → Integrations → Webhooks → New), then point the route
+  # at this receiver. Keep the URL out of git with webhook_url_file (mount a file at /etc/alertmanager/
+  # discord_url), or inline it with webhook_url in a non-committed deploy copy of this file.
+  # - name: "discord"
+  #   discord_configs:
+  #     - webhook_url_file: /etc/alertmanager/discord_url
+  #       send_resolved: true
+  #       title: '{{ .CommonLabels.alertname }} ({{ .Status }})'
+  #       message: >-
+  #         {{ range .Alerts }}{{ .Annotations.summary }}
+  #         {{ .Annotations.description }}
   #         {{ end }}
 
   # ── Email ─────────────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@
 #   docker compose --profile tailscale --profile runners up -d   # tailnet + CI runners
 
 services:
-
   # ── Core app (always runs) ─────────────────────────────────────────────────
   gittensory:
     build:
@@ -39,6 +38,21 @@ services:
     environment:
       PORT: "8787"
       DATABASE_PATH: /data/gittensory.sqlite
+      # Container-private per-repo config (#1390): point at a mounted dir holding {owner}__{repo}/.gittensory.yml
+      # files (and an optional root .gittensory.yml global fallback). Keeps each repo's policy OUT of the public
+      # GitHub repo so contributors can't game the rules. Empty/unmounted ⇒ repos use the public file / defaults.
+      GITTENSORY_REPO_CONFIG_DIR: "${GITTENSORY_REPO_CONFIG_DIR:-/config}"
+      # Claude Code usage telemetry → OTEL collector → Prometheus → Claude usage dashboard. OFF unless you set
+      # CLAUDE_CODE_ENABLE_TELEMETRY=1 in .env (requires --profile observability so the otel-collector is up).
+      CLAUDE_CODE_ENABLE_TELEMETRY: "${CLAUDE_CODE_ENABLE_TELEMETRY:-}"
+      OTEL_METRICS_EXPORTER: "${OTEL_METRICS_EXPORTER:-otlp}"
+      # Claude Code trace export (beta) → OTEL collector → Tempo. Empty by default; set OTEL_TRACES_EXPORTER=otlp
+      # in .env (with CLAUDE_CODE_ENABLE_TELEMETRY=1) to capture per-review spans.
+      OTEL_TRACES_EXPORTER: "${OTEL_TRACES_EXPORTER:-}"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}"
+      OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}"
+      OTEL_METRIC_EXPORT_INTERVAL: "${OTEL_METRIC_EXPORT_INTERVAL:-10000}"
       # Uncomment the next two lines and activate --profile postgres to use Postgres:
       # DATABASE_URL: postgres://gittensory:${POSTGRES_PASSWORD:-CHANGEME}@postgres:5432/gittensory
       # PGVECTOR_ENABLED: "true"
@@ -57,6 +71,9 @@ services:
       # ORB_BROKER_URL: https://gittensory-api.aethereal.dev   # override only for a private Orb deployment
     volumes:
       - gittensory-data:/data
+      # Container-private per-repo config dir (read-only). Create ./gittensory-config/{owner}__{repo}/.gittensory.yml
+      # locally (gitignored — never commit real policy). Absent ⇒ Docker mounts an empty dir ⇒ defaults apply.
+      - ./gittensory-config:/config:ro
     depends_on:
       # Gate startup on a healthy Qdrant when --profile qdrant is active; required:false means the
       # dependency is ignored when qdrant isn't started (default/other profiles). Belt-and-suspenders
@@ -69,7 +86,13 @@ services:
       # whereas /ready returns 503 until the DB answers AND migrations are applied — so dependents that
       # wait on `condition: service_healthy` only start once the app is truly serving. start_period 60s
       # tolerates the Postgres cold start (waitForPostgres blocks up to 30s before the HTTP server binds).
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8787/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8787/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
       interval: 30s
       timeout: 5s
       start_period: 60s
@@ -152,8 +175,8 @@ services:
     # qdrant-vectorize.ts) plus a firewall rule. SSH-forward the port for remote dashboard access. This
     # matches the in-network-only posture of Prometheus/Loki/Alertmanager above.
     ports:
-      - "127.0.0.1:6333:6333"   # REST API + Web UI (localhost only)
-      - "127.0.0.1:6334:6334"   # gRPC (localhost only)
+      - "127.0.0.1:6333:6333" # REST API + Web UI (localhost only)
+      - "127.0.0.1:6334:6334" # gRPC (localhost only)
     volumes:
       - qdrant-data:/qdrant/storage
     # The image is Debian (bash present) but ships no curl/wget/nc. bash's /dev/tcp pseudo-device speaks
@@ -212,7 +235,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "443:443/udp"   # HTTP/3 QUIC
+      - "443:443/udp" # HTTP/3 QUIC
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
@@ -247,7 +270,7 @@ services:
     profiles: ["observability"]
     depends_on: [prometheus]
     expose:
-      - "9093"   # in-network only; reach the UI/API via `docker compose port` or a tunnel
+      - "9093" # in-network only; reach the UI/API via `docker compose port` or a tunnel
     volumes:
       - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager-data:/alertmanager
@@ -266,9 +289,19 @@ services:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      # The app's SQLite DB, for the maintainer dashboards (PR/review tables via the frser-sqlite-datasource).
+      # Mounted read-WRITE — not :ro — on purpose: SQLite WAL mode needs to write the -shm index to read live
+      # committed rows; a read-only mount would fail to open or miss recent writes. The datasource only ever
+      # runs SELECTs (provisioned dashboards, editable:false), so the app DB is never mutated from here.
+      - gittensory-data:/appdb
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env before using --profile observability}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # Maintainer dashboards read the app DB through this SQLite plugin (table/stat panels); the GitHub
+      # data source (official, signed) queries the live GitHub API for the accurate upstream PR/issue census.
+      GF_INSTALL_PLUGINS: frser-sqlite-datasource,grafana-github-datasource
+      # Read-only fine-grained PAT for the GitHub data source provisioning ($GITHUB_TOKEN expansion). From .env.
+      GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
 
   # ── Log pipeline (--profile observability) ─────────────────────────────────
   # Loki stores logs; Promtail discovers every container in this compose project via the read-only
@@ -302,18 +335,22 @@ services:
     restart: unless-stopped
     profiles: ["observability"]
     environment:
-      CONTAINERS: "1"   # GET /containers/* (list, inspect, logs)
-      NETWORKS: "1"     # GET /networks/* — docker_sd computes per-target network labels
-      POST: "0"         # deny every mutating call; strictly read-only (no create/exec/start)
+      CONTAINERS: "1" # GET /containers/* (list, inspect, logs)
+      NETWORKS: "1" # GET /networks/* — docker_sd computes per-target network labels
+      POST: "0" # deny every mutating call; strictly read-only (no create/exec/start)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks: [docker-proxy]   # isolated — only Promtail joins this network
+    networks: [docker-proxy] # isolated — only Promtail joins this network
 
   promtail:
     image: grafana/promtail:3.6.11
     restart: unless-stopped
     profiles: ["observability"]
-    command: ["-config.file=/etc/promtail/promtail-config.yml", "-config.expand-env=true"]
+    command:
+      [
+        "-config.file=/etc/promtail/promtail-config.yml",
+        "-config.expand-env=true",
+      ]
     depends_on: [loki, docker-proxy]
     environment:
       # Promtail expands this into its Docker label filter so discovery stays inside this Compose project.
@@ -326,6 +363,30 @@ services:
     # the only service on `docker-proxy`, so the inspect endpoint (and the env it exposes) is unreachable
     # from any other container. No Docker-socket mount — discovery goes through the proxy's read-only API.
     networks: [default, docker-proxy]
+
+  # ── OTEL collector (--profile observability) ──────────────────────────────
+  # Receives OTLP metrics from the Claude Code review CLI and re-exposes them on :8889 for Prometheus to
+  # scrape — powering the Claude usage analytics (cost / tokens / sessions / models). Enable by setting
+  # CLAUDE_CODE_ENABLE_TELEMETRY=1 in .env. Pinned to a known-good version (image layers are reproducible).
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.155.0
+    restart: unless-stopped
+    profiles: ["observability"]
+    # Mount our config at the image's default path so the stock entrypoint picks it up (no command override).
+    volumes:
+      - ./otel/otel-collector-config.yml:/etc/otelcol-contrib/config.yaml:ro
+
+  # ── Tempo (--profile observability) — trace store for Claude review spans ─────
+  # Receives traces forwarded by the OTEL collector and serves them to Grafana (the Tempo data source).
+  # Local-storage single binary; needs no extra config beyond ./tempo/tempo.yaml.
+  tempo:
+    image: grafana/tempo:2.6.1
+    restart: unless-stopped
+    profiles: ["observability"]
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
 
   # ── Tailscale (--profile tailscale) ───────────────────────────────────────
   # Joins your tailnet so the stack is accessible via Tailscale IP/hostname — no
@@ -350,7 +411,7 @@ services:
     volumes:
       - tailscale-state:/var/lib/tailscale
       - /dev/net/tun:/dev/net/tun
-    network_mode: host   # Tailscale needs host networking to advertise the host's address
+    network_mode: host # Tailscale needs host networking to advertise the host's address
 
   # ── Self-hosted GitHub Actions runner (--profile runners) ─────────────────
   # Runs `runs-on: self-hosted` jobs on this machine. Set RUNNER_TOKEN= (or ACCESS_TOKEN=)
@@ -358,8 +419,8 @@ services:
   # Get a token at: https://github.com/<owner>/<repo>/settings/actions/runners/new
   runner:
     # Pin to a specific version tag — `latest` is mutable. Find a digest via:
-    # docker pull myoung34/github-runner:ubuntu-22.04 && docker inspect --format='{{index .RepoDigests 0}}' myoung34/github-runner:ubuntu-22.04
-    image: myoung34/github-runner:ubuntu-22.04
+    # docker pull myoung34/github-runner:ubuntu-jammy && docker inspect --format='{{index .RepoDigests 0}}' myoung34/github-runner:ubuntu-jammy
+    image: myoung34/github-runner:ubuntu-jammy
     restart: unless-stopped
     profiles: ["runners"]
     environment:
@@ -376,6 +437,27 @@ services:
     volumes:
       - runner-work:/tmp/runner
 
+  # ── Backups (--profile backup) ────────────────────────────────────────────
+  # Online SQLite backup (WAL-safe, consistent even while the app writes) + a Qdrant snapshot, on a loop
+  # (default daily), kept in the gittensory-backups volume with retention. Run on demand:
+  #   docker compose --profile backup run --rm backup sh /backup.sh
+  backup:
+    image: alpine:3.20
+    restart: unless-stopped
+    profiles: ["backup"]
+    environment:
+      DATABASE_PATH: /data/gittensory.sqlite
+      QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
+      BACKUP_RETAIN: ${BACKUP_RETAIN:-7}
+    volumes:
+      # RW (not :ro) so SQLite's online-backup can use the WAL index; the script only ever reads the DB.
+      - gittensory-data:/data
+      - gittensory-backups:/backups
+      - ./scripts/backup.sh:/backup.sh:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - "apk add --no-cache sqlite curl >/dev/null 2>&1 && while true; do sh /backup.sh || echo '[backup] run failed'; sleep ${BACKUP_INTERVAL_SECONDS:-86400}; done"
+
 volumes:
   gittensory-data:
   gittensory-pg:
@@ -390,6 +472,8 @@ volumes:
   promtail-data:
   tailscale-state:
   runner-work:
+  gittensory-backups:
+  tempo-data:
 
 networks:
   # The implicit project network every service joins by default (declared so it can be referenced

--- a/docs/self-host/ai-providers.md
+++ b/docs/self-host/ai-providers.md
@@ -1,0 +1,57 @@
+# AI providers, models, effort & cost
+
+The reviewer is configured by `AI_PROVIDER`. Reviews degrade deterministically (no AI) if it's unset.
+
+## Providers
+
+| `AI_PROVIDER`                             | Backend                                                                 | Needs                                                                                   |
+| ----------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `claude-code`                             | Your **Claude** subscription via the `claude` CLI (read-only, headless) | `CLAUDE_CODE_OAUTH_TOKEN` (`claude setup-token`); CLI baked in (`INSTALL_AI_CLIS=true`) |
+| `codex`                                   | Your **Codex** subscription via the `codex` CLI                         | local `codex` auth (mounted), CLI baked in                                              |
+| `anthropic`                               | Native **Anthropic API** (BYOK, per-token billing — no weekly limit)    | `ANTHROPIC_API_KEY`, `AI_MODEL`                                                         |
+| `ollama` / `openai-compatible` / `openai` | Any OpenAI-compatible `/chat/completions` (+ `/embeddings`)             | `AI_BASE_URL`, `AI_API_KEY`, `AI_MODEL`                                                 |
+
+**Chain / fallback:** `AI_PROVIDER` accepts a comma list, tried in order until one succeeds — e.g.
+`AI_PROVIDER=anthropic,ollama`. **Dual review:** two providers (`claude-code,codex`) run as independent reviewers
+combined per `AI_COMBINE` (`single`/`consensus`/`synthesis`).
+
+> The chat-only CLIs (`claude`, `codex`) **reject embedding requests**, so in a chain the embed call routes through
+> to an embed-capable provider — they never silently swallow embeddings. For RAG use a _dedicated_ embed provider
+> (`AI_EMBED_*`) so reviews stay frontier-only; see [rag-indexing.md](./rag-indexing.md).
+
+## Model & effort (the intelligence dial)
+
+| Var             | Default            | Notes                                                                                                                                                |
+| --------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AI_MODEL`      | provider default   | e.g. `claude-sonnet-4-6`. **Leave unset on a `claude-code,codex` combo** — it's global and a Claude id breaks codex's account default.               |
+| `AI_EFFORT`     | `high`             | `low \| medium \| high \| xhigh \| max` → `claude --effort`. The engine wants substance, not speed.                                                  |
+| `AI_TIMEOUT_MS` | scales with effort | Subprocess timeout. Unset ⇒ low/med 120s, high 240s, xhigh 360s, **max 600s** (so a big max-effort review isn't killed). Override clamped 30s–30min. |
+
+## Cost & usage observability
+
+Every provider's token/cost usage is captured and exported to Prometheus — surfaced in the **AI Usage & Cost**
+row of the Grafana dashboard (`:3000`):
+
+| Metric                                                      | Labels                          | Meaning                                                          |
+| ----------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------- |
+| `gittensory_ai_requests_total`                              | `provider, model, kind, effort` | Review/embed calls (the intelligence dial is the `effort` label) |
+| `gittensory_ai_input_tokens_total` / `_output_tokens_total` | `provider, model, kind`         | Token volume per provider/model                                  |
+| `gittensory_ai_cost_usd_total`                              | `provider`                      | Cumulative USD (from Claude Code's `total_cost_usd`)             |
+
+`kind` is `chat` (reviews) or `embed` (RAG). The embed provider's label is `AI_EMBED_PROVIDER` (default `ollama`).
+
+## Token-spend protection
+
+- **One AI review per code-state** — re-triggers on the same commit (`edited`, duplicate deliveries, redundant
+  `synchronize`) are deduped; only a new push (new head SHA) spends again.
+- **Re-gate sweeps skip the AI review** in advisory mode (deterministic re-gate only).
+- **Reputation** (when on) skips paid AI on burst/low-reputation submitters.
+
+## Getting / rotating the Claude token
+
+```bash
+claude setup-token        # mint a long-lived token (log in with the account that has quota)
+```
+
+Put it in `CLAUDE_CODE_OAUTH_TOKEN` in `.env`, then `docker compose up -d --force-recreate gittensory`. A `429`
+("weekly limit") means the subscription quota is spent — swap accounts or use `AI_PROVIDER=anthropic` (per-token).

--- a/docs/self-host/configuration.md
+++ b/docs/self-host/configuration.md
@@ -1,0 +1,91 @@
+# Self-host configuration reference
+
+Three layers, highest priority first:
+
+1. **Container-private `.gittensory.yml`** (`GITTENSORY_REPO_CONFIG_DIR`) — per-repo policy that contributors
+   can't read or game. **Replaces** the public repo file for that repo.
+2. **Public `.gittensory.yml`** in the repo — the same schema, but visible to contributors.
+3. **Environment variables** (`.env`) — deploy-wide defaults + feature kill-switches + infrastructure.
+
+## Container-private per-repo config
+
+Set `GITTENSORY_REPO_CONFIG_DIR=/config/repos` and mount a directory. For `JSONbored/gittensory` the engine looks,
+in priority order, for:
+
+```
+$GITTENSORY_REPO_CONFIG_DIR/
+├── jsonbored__gittensory/.gittensory.yml   # 1. owner-qualified folder (collision-safe)
+├── gittensory/.gittensory.yml              # 2. bare repo-name folder
+├── jsonbored__gittensory.yml               # 3. flat owner__repo file
+└── .gittensory.yml                         # 4. GLOBAL fallback for any repo without its own file
+```
+
+First match wins (it's a fallback, not a merge). Read fresh each review — **no restart needed** to change per-repo
+policy. `.yaml`/`.json` accepted; names lowercased. Unset ⇒ the public file is fetched as normal.
+
+### Schema (the same `gate:` / `settings:` / `review:` / `features:` blocks)
+
+```yaml
+gate:
+  enabled: true
+  aiReview:
+    mode: advisory # off | advisory | block
+    allAuthors: true # review EVERY author, not only confirmed Gittensor contributors
+settings:
+  commentMode: all_prs # off | detected_contributors_only | all_prs
+  includeMaintainerAuthors: true # review the maintainer's own PRs
+  autoLabelEnabled: false
+  autonomy: # per-action: observe (no act) | …
+    merge: observe
+    close: observe
+  closeOwnerAuthors:
+    false # false (default) = the OWNER's own PRs are exempt from auto-close (merge or
+    #   manual-hold only); true = owner PRs are closeable like a contributor's
+    #   (still gated by `close` autonomy + adverse signals). Automation bots stay exempt.
+  agentDryRun: false # true = suppress ALL writes (no comments/labels/checks) — full dry-run
+features: # per-repo converged-feature toggles (see "Feature flags" below)
+  rag: true
+  reputation: false
+  unifiedComment: true
+  safety: true
+```
+
+The friendly `gate:` block is a typed alias that wins over `settings:` for its fields. Full schema:
+[`../review-configuration.md`](../review-configuration.md).
+
+## Feature flags (env kill-switches + per-repo activation)
+
+Each converged feature has a **global env kill-switch**; when on, per-repo activation is decided by the
+`features:` block, falling back to the `GITTENSORY_REVIEW_REPOS` allowlist when the manifest says nothing.
+
+| Feature         | Env kill-switch                     | Per-repo key     | What it does                                              |
+| --------------- | ----------------------------------- | ---------------- | --------------------------------------------------------- |
+| Unified comment | `GITTENSORY_REVIEW_UNIFIED_COMMENT` | `unifiedComment` | One converged PR comment vs the legacy panel              |
+| Safety          | `GITTENSORY_REVIEW_SAFETY`          | `safety`         | Defang untrusted PR text + secret scan                    |
+| RAG             | `GITTENSORY_REVIEW_RAG`             | `rag`            | Codebase retrieval ([rag-indexing.md](./rag-indexing.md)) |
+| Reputation      | `GITTENSORY_REVIEW_REPUTATION`      | `reputation`     | Internal AI-spend gate on burst/low-rep submitters        |
+| Grounding       | `GITTENSORY_REVIEW_GROUNDING`       | _(allowlist)_    | Feed finished CI + file contents to the reviewer          |
+| Content lane    | `GITTENSORY_REVIEW_CONTENT_LANE`    | _(allowlist)_    | Deterministic registry-surface review                     |
+| Ops             | `GITTENSORY_REVIEW_OPS`             | _(global)_       | Anomaly scan + `/v1/internal/ops/stats`                   |
+| Selftune        | `GITTENSORY_REVIEW_SELFTUNE`        | _(global)_       | Tightening-only auto-tune learning loop                   |
+
+`GITTENSORY_REVIEW_REPOS` — comma-separated `owner/repo` allowlist; activates allowlist-gated features and is the
+default candidate set for RAG indexing.
+
+## AI environment variables
+
+See [ai-providers.md](./ai-providers.md) for the full provider/model/effort/timeout/embed reference. Key ones:
+
+| Var                                          | Purpose                                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `AI_PROVIDER`                                | `claude-code` / `codex` / `anthropic` / `ollama` / … (comma-list = chain/dual-review) |
+| `AI_MODEL`, `AI_EFFORT`                      | Model id + intelligence dial (low…max, default high)                                  |
+| `AI_TIMEOUT_MS`                              | CLI subprocess timeout override (else scales with effort)                             |
+| `CLAUDE_CODE_OAUTH_TOKEN`                    | Claude Code subscription token (`claude setup-token`)                                 |
+| `AI_EMBED_BASE_URL` / `_MODEL` / `_PROVIDER` | Dedicated RAG embed provider                                                          |
+| `GITTENSORY_REPO_CONFIG_DIR`                 | Container-private per-repo config dir                                                 |
+
+## Secrets — never commit them
+
+`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `INTERNAL_JOB_TOKEN`, `TOKEN_ENCRYPTION_SECRET`, the App private
+key, and the webhook secret live in `.env` / mounted files **only** — keep your deploy directory out of any repo.

--- a/docs/self-host/rag-indexing.md
+++ b/docs/self-host/rag-indexing.md
@@ -1,0 +1,110 @@
+# RAG: codebase indexing for smarter reviews
+
+RAG (retrieval-augmented generation) gives the AI reviewer **codebase awareness**: at review time it retrieves the
+existing code most relevant to the PR's diff — callers, similar implementations, conventions — and feeds it into
+the reviewer's prompt. This catches "this duplicates `x`", "this breaks caller `y`", "the convention here is `z`",
+and kills false "undefined symbol" noise. It is the single biggest review-quality lever.
+
+## How it fits together
+
+```
+Review:   PR diff ───────────────────────────► Claude Code / Codex  (frontier reviewer, advisory)
+                                                      ▲
+Retrieval: changed files ─► embed (ollama bge-m3) ─► qdrant ANN ─► relevant code ─┘
+```
+
+The frontier model stays the **only** reviewer. ollama + qdrant are a _background retrieval layer_ — ollama turns
+code into vectors, qdrant finds the nearest ones. They never review; they make the reviewer's context better.
+
+**Why a separate embedder?** Claude and Codex are chat models — they cannot produce embedding vectors (Anthropic
+has no embeddings model at all). So RAG needs a dedicated embed provider. It is wired _separately_ from the review
+chain (`AI_EMBED_*` → its own provider) so that a Claude/Codex outage never causes reviews to fall back to a weak
+local model — embeddings go to ollama, reviews stay frontier-only.
+
+## Setup
+
+```bash
+# .env
+GITTENSORY_REVIEW_RAG=true
+QDRANT_URL=http://qdrant:6333
+AI_EMBED_BASE_URL=http://ollama:11434/v1
+AI_EMBED_MODEL=bge-m3            # see "Choosing an embed model"
+# AI_EMBED_PROVIDER=ollama       # optional metric label (default "ollama")
+# AI_EMBED_API_KEY=...           # only if your embed endpoint needs a key
+```
+
+```bash
+docker compose --profile qdrant --profile ollama up -d qdrant ollama
+docker exec gittensory-ollama-1 ollama pull bge-m3      # ~1.2 GB, one-time
+docker compose up -d --force-recreate gittensory
+```
+
+Boot logs should show `selfhost_embed_provider` and `selfhost_vectorize{backend:"qdrant"}`.
+
+> No qdrant? The SQLite backend ships a built-in `sqlite-vec` vector store, used automatically when `QDRANT_URL`
+> is unset. qdrant is recommended for production (ANN, scales to millions of vectors).
+
+## Choosing an embed model
+
+The vector index is **1024-dimensional**, so use a 1024-d model:
+
+| Model                      | Context     | Notes                                                                |
+| -------------------------- | ----------- | -------------------------------------------------------------------- |
+| **`bge-m3`** (recommended) | 8192 tokens | Long context fits whole code chunks; multilingual; strong retrieval. |
+| `mxbai-embed-large`        | 512 tokens  | Smaller download, but **truncates** code chunks > 512 tokens.        |
+
+## Indexing your repos
+
+Three ways to trigger it:
+
+1. **On demand** (operator action — add/refresh a repo immediately):
+   ```bash
+   # all configured repos:
+   curl -X POST localhost:8787/v1/internal/jobs/rag-index -H "authorization: Bearer $INTERNAL_JOB_TOKEN"
+   # one repo:
+   curl -X POST localhost:8787/v1/internal/jobs/rag-index -H "authorization: Bearer $INTERNAL_JOB_TOKEN" \
+        -H "content-type: application/json" -d '{"repoFullName":"owner/repo"}'
+   ```
+2. **Automatic cron** — the 6-hourly fan-out indexes every repo in `GITTENSORY_REVIEW_REPOS` (and any registered
+   repo) where RAG is active. No `is_registered` needed.
+3. **Incremental, automatic** — every merged PR re-indexes just its changed files, so the index self-maintains.
+
+### Index-only (no reviews) for a repo
+
+To build a repo's knowledge base **without** turning on reviews for it, give it a private config with _only_
+`features.rag: true` and leave it out of `GITTENSORY_REVIEW_REPOS`:
+
+```yaml
+# {repo}/.gittensory.yml  (container-private)
+features:
+  rag: true
+settings:
+  aiReviewMode: off
+  agentDryRun: true
+```
+
+RAG indexes the repo; no review features run, nothing is posted.
+
+## What gets indexed
+
+`isIndexablePath` indexes **code**, skipping `node_modules`, build output, lockfiles, and large content/data
+corpora (e.g. a registry repo's JSON data). A hard `MAX_CHUNKS_PER_REPO` cap (1500) bounds cost. Retrieval is
+**namespaced per `(project, repo)`** — a review on repo A retrieves from A's index (you review A against A's
+conventions). Cross-repo retrieval is a deliberate future enhancement.
+
+## Verifying it works
+
+```bash
+# qdrant collection should be green with a growing point count:
+docker exec gittensory-gittensory-1 node -e \
+ 'fetch("http://qdrant:6333/collections/gittensory").then(r=>r.json()).then(j=>console.log(j.result.points_count,j.result.status))'
+```
+
+Chunk count per repo:
+
+```bash
+docker exec gittensory-gittensory-1 node -e \
+ 'const{DatabaseSync}=require("node:sqlite");console.log(new DatabaseSync("/data/gittensory.sqlite",{readOnly:true}).prepare("SELECT repo,count(*) c FROM repo_chunks GROUP BY repo").all())'
+```
+
+See [troubleshooting.md](./troubleshooting.md) for RAG failure modes.

--- a/docs/self-host/review-modes.md
+++ b/docs/self-host/review-modes.md
@@ -1,0 +1,55 @@
+# Review modes: advisory, dry-run, and live
+
+Two independent dials control how much the engine _says_ vs _does_. Start conservative and open up.
+
+## The two dials
+
+**1. `aiReviewMode`** (per-repo) — how much the AI review can do:
+
+| Mode       | Behaviour                                                                     |
+| ---------- | ----------------------------------------------------------------------------- |
+| `off`      | No AI review (deterministic panel only).                                      |
+| `advisory` | Post AI review notes; **never** a gate blocker.                               |
+| `block`    | Also let a dual-model high-confidence consensus defect become a gate blocker. |
+
+**2. `autonomy` / `agentDryRun`** (per-repo) — whether the engine _acts_:
+
+| Setting                                                   | Effect                                                                               |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `autonomy.{merge,close,approve,request_changes}: observe` | Compute + post the verdict, but **take no GitHub action** (no merge/close/approve).  |
+| `agentDryRun: true`                                       | **Suppress all writes** — no comments, labels, checks, or actions. Pure shadow mode. |
+
+## Recommended progression
+
+1. **Index-only / shadow** — build knowledge + watch, post nothing:
+   `features.rag: true`, `aiReviewMode: off` or `agentDryRun: true`.
+2. **Live advisory** — post real reviews, take no action:
+   `aiReviewMode: advisory`, `autonomy.* : observe`. _(This is the safe "show me the reviews" mode.)_
+3. **Active** — only when you trust the verdicts: relax `autonomy` per action class.
+
+> A brokered self-host posts as `gittensory-orb`. `commentMode: all_prs` comments on every open PR;
+> `includeMaintainerAuthors: true` reviews the maintainer's own PRs (paired with `aiReviewAllAuthors: true`).
+
+## Token-spend guarantees (advisory or not)
+
+- **One AI review per code-state.** The review fires on `opened` / `reopened` / `synchronize` /
+  `ready_for_review` / `edited`, but the head SHA is recorded on attempt — so an `edited` or duplicate event on the
+  **same commit never re-spends**. A new push (new SHA) gets a fresh review.
+- **Sweeps don't re-run the AI** in advisory mode (deterministic re-gate only).
+- **Reputation** (when on) skips paid AI on burst / low-reputation submitters.
+
+So "1 review per PR, max" holds even with active contributors — see
+[ai-providers.md](./ai-providers.md#token-spend-protection).
+
+## The converged features
+
+When enabled (env kill-switch + per-repo/allowlist activation — see
+[configuration.md](./configuration.md#feature-flags-env-kill-switches--per-repo-activation)):
+
+- **safety** — defang untrusted PR text + secret scan before the model sees it.
+- **grounding** — feed the reviewer the finished CI status + full changed-file contents (verify, don't guess).
+- **rag** — retrieve relevant existing code ([rag-indexing.md](./rag-indexing.md)).
+- **reputation** — internal AI-spend gate (never surfaced publicly).
+- **unifiedComment** — one converged PR comment instead of the legacy panel.
+- **contentLane** — deterministic, AI-free registry-surface review (for registry repos).
+- **ops / selftune** — observability + a tightening-only learning loop that improves the gate over time.

--- a/docs/self-host/troubleshooting.md
+++ b/docs/self-host/troubleshooting.md
@@ -1,0 +1,128 @@
+# Self-host troubleshooting
+
+Real failure modes and their fixes, ordered by how often they bite. Each entry is _symptom → cause → fix_.
+
+> First stop for any "the bot isn't doing X": `docker compose logs gittensory --since 10m` (structured JSON
+> logs) and `GET /metrics`. The boot logs (`selfhost_listening`, `selfhost_ai_provider`,
+> `selfhost_embed_provider`, `selfhost_vectorize`, `selfhost_migrations_applied`) tell you what's actually wired.
+
+---
+
+## AI reviews never post
+
+### `claude: not found` / `codex: not found` in the container
+
+**Symptom:** zero `ai_review` activity; reviews silently fall back to the deterministic panel.
+**Cause:** the CLI subscription providers shell out to the `claude` / `codex` binaries, but the image was built
+**without** the AI CLIs.
+**Fix:** rebuild with the build arg:
+
+```bash
+docker compose build --build-arg INSTALL_AI_CLIS=true gittensory
+docker compose up -d --force-recreate gittensory
+docker exec gittensory-gittensory-1 sh -c 'which claude && claude --version'
+```
+
+### `"You've hit your weekly limit"` (HTTP 429)
+
+**Symptom:** `claude` runs but returns `{"is_error":true,"api_error_status":429}`.
+**Cause:** the Claude Code **subscription** quota is exhausted (resets weekly). Auth is fine — it's a quota wall.
+**Fix:** swap `CLAUDE_CODE_OAUTH_TOKEN` for an account with remaining quota (`claude setup-token`), or switch to
+`AI_PROVIDER=anthropic` + `ANTHROPIC_API_KEY` (per-token billing, no weekly limit), then recreate the container.
+
+### The review only runs for confirmed Gittensor contributors
+
+**Symptom:** PRs from you / non-miners get the panel but no AI review.
+**Cause:** the AI review is confirmed-contributor-gated by default (an AI-spend guard).
+**Fix:** set `gate.aiReview.allAuthors: true` (or `settings.aiReviewAllAuthors: true`) in the repo's private
+`.gittensory.yml`. See [configuration.md](./configuration.md).
+
+### A large `AI_EFFORT=max` review produces nothing
+
+**Symptom:** big PRs silently get no review; small ones work.
+**Cause:** the CLI subprocess timed out. (Older builds hard-capped at 120s.)
+**Fix:** the timeout now scales with `AI_EFFORT` (max → 600s); override with `AI_TIMEOUT_MS` (clamped 30s–30min).
+
+---
+
+## RAG returns no context / never indexes
+
+### Embeddings fail with the review provider
+
+**Symptom:** `rag_embed_error` logs; the reviewer never gets a "relevant code" section.
+**Cause:** Claude/Codex **cannot produce embeddings** — they're chat-only. RAG needs a separate embedding model.
+**Fix:** stand up an embed provider and point RAG at it:
+
+```bash
+# .env
+AI_EMBED_BASE_URL=http://ollama:11434/v1
+AI_EMBED_MODEL=bge-m3        # 1024-d, 8192-ctx — the right choice for code
+GITTENSORY_REVIEW_RAG=true
+QDRANT_URL=http://qdrant:6333
+# bring up the services + pull the model
+docker compose --profile qdrant --profile ollama up -d qdrant ollama
+docker exec gittensory-ollama-1 ollama pull bge-m3
+docker compose up -d --force-recreate gittensory
+```
+
+Boot should log `selfhost_embed_provider` + `selfhost_vectorize{backend:qdrant}`. See [rag-indexing.md](./rag-indexing.md).
+
+### A configured repo never gets indexed by the cron
+
+**Symptom:** the 6-hourly fan-out indexes nothing for your repos.
+**Cause:** in the brokered model your repos are `is_registered=0` (they never went through the registration
+webhook), and the fan-out indexes the configured (`GITTENSORY_REVIEW_REPOS`) set as well as registered repos.
+**Fix:** make sure the repo is in `GITTENSORY_REVIEW_REPOS` (or has a per-repo `features.rag: true`), then trigger
+an immediate index instead of waiting for the cron:
+
+```bash
+curl -X POST localhost:8787/v1/internal/jobs/rag-index \
+  -H "authorization: Bearer $INTERNAL_JOB_TOKEN" \
+  -H "content-type: application/json" -d '{"repoFullName":"owner/repo"}'
+```
+
+### Indexing is slow
+
+**Symptom:** the index job runs for many minutes.
+**Cause:** CPU embedding (~1 chunk/s on `bge-m3`). It's a **one-time** cost — afterwards only changed files re-index
+on merge. Indexing runs on a **dedicated queue lane**, so a slow index never blocks live reviews / webhooks /
+sweeps (those drain on the main lane in parallel). Tune index parallelism with `QUEUE_INDEX_CONCURRENCY` (default 1)
+and the main lane with `QUEUE_CONCURRENCY`.
+
+---
+
+## Reviews fire too often / token burn
+
+**Symptom:** the same PR seems to get reviewed repeatedly.
+**Cause/Fix:** the engine guarantees **one AI review per head SHA** — a `synchronize`/`edited`/duplicate event on
+the _same commit_ is deduped (no re-spend); a new push (new SHA) gets a fresh review. The re-gate sweep skips the
+AI review entirely in advisory mode. If you still see repeats, check for an automation pushing new commits.
+
+---
+
+## Container / build
+
+### Two migrations with the same number
+
+**Symptom:** `db:migrations:check` fails on a duplicate number after a rebase.
+**Fix:** renumber your migration to the next free `NNNN_*.sql` (the check prints `Next free:`).
+
+### `codex` "model not supported when using Codex with a ChatGPT account"
+
+**Cause:** forcing `--model gpt-5-codex` on a ChatGPT-account login fails.
+**Fix:** leave `AI_MODEL` unset for codex — it picks the account's own default. (Don't set a Claude model id on a
+`claude-code,codex` combo: `AI_MODEL` is global and a Claude id breaks codex.)
+
+### Reviews post as `gittensory-orb`, not your own bot
+
+**Cause:** a brokered self-host borrows tokens from the central Orb App. To post under your own bot identity you
+need the own-App (non-brokered) path.
+
+---
+
+## Where to look next
+
+- **Observability:** Grafana at `:3000` (the **AI Usage & Cost** row shows token/model/effort/cost per provider).
+- **Health:** `GET /ready` returns 503 until the DB answers and migrations are applied.
+- **Config not taking effect:** the container-private `.gittensory.yml` is read fresh each review — no restart
+  needed for per-repo config; _env_ changes (`.env`) need `docker compose up -d --force-recreate gittensory`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,16 +1,9 @@
 # Self-hosting Gittensory
 
 Gittensory ships as a Cloudflare Worker, but the **same** review engine runs unchanged on a plain Node
-container so you can self-host it on your own infrastructure (Docker, Railway, Fly, a VM …). `docker
-compose up` gives you the full reviewer — webhooks, the deterministic gate, AI summaries, the
-maintain/sweep cron, and (optionally) full maintainer autonomy — backed by a local SQLite database.
-
-Self-host connects to the **Gittensory Orb** — our central GitHub App that brokers GitHub access and
-collects anonymized fleet calibration. This is the **gittensor-Mirror model**: you install the **Orb App**
-on your repos and run the container; you **do not create your own GitHub App or manage a private key**, the
-Orb relays your repos' events to your container and mints short-lived GitHub tokens on demand, and your
-instance contributes anonymized review outcomes that keep the gate calibrated across the whole fleet (and
-power the public stats on gittensory.aethereal.dev).
+container so you can self-host it next to your own GitHub App. `docker compose up` gives you the full
+reviewer — webhooks, the deterministic gate, AI summaries, the maintain/sweep cron, and (optionally) full
+maintainer autonomy — backed by a local SQLite database.
 
 > **How it works (one paragraph).** The Worker's Cloudflare bindings are swapped for self-host adapters and
 > nothing else changes: **D1 → `node:sqlite`** (a faithful `D1Database` shim, so Drizzle + every raw query +
@@ -18,51 +11,32 @@ power the public stats on gittensory.aethereal.dev).
 > `processJob`), and the **cron** is a timer that calls the same `scheduled()` handler. The Hono app is served
 > with `@hono/node-server`. See [`src/server.ts`](../src/server.ts) and [`src/selfhost/`](../src/selfhost).
 
+## Documentation map
+
+This page is the overview + quick start. Deeper topics live in [`docs/self-host/`](./self-host/):
+
+| Guide                                             | What's in it                                                                                                   |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Configuration](./self-host/configuration.md)     | The three config layers, the container-private `.gittensory.yml`, every env var, the `features:` block         |
+| [AI providers](./self-host/ai-providers.md)       | claude-code / codex / anthropic / ollama, model + effort + timeout, cost/usage metrics, token-spend protection |
+| [RAG indexing](./self-host/rag-indexing.md)       | qdrant + ollama embed stack, indexing your repos, the on-demand endpoint, namespacing                          |
+| [Review modes](./self-host/review-modes.md)       | advisory vs dry-run vs live, autonomy, the converged features, the 1-review-per-PR guarantee                   |
+| [Troubleshooting](./self-host/troubleshooting.md) | The real failure modes (CLI not baked, 429 quota, no embed provider, stale index) + fixes                      |
+| [Review configuration](./review-configuration.md) | The full `.gittensory.yml` gate/settings/review schema                                                         |
+
 ---
 
-## 1. Quick start (Orb-brokered)
-
-### Step 1 — Install the Gittensory Orb App
-
-[![Install the Gittensory Orb App](https://img.shields.io/badge/Install-Gittensory%20Orb%20App-1f6feb?style=for-the-badge&logo=github)](https://github.com/apps/gittensory-orb/installations/new)
-
-> **→ [github.com/apps/gittensory-orb](https://github.com/apps/gittensory-orb/installations/new)** — install it on the
-> repositories you want reviewed.
-
-The Orb App is a GitHub App **we** run; you don't create one. Installing it lets the Orb deliver your repos'
-events to your container and mint short-lived GitHub tokens for it on demand.
-
-### Step 2 — Get your enrollment secret (self-service)
-
-When the install is authorized, GitHub returns you to a Gittensory page that — once we've verified server-side
-that you're an **admin of the installed account** — shows your **`ORB_ENROLLMENT_SECRET` once**. Copy it (it
-isn't shown again). This is a per-install secret; treat it like a password.
-
-> The secret is **self-issued — zero-touch.** There's no operator step and no credential hand-off: a verified
-> admin enrolls their own install on the spot. (Lose it? Re-open the install from GitHub to issue a new one.)
-
-### Step 3 — Configure `.env` and run
+## 1. Quick start
 
 ```bash
-cp .env.example .env
-# set in .env:
-#   ORB_ENROLLMENT_SECRET=<the secret from step 2>
-#   ORB_BROKER_URL=https://gittensory-api.aethereal.dev   # default — the Orb broker + collector
-#   PUBLIC_API_ORIGIN=https://<your-host>                 # your container's public URL — MUST be reachable by the Orb
+cp .env.example .env          # then edit .env — see §3
 docker compose up --build
-curl https://<your-host>/health    # {"status":"ok"}
+curl localhost:8787/health    # {"status":"ok"}
 ```
 
-On boot the container creates the SQLite database on the `gittensory-data` volume, applies all migrations
-automatically (`{"event":"selfhost_migrations_applied",…}` in the logs), then **registers its relay URL**
-(`PUBLIC_API_ORIGIN` + `/v1/orb/relay`) with the Orb. From there the Orb **forwards your install's webhooks**
-to the container, HMAC-signed with your enrollment secret — there is **no GitHub webhook to configure**. GitHub
-API actions (comment, label, merge, close) use **short-lived installation tokens brokered from the Orb on
-demand**, so the container never holds a GitHub App private key.
-
-> **The container must be reachable by the Orb.** `PUBLIC_API_ORIGIN` has to resolve from the public internet
-> (the Orb POSTs your events to `PUBLIC_API_ORIGIN/v1/orb/relay`). Put it behind your own TLS / reverse proxy and
-> expose port 8787. Confirm `GET /ready` returns `200` once migrations are applied.
+On first boot the container creates the SQLite database on the `gittensory-data` volume and applies all 56
+migrations automatically (`{"event":"selfhost_migrations_applied","count":56}` in the logs). Point your
+GitHub App's webhook at `https://<your-host>/v1/github/webhook` (expose port 8787 behind your own TLS).
 
 **Or use the published image** (multi-arch, ~254 MB) instead of building:
 
@@ -85,40 +59,42 @@ GitHub Release.
 
 ---
 
-## 2. Telemetry — Orb fleet calibration
+## 2. Create the GitHub App
 
-Self-hosting is a **fleet-telemetry contract**: each instance exports an anonymized, reversal-aware
-review-outcome signal to the Orb collector (`ORB_COLLECTOR_URL`, default the hosted collector). This is
-what calibrates the gate across the whole self-host fleet and produces the accurate aggregate numbers on
-gittensory.aethereal.dev — it is **on by default** once your App is configured.
+**One-click (recommended):** before setting any GitHub secrets, set `PUBLIC_API_ORIGIN` and a long random
+`SELFHOST_SETUP_TOKEN`, boot the container, then visit **`/setup`** and enter your `SELFHOST_SETUP_TOKEN`
+in the form (the token is sent in the POST body, never the URL, so it can't leak to logs or browser history).
+It creates the App for you via GitHub's App-manifest flow (correct permissions/events + webhook URL), then
+writes the credentials to `/data/gittensory-app.env`. Add those to your `.env`, install the App on your repos,
+and restart. `/setup` requires the setup token and is disabled once `GITHUB_APP_ID` is set, so it can't rebind
+a live install. (Scripted setups can pass the token via an `x-setup-token` header instead.)
 
-- **Anonymized.** Repo/PR identifiers are HMAC-hashed with a per-instance secret the collector **never
-  holds**, so it can't de-anonymize you. The payload is only `verdict + outcome + reversal + a bucketed
-  reason category + cycle time` — **no diffs, no code, no comments, no logins, no commit SHAs**.
-- It is part of the broker contract (a brokered instance relies on the Orb for tokens + relay), so it stays on.
-  `ORB_ANONYMIZE` (default `true`) controls the hashing.
+**Or manually**, create a GitHub App (the hosted gittensory[bot] is separate) with:
+
+- **Webhook URL** `https://<your-host>/v1/github/webhook`, and a **webhook secret** (→ `GITHUB_WEBHOOK_SECRET`).
+- **Permissions**: Pull requests (read/write), Contents (read; read/write if you want merge), Issues
+  (read/write), Checks (read), Metadata (read). Commit statuses (read).
+- **Events**: Pull request, Pull request review, Push, Issues, Check suite, Check run, Status.
+- Generate a **private key** (→ `GITHUB_APP_PRIVATE_KEY`), and note the **App ID** (→ `GITHUB_APP_ID`) and the
+  app **slug** (→ `GITHUB_APP_SLUG`). Install the app on the repos you want reviewed.
 
 ---
 
 ## 3. Configuration
 
 Everything is environment variables — see [`.env.example`](../.env.example) for the annotated list (it holds
-**sample placeholders only; never commit a real `.env`** — it is gitignored). The required core secrets for
-the **Orb-brokered** path:
+**sample placeholders only; never commit a real `.env`** — it is gitignored). The required core secrets:
 
-| Variable | What it is |
-| --- | --- |
-| `ORB_ENROLLMENT_SECRET` | your one-time enrollment secret from the install flow (§1, step 2) |
-| `ORB_BROKER_URL` | the Orb broker + collector base (default `https://gittensory-api.aethereal.dev`) |
-| `PUBLIC_API_ORIGIN` | your container's public base URL — **must be reachable by the Orb relay** |
-| `GITTENSOR_REGISTRY_URL` | registry endpoint (or any reachable placeholder if you don't use the registry) |
-| `GITTENSORY_API_TOKEN` / `GITTENSORY_MCP_TOKEN` / `INTERNAL_JOB_TOKEN` | bearer tokens — generate your own (`openssl rand -hex 32`) |
-
-(You set **no** `GITHUB_APP_*` secrets — the Orb holds the App key and mints tokens for you on demand.)
+| Variable                                                               | What it is                                                                     |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `GITHUB_APP_ID` / `GITHUB_APP_SLUG`                                    | your GitHub App's id + slug                                                    |
+| `GITHUB_APP_PRIVATE_KEY`                                               | the App's PKCS#8 private key (or mount `GITHUB_APP_PRIVATE_KEY_FILE`)          |
+| `GITHUB_WEBHOOK_SECRET`                                                | the webhook secret you set on the App                                          |
+| `GITTENSOR_REGISTRY_URL`                                               | registry endpoint (or any reachable placeholder if you don't use the registry) |
+| `GITTENSORY_API_TOKEN` / `GITTENSORY_MCP_TOKEN` / `INTERNAL_JOB_TOKEN` | bearer tokens — generate your own (`openssl rand -hex 32`)                     |
 
 Runtime knobs: `PORT` (default 8787), `DATABASE_PATH` (default `/data/gittensory.sqlite`), `CRON_INTERVAL_MS`
-(default 120000 ≈ the hosted every-2-minutes cron), `QUEUE_CONCURRENCY` (default 4 — how many I/O-bound review
-jobs process at once; raise it to drain bigger PR bursts faster, set `1` for strict serial processing).
+(default 120000 ≈ the hosted every-2-minutes cron).
 
 **Secrets via files.** Any `FOO_FILE=/run/secrets/foo` is read into `FOO` at startup (Docker/Compose
 secrets, multi-line keys) — an explicit `FOO` always wins.
@@ -130,25 +106,30 @@ secrets, multi-line keys) — an explicit `FOO` always wins.
 Without an AI provider the review still runs fully — deterministic signals, the gate, merge/close decisions —
 and only the AI **summary** degrades to "unavailable". To enable AI, set `AI_PROVIDER`:
 
-| `AI_PROVIDER` | Backend | Extra config |
-| --- | --- | --- |
-| `ollama` / `openai-compatible` / `openai` | any OpenAI-compatible `/chat/completions` endpoint (Ollama, OpenAI, Groq, Together, OpenRouter, vLLM, Gemini's OpenAI-compat endpoint, …) | `AI_BASE_URL`, `AI_API_KEY` (or `OPENAI_API_KEY`), `AI_MODEL` |
-| `anthropic` | **native Anthropic Messages API** (BYOK — bills your API key) | `ANTHROPIC_API_KEY`, `AI_MODEL` (e.g. `claude-sonnet-4-6`) |
-| `claude-code` | your **Claude** subscription via the `claude` CLI (read-only, headless) | `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), `AI_MODEL` (default `claude-sonnet-4-6`), `AI_EFFORT` (default `high`) |
-| `codex` | your **Codex** subscription via the `codex` CLI | local `codex` auth, `AI_MODEL` (e.g. `gpt-5`) |
+| `AI_PROVIDER`                             | Backend                                                                                                                                   | Extra config                                                                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `ollama` / `openai-compatible` / `openai` | any OpenAI-compatible `/chat/completions` endpoint (Ollama, OpenAI, Groq, Together, OpenRouter, vLLM, Gemini's OpenAI-compat endpoint, …) | `AI_BASE_URL`, `AI_API_KEY` (or `OPENAI_API_KEY`), `AI_MODEL`                                                                 |
+| `anthropic`                               | **native Anthropic Messages API** (BYOK — bills your API key)                                                                             | `ANTHROPIC_API_KEY`, `AI_MODEL` (e.g. `claude-sonnet-4-6`)                                                                    |
+| `claude-code`                             | your **Claude** subscription via the `claude` CLI (read-only, headless)                                                                   | `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), `AI_MODEL` (default `claude-sonnet-4-6`), `AI_EFFORT` (default `high`) |
+| `codex`                                   | your **Codex** subscription via the `codex` CLI                                                                                           | local `codex` auth, `AI_MODEL` (e.g. `gpt-5`)                                                                                 |
+
+**Review timeout (`AI_TIMEOUT_MS`).** The `claude` / `codex` subprocess timeout. Left unset it **scales with
+`AI_EFFORT`** (low/medium 120s, high 240s, xhigh 360s, max 600s) so a large `max`-effort review isn't SIGKILLed
+mid-generation — the old fixed 120s cap silently dropped long reviews. Set `AI_TIMEOUT_MS` to override (clamped
+30s–30min).
 
 **Fallback chain.** `AI_PROVIDER` accepts a comma-separated list and tries each in order until one succeeds —
 e.g. `AI_PROVIDER=anthropic,ollama` uses the Anthropic API first and falls back to a local Ollama model if it
 errors. If every provider fails, the AI summary degrades to "unavailable" and the review still runs.
 
-**Dual review (consensus / synthesis).** With **two** providers, `AI_PROVIDER=claude-code,codex` runs *both* as
+**Dual review (consensus / synthesis).** With **two** providers, `AI_PROVIDER=claude-code,codex` runs _both_ as
 independent reviewers and combines them per `AI_COMBINE` (#dual-ai-combiner):
 
-| `AI_COMBINE` | Decision | Notes |
-|---|---|---|
-| `single` | one reviewer's verdict (auto when only one provider) | a named blocker blocks |
-| `consensus` | block only when **both** flag a critical defect; lone flag → **hold** for a human | most conservative |
-| `synthesis` *(default for two)* | both review, then **one merged decision** | `AI_ON_MERGE=either` blocks if either flags (default), `both` only when both do |
+| `AI_COMBINE`                    | Decision                                                                          | Notes                                                                           |
+| ------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `single`                        | one reviewer's verdict (auto when only one provider)                              | a named blocker blocks                                                          |
+| `consensus`                     | block only when **both** flag a critical defect; lone flag → **hold** for a human | most conservative                                                               |
+| `synthesis` _(default for two)_ | both review, then **one merged decision**                                         | `AI_ON_MERGE=either` blocks if either flags (default), `both` only when both do |
 
 In `block` mode the combined decision drives the gate; in `advisory` mode it's notes only. Every strategy is
 fail-closed — if a reviewer can't return a usable verdict, the PR is **held** for a human, never auto-merged. The
@@ -166,10 +147,10 @@ bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. N
   `sonnet`, `opus`, `claude-opus-4-8`, …) and `AI_EFFORT` (`low`|`medium`|`high`|`xhigh`|`max`; the CLI clamps a
   level above the model's own ceiling).
 - **Codex:** codex reads `auth.json` from `$CODEX_HOME` (default `~/.codex`) and **must have a WRITABLE home** — it
-  refreshes the token in place, so a read-only mount fails with *"Read-only file system"*. Set `CODEX_HOME` to a
+  refreshes the token in place, so a read-only mount fails with _"Read-only file system"_. Set `CODEX_HOME` to a
   writable path and **copy** your `~/.codex/auth.json` there (don't bind-mount it read-only). With a ChatGPT-
-  subscription login, leave `AI_MODEL` unset for codex — pinning `gpt-5*` returns *"not supported … with a ChatGPT
-  account"*; codex picks the entitled default. (`ca-certificates` for codex's native TLS is baked in by `INSTALL_AI_CLIS`.)
+  subscription login, leave `AI_MODEL` unset for codex — pinning `gpt-5*` returns _"not supported … with a ChatGPT
+  account"_; codex picks the entitled default. (`ca-certificates` for codex's native TLS is baked in by `INSTALL_AI_CLIS`.)
 
 **Local RAG (retrieval-augmented review).** Self-host ships a SQLite-backed vector store, so RAG works without
 Cloudflare Vectorize. Enable it with `GITTENSORY_REVIEW_RAG=true` + the repo in `GITTENSORY_REVIEW_REPOS`, and
@@ -206,26 +187,46 @@ Self-host runs the identical engine, so the behavior is configured exactly as on
   acts on its decisions, gated by the same guardrails (protected-path manual-review globs, owner-PR
   no-auto-close, mergeability + green-CI before approve).
 
-- **Quiet inline comments (CodeRabbit-style).** Set `GITTENSORY_REVIEW_INLINE_COMMENTS=true` + the repo in
-  `GITTENSORY_REVIEW_REPOS` + `review.inline_comments: true` in the repo's config, and on top of the decision
-  summary the reviewer leaves **non-blocking** inline comments on changed lines (`event: COMMENT`) — useful even
-  in advisory mode, telling a contributor exactly what to fix for their next submission. Out-of-diff findings are
-  dropped (never a 422), and a failure never affects the gate.
-
-Per-PR capabilities (safety scan, CI/full-file grounding, RAG, unified comment, inline comments, content lane,
-self-tune, parity audit) are the `GITTENSORY_REVIEW_*` flags — every flag defaults **off** and is fully inert until
+Per-PR capabilities (safety scan, CI/full-file grounding, RAG, unified comment, content lane, self-tune,
+parity audit) are the `GITTENSORY_REVIEW_*` flags — every flag defaults **off** and is fully inert until
 turned on. Per-repo settings (autonomy, required approvals, protected paths) live in `.gittensory.yml` /
 repository settings. The authoritative reference for all of these is
 [`docs/review-configuration.md`](./review-configuration.md).
 
 **Container-private per-repo config (keep policy off the public repo).** `.gittensory.yml` lives in the repo, so
 contributors can read it — and whoever can see the gate thresholds, autonomy, or label policy can game them. To
-keep review policy private, set **`GITTENSORY_REPO_CONFIG_DIR`** to a mounted directory and drop one file per repo
-named `{owner}__{repo}.yml` (lowercased, `/` → double underscore) — e.g. `jsonbored__metagraphed.yml`. When a file
-exists for a repo the engine reads it **instead of** fetching the public `.gittensory.yml`, so the policy never
-appears in contributor-facing previews. It uses the same schema (`gate:` / `settings:` / `review:` — autonomy,
-labels, model/effort), is read fresh each review (edits apply immediately), and `.yaml` / `.json` are also
-accepted. Unset ⇒ the public file is fetched exactly as before.
+keep review policy private, set **`GITTENSORY_REPO_CONFIG_DIR`** to a mounted directory and configure each repo
+there. For a repo `JSONbored/gittensory` the engine looks, in priority order, for:
+
+```
+$GITTENSORY_REPO_CONFIG_DIR/
+├── jsonbored__gittensory/.gittensory.yml   # 1. owner-qualified folder (collision-safe across owners)
+├── gittensory/.gittensory.yml              # 2. bare repo-name folder (clean, human-readable)
+├── jsonbored__gittensory.yml               # 3. flat owner__repo file (original layout; still supported)
+└── .gittensory.yml                         # 4. GLOBAL fallback: applied to every repo without its own file
+```
+
+The first match wins outright (a per-repo file fully **replaces** the global fallback — it is a fallback, not a
+merge). When any of these exists the engine reads it **instead of** fetching the public `.gittensory.yml`, so the
+policy never appears in contributor-facing previews. It uses the same schema (`gate:` / `settings:` / `review:` —
+autonomy, labels, model/effort, and `gate.aiReview.allAuthors` to review every PR's author, not only confirmed
+contributors), is read fresh each review (edits apply immediately), and `.yaml` / `.json` are accepted everywhere.
+Names are lowercased (`/` → double underscore). Unset ⇒ the public file is fetched exactly as before.
+
+**Per-repo converged-feature toggles (`features:`).** Turn individual converged review features on/off per repo:
+
+```yaml
+features:
+  rag: true # codebase-RAG retrieval context for the reviewer
+  reputation: false # internal submitter-reputation AI-spend gate
+  unifiedComment: true # render the converged unified PR comment (vs the legacy panel)
+  safety: true # defang untrusted PR text before the model sees it
+```
+
+Each feature's global env flag (`GITTENSORY_REVIEW_*`) remains a **master kill-switch** — a feature listed here only
+runs when its env flag is also on. When a feature is unset in `features:`, it falls back to the `GITTENSORY_REVIEW_REPOS`
+allowlist (the pre-existing default), so repos that set nothing are unaffected. (grounding, screenshots, and
+content-lane are not yet per-repo toggleable and stay on the allowlist.)
 
 ---
 
@@ -244,13 +245,11 @@ accepted. Unset ⇒ the public file is fetched exactly as before.
   in-flight job, checkpoints the WAL, and closes the DB before exiting.
 - **Logs** are structured JSON (`selfhost_listening`, `selfhost_migrations_applied`, `selfhost_ai_provider`,
   `selfhost_queue_recovered`, `selfhost_job_dead`, `selfhost_cron_error`, `selfhost_shutdown`, …).
-- **Data + backup (do NOT skip).** Everything is the single SQLite file on the `gittensory-data` volume (WAL
-  mode), so **without a backup, losing the volume loses all review state** — and `/ready` still answers `200`,
-  so the gap is silent. The container logs a loud `selfhost_backup_advisory` warning at boot until you set up a
-  backup. For **continuous, point-in-time backup**, enable the [Litestream](https://litestream.io) sidecar in
+- **Data + backup.** Everything is the single SQLite file on the `gittensory-data` volume (WAL mode). Back up
+  by snapshotting the volume or copying the `.sqlite` file. Migrations are idempotent and re-checked at boot.
+  For **continuous, point-in-time backup**, enable the optional [Litestream](https://litestream.io) sidecar in
   `docker-compose.yml` (copy `litestream.yml.example` → `litestream.yml`, set your bucket + credentials); it
-  streams every change to S3/B2/MinIO/R2. Then set **`BACKUP_ACKNOWLEDGED=true`** to silence the warning. (For
-  multi-instance, use `DATABASE_URL=postgres://…` and back up Postgres instead.)
+  streams every change to S3/B2/MinIO/R2.
 - **App-level metrics.** Enable `GITTENSORY_REVIEW_OPS=true` for the read-only gate-block anomaly scan and the
   bearer-gated `GET /v1/internal/ops/stats` aggregate.
 
@@ -275,10 +274,9 @@ is **not** available on the Postgres backend yet — it degrades to no-context.
 
 These are Cloudflare-platform features; they degrade cleanly and the core reviewer is unaffected:
 
-- **Visual PR capture** — off by default (reviews run text-only). To enable on self-host: point
-  `BROWSER_WS_ENDPOINT` at a browserless/chrome sidecar **and** set `REVIEW_AUDIT_DIR` so captured screenshots
-  persist (an fs-backed store standing in for the cloud's R2 bucket); without `REVIEW_AUDIT_DIR` captures degrade
-  to on-demand re-render.
+- **Visual PR capture** (Browser Rendering binding) — off; reviews run text-only.
+- **The `/mcp` server** (Durable-Object-backed Agents SDK) — returns `501`. The deterministic API + review
+  path is unaffected; a native MCP-on-Node port is a follow-up.
 - **Distributed rate limiting** (RateLimiter Durable Object) — off by default; set `REDIS_URL` for a
   Redis-backed fixed-window limiter (see §7). Otherwise put a reverse proxy / WAF in front.
 - **Vectorize-backed RAG** and **R2 audit storage** — inert unless you wire equivalent backends.

--- a/grafana/dashboards/claude-usage.json
+++ b/grafana/dashboards/claude-usage.json
@@ -1,0 +1,391 @@
+{
+  "uid": "gittensory-claude",
+  "title": "Gittensory — Claude usage (OTEL)",
+  "tags": ["gittensory", "claude", "ai"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 3,
+  "refresh": "30s",
+  "time": { "from": "now-7d", "to": "now" },
+  "description": "Claude Code review-CLI usage via OpenTelemetry. Each headless review is a session-scoped cumulative counter, so totals use last_over_time (sum of each session's final value) — increase()/rate() would read flat because a session exports its total in one shot.",
+  "templating": {
+    "list": [
+      {
+        "name": "model",
+        "label": "Model",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(claude_code_cost_usage_USD_total, model)",
+        "query": {
+          "query": "label_values(claude_code_cost_usage_USD_total, model)",
+          "refId": "A"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Summary (over the selected time range)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total cost",
+      "gridPos": { "h": 5, "w": 5, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(last_over_time(claude_code_cost_usage_USD_total{model=~\"$model\"}[$__range]))"
+        }
+      ]
+    },
+
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total tokens",
+      "gridPos": { "h": 5, "w": 5, "x": 5, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "blue" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(last_over_time(claude_code_token_usage_tokens_total{model=~\"$model\"}[$__range]))"
+        }
+      ]
+    },
+
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Sessions",
+      "gridPos": { "h": 5, "w": 5, "x": 10, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "purple" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(last_over_time(claude_code_session_count_total[$__range]))"
+        }
+      ]
+    },
+
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active time",
+      "gridPos": { "h": 5, "w": 4, "x": 15, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "fixed", "fixedColor": "orange" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(last_over_time(claude_code_active_time_seconds_total[$__range]))"
+        }
+      ]
+    },
+
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Lines of code",
+      "gridPos": { "h": 5, "w": 5, "x": 19, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "yellow" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(last_over_time(claude_code_lines_of_code_count_total[$__range]))"
+        }
+      ]
+    },
+
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Breakdowns",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 }
+    },
+
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Cost by model (per scrape interval)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 1,
+            "gradientMode": "opacity"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom",
+          "displayMode": "table",
+          "calcs": ["max"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (model) (last_over_time(claude_code_cost_usage_USD_total{model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+
+    {
+      "id": 9,
+      "type": "piechart",
+      "title": "Tokens by type",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": {
+        "pieType": "donut",
+        "legend": {
+          "showLegend": true,
+          "placement": "right",
+          "values": ["percent", "value"]
+        },
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "displayLabels": ["percent"]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (type) (last_over_time(claude_code_token_usage_tokens_total{model=~\"$model\"}[$__range]))",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+
+    {
+      "id": 10,
+      "type": "bargauge",
+      "title": "Cost by model",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 7 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "color": { "mode": "continuous-GrYlRd" }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (model) (last_over_time(claude_code_cost_usage_USD_total{model=~\"$model\"}[$__range]))",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Tokens by type (per scrape interval)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 0,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      },
+      "options": {
+        "legend": { "showLegend": true, "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (type) (last_over_time(claude_code_token_usage_tokens_total{model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+
+    {
+      "id": 12,
+      "type": "table",
+      "title": "Cost by model × effort",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [{ "displayName": "Cost", "desc": true }]
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Cost" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 4 },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "gauge", "mode": "gradient" }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "expr": "sum by (model, effort) (last_over_time(claude_code_cost_usage_USD_total{model=~\"$model\"}[$__range]))"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": { "Value": "Cost" },
+            "excludeByName": { "Time": true }
+          }
+        }
+      ]
+    },
+
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Cumulative review cost",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 23 },
+      "description": "gittensory's own monotonic cost counter (gittensory_ai_cost_usd_total) — continuously scraped, so it draws a clean cumulative line, complementing the per-session OTEL metrics above. Resets to 0 on a stack restart.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom",
+          "displayMode": "table",
+          "calcs": ["lastNotNull"]
+        },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (provider) (gittensory_ai_cost_usd_total)",
+          "legendFormat": "{{provider}}"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/github-prs.json
+++ b/grafana/dashboards/github-prs.json
@@ -1,0 +1,376 @@
+{
+  "uid": "gittensory-github",
+  "title": "Gittensory — Upstream PRs & issues (GitHub)",
+  "tags": ["gittensory", "github", "maintainer"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": { "from": "now-7d", "to": "now" },
+  "description": "Live upstream census straight from the GitHub API. 'Open' counts ignore the time range (current state); the 'in range' flow counts respect it. Large result sets are capped at 1000 rows by the data source, so flow uses sensible windows rather than all-time totals.",
+  "templating": {
+    "list": [
+      {
+        "name": "scope",
+        "label": "Scope",
+        "type": "custom",
+        "query": "All repos : org:JSONbored, metagraphed : repo:JSONbored/metagraphed, gittensory : repo:JSONbored/gittensory, awesome-claude : repo:JSONbored/awesome-claude, metagraphed-ui : repo:JSONbored/metagraphed-ui",
+        "current": { "text": "All repos", "value": "org:JSONbored" },
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Current state · $scope",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Open PRs",
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": { "query": "$scope is:pr is:open", "timeField": 4 }
+        }
+      ]
+    },
+
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Open & draft",
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "purple" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": {
+            "query": "$scope is:pr is:open is:draft",
+            "timeField": 4
+          }
+        }
+      ]
+    },
+
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Open issues",
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "orange" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Issues",
+          "owner": "",
+          "repository": "",
+          "options": { "query": "$scope is:issue is:open" }
+        }
+      ]
+    },
+
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Mergeable now",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": {
+            "query": "$scope is:pr is:open -is:draft",
+            "timeField": 4
+          }
+        }
+      ]
+    },
+
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Flow (within the selected time range) · $scope",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 }
+    },
+
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "PRs opened",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 7 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": { "query": "$scope is:pr", "timeField": 1 }
+        }
+      ]
+    },
+
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "PRs merged",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 7 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": { "query": "$scope is:pr is:merged", "timeField": 2 }
+        }
+      ]
+    },
+
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "PRs closed unmerged",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 7 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "red" } }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": {
+            "query": "$scope is:pr is:closed is:unmerged",
+            "timeField": 0
+          }
+        }
+      ]
+    },
+
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Open PR triage · $scope",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 }
+    },
+
+    {
+      "id": 11,
+      "type": "table",
+      "title": "Open pull requests (oldest first)",
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 12 },
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [{ "displayName": "Opened", "desc": false }]
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "url" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "number" },
+            "properties": [
+              { "id": "displayName", "value": "PR" },
+              { "id": "custom.width", "value": 64 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open PR on GitHub",
+                    "url": "${__data.fields.url}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "repository" },
+            "properties": [
+              { "id": "displayName", "value": "Repo" },
+              { "id": "custom.width", "value": 130 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "title" },
+            "properties": [
+              { "id": "displayName", "value": "Title" },
+              { "id": "custom.width", "value": 360 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "author_login" },
+            "properties": [
+              { "id": "displayName", "value": "Author" },
+              { "id": "custom.width", "value": 130 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open author on GitHub",
+                    "url": "https://github.com/${__data.fields.author_login}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "is_draft" },
+            "properties": [
+              { "id": "displayName", "value": "Draft" },
+              { "id": "custom.width", "value": 70 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "mergeable" },
+            "properties": [{ "id": "custom.width", "value": 110 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "created_at" },
+            "properties": [
+              { "id": "displayName", "value": "Opened" },
+              { "id": "custom.width", "value": 170 },
+              { "id": "unit", "value": "dateTimeFromNow" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "labels" },
+            "properties": [{ "id": "displayName", "value": "Labels" }]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "additions": true,
+              "deletions": true,
+              "state": true,
+              "author_name": true,
+              "author_email": true,
+              "author_company": true,
+              "closed": true,
+              "locked": true,
+              "merged": true,
+              "closed_at": true,
+              "merged_at": true,
+              "merged_by_name": true,
+              "merged_by_login": true,
+              "merged_by_email": true,
+              "merged_by_company": true,
+              "updated_at": true,
+              "open_time": true
+            },
+            "indexByName": {
+              "number": 0,
+              "repository": 1,
+              "title": 2,
+              "author_login": 3,
+              "is_draft": 4,
+              "mergeable": 5,
+              "created_at": 6,
+              "labels": 7,
+              "url": 8
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "Pull_Requests",
+          "owner": "",
+          "repository": "",
+          "options": { "query": "$scope is:pr is:open", "timeField": 4 }
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/gittensory.json
+++ b/grafana/dashboards/gittensory.json
@@ -1,8 +1,18 @@
 {
   "__inputs": [],
   "__requires": [
-    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
-    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
   ],
   "annotations": { "list": [] },
   "editable": false,
@@ -24,96 +34,231 @@
         "defaults": {
           "color": { "mode": "thresholds" },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
           "unit": "s"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
       "id": 1,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Uptime",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_uptime_seconds", "legendFormat": "uptime" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_uptime_seconds",
+          "legendFormat": "uptime"
+        }
+      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 10 }, { "color": "red", "value": 50 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
           "unit": "short"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "id": 2,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Queue Pending",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_queue_pending", "legendFormat": "pending" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_pending",
+          "legendFormat": "pending"
+        }
+      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 10 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
           "unit": "short"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
       "id": 3,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Dead-Letter Jobs",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_queue_dead", "legendFormat": "dead" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_dead",
+          "legendFormat": "dead"
+        }
+      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
           "unit": "short"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
       "id": 6,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Total Jobs Processed",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_jobs_processed_total", "legendFormat": "processed" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_jobs_processed_total",
+          "legendFormat": "processed"
+        }
+      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
           "unit": "short"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "id": 7,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Webhook Dedups (total)",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_webhook_dedup_total", "legendFormat": "deduped" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_webhook_dedup_total",
+          "legendFormat": "deduped"
+        }
+      ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
           "unit": "short"
         }
       },
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
       "id": 8,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Qdrant Errors (total)",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(gittensory_qdrant_errors_total) or vector(0)", "legendFormat": "errors" }]
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(gittensory_qdrant_errors_total) or vector(0)",
+          "legendFormat": "errors"
+        }
+      ]
     },
     {
       "collapsed": false,
@@ -125,31 +270,69 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "reqps" }
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "reqps"
+        }
       },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
       "id": 4,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "HTTP Request Rate",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_http_requests_total[2m])", "legendFormat": "requests/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_webhook_dedup_total[2m])", "legendFormat": "dedup/s" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_http_requests_total[2m])",
+          "legendFormat": "requests/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_webhook_dedup_total[2m])",
+          "legendFormat": "dedup/s"
+        }
       ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        }
       },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
       "id": 9,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Queue Depth Over Time",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_queue_pending", "legendFormat": "pending" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_queue_dead", "legendFormat": "dead-letter" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_pending",
+          "legendFormat": "pending"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_dead",
+          "legendFormat": "dead-letter"
+        }
       ]
     },
     {
@@ -162,18 +345,45 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ops"
+        }
       },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
       "id": 5,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Job Throughput",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_jobs_processed_total[2m])", "legendFormat": "processed/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_jobs_enqueued_total[2m])", "legendFormat": "enqueued/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_jobs_failed_total[2m])", "legendFormat": "failed/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_jobs_dead_total[2m])", "legendFormat": "dead/s" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_jobs_processed_total[2m])",
+          "legendFormat": "processed/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_jobs_enqueued_total[2m])",
+          "legendFormat": "enqueued/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_jobs_failed_total[2m])",
+          "legendFormat": "failed/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_jobs_dead_total[2m])",
+          "legendFormat": "dead/s"
+        }
       ]
     },
     {
@@ -189,7 +399,14 @@
       },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
       "id": 10,
-      "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "last"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Job Failure Rate",
       "type": "timeseries",
       "targets": [
@@ -210,30 +427,64 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ops"
+        }
       },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
       "id": 11,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Qdrant Query Rate",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_qdrant_queries_total[2m])", "legendFormat": "queries/s" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_qdrant_queries_total[2m])",
+          "legendFormat": "queries/s"
+        }
       ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ops"
+        }
       },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
       "id": 12,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Qdrant Upserts & Errors",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_qdrant_upserts_total[2m])", "legendFormat": "upserts/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_qdrant_errors_total[2m])", "legendFormat": "errors/s" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_qdrant_upserts_total[2m])",
+          "legendFormat": "upserts/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_qdrant_errors_total[2m])",
+          "legendFormat": "errors/s"
+        }
       ]
     },
     {
@@ -245,69 +496,222 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" } },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        }
+      },
       "gridPos": { "h": 4, "w": 6, "x": 0, "y": 33 },
       "id": 13,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "title": "Orb Events Recorded",
       "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_events_recorded_total", "legendFormat": "recorded" }]
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 33 },
-      "id": 14,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "Orb Events Exported",
-      "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_events_exported_total", "legendFormat": "exported" }]
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 33 },
-      "id": 15,
-      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "Orb Export Errors",
-      "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_export_errors_total or vector(0)", "legendFormat": "errors" }]
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 33 },
-      "id": 16,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
-      "title": "Orb Installations",
-      "type": "stat",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_installs_total", "legendFormat": "installs" }]
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
-      "id": 17,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "Orb Event Rate",
-      "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_orb_events_recorded_total[5m])", "legendFormat": "recorded/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_orb_events_exported_total[5m])", "legendFormat": "exported/s" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(gittensory_orb_webhook_total[5m])", "legendFormat": "webhooks/s" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_events_recorded_total",
+          "legendFormat": "recorded"
+        }
       ]
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" } },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 33 },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Orb Events Exported",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_events_exported_total",
+          "legendFormat": "exported"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 33 },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Orb Export Errors",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_export_errors_total or vector(0)",
+          "legendFormat": "errors"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 33 },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Orb Installations",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_installs_total",
+          "legendFormat": "installs"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Orb Event Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_orb_events_recorded_total[5m])",
+          "legendFormat": "recorded/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_orb_events_exported_total[5m])",
+          "legendFormat": "exported/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(gittensory_orb_webhook_total[5m])",
+          "legendFormat": "webhooks/s"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        }
+      },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
       "id": 18,
-      "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "calcs": ["mean", "last"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": { "mode": "multi" }
+      },
       "title": "Orb Pending vs Exported",
       "type": "timeseries",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_events_recorded_total - gittensory_orb_events_exported_total", "legendFormat": "pending" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "gittensory_orb_events_exported_total", "legendFormat": "exported (cumulative)" }
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_events_recorded_total - gittensory_orb_events_exported_total",
+          "legendFormat": "pending"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_orb_events_exported_total",
+          "legendFormat": "exported (cumulative)"
+        }
       ]
     },
     {
@@ -508,10 +912,7 @@
       "id": 21,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "bottom"
         },
@@ -561,10 +962,7 @@
       "id": 22,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
+          "calcs": ["mean", "max"],
           "displayMode": "table",
           "placement": "bottom"
         },
@@ -652,9 +1050,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -767,9 +1163,7 @@
         "cellHeight": "sm",
         "footer": {
           "show": false,
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "fields": ""
         }
       },
@@ -814,6 +1208,174 @@
           }
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 108,
+      "title": "AI Usage & Cost (per provider)",
+      "type": "row"
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens/min by provider",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "id": 109,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (provider) ((rate(gittensory_ai_input_tokens_total[5m]) + rate(gittensory_ai_output_tokens_total[5m])) * 60)",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "AI requests by model + effort (last 1h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "id": 110,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (model, effort) (increase(gittensory_ai_requests_total[1h]))",
+          "legendFormat": "{{model}} \u00b7 {{effort}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cumulative AI cost (USD) by provider",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "id": 111,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (provider) (gittensory_ai_cost_usd_total) or vector(0)",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "currencyUSD"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Total tokens by provider + kind",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "id": 112,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 82
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (provider, kind) (gittensory_ai_input_tokens_total)",
+          "legendFormat": "{{provider}} {{kind}} in"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (provider, kind) (gittensory_ai_output_tokens_total)",
+          "legendFormat": "{{provider}} {{kind}} out"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short"
+        }
+      }
     }
   ],
   "refresh": "30s",
@@ -838,5 +1400,5 @@
   "timezone": "browser",
   "title": "Gittensory Self-Host",
   "uid": "gittensory-selfhost",
-  "version": 4
+  "version": 5
 }

--- a/grafana/dashboards/maintainer-reviews.json
+++ b/grafana/dashboards/maintainer-reviews.json
@@ -1,0 +1,550 @@
+{
+  "uid": "gittensory-maintainer",
+  "title": "Gittensory — Reviews & PRs (maintainer)",
+  "tags": ["gittensory", "maintainer"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 2,
+  "refresh": "1m",
+  "time": { "from": "now-90d", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "repo",
+        "label": "Repository",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "gittensory-db"
+        },
+        "query": "SELECT DISTINCT repo_full_name FROM pull_requests ORDER BY 1",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "__all__",
+        "current": { "text": "All", "value": "__all__" },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Fleet summary · $repo   (counts reflect PRs gittensory has OBSERVED — not the full upstream census; see note below)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Open PRs (observed)",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "queryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Merged (recorded)",
+      "description": "Merges gittensory witnessed via webhook — NOT the repo's all-time merged total. Needs the upstream reconcile to match GitHub.",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.merged_at IS NOT NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "queryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.merged_at IS NOT NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Closed (recorded)",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='closed' AND p.merged_at IS NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "queryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='closed' AND p.merged_at IS NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "PRs reviewed",
+      "description": "Distinct PRs gittensory posted a review on — this IS accurate (it is gittensory's own activity).",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "purple" },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(DISTINCT target_key) AS value FROM audit_events WHERE event_type='github_app.pr_public_surface_published' AND ('$repo'='__all__' OR target_key LIKE '$repo' || '#%')",
+          "queryText": "SELECT COUNT(DISTINCT target_key) AS value FROM audit_events WHERE event_type='github_app.pr_public_surface_published' AND ('$repo'='__all__' OR target_key LIKE '$repo' || '#%')",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Open & awaiting review",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND ('$repo'='__all__' OR p.repo_full_name='$repo') AND NOT EXISTS (SELECT 1 FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key = p.repo_full_name || '#' || p.number)",
+          "queryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND ('$repo'='__all__' OR p.repo_full_name='$repo') AND NOT EXISTS (SELECT 1 FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key = p.repo_full_name || '#' || p.number)",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Open & blocked",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND p.merge_blocked_reason IS NOT NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "queryText": "SELECT COUNT(*) AS value FROM pull_requests p WHERE p.state='open' AND p.merge_blocked_reason IS NOT NULL AND ('$repo'='__all__' OR p.repo_full_name='$repo')",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 14,
+      "type": "text",
+      "title": "",
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 5 },
+      "options": {
+        "mode": "markdown",
+        "content": "> ⚠️ **Data source:** the *Reviewed PRs* counts/log and *Reviews posted* trend are gittensory's own activity and are **accurate**. The *Open / Merged / Closed* tiles count only PRs gittensory observed via webhooks — they do **not** mirror the full upstream GitHub census. → **For the accurate live census (open/merged/closed straight from the GitHub API) + open-PR triage, see the [Upstream PRs & issues (GitHub)](/d/gittensory-github) dashboard.**"
+      }
+    },
+
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Per-repository breakdown (all repos)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }
+    },
+
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Repositories",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 9 },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "options": { "showHeader": true, "cellHeight": "sm" },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Repository" },
+            "properties": [
+              { "id": "custom.width", "value": 280 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open repository on GitHub",
+                    "url": "https://github.com/${__data.fields.Repository}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "timeColumns": [],
+          "rawQueryText": "SELECT p.repo_full_name AS \"Repository\", SUM(CASE WHEN p.state='open' THEN 1 ELSE 0 END) AS \"Open\", SUM(CASE WHEN p.merged_at IS NOT NULL THEN 1 ELSE 0 END) AS \"Merged\", SUM(CASE WHEN p.state='closed' AND p.merged_at IS NULL THEN 1 ELSE 0 END) AS \"Closed\", (SELECT COUNT(DISTINCT a.target_key) FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key LIKE p.repo_full_name || '#%') AS \"Reviewed\", SUM(CASE WHEN p.state='open' AND NOT EXISTS (SELECT 1 FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key = p.repo_full_name || '#' || p.number) THEN 1 ELSE 0 END) AS \"Awaiting\", SUM(CASE WHEN p.state='open' AND p.merge_blocked_reason IS NOT NULL THEN 1 ELSE 0 END) AS \"Blocked\" FROM pull_requests p GROUP BY p.repo_full_name ORDER BY \"Open\" DESC",
+          "queryText": "SELECT p.repo_full_name AS \"Repository\", SUM(CASE WHEN p.state='open' THEN 1 ELSE 0 END) AS \"Open\", SUM(CASE WHEN p.merged_at IS NOT NULL THEN 1 ELSE 0 END) AS \"Merged\", SUM(CASE WHEN p.state='closed' AND p.merged_at IS NULL THEN 1 ELSE 0 END) AS \"Closed\", (SELECT COUNT(DISTINCT a.target_key) FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key LIKE p.repo_full_name || '#%') AS \"Reviewed\", SUM(CASE WHEN p.state='open' AND NOT EXISTS (SELECT 1 FROM audit_events a WHERE a.event_type='github_app.pr_public_surface_published' AND a.target_key = p.repo_full_name || '#' || p.number) THEN 1 ELSE 0 END) AS \"Awaiting\", SUM(CASE WHEN p.state='open' AND p.merge_blocked_reason IS NOT NULL THEN 1 ELSE 0 END) AS \"Blocked\" FROM pull_requests p GROUP BY p.repo_full_name ORDER BY \"Open\" DESC",
+          "timeColumns": []
+        }
+      ]
+    },
+
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Reviewed PRs log · $repo",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+
+    {
+      "id": 11,
+      "type": "table",
+      "title": "Reviewed pull requests",
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 18 },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [{ "displayName": "Last reviewed", "desc": true }]
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "url" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "repo" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "PR" },
+            "properties": [
+              { "id": "custom.width", "value": 64 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open PR on GitHub",
+                    "url": "${__data.fields.url}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Repo" },
+            "properties": [
+              { "id": "custom.width", "value": 130 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open repository on GitHub",
+                    "url": "https://github.com/${__data.fields.repo}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Title" },
+            "properties": [{ "id": "custom.width", "value": 360 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Author" },
+            "properties": [
+              { "id": "custom.width", "value": 130 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open author on GitHub",
+                    "url": "https://github.com/${__data.fields.Author}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Closes" },
+            "properties": [
+              { "id": "custom.width", "value": 80 },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open issue on GitHub",
+                    "url": "https://github.com/${__data.fields.repo}/issues/${__data.fields.Closes}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Status" },
+            "properties": [
+              { "id": "custom.width", "value": 110 },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "basic" }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "🟢 open": { "color": "blue", "index": 0 },
+                      "🟣 merged": { "color": "green", "index": 1 },
+                      "🔴 closed": { "color": "red", "index": 2 }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Outcome" },
+            "properties": [
+              { "id": "custom.width", "value": 90 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "merged": { "color": "green", "index": 0 },
+                      "closed": { "color": "red", "index": 1 }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "timeColumns": ["Last reviewed"],
+          "rawQueryText": "SELECT p.number AS \"PR\", p.html_url AS \"url\", p.repo_full_name AS \"repo\", substr(p.repo_full_name, instr(p.repo_full_name,'/')+1) AS \"Repo\", p.title AS \"Title\", p.author_login AS \"Author\", CASE WHEN p.merged_at IS NOT NULL THEN '🟣 merged' WHEN p.state='closed' THEN '🔴 closed' ELSE '🟢 open' END AS \"Status\", COALESCE(o.decision,'—') AS \"Outcome\", TRIM(REPLACE(REPLACE(REPLACE(p.linked_issues_json,'[',''),']',''),'\"','')) AS \"Closes\", r.last_reviewed AS \"Last reviewed\" FROM pull_requests p JOIN (SELECT target_key, MAX(created_at) AS last_reviewed FROM audit_events WHERE event_type='github_app.pr_public_surface_published' GROUP BY target_key) r ON r.target_key = p.repo_full_name || '#' || p.number LEFT JOIN (SELECT target_id, decision FROM review_audit WHERE event_type='pr_outcome') o ON o.target_id = p.repo_full_name || '#' || p.number WHERE ('$repo'='__all__' OR p.repo_full_name='$repo') ORDER BY r.last_reviewed DESC LIMIT 300",
+          "queryText": "SELECT p.number AS \"PR\", p.html_url AS \"url\", p.repo_full_name AS \"repo\", substr(p.repo_full_name, instr(p.repo_full_name,'/')+1) AS \"Repo\", p.title AS \"Title\", p.author_login AS \"Author\", CASE WHEN p.merged_at IS NOT NULL THEN '🟣 merged' WHEN p.state='closed' THEN '🔴 closed' ELSE '🟢 open' END AS \"Status\", COALESCE(o.decision,'—') AS \"Outcome\", TRIM(REPLACE(REPLACE(REPLACE(p.linked_issues_json,'[',''),']',''),'\"','')) AS \"Closes\", r.last_reviewed AS \"Last reviewed\" FROM pull_requests p JOIN (SELECT target_key, MAX(created_at) AS last_reviewed FROM audit_events WHERE event_type='github_app.pr_public_surface_published' GROUP BY target_key) r ON r.target_key = p.repo_full_name || '#' || p.number LEFT JOIN (SELECT target_id, decision FROM review_audit WHERE event_type='pr_outcome') o ON o.target_id = p.repo_full_name || '#' || p.number WHERE ('$repo'='__all__' OR p.repo_full_name='$repo') ORDER BY r.last_reviewed DESC LIMIT 300"
+        }
+      ]
+    },
+
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Reviews posted per day · $repo",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gittensory-db"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1 },
+          "color": { "mode": "fixed", "fixedColor": "purple" },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": false },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "time series",
+          "timeColumns": ["time"],
+          "rawQueryText": "SELECT strftime('%s', date(created_at)) AS time, COUNT(*) AS \"reviews posted\" FROM audit_events WHERE event_type='github_app.pr_public_surface_published' AND ('$repo'='__all__' OR target_key LIKE '$repo' || '#%') GROUP BY date(created_at) ORDER BY time",
+          "queryText": "SELECT strftime('%s', date(created_at)) AS time, COUNT(*) AS \"reviews posted\" FROM audit_events WHERE event_type='github_app.pr_public_surface_published' AND ('$repo'='__all__' OR target_key LIKE '$repo' || '#%') GROUP BY date(created_at) ORDER BY time"
+        }
+      ]
+    },
+
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Open-PR backlog per repo (Prometheus trend)",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 40 },
+      "description": "Sampled from the gittensory_repo_prs gauges at each /metrics scrape — retains backlog history the point-in-time SQLite panels can't.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "placement": "bottom",
+          "displayMode": "table",
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "gittensory_repo_prs{state=\"open\"}",
+          "legendFormat": "{{repo}}"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/resource-hub.json
+++ b/grafana/dashboards/resource-hub.json
@@ -1,0 +1,65 @@
+{
+  "uid": "gittensory-hub",
+  "title": "Gittensory — Resource hub",
+  "tags": ["gittensory", "hub"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "",
+  "time": { "from": "now-6h", "to": "now" },
+  "links": [
+    {
+      "title": "Reviews & PRs (maintainer)",
+      "type": "dashboards",
+      "tags": ["maintainer"],
+      "asDropdown": false,
+      "icon": "dashboard",
+      "targetBlank": false
+    },
+    {
+      "title": "Qdrant",
+      "type": "link",
+      "url": "http://localhost:6333/dashboard",
+      "icon": "external link",
+      "targetBlank": true,
+      "tooltip": "Vector store UI"
+    },
+    {
+      "title": "Prometheus",
+      "type": "link",
+      "url": "http://localhost:9090",
+      "icon": "external link",
+      "targetBlank": true
+    },
+    {
+      "title": "App /metrics",
+      "type": "link",
+      "url": "http://localhost:8787/metrics",
+      "icon": "external link",
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "Integrated services",
+      "gridPos": { "h": 13, "w": 12, "x": 0, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "## 🧠 AI providers\n- **Claude Code / Codex** — subscription CLIs, the review brain. Health: app boot log `selfhost_ai_provider`.\n- **Ollama** — embeddings (`bge-m3`) for RAG · [API root](http://localhost:11434) · `docker exec gittensory-ollama-1 ollama list`\n\n## 🔎 Vector store (RAG)\n- **Qdrant** — [Dashboard](http://localhost:6333/dashboard) · [Collections API](http://localhost:6333/collections)\n- Embeddings indexed per repo; see the *RAG indexing* doc.\n\n## ⚙️ Engine / API\n- **gittensory app** — [/ ](http://localhost:8787/) · [/ready](http://localhost:8787/ready) · [/metrics](http://localhost:8787/metrics)\n- Internal jobs: `POST /v1/internal/jobs/rag-index` (bearer `INTERNAL_JOB_TOKEN`)\n\n## 💾 Data\n- **SQLite** (default) at `/data/gittensory.sqlite` — surfaced here via the *GittensoryDB* datasource.\n- **Postgres/pgvector** (optional `--profile postgres`).\n\n> Links assume the default published ports on the Docker host. If you run Grafana on a remote host, replace `localhost` with that host, and publish the service `ports:` you want to reach."
+      }
+    },
+
+    {
+      "id": 2,
+      "type": "text",
+      "title": "Observability & dashboards",
+      "gridPos": { "h": 13, "w": 12, "x": 12, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "## 📊 Dashboards\n- **[Upstream PRs & issues (GitHub)](/d/gittensory-github)** — live, accurate census + open-PR triage (GitHub API).\n- **[Reviews & PRs (maintainer)](/d/gittensory-maintainer)** — gittensory's own review activity + reviewed-PR log.\n- **[Claude usage (OTEL)](/d/gittensory-claude)** — cost / tokens / model / effort from the review CLI.\n- **[Gittensory (infra)](/d/gittensory)** — AI usage & cost, queue, jobs, HTTP.\n\n## 📈 Metrics & logs\n- **Prometheus** — [targets](http://localhost:9090/targets) · [graph](http://localhost:9090)\n- **Alertmanager** — [alerts](http://localhost:9093)\n- **Loki** — query in [Explore](/explore) (pick the *Loki* datasource), e.g. `{compose_service=\"gittensory\"}`\n\n## 🩺 Quick health checks\n| What | Where |\n|---|---|\n| App serving | `GET /ready` → 200 |\n| AI wired | boot log `selfhost_ai_provider` |\n| Embeds wired | boot log `selfhost_embed_provider` |\n| Vectors wired | boot log `selfhost_vectorize` |\n| Token spend | infra dashboard → *AI Usage & Cost* |\n\n## 📚 Docs\n- `docs/self-host/` — configuration, ai-providers, rag-indexing, review-modes, troubleshooting."
+      }
+    }
+  ]
+}

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/grafana/provisioning/datasources/sqlite.yml
+++ b/grafana/provisioning/datasources/sqlite.yml
@@ -1,0 +1,14 @@
+# Maintainer-facing datasource: the app's SQLite DB (pull_requests / review_targets / review_audit), so the
+# dashboards can show real PR/review rows — titles, links, authors, verdicts, per-repo counts — not just
+# infra metrics. Read-only in practice (the plugin runs SELECTs); the DB volume is mounted at /appdb in compose.
+# Only loaded when the frser-sqlite-datasource plugin is installed (GF_INSTALL_PLUGINS in the grafana service).
+apiVersion: 1
+datasources:
+  - name: GittensoryDB
+    type: frser-sqlite-datasource
+    uid: gittensory-db
+    access: proxy
+    isDefault: false
+    editable: false
+    jsonData:
+      path: /appdb/gittensory.sqlite

--- a/grafana/provisioning/datasources/tempo.yml
+++ b/grafana/provisioning/datasources/tempo.yml
@@ -1,0 +1,11 @@
+# Tempo trace store for the Claude review CLI's OpenTelemetry spans (--profile observability). Explore traces in
+# Grafana → Explore → Tempo. Inert until the otel-collector forwards traces and Claude Code trace export is on.
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
+    editable: false

--- a/otel/otel-collector-config.yml
+++ b/otel/otel-collector-config.yml
@@ -1,0 +1,51 @@
+# OpenTelemetry Collector for the self-host (--profile observability), following Anthropic's official Claude
+# Code monitoring guide (github.com/anthropics/claude-code-monitoring-guide). Receives OTLP metrics from the
+# review CLI and re-exposes them in Prometheus format on :8889, which Prometheus scrapes.
+#
+# Why a collector (not Prometheus's native OTLP push): the prometheus exporter's `metric_expiration` keeps a
+# finished session's cumulative counters exposed for 3h, so sporadic, short-lived `claude -p` runs don't make
+# the series vanish between reviews — the failure mode of pushing OTLP straight into Prometheus.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    send_timestamps: true
+    metric_expiration: 180m
+    enable_open_metrics: true
+    # Turn OTLP resource attributes (service.name, model, …) into labels for per-model/-user breakdowns.
+    resource_to_telemetry_conversion:
+      enabled: true
+  # Forward Claude review CLI spans to Tempo (the beta tracing pipeline). Inert if Tempo isn't running.
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  telemetry:
+    logs:
+      level: warn
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/tempo]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -22,3 +22,10 @@ scrape_configs:
     metrics_path: /metrics
     scrape_interval: 15s
     scrape_timeout: 10s
+
+  # Claude Code usage telemetry, re-exposed by the OTEL collector's Prometheus exporter (--profile
+  # observability + CLAUDE_CODE_ENABLE_TELEMETRY=1). An absent collector just shows the target as down.
+  - job_name: claude-code-otel
+    static_configs:
+      - targets: ["otel-collector:8889"]
+    scrape_interval: 15s

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Self-host backup: an online SQLite backup (safe while the app is writing) + a Qdrant snapshot, with retention.
+# Run by the `backup` compose service (--profile backup) on a loop, or on demand:
+#   docker compose run --rm backup sh /backup.sh
+# Backups land in the `gittensory-backups` volume at /backups/{sqlite,qdrant}.
+set -eu
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+RETAIN=${BACKUP_RETAIN:-7}
+DB=${DATABASE_PATH:-/data/gittensory.sqlite}
+OUT=/backups
+mkdir -p "$OUT/sqlite" "$OUT/qdrant"
+
+# 1) SQLite — the Online Backup API yields a consistent copy even while the app writes (WAL-safe).
+if [ -f "$DB" ]; then
+  sqlite3 "$DB" ".backup '$OUT/sqlite/gittensory-$TS.sqlite'"
+  gzip -f "$OUT/sqlite/gittensory-$TS.sqlite"
+  echo "[backup] sqlite -> $OUT/sqlite/gittensory-$TS.sqlite.gz"
+else
+  echo "[backup] sqlite db not found at $DB (skipping)"
+fi
+
+# 2) Qdrant — trigger a full storage snapshot, download it, then delete it from Qdrant's own storage so snapshots
+#    don't accumulate inside the vector store. Best-effort: a Qdrant outage must not fail the SQLite backup.
+if [ -n "${QDRANT_URL:-}" ]; then
+  NAME=$(curl -sf -X POST "$QDRANT_URL/snapshots" 2>/dev/null | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+  if [ -n "$NAME" ]; then
+    if curl -sf "$QDRANT_URL/snapshots/$NAME" -o "$OUT/qdrant/$NAME" 2>/dev/null; then
+      echo "[backup] qdrant -> $OUT/qdrant/$NAME"
+    fi
+    curl -sf -X DELETE "$QDRANT_URL/snapshots/$NAME" >/dev/null 2>&1 || true
+  else
+    echo "[backup] qdrant snapshot could not be created (skipping)"
+  fi
+fi
+
+# 3) Retention — keep only the newest $RETAIN in each directory.
+for d in sqlite qdrant; do
+  ls -1t "$OUT/$d" 2>/dev/null | tail -n +"$((RETAIN + 1))" | while IFS= read -r f; do
+    rm -f "$OUT/$d/$f"
+    echo "[backup] pruned old backup $d/$f"
+  done
+done
+
+echo "[backup] complete ($TS); retaining newest $RETAIN per target"

--- a/scripts/setup-github-datasource.sh
+++ b/scripts/setup-github-datasource.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Add (or update) the GitHub data source in Grafana via the API — the live upstream PR/issue census for the
+# maintainer dashboards. Done over the API rather than file-provisioning on purpose: a backend datasource
+# whose plugin/token isn't ready at boot would crash Grafana's provisioning, so we add it after Grafana is up.
+#
+# Prereqs: --profile observability running, the grafana-github-datasource plugin installed (GF_INSTALL_PLUGINS),
+# and a read-only fine-grained PAT (Pull requests: read, Issues: read, Contents: read) on the repos.
+#
+# Usage:
+#   GITHUB_TOKEN=github_pat_xxx GRAFANA_ADMIN_PASSWORD=... ./scripts/setup-github-datasource.sh
+#   # or rely on values already in ./.env (GITHUB_TOKEN, GRAFANA_ADMIN_PASSWORD)
+set -euo pipefail
+
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
+[ -f .env ] && { set -a; . ./.env; set +a; }
+: "${GITHUB_TOKEN:?Set GITHUB_TOKEN (a read-only fine-grained PAT) in the environment or .env}"
+: "${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in the environment or .env}"
+AUTH="admin:${GRAFANA_ADMIN_PASSWORD}"
+
+payload() {
+  cat <<JSON
+{ "name": "GitHub", "type": "grafana-github-datasource", "uid": "github", "access": "proxy",
+  "isDefault": false, "jsonData": { "selectedAuthType": "personal-access-token" },
+  "secureJsonData": { "accessToken": "${GITHUB_TOKEN}" } }
+JSON
+}
+
+# Idempotent: update in place if a datasource with uid "github" already exists, else create it.
+if curl -sf -u "$AUTH" "$GRAFANA_URL/api/datasources/uid/github" >/dev/null 2>&1; then
+  echo "Updating existing GitHub data source…"
+  curl -sf -u "$AUTH" -H 'content-type: application/json' -X PUT \
+    "$GRAFANA_URL/api/datasources/uid/github" -d "$(payload)" >/dev/null
+else
+  echo "Creating GitHub data source…"
+  curl -sf -u "$AUTH" -H 'content-type: application/json' -X POST \
+    "$GRAFANA_URL/api/datasources" -d "$(payload)" >/dev/null
+fi
+
+echo "Done. Verifying health…"
+curl -sf -u "$AUTH" -X POST "$GRAFANA_URL/api/datasources/uid/github/health" 2>/dev/null \
+  | grep -q '"status":"OK"' && echo "✓ GitHub data source healthy" || echo "⚠ Added, but health check did not return OK — verify the token scopes."

--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -1,0 +1,29 @@
+# Grafana Tempo — single-binary, local-storage trace store for the self-host (--profile observability).
+# Receives traces from the OTEL collector (which forwards the Claude review CLI's OpenTelemetry spans) and
+# serves them to Grafana via the Tempo data source. Local filesystem storage on the tempo-data volume.
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h # keep traces 7 days
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
Reconciles the self-host **deploy + docs** from the batch onto main so other self-hosters get the full stack — Grafana dashboards (maintainer/Claude-usage/GitHub-census/resource-hub) + provisioning, the OTEL→Prometheus→Tempo telemetry pipeline, Alertmanager Discord receiver, the online SQLite/Qdrant backup service, the nightly maintenance workflow, the GitHub data-source setup script, and the self-host guide set. **Deploy + docs only — no engine code.** Part of the batch reconciliation.