### PR TITLE
fix(enrichment): stop per-patch ReDoS scanning once finding budget is exhausted

### DIFF
--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -11,6 +11,23 @@ const MAX_PATTERN_CHARS = 1000; // ignore absurdly long literals (a hand-written
 const MAX_LINE_CHARS = 2000; // skip extraction on pathologically long lines (defensive)
 const REPORT_CHARS = 80; // truncate the reported pattern so the brief stays readable
 
+type RedosScanLimits = {
+  maxFindings?: number;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  while (start <= patch.length) {
+    const end = patch.indexOf("\n", start);
+    if (end === -1) {
+      yield patch.slice(start);
+      return;
+    }
+    yield patch.slice(start, end);
+    start = end + 1;
+  }
+}
+
 // Extraction runs as a single LINEAR left-to-right scan — deliberately NOT a regex. A regex with the alternation
 // needed here (escapes | char-classes | other chars, all under `+`) has overlapping branches and would itself
 // backtrack catastrophically on adversarial diff input (e.g. many empty `[]` classes with no closing `/`). The
@@ -225,10 +242,16 @@ export function hasCatastrophicBacktracking(pattern: string): boolean {
 }
 
 /** Scan one file patch's added lines for ReDoS-prone regex literals, line-cited via hunk headers. Pure. */
-export function scanPatchForRedos(path: string, patch: string): RedosFinding[] {
+export function scanPatchForRedos(
+  path: string,
+  patch: string,
+  limits: RedosScanLimits = {},
+): RedosFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
   const findings: RedosFinding[] = [];
   let newLine = 0;
-  for (const line of patch.split("\n")) {
+  for (const line of patchLines(patch)) {
     if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
@@ -244,6 +267,7 @@ export function scanPatchForRedos(path: string, patch: string): RedosFinding[] {
             kind: "nested-quantifier",
             pattern: source.slice(0, REPORT_CHARS),
           });
+          if (findings.length >= maxFindings) return findings;
         }
       }
       newLine++;
@@ -259,7 +283,9 @@ export async function scanRedos(req: EnrichRequest): Promise<RedosFinding[]> {
   const findings: RedosFinding[] = [];
   for (const file of req.files ?? []) {
     if (!file.patch) continue;
-    for (const finding of scanPatchForRedos(file.path, file.patch)) {
+    for (const finding of scanPatchForRedos(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+    })) {
       findings.push(finding);
       if (findings.length >= MAX_FINDINGS) return findings;
     }

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -675,6 +675,26 @@ test("scanRedos: scans every changed file's added lines, caps to its budget", as
   assert.equal(findings[0].file, "src/a.ts");
 });
 
+test("scanPatchForRedos: stops scanning once the finding budget is exhausted", () => {
+  const patch = [
+    "@@ -1,0 +1,4 @@",
+    "+const first = /(a+)+$/;",
+    "+const second = /(b+)+$/;",
+    "+const third = /(c+)+$/;",
+    "+const fourth = /(d+)+$/;",
+  ].join("\n");
+
+  const findings = scanPatchForRedos("src/x.ts", patch, { maxFindings: 2 });
+
+  assert.deepEqual(
+    findings.map(({ line, pattern }) => ({ line, pattern })),
+    [
+      { line: 1, pattern: "(a+)+$" },
+      { line: 2, pattern: "(b+)+$" },
+    ],
+  );
+});
+
 test("renderBrief: renders the ReDoS block, code-spanning + sanitizing the pattern", () => {
   const r = renderBrief({
     redos: [


### PR DESCRIPTION
### Motivation
- Prevent a crafted PR patch from forcing unbounded work/allocation in the ReDoS analyzer by ensuring the global findings cap is enforced during per-file scanning.

### Description
- Add an optional `limits` parameter (`RedosScanLimits`) to `scanPatchForRedos` and honor a `maxFindings` budget inside the per-patch scan so scanning returns as soon as the remaining budget is exhausted.
- Stop using `patch.split("\n")` and replace it with a streaming `patchLines` generator so lines are iterated lazily and the scanner does not allocate the entire line array before the cap can take effect.
- Thread the remaining global budget into `scanRedos` when calling `scanPatchForRedos` so the analyzer never materializes more findings than `MAX_FINDINGS`.
- Add a regression test verifying `scanPatchForRedos` stops scanning once the configured `maxFindings` is reached.

### Testing
- Ran the enrichment package unit tests with `npm test` from `review-enrichment/`, and all tests passed (`45` tests, `0` failures).
- Verified the new regression test that asserts the per-patch finding budget is enforced and observed it passing in the unit test run.
- Attempted the repo-level gate with `npm run test:ci`, but the run could not fully complete due to external Actionlint setup/network and `npm audit` registry access failures (these are environmental/network failures, not test regressions in the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a403eb50f50832c88cfa36937ba774f)