### PR TITLE
fix(selfhost): route single-provider AI through the name-aware router (#1610)

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -436,13 +436,16 @@ export function resolveRequiredCliProviders(env: Record<string, string | undefin
     });
 }
 
-/** Select the self-host AI provider(s) from AI_PROVIDER. A comma-separated list of TWO+ providers is addressable
- *  by name for dual review (see `routeProviders`) and otherwise falls back through them in order; a single
- *  provider is used directly. Returns undefined when unconfigured or no provider has its credential. */
+/** Select the self-host AI provider(s) from AI_PROVIDER and wrap them in the name-aware router. A comma-separated
+ *  list of TWO+ providers is addressable by name for dual review (see `routeProviders`) and otherwise falls back
+ *  through them in order; a SINGLE provider is wrapped the same way — NOT returned bare — so a reviewer-plan address
+ *  that names the provider (`{ model: "claude-code" }`, the single-provider plan from `resolveAiReviewerPlan`)
+ *  resolves to that provider's own default model instead of reaching it verbatim as `claude --model claude-code`
+ *  (a 404 that broke every review on a single-provider self-host, #1610). Returns undefined when unconfigured or no
+ *  provider has its credential. */
 export function createSelfHostAi(env: Record<string, string | undefined>): SelfHostAi | undefined {
   const providers = buildProviders(env);
   if (providers.length === 0) return undefined;
-  if (providers.length === 1) return providers[0]?.ai;
   return routeProviders(providers);
 }
 

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -206,6 +206,20 @@ describe("routeProviders (#dual-ai-combiner — address one provider by name for
     const ai = createSelfHostAi({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant", AI_BASE_URL: "http://o/v1" });
     expect(typeof ai?.run).toBe("function");
   });
+
+  it("createSelfHostAi routes a SINGLE provider through the router too — a name address yields the provider default, never `--model <provider>` (#1610)", async () => {
+    // Regression (#1610): a single-provider self-host returned env.AI as the BARE provider, so the reviewer plan's
+    // name address ({ model: "openai-compatible" } — or "claude-code") reached it as a model id. `claude --model
+    // claude-code` 404'd and broke EVERY review. The router must strip the name to the provider's own default.
+    let sentModel = "";
+    vi.stubGlobal("fetch", vi.fn(async (_u: string, init: { body: string }) => {
+      sentModel = (JSON.parse(init.body) as { model: string }).model;
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+    }));
+    const ai = createSelfHostAi({ AI_PROVIDER: "openai-compatible", AI_BASE_URL: "http://o/v1" });
+    await ai?.run("openai-compatible", { prompt: "x" }); // the single-provider reviewer-plan address IS the provider name
+    expect(sentModel).toBe("llama3.1"); // resolveModel(undefined, "", "llama3.1") — NOT the literal "openai-compatible"
+  });
 });
 
 describe("resolveProviderNames + resolveAiReviewerPlan (#dual-ai-combiner)", () => {


### PR DESCRIPTION
## Summary

Single-provider self-host reviews (`AI_PROVIDER=claude-code`) failed **100%** with an opaque `claude_code_exit_1`. Root cause: `resolveAiReviewerPlan` builds the single-provider plan as `reviewers: [{ model: "claude-code" }]` — the reviewer "model" is the **router address** (the provider name), matching the 2-provider convention. But `createSelfHostAi` returned the **bare** provider for a single-provider setup, bypassing `routeProviders`'s name-stripping. So `createClaudeCodeAi.run("claude-code", …)` ran `resolveModel(undefined, "claude-code", "claude-sonnet-4-6")`, which returns `"claude-code"` verbatim (it only strips `@cf/` ids) → `claude --model claude-code` → **404** (`is_error:true, api_error_status:404, "There's an issue with the selected model (claude-code)"`), exit 1, three times, then `ai_review_provider_exhausted`.

Verified in-container: `claude --model claude-code` ⇒ exit 1 / 404; `claude --model claude-sonnet-4-6` (what the router yields) ⇒ exit 0. The 2-provider path already worked because `routeProviders` strips the name (its test documents exactly this: *"the router never passes the provider NAME through as a model id"*).

Fix: `createSelfHostAi` wraps a single provider in `routeProviders` too, so the provider-name address resolves to the provider's own default model. One-line behavior change (delete the `length === 1` bare-return) plus a regression test that pins it. No public behavior, schema, binding, or migration change.

Closes #1610.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No artifact regeneration needed: backend-only, no API/OpenAPI/schema change (`ui:openapi`), no `wrangler.jsonc` binding/var change (`cf-typegen`), no DB change (migration).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/CORS/session change; this is AI-provider routing.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/MCP surface change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## Notes

- This is the single-provider counterpart of the existing `routeProviders` name-stripping that already covers the 2-provider/dual-review path; it makes `env.AI` uniformly name-aware so a reviewer-plan address never reaches a provider as a literal `--model`.
