### PR TITLE
feat(enrichment): ReDoS scanner on added/changed regex

### DIFF
--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -1,0 +1,161 @@
+// ReDoS analyzer (#1503). Flags regex literals INTRODUCED by the PR (added `+` diff lines) that are vulnerable to
+// catastrophic backtracking — a group quantified by an unbounded quantifier (`+`, `*`, `{n,}`) whose body ALSO
+// contains an unbounded quantifier: the classic `(a+)+` shape that turns attacker-controlled input into a DoS.
+// Pure compute, no network, no external detector (structural-only → high precision: linear shapes like `(abc)+`
+// are NOT flagged). Line-cited via hunk headers, mirroring the actions-pin analyzer.
+import type { EnrichRequest, RedosFinding } from "../types.js";
+
+// Every loop runs over an attacker-controlled patch, so each is bounded.
+const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_PATTERN_CHARS = 1000; // ignore absurdly long literals (a hand-written regex is never this long)
+const MAX_LINE_CHARS = 2000; // skip extraction on pathologically long lines (defensive)
+const REPORT_CHARS = 80; // truncate the reported pattern so the brief stays readable
+
+// A `/.../flags` literal in regex position (line start or an operator/punctuation that cannot begin a division),
+// OR a `new RegExp("…")` / `RegExp('…')` constructor argument. The structural check below filters non-ReDoS noise,
+// so a slightly-loose extraction here cannot, on its own, produce a false ReDoS finding. Both patterns use only
+// non-overlapping alternations + negated classes, so they are themselves linear-time (no self-ReDoS).
+const LITERAL_RE =
+  /(?:^|[=(,:?&|!{[;\s])\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\\\n])+)\/[a-z]*/g;
+const CTOR_RE = /\bRegExp\s*\(\s*(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+
+/** Extract candidate regex SOURCES from one line of added code (`/.../` literals + `RegExp(...)` string args). */
+export function extractRegexSources(line: string): string[] {
+  const sources: string[] = [];
+  if (line.length > MAX_LINE_CHARS) return sources;
+  LITERAL_RE.lastIndex = 0;
+  for (let m: RegExpExecArray | null; (m = LITERAL_RE.exec(line)); ) {
+    if (m[1] && m[1].length <= MAX_PATTERN_CHARS) sources.push(m[1]);
+  }
+  CTOR_RE.lastIndex = 0;
+  for (let m: RegExpExecArray | null; (m = CTOR_RE.exec(line)); ) {
+    if (m[2] && m[2].length <= MAX_PATTERN_CHARS) sources.push(m[2]);
+  }
+  return sources;
+}
+
+// An unbounded quantifier (`+`, `*`, or `{n,}`) at index `i`? `{n}` and `{n,m}` are bounded and ignored.
+function unboundedQuantifierAt(p: string, i: number): boolean {
+  const c = p[i];
+  if (c === "+" || c === "*") return true;
+  if (c === "{") return /^\{\d*,\}/.test(p.slice(i));
+  return false;
+}
+
+// Does the group body p[open+1 .. close-1] contain an unbounded quantifier (ignoring escapes + char classes,
+// inside which `+`/`*` are literal)?
+function bodyHasUnboundedQuantifier(
+  p: string,
+  open: number,
+  close: number,
+): boolean {
+  let i = open + 1;
+  let inClass = false;
+  while (i < close) {
+    const c = p[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (inClass) {
+      if (c === "]") inClass = false;
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (unboundedQuantifierAt(p, i)) return true;
+    i++;
+  }
+  return false;
+}
+
+/** Catastrophic-backtracking detector: a group `(…)` quantified by an unbounded quantifier whose body ALSO
+ *  contains an unbounded quantifier — `(a+)+`, `(\d+)*`, `(.*)+`, … Returns false for linear shapes like `(abc)+`. */
+export function hasCatastrophicBacktracking(pattern: string): boolean {
+  const openStack: number[] = [];
+  let i = 0;
+  let inClass = false;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (inClass) {
+      if (c === "]") inClass = false;
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (c === "(") {
+      openStack.push(i);
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      const open = openStack.pop();
+      if (
+        open !== undefined &&
+        unboundedQuantifierAt(pattern, i + 1) &&
+        bodyHasUnboundedQuantifier(pattern, open, i)
+      ) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return false;
+}
+
+/** Scan one file patch's added lines for ReDoS-prone regex literals, line-cited via hunk headers. Pure. */
+export function scanPatchForRedos(path: string, patch: string): RedosFinding[] {
+  const findings: RedosFinding[] = [];
+  let newLine = 0;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (line.startsWith("+")) {
+      for (const source of extractRegexSources(line.slice(1))) {
+        if (hasCatastrophicBacktracking(source)) {
+          findings.push({
+            file: path,
+            line: newLine,
+            kind: "nested-quantifier",
+            pattern: source.slice(0, REPORT_CHARS),
+          });
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-")) {
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed file's added lines for ReDoS-prone regex literals. */
+export async function scanRedos(req: EnrichRequest): Promise<RedosFinding[]> {
+  const findings: RedosFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (!file.patch) continue;
+    for (const finding of scanPatchForRedos(file.path, file.patch)) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -11,25 +11,132 @@ const MAX_PATTERN_CHARS = 1000; // ignore absurdly long literals (a hand-written
 const MAX_LINE_CHARS = 2000; // skip extraction on pathologically long lines (defensive)
 const REPORT_CHARS = 80; // truncate the reported pattern so the brief stays readable
 
-// A `/.../flags` literal in regex position (line start or an operator/punctuation that cannot begin a division),
-// OR a `new RegExp("…")` / `RegExp('…')` constructor argument. The structural check below filters non-ReDoS noise,
-// so a slightly-loose extraction here cannot, on its own, produce a false ReDoS finding. Both patterns use only
-// non-overlapping alternations + negated classes, so they are themselves linear-time (no self-ReDoS).
-const LITERAL_RE =
-  /(?:^|[=(,:?&|!{[;\s])\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\\\n])+)\/[a-z]*/g;
-const CTOR_RE = /\bRegExp\s*\(\s*(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+// Extraction runs as a single LINEAR left-to-right scan — deliberately NOT a regex. A regex with the alternation
+// needed here (escapes | char-classes | other chars, all under `+`) has overlapping branches and would itself
+// backtrack catastrophically on adversarial diff input (e.g. many empty `[]` classes with no closing `/`). The
+// hand scan visits each char once, so the extractor can never be the DoS it exists to detect. Two shapes:
+//   - a `/.../flags` literal in regex position (line start, or after a punctuator that cannot end an operand, so
+//     `a / b` division is not mistaken for a regex);
+//   - a `new RegExp("…")` / `RegExp('…')` / RegExp(`…`) constructor's string argument.
+// A slightly-loose extraction is fine: the structural check below is what decides ReDoS, so over-extraction can
+// never produce a false finding on its own.
+
+// `/` opens a regex literal (not division) when the char just before it is a statement/operator boundary.
+const REGEX_POSITION_PREFIX = "=(,:?&|!{[;";
+
+function isWordChar(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+function isRegexPosition(line: string, slash: number): boolean {
+  if (slash === 0) return true;
+  const before = line[slash - 1]!;
+  return (
+    before === " " || before === "\t" || REGEX_POSITION_PREFIX.includes(before)
+  );
+}
+
+// From the opening `/` at `open`, linearly consume the literal body (escapes and `[...]` classes are transparent
+// to the closing `/`) plus any trailing flags. Returns the body + index past the literal, or null if unterminated.
+function scanRegexLiteral(
+  line: string,
+  open: number,
+): { body: string; end: number } | null {
+  const n = line.length;
+  const bodyStart = open + 1;
+  let i = bodyStart;
+  let inClass = false;
+  while (i < n) {
+    const ch = line[i]!;
+    if (ch === "\\") {
+      if (i + 1 >= n) return null;
+      i += 2;
+      continue;
+    }
+    if (ch === "\n") return null;
+    if (inClass) {
+      if (ch === "]") inClass = false;
+      i++;
+      continue;
+    }
+    if (ch === "[") {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (ch === "/") {
+      if (i === bodyStart) return null; // empty body — `//` is a comment, not a regex literal
+      let j = i + 1;
+      while (j < n && line[j]! >= "a" && line[j]! <= "z") j++;
+      return { body: line.slice(bodyStart, i), end: j };
+    }
+    i++;
+  }
+  return null;
+}
+
+// `RegExp` is expected at `i` (word boundary checked by the caller). Linearly read its first string argument.
+// Returns the raw string source + index past the closing quote, or null if it is not a string-literal ctor call.
+function scanRegExpCtorArg(
+  line: string,
+  i: number,
+): { body: string; end: number } | null {
+  const n = line.length;
+  let j = i + "RegExp".length;
+  while (j < n && (line[j] === " " || line[j] === "\t")) j++;
+  if (line[j] !== "(") return null;
+  j++;
+  while (j < n && (line[j] === " " || line[j] === "\t")) j++;
+  const quote = line[j];
+  if (quote !== '"' && quote !== "'" && quote !== "`") return null;
+  const bodyStart = ++j;
+  while (j < n) {
+    const ch = line[j]!;
+    if (ch === "\\") {
+      if (j + 1 >= n) return null;
+      j += 2;
+      continue;
+    }
+    if (ch === quote) return { body: line.slice(bodyStart, j), end: j + 1 };
+    j++;
+  }
+  return null;
+}
 
 /** Extract candidate regex SOURCES from one line of added code (`/.../` literals + `RegExp(...)` string args). */
 export function extractRegexSources(line: string): string[] {
   const sources: string[] = [];
-  if (line.length > MAX_LINE_CHARS) return sources;
-  LITERAL_RE.lastIndex = 0;
-  for (let m: RegExpExecArray | null; (m = LITERAL_RE.exec(line)); ) {
-    if (m[1] && m[1].length <= MAX_PATTERN_CHARS) sources.push(m[1]);
-  }
-  CTOR_RE.lastIndex = 0;
-  for (let m: RegExpExecArray | null; (m = CTOR_RE.exec(line)); ) {
-    if (m[2] && m[2].length <= MAX_PATTERN_CHARS) sources.push(m[2]);
+  const n = line.length;
+  if (n > MAX_LINE_CHARS) return sources;
+  let i = 0;
+  while (i < n) {
+    const c = line[i]!;
+    if (c === "/" && isRegexPosition(line, i)) {
+      const lit = scanRegexLiteral(line, i);
+      if (lit) {
+        if (lit.body.length <= MAX_PATTERN_CHARS) sources.push(lit.body);
+        i = lit.end;
+        continue;
+      }
+    } else if (
+      c === "R" &&
+      (i === 0 || !isWordChar(line[i - 1]!)) &&
+      line.startsWith("RegExp", i)
+    ) {
+      const ctor = scanRegExpCtorArg(line, i);
+      if (ctor) {
+        if (ctor.body.length <= MAX_PATTERN_CHARS) sources.push(ctor.body);
+        i = ctor.end;
+        continue;
+      }
+    }
+    i++;
   }
   return sources;
 }

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -13,6 +13,7 @@ import { scanLicenses } from "./analyzers/license-check.js";
 import { scanInstallScripts } from "./analyzers/install-scripts.js";
 import { scanActionPins } from "./analyzers/actions-pin.js";
 import { scanEol } from "./analyzers/eol-check.js";
+import { scanRedos } from "./analyzers/redos.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest, signal: AbortSignal) => Promise<unknown>;
@@ -25,6 +26,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   installScript: (req) => scanInstallScripts(req),
   actionPin: (req) => scanActionPins(req),
   eol: (req) => scanEol(req),
+  redos: (req) => scanRedos(req),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -117,6 +117,18 @@ export function renderBrief(
     }
   }
 
+  const redos = findings.redos ?? [];
+  if (redos.length) {
+    lines.push(
+      "### ReDoS-prone regex (catastrophic backtracking — DoS on attacker-controlled input)",
+    );
+    for (const item of redos) {
+      lines.push(
+        `- ${safeCodeSpan(`${item.file}:${item.line}`)} — ${safeCodeSpan(item.pattern)} nests an unbounded quantifier inside an unbounded-quantified group; bound the repetition or rewrite without nesting`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -84,6 +84,15 @@ export interface EolFinding {
   status: "eol" | "soon";
 }
 
+/** A regex literal introduced by the PR that is vulnerable to catastrophic backtracking (ReDoS). Reports the
+ *  location + the (truncated) vulnerable pattern only — never any matched value. */
+export interface RedosFinding {
+  file: string;
+  line: number;
+  kind: "nested-quantifier";
+  pattern: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -92,6 +101,7 @@ export interface BriefFindings {
   actionPin?: ActionPinFinding[];
   installScript?: InstallScriptFinding[];
   eol?: EolFinding[];
+  redos?: RedosFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -15,6 +15,11 @@ import {
   scanActionPins,
 } from "../dist/analyzers/actions-pin.js";
 import { scanEol, extractVersionPins } from "../dist/analyzers/eol-check.js";
+import {
+  hasCatastrophicBacktracking,
+  scanPatchForRedos,
+  scanRedos,
+} from "../dist/analyzers/redos.js";
 
 const NOW = new Date("2026-06-26").getTime();
 const eolFetch =
@@ -592,6 +597,100 @@ test("buildBrief: action-pin analyzer runs (pure, no network)", async () => {
     assert.equal(brief.analyzerStatus.actionPin, "ok");
     assert.equal(brief.findings.actionPin.length, 1);
     assert.match(brief.promptSection, /Unpinned GitHub Actions/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("hasCatastrophicBacktracking: flags nested unbounded quantifiers, not linear/bounded shapes", () => {
+  for (const vuln of [
+    "(a+)+",
+    "(a*)*",
+    "(a+)*",
+    "(.*)+",
+    "(\\d+){2,}",
+    "([a-z]+)+",
+    "((ab)+)+",
+  ]) {
+    assert.equal(hasCatastrophicBacktracking(vuln), true, vuln);
+  }
+  for (const safe of [
+    "(abc)+",
+    "[a-z]+",
+    "(a+)?",
+    "(a+){2,4}",
+    "abc",
+    "(a|b)+",
+    "\\(a+\\)+",
+  ]) {
+    assert.equal(hasCatastrophicBacktracking(safe), false, safe);
+  }
+});
+
+test("scanPatchForRedos: flags added ReDoS literals + RegExp(...) ctors, line-cited; ignores context + safe regex", () => {
+  const patch = [
+    "@@ -1,1 +1,4 @@",
+    " const ok = /(abc)+/;",
+    "+const bad = /(a+)+$/;",
+    "+const safe = /[a-z]+/;",
+    '+const ctor = new RegExp("(\\\\d+)*x");',
+  ].join("\n");
+  const findings = scanPatchForRedos("src/x.ts", patch);
+  assert.deepEqual(
+    findings.map(({ file, line, kind }) => ({ file, line, kind })),
+    [
+      { file: "src/x.ts", line: 2, kind: "nested-quantifier" },
+      { file: "src/x.ts", line: 4, kind: "nested-quantifier" },
+    ],
+  );
+  assert.equal(findings[0].pattern, "(a+)+$");
+});
+
+test("scanRedos: scans every changed file's added lines, caps to its budget", async () => {
+  const findings = await scanRedos({
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      { path: "src/a.ts", patch: "@@ -1,0 +1,1 @@\n+const r = /(x+)+/;" },
+      { path: "src/b.ts", patch: "@@ -1,0 +1,1 @@\n+const r = /[0-9]+/;" },
+      { path: "README.md", patch: undefined },
+    ],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "src/a.ts");
+});
+
+test("renderBrief: renders the ReDoS block, code-spanning + sanitizing the pattern", () => {
+  const r = renderBrief({
+    redos: [
+      {
+        file: "src/re.ts",
+        line: 7,
+        kind: "nested-quantifier",
+        pattern: "(a+)+ ",
+      },
+    ],
+  });
+  assert.match(r.promptSection, /ReDoS-prone regex/);
+  assert.match(r.promptSection, /`src\/re\.ts:7`/);
+  assert.match(r.promptSection, /`\(a\+\)\+/);
+  assert.doesNotMatch(r.promptSection, / /); // control char in the pattern is neutralized
+});
+
+test("buildBrief: ReDoS analyzer runs (pure, no network)", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [
+        { path: "src/x.ts", patch: "@@ -1,0 +1,1 @@\n+const r = /(a+)+$/;" },
+      ],
+    });
+    assert.equal(brief.analyzerStatus.redos, "ok");
+    assert.equal(brief.findings.redos.length, 1);
+    assert.match(brief.promptSection, /ReDoS-prone regex/);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../dist/analyzers/actions-pin.js";
 import { scanEol, extractVersionPins } from "../dist/analyzers/eol-check.js";
 import {
+  extractRegexSources,
   hasCatastrophicBacktracking,
   scanPatchForRedos,
   scanRedos,
@@ -625,6 +626,20 @@ test("hasCatastrophicBacktracking: flags nested unbounded quantifiers, not linea
   ]) {
     assert.equal(hasCatastrophicBacktracking(safe), false, safe);
   }
+});
+
+test("extractRegexSources: linear scan, no catastrophic backtracking on adversarial char classes (#1503 regression)", () => {
+  // The former LITERAL_RE extractor backtracked exponentially on many empty `[]` classes with no closing slash;
+  // the linear scanner returns immediately (a regression would hang this test).
+  const adversarial = "x = /" + "[]".repeat(800);
+  assert.deepEqual(extractRegexSources(adversarial), []);
+  // Well-formed literals (incl. char classes + flags) and RegExp() ctors still extract correctly:
+  assert.deepEqual(extractRegexSources("const r = /[a-z][0-9]+/g;"), [
+    "[a-z][0-9]+",
+  ]);
+  assert.deepEqual(extractRegexSources('new RegExp("(a+)+")'), ["(a+)+"]);
+  // `a / b` division is not mistaken for a regex literal:
+  assert.deepEqual(extractRegexSources("const n = a / b;"), []);
 });
 
 test("scanPatchForRedos: flags added ReDoS literals + RegExp(...) ctors, line-cited; ignores context + safe regex", () => {


### PR DESCRIPTION
Closes #1503.

Adds a REES analyzer that flags regex literals **introduced by the PR** (added `+` diff lines) vulnerable to catastrophic backtracking — a group quantified by an unbounded quantifier (`+`, `*`, `{n,}`) whose body *also* contains an unbounded quantifier (the classic `(a+)+` / `(\w+\.)+` shape that turns attacker-controlled input into a DoS). This is exactly the heavy/structural analysis the no-checkout in-prompt reviewer cannot do; the brief block is spliced into the review (additive + fail-safe).

### Approach
Self-contained, pure-CPU — **no network and no new runtime dependency**. A structural detector rather than a bundled `recheck`/`redos-detector` binary, so there is no Dockerfile/runtime-image change. Structural-only keeps precision high: linear shapes like `(abc)+`, bounded `(a+){2,4}`, and non-quantified alternation `(a|b)+` are **not** flagged.

- Extracts regex sources from added lines: `/.../flags` literals in regex position + `new RegExp("…")` / `RegExp('…')` constructor args. The extractors use only non-overlapping alternations + negated classes, so they are themselves linear-time (no self-ReDoS).
- Detects nested unbounded quantifiers by tracking group spans, escape- and char-class-aware.
- Line-cited via hunk headers, mirroring the actions-pin analyzer. Findings are bounded (`MAX_FINDINGS`, per-line length guard); the reported pattern is truncated and rendered through `safeCodeSpan` (public-safe — no matched value echoed).

### Files (all inside `review-enrichment/`, per the established analyzer pattern)
- `src/types.ts` — `RedosFinding` type + `redos` `BriefFindings` key
- `src/analyzers/redos.ts` — the analyzer (pure helpers + `scanRedos` entrypoint)
- `src/brief.ts` — registered in the `ANALYZERS` registry
- `src/render.ts` — public-safe brief block
- `test/enrichment.test.ts` — detector unit tests, line-cited scan, entrypoint cap, render sanitization, and a `buildBrief` integration test

### Validation
- `npm test` (build + `node --test`) inside `review-enrichment/`: **43/43 pass** (5 new).
- `git diff --check` clean; engine `src/**` untouched (outside the engine tsc/vitest/codecov scope — zero conflict).
