### PR TITLE
feat(selfhost): forward structured error logs to Sentry (central instrumentation)

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -86,6 +86,38 @@ export function captureReviewFailure(
   });
 }
 
+/** Forward a structured `console.log` line to Sentry when it is an ERROR-level log. The engine logs operational
+ *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as `console.log(JSON.stringify({ level:
+ *  "error", event, … }))` — so wrapping console.log with this surfaces EVERY such error as a Sentry issue with NO
+ *  per-site wiring. No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal —
+ *  routine logs (audit/info/no-level: job_complete, regate_sweep_throttled, …) are intentionally skipped. */
+export function forwardStructuredLogToSentry(line: unknown): void {
+  if (!active || !Sentry) return;
+  if (typeof line !== "string" || line.charCodeAt(0) !== 123 /* "{" */) return;
+  let obj: Record<string, unknown>;
+  try {
+    // A "{"-prefixed string that parses is always an object (else JSON.parse throws → caught below).
+    obj = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return; // not JSON — an ordinary log line
+  }
+  const level = obj.level;
+  if (level !== "error" && level !== "fatal") return;
+  const severity = level === "fatal" ? "fatal" : "error";
+  const title =
+    typeof obj.event === "string"
+      ? obj.event
+      : typeof obj.message === "string"
+        ? obj.message
+        : "error";
+  Sentry.withScope((scope) => {
+    scope.setLevel(severity);
+    scope.setContext("log", obj);
+    if (typeof obj.event === "string") scope.setTag("event", obj.event);
+    Sentry!.captureMessage(title, severity);
+  });
+}
+
 /** Flush buffered events before exit. No-op when off. */
 export async function flushSentry(timeoutMs = 2000): Promise<void> {
   if (!active || !Sentry) return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,12 @@ import {
   makeLocalManifestReader,
   makeLocalReviewContextReader,
 } from "./selfhost/private-config";
-import { captureError, flushSentry, initSentry } from "./selfhost/sentry";
+import {
+  captureError,
+  flushSentry,
+  forwardStructuredLogToSentry,
+  initSentry,
+} from "./selfhost/sentry";
 import {
   setLocalManifestReader,
   setLocalReviewContextReader,
@@ -256,6 +261,22 @@ async function main(): Promise<void> {
       captureError(reason, { kind: "unhandledRejection" });
       console.error(reason);
     });
+    // Central error forwarding (#1468): the engine logs operational failures (orb_broker_unavailable, gate-check
+    // errors, relay drops, …) as structured `console.log` lines with level:"error". Wrap console.log so every such
+    // line surfaces as a Sentry issue WITHOUT per-site wiring; routine logs are skipped inside the forwarder. The
+    // re-entrancy guard prevents a loop if the Sentry path itself ever logs.
+    const baseConsoleLog = console.log.bind(console);
+    let forwardingToSentry = false;
+    console.log = (...args: unknown[]): void => {
+      baseConsoleLog(...args);
+      if (forwardingToSentry) return;
+      forwardingToSentry = true;
+      try {
+        forwardStructuredLogToSentry(args[0]);
+      } finally {
+        forwardingToSentry = false;
+      }
+    };
   }
   const startedAt = Date.now();
 

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     init: vi.fn(),
     withScope: vi.fn((cb: (s: typeof scope) => void) => cb(scope)),
     captureException: vi.fn(),
+    captureMessage: vi.fn(),
     flush: vi.fn().mockResolvedValue(true),
   };
 });
@@ -15,6 +16,7 @@ vi.mock("@sentry/node", () => ({
   init: mocks.init,
   withScope: mocks.withScope,
   captureException: mocks.captureException,
+  captureMessage: mocks.captureMessage,
   flush: mocks.flush,
 }));
 
@@ -23,6 +25,7 @@ import {
   captureError,
   captureReviewFailure,
   flushSentry,
+  forwardStructuredLogToSentry,
   scrubEvent,
   resetSentryForTest,
 } from "../../src/selfhost/sentry";
@@ -151,5 +154,76 @@ describe("enabled when SENTRY_DSN is set", () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     mocks.flush.mockRejectedValueOnce(new Error("network"));
     await expect(flushSentry()).resolves.toBeUndefined();
+  });
+});
+
+describe("forwardStructuredLogToSentry — central console.log → Sentry error forwarding (#1468)", () => {
+  it("is a no-op when Sentry is off", () => {
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "x" }),
+    );
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-strings, non-JSON-object strings, and unparseable JSON when enabled", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(42); // not a string
+    forwardStructuredLogToSentry({ level: "error" }); // not a string
+    forwardStructuredLogToSentry("plain log line"); // doesn't start with "{"
+    forwardStructuredLogToSentry(""); // empty string (charCodeAt(0) is NaN)
+    forwardStructuredLogToSentry("{not valid json"); // throws → caught
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("skips routine (non-error) structured logs", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "audit", event: "job_complete" }),
+    );
+    forwardStructuredLogToSentry(
+      JSON.stringify({ event: "regate_sweep_throttled" }),
+    ); // no level
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("forwards a level:error log titled by event, with context + an event tag", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "orb_broker_unavailable",
+        installationId: 1,
+      }),
+    );
+    expect(mocks.scope.setLevel).toHaveBeenCalledWith("error");
+    expect(mocks.scope.setContext).toHaveBeenCalledWith("log", {
+      level: "error",
+      event: "orb_broker_unavailable",
+      installationId: 1,
+    });
+    expect(mocks.scope.setTag).toHaveBeenCalledWith(
+      "event",
+      "orb_broker_unavailable",
+    );
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      "orb_broker_unavailable",
+      "error",
+    );
+  });
+
+  it("forwards a level:fatal log titled by message (no event ⇒ no tag)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "fatal", message: "boom" }),
+    );
+    expect(mocks.scope.setLevel).toHaveBeenCalledWith("fatal");
+    expect(mocks.scope.setTag).not.toHaveBeenCalled();
+    expect(mocks.captureMessage).toHaveBeenCalledWith("boom", "fatal");
+  });
+
+  it("falls back to a generic title when neither event nor message is present", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(JSON.stringify({ level: "error", code: 500 }));
+    expect(mocks.captureMessage).toHaveBeenCalledWith("error", "error");
   });
 });


### PR DESCRIPTION
The engine logs operational failures (`orb_broker_unavailable`, gate-check errors, relay drops, queue/review degradations) as structured `console.log` lines with `level:"error"`, but only a few sites called `captureError` — so those never reached Sentry (empty Issues feed despite the engine struggling). This adds `forwardStructuredLogToSentry()` + wraps `console.log` in `server.ts` (only when Sentry is active, re-entrancy-guarded) so **every** `level:error/fatal` structured log becomes a Sentry issue (tagged by event, full object as context) with zero per-site wiring. Routine logs are skipped. Self-host only; no-op when `SENTRY_DSN` unset. Helper fully covered.