### PR TITLE
fix(selfhost): continue drifted migration statements

### DIFF
--- a/src/selfhost/migrate.ts
+++ b/src/selfhost/migrate.ts
@@ -14,15 +14,16 @@ export async function runSelfHostMigrations(db: D1Database, dir: string): Promis
   let count = 0;
   for (const file of files) {
     if (applied.has(file)) continue;
-    try {
-      await db.exec(readFileSync(join(dir, file), "utf8"));
-    } catch (error) {
-      // Idempotency (#migrate-drift): a renumbered/duplicated migration whose schema change is ALREADY present (e.g. a
-      // column added under an earlier filename by a prior deploy, then renumbered before merge) must not crash-loop the
-      // boot. "duplicate column" / "already exists" means the target schema is satisfied — record the file applied and
-      // continue. Any OTHER error is a real failure and still aborts the boot.
-      if (!/duplicate column|already exists/i.test(errorMessage(error)))
-        throw error;
+    const sql = readFileSync(join(dir, file), "utf8").replace(/--.*$/gm, "");
+    for (const statement of sql.split(";").map((part) => part.trim()).filter(Boolean)) {
+      try {
+        await db.exec(`${statement};`);
+      } catch (error) {
+        // Idempotency (#migrate-drift): tolerate duplicate DDL per statement so a drifted multi-step migration
+        // still executes the remaining schema changes before the file is recorded as applied.
+        if (!/duplicate column|already exists/i.test(errorMessage(error)))
+          throw error;
+      }
     }
     await db.prepare("INSERT INTO _selfhost_migrations (name, applied_at) VALUES (?, ?)").bind(file, new Date().toISOString()).run();
     count += 1;

--- a/test/unit/selfhost-migrate.test.ts
+++ b/test/unit/selfhost-migrate.test.ts
@@ -36,4 +36,16 @@ describe("runSelfHostMigrations (#980)", () => {
     const db2 = createD1Adapter(nodeSqliteDriver(new DatabaseSync(":memory:") as never));
     await expect(runSelfHostMigrations(db2, dir2)).rejects.toThrow();
   });
+
+  it("continues later statements before recording a drifted migration as applied", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gtmig-"));
+    writeFileSync(join(dir, "0001_base.sql"), "CREATE TABLE t (id INTEGER, x INTEGER);");
+    writeFileSync(join(dir, "0002_drifted.sql"), "ALTER TABLE t ADD COLUMN x INTEGER; ALTER TABLE t ADD COLUMN y INTEGER;");
+    const db = createD1Adapter(nodeSqliteDriver(new DatabaseSync(":memory:") as never));
+
+    expect(await runSelfHostMigrations(db, dir)).toBe(2);
+    expect(await db.prepare("SELECT y FROM t").all()).toMatchObject({ success: true });
+    expect(await runSelfHostMigrations(db, dir)).toBe(0);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- The migration runner previously executed each SQL file as a whole and treated a file-level "duplicate column"/"already exists" error as safe to ignore, which could record a migration as applied even if later statements in the file were skipped.
- That behavior can leave partially-drifted self-host databases missing later DDL (e.g. second columns in multi-statement ALTERs), causing runtime crashes when code expects those columns.
- The change aims to make idempotency tolerant at the statement level so later statements still run before the file is recorded applied.

### Description
- Replace single-call `db.exec(readFileSync(...))` with a statement-by-statement loop that strips SQL comments and splits on `;`, running each non-empty statement via `db.exec` individually in `src/selfhost/migrate.ts`.
- Keep the existing idempotency logic but apply it per-statement: only swallow errors matching `/duplicate column|already exists/i` for the failing statement and rethrow any other errors.
- Record the migration in `_selfhost_migrations` only after all statements for the file have been attempted.
- Add a regression test `continues later statements before recording a drifted migration as applied` in `test/unit/selfhost-migrate.test.ts` that reproduces the partially-drifted multi-statement case.

### Testing
- Ran `npx vitest run test/unit/selfhost-migrate.test.ts` and all unit tests in that file passed (3 tests) successfully.
- Ran `npm run typecheck` and TypeScript typecheck completed successfully with no errors.
- `git diff --check` ran cleanly with no whitespace/conflict marker errors.
- `npm run test:coverage` / coverage remapping failed locally with `TypeError: jsTokens is not a function`, preventing a full coverage confirmation locally, and `npm audit --audit-level=moderate` failed due to a registry `403` during the audit step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f918e9e38832cbe21273a773d8416)