### PR TITLE
fix(orb): bound pull relay pending queue

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -145,20 +145,45 @@ const RELAY_RETRY_CONCURRENCY = 5;
 // (and bounds the ack list), and the TTL drops events the engine never came back for (a long-down container).
 const RELAY_PENDING_BATCH_SIZE = 50;
 const RELAY_PENDING_TTL_HOURS = 24;
+const RELAY_PENDING_MAX_PER_INSTALLATION = 500;
 
 export type RelayPendingEvent = { deliveryId: string; eventName: string; rawBody: string };
 
+/** Drop pull-mode rows that exceeded the raw-body retention window, even if their engine never polls. */
+async function pruneRelayPending(env: Env): Promise<number> {
+  const pruned = await env.DB
+    .prepare("DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')")
+    .bind(RELAY_PENDING_TTL_HOURS)
+    .run();
+  return pruned.meta.changes;
+}
+
 /** Enqueue a pull-mode event for an installation. Idempotent on delivery_id (mirrors storeRelayFailure) — a GitHub
- *  redelivery reaching the Orb twice never double-queues. */
+ *  redelivery reaching the Orb twice never double-queues. Prunes expired rows and caps each install's backlog first so
+ *  an offline/malicious pull enrollment cannot retain raw webhook bodies indefinitely. */
 export async function enqueueRelayPending(
   env: Env,
   args: { deliveryId: string; installationId: number; eventName: string; rawBody: string },
 ): Promise<void> {
+  await pruneRelayPending(env);
   await env.DB
     .prepare(
       "INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body) VALUES (?, ?, ?, ?) ON CONFLICT(delivery_id) DO NOTHING",
     )
     .bind(args.deliveryId, args.installationId, args.eventName, args.rawBody)
+    .run();
+  await env.DB
+    .prepare(
+      `DELETE FROM orb_relay_pending
+       WHERE installation_id = ?
+         AND delivery_id IN (
+           SELECT delivery_id FROM orb_relay_pending
+           WHERE installation_id = ?
+           ORDER BY created_at DESC, delivery_id DESC
+           LIMIT -1 OFFSET ?
+         )`,
+    )
+    .bind(args.installationId, args.installationId, RELAY_PENDING_MAX_PER_INSTALLATION)
     .run();
 }
 
@@ -172,10 +197,7 @@ export async function pullRelayPending(
   opts?: { ack?: string[] | undefined; limit?: number | undefined },
 ): Promise<RelayPendingEvent[]> {
   // Prune rows the engine never came back for (same datetime() comparison style as retryFailedRelays).
-  await env.DB
-    .prepare("DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')")
-    .bind(RELAY_PENDING_TTL_HOURS)
-    .run();
+  await pruneRelayPending(env);
 
   const ack = opts?.ack?.slice(0, RELAY_PENDING_BATCH_SIZE) ?? [];
   if (ack.length) {

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -354,6 +354,34 @@ describe("retryFailedRelays", () => {
 });
 
 describe("enqueueRelayPending", () => {
+  it("prunes expired rows before enqueueing so offline pull-mode installs cannot retain raw bodies indefinitely", async () => {
+    const e = brokeredEnv();
+    await db(e).prepare("INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body, created_at) VALUES (?, ?, ?, ?, datetime('now', '-25 hours'))").bind("stale-before-enqueue", 9599, "pull_request", '{"stale":true}').run();
+    await enqueueRelayPending(e, { deliveryId: "fresh-after-prune", installationId: 9600, eventName: "pull_request", rawBody: '{"fresh":true}' });
+
+    const stale = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='stale-before-enqueue'").first();
+    const fresh = await db(e).prepare("SELECT raw_body FROM orb_relay_pending WHERE delivery_id='fresh-after-prune'").first<{ raw_body: string }>();
+    expect(stale ?? null).toBeNull();
+    expect(fresh?.raw_body).toBe('{"fresh":true}');
+  });
+
+  it("caps each installation's pending queue by dropping the oldest overflow rows", async () => {
+    const e = brokeredEnv();
+    for (let i = 0; i < 501; i += 1) {
+      await enqueueRelayPending(e, { deliveryId: `cap-${String(i).padStart(3, "0")}`, installationId: 9601, eventName: "pull_request", rawBody: JSON.stringify({ i }) });
+    }
+    await enqueueRelayPending(e, { deliveryId: "other-install", installationId: 9602, eventName: "pull_request", rawBody: "{}" });
+
+    const count = await db(e).prepare("SELECT COUNT(*) AS n FROM orb_relay_pending WHERE installation_id=9601").first<{ n: number }>();
+    const dropped = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='cap-000'").first();
+    const newest = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='cap-500'").first();
+    const other = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='other-install'").first();
+    expect(count?.n).toBe(500);
+    expect(dropped ?? null).toBeNull();
+    expect(newest ?? null).not.toBeNull();
+    expect(other ?? null).not.toBeNull();
+  });
+
   it("inserts a pending row; duplicate delivery_id is silently ignored (ON CONFLICT DO NOTHING)", async () => {
     const e = brokeredEnv();
     await enqueueRelayPending(e, { deliveryId: "pend-1", installationId: 9600, eventName: "pull_request", rawBody: '{"n":1}' });


### PR DESCRIPTION
### Motivation

- Prevent unbounded retention of raw webhook bodies queued for pull-mode relays when a pull client never polls, which can cause durable storage growth and privacy/retention violations.

### Description

- Add a fleet-wide TTL prune helper `pruneRelayPending(env)` and call it from both `pullRelayPending` and `enqueueRelayPending` so expired `orb_relay_pending` rows are removed even when the engine never polls.
- Add a per-installation cap `RELAY_PENDING_MAX_PER_INSTALLATION = 500` and delete oldest overflow rows after enqueueing to bound each installation's pending queue size while preserving idempotent `ON CONFLICT(delivery_id)` semantics.
- Reworked `enqueueRelayPending` to run the TTL prune before inserting and to trim oldest rows for the given `installation_id` using a bounded DELETE/SELECT query.
- Add integration tests in `test/integration/orb-relay.test.ts` covering enqueue-time TTL pruning and the per-installation overflow-dropping behavior.

### Testing

- Ran the targeted integration suite: `npx vitest run test/integration/orb-relay.test.ts`, and the file's tests passed (60 tests ran; all passed in this environment).
- Type check: `npm run typecheck` completed successfully.
- Coverage: `npm run test:coverage` (and targeted coverage runs) failed in this environment due to the test coverage provider error `TypeError: jsTokens is not a function` unrelated to the change; targeted integration tests themselves passed before coverage generation failed.
- Dependency audit: `npm audit --audit-level=moderate` could not be completed in this environment due to registry 403; no new dependencies were added by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd142e864832c9610d7c2c312a98e)