### PR TITLE
fix(review): bound RAG index GitHub fetches with abort timeouts

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -45,6 +45,10 @@ type TreeEntry = { path: string; size?: number | undefined };
  *  embedTexts itself batches the AI calls at EMBED_BATCH internally). */
 const UPSERT_BATCH = 50;
 
+/** Abort a GitHub read that hangs — a stalled connection on the tree/contents fetch would otherwise pin the whole
+ *  index job (and the queue consumer running it) indefinitely. Aborts land in the existing fail-safe catches. */
+const GITHUB_FETCH_TIMEOUT_MS = 10_000;
+
 /** Resolve the read token once for a repo: installation token (private-repo read) → public token → none.
  *  Best-effort — a token failure degrades to the next fallback, never throws. (Mirrors makeGithubFileFetcher.) */
 async function resolveReadToken(env: Env, installationId: number | null | undefined): Promise<string | undefined> {
@@ -73,7 +77,7 @@ async function fetchRepoTree(env: Env, repoFullName: string, ref: string, token:
   try {
     const { owner, name } = repoParts(repoFullName);
     const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
-    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github+json") });
+    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github+json"), signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS) });
     if (!response.ok) return null;
     const body = (await response.json()) as { tree?: Array<{ path?: string; type?: string; size?: number }> } | null;
     const entries: TreeEntry[] = [];
@@ -137,7 +141,7 @@ async function fetchFileText(
       .split("/")
       .map(encodeURIComponent)
       .join("/")}?ref=${encodeURIComponent(ref)}`;
-    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github.raw+json") });
+    const response = await fetch(url, { headers: ghHeaders(token, "application/vnd.github.raw+json"), signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS) });
     if (!response.ok) return null;
     return await readTextCapped(response, maxBytes);
   } catch {

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -187,6 +187,23 @@ describe("indexRepo: full repo index (tree → chunk → embed → upsert)", () 
     errSpy.mockRestore();
   });
 
+  it("bounds the tree + contents GitHub fetches with an abort-timeout signal (a hung connection can't stall the queue worker)", async () => {
+    const { env } = indexEnv();
+    const inits: Array<RequestInit | undefined> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      inits.push(init);
+      const url = input.toString();
+      if (url.includes("/git/trees/")) return Response.json({ tree: [{ type: "blob", path: "src/a.ts", size: 20 }], truncated: false });
+      if (url.includes("/contents/")) return new Response("export const a = 1;\n", { status: 200 });
+      return new Response("missing", { status: 404 });
+    });
+    await indexRepo(env, PROJECT, REPO);
+    // Both the tree fetch and each per-file contents fetch must carry an AbortSignal so a stalled GitHub connection
+    // aborts (→ the existing fail-safe catches) instead of pinning the index job + its queue consumer indefinitely.
+    expect(inits.length).toBeGreaterThan(1);
+    expect(inits.every((i) => i?.signal instanceof AbortSignal)).toBe(true);
+  });
+
   it("a storage error while listing stored paths is fail-safe (prunes nothing, still indexes) + surfaces it at ERROR for Sentry (#5)", async () => {
     const { env } = indexEnv();
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary

The RAG index-population fetches (`fetchRepoTree`, `fetchFileText` in `rag-index.ts`) called bare `fetch(url, { headers })` with **no `AbortSignal`/timeout**. A single hung GitHub connection — on the 6-hourly index cron or on a merged-PR incremental re-index — would stall the entire index job and **pin the queue consumer running it indefinitely** (no body, no progress, no abort). Every sibling fetch in the review pipeline (enrichment-wire, alerts, source-evidence) already guards this with `AbortSignal.timeout`.

Add a shared `GITHUB_FETCH_TIMEOUT_MS = 10_000` and pass `signal: AbortSignal.timeout(...)` to both fetches. An abort lands in the existing fail-safe catches: the tree fetch → `null` → `indexRepo` returns empty (skip); a per-file fetch → `null` → that file is skipped while siblings still index. Behavior is unchanged except a stalled connection now aborts instead of hanging.

Surfaced by the 2026-06-27 review-pipeline hardening audit (reliability, high).

## Scope

- [x] Conventional Commit title; focused (one file + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident reliability hardening (no separate issue needed; sibling of the existing timeout pattern).

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — added a test asserting both the tree fetch and each per-file contents fetch carry an `AbortSignal` init; the existing tree-throws / file-skip fail-safe paths remain covered. No new branch (the `signal` is an unconditional init property).
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: a fetch-option addition only.

## Safety

- [x] No secrets/wallets/trust-scores exposed.
- [x] No public GitHub text change · auth/CORS N/A.

## Notes

- Self-host engine code (RAG population runs on the container, flag `GITTENSORY_REVIEW_RAG`, currently on); ships on the next engine rebuild.
