### PR TITLE
fix(selfhost): surface the CLI's structured stdout error before the exit code (#1612)

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -295,9 +295,14 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
         ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "plan", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"],
         { env, input: prompt, timeoutMs: resolveCliTimeoutMs(parentEnv), cwd: await isolatedCliCwd() },
       );
-      if (code !== 0) throw new Error(`claude_code_exit_${code ?? "null"}: ${redactSecrets(stderr ?? "", [token]).slice(0, 500)}`);
+      // Surface the STRUCTURED error envelope FIRST. `claude --output-format json` reports API/auth/model errors in its
+      // stdout JSON ({is_error,api_error_status}) on a NON-ZERO exit too — e.g. an unknown model exits 1 with the 404
+      // envelope in stdout and EMPTY stderr. Checking it before the exit code turns an opaque `claude_code_exit_1: `
+      // (the #1610 symptom) into a precise `claude_code_error_404` — the signal that makes a reviewer outage
+      // diagnosable in logs + Sentry instead of a dead end.
       const errStatus = claudeErrorStatus(stdout);
       if (errStatus) throw new Error(`claude_code_error_${errStatus}`);
+      if (code !== 0) throw new Error(`claude_code_exit_${code ?? "null"}: ${redactSecrets(stderr ?? "", [token]).slice(0, 500)}`);
       const text = extractCliText(stdout);
       if (!text) throw new Error("claude_code_empty_output");
       return { response: text };

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -359,6 +359,13 @@ describe("subscription CLI helpers + fail-safe", () => {
     const stub: StubSpawn = async () => ({ stdout: JSON.stringify({ is_error: true, api_error_status: 401, result: "Failed to authenticate" }), code: 0 });
     await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, stub).run("m", { prompt: "x" })).rejects.toThrow(/claude_code_error_401/);
   });
+  it("surfaces the structured stdout error on a NON-ZERO exit (precise status, not opaque exit code) (#1610)", async () => {
+    // Regression: an unknown model exits 1 with the error envelope in STDOUT ({is_error,api_error_status:404}) and
+    // EMPTY stderr. The exit-code throw used to win → `claude_code_exit_1: ` (blank, undiagnosable). Now the
+    // structured status is checked first → `claude_code_error_404`, the signal that surfaces in logs + Sentry.
+    const stub: StubSpawn = async () => ({ stdout: JSON.stringify({ is_error: true, api_error_status: 404, result: "There's an issue with the selected model (claude-code)." }), code: 1, stderr: "" });
+    await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, stub).run("m", { prompt: "x" })).rejects.toThrow(/claude_code_error_404/);
+  });
   it("Claude Code returns the model text on success and scrubs billable keys", async () => {
     let capturedEnv: Record<string, string | undefined> = {};
     const stub: StubSpawn = async (_c, _a, o) => {


### PR DESCRIPTION
## Summary

`claude --output-format json` reports API/auth/model errors in its **stdout** JSON envelope (`{is_error:true, api_error_status:404, result:"…"}`) — including on a **non-zero exit**, with **empty stderr**. `createClaudeCodeAi.run` threw on the exit code *before* checking that envelope, so such failures surfaced as an opaque `claude_code_exit_1: ` (blank — stderr is empty), discarding the precise status.

This is exactly why #1610 (a `claude --model claude-code` 404 from the single-provider routing bug) was undiagnosable from logs/Sentry and needed in-container reproduction to root-cause. #1605 added stderr capture, but stderr is empty for this whole class of failure — the signal is in stdout.

Fix: check `claudeErrorStatus(stdout)` **before** the exit-code throw, so the structured error surfaces as `claude_code_error_404` (precise, bounded, secret-free) and reaches the central Sentry forwarder. A genuine crash (non-zero exit with no structured stdout envelope) still falls through to the existing exit-code + redacted-stderr path. Two moved lines + a regression test; no public behavior, schema, binding, or migration change.

Closes #1612.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` ≥97% of changed lines AND branches** — both branches of the moved `claudeErrorStatus`/exit-code checks are covered (exit-0 envelope, exit-1 envelope, exit-1 no-envelope, success).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No artifact regeneration needed: backend-only, no API/OpenAPI/schema change, no `wrangler.jsonc` change, no DB change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. — the surfaced status is the bounded `api_error_status` (e.g. `404`); the stderr fallback keeps the existing `redactSecrets`.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: AI-provider error handling.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed. — N/A.

## Notes

- This is the diagnostic companion to #1611: that fixed the single-provider 404; this makes any future CLI error (404/429/auth/model) surface its precise status instead of an opaque `claude_code_exit_1`. Open PR #1608 (`summarizeCliStderr`) targets the *stderr* fallback path and is complementary/superseded — to be reconciled separately.
