### PR TITLE
fix(review): honor all-authors AI preflight

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3469,8 +3469,23 @@ export async function shouldStartAiReviewForAdvisory(
     skipAiReview?: boolean | undefined;
   },
 ): Promise<boolean> {
-  const packAllowsAnyAuthorBlockingReview = args.settings.gatePack === "oss-anti-slop" && args.settings.aiReviewMode === "block";
-  if (args.skipAiReview || args.settings.aiReviewMode === "off" || (!args.confirmedContributor && !packAllowsAnyAuthorBlockingReview) || !args.advisory.headSha || !isEnabled(env.AI_SUMMARIES_ENABLED) || !isEnabled(env.AI_PUBLIC_COMMENTS_ENABLED) || !env.AI) return false;
+  const packAllowsAnyAuthorBlockingReview =
+    args.settings.gatePack === "oss-anti-slop" &&
+    args.settings.aiReviewMode === "block";
+  const reviewableAuthor =
+    args.confirmedContributor ||
+    packAllowsAnyAuthorBlockingReview ||
+    args.settings.aiReviewAllAuthors;
+  if (
+    args.skipAiReview ||
+    args.settings.aiReviewMode === "off" ||
+    !reviewableAuthor ||
+    !args.advisory.headSha ||
+    !isEnabled(env.AI_SUMMARIES_ENABLED) ||
+    !isEnabled(env.AI_PUBLIC_COMMENTS_ENABLED) ||
+    !env.AI
+  )
+    return false;
   return !(isReputationEnabled(env) && isConvergenceRepoAllowed(env, args.repoFullName) && (await shouldSkipAiForReputation(env, { project: args.repoFullName, submitter: args.author })));
 }
 

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -76,6 +76,13 @@ describe("shouldStartAiReviewForAdvisory", () => {
     await expect(shouldStartAiReviewForAdvisory(enabledEnv(), { ...base, skipAiReview: true })).resolves.toBe(false);
     await expect(shouldStartAiReviewForAdvisory(enabledEnv(), { ...base, settings: { aiReviewMode: "off" } as RepositorySettings })).resolves.toBe(false);
     await expect(shouldStartAiReviewForAdvisory(enabledEnv(), { ...base, confirmedContributor: false })).resolves.toBe(false);
+    await expect(
+      shouldStartAiReviewForAdvisory(enabledEnv(), {
+        ...base,
+        settings: { aiReviewMode: "advisory", gatePack: "gittensor", aiReviewAllAuthors: true } as RepositorySettings,
+        confirmedContributor: false,
+      }),
+    ).resolves.toBe(true);
     await expect(shouldStartAiReviewForAdvisory(enabledEnv(), { ...base, settings: { aiReviewMode: "block", gatePack: "oss-anti-slop" } as RepositorySettings, confirmedContributor: false })).resolves.toBe(true);
     const noSha = advisory();
     delete (noSha as Partial<Advisory>).headSha;


### PR DESCRIPTION
### Motivation
- A recent refactor introduced a preflight helper that accidentally omitted the `aiReviewAllAuthors` path when deciding whether to start an AI review, which let non-confirmed authors bypass a repo-configured all-authors AI review.
- The intent is to ensure the preflight gate and the actual `runAiReviewForAdvisory` entry conditions match so configured per-repo opt-ins are honored.

### Description
- Updated `shouldStartAiReviewForAdvisory` in `src/queue/processors.ts` to compute `reviewableAuthor` as `args.confirmedContributor || packAllowsAnyAuthorBlockingReview || args.settings.aiReviewAllAuthors` and use that in the eligibility `if` guard.
- Reformatted the guard for readability and preserved the existing reputation/RAG skip logic at the end of the function.
- Added a regression unit test in `test/unit/ai-review-advisory.test.ts` that asserts a non-confirmed contributor triggers the preflight when `aiReviewAllAuthors` is enabled.

### Testing
- Ran the focused unit suite with `npx vitest run test/unit/ai-review-advisory.test.ts`, which passed (22 tests passed).
- Verified `git diff --check` produced no issues locally. 
- Attempted the full local gate with `npm run test:ci`, but the run was blocked by `actionlint` setup issues in this environment and its WASM fallback not recognizing the custom self-host runner label. 
- Attempted `npm run typecheck` and `npm audit --audit-level=moderate`, both of which were impeded by local dependency/network conditions (`@sentry/node` types missing and npm audit endpoint 403 respectively).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2467a34c832cb06cfa7282c15b08)