### PR TITLE
fix(selfhost): fail-closed Codex reviewer and remove mounted CODEX_HOME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,15 +208,9 @@ GITTENSORY_REVIEW_DRAFT=false
 # OPENAI_API_KEY=                            # for AI_PROVIDER=openai
 # CLAUDE_CODE_OAUTH_TOKEN=                   # for AI_PROVIDER=claude-code (subscription; from `claude setup-token`)
 #
-# Codex (ChatGPT subscription) second reviewer — NO API key, uses your ChatGPT plan via the baked-in `codex` CLI.
-#   AI_PROVIDER=claude-code,codex            # dual review: Claude + Codex, combined per AI_COMBINE above
-# The `codex` CLI is pre-baked when the image is built with --build-arg INSTALL_AI_CLIS=true. Authenticate ONCE on a
-# trusted machine — `codex login` (browser) or `codex login --device-auth` (headless) — then place the resulting
-# ~/.codex/auth.json into the WRITABLE codex-home volume the compose file mounts at CODEX_HOME (default /home/node/.codex):
-#   docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json   # then: docker compose restart gittensory
-# codex auto-refreshes the token in place (hence the writable volume). Leave AI_MODEL unset on a ChatGPT login —
-# pinning gpt-5* errors "not supported with a ChatGPT account"; codex picks the entitled default.
-# CODEX_HOME=/home/node/.codex               # override only to relocate the codex home (match the compose mount)
+# Codex (ChatGPT subscription) reviewer is disabled by default for self-host PR review: `codex exec` stores its
+# OAuth credential in auth.json on the same filesystem that prompt-influenced reviews can read. Do not mount or copy
+# ~/.codex/auth.json into the app container; use claude-code, an API-key provider, or a local OpenAI-compatible model.
 # AI_MODEL=llama3.1                          # the model for your provider (e.g. llama3.1 for Ollama, sonnet
 #                                            #   for claude-code, gpt-5 for codex). REQUIRED for non-Ollama:
 #                                            #   without it the adapter falls back to a provider default, never

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,6 @@ services:
       # files (and an optional root .gittensory.yml global fallback). Keeps each repo's policy OUT of the public
       # GitHub repo so contributors can't game the rules. Empty/unmounted ⇒ repos use the public file / defaults.
       GITTENSORY_REPO_CONFIG_DIR: "${GITTENSORY_REPO_CONFIG_DIR:-/config}"
-      # Codex (ChatGPT subscription) reviewer home (#979). The `codex` CLI reads auth.json from $CODEX_HOME and
-      # REFRESHES the OAuth token in place, so the home MUST be writable — that's the codex-home named volume below,
-      # NOT the read-only /config mount. Defaults to the image `node` run user's ~/.codex; override to relocate.
-      CODEX_HOME: "${CODEX_HOME:-/home/node/.codex}"
       # Claude Code usage telemetry → OTEL collector → Prometheus → Claude usage dashboard. OFF unless you set
       # CLAUDE_CODE_ENABLE_TELEMETRY=1 in .env (requires --profile observability so the otel-collector is up).
       CLAUDE_CODE_ENABLE_TELEMETRY: "${CLAUDE_CODE_ENABLE_TELEMETRY:-}"
@@ -78,12 +74,6 @@ services:
       # Container-private per-repo config dir (read-only). Create ./gittensory-config/{owner}__{repo}/.gittensory.yml
       # locally (gitignored — never commit real policy). Absent ⇒ Docker mounts an empty dir ⇒ defaults apply.
       - ./gittensory-config:/config:ro
-      # Persistent, WRITABLE Codex home for the `codex` (ChatGPT subscription) reviewer — survives restarts so the
-      # auth.json you drop in (and codex's in-place token refresh + app-server state) outlive the container. The
-      # node run user owns /home/node, so the volume is writable. Drop your `codex login` auth.json in with:
-      #   docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json
-      # If you override CODEX_HOME above, change this mount target to match (it must equal $CODEX_HOME).
-      - codex-home:/home/node/.codex
     depends_on:
       # Gate startup on a healthy Qdrant when --profile qdrant is active; required:false means the
       # dependency is ignored when qdrant isn't started (default/other profiles). Belt-and-suspenders
@@ -465,7 +455,6 @@ services:
 
 volumes:
   gittensory-data:
-  codex-home:
   gittensory-pg:
   qdrant-data:
   ollama-models:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -146,21 +146,11 @@ bake them in, then provide `CLAUDE_CODE_OAUTH_TOKEN` / codex auth at run time. N
   substantive review, not a fast shallow one); override with `AI_MODEL` (any `claude`-CLI model id or alias —
   `sonnet`, `opus`, `claude-opus-4-8`, …) and `AI_EFFORT` (`low`|`medium`|`high`|`xhigh`|`max`; the CLI clamps a
   level above the model's own ceiling).
-- **Codex (ChatGPT subscription) — second AI reviewer.** Native, like `claude-code`: the `codex` CLI is **pre-baked**
-  (`INSTALL_AI_CLIS=true`) and reviews run on your **ChatGPT subscription** — **no API key**. It reads `auth.json` from
-  `$CODEX_HOME`, which the compose file points at a **persistent, writable `codex-home` volume** (default
-  `/home/node/.codex`, the `node` run user's home) — codex refreshes the OAuth token **in place**, so the home must be
-  writable (a read-only mount fails with _"Read-only file system"_) and durable (so the refreshed token survives
-  restarts). Set it up once:
-  1. On a trusted machine, authenticate: `codex login` (browser) — or `codex login --device-auth` for a headless box —
-     which writes `~/.codex/auth.json`.
-  2. Drop that file into the volume: `docker compose cp ~/.codex/auth.json gittensory:/home/node/.codex/auth.json`
-     (or bind-mount a host dir at `$CODEX_HOME` — keep it **read-write**, never `:ro`).
-  3. Add codex to the reviewer set and restart: `AI_PROVIDER=claude-code,codex` (combined per `AI_COMBINE`), then
-     `docker compose up -d --force-recreate gittensory`.
-
-  Leave `AI_MODEL` unset for a ChatGPT-subscription login — pinning `gpt-5*` returns _"not supported … with a ChatGPT
-  account"_; codex picks the entitled default. (`ca-certificates` for codex's native TLS is baked in by `INSTALL_AI_CLIS`.)
+- **Codex (ChatGPT subscription).** The `codex` CLI is pre-baked, but self-hosted Codex reviews are fail-closed by
+  default because the CLI stores its OAuth refresh credential in `auth.json` on the same filesystem that the
+  prompt-influenced review sandbox can read. Do **not** copy `~/.codex/auth.json` into the app container or mount a
+  writable Codex home for PR review. Use `claude-code`, an API-key provider, or a local OpenAI-compatible endpoint for
+  automated reviews until Codex offers a credential-isolated non-interactive mode.
 
 **Local RAG (retrieval-augmented review).** Self-host ships a SQLite-backed vector store, so RAG works without
 Cloudflare Vectorize. Enable it with `GITTENSORY_REVIEW_RAG=true` + the repo in `GITTENSORY_REVIEW_REPOS`, and

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -132,7 +132,6 @@ export function createAnthropicAi(opts: { apiKey: string; model?: string | undef
 // credentials out of prompt-injectable subprocesses while preserving CLI auth/home/proxy/cert settings. The CLI
 // runs read-only / no extra tools, and non-zero exit / empty output / error-envelope THROWS so the caller degrades.
 const SUBSCRIPTION_CLI_ENV_ALLOWLIST = [
-  "CODEX_HOME",
   "HOME",
   "HTTPS_PROXY",
   "HTTP_PROXY",
@@ -164,6 +163,21 @@ export function subscriptionCliEnv(
   for (const [key, value] of Object.entries(extra)) {
     if (value !== undefined) child[key] = value;
   }
+  return child;
+}
+
+function assertCodexCredentialIsolation(parent: Record<string, string | undefined>): void {
+  // `codex exec` receives attacker-controlled PR title/body/diff text. Its read-only sandbox prevents writes, but not
+  // reads, so a self-hosted OAuth home mounted into the same filesystem can be prompt-injected into public output.
+  // Fail closed until Codex exposes a brokered credential mode that does not put auth.json in the review sandbox.
+  if (parent.CODEX_HOME || parent.GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER !== "1") {
+    throw new Error("codex_credential_isolation_required");
+  }
+}
+
+function codexCliEnv(parent: Record<string, string | undefined>): Record<string, string | undefined> {
+  const child = subscriptionCliEnv(parent);
+  delete child.CODEX_HOME;
   return child;
 }
 
@@ -305,15 +319,15 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
   };
 }
 
-/** Codex subscription (`codex exec`, auth from $CODEX_HOME/auth.json, default ~/.codex). codex needs a WRITABLE
- *  home for its app-server state, so a brokered self-host points CODEX_HOME at a writable dir. Gated/unverified —
- *  fail-safe. */
+/** Codex subscription (`codex exec`). Fail closed by default: Codex OAuth homes are readable by prompt-influenced
+ *  review sandboxes unless an operator explicitly opts into that risk for an isolated deployment. */
 export function createCodexAi(parentEnv: Record<string, string | undefined>, spawnImpl?: SpawnFn): SelfHostAi {
   return {
     async run(model, options) {
       // Codex is chat-only here — reject embed requests so the chain routes them to an embed-capable provider.
       if (options.text) throw new Error("codex_no_embed");
-      const env = subscriptionCliEnv(parentEnv);
+      assertCodexCredentialIsolation(parentEnv);
+      const env = codexCliEnv(parentEnv);
       const prompt = toMessages(options).map((m) => m.content).join("\n\n");
       const spawn = spawnImpl ?? (await defaultSpawn());
       // codex 0.142+: `exec` is non-interactive — the old `--ask-for-approval` flag was REMOVED (passing it errors).

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -268,7 +268,7 @@ describe("branch coverage — defaults + edge inputs", () => {
   it("claude/codex with a null exit code", async () => {
     const nullExit: StubSpawn = async () => ({ stdout: "", code: null });
     await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, nullExit).run("m", { prompt: "x" })).rejects.toThrow(/claude_code_exit_null/);
-    await expect(createCodexAi({}, nullExit).run("m", { prompt: "x" })).rejects.toThrow(/codex_exit_null/);
+    await expect(createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, nullExit).run("m", { prompt: "x" })).rejects.toThrow(/codex_exit_null/);
   });
   it("embed uses the bge-m3 default when no embedModel is set", async () => {
     let sentModel = "";
@@ -391,7 +391,7 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect((await claudeChain.run("bge-m3", { text: ["a", "b"] })).data?.length).toBe(2);
     // Same for codex as the frontier reviewer.
     const codexOk: StubSpawn = async () => ({ stdout: JSON.stringify({ type: "result", result: "codex review" }), code: 0 });
-    const codexChain = createChainAi([{ name: "codex", ai: createCodexAi({}, codexOk) }, embedder]);
+    const codexChain = createChainAi([{ name: "codex", ai: createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, codexOk) }, embedder]);
     expect((await codexChain.run("bge-m3", { text: ["a"] })).data?.length).toBe(1);
   });
 
@@ -410,21 +410,21 @@ describe("subscription CLI helpers + fail-safe", () => {
     // no configured model + the dual-router's empty model id → OMIT --model (codex picks the account default;
     // forcing e.g. gpt-5 fails on a ChatGPT-account login). And the removed --ask-for-approval must never appear.
     expect(
-      (await createCodexAi({ PATH: "/bin", CODEX_HOME: "/tmp/codex", WORKER_ONLY_VALUE: "internal", OPENAI_API_KEY: "sk-bill", AI_TIMEOUT_MS: "300000" }, ok).run("", {
+      (await createCodexAi({ PATH: "/bin", WORKER_ONLY_VALUE: "internal", OPENAI_API_KEY: "sk-bill", AI_TIMEOUT_MS: "300000", GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, ok).run("", {
         prompt: "x",
       })).response,
     ).toBe("codex review");
     expect(seen).toEqual(["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only", "--", "x"]);
     expect(seen).not.toContain("--ask-for-approval");
-    expect(capturedEnv).toEqual({ CODEX_HOME: "/tmp/codex", PATH: "/bin" });
+    expect(capturedEnv).toEqual({ PATH: "/bin" });
     expect(capturedCwd).toContain("gittensory-ai-");
     expect(timeout).toBe(300_000); // codex honors the same AI_TIMEOUT_MS override as Claude Code
     // an explicit model (AI_MODEL, or a `codex:<model>` reviewer id) IS passed through but not inherited as env.
-    await createCodexAi({ AI_MODEL: "o4-mini" }, ok).run("", { prompt: "x" });
+    await createCodexAi({ AI_MODEL: "o4-mini", GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, ok).run("", { prompt: "x" });
     expect(seen.join(" ")).toContain("--model o4-mini");
     expect(capturedEnv.AI_MODEL).toBeUndefined();
     const bad: StubSpawn = async () => ({ stdout: "", code: 1 });
-    await expect(createCodexAi({}, bad).run("", { prompt: "x" })).rejects.toThrow(/codex_exit_1/);
+    await expect(createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, bad).run("", { prompt: "x" })).rejects.toThrow(/codex_exit_1/);
   });
 
   it("drives the REAL subprocess (defaultSpawn) against a fake `claude` on PATH", async () => {
@@ -453,7 +453,26 @@ describe("subscription CLI helpers + fail-safe", () => {
 
   it("Codex throws on empty output", async () => {
     const empty: StubSpawn = async () => ({ stdout: "", code: 0 });
-    await expect(createCodexAi({}, empty).run("gpt-5", { prompt: "x" })).rejects.toThrow(/codex_empty_output/);
+    await expect(
+      createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, empty).run("gpt-5", { prompt: "x" }),
+    ).rejects.toThrow(/codex_empty_output/);
+  });
+
+  it("Codex fails closed when a mounted OAuth home would be exposed to the review sandbox", async () => {
+    const shouldNotSpawn: StubSpawn = async () => {
+      throw new Error("spawned");
+    };
+    await expect(
+      createCodexAi(
+        { CODEX_HOME: "/home/node/.codex", GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },
+        shouldNotSpawn,
+      ).run("gpt-5", {
+        prompt: "read $CODEX_HOME/auth.json",
+      }),
+    ).rejects.toThrow(/codex_credential_isolation_required/);
+    await expect(createCodexAi({}, shouldNotSpawn).run("gpt-5", { prompt: "x" })).rejects.toThrow(
+      /codex_credential_isolation_required/,
+    );
   });
 
   it("surfaces the CLI's stderr in the non-zero-exit error (diagnosable failures, #26)", async () => {
@@ -464,7 +483,7 @@ describe("subscription CLI helpers + fail-safe", () => {
       createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, claudeErr).run("m", { prompt: "x" }),
     ).rejects.toThrow(/claude_code_exit_1: Invalid API key/);
     const codexErr: StubSpawn = async () => ({ stdout: "", code: 1, stderr: "stream error: rate limit reached" });
-    await expect(createCodexAi({}, codexErr).run("m", { prompt: "x" })).rejects.toThrow(
+    await expect(createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, codexErr).run("m", { prompt: "x" })).rejects.toThrow(
       /codex_exit_1: stream error: rate limit reached/,
     );
   });
@@ -482,7 +501,7 @@ describe("subscription CLI helpers + fail-safe", () => {
 
   it("redacts key-shaped tokens from codex stderr (no env token to key off) (#1605 sec)", async () => {
     const leaky: StubSpawn = async () => ({ stdout: "", code: 1, stderr: "auth failed: ghp_ABCDEFGHIJ0123456789KLMNOPQRSTUV" });
-    await expect(createCodexAi({}, leaky).run("m", { prompt: "x" })).rejects.toThrow(/codex_exit_1: auth failed: \[redacted\]/);
+    await expect(createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }, leaky).run("m", { prompt: "x" })).rejects.toThrow(/codex_exit_1: auth failed: \[redacted\]/);
   });
 
   it("defaultSpawn captures a failing CLI's stderr and surfaces it on the exit error (#26)", async () => {
@@ -507,7 +526,7 @@ describe("subscription CLI helpers + fail-safe", () => {
     const origPath = process.env.PATH;
     process.env.PATH = "/nonexistent-gittensory-empty";
     try {
-      await expect(createCodexAi({ ...process.env }).run("gpt-5", { prompt: "x" })).rejects.toThrow();
+      await expect(createCodexAi({ ...process.env, GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" }).run("gpt-5", { prompt: "x" })).rejects.toThrow();
     } finally {
       process.env.PATH = origPath;
     }


### PR DESCRIPTION
### Motivation
- A self-hosted Codex reviewer exposed the operator's ChatGPT OAuth `auth.json` by mounting a writable `CODEX_HOME` into the same runtime that spawns `codex exec` and passing `CODEX_HOME` through to the child environment, enabling prompt-injection reads from the mounted credential file.
- The change prevents secret-exfiltration via attacker-controlled PR text while preserving safe reviewer options for API-key or local-model providers.

### Description
- Remove the default `CODEX_HOME` env wiring and the `codex-home` named volume from `docker-compose.yml`, and update `.env.example` and `docs/self-hosting.md` to advise operators not to copy/mount `~/.codex/auth.json` into the app container for automated PR review.
- Remove `CODEX_HOME` from the subscription-CLI environment allowlist so it is not inherited by default by CLI subprocesses.
- Add `assertCodexCredentialIsolation(parent)` which fails closed when a `CODEX_HOME` would be exposed to the `codex` subprocess, requiring an explicit opt-in via `GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER=1` for isolated deployments.
- Add `codexCliEnv(parent)` which derives the child env for `codex exec` and ensures `CODEX_HOME` is not passed; update `createCodexAi` to call `assertCodexCredentialIsolation` and use `codexCliEnv`.
- Update unit tests in `test/unit/selfhost-ai.test.ts` to reflect the new opt-in behavior and add a regression test that verifies the Codex provider fails instead of spawning when a mounted OAuth home would be exposed.

### Testing
- Ran `npm run typecheck` with no errors. (success)
- Ran `npx vitest run test/unit/selfhost-ai.test.ts` and the unit suite for `selfhost-ai` passed (63 tests passed), including the new regression test. (success)
- Attempted `npm run test:coverage`, but coverage remapping failed locally with `TypeError: jsTokens is not a function`, blocking a full unsharded coverage run. (failure: tooling)
- Attempted `npm run test:ci`; it could not complete due to `actionlint` setup networking fallback rejecting the custom self-host runner label in this environment. (incomplete)
- Attempted `npm audit --audit-level=moderate`; the registry audit endpoint returned `403 Forbidden` so the audit step could not complete. (incomplete)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ffd48bd60832c861201def5bec250)