### PR TITLE
fix(review): preserve cached review instructions

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -796,6 +796,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
   if (review.note !== null) out.note = review.note;
   if (review.profile !== null) out.profile = review.profile;
   if (review.inlineComments !== null) out.inline_comments = review.inlineComments;
+  if (review.instructions !== null) out.instructions = review.instructions;
   if (review.pathInstructions.length > 0) out.path_instructions = review.pathInstructions.map((entry) => ({ path: entry.path, instructions: entry.instructions }));
   if (review.excludePaths.length > 0) out.exclude_paths = [...review.excludePaths];
   if (review.preMergeChecks.length > 0) {

--- a/test/unit/focus-manifest-loader.test.ts
+++ b/test/unit/focus-manifest-loader.test.ts
@@ -36,6 +36,22 @@ describe("focus-manifest loader", () => {
     expect(fetched).toEqual(["owner/repo"]);
   });
 
+  it("preserves review.instructions across the repo-file cache round trip", async () => {
+    const env = createTestEnv();
+    let fetches = 0;
+    const fetcher = async () => {
+      fetches += 1;
+      return JSON.stringify({ review: { instructions: "Follow our async-error conventions." } });
+    };
+
+    const first = await loadRepoFocusManifest(env, "owner/review-instructions", { fetcher });
+    expect(first.review.instructions).toBe("Follow our async-error conventions.");
+
+    const second = await loadRepoFocusManifest(env, "owner/review-instructions", { fetcher });
+    expect(fetches).toBe(1);
+    expect(second.review.instructions).toBe("Follow our async-error conventions.");
+  });
+
   it("falls back to an empty manifest when no repo file is published and never throws", async () => {
     const env = createTestEnv();
     const manifest = await loadRepoFocusManifest(env, "owner/missing", { fetcher: async () => null });


### PR DESCRIPTION
### Motivation
- The repo-level `review.instructions` field was parsed into the in-memory focus manifest but not emitted when the manifest was serialized for cache persistence, causing maintainer instructions to be lost after a cache round-trip and making per-repo reviewer guidance unreliable.

### Description
- Emit `review.instructions` from `reviewConfigToJson` so `manifestToJson` persists it, and add a regression unit test in `test/unit/focus-manifest-loader.test.ts` that verifies a repo-file manifest with `review.instructions` survives the repo-file cache round trip.

### Testing
- Ran targeted unit tests with `npm test -- --run test/unit/focus-manifest.test.ts test/unit/focus-manifest-loader.test.ts` and all tests passed (158 tests); ran typecheck with `npm run typecheck` (`tsc --noEmit`) which passed; `npm run test:coverage` ran the tests but coverage remapping failed with `TypeError: jsTokens is not a function`; `npm audit --audit-level=moderate` could not complete due to a registry 403, so the full CI gate was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7e52c05c832c83e0fd820f28a220)