### PR TITLE
fix(observability): surface RAG index-population failures to Sentry

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -83,7 +83,7 @@ async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token:
     }
     return entries;
   } catch (error) {
-    console.log(JSON.stringify({ ev: "rag_index_tree_error", repo: repoFullName, message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "rag_index_tree_error", ev: "rag_index_tree_error", repo: repoFullName, message: String(error).slice(0, 200) }));
     return null;
   }
 }
@@ -178,7 +178,7 @@ async function listStoredChunkPaths(infra: ReturnType<typeof createReviewAdapter
       .all<{ path: string }>();
     return (rows.results ?? []).map((row) => row.path).filter((path) => typeof path === "string" && path.length > 0);
   } catch (error) {
-    console.log(JSON.stringify({ ev: "rag_list_paths_error", project, repo, message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "rag_list_paths_error", ev: "rag_list_paths_error", project, repo, message: String(error).slice(0, 200) }));
     return [];
   }
 }

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -173,18 +173,23 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     expect(vec.upserted.length).toBe(0);
   });
 
-  it("a tree fetch that THROWS degrades to nothing indexed (fetchRepoTree catch arm)", async () => {
+  it("a tree fetch that THROWS degrades to nothing indexed (fetchRepoTree catch arm) + surfaces it at ERROR for Sentry (#5)", async () => {
     const { env, vec } = indexEnv();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       if (input.toString().includes("/git/trees/")) throw new Error("network down");
       return new Response("missing", { status: 404 });
     });
     await expect(indexRepo(env, PROJECT, REPO)).resolves.toEqual({ indexed: 0, files: 0, capped: false });
     expect(vec.upserted.length).toBe(0);
+    // A broken RAG index-population (tree fetch) now surfaces at level:error → captured by the central Sentry forwarder.
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("rag_index_tree_error") && String(c[0]).includes('"level":"error"'))).toBe(true);
+    errSpy.mockRestore();
   });
 
-  it("a storage error while listing stored paths is fail-safe (prunes nothing, still indexes)", async () => {
+  it("a storage error while listing stored paths is fail-safe (prunes nothing, still indexes) + surfaces it at ERROR for Sentry (#5)", async () => {
     const { env } = indexEnv();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     // Make ONLY the listStoredChunkPaths SELECT throw; everything else uses the real test D1.
     const realPrepare = env.DB.prepare.bind(env.DB);
     env.DB.prepare = ((query: string) =>
@@ -198,6 +203,9 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     // The list failed → [] → nothing pruned, but the current file still indexes (fail-safe).
     expect(result.files).toBe(1);
     expect(await pathsFor(env, PROJECT, "gittensory")).toContain("src/current.ts");
+    // A broken stored-paths read now surfaces at level:error → captured by the central Sentry forwarder.
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("rag_list_paths_error") && String(c[0]).includes('"level":"error"'))).toBe(true);
+    errSpy.mockRestore();
   });
 
   it("listStoredChunkPaths drops blank paths and tolerates an absent result set (defensive branches)", async () => {


### PR DESCRIPTION
## Summary

Extends the review-pipeline Sentry coverage (after #1619 covered RAG *retrieval* / enrichment / inline failures) to the RAG **index-population** path. `fetchRepoTree` and `listStoredChunkPaths` (`rag-index.ts`) logged their catch failures via `console.log` with **no `level`**, so the central Sentry forwarder (which forwards only `level:"error"`/`"fatal"`) never saw them — a broken index population (GitHub tree fetch down, D1 read error) silently degraded RAG quality with no Sentry signal.

Promote both to `level:"error"` `event:"rag_index_tree_error"` / `"rag_list_paths_error"` (keeping the `ev` tag for log continuity), mirroring the #1619 rag.ts pattern. Both remain fail-safe (population still degrades gracefully) — only visibility changes.

Extends #1618. (The two outer-catch population sites — `rag_index_repo_error` / `rag_reindex_paths_error` — are defensive/unreachable in the current tests and are a separate follow-up with their own coverage.)

## Scope

- [x] Conventional Commit title; focused (one file + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident extension of #1618/#1619 (no separate issue needed).

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — both promoted catches are exercised by the existing rag-index tests (tree-throws; stored-paths read error), now asserting the `level:"error"` log; no new branches.
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: logging-level change only.

## Safety

- [x] No secrets/wallets/trust-scores exposed — logs carry repo/project + a bounded error message.
- [x] No public GitHub text change · auth/CORS N/A.

## Notes

- This is self-host engine code (RAG index population runs on the container); it ships on the next self-host rsync+rebuild (logging-only, non-urgent — can batch with other self-host changes).
