### PR TITLE
ci: run gittensory CI on self-hosted runners (fork PRs stay hosted)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   audit:
     name: audit
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   # On push to main everything runs regardless (keeps the coverage baseline solid).
   changes:
     name: changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -71,7 +71,7 @@ jobs:
     name: lint
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
     name: test
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -192,7 +192,7 @@ jobs:
     name: coverage-upload
     needs: [changes, test]
     if: ${{ (github.event_name == 'push' || needs.changes.outputs.backend == 'true') && needs.test.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -246,7 +246,7 @@ jobs:
     name: workers
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -277,7 +277,7 @@ jobs:
     name: mcp
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -310,7 +310,7 @@ jobs:
     name: ui
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 15
     env:
       VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
@@ -354,7 +354,7 @@ jobs:
   security:
     name: security
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -375,7 +375,7 @@ jobs:
     name: validate
     needs: [changes, lint, test, coverage-upload, workers, mcp, ui, security]
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 2
     steps:
       - name: All required jobs passed


### PR DESCRIPTION
## Summary

Pilot routing gittensory's heavy CI to the self-hosted runner pool, fork-safe.

Every job in `ci.yml` (all 9: `changes`, `lint`, `test`, `coverage-upload`, `workers`, `mcp`, `ui`, `security`, `validate`) and the single job in `audit.yml` now select the runner with one conditional:

```yaml
runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
```

- **Fork PRs stay on `ubuntu-latest`** — untrusted contributor code must never execute on the self-hosted box.
- **Trusted pushes to `main` and same-repo PRs use `self-hosted`** — the fast self-hosted runner pool.

The bare `self-hosted` label is sufficient because only this repo's registered runner is reachable from this repo. Deploy/publish workflows (`npm-publish`, `release-selfhost`, `selfhost`, `ui-deploy`, `ui-preview*`, `mcp-*`, `upstream-contract`, `self-host-nightly`) are intentionally untouched and remain on `ubuntu-latest`.

This PR is a same-repo PR, so its own CI run executes on the self-hosted runners — that run is the verification.

No issue is linked: this is a small, self-evident infra change scoped to two workflow files, touching only `runs-on`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — n/a, no `src/**` change; covered by the full `npm run test:ci` run below
- [ ] `npm run test:coverage` — n/a, workflow-only change; no `src/**` lines changed, so `codecov/patch` emits no context
- [x] `npm run test:ci` (the full local gate, green: actionlint, db:migrations:check, typecheck, test:coverage, test:workers, build:mcp, test:mcp-pack, ui:openapi:check, ui:version-audit, ui:lint, ui:typecheck, ui:test, ui:build)
- [x] `npm audit --audit-level=moderate`
- [x] YAML/Actions-expression validity confirmed (parsed cleanly; `actionlint` clean)

If any required check was skipped, explain why:

- Coverage-specific checks are not applicable: the diff touches only `.github/workflows/*.yml` (no `src/**`), so there is no patch coverage obligation. The full `npm run test:ci` gate was still run and is green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — n/a, no such changes; the fork-safety guard keeps untrusted code off the self-hosted runner.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — n/a, no API/MCP change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section. — n/a, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — n/a.

## Notes

- Pilot only on this repo; rollout to metagraphed + awesome-claude follows after a confirmed-green self-hosted run here.
