### PR TITLE
fix(review): drop stale files on resync failure

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -28,6 +28,7 @@ import {
   listOpenPullRequests,
   listPullRequests,
   listPullRequestFiles,
+  deletePullRequestFiles,
   listRecentMergedPullRequests,
   updatePullRequestSlopAssessment,
   listRepoLabels,
@@ -1499,13 +1500,11 @@ async function reReviewStoredPullRequest(
     resyncToken,
   );
   if (live?.head?.sha && live.head.sha !== pr.headSha) {
-    await upsertPullRequestFromGitHub(env, repoFullName, live).catch(
-      () => undefined,
-    );
-    await refreshPullRequestDetails(env, repoFullName, prNumber).catch(
-      () => undefined,
-    );
-    /* v8 ignore next -- the row was just upserted above, so the re-read always returns it; `?? pr` is belt-and-suspenders fail-open. */
+    const resynced = await upsertPullRequestFromGitHub(env, repoFullName, live).catch(() => undefined);
+    const detailRefresh = resynced ? await refreshPullRequestDetails(env, repoFullName, prNumber).catch(() => undefined) : undefined;
+    if (detailRefresh?.status !== "complete") {
+      await deletePullRequestFiles(env, repoFullName, prNumber).catch(() => undefined);
+    }
     pr = (await getPullRequest(env, repoFullName, prNumber)) ?? pr;
   }
   // Operator review flow: rebase-if-behind → wait for ALL CI to finish → only THEN review. Defers (returns) when

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -768,6 +768,33 @@ describe("queue processors", () => {
     expect(liveFilesFetched).toBe(true);
   });
 
+  it("#sweep-resync: failed live-head file refresh drops stale cached files before review", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    await upsertPullRequestFile(env, { repoFullName: "owner/agent-repo", pullNumber: 7, path: "src/old.ts", status: "modified", additions: 1, deletions: 0, changes: 1, payload: { patch: "@@\n+export const oldHead = true;" } });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Drifted PR", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return new Response("temporary files outage", { status: 503 });
+      if (url.includes("/commits/b8/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/b8/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await expect(processJob(env, { type: "agent-regate-pr", deliveryId: "resync-file-fail", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 })).resolves.toBeUndefined();
+
+    const stored = await getPullRequest(env, "owner/agent-repo", 7);
+    expect(stored?.headSha).toBe("b8");
+    expect(await listPullRequestFiles(env, "owner/agent-repo", 7)).toEqual([]);
+  });
+
   it("#sweep-resync: re-review does NOT resync when the stored head already matches the live head", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
### Motivation
- The live-head resync path could advance the stored PR `headSha` before its dependent pull-request file refresh completed, allowing stale `pull_request_files` rows from the old head to be trusted for review and merge planning.
- This created a TOCTOU where a missed `synchronize` webhook + a partial/failed file-sync could let unreviewed live heads be auto-approved/merged.
- The change prevents stale file rows from surviving a failed detail refresh so subsequent review logic must re-fetch live files or degrade safely.

### Description
- Import and use `deletePullRequestFiles` and, during resync, only treat the detail refresh as authoritative when it reports `status: "complete"`.
- Change `reReviewStoredPullRequest` so that after upserting the live PR we attempt `refreshPullRequestDetails`, and when that refresh is not `complete` we delete the `pull_request_files` rows for the PR to avoid trusting stale file data.
- Add a regression test `#sweep-resync: failed live-head file refresh drops stale cached files before review` that seeds an old-head file row, simulates live head drift and a failing `/pulls/:n/files` response, and asserts the stored head advances while cached files are cleared.

### Testing
- Ran targeted unit tests in `test/unit/queue.test.ts -t "sweep-resync"` and the new regression test passed. 
- Ran the same file with the specific `-t "failed live-head"` case and it passed (Vitest). 
- Typecheck (`npm run typecheck`) completed with no errors. 
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry returning `403 Forbidden` (external audit endpoint), not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb6fdad4c832cbcc9433a614641fe)