### PR TITLE
fix(ci): declare the gittensory self-hosted runner label for actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# actionlint configuration. Declares the project's custom self-hosted runner labels so actionlint does not flag
+# `runs-on: [self-hosted, <label>]` as an unknown label (runner-label rule). The `gittensory` label is the
+# self-hosted runner that runs the self-host nightly maintenance workflow (.github/workflows/self-host-nightly.yml).
+self-hosted-runner:
+  labels:
+    - gittensory

--- a/.github/workflows/self-host-nightly.yml
+++ b/.github/workflows/self-host-nightly.yml
@@ -30,7 +30,12 @@ jobs:
     steps:
       - name: Self-host health
         run: |
-          curl -fsS "$SELF_HOST_URL/ready" >/dev/null && echo "✓ self-host ready" || { echo "✗ self-host not ready"; exit 1; }
+          if curl -fsS "$SELF_HOST_URL/ready" >/dev/null; then
+            echo "✓ self-host ready"
+          else
+            echo "✗ self-host not ready"
+            exit 1
+          fi
 
       - name: Refresh the RAG index (fan out over configured repos)
         run: |


### PR DESCRIPTION
## Summary

#1549 added `.github/workflows/self-host-nightly.yml` with `runs-on: [self-hosted, gittensory]`, but no `.github/actionlint.yaml` declares the custom label — so **actionlint fails the `lint` job on every PR** with `label "gittensory" is unknown [runner-label]`. This is a main-branch regression, not a per-PR issue.

- Adds `.github/actionlint.yaml` declaring `gittensory` as a known self-hosted-runner label.
- Rewrites the one `curl … && echo … || { … }` health-check line as a proper `if/then/else` to clear the SC2015 shellcheck warning actionlint surfaces, so `npm run actionlint` is green whether or not the runner has shellcheck installed.

## Validation
- `npm run actionlint` → exit 0 (was exit 1 on the runner-label)

## Safety
- CI-config only; no source/runtime change. Unblocks the `lint` job on all open PRs.