### PR TITLE
fix(selfhost): preflight comma-listed AI CLIs

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -394,6 +394,20 @@ export function resolveProviderNames(env: Record<string, string | undefined>): s
   return buildProviders(env).map((p) => p.name);
 }
 
+/** CLI-subscription providers need their binary present on PATH; keep boot preflight parsing identical to AI_PROVIDER. */
+export function resolveRequiredCliProviders(env: Record<string, string | undefined>): Array<{ provider: string; cli: string }> {
+  const seen = new Set<string>();
+  return resolveProviderNames(env)
+    .map((provider) =>
+      provider === "claude-code" ? { provider, cli: "claude" } : provider === "codex" ? { provider, cli: "codex" } : undefined,
+    )
+    .filter((required): required is { provider: string; cli: string } => {
+      if (!required || seen.has(required.provider)) return false;
+      seen.add(required.provider);
+      return true;
+    });
+}
+
 /** Select the self-host AI provider(s) from AI_PROVIDER. A comma-separated list of TWO+ providers is addressable
  *  by name for dual review (see `routeProviders`) and otherwise falls back through them in order; a single
  *  provider is used directly. Returns undefined when unconfigured or no provider has its credential. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
   createOpenAiCompatibleAi,
   createSelfHostAi,
   resolveAiReviewerPlan,
+  resolveRequiredCliProviders,
 } from "./selfhost/ai";
 import {
   cookieValue,
@@ -328,27 +329,19 @@ async function main(): Promise<void> {
   // Fail-LOUD preflight (#1566): a CLI-subscription provider (claude-code/codex) reviews by spawning the CLI as a
   // subprocess; if the binary is absent (image built without INSTALL_AI_CLIS=true) the spawn ENOENTs and EVERY AI
   // review silently degrades to "no usable output". Shout at boot so the misconfig is obvious, never invisible.
-  const requiredCli =
-    process.env.AI_PROVIDER === "claude-code"
-      ? "claude"
-      : process.env.AI_PROVIDER === "codex"
-        ? "codex"
-        : null;
-  if (
-    requiredCli &&
-    !(process.env.PATH ?? "")
-      .split(delimiter)
-      .some((d) => d && existsSync(join(d, requiredCli)))
-  )
+  const pathDirs = (process.env.PATH ?? "").split(delimiter);
+  for (const { provider, cli } of resolveRequiredCliProviders(process.env)) {
+    if (pathDirs.some((d) => d && existsSync(join(d, cli)))) continue;
     console.error(
       JSON.stringify({
         level: "error",
         event: "selfhost_ai_cli_missing",
-        provider: process.env.AI_PROVIDER,
-        cli: requiredCli,
-        message: `AI_PROVIDER=${process.env.AI_PROVIDER} but '${requiredCli}' is not on PATH — every AI review will produce NO output. Rebuild the image with --build-arg INSTALL_AI_CLIS=true (or use the published image) and authenticate the CLI.`,
+        provider,
+        cli,
+        message: `AI_PROVIDER=${process.env.AI_PROVIDER} includes ${provider} but '${cli}' is not on PATH — every ${provider} AI review will produce NO output. Rebuild the image with --build-arg INSTALL_AI_CLIS=true (or use the published image) and authenticate the CLI.`,
       }),
     );
+  }
   // Dedicated RAG embed provider (keeps the review chain frontier-only): when AI_EMBED_BASE_URL is set, embeddings
   // route to a SEPARATE openai-compatible endpoint (e.g. ollama at http://ollama:11434/v1, model bge-m3) instead of
   // the review chain — so a Claude/Codex outage never falls reviews back to a weak local model. Unset ⇒ absent ⇒

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveAiReviewerPlan, resolveCliTimeoutMs, resolveEffort, resolveModel, resolveProviderNames, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
+import { buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, resolveAiReviewerPlan, resolveCliTimeoutMs, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
 
 describe("resolveModel (#979 — never leak the Workers-AI default to a self-host backend)", () => {
   const WORKERS_DEFAULT = "@cf/meta/llama-3.1-8b-instruct-fp8-fast";
@@ -214,6 +214,19 @@ describe("resolveProviderNames + resolveAiReviewerPlan (#dual-ai-combiner)", () 
     expect(resolveProviderNames({ AI_PROVIDER: "  Claude-Code , CODEX " })).toEqual(["claude-code", "codex"]); // CLI providers always credentialed
     expect(resolveProviderNames({ AI_PROVIDER: "anthropic,ollama" })).toEqual(["ollama"]); // anthropic dropped (no key); ollama needs none
     expect(resolveProviderNames({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant" })).toEqual(["anthropic", "ollama"]);
+  });
+
+  it("resolveRequiredCliProviders mirrors comma-list AI_PROVIDER parsing for boot preflight", () => {
+    expect(resolveRequiredCliProviders({})).toEqual([]);
+    expect(resolveRequiredCliProviders({ AI_PROVIDER: "ollama,anthropic" })).toEqual([]);
+    expect(resolveRequiredCliProviders({ AI_PROVIDER: "  Claude-Code , CODEX , ollama " })).toEqual([
+      { provider: "claude-code", cli: "claude" },
+      { provider: "codex", cli: "codex" },
+    ]);
+    expect(resolveRequiredCliProviders({ AI_PROVIDER: "claude-code,codex,claude-code" })).toEqual([
+      { provider: "claude-code", cli: "claude" },
+      { provider: "codex", cli: "codex" },
+    ]);
   });
 
   it("resolveAiReviewerPlan: undefined with no provider; single ⇒ single; two ⇒ default synthesis", () => {


### PR DESCRIPTION
### Motivation
- The boot-time CLI preflight only checked `process.env.AI_PROVIDER` for exact matches and therefore skipped comma-separated provider lists, which let missing CLI binaries go unnoticed for multi-provider self-host configs.

### Description
- Add `resolveRequiredCliProviders` in `src/selfhost/ai.ts` to reuse the same comma-separated, credentialed `AI_PROVIDER` parsing and map CLI-backed providers to their required binaries while deduplicating entries.
- Replace the single-value preflight in `src/server.ts` with an iteration over `resolveRequiredCliProviders(...)` so every configured CLI-backed provider (e.g. `claude-code`, `codex`) is checked and missing binaries are logged at boot.
- Add regression coverage in `test/unit/selfhost-ai.test.ts` for unset, non-CLI, mixed-case/trimmed comma-lists, and duplicate CLI-provider lists to exercise the new parsing and deduplication behavior.

### Testing
- Ran typecheck with `npm run typecheck -- --pretty false`, which completed successfully.
- Ran the unit file with `npx vitest run test/unit/selfhost-ai.test.ts` and the test file passed (`55 tests` passed in the file run).
- Built the self-host bundle with `node scripts/build-selfhost.mjs`, which produced `dist/server.mjs` successfully.
- Full `npm run test:ci` could not complete in this environment because `actionlint` setup failed due to external DNS/network issues and the WASM fallback flagged a custom runner label in `.github/workflows/self-host-nightly.yml` (CI step blocked, not a code regression).
- Coverage reporting (`npx vitest run --coverage ...`) ran tests but coverage remapping failed here with `TypeError: jsTokens is not a function` from `ast-v8-to-istanbul`; this is an environment/local tooling issue not caused by the change.
- `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7e52a1a4832cb3204b2e5d190ce5)