### PR TITLE
fix(review): preserve manual holds in surface lane

### DIFF
--- a/src/review/content-lane-wire.ts
+++ b/src/review/content-lane-wire.ts
@@ -72,7 +72,14 @@ export function applySurfaceGate(
   surface: GateCheckEvaluation | null,
 ): GateCheckEvaluation | undefined {
   if (surface === null) return generic;
-  if (!generic || generic.blockers.length === 0) return surface; // gate off, or generic was clean → surface stands
+  if (!generic) return surface; // gate off → surface stands
+  // A generic manual-review HOLD is encoded as a non-success conclusion with warning(s), not as a hard blocker.
+  // Preserve it over a surface-lane merge so size/guardrail holds cannot be erased by the content lane (#gate-size).
+  if (generic.blockers.length === 0 && generic.conclusion === "success") return surface; // generic was clean → surface stands
+  if (generic.blockers.length === 0) {
+    if (surface.conclusion === "success") return generic;
+    return surface;
+  }
   return {
     enabled: true,
     conclusion: "failure",

--- a/test/unit/content-lane-wire.test.ts
+++ b/test/unit/content-lane-wire.test.ts
@@ -70,6 +70,33 @@ describe("applySurfaceGate", () => {
   it("a clean generic gate (no blockers) lets the surface verdict stand", () => {
     expect(applySurfaceGate(gate({ conclusion: "success", blockers: [] }), surfaceClose)).toBe(surfaceClose);
   });
+  it("preserves a generic manual-review hold over a surface merge", () => {
+    const oversized: AdvisoryFinding = {
+      code: "oversized_pr",
+      title: "Large change — held for manual review",
+      severity: "warning",
+      detail: "This PR is large.",
+    };
+    const genericHold = gate({
+      conclusion: "neutral",
+      title: "Gittensory Gate — held for manual review",
+      summary: "Large change — held for manual review",
+      blockers: [],
+      warnings: [oversized],
+    });
+    const surfaceMerge = gate({ conclusion: "success", title: "Surface", summary: "valid entry" });
+
+    expect(applySurfaceGate(genericHold, surfaceMerge)).toBe(genericHold);
+  });
+  it("lets a surface hard failure override a generic warning-only hold", () => {
+    const genericHold = gate({
+      conclusion: "neutral",
+      blockers: [],
+      warnings: [{ code: "oversized_pr", title: "Large change", severity: "warning", detail: "large" }],
+    });
+
+    expect(applySurfaceGate(genericHold, surfaceClose)).toBe(surfaceClose);
+  });
   it("PRESERVES a generic hard blocker over a surface merge (a committed secret can never merge)", () => {
     const secret: AdvisoryFinding = { code: "secret_leak", title: "Secret", severity: "critical", detail: "leaked key" };
     const generic = gate({ conclusion: "failure", blockers: [secret], warnings: [] });


### PR DESCRIPTION
### Motivation
- Prevent the deterministic content/registry surface-lane from erasing repo-configured manual-review holds (e.g. oversized-PR or guardrail holds) by treating neutral/warning-only holds as actionable protections that must survive a surface `success` override.
- Restore the intended behavior where an oversized or guardrail-hit PR is held for maintainer review (never auto-merged) while preserving existing semantics that a surface hard failure still wins.

### Description
- Change `applySurfaceGate` in `src/review/content-lane-wire.ts` to preserve generic neutral/manual holds (warning-only findings) when the surface lane returns `success`, while still allowing genuine generic blockers to keep a `failure` conclusion.
- Add unit tests in `test/unit/content-lane-wire.test.ts` that assert a generic manual-review hold survives a surface `merge`, that a surface hard `failure` can override a generic warning-only hold, and that generic hard blockers are preserved over surface merges.
- No schema, API, or generated artifacts were changed; this is a focused logic + test update to the review/gate merging behavior.

### Testing
- Ran the targeted unit suite with `npx vitest run test/unit/content-lane-wire.test.ts` and the file passed (all tests green).
- Ran the combined unit run `npm test -- --run test/unit/gate-check-policy.test.ts test/unit/content-lane-wire.test.ts` and observed all tests in those files pass (94 tests passed).
- Ran `npm run typecheck` which completed cleanly with no TypeScript errors.
- Attempted `npm run test:coverage` (full local coverage) but it did not complete within the local session; the targeted unit runs above exercise the changed behavior and are included as regression coverage for this fix.
- `npm audit --audit-level=moderate` could not be completed in this environment due to the registry returning `403 Forbidden` (network audit endpoint), so that check is noted but not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f914facb4832cadb71539e4aaaa35)