### PR TITLE
fix(orb): make self-host webhook-delivery loss visible to operators

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -155,6 +155,11 @@ async function pruneRelayPending(env: Env): Promise<number> {
     .prepare("DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')")
     .bind(RELAY_PENDING_TTL_HOURS)
     .run();
+  // Make pull-mode loss VISIBLE too (parity with the push-path drop): a pruned row is a webhook a long-down tailnet
+  // container never drained — emit an alertable error-level log (distinct event name) so it leaves a Sentry trace.
+  if (pruned.meta.changes > 0) {
+    console.error(JSON.stringify({ level: "error", event: "orb_relay_pending_dropped", count: pruned.meta.changes }));
+  }
   return pruned.meta.changes;
 }
 
@@ -244,7 +249,7 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
   // retries exhausted) — e.g. a container down for over an hour. Emit an alertable structured log so the loss
   // leaves a trace instead of vanishing silently.
   if (pruned.meta.changes > 0) {
-    console.warn(JSON.stringify({ level: "warn", event: "orb_relay_events_dropped", count: pruned.meta.changes }));
+    console.error(JSON.stringify({ level: "error", event: "orb_relay_events_dropped", count: pruned.meta.changes }));
   }
   const { results } = await env.DB
     .prepare(

--- a/src/server.ts
+++ b/src/server.ts
@@ -743,12 +743,15 @@ async function main(): Promise<void> {
     PUBLIC_API_ORIGIN: process.env.PUBLIC_API_ORIGIN,
   })
     .then((r) => {
-      if (r !== "skipped")
-        console.log(
-          JSON.stringify({ event: "selfhost_orb_relay_register", result: r }),
-        );
+      if (r === "registered") {
+        console.log(JSON.stringify({ event: "selfhost_orb_relay_register", result: r }));
+      } else if (r === "failed") {
+        // A failed registration means the central Orb won't forward this install's webhooks here — the container
+        // looks alive but reviews NOTHING. Surface at error level so the operator sees a deaf container.
+        console.error(JSON.stringify({ level: "error", event: "selfhost_orb_relay_register_failed" }));
+      }
     })
-    .catch(() => {});
+    .catch((error) => captureError(error, { kind: "orb_relay_register" }));
 
   // Graceful shutdown: stop accepting HTTP, let the queue finish, close the backend.
   let shuttingDown = false;

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -344,17 +344,17 @@ describe("retryFailedRelays", () => {
     expect(untouched?.n).toBe(5);
   });
 
-  it("PRUNES rows that have exhausted their attempt budget (attempts >= 5) and logs the drop (#5)", async () => {
+  it("PRUNES rows that have exhausted their attempt budget (attempts >= 5) and logs the drop at error level (#5)", async () => {
     const e = brokeredEnv();
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
     // Manually insert a row at the attempt ceiling.
     await db(e).prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, attempts) VALUES (?, ?, ?, ?, ?)").bind("exhausted-1", "pull_request", 9300, "{}", 5).run();
     await retryFailedRelays(e);
     const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='exhausted-1'").first();
     expect(row ?? null).toBeNull(); // pruned on the DELETE pass before the SELECT
-    // The drop is no longer silent — an alertable structured log records the lost event count.
-    expect(warn.mock.calls.some(([line]) => String(line).includes("orb_relay_events_dropped"))).toBe(true);
-    warn.mockRestore();
+    // The drop is no longer silent OR warn-only — an alertable level:error log reaches the Sentry forwarder.
+    expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_events_dropped") && String(line).includes('"level":"error"'))).toBe(true);
+    errLog.mockRestore();
   });
 
   it("PRUNES expired rows (expires_at in the past) without attempting to forward", async () => {
@@ -468,14 +468,18 @@ describe("pullRelayPending", () => {
     expect((await pullRelayPending(e, 9705, { limit: 5 })).length).toBe(5); // a smaller requested limit is honoured
   });
 
-  it("PRUNES rows older than the TTL before returning the batch", async () => {
+  it("PRUNES rows older than the TTL before returning the batch, and logs the drop at error level", async () => {
     const e = brokeredEnv();
+    const errLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
     await db(e).prepare("INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body, created_at) VALUES (?, ?, ?, ?, datetime('now', '-25 hours'))").bind("stale-1", 9706, "pull_request", "{}").run();
     await enqueueRelayPending(e, { deliveryId: "fresh-1", installationId: 9706, eventName: "pull_request", rawBody: "{}" });
     const events = await pullRelayPending(e, 9706);
     expect(events.map((ev) => ev.deliveryId)).toEqual(["fresh-1"]); // the 25h-old row was pruned (TTL 24h)
     const stale = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='stale-1'").first();
     expect(stale ?? null).toBeNull();
+    // Pull-mode loss is now traced for the operator at error level (parity with the push-path drop).
+    expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_pending_dropped") && String(line).includes('"level":"error"'))).toBe(true);
+    errLog.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Makes self-host **webhook-delivery loss visible** to operators — the failure class a self-host operator most needs to trust ("the container looks alive but reviews nothing"). The self-host Sentry forwarder only forwards `level:"error"`/`"fatal"` lines, so these losses were silent or warn-only:

1. **Push-path relay drop** (`retryFailedRelays`, `relay.ts`): a relay event abandoned after its 1h TTL / 5-retry budget was logged at `level:"warn"` → invisible to Sentry. Escalated to `level:"error"` (`orb_relay_events_dropped`).
2. **Pull-path relay drop** (`pruneRelayPending`, `relay.ts`): a pull-mode (NAT/tailnet) container offline past the 24h retention window lost its queued webhooks with **no log at all** — the push path was hardened but the functionally-identical pull path wasn't. Added a distinct `orb_relay_pending_dropped` at `level:"error"` (distinct event name so operators can tell pull-mode loss from push-mode loss).
3. **Boot relay-registration failure** (`server.ts`): `registerOrbRelayTarget` returning `"failed"` was logged at info (no `level`) and the `.catch` was swallowed (`() => {}`). A failed registration means the central Orb never forwards this install's webhooks here — the container reviews nothing. Now `"failed"` logs at `level:"error"` (`selfhost_orb_relay_register_failed`) and the catch routes to `captureError` (already imported).

Surfaced by the 2026-06-27 review-pipeline hardening audit (observability) — consolidates the "self-host delivery integrity" cluster the audit's completeness-critic called out. (The companion `retryFailedRelays` *not_forwardable* retry-semantics fix is deferred to its own PR — it changes `forwardOrbEvent`'s return type and ripples into the webhook handler.)

## Scope

- [x] Conventional Commit title; focused (`relay.ts` + `server.ts` + the relay test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident extension of the #1481 relay-drop-log / #1605 Sentry line.

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — updated the exhausted-budget drop test to assert `console.error` + `"level":"error"`; extended the TTL-prune test to assert `orb_relay_pending_dropped` at error level. Both `changes>0`/`changes===0` arms remain covered (the many no-stale enqueue/retry paths). `server.ts` is codecov-ignored (boot wiring).
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: logging/escalation only.

## Safety

- [x] No secrets/wallets/trust-scores exposed — logs carry only an event name + a dropped-count.
- [x] No public GitHub text change · auth/CORS N/A.

## Notes

- `relay.ts` runs on the cloud Orb (`gittensory-api`, auto-deploys on merge); the `server.ts` boot wiring runs on the self-host engine (ships on the next rebuild).
