### PR TITLE
feat(selfhost): Discord disposition notifications enriched with the AI gate verdict

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -24,6 +24,7 @@
 // once a repo's merge precision actually drops below the floor over a real sample.
 
 import { recordAuditEvent } from "../db/repositories";
+import { notifyDiscordReview } from "../selfhost/discord-notify";
 import type { GitHubWebhookPayload } from "../types";
 import { errorMessage, nowIso } from "../utils/json";
 import {
@@ -40,7 +41,9 @@ import { computeGateEval } from "./parity";
 
 /** PURE: parse the PR number an "Reverts #N / Reverts owner/repo#N" body refers to (GitHub's revert PRs).
  *  Mirrors reviewbot runtime.ts parseRevertedPrNumber. Returns undefined when the body isn't a revert. */
-export function parseRevertedPrNumber(body: string | null | undefined): number | undefined {
+export function parseRevertedPrNumber(
+  body: string | null | undefined,
+): number | undefined {
   const m = /Reverts\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/i.exec(body ?? "");
   return m ? Number(m[1]) : undefined;
 }
@@ -57,12 +60,19 @@ function flagTruthy(v: string | null | undefined): boolean {
  *  This is the read the merge path consults to downgrade a would-MERGE into a HOLD. */
 export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
   try {
-    const res = await env.DB.prepare("SELECT key, value FROM system_flags").all<{ key: string; value: string }>();
+    const res = await env.DB.prepare(
+      "SELECT key, value FROM system_flags",
+    ).all<{ key: string; value: string }>();
     const set = new Set<string>();
     for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
     return set.has("holdonly:global") || set.has(`holdonly:${project}`);
   } catch (error) {
-    console.warn(JSON.stringify({ ev: "flags_read_error", message: errorMessage(error).slice(0, 120) }));
+    console.warn(
+      JSON.stringify({
+        ev: "flags_read_error",
+        message: errorMessage(error).slice(0, 120),
+      }),
+    );
     return false; // fail-OPEN: a DB blip must never silently change the merge path
   }
 }
@@ -71,14 +81,24 @@ export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
  *  globally)? Reads the SAME system_flags table via a single scan and tests the `closehold:` namespace. This is
  *  the read the close path consults to downgrade a would-CLOSE into a HOLD. Fail-OPEN (false) on a DB error so a
  *  blip never silently changes the close path. */
-export async function isCloseHoldOnly(env: Env, project: string): Promise<boolean> {
+export async function isCloseHoldOnly(
+  env: Env,
+  project: string,
+): Promise<boolean> {
   try {
-    const res = await env.DB.prepare("SELECT key, value FROM system_flags").all<{ key: string; value: string }>();
+    const res = await env.DB.prepare(
+      "SELECT key, value FROM system_flags",
+    ).all<{ key: string; value: string }>();
     const set = new Set<string>();
     for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
     return set.has("closehold:global") || set.has(`closehold:${project}`);
   } catch (error) {
-    console.warn(JSON.stringify({ ev: "flags_read_error", message: errorMessage(error).slice(0, 120) }));
+    console.warn(
+      JSON.stringify({
+        ev: "flags_read_error",
+        message: errorMessage(error).slice(0, 120),
+      }),
+    );
     return false; // fail-OPEN: a DB blip must never silently change the close path
   }
 }
@@ -91,7 +111,11 @@ export function createFlagStore(env: Env): FlagStore {
       // Per-key check (NOT the global-or-project read above): applyAutoTune dedups on whether THIS project's
       // breaker is already engaged, so it must read the per-project key, not fold in the global one.
       try {
-        const row = await env.DB.prepare("SELECT value FROM system_flags WHERE key = ?").bind(`holdonly:${project}`).first<{ value: string }>();
+        const row = await env.DB.prepare(
+          "SELECT value FROM system_flags WHERE key = ?",
+        )
+          .bind(`holdonly:${project}`)
+          .first<{ value: string }>();
         return flagTruthy(row?.value);
       } catch {
         return false;
@@ -101,7 +125,11 @@ export function createFlagStore(env: Env): FlagStore {
       // Per-key check (mirrors isHoldOnly): applyCloseAutoTune dedups on whether THIS project's CLOSE breaker is
       // already engaged, so it reads the per-project `closehold:` key, not the global-or-project read above.
       try {
-        const row = await env.DB.prepare("SELECT value FROM system_flags WHERE key = ?").bind(`closehold:${project}`).first<{ value: string }>();
+        const row = await env.DB.prepare(
+          "SELECT value FROM system_flags WHERE key = ?",
+        )
+          .bind(`closehold:${project}`)
+          .first<{ value: string }>();
         return flagTruthy(row?.value);
       } catch {
         return false;
@@ -109,14 +137,24 @@ export function createFlagStore(env: Env): FlagStore {
     },
     async setFlag(key: string, on: boolean): Promise<void> {
       if (on) {
-        await env.DB.prepare("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES (?, '1', CURRENT_TIMESTAMP)").bind(key).run();
+        await env.DB.prepare(
+          "INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES (?, '1', CURRENT_TIMESTAMP)",
+        )
+          .bind(key)
+          .run();
       } else {
-        await env.DB.prepare("DELETE FROM system_flags WHERE key = ?").bind(key).run();
+        await env.DB.prepare("DELETE FROM system_flags WHERE key = ?")
+          .bind(key)
+          .run();
       }
     },
     async flagSetAt(key: string): Promise<string | null> {
       try {
-        const row = await env.DB.prepare("SELECT updated_at FROM system_flags WHERE key = ?").bind(key).first<{ updated_at: string }>();
+        const row = await env.DB.prepare(
+          "SELECT updated_at FROM system_flags WHERE key = ?",
+        )
+          .bind(key)
+          .first<{ updated_at: string }>();
         return row?.updated_at ?? null;
       } catch {
         return null;
@@ -137,17 +175,38 @@ function reviewAuditTargetId(repoFullName: string, pullNumber: number): string {
  *  webhook). `decision` is the realized merge/close for a pr_outcome row; null for a reversal marker row. */
 async function appendReviewAudit(
   env: Env,
-  input: { project: string; targetId: string; eventType: string; decision?: string | null; summary?: string | null },
+  input: {
+    project: string;
+    targetId: string;
+    eventType: string;
+    decision?: string | null;
+    summary?: string | null;
+  },
 ): Promise<void> {
   try {
     await env.DB.prepare(
       `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at)
        VALUES (?, ?, ?, ?, ?, 'gittensory-native', NULL, ?, ?)`,
     )
-      .bind(`${input.eventType}:${input.targetId}:${nowIso()}:${Math.random().toString(36).slice(2, 8)}`, input.project, input.targetId, input.eventType, input.decision ?? null, input.summary ?? null, nowIso())
+      .bind(
+        `${input.eventType}:${input.targetId}:${nowIso()}:${Math.random().toString(36).slice(2, 8)}`,
+        input.project,
+        input.targetId,
+        input.eventType,
+        input.decision ?? null,
+        input.summary ?? null,
+        nowIso(),
+      )
       .run();
   } catch (error) {
-    console.warn(JSON.stringify({ ev: "review_audit_record_error", event: input.eventType, project: input.project, message: errorMessage(error).slice(0, 160) }));
+    console.warn(
+      JSON.stringify({
+        ev: "review_audit_record_error",
+        event: input.eventType,
+        project: input.project,
+        message: errorMessage(error).slice(0, 160),
+      }),
+    );
   }
 }
 
@@ -162,7 +221,31 @@ async function appendReviewAudit(
  * general audit ledger (audit_events, via recordAuditEvent, per the GAP-4 task). Best-effort throughout. A
  * non-closed action, or a payload with no PR number, records nothing.
  */
-export async function recordPrOutcome(env: Env, eventName: string, payload: GitHubWebhookPayload): Promise<void> {
+/** Enrich a disposition notification with the AI's reasoning: the latest recorded gate verdict (the reasonCode
+ *  summary on the most recent `gate_decision` row for this PR). Falls back to the plain disposition reason when
+ *  no verdict is recorded or the read fails. Exported for tests. */
+export async function resolveDispositionReason(
+  env: Env,
+  targetId: string,
+  fallback: string,
+): Promise<string> {
+  try {
+    const verdict = await env.DB.prepare(
+      "SELECT summary FROM review_audit WHERE target_id = ? AND event_type = 'gate_decision' AND summary IS NOT NULL ORDER BY created_at DESC LIMIT 1",
+    )
+      .bind(targetId)
+      .first<{ summary: string | null }>();
+    return verdict?.summary || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function recordPrOutcome(
+  env: Env,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): Promise<void> {
   if (eventName !== "pull_request" || payload.action !== "closed") return;
   const pr = payload.pull_request;
   const repoFullName = payload.repository?.full_name;
@@ -176,12 +259,24 @@ export async function recordPrOutcome(env: Env, eventName: string, payload: GitH
   // authoritative ground truth for the repository's merge/close decision and must not feed the precision
   // circuit-breaker; otherwise contributors can poison merge precision by closing their own mergeable PRs.
   // Merges remain trusted because GitHub requires merge permission, and maintainer/bot closes are not self-closes.
-  if (!merged && !botWasActor && senderLogin && authorLogin && senderLogin === authorLogin) return;
+  if (
+    !merged &&
+    !botWasActor &&
+    senderLogin &&
+    authorLogin &&
+    senderLogin === authorLogin
+  )
+    return;
 
   const decision = merged ? "merged" : "closed";
   const targetId = reviewAuditTargetId(repoFullName, pr.number);
 
-  await appendReviewAudit(env, { project: repoFullName.slice(0, 200), targetId, eventType: "pr_outcome", decision });
+  await appendReviewAudit(env, {
+    project: repoFullName.slice(0, 200),
+    targetId,
+    eventType: "pr_outcome",
+    decision,
+  });
   await recordAuditEvent(env, {
     eventType: "pr_outcome",
     actor: payload.sender?.login ?? null,
@@ -189,7 +284,30 @@ export async function recordPrOutcome(env: Env, eventName: string, payload: GitH
     outcome: "completed",
     detail: decision,
     metadata: { repoFullName, pullNumber: pr.number, merged, botWasActor },
-  }).catch((error) => console.warn(JSON.stringify({ ev: "pr_outcome_audit_error", message: errorMessage(error).slice(0, 160) })));
+  }).catch((error) =>
+    console.warn(
+      JSON.stringify({
+        ev: "pr_outcome_audit_error",
+        message: errorMessage(error).slice(0, 160),
+      }),
+    ),
+  );
+
+  // Per-repo Discord notification on the FINAL disposition (self-host; no-op unless a webhook is configured).
+  // Reason = the AI's recorded gate verdict for this PR, falling back to the plain disposition.
+  const fallbackReason = merged
+    ? "Pull request merged into the base branch."
+    : botWasActor
+      ? "Closed by Gittensory after review."
+      : "Pull request closed without merging.";
+  await notifyDiscordReview({
+    repoFullName,
+    prNumber: pr.number,
+    author: pr.user?.login ?? "unknown",
+    outcome: decision,
+    reason: await resolveDispositionReason(env, targetId, fallbackReason),
+    url: `https://github.com/${repoFullName}/pull/${pr.number}`,
+  });
 }
 
 // ── 2) reversals — a human undid a bot action ────────────────────────────────────────────────────────────────
@@ -198,18 +316,20 @@ export async function recordPrOutcome(env: Env, eventName: string, payload: GitH
  *  eventType `agent.action.<class>`, written by buildAgentActionAudit) — the most-recent SUCCESSFUL action for
  *  this target. A reopen of a bot-CLOSED PR is the high-value "human disagreed with the close" reversal signal.
  *  Fail-safe: a read error → false (record nothing rather than a false reversal). */
-async function lastBotActionWasClose(env: Env, targetKey: string): Promise<boolean> {
+async function lastBotActionWasClose(
+  env: Env,
+  targetKey: string,
+): Promise<boolean> {
   try {
-    const row = await env.DB
-      .prepare(
-        // The executor records performed and dry-run actions as outcome 'completed', with the real mode only in
-        // metadata. Exclude dry-run shadows so a "would close" cannot masquerade as an actual bot close.
-        // 'success' is only a legacy value. (#audit-reversal-reopened)
-        `SELECT event_type FROM audit_events
+    const row = await env.DB.prepare(
+      // The executor records performed and dry-run actions as outcome 'completed', with the real mode only in
+      // metadata. Exclude dry-run shadows so a "would close" cannot masquerade as an actual bot close.
+      // 'success' is only a legacy value. (#audit-reversal-reopened)
+      `SELECT event_type FROM audit_events
          WHERE target_key = ? AND event_type LIKE 'agent.action.%' AND outcome IN ('success', 'completed')
            AND COALESCE(json_extract(metadata_json, '$.mode'), 'live') <> 'dry_run'
          ORDER BY created_at DESC LIMIT 1`,
-      )
+    )
       .bind(targetKey)
       .first<{ event_type: string }>();
     return row?.event_type === "agent.action.close";
@@ -224,8 +344,9 @@ async function lastBotActionWasClose(env: Env, targetKey: string): Promise<boole
  *  Fail-safe: a read error → false (record nothing rather than a false reversal). (#audit-3.2) */
 async function wasMergeRecorded(env: Env, targetId: string): Promise<boolean> {
   try {
-    const row = await env.DB
-      .prepare(`SELECT 1 AS hit FROM review_audit WHERE target_id = ? AND event_type = 'pr_outcome' AND decision = 'merged' LIMIT 1`)
+    const row = await env.DB.prepare(
+      `SELECT 1 AS hit FROM review_audit WHERE target_id = ? AND event_type = 'pr_outcome' AND decision = 'merged' LIMIT 1`,
+    )
       .bind(targetId)
       .first<{ hit: number }>();
     return Boolean(row);
@@ -245,7 +366,11 @@ async function wasMergeRecorded(env: Env, targetId: string): Promise<boolean> {
  * Writes to BOTH review_audit (what ops.ts joins for reversalRate/calibration) and audit_events (the general
  * ledger). Best-effort + independent of the review path. A non-reversal event records nothing.
  */
-export async function recordReversalSignals(env: Env, eventName: string, payload: GitHubWebhookPayload): Promise<void> {
+export async function recordReversalSignals(
+  env: Env,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): Promise<void> {
   if (eventName !== "pull_request") return;
   const pr = payload.pull_request;
   const repoFullName = payload.repository?.full_name;
@@ -256,12 +381,18 @@ export async function recordReversalSignals(env: Env, eventName: string, payload
   if (payload.action === "reopened") {
     const ownerLogin = (repoFullName.split("/")[0] || "").toLowerCase();
     const senderLogin = (payload.sender?.login || "").toLowerCase();
-    const senderIsOwner = !!ownerLogin && !!senderLogin && ownerLogin === senderLogin;
+    const senderIsOwner =
+      !!ownerLogin && !!senderLogin && ownerLogin === senderLogin;
     const senderIsBot = payload.sender?.type === "Bot";
     if (senderIsBot || senderIsOwner) return; // administrative / bot reopen — not a contributor dispute
     const targetId = reviewAuditTargetId(repoFullName, pr.number);
     if (!(await lastBotActionWasClose(env, targetId))) return; // only a bot-CLOSED PR reopening is a reversal
-    await appendReviewAudit(env, { project, targetId, eventType: "reversal_reopened", summary: `Bot-closed PR #${pr.number} reopened by a contributor.` });
+    await appendReviewAudit(env, {
+      project,
+      targetId,
+      eventType: "reversal_reopened",
+      summary: `Bot-closed PR #${pr.number} reopened by a contributor.`,
+    });
     await recordAuditEvent(env, {
       eventType: "reversal_reopened",
       actor: payload.sender?.login ?? null,
@@ -285,14 +416,23 @@ export async function recordReversalSignals(env: Env, eventName: string, payload
     // The reverted PR (#N) had a recorded pr_outcome=merged; the reversal_reverted row marks that merge as later
     // undone so reversalRate/calibration reflect it. (Auto-revert — opening a revert PR — is a separate, larger
     // feature and intentionally NOT wired here; this records the human-driven revert signal.)
-    await appendReviewAudit(env, { project, targetId: revertedTargetKey, eventType: "reversal_reverted", summary: `Merged PR #${reverted} was reverted by #${pr.number}.` });
+    await appendReviewAudit(env, {
+      project,
+      targetId: revertedTargetKey,
+      eventType: "reversal_reverted",
+      summary: `Merged PR #${reverted} was reverted by #${pr.number}.`,
+    });
     await recordAuditEvent(env, {
       eventType: "reversal_reverted",
       actor: payload.sender?.login ?? null,
       targetKey: revertedTargetKey,
       outcome: "completed",
       detail: `Merged PR #${reverted} was reverted by #${pr.number}.`,
-      metadata: { repoFullName, revertedPullNumber: reverted, revertPullNumber: pr.number },
+      metadata: {
+        repoFullName,
+        revertedPullNumber: reverted,
+        revertPullNumber: pr.number,
+      },
     }).catch(() => undefined);
   }
 }
@@ -319,32 +459,71 @@ const BREAKER_EVAL_WINDOW_DAYS = 90;
 export async function runSelfTuneBreaker(env: Env): Promise<void> {
   try {
     const nowMs = Date.now();
-    const report: GateEvalReport = await computeGateEval(env, { days: BREAKER_EVAL_WINDOW_DAYS, nowMs });
+    const report: GateEvalReport = await computeGateEval(env, {
+      days: BREAKER_EVAL_WINDOW_DAYS,
+      nowMs,
+    });
     const flags = createFlagStore(env);
     const engaged = await applyAutoTune(flags, report);
     for (const action of engaged) {
-      console.warn(JSON.stringify({ ev: "breaker_engaged", project: action.project, mergePrecision: action.mergePrecision, decided: action.decided, floor: AUTOTUNE_MERGE_PRECISION_FLOOR }));
+      console.warn(
+        JSON.stringify({
+          ev: "breaker_engaged",
+          project: action.project,
+          mergePrecision: action.mergePrecision,
+          decided: action.decided,
+          floor: AUTOTUNE_MERGE_PRECISION_FLOOR,
+        }),
+      );
     }
     // CLOSE-side breaker: engage closehold for any repo whose close precision dropped below the floor.
     const closeEngaged = await applyCloseAutoTune(flags, report);
     for (const action of closeEngaged) {
-      console.warn(JSON.stringify({ ev: "close_breaker_engaged", project: action.project, closePrecision: action.closePrecision, decided: action.decided, floor: AUTOTUNE_CLOSE_PRECISION_FLOOR }));
+      console.warn(
+        JSON.stringify({
+          ev: "close_breaker_engaged",
+          project: action.project,
+          closePrecision: action.closePrecision,
+          decided: action.decided,
+          floor: AUTOTUNE_CLOSE_PRECISION_FLOOR,
+        }),
+      );
     }
     // OBSERVABILITY: a single summary line of the engaged close-hold backlog so a human can see, at a glance,
     // how many (and which) repos are currently holding would-closes for review. Only emitted when ≥1 engaged.
     if (closeEngaged.length > 0) {
-      console.warn(JSON.stringify({ ev: "closehold_backlog", count: closeEngaged.length, projects: closeEngaged.map((a) => a.project) }));
+      console.warn(
+        JSON.stringify({
+          ev: "closehold_backlog",
+          count: closeEngaged.length,
+          projects: closeEngaged.map((a) => a.project),
+        }),
+      );
     }
     // Auto-clear any auto-engaged breaker (merge AND close) that has cooled down + recovered (one per repo in the report).
     for (const row of report.rows) {
       if (await maybeAutoClearHoldOnly(flags, report, row.project, nowMs)) {
-        console.log(JSON.stringify({ ev: "breaker_auto_cleared", project: row.project }));
+        console.log(
+          JSON.stringify({ ev: "breaker_auto_cleared", project: row.project }),
+        );
       }
-      if (await maybeAutoClearCloseHoldOnly(flags, report, row.project, nowMs)) {
-        console.log(JSON.stringify({ ev: "close_breaker_auto_cleared", project: row.project }));
+      if (
+        await maybeAutoClearCloseHoldOnly(flags, report, row.project, nowMs)
+      ) {
+        console.log(
+          JSON.stringify({
+            ev: "close_breaker_auto_cleared",
+            project: row.project,
+          }),
+        );
       }
     }
   } catch (error) {
-    console.warn(JSON.stringify({ ev: "breaker_tick_error", message: errorMessage(error).slice(0, 200) }));
+    console.warn(
+      JSON.stringify({
+        ev: "breaker_tick_error",
+        message: errorMessage(error).slice(0, 200),
+      }),
+    );
   }
 }

--- a/src/selfhost/discord-notify.ts
+++ b/src/selfhost/discord-notify.ts
@@ -1,0 +1,101 @@
+// Per-repo (with global fallback) Discord notifications when gittensory publishes a review (#notify). Reads
+// DISCORD_REPO_WEBHOOKS (a JSON map "owner/repo" → webhook URL) and DISCORD_WEBHOOK_URL (global fallback) from
+// the environment — self-host only, and a no-op when neither is set or in a runtime without process.env.
+// Best-effort: an absent or failing webhook never affects the review (all errors are swallowed).
+
+function readConfig(): { map: Record<string, string>; global: string | null } {
+  /* v8 ignore next */ // process is always defined in the self-host (node) runtime; the guard is for the Worker bundle
+  const env: Record<string, string | undefined> =
+    (typeof process !== "undefined" ? process.env : undefined) ?? {};
+  let map: Record<string, string> = {};
+  if (env.DISCORD_REPO_WEBHOOKS) {
+    try {
+      const parsed = JSON.parse(env.DISCORD_REPO_WEBHOOKS) as unknown;
+      if (parsed && typeof parsed === "object")
+        map = parsed as Record<string, string>;
+    } catch {
+      /* malformed map → ignore, fall back to global */
+    }
+  }
+  return { map, global: env.DISCORD_WEBHOOK_URL ?? null };
+}
+
+/** The repo's own webhook if configured, else the global webhook, else null (notifications disabled). */
+export function resolveDiscordWebhook(repoFullName: string): string | null {
+  const { map, global } = readConfig();
+  const repoUrl = map[repoFullName];
+  return typeof repoUrl === "string" && repoUrl.length > 0
+    ? repoUrl
+    : global && global.length > 0
+      ? global
+      : null;
+}
+
+// Embed accent colour by outcome — green = good, amber = caution, red = blocked/closed (matches the hosted look).
+const OUTCOME_COLORS: Record<string, number> = {
+  approve: 0x2ecc71,
+  approved: 0x2ecc71,
+  merge: 0x2ecc71,
+  merged: 0x2ecc71,
+  pass: 0x2ecc71,
+  clean: 0x2ecc71,
+  hold: 0xf1c40f,
+  warn: 0xf1c40f,
+  flagged: 0xf1c40f,
+  block: 0xe74c3c,
+  blocked: 0xe74c3c,
+  close: 0xe74c3c,
+  closed: 0xe74c3c,
+  fail: 0xe74c3c,
+};
+
+export interface DiscordReviewNotification {
+  repoFullName: string;
+  prNumber: number;
+  author: string;
+  outcome: string;
+  reason: string;
+  url: string;
+}
+
+export async function notifyDiscordReview(
+  n: DiscordReviewNotification,
+): Promise<void> {
+  const webhook = resolveDiscordWebhook(n.repoFullName);
+  if (!webhook) return;
+  const color = OUTCOME_COLORS[n.outcome.toLowerCase()] ?? 0x5865f2;
+  const body = {
+    embeds: [
+      {
+        title: `${n.repoFullName}#${n.prNumber} · ${n.outcome}`.slice(0, 256),
+        url: n.url,
+        description: n.reason.slice(0, 2048),
+        color,
+        fields: [
+          {
+            name: "Outcome",
+            value: `\`${n.outcome}\``.slice(0, 1024),
+            inline: true,
+          },
+          { name: "PR", value: `#${n.prNumber}`, inline: true },
+          {
+            name: "Submitter",
+            value: `@${n.author}`.slice(0, 1024),
+            inline: true,
+          },
+        ],
+        footer: { text: `Gittensory · ${n.repoFullName}`.slice(0, 2048) },
+      },
+    ],
+  };
+  try {
+    await fetch(webhook, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    /* best-effort: a Discord outage must never break the review */
+  }
+}

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -7,25 +7,51 @@ import {
   parseRevertedPrNumber,
   recordPrOutcome,
   recordReversalSignals,
+  resolveDispositionReason,
   runSelfTuneBreaker,
 } from "../../src/review/outcomes-wire";
 import { applyAutoTune, type GateEvalReport } from "../../src/review/auto-tune";
-import { downgradeMergeToHold, type PlannedAgentAction } from "../../src/settings/agent-actions";
+import {
+  downgradeMergeToHold,
+  type PlannedAgentAction,
+} from "../../src/settings/agent-actions";
 import { recordAuditEvent } from "../../src/db/repositories";
 import type { GitHubPullRequestPayload } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
 // ── helpers ────────────────────────────────────────────────────────────────────────────────────────────────
 
-async function reviewAuditRows(env: Env, eventType: string): Promise<Array<{ project: string; target_id: string; decision: string | null; summary: string | null }>> {
-  const res = await env.DB.prepare("SELECT project, target_id, decision, summary FROM review_audit WHERE event_type = ?")
+async function reviewAuditRows(
+  env: Env,
+  eventType: string,
+): Promise<
+  Array<{
+    project: string;
+    target_id: string;
+    decision: string | null;
+    summary: string | null;
+  }>
+> {
+  const res = await env.DB.prepare(
+    "SELECT project, target_id, decision, summary FROM review_audit WHERE event_type = ?",
+  )
     .bind(eventType)
-    .all<{ project: string; target_id: string; decision: string | null; summary: string | null }>();
+    .all<{
+      project: string;
+      target_id: string;
+      decision: string | null;
+      summary: string | null;
+    }>();
   return res.results ?? [];
 }
 
-async function auditEventRows(env: Env, eventType: string): Promise<Array<{ target_key: string | null; detail: string | null }>> {
-  const res = await env.DB.prepare("SELECT target_key, detail FROM audit_events WHERE event_type = ?")
+async function auditEventRows(
+  env: Env,
+  eventType: string,
+): Promise<Array<{ target_key: string | null; detail: string | null }>> {
+  const res = await env.DB.prepare(
+    "SELECT target_key, detail FROM audit_events WHERE event_type = ?",
+  )
     .bind(eventType)
     .all<{ target_key: string | null; detail: string | null }>();
   return res.results ?? [];
@@ -40,11 +66,25 @@ async function seedBotAction(
   outcome: "success" | "completed" | "denied" = "completed",
   mode?: "live" | "dry_run",
 ): Promise<void> {
-  await recordAuditEvent(env, { eventType: `agent.action.${actionClass}`, targetKey, outcome, metadata: mode ? { mode } : undefined });
+  await recordAuditEvent(env, {
+    eventType: `agent.action.${actionClass}`,
+    targetKey,
+    outcome,
+    metadata: mode ? { mode } : undefined,
+  });
 }
 
-function pullRequestPayload(over: Partial<GitHubPullRequestPayload> = {}): GitHubPullRequestPayload {
-  return { number: 7, title: "PR", state: "closed", head: { sha: "s7" }, labels: [], ...over };
+function pullRequestPayload(
+  over: Partial<GitHubPullRequestPayload> = {},
+): GitHubPullRequestPayload {
+  return {
+    number: 7,
+    title: "PR",
+    state: "closed",
+    head: { sha: "s7" },
+    labels: [],
+    ...over,
+  };
 }
 
 // ── 1) pr_outcome — realized ground truth (merged + closed) ───────────────────────────────────────────────────
@@ -54,36 +94,96 @@ describe("recordPrOutcome — realized merge/close ground truth", () => {
     const env = createTestEnv();
     await recordPrOutcome(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 42, merged_at: "2026-06-20T00:00:00.000Z" }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 42,
+        merged_at: "2026-06-20T00:00:00.000Z",
+      }),
       sender: { login: "owner", type: "User" },
     });
     const eval_ = await reviewAuditRows(env, "pr_outcome");
     expect(eval_).toHaveLength(1);
-    expect(eval_[0]).toMatchObject({ project: "owner/repo", target_id: "owner/repo#42", decision: "merged" });
+    expect(eval_[0]).toMatchObject({
+      project: "owner/repo",
+      target_id: "owner/repo#42",
+      decision: "merged",
+    });
     const ledger = await auditEventRows(env, "pr_outcome");
     expect(ledger).toHaveLength(1);
-    expect(ledger[0]).toMatchObject({ target_key: "owner/repo#42", detail: "merged" });
+    expect(ledger[0]).toMatchObject({
+      target_key: "owner/repo#42",
+      detail: "merged",
+    });
   });
 
   it("writes a pr_outcome=closed row when a maintainer closes a PR WITHOUT merging", async () => {
     const env = createTestEnv();
     await recordPrOutcome(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 43, merged_at: null, user: { login: "contributor", type: "User" } }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 43,
+        merged_at: null,
+        user: { login: "contributor", type: "User" },
+      }),
       sender: { login: "owner", type: "User" },
     });
-    expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({ target_id: "owner/repo#43", decision: "closed" });
-    expect((await auditEventRows(env, "pr_outcome"))[0]).toMatchObject({ detail: "closed" });
+    expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({
+      target_id: "owner/repo#43",
+      decision: "closed",
+    });
+    expect((await auditEventRows(env, "pr_outcome"))[0]).toMatchObject({
+      detail: "closed",
+    });
+  });
+
+  it("writes a pr_outcome=closed row when Gittensory (a bot) closes a PR", async () => {
+    const env = createTestEnv();
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 44,
+        merged_at: null,
+        user: { login: "contributor", type: "User" },
+      }),
+      sender: { login: "gittensory[bot]", type: "Bot" },
+    });
+    expect((await reviewAuditRows(env, "pr_outcome"))[0]).toMatchObject({
+      target_id: "owner/repo#44",
+      decision: "closed",
+    });
+    expect((await auditEventRows(env, "pr_outcome"))[0]).toMatchObject({
+      detail: "closed",
+    });
   });
 
   it("records NOTHING for an unmerged contributor PR self-close", async () => {
     const env = createTestEnv();
     await recordPrOutcome(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 43, merged_at: null, user: { login: "contributor", type: "User" } }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 43,
+        merged_at: null,
+        user: { login: "contributor", type: "User" },
+      }),
       sender: { login: "contributor", type: "User" },
     });
     expect(await reviewAuditRows(env, "pr_outcome")).toHaveLength(0);
@@ -92,8 +192,15 @@ describe("recordPrOutcome — realized merge/close ground truth", () => {
 
   it("records NOTHING for a non-closed action or a payload with no PR number", async () => {
     const env = createTestEnv();
-    await recordPrOutcome(env, "pull_request", { action: "opened", repository: { name: "repo", full_name: "owner/repo" }, pull_request: pullRequestPayload({ number: 44, state: "open" }) });
-    await recordPrOutcome(env, "pull_request", { action: "closed", repository: { name: "repo", full_name: "owner/repo" } });
+    await recordPrOutcome(env, "pull_request", {
+      action: "opened",
+      repository: { name: "repo", full_name: "owner/repo" },
+      pull_request: pullRequestPayload({ number: 44, state: "open" }),
+    });
+    await recordPrOutcome(env, "pull_request", {
+      action: "closed",
+      repository: { name: "repo", full_name: "owner/repo" },
+    });
     expect(await reviewAuditRows(env, "pr_outcome")).toHaveLength(0);
     expect(await auditEventRows(env, "pr_outcome")).toHaveLength(0);
   });
@@ -107,13 +214,20 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await seedBotAction(env, "owner/repo#7", "close"); // the bot's last action on this PR was a close
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "contributor", type: "User" }, // not the owner, not a bot → a genuine dispute
     });
     const eval_ = await reviewAuditRows(env, "reversal_reopened");
     expect(eval_).toHaveLength(1);
-    expect(eval_[0]).toMatchObject({ project: "owner/repo", target_id: "owner/repo#7" });
+    expect(eval_[0]).toMatchObject({
+      project: "owner/repo",
+      target_id: "owner/repo#7",
+    });
     expect(await auditEventRows(env, "reversal_reopened")).toHaveLength(1);
   });
 
@@ -122,7 +236,11 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await seedBotAction(env, "owner/repo#7", "approve");
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "contributor", type: "User" },
     });
@@ -135,14 +253,22 @@ describe("recordReversalSignals — reversal_reopened", () => {
     // Owner reopen — administrative re-queue, not a dispute.
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "owner", type: "User" },
     });
     // Bot reopen — not a human dispute.
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "some-bot[bot]", type: "Bot" },
     });
@@ -154,7 +280,11 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await seedBotAction(env, "owner/repo#7", "close", "success");
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "contributor", type: "User" },
     });
@@ -166,7 +296,11 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await seedBotAction(env, "owner/repo#7", "close", "completed", "dry_run");
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "contributor", type: "User" },
     });
@@ -179,26 +313,45 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await seedBotAction(env, "owner/repo#7", "close", "completed", "live");
     await recordReversalSignals(env, "pull_request", {
       action: "reopened",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
       pull_request: pullRequestPayload({ number: 7, state: "open" }),
       sender: { login: "contributor", type: "User" },
     });
     expect(await reviewAuditRows(env, "reversal_reopened")).toHaveLength(1);
   });
 
-  it("records reversal_reverted against PR #N for a merged \"Reverts #N\" PR — when #N's merge was recorded", async () => {
+  it('records reversal_reverted against PR #N for a merged "Reverts #N" PR — when #N\'s merge was recorded', async () => {
     const env = createTestEnv();
     // Corroboration: our ledger must have observed PR #50 merge first.
     await recordPrOutcome(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 50, merged_at: "2026-06-19T00:00:00.000Z" }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 50,
+        merged_at: "2026-06-19T00:00:00.000Z",
+      }),
       sender: { login: "owner", type: "User" },
     });
     await recordReversalSignals(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50\n\nThis reverts the change." }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 99,
+        merged_at: "2026-06-20T00:00:00.000Z",
+        body: "Reverts #50\n\nThis reverts the change.",
+      }),
       sender: { login: "contributor", type: "User" },
     });
     const eval_ = await reviewAuditRows(env, "reversal_reverted");
@@ -212,8 +365,16 @@ describe("recordReversalSignals — reversal_reopened", () => {
     // No pr_outcome=merged recorded for #50 → a contributor's merged \"Reverts #50\" must not forge a reversal.
     await recordReversalSignals(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50\n\nThis reverts the change." }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 99,
+        merged_at: "2026-06-20T00:00:00.000Z",
+        body: "Reverts #50\n\nThis reverts the change.",
+      }),
       sender: { login: "contributor", type: "User" },
     });
     expect(await reviewAuditRows(env, "reversal_reverted")).toHaveLength(0);
@@ -226,8 +387,16 @@ describe("recordReversalSignals — reversal_reopened", () => {
     await expect(
       recordReversalSignals(broken, "pull_request", {
         action: "closed",
-        repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-        pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "Reverts #50" }),
+        repository: {
+          name: "repo",
+          full_name: "owner/repo",
+          owner: { login: "owner" },
+        },
+        pull_request: pullRequestPayload({
+          number: 99,
+          merged_at: "2026-06-20T00:00:00.000Z",
+          body: "Reverts #50",
+        }),
         sender: { login: "contributor", type: "User" },
       }),
     ).resolves.toBeUndefined();
@@ -237,8 +406,16 @@ describe("recordReversalSignals — reversal_reopened", () => {
     const env = createTestEnv();
     await recordReversalSignals(env, "pull_request", {
       action: "closed",
-      repository: { name: "repo", full_name: "owner/repo", owner: { login: "owner" } },
-      pull_request: pullRequestPayload({ number: 99, merged_at: "2026-06-20T00:00:00.000Z", body: "A normal feature PR." }),
+      repository: {
+        name: "repo",
+        full_name: "owner/repo",
+        owner: { login: "owner" },
+      },
+      pull_request: pullRequestPayload({
+        number: 99,
+        merged_at: "2026-06-20T00:00:00.000Z",
+        body: "A normal feature PR.",
+      }),
       sender: { login: "contributor", type: "User" },
     });
     expect(await reviewAuditRows(env, "reversal_reverted")).toHaveLength(0);
@@ -257,9 +434,23 @@ describe("parseRevertedPrNumber (pure)", () => {
 // ── 3a) downgradeMergeToHold (pure) — the precision-breaker merge→hold transform ───────────────────────────────
 
 describe("downgradeMergeToHold (pure)", () => {
-  const mergeAction: PlannedAgentAction = { actionClass: "merge", requiresApproval: false, reason: "ready" };
-  const readyLabel: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "ready", label: "gittensory:ready-to-merge", labelOp: "add" };
-  const closeAction: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "bad" };
+  const mergeAction: PlannedAgentAction = {
+    actionClass: "merge",
+    requiresApproval: false,
+    reason: "ready",
+  };
+  const readyLabel: PlannedAgentAction = {
+    actionClass: "label",
+    requiresApproval: false,
+    reason: "ready",
+    label: "gittensory:ready-to-merge",
+    labelOp: "add",
+  };
+  const closeAction: PlannedAgentAction = {
+    actionClass: "close",
+    requiresApproval: false,
+    reason: "bad",
+  };
 
   it("holdOnly=false → returns the plan UNCHANGED (byte-identical common path)", () => {
     const plan = [readyLabel, mergeAction];
@@ -269,8 +460,20 @@ describe("downgradeMergeToHold (pure)", () => {
   it("holdOnly=true + a planned merge → drops the merge + ready label, adds needs-human-review", () => {
     const out = downgradeMergeToHold([readyLabel, mergeAction], true);
     expect(out.some((a) => a.actionClass === "merge")).toBe(false);
-    expect(out.some((a) => a.actionClass === "label" && a.label === "gittensory:ready-to-merge")).toBe(false);
-    expect(out.some((a) => a.actionClass === "label" && a.label === "gittensory:needs-human-review" && a.labelOp === "add")).toBe(true);
+    expect(
+      out.some(
+        (a) =>
+          a.actionClass === "label" && a.label === "gittensory:ready-to-merge",
+      ),
+    ).toBe(false);
+    expect(
+      out.some(
+        (a) =>
+          a.actionClass === "label" &&
+          a.label === "gittensory:needs-human-review" &&
+          a.labelOp === "add",
+      ),
+    ).toBe(true);
   });
 
   it("holdOnly=true but NO merge planned (e.g. a close) → no-op (returns the plan unchanged)", () => {
@@ -338,7 +541,9 @@ describe("isCloseHoldOnly + createFlagStore.isCloseHoldOnly (closehold:<scope>, 
   it("isCloseHoldOnly ignores a closehold row whose value is falsy (flagTruthy false arm)", async () => {
     const env = createTestEnv();
     // A row exists for this project but its value is '0' (not truthy) → must NOT count as engaged.
-    await env.DB.prepare("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES ('closehold:owner/repo', '0', CURRENT_TIMESTAMP)").run();
+    await env.DB.prepare(
+      "INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES ('closehold:owner/repo', '0', CURRENT_TIMESTAMP)",
+    ).run();
     expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
   });
 
@@ -348,7 +553,9 @@ describe("isCloseHoldOnly + createFlagStore.isCloseHoldOnly (closehold:<scope>, 
     env.DB.prepare = ((sql: string) => {
       // Force the system_flags scan to return an object WITHOUT a `results` array so `res.results ?? []` falls back.
       if (/SELECT key, value FROM system_flags/i.test(sql)) {
-        return { all: async () => ({}) } as unknown as ReturnType<typeof realPrepare>;
+        return { all: async () => ({}) } as unknown as ReturnType<
+          typeof realPrepare
+        >;
       }
       return realPrepare(sql);
     }) as typeof env.DB.prepare;
@@ -375,7 +582,9 @@ describe("isCloseHoldOnly + createFlagStore.isCloseHoldOnly (closehold:<scope>, 
     }) as typeof env.DB.prepare;
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("flags_read_error"));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("flags_read_error"),
+    );
     warn.mockRestore();
   });
 });
@@ -386,7 +595,21 @@ describe("applyAutoTune over the live FlagStore — engages holdonly on low merg
     const flags = createFlagStore(env);
     // 5 confirmed / 12 would-merge = ~42% precision over 12 decided → below the 85% floor with a real sample.
     const report: GateEvalReport = {
-      rows: [{ project: "owner/repo", wouldMerge: 12, mergeConfirmed: 5, mergeFalse: 7, wouldClose: 0, closeConfirmed: 0, closeFalse: 0, hold: 0, decided: 12, mergePrecision: 5 / 12, closePrecision: null }],
+      rows: [
+        {
+          project: "owner/repo",
+          wouldMerge: 12,
+          mergeConfirmed: 5,
+          mergeFalse: 7,
+          wouldClose: 0,
+          closeConfirmed: 0,
+          closeFalse: 0,
+          hold: 0,
+          decided: 12,
+          mergePrecision: 5 / 12,
+          closePrecision: null,
+        },
+      ],
       hasSignal: true,
     };
     const engaged = await applyAutoTune(flags, report);
@@ -397,11 +620,23 @@ describe("applyAutoTune over the live FlagStore — engages holdonly on low merg
 
 describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engages/clears the breaker", () => {
   // Seed a gate_decision prediction + the realized pr_outcome for one PR (the join computeGateEval folds).
-  async function seedDecisionAndOutcome(env: Env, project: string, pr: number, pred: "merge" | "close", truth: "merged" | "closed"): Promise<void> {
+  async function seedDecisionAndOutcome(
+    env: Env,
+    project: string,
+    pr: number,
+    pred: "merge" | "close",
+    truth: "merged" | "closed",
+  ): Promise<void> {
     await env.DB.prepare(
       "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?, ?, ?, 'gate_decision', ?, 'gittensory-native', ?, NULL, CURRENT_TIMESTAMP)",
     )
-      .bind(`gd:${project}#${pr}`, project, `${project}#${pr}`, pred, `sha${pr}`)
+      .bind(
+        `gd:${project}#${pr}`,
+        project,
+        `${project}#${pr}`,
+        pred,
+        `sha${pr}`,
+      )
       .run();
     await env.DB.prepare(
       "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?, ?, ?, 'pr_outcome', ?, 'gittensory-native', NULL, NULL, CURRENT_TIMESTAMP)",
@@ -413,8 +648,10 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
   it("ENGAGES the breaker when recorded outcomes show merge precision below the floor", async () => {
     const env = createTestEnv();
     // 12 would-merge predictions: 4 confirmed merged, 8 the human actually CLOSED → 33% precision over 12 decided.
-    for (let i = 0; i < 4; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
-    for (let i = 4; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "closed");
+    for (let i = 0; i < 4; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
+    for (let i = 4; i < 12; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "closed");
 
     await runSelfTuneBreaker(env);
 
@@ -424,8 +661,10 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
   it("ENGAGES the CLOSE breaker when recorded outcomes show close precision below the floor", async () => {
     const env = createTestEnv();
     // 12 would-CLOSE predictions: 4 confirmed (human closed), 8 the human actually MERGED → 33% close precision.
-    for (let i = 0; i < 4; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
-    for (let i = 4; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "merged");
+    for (let i = 0; i < 4; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+    for (let i = 4; i < 12; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "close", "merged");
 
     await runSelfTuneBreaker(env);
 
@@ -437,7 +676,8 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
   it("does NOT engage the CLOSE breaker when recorded close precision is healthy", async () => {
     const env = createTestEnv();
     // 12 would-CLOSE predictions: 12 confirmed (human closed) → 100% close precision, well above the floor.
-    for (let i = 0; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+    for (let i = 0; i < 12; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
 
     await runSelfTuneBreaker(env);
 
@@ -457,12 +697,16 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
     // Engage both breakers directly, then backdate their updated_at past the 24h cooldown.
     await flags.setFlag("holdonly:owner/repo", true);
     await flags.setFlag("closehold:owner/repo", true);
-    await env.DB.prepare("UPDATE system_flags SET updated_at = datetime('now', '-2 days') WHERE key IN ('holdonly:owner/repo', 'closehold:owner/repo')").run();
+    await env.DB.prepare(
+      "UPDATE system_flags SET updated_at = datetime('now', '-2 days') WHERE key IN ('holdonly:owner/repo', 'closehold:owner/repo')",
+    ).run();
     expect(await isHoldOnly(env, "owner/repo")).toBe(true);
     expect(await isCloseHoldOnly(env, "owner/repo")).toBe(true);
     // Seed RECOVERED outcomes for both directions: every merge prediction merged, every close prediction closed.
-    for (let i = 0; i < 12; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
-    for (let i = 12; i < 24; i += 1) await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
+    for (let i = 0; i < 12; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "merged");
+    for (let i = 12; i < 24; i += 1)
+      await seedDecisionAndOutcome(env, "owner/repo", i, "close", "closed");
 
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     await runSelfTuneBreaker(env);
@@ -492,7 +736,8 @@ describe("processJob(github-webhook) wires pr_outcome recording on a PR close", 
     const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       return new Response("not found", { status: 404 });
     });
@@ -503,9 +748,26 @@ describe("processJob(github-webhook) wires pr_outcome recording on a PR close", 
         eventName: "pull_request",
         payload: {
           action: "closed",
-          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
-          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } },
-          pull_request: { number: 5151, title: "Merged PR", state: "closed", merged_at: "2026-06-20T00:00:00.000Z", user: { login: "contributor" }, head: { sha: "abc123" }, labels: [], body: "Adds a feature." },
+          installation: {
+            id: 123,
+            account: { login: "JSONbored", id: 1, type: "User" },
+          },
+          repository: {
+            name: "gittensory",
+            full_name: "JSONbored/gittensory",
+            private: true,
+            owner: { login: "JSONbored" },
+          },
+          pull_request: {
+            number: 5151,
+            title: "Merged PR",
+            state: "closed",
+            merged_at: "2026-06-20T00:00:00.000Z",
+            user: { login: "contributor" },
+            head: { sha: "abc123" },
+            labels: [],
+            body: "Adds a feature.",
+          },
           sender: { login: "contributor", type: "User" },
         },
       });
@@ -513,6 +775,73 @@ describe("processJob(github-webhook) wires pr_outcome recording on a PR close", 
       vi.unstubAllGlobals();
     }
     const eval_ = await reviewAuditRows(env, "pr_outcome");
-    expect(eval_.some((r) => r.target_id === "JSONbored/gittensory#5151" && r.decision === "merged")).toBe(true);
+    expect(
+      eval_.some(
+        (r) =>
+          r.target_id === "JSONbored/gittensory#5151" &&
+          r.decision === "merged",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("resolveDispositionReason (enriched Discord reason)", () => {
+  it("returns the latest recorded gate verdict summary for the PR", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+    )
+      .bind(
+        "g1",
+        "owner/repo",
+        "owner/repo#7",
+        "gate_decision",
+        "close",
+        "gittensory-native",
+        "sha1",
+        "older verdict",
+        "2026-06-20T00:00:00.000Z",
+      )
+      .run();
+    await env.DB.prepare(
+      "INSERT INTO review_audit (id, project, target_id, event_type, decision, source, head_sha, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+    )
+      .bind(
+        "g2",
+        "owner/repo",
+        "owner/repo#7",
+        "gate_decision",
+        "close",
+        "gittensory-native",
+        "sha2",
+        "An AI reviewer flagged a likely blocking defect",
+        "2026-06-21T00:00:00.000Z",
+      )
+      .run();
+    expect(
+      await resolveDispositionReason(env, "owner/repo#7", "fallback"),
+    ).toBe("An AI reviewer flagged a likely blocking defect");
+  });
+  it("falls back when no gate verdict is recorded for the PR", async () => {
+    const env = createTestEnv();
+    expect(
+      await resolveDispositionReason(
+        env,
+        "owner/repo#999",
+        "Pull request merged into the base branch.",
+      ),
+    ).toBe("Pull request merged into the base branch.");
+  });
+  it("falls back when the read throws", async () => {
+    const broken = {
+      DB: {
+        prepare: () => {
+          throw new Error("db down");
+        },
+      },
+    } as unknown as Env;
+    expect(
+      await resolveDispositionReason(broken, "owner/repo#7", "fallback"),
+    ).toBe("fallback");
   });
 });

--- a/test/unit/selfhost-discord-notify.test.ts
+++ b/test/unit/selfhost-discord-notify.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  notifyDiscordReview,
+  resolveDiscordWebhook,
+} from "../../src/selfhost/discord-notify";
+
+const ORIG = {
+  repo: process.env.DISCORD_REPO_WEBHOOKS,
+  global: process.env.DISCORD_WEBHOOK_URL,
+};
+function setEnv(repo: string | undefined, global: string | undefined): void {
+  if (repo === undefined) delete process.env.DISCORD_REPO_WEBHOOKS;
+  else process.env.DISCORD_REPO_WEBHOOKS = repo;
+  if (global === undefined) delete process.env.DISCORD_WEBHOOK_URL;
+  else process.env.DISCORD_WEBHOOK_URL = global;
+}
+afterEach(() => {
+  setEnv(ORIG.repo, ORIG.global);
+  vi.unstubAllGlobals();
+});
+
+describe("resolveDiscordWebhook", () => {
+  it("returns the repo-specific webhook when configured", () => {
+    setEnv(JSON.stringify({ "o/a": "https://discord/a" }), undefined);
+    expect(resolveDiscordWebhook("o/a")).toBe("https://discord/a");
+  });
+  it("falls back to the global webhook for an unmapped repo", () => {
+    setEnv(
+      JSON.stringify({ "o/a": "https://discord/a" }),
+      "https://discord/global",
+    );
+    expect(resolveDiscordWebhook("o/b")).toBe("https://discord/global");
+  });
+  it("returns null when nothing is configured", () => {
+    setEnv(undefined, undefined);
+    expect(resolveDiscordWebhook("o/a")).toBeNull();
+  });
+  it("ignores malformed JSON and uses the global", () => {
+    setEnv("{not json", "https://discord/global");
+    expect(resolveDiscordWebhook("o/a")).toBe("https://discord/global");
+  });
+  it("ignores a non-object map value and uses the global", () => {
+    setEnv("123", "https://discord/global");
+    expect(resolveDiscordWebhook("o/a")).toBe("https://discord/global");
+  });
+});
+
+describe("notifyDiscordReview", () => {
+  it("posts a rich embed (title repo#pr·outcome, reason, Outcome/PR/Submitter fields, footer) — closed → red", async () => {
+    setEnv(
+      JSON.stringify({ "JSONbored/gittensory": "https://discord/gt" }),
+      undefined,
+    );
+    let posted: {
+      url: string;
+      body: {
+        embeds: {
+          title: string;
+          url: string;
+          description: string;
+          color: number;
+          fields: { name: string; value: string; inline: boolean }[];
+          footer: { text: string };
+        }[];
+      };
+    } | null = null;
+    vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
+      posted = { url, body: JSON.parse(init.body) };
+      return new Response(null, { status: 204 });
+    });
+    await notifyDiscordReview({
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 1171,
+      author: "jaso0n0818",
+      outcome: "closed",
+      reason: "An AI reviewer flagged a likely blocking defect",
+      url: "https://gh/JSONbored/gittensory/pull/1171",
+    });
+    const e = posted!.body.embeds[0]!;
+    expect(posted!.url).toBe("https://discord/gt");
+    expect(e.title).toBe("JSONbored/gittensory#1171 · closed");
+    expect(e.url).toBe("https://gh/JSONbored/gittensory/pull/1171");
+    expect(e.description).toBe(
+      "An AI reviewer flagged a likely blocking defect",
+    );
+    expect(e.color).toBe(0xe74c3c); // closed → red
+    expect(e.fields.map((f) => f.name)).toEqual(["Outcome", "PR", "Submitter"]);
+    expect(e.fields[0]!.value).toBe("`closed`");
+    expect(e.fields[1]!.value).toBe("#1171");
+    expect(e.fields[2]!.value).toBe("@jaso0n0818");
+    expect(e.footer.text).toBe("Gittensory · JSONbored/gittensory");
+  });
+  it("no-ops (no fetch) when no webhook is configured", async () => {
+    setEnv(undefined, undefined);
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    await notifyDiscordReview({
+      repoFullName: "o/a",
+      prNumber: 1,
+      author: "a",
+      outcome: "reviewed",
+      reason: "x",
+      url: "u",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+  it("swallows fetch errors (best-effort)", async () => {
+    setEnv(undefined, "https://discord/global");
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("network down");
+    });
+    await expect(
+      notifyDiscordReview({
+        repoFullName: "o/a",
+        prNumber: 1,
+        author: "a",
+        outcome: "hold",
+        reason: "x",
+        url: "u",
+      }),
+    ).resolves.toBeUndefined();
+  });
+  it("uses the default colour for an unknown outcome", async () => {
+    setEnv(undefined, "https://discord/global");
+    let color = -1;
+    vi.stubGlobal("fetch", async (_u: string, init: { body: string }) => {
+      color = JSON.parse(init.body).embeds[0].color;
+      return new Response(null, { status: 204 });
+    });
+    await notifyDiscordReview({
+      repoFullName: "o/a",
+      prNumber: 1,
+      author: "a",
+      outcome: "reviewed",
+      reason: "x",
+      url: "u",
+    });
+    expect(color).toBe(0x5865f2);
+  });
+});


### PR DESCRIPTION
Reconciles the Discord notify from the batch onto main. Fires on the **final PR disposition** (merged/closed) via `recordPrOutcome`, with a per-repo webhook map (`DISCORD_REPO_WEBHOOKS`) + global fallback (`DISCORD_WEBHOOK_URL`) — a no-op when neither is set. The reason is the AI's recorded gate verdict (`resolveDispositionReason`), falling back to the plain disposition. Self-host only. Part of the batch reconciliation.