### PR TITLE
fix(selfhost): stop GitHub rate-limit exhaustion (optimize sweep/backfill polling)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,18 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
   if (isOrbBrokerEnabled(env)) jobs.push({ type: "retry-orb-relay", requestedBy: "schedule" });
   // The heavier sync/health jobs keep their ~30-minute cadence even though the cron now ticks every ~2 minutes.
   if (minute % 30 === 0) {
-    jobs.push({ type: "backfill-registered-repos", requestedBy: "schedule", mode: isFullSyncWindow ? "full" : "light" });
+    // BACKPRESSURE (#audit-rate-headroom): the open-data backfill lists every registered repo and fans out a
+    // per-repo segment + per-PR detail sync — a large GitHub-budget consumer second only to the sweep. Gate it
+    // behind the SAME maintenance headroom the sweep yields at, so when the shared REST budget is low the backfill
+    // SKIPS this 30-min tick and hands the remaining budget to webhooks (which drive timely reviews); the next
+    // 30-min tick retries, and after the bucket resets the backfill resumes. The cheap single-call health jobs
+    // (repair-data-fidelity, refresh-installation-health) stay unconditional — they cost ~one call and keep
+    // installation/health state fresh even while the budget is reserved.
+    if (!sweepThrottledUntil) {
+      jobs.push({ type: "backfill-registered-repos", requestedBy: "schedule", mode: isFullSyncWindow ? "full" : "light" });
+    } else {
+      console.log(JSON.stringify({ event: "backfill_throttled", resetAt: sweepThrottledUntil }));
+    }
     jobs.push({ type: "repair-data-fidelity", requestedBy: "schedule" });
     jobs.push({ type: "refresh-installation-health", requestedBy: "schedule" });
   }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1510,7 +1510,9 @@ async function reReviewStoredPullRequest(
   }
   // Operator review flow: rebase-if-behind → wait for ALL CI to finish → only THEN review. Defers (returns) when
   // a rebase fired a synchronize, or CI is still running — the synchronize / CI-completion webhook re-triggers
-  // once the head is current and CI has settled (the sweep backstops a missed event).
+  // once the head is current and CI has settled (the sweep backstops a missed event). REST-budget dedup
+  // (#audit-rate-headroom): thread the already-fetched live PR's `mergeable_state` so prReadyForReview reuses it
+  // instead of issuing a second `GET /pulls/{n}` for the behind-base check.
   if (
     !(await prReadyForReview(
       env,
@@ -1519,6 +1521,7 @@ async function reReviewStoredPullRequest(
       pr,
       settings,
       deliveryId,
+      { liveMergeState: live?.mergeable_state ?? undefined },
     ))
   )
     return;
@@ -1625,6 +1628,12 @@ async function prReadyForReview(
   pr: PullRequestRecord,
   settings: RepositorySettings,
   deliveryId: string,
+  // REST-budget dedup (#audit-rate-headroom): the re-gate sweep already fetched the FULL live PR once (the resync
+  // `GET /pulls/{n}`), whose `mergeable_state` is exactly what the behind-base check needs. When the caller passes
+  // it, REUSE it instead of issuing a second `GET /pulls/{n}` here. `undefined` ⇒ no payload (the webhook path,
+  // which has no pre-fetched live PR) ⇒ fall back to the live fetch. The shared installation REST bucket is one
+  // hourly budget across all repos, so removing the duplicate GET halves the per-regate `GET /pulls/{n}` cost.
+  options: { liveMergeState?: string | undefined } = {},
 ): Promise<boolean> {
   // Only gate an OPEN, non-draft, agent-configured PR. A closed PR (the live path also runs on `closed` to
   // finalize / record reputation) must NOT be rebased or CI-waited — proceed so finalization runs.
@@ -1640,13 +1649,14 @@ async function prReadyForReview(
       () => undefined,
     )) ?? env.GITHUB_PUBLIC_TOKEN;
   if (!token) return true;
-  // 1) rebase if BEHIND base — the synchronize on the new head re-triggers this flow on the merged result.
-  const liveMergeState = await fetchLivePullRequestMergeState(
-    env,
-    repoFullName,
-    pr.number,
-    token,
-  ).catch(() => undefined);
+  // 1) rebase if BEHIND base — the synchronize on the new head re-triggers this flow on the merged result. Reuse a
+  // caller-supplied mergeable_state (the sweep's resync payload) to skip a redundant `GET /pulls/{n}`; fall back to
+  // the live fetch only when no payload was threaded (the webhook path). fetchLivePullRequestMergeState fails open
+  // internally (swallows its own fetch errors → undefined), so the fallback needs no extra catch — mirroring the
+  // resync's fetchLivePullRequest call above.
+  const liveMergeState =
+    options.liveMergeState ??
+    (await fetchLivePullRequestMergeState(env, repoFullName, pr.number, token));
   if (liveMergeState === "behind") {
     const autonomyLevel = resolveAutonomy(settings.autonomy, "update_branch");
     const installation = await getInstallation(env, installationId);

--- a/src/settings/agent-sweep.ts
+++ b/src/settings/agent-sweep.ts
@@ -7,7 +7,17 @@ import type { PullRequestRecord } from "../types";
 
 // Rate-aware ceiling: never recompute more than this many PRs per repo per sweep, so a repo with a large
 // open queue cannot blow the queue-message budget. The stalest are picked first.
-export const SWEEP_MAX_PRS = 25;
+//
+// REST-budget sizing (#audit-rate-headroom): all managed repos share ONE GitHub App installation = ONE ~5000/hr
+// REST bucket. Each fanned-out per-PR re-review costs ~9 REST GETs (1 resync `GET /pulls/{n}`, then required-
+// contexts + CI aggregate in prReadyForReview, then required-contexts + merge-state + CI aggregate + files in
+// auto-maintain). The sweep re-arms every ~2 min (≈30 ticks/hr) and fans out per repo, so the worst-case hourly
+// sweep cost is `SWEEP_MAX_PRS × repos × 9 × 30`. At the old cap of 25 over 3 self-host repos that is ~200k/hr —
+// far over budget, the cause of the `regate_sweep_throttled` exhaustion. A cap of 6 bounds the worst case to
+// `6 × 3 × 9 × 30 ≈ 4.9k/hr` (and steady state is far lower — the freshness skip + the in-flight drain guard stop
+// re-regating just-touched PRs), reserving headroom for webhooks. A 30-PR backlog still fully converges in
+// ceil(30/6)=5 sweeps (~10 min), so no PR's merge/close is meaningfully delayed.
+export const SWEEP_MAX_PRS = 6;
 
 // Skip-if-fresh window: a PR touched within this span was almost certainly just gated by its webhook, so the
 // sweep leaves it alone for that brief moment to avoid racing the in-flight webhook review. Kept SHORT (2 min)

--- a/test/unit/agent-sweep.test.ts
+++ b/test/unit/agent-sweep.test.ts
@@ -104,15 +104,18 @@ describe("selectRegateCandidates (#777 re-gate sweep selection)", () => {
     expect(picked.map((p) => p.number)).toEqual([3]);
   });
 
-  it("REGRESSION (convergence): ceil(50/25)=2 sweeps with all GitHub writes suppressed cover ALL 50 open PRs, none re-selected before the rest are stamped", () => {
+  it("REGRESSION (convergence): ceil(open/cap) sweeps with all GitHub writes suppressed cover ALL open PRs, none re-selected before the rest are stamped", () => {
     // Simulate the dry-run / paused world: a re-gate stamps lastRegatedAt (a D1 write, never suppressed) but the
-    // GitHub updatedAt is frozen. Without the fix the same 25 stalest would recur every sweep forever; with it,
-    // two sweeps of 25 (the cap) cover all 50 distinct PRs exactly once — full coverage in ceil(open/max) sweeps.
-    const pulls = Array.from({ length: 50 }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(1000 - i), updatedAt: minutesAgo(1000) }));
+    // GitHub updatedAt is frozen. Without the fix the same `cap` stalest would recur every sweep forever; with it,
+    // ceil(open/cap) sweeps cover all distinct PRs exactly once — full coverage in ceil(open/max) sweeps. Sized off
+    // the live cap so it stays correct as SWEEP_MAX_PRS is tuned for the REST budget (#audit-rate-headroom).
+    const open = SWEEP_MAX_PRS * 2; // exactly two full sweeps' worth of stale open PRs
+    const sweepsNeeded = Math.ceil(open / SWEEP_MAX_PRS);
+    const pulls = Array.from({ length: open }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(1000 - i), updatedAt: minutesAgo(1000) }));
     const stampedAt = new Map<number, string>();
     const covered = new Set<number>();
     let sweepNow = nowMs;
-    for (let sweep = 0; sweep < 2; sweep++) {
+    for (let sweep = 0; sweep < sweepsNeeded; sweep++) {
       sweepNow += 5 * 60 * 1000; // each sweep runs ~5 min later (outside the freshness window)
       const now = new Date(sweepNow).toISOString();
       const view = pulls.map((p) => ({ ...p, lastRegatedAt: stampedAt.get(p.number) ?? p.lastRegatedAt }));
@@ -124,14 +127,14 @@ describe("selectRegateCandidates (#777 re-gate sweep selection)", () => {
         stampedAt.set(p.number, now); // the sweep stamps lastRegatedAt = now
       }
     }
-    expect(covered.size).toBe(50); // full coverage of every open PR
+    expect(covered.size).toBe(open); // full coverage of every open PR
   });
 
-  it("defaults: freshness window is two minutes and the cap is 25", () => {
+  it("defaults: freshness window is two minutes and the cap is bounded for the shared REST budget (#audit-rate-headroom)", () => {
     expect(SWEEP_FRESHNESS_MS).toBe(2 * 60 * 1000);
-    expect(SWEEP_MAX_PRS).toBe(25);
+    expect(SWEEP_MAX_PRS).toBe(6); // lowered from 25: 6 × 3 repos × 9 GETs × 30 ticks/hr ≈ 4.9k/hr ≤ the 5000 bucket
     const pulls = Array.from({ length: 40 }, (_, i) => pr({ number: i + 1, createdAt: minutesAgo(120 + i) }));
-    expect(selectRegateCandidates({ pulls, now: NOW })).toHaveLength(25);
+    expect(selectRegateCandidates({ pulls, now: NOW })).toHaveLength(SWEEP_MAX_PRS);
   });
 });
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -168,6 +168,38 @@ describe("worker entrypoint", () => {
     expect(sent.find((m) => m.type === "agent-regate-sweep")).toBeUndefined();
   });
 
+  it("THROTTLES the open-data backfill too when the REST budget is at/below the maintenance headroom, keeping the cheap health jobs (#audit-rate-headroom)", async () => {
+    const sent: Array<import("../../src/types").JobMessage> = [];
+    const env = createTestEnv({
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    // Low REST budget (remaining 50 <= MAINTENANCE_RESERVED_HEADROOM=150) with a future reset.
+    await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 50, resetAt: new Date(Date.now() + 600_000).toISOString(), observedAt: new Date().toISOString() });
+    const waitUntil: Promise<unknown>[] = [];
+    // A :30 tick is when the backfill would normally enqueue — assert it does NOT while the budget is reserved.
+    await worker.scheduled(controllerFor("2026-05-25T05:30:00.000Z"), env, executionContext(waitUntil));
+    await Promise.all(waitUntil);
+    // Backfill (+ sweep) yield the budget to webhooks; the cheap single-call health jobs still run.
+    expect(sent.some((m) => m.type === "backfill-registered-repos")).toBe(false);
+    expect(sent.some((m) => m.type === "agent-regate-sweep")).toBe(false);
+    expect(sent.some((m) => m.type === "repair-data-fidelity")).toBe(true);
+    expect(sent.some((m) => m.type === "refresh-installation-health")).toBe(true);
+  });
+
+  it("enqueues the open-data backfill on a :30 tick when there is REST headroom (#audit-rate-headroom)", async () => {
+    const sent: Array<import("../../src/types").JobMessage> = [];
+    const env = createTestEnv({
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    // Ample REST budget (remaining 4000 > MAINTENANCE_RESERVED_HEADROOM=150) → the throttle does NOT engage.
+    await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 4000, resetAt: new Date(Date.now() + 600_000).toISOString(), observedAt: new Date().toISOString() });
+    const waitUntil: Promise<unknown>[] = [];
+    await worker.scheduled(controllerFor("2026-05-25T05:30:00.000Z"), env, executionContext(waitUntil));
+    await Promise.all(waitUntil);
+    expect(sent.some((m) => m.type === "backfill-registered-repos")).toBe(true);
+    expect(sent.some((m) => m.type === "agent-regate-sweep")).toBe(true);
+  });
+
   it("enqueues hourly refreshes without full detail work outside the six-hour window", async () => {
     const sent: Array<import("../../src/types").JobMessage> = [];
     const env = createTestEnv({

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -798,6 +798,42 @@ describe("queue processors", () => {
     resyncUpsertSpy.mockRestore();
   });
 
+  // REST-budget dedup (#audit-rate-headroom): the sweep resync already fetched the full live PR (its mergeable_state
+  // covers the behind-base check), so prReadyForReview must REUSE it instead of issuing its own `GET /pulls/{n}`. The
+  // only bare `GET /pulls/7` reads in the per-PR re-review are now the resync (1) + auto-maintain's merge-state (1) —
+  // never a third from prReadyForReview. (This pins the redundancy removal: before the dedup there were three.)
+  it("#audit-rate-headroom: the per-PR re-review reuses the resync payload's merge state — prReadyForReview issues NO extra GET /pulls/{n}", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    let barePullGets = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // The full PR payload carries mergeable_state CLEAN (not behind) + the live head. Count only the bare
+      // `GET /pulls/7` (no sub-resource, GET only) — the redundant prReadyForReview fetch would be a third here.
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") {
+        barePullGets += 1;
+        return Response.json({ number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      }
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "dedup-pulls-get", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+    // Resync (1) + auto-maintain merge-state (1) = 2; the deduped prReadyForReview adds NONE (was 3 before the fix).
+    expect(barePullGets).toBe(2);
+  });
+
   it("#sweep-resync: a failing resync upsert is swallowed (fail-open) — the sweep never throws", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
The self-host shares ONE ~5000/hr GitHub REST budget per repo-installation, but the re-gate sweep was making ~9 GETs/PR × up to 25 PRs × 3 repos × 30 ticks/hr (~200k/hr worst case) → budget exhausted → `regate_sweep_throttled` churn → reviews never ran.

Three levers (measured, gate green):
1. **Dedup** the redundant per-regate `GET /pulls/{n}` — `prReadyForReview` now reuses the resync's live payload (3→2 GETs/regate; webhook path unchanged).
2. **SWEEP_MAX_PRS 25→6** — worst case ~4.9k/hr (≤ budget; freshness-skip makes steady-state far lower; a 30-PR backlog still converges in ~5 sweeps / ~10 min, no merge/close starvation).
3. **Backfill yields headroom** — the 30-min `backfill-registered-repos` fan-out now defers below the maintenance headroom, reserving budget for reviews.

Net: the budget lasts → the sweep stops throttling → reviews run (coherently, via the #1594 resync). Long-term fix is the event-driven relay (no polling). typecheck PASS, test:ci PASS (4824), patch coverage 0 uncovered, audit clean.