### PR TITLE
fix(observability): surface publish/checks-perm/secret-scan failures to Sentry

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3883,7 +3883,7 @@ export async function maybeAddSecretLeakFinding(
     /* v8 ignore next -- fail-safe: a file-load error never destabilizes the gate. */
     console.error(
       JSON.stringify({
-        level: "warn",
+        level: "error",
         event: "secret_scan_failed",
         repository: args.repoFullName,
         pullNumber: args.pullNumber,
@@ -4070,6 +4070,9 @@ async function auditGateCheckPermissionMissing(
     detail: warning,
     metadata: { deliveryId, repoFullName },
   });
+  // Surface the install-wide Checks:write gap to Sentry — until the scope is granted the required gate check-run
+  // silently never posts on ANY PR for this install; an operator must SEE this config fault, not just the ledger.
+  console.error(JSON.stringify({ level: "error", event: "gate_check_permission_missing", repository: repoFullName, pullNumber, deliveryId }));
 }
 
 /**
@@ -4899,6 +4902,7 @@ async function maybePublishPrPublicSurface(
           detail: checkRunResult.warning,
           metadata: { deliveryId: webhook.deliveryId, repoFullName },
         });
+        console.error(JSON.stringify({ level: "error", event: "check_run_permission_missing", repository: repoFullName, pullNumber: pr.number, deliveryId: webhook.deliveryId }));
       } else if (checkRunResult?.kind === "published") {
         publishedOutputs.push("check_run");
       }
@@ -5304,6 +5308,16 @@ async function maybePublishPrPublicSurface(
           repoFullName,
           failedOutputs,
         },
+      });
+      // The advisory ran but NOTHING reached the PR (revoked token / perms removed / GitHub 5xx). For an
+      // advisory-only bot this is the worst failure — escalate to Sentry at error level, not just the audit ledger.
+      captureReviewFailure(new Error("PR public-surface publish failed — review produced output but nothing was posted to the PR"), {
+        kind: "publish",
+        owner: repoFullName.split("/")[0],
+        repo: repoFullName,
+        pr: pr.number,
+        head_sha: advisory.headSha,
+        failedOutputs: failedOutputs.map((failure) => failure.output),
       });
     }
     return gateEvaluation;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import * as repositoriesModule from "../../src/db/repositories";
+import * as sentryModule from "../../src/selfhost/sentry";
 import {
   listCollisionEdges,
   createAgentRun,
@@ -4673,6 +4674,7 @@ describe("queue processors", () => {
       if (url.includes("/commits/context500/check-runs")) return new Response("GitHub check API failed", { status: 500 });
       return new Response("not found", { status: 404 });
     });
+    const captureSpy = vi.spyOn(sentryModule, "captureReviewFailure");
 
     await expect(
       processJob(env, {
@@ -4698,6 +4700,9 @@ describe("queue processors", () => {
       .first<{ detail: string; metadata_json: string }>();
     expect(aggregate).toMatchObject({ detail: "check_run" });
     expect(aggregate?.metadata_json).toContain('"output":"check_run"');
+    // The total publish failure (nothing reached the PR) escalates to Sentry at error level, not just the ledger.
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ kind: "publish", repo: "JSONbored/gittensory" }));
+    captureSpy.mockRestore();
   });
 
   it("audits disabled public-surface skips without miner lookup", async () => {


### PR DESCRIPTION
## Summary

Surfaces three review-pipeline failure classes in `processors.ts` to Sentry. The self-host forwarder (`src/selfhost/sentry.ts`) only forwards `level:"error"`/`"fatal"` console lines, so these were invisible to operators:

1. **Total public-surface publish failure** (`maybePublishPrPublicSurface`, the `publishedOutputs.length === 0 && failedOutputs.length > 0` branch): the advisory ran but **nothing reached the PR** (revoked token / perms removed / GitHub 5xx) — the worst failure for an advisory-only bot — was recorded only to the DB audit ledger. Now escalated via `captureReviewFailure(..., { kind:"publish", owner, repo, pr, head_sha, failedOutputs })` (already imported; no-op when Sentry is off). Scoped to the **total**-failure branch (a partial publish stays ledger-only to avoid noise).
2. **Install-wide `Checks:write` gap** (`auditGateCheckPermissionMissing` chokepoint + the context check-run branch): a common self-host misconfig silently prevents the required gate check-run from ever posting on any PR — now logged at `level:"error"` (`gate_check_permission_missing` / `check_run_permission_missing`). Volume bounded (once-per-install config fault).
3. **Secret-leak scan crash** (`maybeAddSecretLeakFinding` catch): a crashed credential scanner degraded silently to "no finding" at `level:"warn"` — flipped to `level:"error"` (a security-observability event).

Surfaced by the 2026-06-27 review-pipeline hardening audit (observability — high + medium).

## Scope

- [x] Conventional Commit title; focused (one src file + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident extension of the #1605/#1619 Sentry-instrumentation line.

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — all three branches are exercised by existing tests (`pr_public_surface_failed`, `gate_check_permission_missing`, `check_run_permission_missing`); the new log/capture lines add no branches. Added a `captureReviewFailure` spy to the existing total-failure test pinning the `kind:"publish"` escalation. The secret-scan catch is `/* v8 ignore */`.
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: logging/escalation only.

## Safety

- [x] No secrets/wallets/trust-scores exposed — logs carry repo/PR/SHA + bounded fields.
- [x] No public GitHub text change · auth/CORS N/A.

## Notes

- Self-host engine code; ships on the next engine rebuild. `captureReviewFailure` is a no-op on cloud/Workers and on self-host without a Sentry DSN.
