### PR TITLE
fix(api): preserve owner-close ai-review setting

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -715,7 +715,7 @@ const repositoryAiReviewSchema = z.object({
   provider: z.enum(["anthropic", "openai"]).nullable().optional(),
   model: z.string().trim().min(1).max(120).nullable().optional(),
   allAuthors: z.boolean().default(false),
-  closeOwnerAuthors: z.boolean().default(false),
+  closeOwnerAuthors: z.boolean().optional(),
 });
 
 const contributorIssueDraftGenerateSchema = z.object({
@@ -2253,7 +2253,7 @@ export function createApp() {
       aiReviewProvider: parsed.data.provider,
       aiReviewModel: parsed.data.model,
       aiReviewAllAuthors: parsed.data.allAuthors,
-      closeOwnerAuthors: parsed.data.closeOwnerAuthors,
+      closeOwnerAuthors: parsed.data.closeOwnerAuthors ?? current.closeOwnerAuthors,
     });
     // getRepositorySettings normalizes these to a concrete value or null (never undefined).
     return c.json({

--- a/test/unit/routes-ai-byok.test.ts
+++ b/test/unit/routes-ai-byok.test.ts
@@ -62,6 +62,22 @@ describe("maintainer AI-review config route", () => {
     expect((await getRepositorySettings(env, REPO)).closeOwnerAuthors).toBe(false);
   });
 
+  it("preserves closeOwnerAuthors when an AI-review update omits it", async () => {
+    const app = createApp();
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
+    await upsertRepositorySettings(env, { repoFullName: REPO, closeOwnerAuthors: true });
+
+    const res = await app.request(
+      `/v1/repos/${REPO}/ai-review`,
+      { method: "PUT", headers: apiHeaders(env), body: JSON.stringify({ mode: "advisory", byok: false }) },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ aiReviewMode: "advisory", closeOwnerAuthors: true });
+    expect((await getRepositorySettings(env, REPO)).closeOwnerAuthors).toBe(true);
+  });
+
   it("accepts a config without provider/model (stored as null)", async () => {
     const app = createApp();
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });


### PR DESCRIPTION
### Motivation
- The AI-review update route accidentally reset the per-repo `closeOwnerAuthors` flag to `false` when callers omitted the new field because the Zod schema defaulted it to `false` and the handler unconditionally persisted that value.

### Description
- Make the AI-review payload accept `closeOwnerAuthors` as optional instead of defaulting to `false` by changing the schema to `closeOwnerAuthors: z.boolean().optional()` in `src/api/routes.ts`.
- Preserve an existing `closeOwnerAuthors` value when the maintainer AI-review update omits the field by persisting `parsed.data.closeOwnerAuthors ?? current.closeOwnerAuthors` in `src/api/routes.ts`.
- Add a regression unit test `preserves closeOwnerAuthors when an AI-review update omits it` to `test/unit/routes-ai-byok.test.ts` that seeds `closeOwnerAuthors: true`, issues an AI-review `PUT` without the field, and verifies the value remains `true`.

### Testing
- Ran `git diff --check` and `npm run typecheck`, both succeeded locally with no new type errors.
- Ran the modified unit test file with `npx vitest run test/unit/routes-ai-byok.test.ts` and all tests in that file passed (20/20).
- Ran `npm run ui:openapi` which regenerated `apps/gittensory-ui/public/openapi.json` successfully.
- Attempted `npm run test:coverage` but coverage remapping failed after tests passed due to an upstream dependency mismatch (`js-tokens@4.0.0` vs `ast-v8-to-istanbul` needing `js-tokens@^10.0.0`) producing `TypeError: jsTokens is not a function`, and `npm audit --audit-level=moderate` could not complete due to a registry 403; the functional unit tests and typecheck are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7e53e1fc832cb3879327b9463d48)