### PR TITLE
fix(migrations): report all grandfathered duplicate numbers in checker summary

### DIFF
--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -76,4 +76,7 @@ for (let i = 1; i < numbers.length; i += 1) {
 
 const first = String(numbers[0]).padStart(4, "0");
 const last = String(numbers.at(-1)).padStart(4, "0");
-process.stdout.write(`check-migrations: ${files.length} migrations OK — contiguous ${first}..${last} (2 grandfathered duplicates: 0015, 0017), no new duplicates. Next free: ${nextFree()}\n`);
+const grandfatheredNumbers = [...KNOWN_DUPLICATES.keys()]
+  .sort((a, b) => a - b)
+  .map((number) => String(number).padStart(4, "0"));
+process.stdout.write(`check-migrations: ${files.length} migrations OK — contiguous ${first}..${last} (${grandfatheredNumbers.length} grandfathered duplicates: ${grandfatheredNumbers.join(", ")}), no new duplicates. Next free: ${nextFree()}\n`);

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -1,0 +1,10 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("check-migrations script", () => {
+  it("reports every grandfathered duplicate migration number in the success summary", () => {
+    const output = execFileSync(process.execPath, ["scripts/check-migrations.mjs"], { encoding: "utf8" });
+
+    expect(output).toContain("(3 grandfathered duplicates: 0015, 0017, 0074)");
+  });
+});


### PR DESCRIPTION
### Motivation
- The migration checker printed a hard-coded success message that listed only two grandfathered duplicate numbers (0015, 0017) despite `KNOWN_DUPLICATES` including 0074, producing a stale/incorrect diagnostic line in CI output.

### Description
- Update `scripts/check-migrations.mjs` to derive `grandfatheredNumbers` from `KNOWN_DUPLICATES` and print the computed count and zero-padded list in the success summary instead of a hard-coded message.
- Preserve the existing duplicate-enforcement logic so grandfathering remains an exact-filename match and no enforcement behavior changed.
- Add `test/unit/check-migrations-script.test.ts` which runs the checker and asserts the success summary contains `(3 grandfathered duplicates: 0015, 0017, 0074)`.
- Change scope is limited to `scripts/` and `test/` and does not require regenerating artifacts.

### Testing
- Ran `npm run db:migrations:check` and it exited successfully while printing the corrected summary including `0074`.
- Ran the new unit test with `npx vitest run test/unit/check-migrations-script.test.ts` and it passed.
- Ran `git diff --check` with no issues reported.
- Full `npm run test:ci` was not completed due to an unrelated `@sentry/node` type resolution error during `typecheck`, and `npm audit --audit-level=moderate` was blocked by an npm registry audit endpoint `403` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eefc7729c832c9f3cb72c456c5f2e)