### PR TITLE
fix(api): preserve closeOwnerAuthors in settings schemas and routes

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -621,6 +621,7 @@ const repositorySettingsSchema = z.object({
   aiReviewProvider: z.enum(["anthropic", "openai"]).nullable().optional(),
   aiReviewModel: z.string().trim().min(1).max(120).nullable().optional(),
   aiReviewAllAuthors: z.boolean().default(false),
+  closeOwnerAuthors: z.boolean().default(false),
   autoLabelEnabled: z.boolean().default(true),
   gittensorLabel: z.string().trim().min(1).max(50).default("gittensor"),
   blacklistLabel: z.string().trim().min(1).max(50).default("slop"),
@@ -675,6 +676,7 @@ const maintainerSettingsSchema = z
     blacklistLabel: z.string().trim().min(1).max(50),
     createMissingLabel: z.boolean(),
     includeMaintainerAuthors: z.boolean(),
+    closeOwnerAuthors: z.boolean(),
     requireLinkedIssue: z.boolean(),
     badgeEnabled: z.boolean(),
     agentPaused: z.boolean(),
@@ -713,6 +715,7 @@ const repositoryAiReviewSchema = z.object({
   provider: z.enum(["anthropic", "openai"]).nullable().optional(),
   model: z.string().trim().min(1).max(120).nullable().optional(),
   allAuthors: z.boolean().default(false),
+  closeOwnerAuthors: z.boolean().default(false),
 });
 
 const contributorIssueDraftGenerateSchema = z.object({
@@ -2250,6 +2253,7 @@ export function createApp() {
       aiReviewProvider: parsed.data.provider,
       aiReviewModel: parsed.data.model,
       aiReviewAllAuthors: parsed.data.allAuthors,
+      closeOwnerAuthors: parsed.data.closeOwnerAuthors,
     });
     // getRepositorySettings normalizes these to a concrete value or null (never undefined).
     return c.json({
@@ -3387,6 +3391,7 @@ export function createApp() {
         aiReviewProvider: parsed.data.aiReviewProvider,
         aiReviewModel: parsed.data.aiReviewModel,
         aiReviewAllAuthors: parsed.data.aiReviewAllAuthors,
+        closeOwnerAuthors: parsed.data.closeOwnerAuthors,
         autoLabelEnabled: parsed.data.autoLabelEnabled,
         gittensorLabel: parsed.data.gittensorLabel,
         blacklistLabel: parsed.data.blacklistLabel,

--- a/test/unit/routes-ai-byok.test.ts
+++ b/test/unit/routes-ai-byok.test.ts
@@ -35,17 +35,31 @@ describe("maintainer AI-review config route", () => {
     await upsertRepositorySettings(env, { repoFullName: REPO, gateCheckMode: "enabled", gittensorLabel: "custom-label", blacklistLabel: "abuse" });
     const res = await app.request(
       `/v1/repos/${REPO}/ai-review`,
+      { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "block", byok: true, provider: "anthropic", model: "claude-3-5-sonnet-latest", allAuthors: true, closeOwnerAuthors: true }) },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ aiReviewMode: "block", aiReviewByok: true, aiReviewProvider: "anthropic", aiReviewModel: "claude-3-5-sonnet-latest", aiReviewAllAuthors: true, closeOwnerAuthors: true });
+    const settings = await getRepositorySettings(env, REPO);
+    expect(settings.aiReviewMode).toBe("block");
+    expect(settings.aiReviewAllAuthors).toBe(true); // persisted + read back (DB column round-trip)
+    expect(settings.closeOwnerAuthors).toBe(true); // persisted + read back (DB column round-trip)
+    expect(settings.gateCheckMode).toBe("enabled"); // preserved
+    expect(settings.gittensorLabel).toBe("custom-label"); // preserved
+    expect(settings.blacklistLabel).toBe("abuse"); // #1425 round-trips through the DB
+  });
+
+  it("defaults closeOwnerAuthors off when the AI-review config omits it", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
+    const res = await app.request(
+      `/v1/repos/${REPO}/ai-review`,
       { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "block", byok: true, provider: "anthropic", model: "claude-3-5-sonnet-latest", allAuthors: true }) },
       env,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ aiReviewMode: "block", aiReviewByok: true, aiReviewProvider: "anthropic", aiReviewModel: "claude-3-5-sonnet-latest", aiReviewAllAuthors: true , closeOwnerAuthors: false});
-    const settings = await getRepositorySettings(env, REPO);
-    expect(settings.aiReviewMode).toBe("block");
-    expect(settings.aiReviewAllAuthors).toBe(true); // persisted + read back (DB column round-trip)
-    expect(settings.gateCheckMode).toBe("enabled"); // preserved
-    expect(settings.gittensorLabel).toBe("custom-label"); // preserved
-    expect(settings.blacklistLabel).toBe("abuse"); // #1425 round-trips through the DB
+    expect(await res.json()).toMatchObject({ closeOwnerAuthors: false });
+    expect((await getRepositorySettings(env, REPO)).closeOwnerAuthors).toBe(false);
   });
 
   it("accepts a config without provider/model (stored as null)", async () => {
@@ -61,6 +75,27 @@ describe("maintainer AI-review config route", () => {
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
     const res = await app.request(`/v1/repos/${REPO}/ai-review`, { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "loud" }) }, env);
     expect(res.status).toBe(400);
+  });
+
+  it("lets maintainer settings set closeOwnerAuthors without resetting unrelated fields", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
+    await upsertRepositorySettings(env, { repoFullName: REPO, gateCheckMode: "enabled", gittensorLabel: "custom-label" });
+    const res = await app.request(`/v1/repos/${REPO}/settings`, { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ closeOwnerAuthors: true }) }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ closeOwnerAuthors: true, gateCheckMode: "enabled", gittensorLabel: "custom-label" });
+    const settings = await getRepositorySettings(env, REPO);
+    expect(settings.closeOwnerAuthors).toBe(true);
+    expect(settings.gateCheckMode).toBe("enabled");
+  });
+
+  it("lets the internal full settings route persist closeOwnerAuthors", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
+    const res = await app.request(`/v1/internal/repos/${REPO}/settings`, { method: "POST", headers: { authorization: `Bearer ${env.INTERNAL_JOB_TOKEN}`, "content-type": "application/json" }, body: JSON.stringify({ closeOwnerAuthors: true }) }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ closeOwnerAuthors: true });
+    expect((await getRepositorySettings(env, REPO)).closeOwnerAuthors).toBe(true);
   });
 });
 


### PR DESCRIPTION
### Motivation
- A new `closeOwnerAuthors` repository setting was stored and used internally but omitted from the HTTP/Zod schemas, so API writes to maintainer, ai-review, and internal settings endpoints were stripped or reset to the DB default.

### Description
- Added `closeOwnerAuthors` to the Zod schemas: `repositorySettingsSchema`, `maintainerSettingsSchema`, and `repositoryAiReviewSchema` in `src/api/routes.ts` so requests can carry the field.
- Persisted `closeOwnerAuthors` from the AI-review route and the internal full-settings route by including `closeOwnerAuthors: parsed.data.closeOwnerAuthors` when calling `upsertRepositorySettings`.
- Added regression tests in `test/unit/routes-ai-byok.test.ts` to cover setting/persistence via the AI-review route, maintainer settings route, and internal settings route, and to assert the default when omitted.
- Regenerated the UI OpenAPI file via `npm run ui:openapi` to reflect the API surface change.

### Testing
- Ran the targeted unit suite with `npx vitest run test/unit/routes-ai-byok.test.ts --reporter verbose`, and all tests in that file passed (19/19).
- Executed `npm run ui:openapi` and `npm run ui:openapi:check`, both succeeded and wrote/validated `apps/gittensory-ui/public/openapi.json`.
- `git diff --check` passed locally.
- Known local checks that did not complete here: `npm run typecheck` failed due to a pre-existing missing `@sentry/node` types issue in `src/selfhost/sentry.ts`, and a full `npm run test:coverage` run produced a V8 coverage remapping error (`TypeError: jsTokens is not a function`) after the targeted tests ran; `npm run test:ci` is blocked by external actionlint/network environment issues and `npm audit` was blocked by a 403 from the npm audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0d2d75dc832c91d86729ce7fcb7f)