### PR TITLE
docs(selfhost): manual GitHub App setup needs Checks (read/write), not read

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -73,7 +73,7 @@ a live install. (Scripted setups can pass the token via an `x-setup-token` heade
 
 - **Webhook URL** `https://<your-host>/v1/github/webhook`, and a **webhook secret** (→ `GITHUB_WEBHOOK_SECRET`).
 - **Permissions**: Pull requests (read/write), Contents (read; read/write if you want merge), Issues
-  (read/write), Checks (read), Metadata (read). Commit statuses (read).
+  (read/write), Checks (read/write), Metadata (read). Commit statuses (read).
 - **Events**: Pull request, Pull request review, Push, Issues, Check suite, Check run, Status.
 - Generate a **private key** (→ `GITHUB_APP_PRIVATE_KEY`), and note the **App ID** (→ `GITHUB_APP_ID`) and the
   app **slug** (→ `GITHUB_APP_SLUG`). Install the app on the repos you want reviewed.


### PR DESCRIPTION
The manual GitHub App setup in `docs/self-hosting.md` listed **Checks (read)**, but the engine POSTs check-runs to publish the Gittensory Gate + Context checks (`createOrUpdateNamedCheckRun`, src/github/app.ts) — which needs **Checks: write**. With only `checks:read` the POST 403s and is swallowed as a `permission_missing` warning, so the gate check never appears and the first review fails silently. The `/setup` App-manifest flow already requests `checks:write` (`setup-wizard.ts` buildManifest, line 52) — the manual docs had drifted. One-word fix; docs-only.