### PR TITLE
feat(selfhost): native codex subscription provider (CODEX_HOME volume + setup docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,17 @@ GITTENSORY_REVIEW_DRAFT=false
 # AI_API_KEY=                                # generic key for the openai-compatible endpoint
 # ANTHROPIC_API_KEY=                         # for AI_PROVIDER=anthropic (native Messages API, BYOK)
 # OPENAI_API_KEY=                            # for AI_PROVIDER=openai
+# CLAUDE_CODE_OAUTH_TOKEN=                   # for AI_PROVIDER=claude-code (subscription; from `claude setup-token`)
+#
+# Codex (ChatGPT subscription) second reviewer — NO API key, uses your ChatGPT plan via the baked-in `codex` CLI.
+#   AI_PROVIDER=claude-code,codex            # dual review: Claude + Codex, combined per AI_COMBINE above
+# The `codex` CLI is pre-baked when the image is built with --build-arg INSTALL_AI_CLIS=true. Authenticate ONCE on a
+# trusted machine — `codex login` (browser) or `codex login --device-auth` (headless) — then place the resulting
+# ~/.codex/auth.json into the WRITABLE codex-home volume the compose file mounts at CODEX_HOME (default /home/node/.codex):
+#   docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json   # then: docker compose restart gittensory
+# codex auto-refreshes the token in place (hence the writable volume). Leave AI_MODEL unset on a ChatGPT login —
+# pinning gpt-5* errors "not supported with a ChatGPT account"; codex picks the entitled default.
+# CODEX_HOME=/home/node/.codex               # override only to relocate the codex home (match the compose mount)
 # AI_MODEL=llama3.1                          # the model for your provider (e.g. llama3.1 for Ollama, sonnet
 #                                            #   for claude-code, gpt-5 for codex). REQUIRED for non-Ollama:
 #                                            #   without it the adapter falls back to a provider default, never

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       # files (and an optional root .gittensory.yml global fallback). Keeps each repo's policy OUT of the public
       # GitHub repo so contributors can't game the rules. Empty/unmounted ⇒ repos use the public file / defaults.
       GITTENSORY_REPO_CONFIG_DIR: "${GITTENSORY_REPO_CONFIG_DIR:-/config}"
+      # Codex (ChatGPT subscription) reviewer home (#979). The `codex` CLI reads auth.json from $CODEX_HOME and
+      # REFRESHES the OAuth token in place, so the home MUST be writable — that's the codex-home named volume below,
+      # NOT the read-only /config mount. Defaults to the image `node` run user's ~/.codex; override to relocate.
+      CODEX_HOME: "${CODEX_HOME:-/home/node/.codex}"
       # Claude Code usage telemetry → OTEL collector → Prometheus → Claude usage dashboard. OFF unless you set
       # CLAUDE_CODE_ENABLE_TELEMETRY=1 in .env (requires --profile observability so the otel-collector is up).
       CLAUDE_CODE_ENABLE_TELEMETRY: "${CLAUDE_CODE_ENABLE_TELEMETRY:-}"
@@ -74,6 +78,12 @@ services:
       # Container-private per-repo config dir (read-only). Create ./gittensory-config/{owner}__{repo}/.gittensory.yml
       # locally (gitignored — never commit real policy). Absent ⇒ Docker mounts an empty dir ⇒ defaults apply.
       - ./gittensory-config:/config:ro
+      # Persistent, WRITABLE Codex home for the `codex` (ChatGPT subscription) reviewer — survives restarts so the
+      # auth.json you drop in (and codex's in-place token refresh + app-server state) outlive the container. The
+      # node run user owns /home/node, so the volume is writable. Drop your `codex login` auth.json in with:
+      #   docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json
+      # If you override CODEX_HOME above, change this mount target to match (it must equal $CODEX_HOME).
+      - codex-home:/home/node/.codex
     depends_on:
       # Gate startup on a healthy Qdrant when --profile qdrant is active; required:false means the
       # dependency is ignored when qdrant isn't started (default/other profiles). Belt-and-suspenders
@@ -455,6 +465,7 @@ services:
 
 volumes:
   gittensory-data:
+  codex-home:
   gittensory-pg:
   qdrant-data:
   ollama-models:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -146,10 +146,20 @@ bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. N
   substantive review, not a fast shallow one); override with `AI_MODEL` (any `claude`-CLI model id or alias —
   `sonnet`, `opus`, `claude-opus-4-8`, …) and `AI_EFFORT` (`low`|`medium`|`high`|`xhigh`|`max`; the CLI clamps a
   level above the model's own ceiling).
-- **Codex:** codex reads `auth.json` from `$CODEX_HOME` (default `~/.codex`) and **must have a WRITABLE home** — it
-  refreshes the token in place, so a read-only mount fails with _"Read-only file system"_. Set `CODEX_HOME` to a
-  writable path and **copy** your `~/.codex/auth.json` there (don't bind-mount it read-only). With a ChatGPT-
-  subscription login, leave `AI_MODEL` unset for codex — pinning `gpt-5*` returns _"not supported … with a ChatGPT
+- **Codex (ChatGPT subscription) — second AI reviewer.** Native, like `claude-code`: the `codex` CLI is **pre-baked**
+  (`INSTALL_AI_CLIS=true`) and reviews run on your **ChatGPT subscription** — **no API key**. It reads `auth.json` from
+  `$CODEX_HOME`, which the compose file points at a **persistent, writable `codex-home` volume** (default
+  `/home/node/.codex`, the `node` run user's home) — codex refreshes the OAuth token **in place**, so the home must be
+  writable (a read-only mount fails with _"Read-only file system"_) and durable (so the refreshed token survives
+  restarts). Set it up once:
+  1. On a trusted machine, authenticate: `codex login` (browser) — or `codex login --device-auth` for a headless box —
+     which writes `~/.codex/auth.json`.
+  2. Drop that file into the volume: `docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json`
+     (or bind-mount a host dir at `$CODEX_HOME` — keep it **read-write**, never `:ro`).
+  3. Add codex to the reviewer set and restart: `AI_PROVIDER=claude-code,codex` (combined per `AI_COMBINE`), then
+     `docker compose up -d --force-recreate gittensory`.
+
+  Leave `AI_MODEL` unset for a ChatGPT-subscription login — pinning `gpt-5*` returns _"not supported … with a ChatGPT
   account"_; codex picks the entitled default. (`ca-certificates` for codex's native TLS is baked in by `INSTALL_AI_CLIS`.)
 
 **Local RAG (retrieval-augmented review).** Self-host ships a SQLite-backed vector store, so RAG works without


### PR DESCRIPTION
Makes the codex (ChatGPT subscription) provider native in the self-host stack: persistent CODEX_HOME volume + env + docs so a self-hoster's `codex login` auth.json plugs in for dual-review. CLI already baked; CODEX_HOME already allowlisted.