### PR TITLE
fix(gate): reconcile dry-run display verdicts for green-CI AI refutation

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -80,6 +80,9 @@ export type GateCheckEvaluation = {
   /** Dry-run only (#gate-dryrun): the would-be conclusion (advisory sub-gates promoted to block) used to render the
    *  merge/close/manual verdict. Absent ⇒ the renderer falls back to `conclusion`. Never affects what is posted. */
   displayConclusion?: GateCheckConclusion | undefined;
+  /** Dry-run only (#gate-dryrun): blockers from the would-be evaluation, kept so green-CI AI refutation can reconcile
+   *  the rendered verdict with the same safety rule as the posted gate. Not rendered directly. */
+  displayBlockers?: AdvisoryFinding[] | undefined;
   title: string;
   summary: string;
   blockers: AdvisoryFinding[];
@@ -98,6 +101,11 @@ export function isAiJudgmentOnlyFailure(evaluation: GateCheckEvaluation): boolea
   return evaluation.conclusion === "failure" && evaluation.blockers.length > 0 && evaluation.blockers.every((blocker) => AI_JUDGMENT_BLOCKER_CODES.has(blocker.code));
 }
 
+function isAiJudgmentOnlyDisplayFailure(evaluation: GateCheckEvaluation): boolean {
+  const blockers = evaluation.displayBlockers ?? [];
+  return evaluation.displayConclusion === "failure" && blockers.length > 0 && blockers.every((blocker) => AI_JUDGMENT_BLOCKER_CODES.has(blocker.code));
+}
+
 /**
  * Reconcile a gate evaluation with the deterministic CI for the PUBLIC review comment (#ai-ci-refutation).
  * When the gate FAILED solely on an AI-judgment blocker (ai_consensus_defect / ai_review_split) but the real CI
@@ -110,13 +118,15 @@ export function isAiJudgmentOnlyFailure(evaluation: GateCheckEvaluation): boolea
  * non-AI-only failure ⇒ the evaluation is returned UNCHANGED.
  */
 export function reconcileGateEvaluationForGreenCi(evaluation: GateCheckEvaluation, ciState: "passed" | "failed" | "unverified", enabled: boolean): GateCheckEvaluation {
-  if (!enabled || ciState !== "passed" || !isAiJudgmentOnlyFailure(evaluation)) return evaluation;
+  if (!enabled || ciState !== "passed" || (!isAiJudgmentOnlyFailure(evaluation) && !isAiJudgmentOnlyDisplayFailure(evaluation))) return evaluation;
   return {
     ...evaluation,
     conclusion: "success",
+    displayConclusion: "success",
     title: "Gittensory Gate passed",
     summary: "The AI review raised a concern, but the deterministic checks (CI) are green — the concern is advisory, not blocking.",
     blockers: [],
+    displayBlockers: [],
   };
 }
 
@@ -458,7 +468,7 @@ export function evaluateGateCheck(advisoryResult: Advisory, policy: GateCheckPol
   const result = evaluateGateCheckCore(advisoryResult, policy);
   if (!policy.dryRun) return result;
   const wouldBe = evaluateGateCheckCore(advisoryResult, promoteAdvisoryToBlock(policy));
-  return { ...result, displayConclusion: wouldBe.conclusion };
+  return { ...result, displayConclusion: wouldBe.conclusion, displayBlockers: wouldBe.blockers };
 }
 
 function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy = {}): GateCheckEvaluation {

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -609,10 +609,13 @@ describe("dry-run disposition (#gate-dryrun): would-be verdict without enforcing
     const out = evaluateGateCheck(missingIssueAdvisory(), { dryRun: true, linkedIssueGateMode: "advisory" });
     expect(out.conclusion).toBe("success"); // POSTED — non-blocking pass
     expect(out.displayConclusion).toBe("failure"); // would-be — drives the "close" verdict in the comment
+    expect(out.displayBlockers?.map((finding) => finding.code)).toEqual(["missing_linked_issue"]);
   });
   it("a clean PR in dry-run shows a would-be PASS (displayConclusion = success)", () => {
     const clean = { ...missingIssueAdvisory(), findings: [] };
-    expect(evaluateGateCheck(clean, { dryRun: true, linkedIssueGateMode: "advisory" }).displayConclusion).toBe("success");
+    const out = evaluateGateCheck(clean, { dryRun: true, linkedIssueGateMode: "advisory" });
+    expect(out.displayConclusion).toBe("success");
+    expect(out.displayBlockers).toEqual([]);
   });
   it("outside dry-run, displayConclusion is absent (the verdict falls back to the posted conclusion)", () => {
     const out = evaluateGateCheck(missingIssueAdvisory(), { linkedIssueGateMode: "advisory" });

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -1103,11 +1103,40 @@ describe("CI-refutation of the public comment gate (#ai-ci-refutation)", () => {
   });
 
   it("enabled + green CI + AI-judgment-only failure → SUCCESS with cleared blockers (matches the merge disposition)", () => {
-    const out = reconcileGateEvaluationForGreenCi(failure(["ai_consensus_defect"]), "passed", true);
+    const out = reconcileGateEvaluationForGreenCi(
+      { ...failure(["ai_consensus_defect"]), displayConclusion: "failure", displayBlockers: [finding("ai_consensus_defect")] },
+      "passed",
+      true,
+    );
     expect(out.conclusion).toBe("success");
+    expect(out.displayConclusion).toBe("success");
     expect(out.blockers).toEqual([]);
+    expect(out.displayBlockers).toEqual([]);
     expect(out.title).toBe("Gittensory Gate passed");
     expect(out.summary).toContain("advisory, not blocking");
+  });
+
+  it("reconciles a dry-run AI-only display failure even when the posted gate already passed", () => {
+    const out = reconcileGateEvaluationForGreenCi(
+      { ...failure([]), conclusion: "success", blockers: [], displayConclusion: "failure", displayBlockers: [finding("ai_consensus_defect")] },
+      "passed",
+      true,
+    );
+    expect(out.conclusion).toBe("success");
+    expect(out.displayConclusion).toBe("success");
+    expect(out.blockers).toEqual([]);
+    expect(out.displayBlockers).toEqual([]);
+  });
+
+  it("keeps a dry-run deterministic display failure visible on green CI", () => {
+    const fail = {
+      ...failure([]),
+      conclusion: "success" as const,
+      blockers: [],
+      displayConclusion: "failure" as const,
+      displayBlockers: [finding("duplicate_open_pr")],
+    };
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true)).toBe(fail);
   });
 
   it("enabled + green CI + split-only failure → SUCCESS too", () => {


### PR DESCRIPTION
### Motivation
- The dry-run feature exposed a shadow `displayConclusion` (would-be verdict) that could remain `failure` even when the posted `conclusion` was `success`, causing the public unified comment to show a closed/blocked headline for a PR that is actually mergeable under green CI. 
- The existing CI-refutation path (`reconcileGateEvaluationForGreenCi`) only cleared `conclusion` and `blockers`, so a stale `displayConclusion` (and its shadow blockers) could drive a contradictory public comment. 

### Description
- Add `displayBlockers?: AdvisoryFinding[]` to `GateCheckEvaluation` and populate it from the dry-run shadow evaluation in `evaluateGateCheck` so the shadow blockers travel with `displayConclusion`. 
- Add `isAiJudgmentOnlyDisplayFailure` helper and update `reconcileGateEvaluationForGreenCi` to consider and reconcile AI-only dry-run display failures by clearing both `displayConclusion` and `displayBlockers` (setting them to success/empty) when CI is green and the refutation gate is enabled. 
- Keep deterministic dry-run display failures visible by only reconciling AI-judgment-only display failures and preserving deterministic blockers. 
- Add regression and invariant tests that assert dry-run shadow blockers are captured and that green-CI reconciliation clears AI-only display failures while leaving deterministic display failures intact. 

### Testing
- Ran `tsc --noEmit` and the TypeScript typecheck which passed. 
- Ran the affected unit suites with `npx vitest run test/unit/rules.test.ts test/unit/gate-check-policy.test.ts` and all tests passed. 
- Attempted coverage (`npm run test:coverage`) and the unit tests executed and passed, but local coverage report generation failed due to a runtime coverage-provider error (`TypeError: jsTokens is not a function`) unrelated to the logic change. 
- Full `npm run test:ci` / audit could not be completed in the local environment due to external network/tooling fallbacks (actionlint runner label validation and npm audit endpoint), so those end-to-end CI steps remain unrun locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8ee47dc8832cadc35d1b5e563cb2)