### PR TITLE
fix(selfhost): probe Qdrant /readyz for readiness

### DIFF
--- a/src/selfhost/qdrant-vectorize.ts
+++ b/src/selfhost/qdrant-vectorize.ts
@@ -48,6 +48,11 @@ function qdrantHeaders(): Record<string, string> {
   return h;
 }
 
+/** Build the unauthenticated Kubernetes-style readiness endpoint for a configured Qdrant base URL. */
+export function qdrantReadyzUrl(url: string): string {
+  return `${url.replace(/\/+$/, "")}/readyz`;
+}
+
 /**
  * Ensures the Qdrant collection exists. Safe to call on every startup — a 409 (already exists)
  * is silently ignored. Call this before createQdrantVectorize() when QDRANT_URL is set.

--- a/src/server.ts
+++ b/src/server.ts
@@ -380,7 +380,7 @@ async function main(): Promise<void> {
   let vectorizeOverride: Vectorize | undefined;
   if (process.env.QDRANT_URL) {
     const qdrantUrl = process.env.QDRANT_URL;
-    const { createQdrantVectorize, initQdrantCollection } =
+    const { createQdrantVectorize, initQdrantCollection, qdrantReadyzUrl } =
       await import("./selfhost/qdrant-vectorize");
     // Retry until Qdrant accepts the collection PUT — the container may still be booting when we start.
     await retryUntilReady("qdrant", () => initQdrantCollection(qdrantUrl));
@@ -389,7 +389,7 @@ async function main(): Promise<void> {
       name: "qdrant",
       check: () =>
         withTimeout(
-          fetch(qdrantUrl, { signal: AbortSignal.timeout(1500) })
+          fetch(qdrantReadyzUrl(qdrantUrl), { signal: AbortSignal.timeout(1500) })
             .then((r) => r.ok)
             .catch(() => false),
         ),

--- a/test/unit/selfhost-qdrant-vectorize.test.ts
+++ b/test/unit/selfhost-qdrant-vectorize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { createQdrantVectorize, initQdrantCollection } from "../../src/selfhost/qdrant-vectorize";
+import { createQdrantVectorize, initQdrantCollection, qdrantReadyzUrl } from "../../src/selfhost/qdrant-vectorize";
 import { resetMetrics, renderMetrics } from "../../src/selfhost/metrics";
 
 const BASE = "http://qdrant:6333";
@@ -8,6 +8,13 @@ const BASE = "http://qdrant:6333";
 function mockFetch(status: number, body: unknown = {}) {
   return vi.fn(async () => new Response(JSON.stringify(body), { status }));
 }
+
+describe("qdrantReadyzUrl (#1482 regression)", () => {
+  it("points readiness probes at Qdrant's unauthenticated /readyz endpoint", () => {
+    expect(qdrantReadyzUrl(BASE)).toBe(`${BASE}/readyz`);
+    expect(qdrantReadyzUrl(`${BASE}/`)).toBe(`${BASE}/readyz`);
+  });
+});
 
 describe("initQdrantCollection (#1217)", () => {
   afterEach(() => { vi.restoreAllMocks(); resetMetrics(); });


### PR DESCRIPTION
### Motivation
- The self-host `/ready` probe queried the raw `QDRANT_URL` without the configured `QDRANT_API_KEY` and without using Qdrant's documented unauthenticated `/readyz` endpoint, causing healthy API-key-protected Qdrant deployments to make the instance report `503`.
- Readiness should avoid re-probing the authenticated root and instead use the unauthenticated readiness endpoint (or authenticate) so load balancers don't evict otherwise healthy instances.

### Description
- Added `qdrantReadyzUrl(url: string)` in `src/selfhost/qdrant-vectorize.ts` to normalize a configured Qdrant base URL and produce the unauthenticated `/readyz` URL. 
- Updated the self-host readiness probe in `src/server.ts` to call `qdrantReadyzUrl(qdrantUrl)` instead of fetching the raw base URL, while leaving authenticated collection initialization via `initQdrantCollection()` unchanged. 
- Added a regression unit test in `test/unit/selfhost-qdrant-vectorize.test.ts` to assert `/readyz` is chosen for both plain and trailing-slash base URLs.

### Testing
- Ran the Qdrant unit suite with `npx vitest run test/unit/selfhost-qdrant-vectorize.test.ts`, and the tests passed successfully. 
- Ran `npm run typecheck`, which failed in this environment due to missing `@sentry/node` type declarations unrelated to the change. 
- Attempted coverage with `npx vitest run --coverage test/unit/selfhost-qdrant-vectorize.test.ts`, which exercised tests but coverage remapping failed here with `TypeError: jsTokens is not a function` (environmental tooling issue). 
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate`, both of which failed in this environment due to external tool/registry issues (`actionlint`/runner-label DNS fallback and npm audit 403) and not because of the PR logic or behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f0f16a640832caca0d4507316d147)