### PR TITLE
fix(review): hold low-confidence AI defects

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3765,13 +3765,13 @@ export async function runAiReviewForAdvisory(
         detail: result.consensusDefect.detail,
         action:
           "Resolve the flagged defect, or override if the AI reviewers are mistaken, then re-run the gate.",
-        // Calibrated confidence (#8): the gate blocks this defect only when it clears aiReviewCloseConfidence.
+        // Calibrated confidence (#8): clears aiReviewCloseConfidence ⇒ block; below it ⇒ human-review hold.
         confidence: result.consensusDefect.confidence,
       });
     } else if (result.split) {
-      // The reviewers DISAGREED — exactly one flagged a blocking defect. reviewbot's quorum: ANY reviewer
-      // rejection closes the PR, so a split is a HARD BLOCKER (advisory.ts gates `ai_review_split` like a
-      // consensus defect → gate failure → close); the contributor resubmits a fresh PR. (#ai-review-split)
+      // The reviewers DISAGREED — exactly one flagged a blocking defect. reviewbot's quorum treats any reviewer
+      // rejection as a configured AI defect; advisory.ts gates `ai_review_split` like a consensus defect, with
+      // the same confidence floor deciding block vs human-review hold. (#ai-review-split)
       findings.push({
         code: "ai_review_split",
         severity: "critical",
@@ -3780,10 +3780,10 @@ export async function runAiReviewForAdvisory(
           "One AI reviewer independently flagged a concrete must-fix defect in this change (the other did not). Under the quorum rule, a single rejection closes the PR; see the review notes for specifics.",
         action:
           "Resolve the flagged defect and open a new pull request, or override if the reviewers are mistaken.",
-        // Calibrated confidence (#8) of the lone flagging reviewer; the gate blocks only when it clears
-        // aiReviewCloseConfidence. A consensus split ALWAYS carries this (combineReviews sets it whenever split is
-        // true), so the spread is effectively unconditional; the guard is a defensive belt-and-braces — an absent
-        // value would degrade to 1.0 in the threshold check (advisory.ts `?? 1`), matching today's always-block.
+        // Calibrated confidence (#8) of the lone flagging reviewer; clears aiReviewCloseConfidence ⇒ block,
+        // below it ⇒ human-review hold. A consensus split ALWAYS carries this (combineReviews sets it whenever
+        // split is true), so the spread is effectively unconditional; the guard is a defensive belt-and-braces —
+        // an absent value degrades to 1.0 in the threshold check (advisory.ts `?? 1`), matching today's always-block.
         /* v8 ignore next 3 -- a split always carries splitConfidence; the absent arm is an unreachable guard. */
         ...(result.splitConfidence !== undefined
           ? { confidence: result.splitConfidence }

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -25,9 +25,9 @@ export type GateCheckPolicy = {
   aiReviewGateMode?: GateRuleMode | undefined;
   /** Minimum calibrated confidence (0-1) for an AI-judgment defect (`ai_consensus_defect` / `ai_review_split`) to
    *  BLOCK under `aiReviewGateMode: block` (#7). The finding blocks only when its `confidence >= this`; below-threshold
-   *  AI defects stay advisory (visible, never block). `null`/undefined ⇒ the 0.9 default. A finding with no
-   *  confidence (deterministic, or a graceful-fallback AI defect) is treated as 1.0 and always clears the floor —
-   *  matching the historical always-block behavior. */
+   *  AI defects hold for human review instead of passing or auto-closing. `null`/undefined ⇒ the 0.9 default. A finding
+   *  with no confidence (deterministic, or a graceful-fallback AI defect) is treated as 1.0 and always clears the floor
+   *  — matching the historical always-block behavior. */
   aiReviewCloseConfidence?: number | null | undefined;
   readinessScore?: number | null | undefined;
   /** When `block`, the deterministic slop score becomes a hard blocker once `slopRisk >= slopGateMinScore`
@@ -487,6 +487,7 @@ function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy
   const qualityBlocker = buildQualityGateBlocker(effective);
   const slopBlocker = buildSlopGateBlocker(effective);
   const blockers = [...configuredBlockers, ...(qualityBlocker ? [qualityBlocker] : []), ...(slopBlocker ? [slopBlocker] : [])];
+  const lowConfidenceAiHolds = advisoryResult.findings.filter((finding) => isLowConfidenceAiReviewHold(finding, effective));
   // Non-confirmed contributors are gated NORMALLY (real blockers → failure → one-shot close; clean → success →
   // merge), the SAME as confirmed contributors: the review + CI + guardrail vet every PR, and confirmed-status
   // affects only on-chain SCORING, never the merge/close decision. (#gate-nonconfirmed) The old blanket
@@ -512,6 +513,16 @@ function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy
     };
   }
   if (blockers.length === 0) {
+    if (lowConfidenceAiHolds.length > 0) {
+      return {
+        enabled: true,
+        conclusion: "neutral",
+        title: "Gittensory Gate — held for human review",
+        summary: "The AI review flagged a possible must-fix defect below the automatic close-confidence floor, so the gate is held for a human reviewer instead of passed automatically.",
+        blockers: [],
+        warnings: [...warnings, ...lowConfidenceAiHolds],
+      };
+    }
     // Fail-CLOSED AI hold (#ai-fail-closed, #audit-3.5): with NO deterministic blocker, a block-mode AI review
     // that could not return a usable verdict HOLDS the gate (neutral) for a human rather than passing
     // automatically — NEVER a failure, so a contributor PR is never auto-CLOSED because a model hiccupped. This
@@ -830,10 +841,10 @@ function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPoli
   // most conservative AI signal (two independent models) but still confirmed-contributor gated by
   // evaluateGateCheck, and advisory by default.
   // A consensus defect (both reviewers) OR a SPLIT (one reviewer flagged a blocker the other did not) both block
-  // when aiReviewGateMode is `block` AND the finding's CALIBRATED confidence clears the close-confidence floor (#7):
-  // the historical hardcoded `confidence: 1` always blocked, so a below-floor AI defect now stays advisory (visible,
-  // never closes) instead of false-closing. A finding with no confidence (graceful fallback) is treated as 1.0 and
-  // always clears the floor — byte-identical to today's behavior. (#ai-review-split)
+  // when aiReviewGateMode is `block` AND the finding's CALIBRATED confidence clears the close-confidence floor (#7).
+  // Below-floor AI defects are handled as a neutral human-review HOLD in evaluateGateCheckCore: the LLM-provided
+  // confidence must never turn a concrete AI defect into an auto-mergeable passing gate. A finding with no confidence
+  // (graceful fallback) is treated as 1.0 and always clears the floor — byte-identical to today's behavior. (#ai-review-split)
   if (code === "ai_consensus_defect" || code === "ai_review_split") {
     if (gateMode(policy.aiReviewGateMode ?? "advisory") !== "block") return false;
     const confidence = finding.confidence ?? 1;
@@ -859,6 +870,13 @@ function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPoli
   // advisory — the finding surfaces in the panel without ever closing the PR unless explicitly configured.
   if (code === "self_authored_linked_issue") return gateMode(policy.selfAuthoredLinkedIssueGateMode ?? "advisory") === "block";
   return false;
+}
+
+function isLowConfidenceAiReviewHold(finding: AdvisoryFinding, policy: GateCheckPolicy): boolean {
+  if (!AI_JUDGMENT_BLOCKER_CODES.has(finding.code)) return false;
+  if (gateMode(policy.aiReviewGateMode ?? "advisory") !== "block") return false;
+  const confidence = finding.confidence ?? 1;
+  return confidence < (policy.aiReviewCloseConfidence ?? DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE);
 }
 
 function buildQualityGateBlocker(policy: GateCheckPolicy): AdvisoryFinding | null {

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -221,7 +221,7 @@ export type ModelReview = {
   nits: string[];
   suggestions: string[];
   // Calibrated confidence in [0,1] (#8): the reviewer's own probability that its blocker(s) are a REAL defect. Drives
-  // the gate's `aiReviewCloseConfidence` floor (an AI defect blocks only when confidence clears it). parseModelReview
+  // the gate's `aiReviewCloseConfidence` floor (clear ⇒ block; below ⇒ human-review hold). parseModelReview
   // sets it from the model's `confidence` field; an absent/unparseable/out-of-range value degrades to 1.0 (FALLBACK),
   // so behavior matches the historical hardcoded `confidence: 1` until a calibrated value is actually present.
   confidence: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -564,7 +564,7 @@ export type RepositorySettings = {
   aiReviewAllAuthors: boolean;
   /** Minimum calibrated AI-reviewer confidence (0-1) for an AI defect to BLOCK under `aiReviewMode: block` (#7).
    *  A dual-model consensus defect / split blocks only when its finding `confidence >= aiReviewCloseConfidence`;
-   *  below-threshold AI defects stay advisory (visible, never block). Config-as-code only — set via
+   *  below-threshold AI defects hold for human review rather than passing. Config-as-code only — set via
    *  `.gittensory.yml gate.aiReview.closeConfidence` (no dashboard/DB column); unset ⇒ the gate uses the 0.9
    *  default. Clamped to [0,1] at parse time. */
   aiReviewCloseConfidence?: number | null | undefined;

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -229,23 +229,25 @@ describe("AI close-confidence threshold gate (#7)", () => {
     expect(out.blockers.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
   });
 
-  it("does NOT block when mode=block but confidence < the floor — the AI defect stays advisory (#7)", () => {
+  it("holds for human review when mode=block but confidence < the floor (#7 regression)", () => {
     const out = evaluateGateCheck(aiDefectWith(0.5), gateCheckPolicy(settings({ aiReviewMode: "block" }), null, true));
-    expect(out.conclusion).toBe("success"); // below 0.9 → not a blocker, never closes
+    expect(out.conclusion).toBe("neutral"); // below 0.9 → manual hold, not an auto-mergeable pass
+    expect(out.title).toBe("Gittensory Gate — held for human review");
     expect(out.blockers).toEqual([]);
+    expect(out.warnings.map((f) => f.code)).toContain("ai_consensus_defect");
   });
 
   it("blocks exactly AT the floor (>= boundary) and not just below it", () => {
     // policy.aiReviewCloseConfidence is threaded onto the policy from settings.
     const policy = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.7 }), null, true);
     expect(evaluateGateCheck(aiDefectWith(0.7), policy).conclusion).toBe("failure"); // == threshold → blocks
-    expect(evaluateGateCheck(aiDefectWith(0.69), policy).conclusion).toBe("success"); // just below → advisory
+    expect(evaluateGateCheck(aiDefectWith(0.69), policy).conclusion).toBe("neutral"); // just below → manual hold
   });
 
   it("honors a custom aiReviewCloseConfidence (the `?? 0.9` default is NOT used when set) (#7)", () => {
-    // A high custom floor of 0.99 keeps a 0.95 defect advisory (the 0.9 default would have blocked it).
+    // A high custom floor of 0.99 holds a 0.95 defect for human review (the 0.9 default would have blocked it).
     const strict = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.99 }), null, true);
-    expect(evaluateGateCheck(aiDefectWith(0.95), strict).conclusion).toBe("success");
+    expect(evaluateGateCheck(aiDefectWith(0.95), strict).conclusion).toBe("neutral");
     // A low custom floor of 0.3 blocks a 0.5 defect that the 0.9 default would have left advisory.
     const lenient = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.3 }), null, true);
     expect(evaluateGateCheck(aiDefectWith(0.5), lenient).conclusion).toBe("failure");
@@ -263,7 +265,7 @@ describe("AI close-confidence threshold gate (#7)", () => {
   it("applies the same confidence floor to an ai_review_split finding (#7)", () => {
     const policy = gateCheckPolicy(settings({ aiReviewMode: "block" }), null, true);
     expect(evaluateGateCheck(splitDefectWith(0.95), policy).conclusion).toBe("failure"); // clears 0.9 → blocks
-    expect(evaluateGateCheck(splitDefectWith(0.5), policy).conclusion).toBe("success"); // below 0.9 → advisory
+    expect(evaluateGateCheck(splitDefectWith(0.5), policy).conclusion).toBe("neutral"); // below 0.9 → manual hold
   });
 
   it("resolveEffectiveSettings maps gate.aiReview.closeConfidence (clamped) into the policy floor (#7)", () => {


### PR DESCRIPTION
### Motivation
- Prevent model-supplied low confidence from turning a concretely-flagged AI critical finding into an auto-mergeable pass by treating below-threshold AI defects as a human-review hold instead of a silent success.

### Description
- Add a helper `isLowConfidenceAiReviewHold` and wire a low-confidence HOLD path into `evaluateGateCheckCore` so below-floor `ai_consensus_defect` / `ai_review_split` findings return a neutral "held for human review" conclusion and surface the finding in `warnings` instead of `blockers` (`src/rules/advisory.ts`).
- Preserve existing blocking semantics for high-confidence findings and the graceful fallback that treats a missing/unparseable confidence as blocking (1.0), leaving `isConfiguredGateBlocker` behavior unchanged for the >= threshold case (`src/rules/advisory.ts`).
- Update AI-review plumbing and comments to reflect the new semantics for clears/holds (confidence clears => block; below => human-review hold) in `src/queue/processors.ts`, `src/services/ai-review.ts`, and `src/types.ts`.
- Update unit coverage to assert the new boundary behavior (tests in `test/unit/gate-check-policy.test.ts` now expect `neutral` + a held warning for below-floor consensus/split cases).

### Testing
- Ran the focused unit suite `npx vitest run test/unit/gate-check-policy.test.ts` and the updated tests passed (83 tests, all green).
- Typechecked with `npx tsc --noEmit` and it succeeded with no errors.
- Attempted the full local gate `npm run test:ci` and `npm run test:coverage`; these runs were blocked/interrupted by external network/tooling issues (actionlint registry lookup / audit endpoint), so the end-to-end CI aggregate could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe6fc4d6c832ca4df6907fabc0d7c)