### PR TITLE
ci: keep pull request jobs on hosted runners

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   audit:
     name: audit
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   # On push to main everything runs regardless (keeps the coverage baseline solid).
   changes:
     name: changes
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -71,7 +71,7 @@ jobs:
     name: lint
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
     name: test
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -192,7 +192,7 @@ jobs:
     name: coverage-upload
     needs: [changes, test]
     if: ${{ (github.event_name == 'push' || needs.changes.outputs.backend == 'true') && needs.test.result == 'success' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -246,7 +246,7 @@ jobs:
     name: workers
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -277,7 +277,7 @@ jobs:
     name: mcp
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -310,7 +310,7 @@ jobs:
     name: ui
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 15
     env:
       VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
@@ -354,7 +354,7 @@ jobs:
   security:
     name: security
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -375,7 +375,7 @@ jobs:
     name: validate
     needs: [changes, lint, test, coverage-upload, workers, mcp, ui, security]
     if: ${{ always() }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 2
     steps:
       - name: All required jobs passed


### PR DESCRIPTION
### Motivation

- Prevent same-repo `pull_request` runs from executing PR-controlled code on the persistent self-hosted runner by moving PR jobs to GitHub-hosted runners. 
- Close a CI-to-infrastructure escape where checked-out PR heads could run `npm ci` / lifecycle scripts on a self-hosted host with elevated access. 
- Keep trusted non-PR events (push / workflow_dispatch / scheduled) on the `self-hosted` runner where required.

### Description

- Updated `runs-on` expressions in `.github/workflows/ci.yml` so every `pull_request` job uses `ubuntu-latest` and non-PR events use `self-hosted` (replaced the prior expression that routed same-repo PRs to the bare `self-hosted` label). 
- Set the scheduled audit workflow `.github/workflows/audit.yml` to run on `self-hosted` directly since it is not triggered by PRs. 
- Changes are limited to `.github/workflows/ci.yml` and `.github/workflows/audit.yml` and preserve existing job steps and path filters.

### Testing

- `git diff --check` succeeded. 
- `npm run actionlint` encountered transient DNS failures contacting GitHub and fell back to the WASM linter which reported the repo's custom `gittensory` self-hosted label (the fallback reported a warning/error); the network issue caused the lint step to not fully validate in this environment. 
- A local Node expression check verifying the `pull_request` vs `push`/`workflow_dispatch` branching for `runs-on` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe10ba560832c8d3a6bf2139cacfc)