### PR TITLE
fix(review): fail closed on incoherent AI verdicts

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -42,6 +42,9 @@ export const RELIABLE_FALLBACK_MODELS: readonly [string, string] = [
   "@cf/mistralai/mistral-small-3.1-24b-instruct",
 ];
 
+export const INCOHERENT_DIFF_ASSESSMENT =
+  "Cannot review — the diff appears out of sync with the PR head.";
+
 const REVIEW_SYSTEM_PROMPT = [
   "You are a senior open-source maintainer giving a FOCUSED, high-signal code review of a single pull request diff.",
   "Read each meaningful hunk and review like a careful human; judge ONLY the diff and the context provided.",
@@ -56,7 +59,7 @@ const REVIEW_SYSTEM_PROMPT = [
   "SEVERITY DISCIPLINE — defensive or speculative hardening ('should handle X', 'consider validating', 'add error handling') is a NIT, not a blocker, UNLESS a real input WILL actually trigger the failure. CI or check status itself (failing, pending, unverified) is NOT a code defect — never list it (the gate evaluates CI separately).",
   "DIFF SCOPE — the diff shows only CHANGED lines, NOT whole files. A function, variable, import, type, or symbol you do not SEE may already be defined or imported elsewhere in the same file/module. NEVER report a 'missing import', 'undefined/not-imported symbol', or 'X is not defined -> ReferenceError' as a blocker unless the diff ITSELF removes the definition or introduces the symbol without defining it anywhere shown. When you cannot confirm a symbol is missing from the visible diff, it is NOT a blocker — at most a nit ('verify X is imported/defined').",
   "TRACE BEFORE ASSERTING ABSENCE — this rule extends to ANY 'X is missing' blocker (a missing schema/annotation/field, a missing null/array/type guard, a missing await/error-handler, an unregistered route/tool/handler): a backfill loop, a default, an early guard, or a registration ELSEWHERE may already supply it. Before calling absence a blocker, find the line in the visible context that WOULD break and reference it; if you cannot SEE the breaking code, downgrade to a nit phrased as a verification ('confirm X is registered/guarded'), never a blocker.",
-  "FAIL CLOSED ON AN INCOHERENT DIFF — if the diff does not cohere with the PR title/description (it appears to describe a DIFFERENT change, the changed-file set looks stale or wrong, or you cannot map it to one coherent change), DO NOT emit a confident assessment or approval: set assessment to exactly 'Cannot review — the diff appears out of sync with the PR head.' and return empty blockers, nits, and suggestions. Never rubber-stamp a change you cannot actually see.",
+  `FAIL CLOSED ON AN INCOHERENT DIFF — if the diff does not cohere with the PR title/description (it appears to describe a DIFFERENT change, the changed-file set looks stale or wrong, or you cannot map it to one coherent change), DO NOT emit a confident assessment or approval: set assessment to exactly '${INCOHERENT_DIFF_ASSESSMENT}' and return empty blockers, nits, and suggestions. Never rubber-stamp a change you cannot actually see.`,
   "Do NOT rubber-stamp: if the diff is genuinely clean, the assessment states specifically why and blockers is [].",
   "Never mention rewards, rankings, payouts, wallets, hotkeys, coldkeys, trust scores, scoreability, reviewability, or farming.",
 ].join(" ");
@@ -384,6 +387,7 @@ export function parseModelReview(text: string): ModelReview | null {
     const nits = toList(obj.nits);
     const suggestions = toList(obj.suggestions);
     const inlineFindings = toInlineFindings(obj.inlineFindings);
+    if (assessment === INCOHERENT_DIFF_ASSESSMENT) return null;
     if (
       !assessment &&
       blockers.length === 0 &&

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -824,6 +824,29 @@ describe("pure helpers", () => {
     expect(parsed?.blockers).toContain("Null deref in src/a.ts");
   });
 
+  it("parseModelReview treats the incoherent-diff sentinel as unparseable so block mode holds fail-closed", () => {
+    const sentinel =
+      "Cannot review — the diff appears out of sync with the PR head.";
+
+    const parsed = parseModelReview(
+      JSON.stringify({
+        assessment: sentinel,
+        blockers: [],
+        nits: [],
+        suggestions: [],
+      }),
+    );
+
+    expect(parsed).toBeNull();
+    expect(combineReviews([parsed, parsed], { strategy: "consensus" })).toEqual(
+      {
+        defect: null,
+        split: false,
+        inconclusive: true,
+      },
+    );
+  });
+
   it("parseModelReview coerces non-string/non-array fields to safe defaults", () => {
     const parsed = parseModelReview(
       '{"assessment":"ok","suggestions":"not-an-array","blockers":7,"nits":null}',


### PR DESCRIPTION
### Motivation
- The AI prompt instructs the model to emit a sentinel assessment when the diff is incoherent, but downstream parsing/combining treated that sentinel as a valid (clean) review, causing intended fail-closed behavior to fail open. This creates a risk that a malicious PR author could craft title/body to bypass AI block-mode reviews and reach auto-merge.

### Description
- Introduce a single reusable sentinel `INCOHERENT_DIFF_ASSESSMENT` and reference it in the system prompt via the existing prompt assembly (`src/services/ai-review.ts`).
- Update `parseModelReview` to treat the sentinel assessment as unparseable (return `null`), so downstream combining logic will treat the reviewer slot as missing and produce `inconclusive` (hold) per existing fail-closed rules.
- Add a regression unit test that asserts a model response containing only the sentinel parses to `null` and that `combineReviews(..., { strategy: "consensus" })` yields `inconclusive: true`.

### Testing
- Ran the unit suite for the AI review helpers: `npx vitest run test/unit/ai-review.test.ts`, and the tests passed (including the new sentinel regression test).
- Ran the focused test `npx vitest run test/unit/ai-review.test.ts -t incoherent`, and it passed (the sentinel path is exercised).
- Attempted coverage run `npm run test:coverage -- test/unit/ai-review.test.ts`; the tests passed but local coverage remapping failed with `TypeError: jsTokens is not a function` in the coverage remapper (local toolchain issue, not related to the logic change).
- `npm run typecheck` surfaced pre-existing unrelated TypeScript errors in `src/selfhost/sentry.ts` (missing `@sentry/node` types), and `npm run test:ci` encountered environment/tooling failures (offline `actionlint` setup and label check) and did not fully complete; these are unrelated to the fix itself but block a full CI run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f50170d8c832c87bedad29f19eb66)