### PR TITLE
feat(enrichment): commit-signature and verified-author provenance

### DIFF
--- a/review-enrichment/src/analyzers/commit-signature.ts
+++ b/review-enrichment/src/analyzers/commit-signature.ts
@@ -12,6 +12,10 @@ const MAX_HISTORY_COMMITS = 20;
 const MIN_HISTORY_FOR_PATTERN = 3;    // need ≥ this many non-head commits to infer the repo's signing pattern
 const VERIFIED_RATIO_THRESHOLD = 0.8; // only flag new-committer when ≥80% of recent commits are verified
 
+// Allowlists to prevent path traversal when these values are interpolated into API URL paths.
+const SHA_RE = /^[a-f0-9]{7,40}$/i;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // must start with alphanumeric — rejects ".." and other dot-only traversal segments
+
 interface GitHubCommit {
   sha: string;
   commit: {
@@ -32,10 +36,12 @@ export async function scanCommitSignature(
   const { repoFullName, headSha, githubToken } = req;
   if (!githubToken || !headSha) return [];
 
+  if (!SHA_RE.test(headSha)) return [];
+
   const parts = repoFullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
-  if (!owner || !repo) return [];
+  if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${githubToken}`,
@@ -47,7 +53,7 @@ export async function scanCommitSignature(
   let headCommit: GitHubCommit;
   try {
     const resp = await fetchFn(
-      `https://api.github.com/repos/${owner}/${repo}/commits/${headSha}`,
+      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(headSha)}`,
       { headers, signal: opts?.signal },
     );
     if (!resp.ok) return [];

--- a/review-enrichment/src/analyzers/commit-signature.ts
+++ b/review-enrichment/src/analyzers/commit-signature.ts
@@ -1,0 +1,102 @@
+// Commit-signature / verified-author provenance analyzer (#1517). Detects two supply-chain signals that the
+// no-checkout reviewer cannot assess on their own:
+//   "unsigned"      — the PR head commit is not signed/verified by GitHub
+//                     (commit.verification.verified = false; reason exposed as context).
+//   "new-committer" — the committing author has no prior commits in this repo, yet the repo's recent history
+//                     is ≥80% verified-commit signed — a potential impersonation/injection vector.
+// Network: two or three GitHub REST calls (head commit, recent repo commits, author history) under the shared
+// AbortSignal timeout. Fail-safe: returns [] on any error or missing prerequisite.
+import type { EnrichRequest, CommitSignatureFinding } from "../types.js";
+
+const MAX_HISTORY_COMMITS = 20;
+const MIN_HISTORY_FOR_PATTERN = 3;    // need ≥ this many non-head commits to infer the repo's signing pattern
+const VERIFIED_RATIO_THRESHOLD = 0.8; // only flag new-committer when ≥80% of recent commits are verified
+
+interface GitHubCommit {
+  sha: string;
+  commit: {
+    verification: {
+      verified: boolean;
+      reason: string;
+    };
+  };
+  author: { login: string } | null;
+}
+
+/** Fetch head-commit verification status, then optionally check for never-before-seen committers. */
+export async function scanCommitSignature(
+  req: EnrichRequest,
+  fetchFn: typeof fetch,
+  opts?: { signal?: AbortSignal },
+): Promise<CommitSignatureFinding[]> {
+  const { repoFullName, headSha, githubToken } = req;
+  if (!githubToken || !headSha) return [];
+
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (!owner || !repo) return [];
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${githubToken}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  // Phase 1: fetch the head commit and check its verification status.
+  let headCommit: GitHubCommit;
+  try {
+    const resp = await fetchFn(
+      `https://api.github.com/repos/${owner}/${repo}/commits/${headSha}`,
+      { headers, signal: opts?.signal },
+    );
+    if (!resp.ok) return [];
+    headCommit = (await resp.json()) as GitHubCommit;
+  } catch {
+    return [];
+  }
+
+  const authorLogin = headCommit.author?.login ?? null;
+  const verification = headCommit.commit.verification;
+
+  if (!verification.verified) {
+    return [{ headSha, authorLogin, kind: "unsigned", reason: verification.reason }];
+  }
+
+  // Phase 2: check whether this is a new committer in a repo with a verified-commit pattern.
+  // Skip the check when the author identity is unknown (no GitHub user linked to the commit email).
+  if (!authorLogin) return [];
+
+  try {
+    const recentResp = await fetchFn(
+      `https://api.github.com/repos/${owner}/${repo}/commits?per_page=${MAX_HISTORY_COMMITS}`,
+      { headers, signal: opts?.signal },
+    );
+    if (!recentResp.ok) return [];
+    const recentCommits = (await recentResp.json()) as GitHubCommit[];
+
+    // Exclude the current head from history so the ratio reflects the pre-existing signing pattern.
+    const others = recentCommits.filter((c) => c.sha !== headSha);
+    if (others.length < MIN_HISTORY_FOR_PATTERN) return [];
+
+    const verifiedCount = others.filter((c) => c.commit.verification.verified).length;
+    if (verifiedCount / others.length < VERIFIED_RATIO_THRESHOLD) return [];
+
+    // Repo uses verified commits — does this author have any prior commits here?
+    const authorHistoryResp = await fetchFn(
+      `https://api.github.com/repos/${owner}/${repo}/commits?author=${encodeURIComponent(authorLogin)}&per_page=3`,
+      { headers, signal: opts?.signal },
+    );
+    if (!authorHistoryResp.ok) return [];
+    const authorHistory = (await authorHistoryResp.json()) as { sha: string }[];
+
+    const priorCommits = authorHistory.filter((c) => c.sha !== headSha);
+    if (priorCommits.length === 0) {
+      return [{ headSha, authorLogin, kind: "new-committer", reason: null }];
+    }
+  } catch {
+    return [];
+  }
+
+  return [];
+}

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -14,6 +14,7 @@ import { scanInstallScripts } from "./analyzers/install-scripts.js";
 import { scanActionPins } from "./analyzers/actions-pin.js";
 import { scanEol } from "./analyzers/eol-check.js";
 import { scanRedos } from "./analyzers/redos.js";
+import { scanCommitSignature } from "./analyzers/commit-signature.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest, signal: AbortSignal) => Promise<unknown>;
@@ -27,6 +28,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   actionPin: (req) => scanActionPins(req),
   eol: (req) => scanEol(req),
   redos: (req) => scanRedos(req),
+  commitSignature: (req, signal) => scanCommitSignature(req, fetch, { signal }),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -129,6 +129,27 @@ export function renderBrief(
     }
   }
 
+  const commitSigs = findings.commitSignature ?? [];
+  if (commitSigs.length) {
+    lines.push("### Commit-signature / verified-author provenance");
+    for (const item of commitSigs) {
+      const sha = safeCodeSpan(item.headSha.slice(0, 8));
+      if (item.kind === "unsigned") {
+        const reason = safeCodeSpan(item.reason ?? "unknown");
+        lines.push(
+          `- ${sha} — commit is not signed or verified (reason: ${reason}); sign commits via gpg or ssh`,
+        );
+      } else {
+        const who = item.authorLogin
+          ? safeCodeSpan(item.authorLogin)
+          : "the commit author";
+        lines.push(
+          `- ${sha} — ${who} is a first-time committer in this repository, which otherwise uses verified commits (supply-chain risk: potential impersonation)`,
+        );
+      }
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -147,6 +147,9 @@ export function renderBrief(
           `- ${sha} — ${who} is a first-time committer in this repository, which otherwise uses verified commits (supply-chain risk: potential impersonation)`,
         );
       }
+    }
+  }
+
   const codeownersViolations = findings.codeowners ?? [];
   if (codeownersViolations.length) {
     const allOwners = new Set(codeownersViolations.flatMap((f) => f.owners));

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -102,6 +102,8 @@ export interface CommitSignatureFinding {
   authorLogin: string | null;
   kind: "unsigned" | "new-committer";
   reason: string | null;
+}
+
 /** A changed file governed by a CODEOWNERS rule where the PR author is not listed as an owner (#1515).
  *  The blast radius (distinct ownership domains crossed) is derived at render time from the full findings set. */
 export interface CodeownersFinding {

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -93,6 +93,17 @@ export interface RedosFinding {
   pattern: string;
 }
 
+/** A commit-signature or verified-author provenance signal (#1517).
+ *  "unsigned": head commit is not signed/verified by GitHub.
+ *  "new-committer": the author has no prior commits in a repo that otherwise uses verified commits
+ *  (supply-chain / impersonation risk). */
+export interface CommitSignatureFinding {
+  headSha: string;
+  authorLogin: string | null;
+  kind: "unsigned" | "new-committer";
+  reason: string | null;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -102,6 +113,7 @@ export interface BriefFindings {
   installScript?: InstallScriptFinding[];
   eol?: EolFinding[];
   redos?: RedosFinding[];
+  commitSignature?: CommitSignatureFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -1258,6 +1258,21 @@ test("buildBrief: commitSignature analyzer is wired into the orchestrator", asyn
       return { ok: true, json: async () => UNSIGNED_COMMIT };
     return { ok: true, json: async () => ({}) };
   };
+  try {
+    const brief = await buildBrief({
+      repoFullName: "owner/repo",
+      prNumber: 1,
+      headSha: "abc1234abc1234ab",
+      githubToken: "tok",
+    });
+    assert.equal(brief.analyzerStatus.commitSignature, "ok");
+    assert.equal(brief.findings.commitSignature.length, 1);
+    assert.equal(brief.findings.commitSignature[0].kind, "unsigned");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("codeOnly: blanks string messages, keeps ${...} interpolation bodies", () => {
   assert.equal(codeOnly('"a secret here"'), " ");
   assert.equal(codeOnly("'plain'"), " ");
@@ -1405,9 +1420,20 @@ test("renderBrief: renders the secret-log block, code-spanning + sanitizing", ()
   assert.match(r.promptSection, /a secret\/credential/);
 });
 
-test("buildBrief: secret-log analyzer runs (pure, no network)", async () => {
+test("buildBrief: commitSignature analyzer runs and reports unsigned commit", async () => {
   const realFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/commits/abc1234abc1234ab"))
+      return {
+        ok: true,
+        json: async () => ({
+          sha: "abc1234abc1234ab",
+          commit: { verification: { verified: false, reason: "unsigned" } },
+          author: { login: "alice" },
+        }),
+      };
+    return { ok: true, json: async () => ({}) };
+  };
   try {
     const brief = await buildBrief({
       repoFullName: "o/r",
@@ -1419,6 +1445,18 @@ test("buildBrief: secret-log analyzer runs (pure, no network)", async () => {
     assert.equal(brief.findings.commitSignature.length, 1);
     assert.equal(brief.findings.commitSignature[0].kind, "unsigned");
     assert.match(brief.promptSection, /Commit-signature/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("buildBrief: secret-log analyzer runs (pure, no network)", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 1,
       files: [
         {
           path: "src/a.ts",

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -1177,3 +1177,37 @@ test("buildBrief: commitSignature analyzer is wired into the orchestrator", asyn
     globalThis.fetch = realFetch;
   }
 });
+
+test("scanCommitSignature: returns [] when headSha fails SHA format validation (path traversal guard)", async () => {
+  let fetched = false;
+  const fakeFetch = async () => { fetched = true; return { ok: true, json: async () => ({}) }; };
+  for (const badSha of ["../../../evil", "refs/heads/main", "HEAD~1", "", "xyz!@#"]) {
+    const findings = await scanCommitSignature(sigReq({ headSha: badSha }), fakeFetch);
+    assert.deepEqual(findings, [], `expected [] for headSha=${JSON.stringify(badSha)}`);
+  }
+  assert.equal(fetched, false, "no fetch should occur for invalid headSha");
+});
+
+test("scanCommitSignature: returns [] when owner or repo segment is a path traversal sequence", async () => {
+  let fetched = false;
+  const fakeFetch = async () => { fetched = true; return { ok: true, json: async () => ({}) }; };
+  // "../evil/repo" → owner="..", repo="evil" — ".." starts with '.' so SLUG_RE rejects it
+  // "owner/../commits" → repo=".." — same
+  // "./sneaky/repo" → owner="." — "." starts with '.', SLUG_RE rejects it
+  for (const badRepo of ["../evil/repo", "owner/../commits", "./sneaky/repo"]) {
+    const findings = await scanCommitSignature(sigReq({ repoFullName: badRepo }), fakeFetch);
+    assert.deepEqual(findings, [], `expected [] for repoFullName=${JSON.stringify(badRepo)}`);
+  }
+  assert.equal(fetched, false, "no fetch should occur for invalid owner/repo");
+});
+
+test("scanCommitSignature: valid short SHA (7 chars) passes format check and proceeds to fetch", async () => {
+  let didFetch = false;
+  const fetch = async () => {
+    didFetch = true;
+    return { ok: false, json: async () => ({}) };
+  };
+  const findings = await scanCommitSignature(sigReq({ headSha: "abc1234" }), fetch);
+  assert.deepEqual(findings, []);
+  assert.ok(didFetch, "a valid 7-char SHA should reach the fetch");
+});

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -21,6 +21,7 @@ import {
   scanPatchForRedos,
   scanRedos,
 } from "../dist/analyzers/redos.js";
+import { scanCommitSignature } from "../dist/analyzers/commit-signature.js";
 
 const NOW = new Date("2026-06-26").getTime();
 const eolFetch =
@@ -933,6 +934,245 @@ test("buildBrief: eol analyzer runs (real now, 2023 cycle is past)", async () =>
     assert.equal(brief.analyzerStatus.eol, "ok");
     assert.equal(brief.findings.eol.length, 1);
     assert.match(brief.promptSection, /End-of-life runtimes/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// ── scanCommitSignature ──────────────────────────────────────────────────────
+
+const VERIFIED_COMMIT = {
+  sha: "abc1234abc1234ab",
+  commit: { verification: { verified: true, reason: "valid" } },
+  author: { login: "alice" },
+};
+const UNSIGNED_COMMIT = {
+  sha: "abc1234abc1234ab",
+  commit: { verification: { verified: false, reason: "unsigned" } },
+  author: { login: "alice" },
+};
+const REPO_VERIFIED_HISTORY = Array.from({ length: 5 }, (_, i) => ({
+  sha: `old${i}`,
+  commit: { verification: { verified: true, reason: "valid" } },
+  author: { login: "bob" },
+}));
+
+const sigReq = (overrides = {}) => ({
+  repoFullName: "owner/repo",
+  prNumber: 1,
+  headSha: "abc1234abc1234ab",
+  githubToken: "tok",
+  ...overrides,
+});
+
+function makeSigFetch(headCommit, recentCommits = [], authorHistory = []) {
+  return async (url) => {
+    const u = String(url);
+    if (u.includes("/commits/abc1234abc1234ab"))
+      return { ok: true, json: async () => headCommit };
+    if (u.includes("/commits?author="))
+      return { ok: true, json: async () => authorHistory };
+    if (u.includes("/commits?per_page="))
+      return { ok: true, json: async () => recentCommits };
+    return { ok: false, json: async () => ({}) };
+  };
+}
+
+test("scanCommitSignature: returns [] when githubToken is absent", async () => {
+  const findings = await scanCommitSignature(
+    sigReq({ githubToken: undefined }),
+    async () => { throw new Error("should not fetch"); },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] when headSha is absent", async () => {
+  const findings = await scanCommitSignature(
+    sigReq({ headSha: undefined }),
+    async () => { throw new Error("should not fetch"); },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] on non-ok head commit response", async () => {
+  const findings = await scanCommitSignature(
+    sigReq(),
+    async () => ({ ok: false, json: async () => ({}) }),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] on network error (fail-safe)", async () => {
+  const findings = await scanCommitSignature(sigReq(), async () => {
+    throw new Error("network down");
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: flags unsigned commit with its reason", async () => {
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(UNSIGNED_COMMIT),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "unsigned");
+  assert.equal(findings[0].reason, "unsigned");
+  assert.equal(findings[0].authorLogin, "alice");
+  assert.equal(findings[0].headSha, "abc1234abc1234ab");
+});
+
+test("scanCommitSignature: returns [] for verified commit when author login is null", async () => {
+  const noLoginCommit = {
+    sha: "abc1234abc1234ab",
+    commit: { verification: { verified: true, reason: "valid" } },
+    author: null,
+  };
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(noLoginCommit),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] when recent commits response is non-ok", async () => {
+  const fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("/commits/abc1234abc1234ab"))
+      return { ok: true, json: async () => VERIFIED_COMMIT };
+    return { ok: false, json: async () => ({}) };
+  };
+  const findings = await scanCommitSignature(sigReq(), fetch);
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] when repo has insufficient commit history", async () => {
+  // Only 2 non-head commits — below MIN_HISTORY_FOR_PATTERN (3)
+  const twoCommits = [
+    { sha: "old0", commit: { verification: { verified: true, reason: "valid" } }, author: { login: "bob" } },
+    { sha: "old1", commit: { verification: { verified: true, reason: "valid" } }, author: { login: "bob" } },
+  ];
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(VERIFIED_COMMIT, twoCommits),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] when repo history is not mostly verified (<80%)", async () => {
+  // 3 commits, only 1 verified (33%)
+  const mixedHistory = [
+    { sha: "old0", commit: { verification: { verified: true, reason: "valid" } }, author: { login: "bob" } },
+    { sha: "old1", commit: { verification: { verified: false, reason: "unsigned" } }, author: { login: "bob" } },
+    { sha: "old2", commit: { verification: { verified: false, reason: "unsigned" } }, author: { login: "bob" } },
+  ];
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(VERIFIED_COMMIT, mixedHistory),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] when author history response is non-ok", async () => {
+  const fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("/commits/abc1234abc1234ab"))
+      return { ok: true, json: async () => VERIFIED_COMMIT };
+    if (u.includes("/commits?per_page="))
+      return { ok: true, json: async () => REPO_VERIFIED_HISTORY };
+    return { ok: false, json: async () => ({}) };
+  };
+  const findings = await scanCommitSignature(sigReq(), fetch);
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: flags new-committer in verified repo when author has no prior commits", async () => {
+  // authorHistory returns empty list → alice has no prior commits
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(VERIFIED_COMMIT, REPO_VERIFIED_HISTORY, []),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "new-committer");
+  assert.equal(findings[0].authorLogin, "alice");
+  assert.equal(findings[0].reason, null);
+});
+
+test("scanCommitSignature: returns [] for known committer (has prior commits in repo)", async () => {
+  // authorHistory contains a prior commit (different SHA)
+  const priorCommit = { sha: "prior000" };
+  const findings = await scanCommitSignature(
+    sigReq(),
+    makeSigFetch(VERIFIED_COMMIT, REPO_VERIFIED_HISTORY, [priorCommit]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitSignature: returns [] on phase-2 network error (fail-safe)", async () => {
+  let calls = 0;
+  const fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("/commits/abc1234abc1234ab"))
+      return { ok: true, json: async () => VERIFIED_COMMIT };
+    calls++;
+    throw new Error("network down");
+  };
+  const findings = await scanCommitSignature(sigReq(), fetch);
+  assert.deepEqual(findings, []);
+  assert.ok(calls >= 1, "phase 2 did attempt a fetch before throwing");
+});
+
+test("renderBrief: renders unsigned-commit finding with sha and reason", () => {
+  const r = renderBrief({
+    commitSignature: [
+      { headSha: "deadbeef0011", authorLogin: "alice", kind: "unsigned", reason: "unsigned" },
+    ],
+  });
+  assert.match(r.promptSection, /Commit-signature/);
+  assert.match(r.promptSection, /`deadbeef`/);
+  assert.match(r.promptSection, /not signed or verified/);
+  assert.match(r.promptSection, /`unsigned`/);
+});
+
+test("renderBrief: renders new-committer finding with sha and login", () => {
+  const r = renderBrief({
+    commitSignature: [
+      { headSha: "cafe1234abcd", authorLogin: "eve", kind: "new-committer", reason: null },
+    ],
+  });
+  assert.match(r.promptSection, /Commit-signature/);
+  assert.match(r.promptSection, /`cafe1234`/);
+  assert.match(r.promptSection, /`eve`.*first-time committer|first-time committer.*`eve`/);
+  assert.match(r.promptSection, /supply-chain risk/);
+});
+
+test("renderBrief: renders new-committer finding when authorLogin is null", () => {
+  const r = renderBrief({
+    commitSignature: [
+      { headSha: "aabb1234ccdd", authorLogin: null, kind: "new-committer", reason: null },
+    ],
+  });
+  assert.match(r.promptSection, /the commit author.*first-time committer|first-time committer/);
+});
+
+test("buildBrief: commitSignature analyzer is wired into the orchestrator", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("/commits/abc123"))
+      return { ok: true, json: async () => UNSIGNED_COMMIT };
+    return { ok: true, json: async () => ({}) };
+  };
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 1,
+      headSha: "abc1234abc1234ab",
+      githubToken: "tok",
+    });
+    assert.equal(brief.analyzerStatus.commitSignature, "ok");
+    assert.equal(brief.findings.commitSignature.length, 1);
+    assert.equal(brief.findings.commitSignature[0].kind, "unsigned");
+    assert.match(brief.promptSection, /Commit-signature/);
   } finally {
     globalThis.fetch = realFetch;
   }


### PR DESCRIPTION
## Summary

- Adds a `CommitSignatureFinding` type and `commitSignature` key to `BriefFindings` in `review-enrichment/src/types.ts`.
- Implements `review-enrichment/src/analyzers/commit-signature.ts`: two-phase GitHub REST analysis of the PR head commit. Phase 1 fetches `GET /repos/{owner}/{repo}/commits/{headSha}` and checks `commit.verification.verified`; an unsigned or unverified commit produces a `kind: "unsigned"` finding with the `verification.reason` (e.g. `"unsigned"`, `"gpgkeys_missing"`, `"no_user"`). Phase 2 (verified commits only) fetches up to 20 recent repo commits to compute the verified-commit ratio; if ≥80%, fetches `GET /commits?author={login}&per_page=3` — a never-before-seen author in that context produces a `kind: "new-committer"` finding (supply-chain / impersonation signal). Bounded at 3 API calls per brief; fail-safe on any network error, non-ok response, missing token, or missing sha.
- Registers the analyzer in `src/brief.ts` ANALYZERS registry with abort-signal forwarding.
- Renders a `### Commit-signature / verified-author provenance` block in `src/render.ts`; unsigned findings cite the abbreviated sha + reason; new-committer findings cite the sha + login with an impersonation-risk note. `safeCodeSpan` wraps all user-controlled values.
- Adds 17 `node:test` unit and integration tests covering every branch: missing token/sha, network failure (phases 1 and 2), non-ok responses for all three fetch calls, unsigned detection, null author login, insufficient history, below-threshold verified ratio, known committer, new-committer detection, render block (unsigned, new-committer with login, new-committer with null login), and orchestrator wiring. Total: 61 tests, all passing.

Closes #1517. Parent: #1499.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- All changes are confined to `review-enrichment/`, which is a standalone Node.js service outside the main Cloudflare Worker build and outside the Codecov `src/**` include path. The enrichment-service test suite (`npm test` inside `review-enrichment/`) runs **61 tests, all passing**, including the 17 new commit-signature tests. The root-level CI checks above apply to the Worker and do not cover this service.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/CORS/session changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API schema changes; the enrichment service is an internal analysis layer, not a public endpoint change.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. — N/A: no visible UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI, frontend, docs, or extension changes.

## Notes

- The `githubToken` from `EnrichRequest` is forwarded only in `Authorization: Bearer` headers for GitHub API calls; it is never logged or included in any finding output.
- `safeCodeSpan` is used for all user-controlled strings in the render block (sha, reason, author login) — same convention as every other network-based analyzer in the service.
- Phase 2 only runs when the head commit is already verified — if it is unsigned, phase 2 is skipped entirely (the unsigned finding is more actionable and the additional API calls would not change the result).
- The 80% verified-ratio threshold avoids false positives on repos with mixed signing discipline while reliably triggering on repos where signing is a hard requirement.
