### PR TITLE
fix(signals): preserve optional globstar cap semantics

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -933,8 +933,10 @@ function expandGlobstarSlash(pattern: string): string[] {
       const canKeepRootAlternatives = count * 2 <= MAX_GLOBSTAR_SLASH_ALTERNATIVES;
       for (let altIdx = count - 1; altIdx >= 0; altIdx -= 1) {
         const prefix = alternatives[altIdx]!;
-        alternatives[altIdx] = `${prefix}*/`;
-        if (canKeepRootAlternatives) alternatives.push(prefix);
+        if (canKeepRootAlternatives) {
+          alternatives[altIdx] = `${prefix}*/`;
+          alternatives.push(prefix);
+        }
       }
       idx += 3;
       continue;

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -227,7 +227,7 @@ describe("matchesManifestPath", () => {
     const start = performance.now();
     const result = matchesManifestPath("a/b/c/safe.ts", globstarRun);
     const elapsed = performance.now() - start;
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(elapsed).toBeLessThan(100);
   });
 });


### PR DESCRIPTION
### Motivation
- Fix a regression where the capped expansion for repeated `**/` patterns dropped the zero-depth (root) alternative once the alternatives count hit the cap, producing false negatives for manifest path matching and allowing path-gated checks to be skipped.

### Description
- Adjust `expandGlobstarSlash` so the rewrite to `${prefix}*/` and the push of the root `prefix` occur only when `canKeepRootAlternatives` is true, preserving the optional zero-segment branch; also update the targeted regression test in `test/unit/focus-manifest.test.ts` to assert that a bounded repeated `**/` pattern still matches a valid nested path.

### Testing
- Ran the focused unit suite: `npx vitest run test/unit/focus-manifest.test.ts` and the updated "bounds repeated **/ expansion" test passed; a local `tsc --noEmit` run reported unrelated missing `@sentry/node` types in this environment and a coverage remapping step failed due to a local `js-tokens` dependency mismatch, both of which are environmental and unrelated to the logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eefc76a78832cbc8d3e715c497e57)