### PR TITLE
fix(review): demote AI review nits into the collapsible Nits section, not the headline

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -122,11 +122,27 @@ export function panelRowsToSignalRows(rows: PublicPrPanelSignalRow[]): UnifiedSi
   });
 }
 
-/** Build the single AI reviewer note from gittensory's AI output: the composed advisory write-up becomes
- *  the assessment; a consensus defect (recovered from the advisory findings) becomes a blocker; the gate's
- *  non-blocking warnings become nits. Returns `[]` when there is nothing reviewer-side to surface (no AI
- *  notes, no consensus defect) so the renderer hides the reviewer chip. The gate `decision` (passed
- *  separately) stays authoritative over `recommendation` — this is advisory framing only. */
+/** Split the composed AI advisory notes (#focused-reviews) into the prominent body (the assessment prose + any
+ *  `**Blockers**` section — real problems stay headline) and the trailing `**Nits (N)**` bullet lines, so the renderer
+ *  can DEMOTE nits into the collapsible Nits section instead of the headline assessment (nits are never blockers).
+ *  When there is no Nits section the whole blob is the body and `nits` is empty (byte-identical to before). */
+export function splitAiReviewNits(notes: string): { main: string; nits: string[] } {
+  const marker = notes.indexOf("**Nits (");
+  if (marker === -1) return { main: notes.trim(), nits: [] };
+  const nits = notes
+    .slice(marker)
+    .split("\n")
+    .slice(1) // drop the "**Nits (N)**" header line itself
+    .map((line) => line.replace(/^\s*[-*]\s*/, "").trim())
+    .filter(Boolean);
+  return { main: notes.slice(0, marker).trim(), nits };
+}
+
+/** Build the single AI reviewer note from gittensory's AI output: the composed advisory write-up (minus its nits)
+ *  becomes the assessment; a consensus defect (recovered from the advisory findings) becomes a blocker; the AI's own
+ *  nits AND the gate's non-blocking warnings become the collapsible nits. Returns `[]` when there is nothing
+ *  reviewer-side to surface (no AI notes, no consensus defect) so the renderer hides the reviewer chip. The gate
+ *  `decision` (passed separately) stays authoritative over `recommendation` — this is advisory framing only. */
 export function buildDualReviewNotes(args: {
   aiReview?: { notes: string } | undefined;
   consensusDefect?: { title: string; detail: string } | undefined;
@@ -141,7 +157,9 @@ export function buildDualReviewNotes(args: {
   verdict: Verdict;
   reviewerModel?: string;
 }): DualReviewNote[] {
-  const assessment = args.aiReview?.notes?.trim() ?? "";
+  const { main: assessment, nits: aiNitLines } = splitAiReviewNits(
+    args.aiReview?.notes?.trim() ?? "",
+  );
   const consensusBlocker = args.consensusDefect ? [`${args.consensusDefect.title}${args.consensusDefect.detail ? `: ${args.consensusDefect.detail}` : ""}`.trim()] : [];
   // FIX D1: fold the gate's own hard blockers into the reviewer blockers (so a non-AI gate failure populates
   // "Why this is blocked"). Exclude `ai_consensus_defect` (already surfaced via consensusDefect → appears once)
@@ -157,11 +175,18 @@ export function buildDualReviewNotes(args: {
   // raw warning findings). Scrub each with the private-term boundary and DROP any that still leaks. See
   // PRIVATE_FORBIDDEN_TERMS above. (The consensus-defect blocker is already public-safe via toPublicSafe; the
   // gate blockers above go through the SAME scrub as Nits.)
-  const nits = (args.warnings ?? [])
+  const gateNits = (args.warnings ?? [])
     .map((warning) => `${warning.title}${warning.action ? ` — ${warning.action}` : ""}`.trim())
     .filter(Boolean)
     .map((line) => publicSafeNit(line))
     .filter((line): line is string => line !== null);
+  // The AI review's own nits (#focused-reviews) are non-blocking — fold them into the SAME collapsible Nits section as
+  // the gate warnings, ahead of them, rather than leaving them in the prominent assessment blob. Already public-safe
+  // via composeAdvisoryNotes → toPublicSafe; re-scrubbed here for defense-in-depth, consistent with the gate nits.
+  const aiNits = aiNitLines
+    .map((line) => publicSafeNit(line))
+    .filter((line): line is string => line !== null);
+  const nits = [...aiNits, ...gateNits];
   if (!assessment && blockers.length === 0 && nits.length === 0) return [];
   const notes: ReviewNotes = {
     assessment,

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -8,6 +8,7 @@ import {
   isUnifiedReviewCommentEnabled,
   panelRowsToSignalRows,
   PR_PANEL_COMMENT_MARKER,
+  splitAiReviewNits,
   verdictToRecommendation,
 } from "../../src/review/unified-comment-bridge";
 import { PR_PANEL_COMMENT_MARKER as MARKER_FROM_COMMENTS } from "../../src/github/comments";
@@ -118,6 +119,41 @@ describe("buildDualReviewNotes", () => {
     });
     expect(reviews[0]?.notes?.blockers).toEqual(["Null deref"]); // title only, no trailing ": "
     expect(reviews[0]?.notes?.nits).toEqual(["No test"]); // title only, no trailing " — "
+  });
+
+  it("demotes the AI review's **Nits (N)** out of the assessment into the collapsible nits, ahead of gate warnings", () => {
+    const reviews = buildDualReviewNotes({
+      aiReview: {
+        notes:
+          "Solid change.\n\n**Blockers**\n- none\n\n**Nits (2)**\n- Rename `x` to `count`.\n- Add a doc comment.",
+      },
+      warnings: [{ code: "w1", severity: "warning", title: "Missing test", detail: "...", action: "Add a test." }],
+      recommendation: "merge",
+      verdict: "comment",
+    });
+    // assessment keeps the prose + real Blockers; the nits are gone from the headline
+    expect(reviews[0]?.notes?.assessment).toBe("Solid change.\n\n**Blockers**\n- none");
+    // AI nits lead, gate warnings follow — all in the collapsible nits section
+    expect(reviews[0]?.notes?.nits).toEqual([
+      "Rename `x` to `count`.",
+      "Add a doc comment.",
+      "Missing test — Add a test.",
+    ]);
+  });
+});
+
+describe("splitAiReviewNits", () => {
+  it("splits trailing **Nits (N)** bullets from the body, leaving the assessment + blockers in the body", () => {
+    expect(splitAiReviewNits("Assessment.\n\n**Blockers**\n- bug\n\n**Nits (2)**\n- a\n- b")).toEqual({
+      main: "Assessment.\n\n**Blockers**\n- bug",
+      nits: ["a", "b"],
+    });
+  });
+  it("returns the whole blob as main with no nits when there is no Nits section (byte-identical to before)", () => {
+    expect(splitAiReviewNits("Just an assessment.")).toEqual({ main: "Just an assessment.", nits: [] });
+  });
+  it("handles an empty blob", () => {
+    expect(splitAiReviewNits("")).toEqual({ main: "", nits: [] });
   });
 });
 


### PR DESCRIPTION
The composed advisory notes baked the AI's `**Nits (N)**` bullets into the prominent assessment blob, so non-blocking nits rendered like top-line findings. `splitAiReviewNits` now peels the trailing nits off the notes — the assessment keeps the prose + any `**Blockers**` (real problems stay headline), and the AI nits fold into the same collapsible Nits section as the gate warnings. Nits are never blockers.