### PR TITLE
fix(review): scope private review context by owner

### DIFF
--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -84,15 +84,16 @@ export function makeLocalManifestReader(dir: string | undefined): RepoFocusManif
   };
 }
 
-/** Per-repo review-context candidate FOLDERS (relative to GITTENSORY_REPO_CONFIG_DIR): `{owner}__{repo}/review` then
- *  `{repo}/review`. Same owner/repo validation as localConfigCandidates; an invalid full name yields none. (#review-skills) */
+/** Per-repo review-context candidate FOLDERS (relative to GITTENSORY_REPO_CONFIG_DIR): only
+ *  `{owner}__{repo}/review`. Review prompt material is private and must stay owner-scoped; an invalid full name
+ *  yields none. (#review-skills) */
 function reviewContextFolders(repoFullName: string): string[] {
   const slash = repoFullName.indexOf("/");
   if (slash <= 0 || slash === repoFullName.length - 1 || slash !== repoFullName.lastIndexOf("/")) return [];
   const owner = repoFullName.slice(0, slash).toLowerCase();
   const repo = repoFullName.slice(slash + 1).toLowerCase();
   if (!GITHUB_OWNER_SEGMENT.test(owner) || !isSafeRepoSegment(repo)) return [];
-  return [join(`${owner}__${repo}`, "review"), join(repo, "review")];
+  return [join(`${owner}__${repo}`, "review")];
 }
 
 /** Parse a skill markdown file into {name, when, body}. YAML frontmatter (`---\nname:\nwhen:\n---`) is optional; name
@@ -108,7 +109,7 @@ export function parseReviewSkill(filename: string, text: string): RepoReviewSkil
 }
 
 /** Build the container-local review-context reader over GITTENSORY_REPO_CONFIG_DIR, or null when the dir is unset. Per
- *  repo (first existing folder wins) reads `review/CLAUDE.md` (the guide) + every `review/skills/*.md` (rubric modules,
+ *  repo reads owner-qualified `review/CLAUDE.md` (the guide) + every `review/skills/*.md` (rubric modules,
  *  sorted). Missing files/dir degrade to nulls/empty; a per-file read error skips that file. (#review-skills) */
 export function makeLocalReviewContextReader(dir: string | undefined): RepoReviewContextReader | null {
   const trimmed = (dir ?? "").trim();

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -138,12 +138,17 @@ describe("makeLocalReviewContextReader (#review-skills)", () => {
     expect(ctx.skills.map((s) => s.name)).toEqual(["a-first", "second"]); // sorted by filename; .txt ignored
   });
 
-  it("falls back to the bare repo-name folder; returns empty for a missing or invalid repo", async () => {
+  it("ignores bare repo-name review folders to keep private prompt material owner-scoped", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gt-review-"));
     mkdirSync(join(dir, "metagraphed", "review"), { recursive: true });
     writeFileSync(join(dir, "metagraphed", "review", "CLAUDE.md"), "Bare-folder guide.\n");
     const reader = makeLocalReviewContextReader(dir)!;
-    expect((await reader("JSONbored/metagraphed")).guide).toContain("Bare-folder guide.");
+    expect(await reader("JSONbored/metagraphed")).toEqual({ guide: null, skills: [] });
+  });
+
+  it("returns empty for a missing or invalid repo", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-review-"));
+    const reader = makeLocalReviewContextReader(dir)!;
     expect(await reader("JSONbored/unknown-repo")).toEqual({ guide: null, skills: [] }); // no folder
     expect(await reader("owner/..")).toEqual({ guide: null, skills: [] }); // invalid repo segment → no candidates
     expect(await reader("noslash")).toEqual({ guide: null, skills: [] }); // invalid full name (no slash)


### PR DESCRIPTION
### Motivation
- The previous per-repo review-context resolver fell back to bare `{repo}/review` folders, allowing cross-owner collisions and leakage of private review prompt material to other repos.
- Review guide and skill text is sensitive operator-provided material and must be bound to the repository owner to prevent cross-tenant disclosure.

### Description
- Removed the bare repo-name fallback so `reviewContextFolders` only returns owner-qualified `
  {owner}__{repo}/review` candidates, ensuring review prompts are owner-scoped.
- Clarified the `makeLocalReviewContextReader` documentation to state that review prompt material is owner-qualified only.
- Added a regression unit test in `test/unit/private-config.test.ts` that verifies bare repo-name `review` folders are ignored for a different owner and that missing/invalid repos degrade to an empty review context.

### Testing
- Ran unit tests with `npm test -- --run test/unit/private-config.test.ts`, which passed (20 tests).
- Ran static type checking with `npm run typecheck`, which passed.
- Attempted coverage with `npm run test:coverage -- --run test/unit/private-config.test.ts`, where tests passed but coverage generation failed with `TypeError: jsTokens is not a function` from the local coverage provider.
- Attempted `npm audit --audit-level=moderate`, which was blocked by the registry audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f785ce774832cb7368045d48353a6)