### PR TITLE
feat(orb): add pull-mode relay queue + /v1/orb/relay/pull (inert)

### DIFF
--- a/migrations/0079_orb_relay_pull.sql
+++ b/migrations/0079_orb_relay_pull.sql
@@ -1,0 +1,13 @@
+-- Pull-mode relay (#16): a brokered self-host behind NAT/tailnet cannot receive PUSHED webhooks, so it PULLS
+-- queued events from the Orb. Adds a per-enrollment delivery mode (default 'push' = unchanged) and a
+-- per-installation pending-event queue the engine drains.
+ALTER TABLE orb_enrollments ADD COLUMN relay_mode TEXT NOT NULL DEFAULT 'push';
+
+CREATE TABLE IF NOT EXISTS orb_relay_pending (
+  delivery_id TEXT PRIMARY KEY,
+  installation_id INTEGER NOT NULL,
+  event_name TEXT NOT NULL,
+  raw_body TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_orb_relay_pending_install ON orb_relay_pending (installation_id, created_at);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -128,7 +128,7 @@ import { handleOrbIngest, readOrbIngestBody } from "../orb/ingest";
 import { handleOrbWebhook } from "../orb/webhook";
 import { handleOrbOAuthCallback } from "../orb/oauth";
 import { brokerOrbToken, isOrbBrokerEnabled, issueOrbEnrollment } from "../orb/broker";
-import { readOrbRelayRegisterBody, registerValidatedOrbRelay, validateOrbRelayEnrollment } from "../orb/relay";
+import { pullRelayPending, readOrbRelayRegisterBody, registerValidatedOrbRelay, validateOrbRelayEnrollment } from "../orb/relay";
 import { computeFleetAnalytics } from "../orb/analytics";
 import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
@@ -2930,20 +2930,47 @@ export function createApp() {
     if ("error" in enrollment) return c.json(enrollment, enrollment.error === "invalid_enrollment" ? 401 : 403);
     const rawBody = await readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"));
     if (rawBody === null) return c.json({ error: "payload_too_large" }, 413);
-    let body: { relayUrl?: unknown } | null;
+    let body: { relayUrl?: unknown; mode?: unknown } | null;
     try {
-      body = JSON.parse(rawBody) as { relayUrl?: unknown };
+      body = JSON.parse(rawBody) as { relayUrl?: unknown; mode?: unknown };
     } catch {
       body = null;
     }
+    // Pull mode (#16): a tailnet container registers to PULL events (no relay_url to push to). Default 'push'.
+    const mode = body?.mode === "pull" ? "pull" : body?.mode === "push" || body?.mode === undefined ? "push" : null;
+    if (mode === null) return c.json({ error: "invalid_mode" }, 400);
     const relayUrl = typeof body?.relayUrl === "string" ? body.relayUrl.trim() : "";
-    if (!relayUrl) return c.json({ error: "missing_relay_url" }, 400);
-    const result = await registerValidatedOrbRelay(c.env, enrollment, secret, relayUrl);
+    if (mode === "push" && !relayUrl) return c.json({ error: "missing_relay_url" }, 400);
+    const result = await registerValidatedOrbRelay(c.env, enrollment, secret, relayUrl, mode);
     if ("error" in result) {
       const status = result.error === "invalid_enrollment" ? 401 : result.error === "installation_not_eligible" ? 403 : result.error === "encryption_unavailable" ? 500 : 400;
       return c.json(result, status);
     }
     return c.json(result);
+  });
+
+  // Pull-mode relay drain (#16) — a brokered self-host behind NAT/tailnet can't be PUSHED events, so it PULLS its
+  // queued events here (the engine drives this outbound). Auth: the container's own enrollment secret (Bearer).
+  // Body (optional) `{ ack: string[] }` acks the delivery_ids it durably accepted on its previous pull (deleted
+  // before the next batch is returned). Flag-gated (404 until enabled).
+  app.post("/v1/orb/relay/pull", async (c) => {
+    if (!isOrbBrokerEnabled(c.env)) return c.json({ error: "not_found" }, 404);
+    const auth = c.req.header("authorization") ?? "";
+    const secret = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+    if (!secret) return c.json({ error: "missing_enrollment_secret" }, 401);
+    const enrollment = await validateOrbRelayEnrollment(c.env, secret);
+    if ("error" in enrollment) return c.json(enrollment, enrollment.error === "invalid_enrollment" ? 401 : 403);
+    const rawBody = await readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"));
+    if (rawBody === null) return c.json({ error: "payload_too_large" }, 413);
+    let ack: string[] | undefined;
+    try {
+      const body = rawBody ? (JSON.parse(rawBody) as { ack?: unknown }) : null;
+      if (Array.isArray(body?.ack)) ack = body.ack.filter((id): id is string => typeof id === "string");
+    } catch {
+      ack = undefined; // tolerate an empty/invalid body — just no ack this round
+    }
+    const events = await pullRelayPending(c.env, enrollment.installationId, { ack });
+    return c.json({ events }, 200);
   });
 
   // Gittensory Orb (#1255) — central fleet-calibration collector. Receives anonymized, reversal-aware outcome
@@ -5029,6 +5056,7 @@ function requiresApiToken(path: string): boolean {
   if (path === "/v1/orb/oauth/callback") return false;
   if (path === "/v1/orb/token") return false;
   if (path === "/v1/orb/relay/register") return false;
+  if (path === "/v1/orb/relay/pull") return false;
   if (path === "/v1/orb/ingest") return false;
   if (path.startsWith("/v1/internal/")) return false;
   return path.startsWith("/v1/");

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -103,14 +103,24 @@ export async function validateOrbRelayEnrollment(env: Env, secret: string): Prom
   return { enrollId: row.enroll_id, installationId: row.installation_id };
 }
 
-export async function registerValidatedOrbRelay(env: Env, enrollment: RelayEnrollment, secret: string, relayUrl: string): Promise<RegisterResult> {
+export async function registerValidatedOrbRelay(env: Env, enrollment: RelayEnrollment, secret: string, relayUrl: string, mode: "push" | "pull" = "push"): Promise<RegisterResult> {
+  // Pull mode (#16): a tailnet container is never POSTed to, so there's no URL to SSRF-validate and no secret to
+  // store for a forward-time HMAC (the engine authenticates its OWN outbound pull). Just flag the enrollment.
+  if (mode === "pull") {
+    await env.DB
+      .prepare("UPDATE orb_enrollments SET relay_mode = 'pull', relay_registered_at = CURRENT_TIMESTAMP WHERE enroll_id = ?")
+      .bind(enrollment.enrollId)
+      .run();
+    return { ok: true, installationId: enrollment.installationId };
+  }
   // SSRF guard: the Orb will POST events to this URL — it must be a public https endpoint (no loopback / private /
   // link-local host), so a registered relay URL can never coerce the Orb into hitting an internal service.
   if (!isSafeHttpUrl(relayUrl)) return { error: "invalid_relay_url" };
   if (!env.TOKEN_ENCRYPTION_SECRET) return { error: "encryption_unavailable" };
   const enc = await encryptSecret(secret, env.TOKEN_ENCRYPTION_SECRET);
+  // Set relay_mode='push' too so a re-register from a previously-pull enrollment flips back to push.
   await env.DB
-    .prepare("UPDATE orb_enrollments SET relay_url = ?, relay_secret_enc = ?, relay_secret_iv = ?, relay_secret_salt = ?, relay_registered_at = CURRENT_TIMESTAMP WHERE enroll_id = ?")
+    .prepare("UPDATE orb_enrollments SET relay_mode = 'push', relay_url = ?, relay_secret_enc = ?, relay_secret_iv = ?, relay_secret_salt = ?, relay_registered_at = CURRENT_TIMESTAMP WHERE enroll_id = ?")
     .bind(relayUrl, enc.ciphertext, enc.iv, enc.salt, enrollment.enrollId)
     .run();
   return { ok: true, installationId: enrollment.installationId };
@@ -120,15 +130,69 @@ export async function registerValidatedOrbRelay(env: Env, enrollment: RelayEnrol
  *  registered, non-suspended install — same gate as the token broker), SSRF-validates the relay URL, then stores
  *  the URL + the enrollment secret encrypted at rest (for the forward-time HMAC). The container presents its OWN
  *  plaintext enrollment secret as the Bearer, so this is self-service + bound to that install. */
-export async function registerOrbRelay(env: Env, secret: string, relayUrl: string): Promise<RegisterResult> {
+export async function registerOrbRelay(env: Env, secret: string, relayUrl: string, mode: "push" | "pull" = "push"): Promise<RegisterResult> {
   const enrollment = await validateOrbRelayEnrollment(env, secret);
   if ("error" in enrollment) return enrollment;
-  return registerValidatedOrbRelay(env, enrollment, secret, relayUrl);
+  return registerValidatedOrbRelay(env, enrollment, secret, relayUrl, mode);
 }
 
 const RELAY_RETRY_MAX_ATTEMPTS = 5;
 const RELAY_RETRY_BATCH_SIZE = 25;
 const RELAY_RETRY_CONCURRENCY = 5;
+
+// Pull-mode relay (#16): a brokered self-host behind NAT/tailnet can't receive PUSHED forwards, so the Orb instead
+// ENQUEUES its events here and the engine drains them outbound. The batch caps how many rows a single pull returns
+// (and bounds the ack list), and the TTL drops events the engine never came back for (a long-down container).
+const RELAY_PENDING_BATCH_SIZE = 50;
+const RELAY_PENDING_TTL_HOURS = 24;
+
+export type RelayPendingEvent = { deliveryId: string; eventName: string; rawBody: string };
+
+/** Enqueue a pull-mode event for an installation. Idempotent on delivery_id (mirrors storeRelayFailure) — a GitHub
+ *  redelivery reaching the Orb twice never double-queues. */
+export async function enqueueRelayPending(
+  env: Env,
+  args: { deliveryId: string; installationId: number; eventName: string; rawBody: string },
+): Promise<void> {
+  await env.DB
+    .prepare(
+      "INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body) VALUES (?, ?, ?, ?) ON CONFLICT(delivery_id) DO NOTHING",
+    )
+    .bind(args.deliveryId, args.installationId, args.eventName, args.rawBody)
+    .run();
+}
+
+/** Drain pending pull-mode events for an installation. The engine calls this outbound (it can't be pushed to):
+ *  1) prune TTL-expired rows fleet-wide, 2) delete rows the caller ACKs (scoped to this install so one container
+ *  can never ack another's), then 3) return the next ordered batch. `ack` and `limit` are both capped at the batch
+ *  size to bound the SQL and the response. */
+export async function pullRelayPending(
+  env: Env,
+  installationId: number,
+  opts?: { ack?: string[] | undefined; limit?: number | undefined },
+): Promise<RelayPendingEvent[]> {
+  // Prune rows the engine never came back for (same datetime() comparison style as retryFailedRelays).
+  await env.DB
+    .prepare("DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')")
+    .bind(RELAY_PENDING_TTL_HOURS)
+    .run();
+
+  const ack = opts?.ack?.slice(0, RELAY_PENDING_BATCH_SIZE) ?? [];
+  if (ack.length) {
+    const placeholders = ack.map(() => "?").join(", ");
+    await env.DB
+      .prepare(`DELETE FROM orb_relay_pending WHERE installation_id = ? AND delivery_id IN (${placeholders})`)
+      .bind(installationId, ...ack)
+      .run();
+  }
+
+  const limit = Math.min(opts?.limit ?? RELAY_PENDING_BATCH_SIZE, RELAY_PENDING_BATCH_SIZE);
+  const { results } = await env.DB
+    .prepare("SELECT delivery_id, event_name, raw_body FROM orb_relay_pending WHERE installation_id = ? ORDER BY created_at, delivery_id LIMIT ?")
+    .bind(installationId, limit)
+    .all<{ delivery_id: string; event_name: string; raw_body: string }>();
+  return results.map((r) => ({ deliveryId: r.delivery_id, eventName: r.event_name, rawBody: r.raw_body }));
+}
 
 /** Record a failed relay forward in the retry queue. Idempotent on delivery_id — a duplicate insert (e.g. from a
  *  GitHub redelivery reaching the same event before the retry fires) is silently ignored. */
@@ -174,7 +238,7 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
       { eventName: row.event_name, installationId: row.installation_id, deliveryId: row.delivery_id, rawBody: row.raw_body },
       opts?.fetchImpl,
     );
-    if (result === "forwarded" || result === "skipped") {
+    if (result === "forwarded" || result === "queued" || result === "skipped") {
       await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
     } else {
       await env.DB
@@ -198,15 +262,23 @@ export async function forwardOrbEvent(
   env: Env,
   args: { eventName: string; installationId: number | null | undefined; deliveryId: string; rawBody: string },
   fetchImpl: typeof fetch = fetch,
-): Promise<"forwarded" | "skipped" | "failed"> {
+): Promise<"forwarded" | "queued" | "skipped" | "failed"> {
   if (!args.installationId || !RELAY_FORWARD_EVENTS.has(args.eventName)) return "skipped";
   const row = await env.DB
-    .prepare("SELECT relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL AND relay_url IS NOT NULL")
+    .prepare("SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL")
     .bind(args.installationId)
-    .first<{ relay_url: string; relay_secret_enc: string; relay_secret_iv: string; relay_secret_salt: string | null }>();
-  if (!row || !env.TOKEN_ENCRYPTION_SECRET) return "skipped";
+    .first<{ relay_mode: string; relay_url: string | null; relay_secret_enc: string | null; relay_secret_iv: string | null; relay_secret_salt: string | null }>();
+  if (!row) return "skipped"; // not a brokered self-host (or revoked) — nothing to relay to
+  // Pull mode (#16): a tailnet container can't be pushed to, so ENQUEUE the event for it to drain outbound.
+  if (row.relay_mode === "pull") {
+    await enqueueRelayPending(env, { deliveryId: args.deliveryId, installationId: args.installationId, eventName: args.eventName, rawBody: args.rawBody });
+    return "queued";
+  }
+  // Push mode with nothing registered (relay_url null) or no decryption key → skip. relay_secret_enc/iv are written
+  // atomically with relay_url at registration, so they're non-null whenever relay_url is (asserted below).
+  if (!row.relay_url || !env.TOKEN_ENCRYPTION_SECRET) return "skipped";
   try {
-    const secret = await decryptSecret(row.relay_secret_enc, row.relay_secret_iv, env.TOKEN_ENCRYPTION_SECRET, row.relay_secret_salt);
+    const secret = await decryptSecret(row.relay_secret_enc!, row.relay_secret_iv!, env.TOKEN_ENCRYPTION_SECRET, row.relay_secret_salt);
     const signature = await relaySignature(secret, args.rawBody);
     const res = await fetchImpl(row.relay_url, {
       method: "POST",

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { issueOrbEnrollment } from "../../src/orb/broker";
-import { forwardOrbEvent, MAX_ORB_RELAY_REGISTER_BODY_BYTES, readOrbRelayRegisterBody, registerOrbRelay, relaySignature, relayVerify, retryFailedRelays, storeRelayFailure } from "../../src/orb/relay";
+import { enqueueRelayPending, forwardOrbEvent, MAX_ORB_RELAY_REGISTER_BODY_BYTES, pullRelayPending, readOrbRelayRegisterBody, registerOrbRelay, relaySignature, relayVerify, retryFailedRelays, storeRelayFailure } from "../../src/orb/relay";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 
 const db = (e: Env) => e.DB as unknown as TestD1Database;
@@ -350,5 +350,257 @@ describe("retryFailedRelays", () => {
     expect(fetchCalled).toBe(false); // expired row deleted before SELECT — fetch was never called
     const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='expired-1'").first();
     expect(row ?? null).toBeNull();
+  });
+});
+
+describe("enqueueRelayPending", () => {
+  it("inserts a pending row; duplicate delivery_id is silently ignored (ON CONFLICT DO NOTHING)", async () => {
+    const e = brokeredEnv();
+    await enqueueRelayPending(e, { deliveryId: "pend-1", installationId: 9600, eventName: "pull_request", rawBody: '{"n":1}' });
+    const row = await db(e).prepare("SELECT installation_id, event_name, raw_body FROM orb_relay_pending WHERE delivery_id='pend-1'").first<{ installation_id: number; event_name: string; raw_body: string }>();
+    expect(row?.installation_id).toBe(9600);
+    expect(row?.event_name).toBe("pull_request");
+    expect(row?.raw_body).toBe('{"n":1}');
+    // Second call with same delivery_id keeps the original (no throw, no duplicate, no overwrite).
+    await enqueueRelayPending(e, { deliveryId: "pend-1", installationId: 9600, eventName: "issues", rawBody: '{"n":2}' });
+    const after = await db(e).prepare("SELECT COUNT(*) AS n, MAX(raw_body) AS body FROM orb_relay_pending WHERE delivery_id='pend-1'").first<{ n: number; body: string }>();
+    expect(after?.n).toBe(1);
+    expect(after?.body).toBe('{"n":1}'); // original retained
+  });
+});
+
+describe("pullRelayPending", () => {
+  it("returns an empty array when nothing is queued (and no ack)", async () => {
+    expect(await pullRelayPending(brokeredEnv(), 9700)).toEqual([]);
+  });
+
+  it("returns this installation's queued events, mapped + ordered, and scoped to the install", async () => {
+    const e = brokeredEnv();
+    await enqueueRelayPending(e, { deliveryId: "a", installationId: 9701, eventName: "pull_request", rawBody: "{}" });
+    await enqueueRelayPending(e, { deliveryId: "b", installationId: 9701, eventName: "issues", rawBody: "{}" });
+    await enqueueRelayPending(e, { deliveryId: "other", installationId: 9999, eventName: "pull_request", rawBody: "{}" }); // a different install
+    const events = await pullRelayPending(e, 9701);
+    expect(events.map((ev) => ev.deliveryId)).toEqual(["a", "b"]); // only this install, ordered
+    expect(events[0]).toEqual({ deliveryId: "a", eventName: "pull_request", rawBody: "{}" });
+  });
+
+  it("ACK-deletes only the named rows, scoped to this installation (can't ack another install's row)", async () => {
+    const e = brokeredEnv();
+    await enqueueRelayPending(e, { deliveryId: "k1", installationId: 9702, eventName: "pull_request", rawBody: "{}" });
+    await enqueueRelayPending(e, { deliveryId: "k2", installationId: 9702, eventName: "issues", rawBody: "{}" });
+    await enqueueRelayPending(e, { deliveryId: "victim", installationId: 8888, eventName: "pull_request", rawBody: "{}" }); // another install
+    // Ack k1 (own) AND victim (another install's id) — only k1 is removed; victim is protected by the install scope.
+    const remaining = await pullRelayPending(e, 9702, { ack: ["k1", "victim"] });
+    expect(remaining.map((ev) => ev.deliveryId)).toEqual(["k2"]);
+    const victim = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='victim'").first();
+    expect(victim ?? null).not.toBeNull(); // the other install's row survived the cross-install ack
+  });
+
+  it("treats an empty ack array as no-op (the ack.length === 0 branch)", async () => {
+    const e = brokeredEnv();
+    await enqueueRelayPending(e, { deliveryId: "n1", installationId: 9703, eventName: "pull_request", rawBody: "{}" });
+    const events = await pullRelayPending(e, 9703, { ack: [] });
+    expect(events.map((ev) => ev.deliveryId)).toEqual(["n1"]); // nothing deleted
+  });
+
+  it("caps the ack list at the batch size so the IN(...) SQL is bounded", async () => {
+    const e = brokeredEnv();
+    // Queue 60 rows, ack 60 ids — only the first 50 (batch cap) are actually deleted.
+    for (let i = 0; i < 60; i += 1) await enqueueRelayPending(e, { deliveryId: `ack-${String(i).padStart(2, "0")}`, installationId: 9704, eventName: "pull_request", rawBody: "{}" });
+    const ackIds = Array.from({ length: 60 }, (_, i) => `ack-${String(i).padStart(2, "0")}`);
+    await pullRelayPending(e, 9704, { ack: ackIds, limit: 1 });
+    const left = await db(e).prepare("SELECT COUNT(*) AS n FROM orb_relay_pending WHERE installation_id=9704").first<{ n: number }>();
+    expect(left?.n).toBe(10); // 60 queued − 50 acked (cap) = 10 remain
+  });
+
+  it("returns at most the batch size, and clamps an over-large requested limit down to it", async () => {
+    const e = brokeredEnv();
+    for (let i = 0; i < 55; i += 1) await enqueueRelayPending(e, { deliveryId: `bulk-${String(i).padStart(2, "0")}`, installationId: 9705, eventName: "pull_request", rawBody: "{}" });
+    expect((await pullRelayPending(e, 9705, { limit: 1000 })).length).toBe(50); // clamped to RELAY_PENDING_BATCH_SIZE
+    expect((await pullRelayPending(e, 9705)).length).toBe(50); // default limit is the batch too (opts undefined arm)
+    expect((await pullRelayPending(e, 9705, { limit: 5 })).length).toBe(5); // a smaller requested limit is honoured
+  });
+
+  it("PRUNES rows older than the TTL before returning the batch", async () => {
+    const e = brokeredEnv();
+    await db(e).prepare("INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body, created_at) VALUES (?, ?, ?, ?, datetime('now', '-25 hours'))").bind("stale-1", 9706, "pull_request", "{}").run();
+    await enqueueRelayPending(e, { deliveryId: "fresh-1", installationId: 9706, eventName: "pull_request", rawBody: "{}" });
+    const events = await pullRelayPending(e, 9706);
+    expect(events.map((ev) => ev.deliveryId)).toEqual(["fresh-1"]); // the 25h-old row was pruned (TTL 24h)
+    const stale = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='stale-1'").first();
+    expect(stale ?? null).toBeNull();
+  });
+});
+
+describe("forwardOrbEvent (pull mode #16)", () => {
+  it("ENQUEUES instead of pushing and returns 'queued' for a pull-mode enrollment", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8100);
+    expect(await registerOrbRelay(e, secret, "", "pull")).toEqual({ ok: true, installationId: 8100 });
+    let fetched = false;
+    const fetchSpy = (() => { fetched = true; return Promise.resolve(new Response("ok")); }) as typeof fetch;
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 8100, deliveryId: "q-1", rawBody: '{"a":1}' }, fetchSpy)).toBe("queued");
+    expect(fetched).toBe(false); // pull mode never pushes
+    const row = await db(e).prepare("SELECT event_name, raw_body FROM orb_relay_pending WHERE delivery_id='q-1' AND installation_id=8100").first<{ event_name: string; raw_body: string }>();
+    expect(row?.event_name).toBe("pull_request");
+    expect(row?.raw_body).toBe('{"a":1}');
+  });
+
+  it("SKIPS an enrolled install with no relay registered (push default, relay_url still null)", async () => {
+    const e = brokeredEnv();
+    await enroll(e, 8101); // enrolled, relay_mode defaults to 'push', no relay_url
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 8101, deliveryId: "d", rawBody: "{}" })).toBe("skipped");
+  });
+
+  it("SKIPS a forwardable event for an install with NO enrollment row at all (the !row arm)", async () => {
+    const e = brokeredEnv();
+    // installationId 8199 is never enrolled → the enrollment lookup returns no row.
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 8199, deliveryId: "d", rawBody: "{}" })).toBe("skipped");
+  });
+
+  it("re-registering a pull enrollment in push mode flips relay_mode back so it PUSHES again", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8102);
+    await registerOrbRelay(e, secret, "", "pull"); // first: pull
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay", "push"); // re-register: push
+    const { fetchImpl, calls } = (() => {
+      const c: { url: string }[] = [];
+      return { fetchImpl: ((u: RequestInfo | URL) => { c.push({ url: String(u) }); return Promise.resolve(new Response("ok")); }) as typeof fetch, calls: c };
+    })();
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 8102, deliveryId: "d", rawBody: "{}" }, fetchImpl)).toBe("forwarded");
+    expect(calls[0]?.url).toBe("https://c.example/v1/orb/relay");
+    const mode = await db(e).prepare("SELECT relay_mode FROM orb_enrollments WHERE installation_id=8102").first<{ relay_mode: string }>();
+    expect(mode?.relay_mode).toBe("push");
+  });
+});
+
+describe("retryFailedRelays treats 'queued' as terminal-success", () => {
+  it("DELETES a failure row once the enrollment switches to pull (forwardOrbEvent now queues it)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8200);
+    await registerOrbRelay(e, secret, "", "pull");
+    // A failure recorded before the switch (or a stale row) is now resolved by queuing on retry.
+    await storeRelayFailure(e, { deliveryId: "requeue-1", eventName: "pull_request", installationId: 8200, rawBody: "{}" });
+    await retryFailedRelays(e);
+    const fail = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='requeue-1'").first();
+    expect(fail ?? null).toBeNull(); // failure row cleaned up — 'queued' is terminal-success
+    const pending = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='requeue-1'").first();
+    expect(pending ?? null).not.toBeNull(); // and the event was moved into the pull queue
+  });
+});
+
+describe("registerOrbRelay pull vs push", () => {
+  it("pull mode sets relay_mode='pull', stamps relay_registered_at, and skips the SSRF + encryption path", async () => {
+    const e = createTestEnv({ ORB_BROKER_ENABLED: "true" }); // no TOKEN_ENCRYPTION_SECRET — pull must not need it
+    const secret = await enroll(e, 8300);
+    expect(await registerOrbRelay(e, secret, "", "pull")).toEqual({ ok: true, installationId: 8300 }); // no encryption_unavailable
+    const row = await db(e).prepare("SELECT relay_mode, relay_url, relay_secret_enc, relay_registered_at FROM orb_enrollments WHERE installation_id=8300").first<{ relay_mode: string; relay_url: string | null; relay_secret_enc: string | null; relay_registered_at: string | null }>();
+    expect(row?.relay_mode).toBe("pull");
+    expect(row?.relay_url ?? null).toBeNull(); // no URL stored for pull
+    expect(row?.relay_secret_enc ?? null).toBeNull(); // no secret encrypted for pull
+    expect(row?.relay_registered_at).toBeTruthy();
+  });
+
+  it("push mode still SSRF-validates and still errors when encryption is unavailable", async () => {
+    const e = brokeredEnv();
+    const s1 = await enroll(e, 8301);
+    expect(await registerOrbRelay(e, s1, "http://127.0.0.1/relay", "push")).toEqual({ error: "invalid_relay_url" }); // SSRF still enforced
+    const noEnc = createTestEnv({ ORB_BROKER_ENABLED: "true" });
+    const s2 = await enroll(noEnc, 8302);
+    expect(await registerOrbRelay(noEnc, s2, "https://x.example/relay", "push")).toEqual({ error: "encryption_unavailable" });
+  });
+
+  it("defaults to push (the mode arm omitted) and sets relay_mode='push'", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8303);
+    expect(await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay")).toEqual({ ok: true, installationId: 8303 });
+    const row = await db(e).prepare("SELECT relay_mode FROM orb_enrollments WHERE installation_id=8303").first<{ relay_mode: string }>();
+    expect(row?.relay_mode).toBe("push");
+  });
+});
+
+describe("POST /v1/orb/relay/register (mode field)", () => {
+  const app = createApp();
+
+  it("accepts mode='pull' WITHOUT a relayUrl and flags the enrollment for pull", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8400);
+    const res = await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ mode: "pull" }) }, e);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, installationId: 8400 });
+    const row = await db(e).prepare("SELECT relay_mode FROM orb_enrollments WHERE installation_id=8400").first<{ relay_mode: string }>();
+    expect(row?.relay_mode).toBe("pull");
+  });
+
+  it("still requires relayUrl for mode='push' (and an omitted mode defaults to push)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8401);
+    expect((await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ mode: "push" }) }, e)).status).toBe(400); // missing_relay_url
+    expect((await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({}) }, e)).status).toBe(400); // default push, missing url
+  });
+
+  it("400s on an unrecognized mode value (neither push nor pull)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8402);
+    const res = await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ mode: "sideways" }) }, e);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_mode" });
+  });
+});
+
+describe("POST /v1/orb/relay/pull", () => {
+  const app = createApp();
+
+  it("404s when the broker flag is off (byte-identical deploy)", async () => {
+    expect((await app.request("/v1/orb/relay/pull", { method: "POST" }, createTestEnv())).status).toBe(404);
+  });
+
+  it("401 without a secret", async () => {
+    expect((await app.request("/v1/orb/relay/pull", { method: "POST" }, brokeredEnv())).status).toBe(401);
+  });
+
+  it("401 on an unknown secret, 403 on an ineligible install", async () => {
+    const e = brokeredEnv();
+    expect((await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: "Bearer orbsec_bad" } }, e)).status).toBe(401);
+    const secret = await enroll(e, 8500);
+    await db(e).prepare("UPDATE orb_github_installations SET registered=0 WHERE installation_id=8500").run();
+    expect((await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e)).status).toBe(403);
+  });
+
+  it("413 when the body exceeds the register-body ceiling", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8501);
+    const res = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: "x".repeat(MAX_ORB_RELAY_REGISTER_BODY_BYTES + 1) }, e);
+    expect(res.status).toBe(413);
+  });
+
+  it("returns the queued events for the bound install (no ack, empty body)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8502);
+    await enqueueRelayPending(e, { deliveryId: "pe-1", installationId: 8502, eventName: "pull_request", rawBody: '{"x":1}' });
+    const res = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ events: [{ deliveryId: "pe-1", eventName: "pull_request", rawBody: '{"x":1}' }] });
+  });
+
+  it("passes a valid ack[] through (acked rows are deleted), and tolerates a non-string ack entry", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8503);
+    await enqueueRelayPending(e, { deliveryId: "ack-a", installationId: 8503, eventName: "pull_request", rawBody: "{}" });
+    await enqueueRelayPending(e, { deliveryId: "ack-b", installationId: 8503, eventName: "issues", rawBody: "{}" });
+    const res = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ ack: ["ack-a", 123] }) }, e); // 123 filtered out
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ events: [{ deliveryId: "ack-b", eventName: "issues", rawBody: "{}" }] }); // ack-a removed
+  });
+
+  it("tolerates a non-array ack field and an unparseable body (no ack, returns events)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8504);
+    await enqueueRelayPending(e, { deliveryId: "keep-1", installationId: 8504, eventName: "pull_request", rawBody: "{}" });
+    const nonArray = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ ack: "nope" }) }, e); // ack not an array
+    expect(await nonArray.json()).toEqual({ events: [{ deliveryId: "keep-1", eventName: "pull_request", rawBody: "{}" }] });
+    const bad = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: "{not json" }, e); // unparseable → catch
+    expect(bad.status).toBe(200);
+    expect(await bad.json()).toEqual({ events: [{ deliveryId: "keep-1", eventName: "pull_request", rawBody: "{}" }] });
   });
 });


### PR DESCRIPTION
## Summary

A brokered self-host engine behind NAT/tailnet **cannot receive the Orb's pushed webhook forwards**: `forwardOrbEvent` (in `src/orb/relay.ts`) POSTs each event to the enrollment's registered `relay_url`, but a tailnet engine's URL is unreachable from the public Orb Worker — so every forward fails, gets recorded as a relay failure, retried fruitlessly for an hour, then dropped. Those engines simply never see their repos' events.

This PR adds the **inert Orb-side half** of the fix ("pull-relay", option 3): instead of being pushed to, a `relay_mode='pull'` enrollment has its events **enqueued** in a per-installation pending queue, and the engine drains that queue **outbound** (which works through NAT). Default behavior is unchanged — `relay_mode` defaults to `'push'`, nothing enqueues unless an enrollment opts into pull, and no engine pulls yet. A later **activation PR** will wire the engine's outbound pull loop; until then this is byte-identical at runtime.

It mirrors the existing `orb_relay_failures` table/code patterns (migration 0070, `storeRelayFailure`/`retryFailedRelays`).

What's included:

- **Migration `0079_orb_relay_pull.sql`** — `relay_mode TEXT NOT NULL DEFAULT 'push'` on `orb_enrollments`, plus the `orb_relay_pending` queue table + `(installation_id, created_at)` index. (These are raw-SQL feature tables, not Drizzle core tables, so there is no `src/db/schema.ts` change — consistent with how `orb_relay_failures`/`orb_enrollments` are represented.)
- **`enqueueRelayPending` / `pullRelayPending`** — idempotent insert (`ON CONFLICT DO NOTHING`); the drain prunes TTL-expired rows (24h), deletes caller-acked rows **scoped to the installation** (so one container can't ack another's), and returns the next ordered batch with both the ack list and the limit clamped to the batch size (50).
- **`forwardOrbEvent`** — for a pull enrollment it enqueues and returns the new `"queued"` status; push behavior is unchanged. `retryFailedRelays` now treats `"queued"` as terminal-success (deletes the failure row).
- **`registerValidatedOrbRelay` / `registerOrbRelay`** — take a `mode: "push" | "pull"` param (default push). Pull flags the enrollment and **skips the SSRF + encryption path entirely** (there's no URL to validate and no forward-time HMAC to store); push also pins `relay_mode='push'` so a re-register flips a pull enrollment back.
- **Routes** — `POST /v1/orb/relay/register` accepts an optional `mode` (push requires `relayUrl`, pull does not; an unknown value is `400 invalid_mode`); new outbound `POST /v1/orb/relay/pull` drains the queue (Bearer enrollment-secret auth, optional `{ ack: string[] }`), added to the token-exempt public-path allowlist. Both endpoints remain flag-gated (`404` until `ORB_BROKER_ENABLED`).

Linked to the relay / self-host work (#16); this is infrastructure-only, hence a direct PR.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- All of `npm run test:ci` ran green (exit 0). Measured patch coverage unsharded with `npm run test:coverage`: **100% statements and 100% branches on every changed line** of both `src/orb/relay.ts` and `src/api/routes.ts`. `npm run ui:openapi` was a no-op (the orb relay routes are internal, not part of the generated OpenAPI surface), so there is no spec drift.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Negative-path tests for the new endpoints/auth: `/v1/orb/relay/pull` covers flag-off `404`, missing-secret `401`, unknown-secret `401`, ineligible-install `403`, oversized-body `413`, and tolerates non-array / non-string-entry / unparseable ack bodies. `/v1/orb/relay/register` covers the new `invalid_mode` `400`, push-still-requires-`relayUrl`, and pull-without-`relayUrl` success. No UI changes, so the UI Evidence boxes are not applicable.

## UI Evidence

No UI, frontend, docs, or extension changes — backend (relay engine + routes) and a DB migration only.

## Notes

- This is the **inert** Orb-side infrastructure. A follow-up activation PR will add the engine's outbound pull loop that calls `POST /v1/orb/relay/pull` and acks delivered events; nothing exercises pull mode until then, so the deploy is byte-identical to today.
