### PR TITLE
fix(selfhost): forward Sentry structured stderr logs

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -86,11 +86,10 @@ export function captureReviewFailure(
   });
 }
 
-/** Forward a structured `console.log` line to Sentry when it is an ERROR-level log. The engine logs operational
- *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as `console.log(JSON.stringify({ level:
- *  "error", event, … }))` — so wrapping console.log with this surfaces EVERY such error as a Sentry issue with NO
- *  per-site wiring. No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal —
- *  routine logs (audit/info/no-level: job_complete, regate_sweep_throttled, …) are intentionally skipped. */
+/** Forward a structured console line to Sentry when it is an ERROR-level log. The engine logs operational
+ *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as JSON strings, often via console.error.
+ *  No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal — routine logs
+ *  (audit/info/no-level: job_complete, regate_sweep_throttled, …) are intentionally skipped. */
 export function forwardStructuredLogToSentry(line: unknown): void {
   if (!active || !Sentry) return;
   if (typeof line !== "string" || line.charCodeAt(0) !== 123 /* "{" */) return;
@@ -128,4 +127,35 @@ export async function flushSentry(timeoutMs = 2000): Promise<void> {
 export function resetSentryForTest(): void {
   Sentry = undefined;
   active = false;
+}
+
+interface StructuredLogConsole {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+/** Install central structured-log forwarding for both stdout and stderr sinks used by self-host. */
+export function installStructuredLogForwarding(
+  target: StructuredLogConsole = console,
+): void {
+  const baseConsoleLog = target.log.bind(target);
+  const baseConsoleError = target.error.bind(target);
+  let forwardingToSentry = false;
+  const forward = (line: unknown): void => {
+    if (forwardingToSentry) return;
+    forwardingToSentry = true;
+    try {
+      forwardStructuredLogToSentry(line);
+    } finally {
+      forwardingToSentry = false;
+    }
+  };
+  target.log = (...args: unknown[]): void => {
+    baseConsoleLog(...args);
+    forward(args[0]);
+  };
+  target.error = (...args: unknown[]): void => {
+    baseConsoleError(...args);
+    forward(args[0]);
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,8 +54,8 @@ import {
 import {
   captureError,
   flushSentry,
-  forwardStructuredLogToSentry,
   initSentry,
+  installStructuredLogForwarding,
 } from "./selfhost/sentry";
 import {
   setLocalManifestReader,
@@ -261,22 +261,9 @@ async function main(): Promise<void> {
       captureError(reason, { kind: "unhandledRejection" });
       console.error(reason);
     });
-    // Central error forwarding (#1468): the engine logs operational failures (orb_broker_unavailable, gate-check
-    // errors, relay drops, …) as structured `console.log` lines with level:"error". Wrap console.log so every such
-    // line surfaces as a Sentry issue WITHOUT per-site wiring; routine logs are skipped inside the forwarder. The
-    // re-entrancy guard prevents a loop if the Sentry path itself ever logs.
-    const baseConsoleLog = console.log.bind(console);
-    let forwardingToSentry = false;
-    console.log = (...args: unknown[]): void => {
-      baseConsoleLog(...args);
-      if (forwardingToSentry) return;
-      forwardingToSentry = true;
-      try {
-        forwardStructuredLogToSentry(args[0]);
-      } finally {
-        forwardingToSentry = false;
-      }
-    };
+    // Central error forwarding (#1468): operational failures are structured JSON logs emitted through stdout and
+    // stderr. Wrap both sinks so every level:"error"/"fatal" line surfaces as a Sentry issue WITHOUT per-site wiring.
+    installStructuredLogForwarding();
   }
   const startedAt = Date.now();
 

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -26,6 +26,7 @@ import {
   captureReviewFailure,
   flushSentry,
   forwardStructuredLogToSentry,
+  installStructuredLogForwarding,
   scrubEvent,
   resetSentryForTest,
 } from "../../src/selfhost/sentry";
@@ -225,5 +226,61 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(JSON.stringify({ level: "error", code: 500 }));
     expect(mocks.captureMessage).toHaveBeenCalledWith("error", "error");
+  });
+});
+
+describe("installStructuredLogForwarding — central console sink instrumentation (#1468)", () => {
+  const makeConsole = () => {
+    const base = { log: vi.fn(), error: vi.fn() };
+    return { target: { ...base }, base };
+  };
+
+  it("forwards structured level:error logs emitted through console.error (regression)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target, base } = makeConsole();
+
+    installStructuredLogForwarding(target);
+    target.error(
+      JSON.stringify({
+        level: "error",
+        event: "orb_broker_unavailable",
+        installationId: 1,
+      }),
+    );
+
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      "orb_broker_unavailable",
+      "error",
+    );
+    expect(base.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps forwarding structured level:error logs emitted through console.log", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target, base } = makeConsole();
+
+    installStructuredLogForwarding(target);
+    target.log(JSON.stringify({ level: "error", event: "gate_check_failed" }));
+
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      "gate_check_failed",
+      "error",
+    );
+    expect(base.log).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recursively forward if the Sentry path logs while forwarding", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target, base } = makeConsole();
+    installStructuredLogForwarding(target);
+    mocks.captureMessage.mockImplementationOnce(() => {
+      target.error(JSON.stringify({ level: "error", event: "recursive" }));
+    });
+
+    target.error(JSON.stringify({ level: "error", event: "outer" }));
+
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.captureMessage).toHaveBeenCalledWith("outer", "error");
+    expect(base.error).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
### Motivation

- The existing central Sentry forwarding wrapped only `console.log`, but many operational error JSON lines are emitted via `console.error`, so those errors were not forwarded to Sentry. 
- Ensure every structured `level:"error"`/`fatal` line from both stdout and stderr surfaces as a Sentry issue without per-site wiring. 
- Add a regression test to prevent the forwarding gap from regressing.

### Description

- Add `installStructuredLogForwarding(target = console)` to `src/selfhost/sentry.ts` that wraps both `log` and `error` on the provided console-like object and forwards the first argument to `forwardStructuredLogToSentry` with a shared re-entrancy guard. 
- Call `installStructuredLogForwarding()` in `src/server.ts` when `initSentry()` returns true so both stdout and stderr sinks are instrumented. 
- Update the `forwardStructuredLogToSentry` comment to reflect that structured error JSON may arrive via `console.error`. 
- Add regression tests in `test/unit/selfhost-sentry.test.ts` exercising `console.error` and `console.log` forwarding and recursion protection.

### Testing

- Ran `npx vitest run test/unit/selfhost-sentry.test.ts --reporter=verbose` and the unit test file passed (19/19 tests passed). 
- Ran `npm run typecheck` and it succeeded (`tsc --noEmit`). 
- Ran `git diff --check` and it reported no issues. 
- Attempted coverage remapping with `npm run test:coverage -- --run test/unit/selfhost-sentry.test.ts`, but it failed in this environment due to a dependency mismatch (`js-tokens@4.0.0` vs `ast-v8-to-istanbul` expecting `^10.0.0`), producing `TypeError: jsTokens is not a function`. 
- `npm run test:ci` could not complete here because `actionlint` setup could not reach GitHub and the WASM fallback flagged the repository's custom self-hosted runner label, and `npm audit --audit-level=moderate` returned a 403 from the audit endpoint in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fae5b1488832ca44a5d7beef21a45)