### PR TITLE
fix(review): scope surface dedup to sweeps

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1146,7 +1146,10 @@ async function regatePullRequest(
     // Run the AI review on the sweep for BOTH advisory and block modes (#sweep-all-modes) — only skip when AI is
     // OFF. The #1462 per-(repo,pr,headSha,mode) cache bounds the cost: an unchanged PR re-gates from cache with no
     // re-spend, so an advisory PR gets a posted review without burning a token every sweep tick.
-    { skipAiReview: settings.aiReviewMode === "off" },
+    {
+      skipAiReview: settings.aiReviewMode === "off",
+      skipWhenSurfaceCurrent: true,
+    },
   ).catch((error) => {
     console.error(
       JSON.stringify({
@@ -1476,7 +1479,7 @@ async function reReviewStoredPullRequest(
   repoFullName: string,
   prNumber: number,
   previewPollAttempt?: number,
-  options: { skipAiReview?: boolean } = {},
+  options: { skipAiReview?: boolean; skipWhenSurfaceCurrent?: boolean } = {},
 ): Promise<void> {
   const [repo, settings] = await Promise.all([
     getRepository(env, repoFullName),
@@ -1509,13 +1512,13 @@ async function reReviewStoredPullRequest(
     /* v8 ignore next -- the row was just upserted above, so the re-read always returns it; `?? pr` is belt-and-suspenders fail-open. */
     pr = (await getPullRequest(env, repoFullName, prNumber)) ?? pr;
   }
-  // Over-publish dedup (#4): the resync above made pr.headSha the LIVE head. If the public surface was already
-  // published at this exact head, the verdict + comment are already current — skip the re-review + re-publish so the
-  // sweep stops re-publishing every open PR every ~2-min cycle. A never-published PR (NULL marker) or a drifted head
-  // (push/rebase/force-push → marker !== live head) falls THROUGH and re-reviews at the new head; the AI cache is
-  // head_sha-keyed too, so a rebase misses it and gets a fresh review. (Webhook synchronize/opened paths review
-  // directly and always re-stamp — this guard only gates the scheduled sweep.)
-  if (pr.lastPublishedSurfaceSha && pr.lastPublishedSurfaceSha === pr.headSha) {
+  // Over-publish dedup (#4): only scheduled sweeps opt into the head-only shortcut. Event-driven
+  // re-reviews (CI completion, deployment/preview refreshes) must re-evaluate dynamic same-head state.
+  if (
+    options.skipWhenSurfaceCurrent &&
+    pr.lastPublishedSurfaceSha &&
+    pr.lastPublishedSurfaceSha === pr.headSha
+  ) {
     console.log(JSON.stringify({ level: "info", event: "rereview_skipped_surface_current", deliveryId, repository: repoFullName, pullNumber: prNumber, headSha: pr.headSha }));
     return;
   }

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -888,6 +888,42 @@ describe("queue processors", () => {
     expect(checkRunsFetched).toBe(false);
   });
 
+  it("#4 over-publish dedup: same-head CI completions bypass the sweep-only surface-current shortcut", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_REPOS: "owner/agent-repo" });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 7, "a7");
+    let checkRunsFetched = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) { checkRunsFetched = true; return Response.json({ total_count: 0, check_runs: [] }); }
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "ci-bypass-current",
+      eventName: "check_suite",
+      payload: {
+        action: "completed",
+        repository: { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } },
+        installation: { id: 9001 },
+        check_suite: { head_sha: "a7", pull_requests: [{ number: 7 }] },
+      } as never,
+    });
+
+    // CI completion is event-driven dynamic state, so it must re-run prReadyForReview even when the last surface
+    // publish marker already matches this head SHA. Only the scheduled sweep may use the head-only shortcut.
+    expect(checkRunsFetched).toBe(true);
+  });
+
   it("#4 over-publish dedup: a rebased PR (marker != live head) is NOT skipped — it resyncs + re-reviews at the new head, and the marker survives the resync", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
### Motivation
- A scheduled-sweep optimization returned early from a shared re-review path when `lastPublishedSurfaceSha === headSha`, which also prevented event-driven re-reviews (CI completion, deployment/preview) from re-evaluating dynamic same-head state and caused stale gate/comment/maintenance decisions. 
- The intent is to keep the over-publish dedup for periodic sweeps while ensuring webhook-driven events still run the full review logic.

### Description
- Add an optional `skipWhenSurfaceCurrent` flag to `reReviewStoredPullRequest` and only short-circuit on the `lastPublishedSurfaceSha === headSha` guard when that flag is set. 
- Pass `skipWhenSurfaceCurrent: true` only from the scheduled re-gate sweep (`regatePullRequest`) so the head-only shortcut is scoped to sweeps. 
- Keep CI-completion (`check_run`/`check_suite`) and `deployment_status` paths calling `reReviewStoredPullRequest` without the shortcut so they always re-evaluate same-head dynamic state. 
- Add a regression unit test proving a same-head `check_suite.completed` webhook still triggers CI evaluation even after the surface marker was stamped.

### Testing
- Ran the focused unit suite for the change with `npx vitest run test/unit/queue.test.ts -t "over-publish dedup"`, and the new/affected tests passed. 
- Ran `npm run typecheck` and `git diff --check`, both of which succeeded locally. 
- Attempted `npm run test:ci`, but it failed in this environment due to external network/setup issues (actionlint runner-label lookup and `npm audit` contacting the registry), not due to the code change. 
- The change includes a regression test and local test iterations that demonstrate the fix for the vulnerability case.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a403c1c0d54832cb7e19741ff48aedc)