### PR TITLE
fix(selfhost): keep reviews on the live PR head + surface review failures as Sentry errors

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2159,6 +2159,16 @@ export async function fetchLivePullRequestHeadSha(env: Env, repoFullName: string
   return result?.data.head?.sha ?? undefined;
 }
 
+/** The PR's FULL live payload via REST `GET /pulls/{n}`, ready to feed `upsertPullRequestFromGitHub`. The scheduled
+ *  re-gate sweep uses this to RESYNC a stored PR to its live head when a `synchronize` webhook was lost (e.g. the
+ *  self-host relay was down), so the re-review runs on the current head + fresh files instead of a stale cached diff
+ *  the AI fail-closes as INCOHERENT_DIFF (#sweep-resync). Best-effort: returns undefined on any error so the caller
+ *  fails open to the stored PR (the sweep must never stall on a hiccup). */
+export async function fetchLivePullRequest(env: Env, repoFullName: string, prNumber: number, token: string | undefined): Promise<GitHubPullRequestPayload | undefined> {
+  const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, token).catch(() => undefined);
+  return result?.data ?? undefined;
+}
+
 /** Resolve the OPEN PRs associated with a commit SHA via the REST `GET /repos/{owner}/{repo}/commits/{sha}/pulls`
  *  endpoint. This is the only PR↔commit resolution that works for FORK (cross-repo) PRs, whose CI-completion
  *  webhooks (`check_suite`/`check_run`) carry an EMPTY `pull_requests[]`. Returns the de-duplicated open PR numbers.

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -74,6 +74,7 @@ import {
   fetchAndStorePullRequestFilesForReview,
   fetchLinkedIssueFacts,
   fetchLiveCiAggregate,
+  fetchLivePullRequest,
   fetchLivePullRequestHeadSha,
   fetchLivePullRequestMergeState,
   fetchLivePullRequestReviewDecision,
@@ -1480,8 +1481,33 @@ async function reReviewStoredPullRequest(
     getRepository(env, repoFullName),
     resolveRepositorySettings(env, repoFullName),
   ]);
-  const pr = await getPullRequest(env, repoFullName, prNumber);
+  let pr = await getPullRequest(env, repoFullName, prNumber);
   if (!pr || pr.state !== "open") return;
+  // #sweep-resync: RESYNC the stored PR to its LIVE head before reviewing. The self-host relay can drop the
+  // `synchronize` webhook (relay down), so a push/rebase never refreshes the stored head SHA + cached files; the
+  // sweep would then review a STALE diff and the AI fail-closes it as INCOHERENT_DIFF, stranding the PR in "held".
+  // Fetch the live PR, and if its head drifted, upsert it + refresh the files so the review runs on the current
+  // head. FAIL OPEN: any token/fetch/undefined-head hiccup proceeds with the stored `pr` (never stall the sweep).
+  const resyncToken =
+    (await createInstallationToken(env, installationId).catch(
+      () => undefined,
+    )) ?? env.GITHUB_PUBLIC_TOKEN;
+  const live = await fetchLivePullRequest(
+    env,
+    repoFullName,
+    prNumber,
+    resyncToken,
+  );
+  if (live?.head?.sha && live.head.sha !== pr.headSha) {
+    await upsertPullRequestFromGitHub(env, repoFullName, live).catch(
+      () => undefined,
+    );
+    await refreshPullRequestDetails(env, repoFullName, prNumber).catch(
+      () => undefined,
+    );
+    /* v8 ignore next -- the row was just upserted above, so the re-read always returns it; `?? pr` is belt-and-suspenders fail-open. */
+    pr = (await getPullRequest(env, repoFullName, prNumber)) ?? pr;
+  }
   // Operator review flow: rebase-if-behind → wait for ALL CI to finish → only THEN review. Defers (returns) when
   // a rebase fired a synchronize, or CI is still running — the synchronize / CI-completion webhook re-triggers
   // once the head is current and CI has settled (the sweep backstops a missed event).
@@ -3751,6 +3777,16 @@ export async function runAiReviewForAdvisory(
           "The dual-model AI review did not return a usable verdict for this change.",
         action:
           "The gate is held for a human reviewer rather than passed automatically; it re-evaluates on the next update.",
+      });
+      // A review that could not be produced is a real failure the maintainer must SEE — surface it to Sentry as an
+      // ERROR (this also covers the INCOHERENT_DIFF bail, which parses to a missing opinion → inconclusive). (#1468)
+      captureReviewFailure(new Error("AI review inconclusive — no usable verdict for the PR head"), {
+        kind: "review",
+        reason: "ai_review_inconclusive",
+        owner: args.repoFullName.split("/")[0],
+        repo: args.repoFullName,
+        pr: args.pr.number,
+        head_sha: args.advisory.headSha,
       });
     }
     args.advisory.findings.push(...findings);

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -64,14 +64,15 @@ export function captureError(
   });
 }
 
-/** Capture a degraded/failed review at WARNING level, tagged by repo/PR/SHA for triage. No-op when off. */
+/** Capture a failed review at ERROR level, tagged by repo/PR/SHA for triage. A review that cannot be produced is a
+ *  real failure the maintainer must SEE — not a warning that hides in the noise. No-op when off. */
 export function captureReviewFailure(
   error: unknown,
   context?: Record<string, unknown>,
 ): void {
   if (!active || !Sentry) return;
   Sentry.withScope((scope) => {
-    scope.setLevel("warning");
+    scope.setLevel("error");
     if (context) {
       scope.setContext("review", context);
       for (const tag of ["owner", "repo", "pr", "head_sha"]) {

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildAiReviewDiff, runAiReviewForAdvisory, shouldStartAiReviewForAdvisory } from "../../src/queue/processors";
-import { BEST_REVIEW_MODELS } from "../../src/services/ai-review";
+import { BEST_REVIEW_MODELS, INCOHERENT_DIFF_ASSESSMENT } from "../../src/services/ai-review";
+import * as sentryModule from "../../src/selfhost/sentry";
 import { upsertRepositoryAiKey } from "../../src/db/repositories";
 import type { Advisory, PullRequestFileRecord, RepositorySettings } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
@@ -211,11 +212,12 @@ describe("runAiReviewForAdvisory", () => {
     expect(result?.notes).toContain("Likely crash.");
   });
 
-  it("appends an ai_review_inconclusive finding (fail-closed hold) when block-mode AI lacks a second opinion", async () => {
+  it("appends an ai_review_inconclusive finding (fail-closed hold) when block-mode AI lacks a second opinion, surfacing it to Sentry as an error", async () => {
     const adv = advisory();
     // The first slot parses; the second slot's primary AND its reliable fallback fail → no consensus possible.
     const run = (async (model: string) => ({ response: model === BEST_REVIEW_MODELS[0] ? notesOnlyJson() : "garbage" })) as unknown as () => Promise<unknown>;
     const env = aiEnv(run);
+    const captureSpy = vi.spyOn(sentryModule, "captureReviewFailure");
     const result = await runAiReviewForAdvisory(env, {
       settings: { aiReviewMode: "block" } as RepositorySettings,
       advisory: adv,
@@ -226,6 +228,36 @@ describe("runAiReviewForAdvisory", () => {
     });
     expect(adv.findings.map((f) => f.code)).toEqual(["ai_review_inconclusive"]);
     expect(result?.notes).toBeDefined(); // the single parseable opinion still produces advisory notes
+    // The unproducible review is reported to Sentry with PR context so the maintainer can SEE it (#1468).
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), {
+      kind: "review",
+      reason: "ai_review_inconclusive",
+      owner: "acme",
+      repo: "acme/widgets",
+      pr: 3,
+      head_sha: "sha3",
+    });
+    captureSpy.mockRestore();
+  });
+
+  it("surfaces the INCOHERENT_DIFF bail to Sentry as a review failure (stale-head review)", async () => {
+    const adv = advisory();
+    // Both reviewers return the INCOHERENT_DIFF assessment — the diff is out of sync with the PR head, so each
+    // opinion parses to null → the combiner yields `inconclusive`, the same review-failure path as a missing opinion.
+    const incoherent = JSON.stringify({ assessment: INCOHERENT_DIFF_ASSESSMENT, blockers: [], nits: [], suggestions: [] });
+    const env = aiEnv((async () => ({ response: incoherent })) as unknown as () => Promise<unknown>);
+    const captureSpy = vi.spyOn(sentryModule, "captureReviewFailure");
+    await runAiReviewForAdvisory(env, {
+      settings: { aiReviewMode: "block" } as RepositorySettings,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+    });
+    expect(adv.findings.map((f) => f.code)).toEqual(["ai_review_inconclusive"]);
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ reason: "ai_review_inconclusive", repo: "acme/widgets", head_sha: "sha3" }));
+    captureSpy.mockRestore();
   });
 
   it("appends an ai_review_split finding (lone-blocker HOLD) when the two block-mode reviewers disagree", async () => {

--- a/test/unit/fetch-live-pull-request.test.ts
+++ b/test/unit/fetch-live-pull-request.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLivePullRequest } from "../../src/github/backfill";
+import { createTestEnv } from "../helpers/d1";
+
+describe("fetchLivePullRequest (#sweep-resync)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the full live payload from GET /pulls/{n}", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("/repos/owner/repo/pulls/7");
+      return Response.json({
+        number: 7,
+        title: "Live PR",
+        state: "open",
+        head: { sha: "live-sha", ref: "feature" },
+      });
+    });
+    const live = await fetchLivePullRequest(env, "owner/repo", 7, "tok");
+    expect(live?.number).toBe(7);
+    expect(live?.head?.sha).toBe("live-sha");
+  });
+
+  it("returns undefined (fail-open) when the fetch errors", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async () => new Response("nope", { status: 500 }));
+    expect(
+      await fetchLivePullRequest(env, "owner/repo", 7, "tok"),
+    ).toBeUndefined();
+  });
+});

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -735,6 +735,99 @@ describe("queue processors", () => {
     expect(mergeAudit?.n).toBe(0);
   });
 
+  // #sweep-resync: when a `synchronize` webhook is lost (self-host relay down), the stored head SHA + cached files
+  // go stale and the sweep would review an INCOHERENT diff. The re-review now RESYNCS the stored PR to its live head
+  // before reviewing. These two cases pin both arms of the drift check (differs → resync fires, matches → no-op).
+  it("#sweep-resync: re-review RESYNCS the stored PR to the live head when it drifted, then reviews on the new head", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    // STORED head is the stale a7; GitHub's LIVE head is b8 (a push the lost synchronize never delivered).
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    let liveFilesFetched = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // GET /pulls/7 reports the live head b8 — the resync upserts this over the stale a7.
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) { liveFilesFetched = true; return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]); }
+      if (url.includes("/commits/b8/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/b8/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "resync-drift", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+    // The stored PR was resynced to the live head, and its files were refreshed (so the review runs on b8, not a7).
+    const stored = await getPullRequest(env, "owner/agent-repo", 7);
+    expect(stored?.headSha).toBe("b8");
+    expect(liveFilesFetched).toBe(true);
+  });
+
+  it("#sweep-resync: re-review does NOT resync when the stored head already matches the live head", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    const resyncUpsertSpy = vi.spyOn(repositoriesModule, "upsertPullRequestFromGitHub");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // GET /pulls/7 reports the SAME head a7 — no drift, so the resync upsert must not fire.
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "resync-nodrift", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+    // No drift → the resync branch's upsert never ran; the stored head is unchanged.
+    expect(resyncUpsertSpy).not.toHaveBeenCalled();
+    const stored = await getPullRequest(env, "owner/agent-repo", 7);
+    expect(stored?.headSha).toBe("a7");
+    resyncUpsertSpy.mockRestore();
+  });
+
+  it("#sweep-resync: a failing resync upsert is swallowed (fail-open) — the sweep never throws", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    // The live head drifted (b8 ≠ a7), so the resync upsert fires — but it REJECTS. The `.catch(() => undefined)`
+    // must swallow it so the sweep proceeds on the stored `pr` rather than stalling (#sweep-resync fail-open).
+    const resyncUpsertSpy = vi.spyOn(repositoriesModule, "upsertPullRequestFromGitHub").mockRejectedValueOnce(new Error("D1 upsert failed"));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs") || url.includes("/commits/b8/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status") || url.includes("/commits/b8/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    // The rejecting upsert is caught; the job resolves without throwing and the stored head stays a7 (fail-open).
+    await expect(processJob(env, { type: "agent-regate-pr", deliveryId: "resync-failopen", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 })).resolves.toBeUndefined();
+    expect(resyncUpsertSpy).toHaveBeenCalledTimes(1);
+    const stored = await getPullRequest(env, "owner/agent-repo", 7);
+    expect(stored?.headSha).toBe("a7");
+    resyncUpsertSpy.mockRestore();
+  });
+
   it("#1: the block-mode re-gate sweep replays cached AI findings before gate evaluation", async () => {
     let aiCalls = 0;
     const env = createTestEnv({

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -124,7 +124,7 @@ describe("enabled when SENTRY_DSN is set", () => {
     expect(mocks.captureException).toHaveBeenCalledTimes(2);
   });
 
-  it("captureReviewFailure sets warning level + repo/PR/SHA tags, skipping null/undefined, and works without context", async () => {
+  it("captureReviewFailure sets error level + repo/PR/SHA tags, skipping null/undefined, and works without context", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     captureReviewFailure(new Error("rev"), {
       repo: "o/r",
@@ -132,7 +132,7 @@ describe("enabled when SENTRY_DSN is set", () => {
       head_sha: "abc",
       owner: null,
     });
-    expect(mocks.scope.setLevel).toHaveBeenCalledWith("warning");
+    expect(mocks.scope.setLevel).toHaveBeenCalledWith("error");
     expect(mocks.scope.setTag).toHaveBeenCalledWith("repo", "o/r");
     expect(mocks.scope.setTag).toHaveBeenCalledWith("pr", "7");
     expect(mocks.scope.setTag).toHaveBeenCalledWith("head_sha", "abc");


### PR DESCRIPTION
Two fixes for broken self-host reviews:

1. **Reviews stay on the live head.** With the webhook relay down, the `synchronize` event that refreshes a PR's stored head never arrives, so the sweep reviewed from a stale `pr.headSha` + cached files → the AI got a diff that didn't match the head → fail-closed with "diff out of sync" → stuck "held for manual." The sweep now resyncs the stored PR to the **live head + fresh files** before reviewing (`fetchLivePullRequest` → `upsertPullRequestFromGitHub` → `refreshPullRequestDetails`), fully fail-open. Reviews now produce a coherent diff without depending on a webhook.

2. **Review failures are Sentry ERRORS.** `captureReviewFailure` now captures at `error` level (was `warning`), and the inconclusive/incoherent review path calls it with PR context — so a review that can't be produced surfaces as a Sentry issue instead of hiding. 

Gate green: typecheck PASS, test:ci PASS (4821 passed), patch coverage 100% (0 uncovered), npm audit clean.