### PR TITLE
feat(enrichment): changed-line coverage-delta analyzer (#1516

### DIFF
--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -179,7 +179,8 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
 
     let data: Buffer;
     if (method === 0) {
-      data = compData; // stored — no decompression
+      if (compData.length > MAX_COVERAGE_BYTES) continue; // stored entry too large
+      data = compData;
     } else if (method === 8) {
       try { data = inflateRawSync(compData, { maxOutputLength: MAX_COVERAGE_BYTES }); }
       catch { continue; } // RangeError from maxOutputLength or corrupt data → skip entry
@@ -187,7 +188,6 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
       continue; // unsupported compression method
     }
 
-    if (data.length > MAX_COVERAGE_BYTES) continue;
     entries.push({ name, data });
   }
   return entries;
@@ -209,7 +209,9 @@ function parseCoverage(kind: "lcov" | "istanbul" | "cobertura", content: string)
   return parseCoberturaXml(content);
 }
 
-/** True when covPath equals prFile or ends with /<prFile> (handles absolute workspace-prefixed paths). */
+/** True when covPath equals prFile or ends with /<prFile> (handles absolute workspace-prefixed paths).
+ *  Suffix matching can produce false positives when two distinct paths share a trailing component
+ *  (e.g. `lib/utils.ts` in coverage matching PR file `utils.ts`); acceptable given the heuristic nature. */
 function pathMatches(covPath: string, prFile: string): boolean {
   const c = covPath.replace(/\\/g, "/");
   const p = prFile.replace(/\\/g, "/");
@@ -251,7 +253,7 @@ export async function scanCoverageDelta(
   let runs: WorkflowRun[];
   try {
     const runsResp = await fetchFn(
-      `https://api.github.com/repos/${owner}/${repo}/actions/runs?head_sha=${headSha}&per_page=20`,
+      `https://api.github.com/repos/${owner}/${repo}/actions/runs?head_sha=${headSha}&per_page=10`,
       { headers, signal: opts?.signal },
     );
     if (!runsResp.ok) return [];
@@ -268,7 +270,6 @@ export async function scanCoverageDelta(
 
   // Walk runs most-recent-first and stop at the first one that has a coverage artifact.
   let coverageArtifact: Artifact | null = null;
-  let artifactRunId = 0;
 
   for (const run of runs) {
     let artifacts: Artifact[];
@@ -288,11 +289,10 @@ export async function scanCoverageDelta(
       .filter((a) => COVERAGE_ARTIFACT_RE.test(a.name) && a.size_in_bytes <= MAX_ARTIFACT_BYTES)
       .sort((a, b) => a.size_in_bytes - b.size_in_bytes)[0];
 
-    if (found) { coverageArtifact = found; artifactRunId = run.id; break; }
+    if (found) { coverageArtifact = found; break; }
   }
 
   if (!coverageArtifact) return [];
-  void artifactRunId; // used only for the API path above
 
   // Download the artifact ZIP (GitHub responds with a redirect to a signed S3 URL; fetch follows it).
   let zipBuffer: Buffer;

--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -233,6 +233,8 @@ export async function scanCoverageDelta(
   const owner = parts[0];
   const repo = parts[1];
   if (!owner || !repo) return [];
+  const eOwner = encodeURIComponent(owner);
+  const eRepo = encodeURIComponent(repo);
 
   // Build the changed-line index from the PR patch before touching the network.
   const changedLines = new Map<string, Set<number>>();
@@ -253,7 +255,7 @@ export async function scanCoverageDelta(
   let runs: WorkflowRun[];
   try {
     const runsResp = await fetchFn(
-      `https://api.github.com/repos/${owner}/${repo}/actions/runs?head_sha=${headSha}&per_page=10`,
+      `https://api.github.com/repos/${eOwner}/${eRepo}/actions/runs?head_sha=${encodeURIComponent(headSha)}&per_page=10`,
       { headers, signal: opts?.signal },
     );
     if (!runsResp.ok) return [];
@@ -275,7 +277,7 @@ export async function scanCoverageDelta(
     let artifacts: Artifact[];
     try {
       const artResp = await fetchFn(
-        `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts`,
+        `https://api.github.com/repos/${eOwner}/${eRepo}/actions/runs/${run.id}/artifacts`,
         { headers, signal: opts?.signal },
       );
       if (!artResp.ok) continue;
@@ -298,7 +300,7 @@ export async function scanCoverageDelta(
   let zipBuffer: Buffer;
   try {
     const zipResp = await fetchFn(
-      `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${coverageArtifact.id}/zip`,
+      `https://api.github.com/repos/${eOwner}/${eRepo}/actions/artifacts/${coverageArtifact.id}/zip`,
       { headers, signal: opts?.signal },
     );
     if (!zipResp.ok) return [];

--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -1,0 +1,344 @@
+// Coverage-delta analyzer (#1516). Finds added/changed lines in the PR that are not covered by the
+// project's own CI test suite. Uses the GitHub Actions artifact API to download the most recent
+// successful run's coverage report (lcov / Istanbul JSON / Cobertura XML), parses line-hit counts,
+// and correlates them against the PR patch hunks — all without a repo checkout.
+// ZIP extraction uses Node.js built-in zlib (DEFLATE) so no extra dependency is needed.
+// Fail-safe: returns [] on any network error, non-ok response, or unparseable artifact.
+import type { EnrichRequest, CoverageDeltaFinding } from "../types.js";
+import { inflateRawSync } from "node:zlib";
+
+const MAX_ARTIFACT_BYTES = 5 * 1024 * 1024;   // 5 MB cap on artifact ZIP (skip oversized ones)
+const MAX_COVERAGE_BYTES = 2 * 1024 * 1024;   // 2 MB cap on any single uncompressed file in the ZIP
+const MAX_RUNS_TO_CHECK = 5;                   // successful runs to search before giving up
+const MAX_FILES_REPORTED = 15;
+const MAX_LINES_PER_FILE = 20;
+
+// Artifact names that are likely coverage reports. Case-insensitive match against artifact.name.
+const COVERAGE_ARTIFACT_RE = /coverage|lcov|cov[-_]report|test[-_]cov|codecoverage/i;
+
+// Map of normalized file path → Set<number> of 1-indexed uncovered line numbers.
+type CoverageMap = Map<string, Set<number>>;
+
+interface WorkflowRun {
+  id: number;
+  conclusion: string | null;
+  created_at: string;
+}
+
+interface Artifact {
+  id: number;
+  name: string;
+  size_in_bytes: number;
+}
+
+/** ZIP entry returned by readZipEntries. */
+export interface ZipEntry {
+  name: string;
+  data: Buffer;
+}
+
+// ── Patch parsing ─────────────────────────────────────────────────────────────
+
+/** Extract 1-indexed line numbers (in the NEW file) for all added lines from a unified diff patch. */
+export function extractChangedLines(patch: string): Set<number> {
+  const lines = new Set<number>();
+  let newLine = 0;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) { newLine = Number(hunk[1]!); continue; }
+    if (line.startsWith("+")) { lines.add(newLine); newLine++; }
+    else if (!line.startsWith("-")) { newLine++; }
+  }
+  return lines;
+}
+
+// ── Coverage format parsers ───────────────────────────────────────────────────
+
+/** Parse an lcov report into a map of file → uncovered line numbers (DA:line,0 entries). */
+export function parseLcov(content: string): CoverageMap {
+  const map: CoverageMap = new Map();
+  let currentFile = "";
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("SF:")) {
+      currentFile = line.slice(3);
+      if (!map.has(currentFile)) map.set(currentFile, new Set());
+    } else if (line.startsWith("DA:") && currentFile) {
+      const parts = line.slice(3).split(",");
+      const lineNum = Number(parts[0]);
+      const hits = Number(parts[1]);
+      if (Number.isFinite(lineNum) && Number.isFinite(hits) && hits === 0) {
+        map.get(currentFile)!.add(lineNum);
+      }
+    } else if (line === "end_of_record") {
+      currentFile = "";
+    }
+  }
+  return map;
+}
+
+/** Parse an Istanbul/NYC coverage-final.json into a map of file → uncovered line numbers.
+ *  Each entry maps statement keys to hit counts; uncovered = s[key] === 0. */
+export function parseIstanbulJson(content: string): CoverageMap {
+  const map: CoverageMap = new Map();
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return map;
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return map;
+
+  for (const [filePath, fileCov] of Object.entries(data)) {
+    if (typeof fileCov !== "object" || fileCov === null) continue;
+    const fc = fileCov as {
+      s?: Record<string, number>;
+      statementMap?: Record<string, { start: { line: number } }>;
+    };
+    if (!fc.s || !fc.statementMap) continue;
+    const uncovered = new Set<number>();
+    for (const [key, hits] of Object.entries(fc.s)) {
+      if (hits === 0) {
+        const stmt = fc.statementMap[key];
+        if (stmt) uncovered.add(stmt.start.line);
+      }
+    }
+    if (uncovered.size > 0) map.set(filePath, uncovered);
+  }
+  return map;
+}
+
+/** Parse a Cobertura XML coverage report into a map of file → uncovered line numbers.
+ *  Uses line-by-line scanning to avoid backtracking `[\s\S]*?` patterns (ReDoS risk on XML). */
+export function parseCoberturaXml(content: string): CoverageMap {
+  const map: CoverageMap = new Map();
+  let currentFile = "";
+  for (const rawLine of content.split("\n")) {
+    if (rawLine.includes("<class")) {
+      const m = /filename="([^"]+)"/.exec(rawLine);
+      if (m) {
+        currentFile = m[1]!;
+        if (!map.has(currentFile)) map.set(currentFile, new Set());
+      }
+    } else if (rawLine.includes("</class>")) {
+      currentFile = "";
+    } else if (rawLine.includes("<line") && currentFile) {
+      const numM = /number="(\d+)"/.exec(rawLine);
+      const hitsM = /hits="(\d+)"/.exec(rawLine);
+      if (numM && hitsM && Number(hitsM[1]) === 0) {
+        map.get(currentFile)?.add(Number(numM[1]));
+      }
+    }
+  }
+  return map;
+}
+
+// ── ZIP reader ────────────────────────────────────────────────────────────────
+
+/** Minimal ZIP reader using Node.js built-in zlib. Reads from the central directory for reliability.
+ *  Supports stored (method 0) and deflated (method 8) entries; skips unknown compression methods. */
+export function readZipEntries(buf: Buffer): ZipEntry[] {
+  const entries: ZipEntry[] = [];
+  if (buf.length < 22) return entries;
+
+  // Locate End of Central Directory (EOCD) by scanning backwards for its signature 0x06054b50.
+  // The comment field (up to 65535 bytes) sits after the fixed 22-byte EOCD, so scan that far back.
+  let eocdAt = -1;
+  for (let i = buf.length - 22; i >= Math.max(0, buf.length - 65558); i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) { eocdAt = i; break; }
+  }
+  if (eocdAt < 0) return entries;
+
+  const cdSize = buf.readUInt32LE(eocdAt + 12);
+  const cdStart = buf.readUInt32LE(eocdAt + 16);
+  if (cdStart + cdSize > buf.length) return entries;
+
+  let pos = cdStart;
+  while (pos + 46 <= cdStart + cdSize) {
+    if (buf.readUInt32LE(pos) !== 0x02014b50) break; // central directory entry signature
+    const method = buf.readUInt16LE(pos + 10);
+    const compressedSize = buf.readUInt32LE(pos + 20);
+    const nameLen = buf.readUInt16LE(pos + 28);
+    const extraLen = buf.readUInt16LE(pos + 30);
+    const commentLen = buf.readUInt16LE(pos + 32);
+    const localOffset = buf.readUInt32LE(pos + 42);
+    const name = buf.slice(pos + 46, pos + 46 + nameLen).toString("utf-8");
+
+    const entrySize = 46 + nameLen + extraLen + commentLen;
+    if (pos + entrySize > cdStart + cdSize) break;
+    pos += entrySize;
+
+    // Read local file header to find the actual data offset (local extra can differ from central).
+    if (localOffset + 30 > buf.length) continue;
+    const localNameLen = buf.readUInt16LE(localOffset + 26);
+    const localExtraLen = buf.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLen + localExtraLen;
+    if (dataStart + compressedSize > buf.length) continue;
+    const compData = buf.slice(dataStart, dataStart + compressedSize);
+
+    let data: Buffer;
+    if (method === 0) {
+      data = compData; // stored — no decompression
+    } else if (method === 8) {
+      try { data = inflateRawSync(compData); }
+      catch { continue; }
+    } else {
+      continue; // unsupported compression method
+    }
+
+    if (data.length > MAX_COVERAGE_BYTES) continue;
+    entries.push({ name, data });
+  }
+  return entries;
+}
+
+// ── Coverage file identification and parsing dispatch ─────────────────────────
+
+function coverageFileKind(name: string): "lcov" | "istanbul" | "cobertura" | null {
+  const base = name.split("/").pop()?.toLowerCase() ?? "";
+  if (base === "lcov.info" || base.endsWith(".lcov")) return "lcov";
+  if (base === "coverage-final.json") return "istanbul";
+  if (base === "coverage.xml" || base === "cobertura.xml") return "cobertura";
+  return null;
+}
+
+function parseCoverage(kind: "lcov" | "istanbul" | "cobertura", content: string): CoverageMap {
+  if (kind === "lcov") return parseLcov(content);
+  if (kind === "istanbul") return parseIstanbulJson(content);
+  return parseCoberturaXml(content);
+}
+
+/** True when covPath equals prFile or ends with /<prFile> (handles absolute workspace-prefixed paths). */
+function pathMatches(covPath: string, prFile: string): boolean {
+  const c = covPath.replace(/\\/g, "/");
+  const p = prFile.replace(/\\/g, "/");
+  return c === p || c.endsWith("/" + p);
+}
+
+// ── Analyzer entrypoint ───────────────────────────────────────────────────────
+
+/** Analyzer entrypoint: find added/changed lines with zero test coverage using the repo's own CI run. */
+export async function scanCoverageDelta(
+  req: EnrichRequest,
+  fetchFn: typeof fetch,
+  opts?: { signal?: AbortSignal },
+): Promise<CoverageDeltaFinding[]> {
+  const { repoFullName, headSha, githubToken, files = [] } = req;
+  if (!githubToken || !headSha) return [];
+
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (!owner || !repo) return [];
+
+  // Build the changed-line index from the PR patch before touching the network.
+  const changedLines = new Map<string, Set<number>>();
+  for (const file of files) {
+    if (!file.patch) continue;
+    const lines = extractChangedLines(file.patch);
+    if (lines.size > 0) changedLines.set(file.path, lines);
+  }
+  if (changedLines.size === 0) return [];
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${githubToken}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  // Fetch recent successful workflow runs for this head SHA.
+  let runs: WorkflowRun[];
+  try {
+    const runsResp = await fetchFn(
+      `https://api.github.com/repos/${owner}/${repo}/actions/runs?head_sha=${headSha}&per_page=20`,
+      { headers, signal: opts?.signal },
+    );
+    if (!runsResp.ok) return [];
+    const runsJson = (await runsResp.json()) as { workflow_runs?: WorkflowRun[] };
+    runs = (runsJson.workflow_runs ?? [])
+      .filter((r) => r.conclusion === "success")
+      .sort((a, b) => b.created_at.localeCompare(a.created_at))
+      .slice(0, MAX_RUNS_TO_CHECK);
+  } catch {
+    return [];
+  }
+
+  if (runs.length === 0) return [];
+
+  // Walk runs most-recent-first and stop at the first one that has a coverage artifact.
+  let coverageArtifact: Artifact | null = null;
+  let artifactRunId = 0;
+
+  for (const run of runs) {
+    let artifacts: Artifact[];
+    try {
+      const artResp = await fetchFn(
+        `https://api.github.com/repos/${owner}/${repo}/actions/runs/${run.id}/artifacts`,
+        { headers, signal: opts?.signal },
+      );
+      if (!artResp.ok) continue;
+      const artJson = (await artResp.json()) as { artifacts?: Artifact[] };
+      artifacts = artJson.artifacts ?? [];
+    } catch {
+      continue;
+    }
+
+    const found = artifacts
+      .filter((a) => COVERAGE_ARTIFACT_RE.test(a.name) && a.size_in_bytes <= MAX_ARTIFACT_BYTES)
+      .sort((a, b) => a.size_in_bytes - b.size_in_bytes)[0];
+
+    if (found) { coverageArtifact = found; artifactRunId = run.id; break; }
+  }
+
+  if (!coverageArtifact) return [];
+  void artifactRunId; // used only for the API path above
+
+  // Download the artifact ZIP (GitHub responds with a redirect to a signed S3 URL; fetch follows it).
+  let zipBuffer: Buffer;
+  try {
+    const zipResp = await fetchFn(
+      `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${coverageArtifact.id}/zip`,
+      { headers, signal: opts?.signal },
+    );
+    if (!zipResp.ok) return [];
+    zipBuffer = Buffer.from(await zipResp.arrayBuffer());
+  } catch {
+    return [];
+  }
+
+  // Parse the first recognised coverage file inside the ZIP.
+  const zipEntries = readZipEntries(zipBuffer);
+  let coverageMap: CoverageMap | null = null;
+  for (const entry of zipEntries) {
+    const kind = coverageFileKind(entry.name);
+    if (!kind) continue;
+    const parsed = parseCoverage(kind, entry.data.toString("utf-8"));
+    if (parsed.size > 0) { coverageMap = parsed; break; }
+  }
+  if (!coverageMap) return [];
+
+  // Correlate changed lines with uncovered lines.
+  const findings: CoverageDeltaFinding[] = [];
+  for (const [prFile, prLines] of changedLines) {
+    if (findings.length >= MAX_FILES_REPORTED) break;
+
+    let uncoveredForFile: Set<number> | null = null;
+    for (const [covPath, uncovered] of coverageMap) {
+      if (pathMatches(covPath, prFile)) { uncoveredForFile = uncovered; break; }
+    }
+    if (!uncoveredForFile) continue;
+
+    const uncoveredChanged: number[] = [];
+    for (const line of prLines) {
+      if (uncoveredForFile.has(line)) uncoveredChanged.push(line);
+      if (uncoveredChanged.length >= MAX_LINES_PER_FILE) break;
+    }
+    if (uncoveredChanged.length === 0) continue;
+
+    uncoveredChanged.sort((a, b) => a - b);
+    findings.push({ file: prFile, uncoveredLines: uncoveredChanged });
+  }
+
+  return findings;
+}

--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -181,8 +181,8 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
     if (method === 0) {
       data = compData; // stored — no decompression
     } else if (method === 8) {
-      try { data = inflateRawSync(compData); }
-      catch { continue; }
+      try { data = inflateRawSync(compData, { maxOutputLength: MAX_COVERAGE_BYTES }); }
+      catch { continue; } // RangeError from maxOutputLength or corrupt data → skip entry
     } else {
       continue; // unsupported compression method
     }

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -14,6 +14,7 @@ import { scanInstallScripts } from "./analyzers/install-scripts.js";
 import { scanActionPins } from "./analyzers/actions-pin.js";
 import { scanEol } from "./analyzers/eol-check.js";
 import { scanRedos } from "./analyzers/redos.js";
+import { scanCoverageDelta } from "./analyzers/coverage-delta.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest, signal: AbortSignal) => Promise<unknown>;
@@ -27,6 +28,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   actionPin: (req) => scanActionPins(req),
   eol: (req) => scanEol(req),
   redos: (req) => scanRedos(req),
+  coverageDelta: (req, signal) => scanCoverageDelta(req, fetch, { signal }),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -139,6 +139,9 @@ export function renderBrief(
       lines.push(
         `- ${safeCodeSpan(item.file)} — uncovered changed lines: ${lineList}`,
       );
+    }
+  }
+
   const codeownersViolations = findings.codeowners ?? [];
   if (codeownersViolations.length) {
     const allOwners = new Set(codeownersViolations.flatMap((f) => f.owners));

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -129,6 +129,19 @@ export function renderBrief(
     }
   }
 
+  const coverageDeltas = findings.coverageDelta ?? [];
+  if (coverageDeltas.length) {
+    lines.push(
+      "### Changed lines not covered by tests (CI coverage artifact)",
+    );
+    for (const item of coverageDeltas) {
+      const lineList = item.uncoveredLines.join(", ");
+      lines.push(
+        `- ${safeCodeSpan(item.file)} — uncovered changed lines: ${lineList}`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -98,6 +98,8 @@ export interface RedosFinding {
 export interface CoverageDeltaFinding {
   file: string;
   uncoveredLines: number[]; // sorted, 1-indexed new-file line numbers with zero hits
+}
+
 /** A changed file governed by a CODEOWNERS rule where the PR author is not listed as an owner (#1515).
  *  The blast radius (distinct ownership domains crossed) is derived at render time from the full findings set. */
 export interface CodeownersFinding {

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -93,6 +93,13 @@ export interface RedosFinding {
   pattern: string;
 }
 
+/** Changed lines in the PR that are not covered by the project's own CI coverage report (#1516).
+ *  Sourced from GitHub Actions artifacts (lcov / Istanbul JSON / Cobertura XML). */
+export interface CoverageDeltaFinding {
+  file: string;
+  uncoveredLines: number[]; // sorted, 1-indexed new-file line numbers with zero hits
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -102,6 +109,7 @@ export interface BriefFindings {
   installScript?: InstallScriptFinding[];
   eol?: EolFinding[];
   redos?: RedosFinding[];
+  coverageDelta?: CoverageDeltaFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -1460,6 +1460,26 @@ test("scanCoverageDelta: forwards abort signal to fetch calls", async () => {
   assert.ok(seenSignals.every((s) => s instanceof AbortSignal));
 });
 
+test("scanCoverageDelta: percent-encodes owner, repo, and headSha in API URLs", async () => {
+  const urls: string[] = [];
+  await scanCoverageDelta(
+    COV_REQ({ repoFullName: "owner name/repo name", headSha: "sha with spaces" }),
+    async (url) => {
+      urls.push(String(url));
+      return { ok: true, json: async () => ({ workflow_runs: [] }) };
+    },
+  );
+  assert.ok(urls.length >= 1, "at least one fetch should be made");
+  assert.ok(
+    urls[0].includes("owner%20name/repo%20name"),
+    `owner/repo segments should be encoded; got ${urls[0]}`,
+  );
+  assert.ok(
+    urls[0].includes("head_sha=sha%20with%20spaces"),
+    `headSha should be encoded; got ${urls[0]}`,
+  );
+});
+
 // ── renderBrief: coverage-delta ───────────────────────────────────────────────
 
 test("renderBrief: renders the coverage-delta block with file and line list", () => {

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -21,6 +21,14 @@ import {
   scanPatchForRedos,
   scanRedos,
 } from "../dist/analyzers/redos.js";
+import {
+  extractChangedLines,
+  parseLcov,
+  parseIstanbulJson,
+  parseCoberturaXml,
+  readZipEntries,
+  scanCoverageDelta,
+} from "../dist/analyzers/coverage-delta.js";
 
 const NOW = new Date("2026-06-26").getTime();
 const eolFetch =
@@ -933,6 +941,421 @@ test("buildBrief: eol analyzer runs (real now, 2023 cycle is past)", async () =>
     assert.equal(brief.analyzerStatus.eol, "ok");
     assert.equal(brief.findings.eol.length, 1);
     assert.match(brief.promptSection, /End-of-life runtimes/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// ── coverage-delta helpers ────────────────────────────────────────────────────
+
+/** Build a minimal stored-only (method=0) ZIP buffer from an array of {name, data} entries. */
+function makeStoredZip(entries) {
+  const localParts = [];
+  const cdParts = [];
+  let offset = 0;
+
+  for (const { name, data } of entries) {
+    const nameBytes = Buffer.from(name, "utf-8");
+    const dataBytes = Buffer.isBuffer(data) ? data : Buffer.from(data, "utf-8");
+
+    const lh = Buffer.alloc(30);
+    lh.writeUInt32LE(0x04034b50, 0);
+    lh.writeUInt16LE(0, 4); lh.writeUInt16LE(0, 6); lh.writeUInt16LE(0, 8);
+    lh.writeUInt16LE(0, 10); lh.writeUInt16LE(0, 12); lh.writeUInt32LE(0, 14);
+    lh.writeUInt32LE(dataBytes.length, 18);
+    lh.writeUInt32LE(dataBytes.length, 22);
+    lh.writeUInt16LE(nameBytes.length, 26); lh.writeUInt16LE(0, 28);
+
+    const cd = Buffer.alloc(46);
+    cd.writeUInt32LE(0x02014b50, 0);
+    cd.writeUInt16LE(0, 4); cd.writeUInt16LE(0, 6); cd.writeUInt16LE(0, 8);
+    cd.writeUInt16LE(0, 10); cd.writeUInt16LE(0, 12); cd.writeUInt16LE(0, 14);
+    cd.writeUInt32LE(0, 16);
+    cd.writeUInt32LE(dataBytes.length, 20);
+    cd.writeUInt32LE(dataBytes.length, 24);
+    cd.writeUInt16LE(nameBytes.length, 28); cd.writeUInt16LE(0, 30);
+    cd.writeUInt16LE(0, 32); cd.writeUInt16LE(0, 34); cd.writeUInt16LE(0, 36);
+    cd.writeUInt32LE(0, 38); cd.writeUInt32LE(offset, 42);
+
+    localParts.push(lh, nameBytes, dataBytes);
+    cdParts.push(cd, nameBytes);
+    offset += 30 + nameBytes.length + dataBytes.length;
+  }
+
+  const cd = Buffer.concat(cdParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8); eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cd.length, 12); eocd.writeUInt32LE(offset, 16);
+  eocd.writeUInt16LE(0, 20);
+  return Buffer.concat([...localParts, cd, eocd]);
+}
+
+const PATCH_WITH_ADDS = [
+  "@@ -1,3 +1,5 @@",
+  " context",
+  "+added line 2",
+  " context",
+  "+added line 4",
+  "-removed",
+  " context",
+].join("\n");
+
+const LCOV_CONTENT = [
+  "SF:src/foo.ts",
+  "DA:2,0",   // uncovered
+  "DA:3,1",   // covered
+  "DA:4,0",   // uncovered
+  "end_of_record",
+  "SF:src/bar.ts",
+  "DA:1,1",
+  "end_of_record",
+].join("\n");
+
+const ISTANBUL_CONTENT = JSON.stringify({
+  "/workspace/src/foo.ts": {
+    s: { "0": 0, "1": 1, "2": 0 },
+    statementMap: {
+      "0": { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+      "1": { start: { line: 3, column: 0 }, end: { line: 3, column: 10 } },
+      "2": { start: { line: 4, column: 0 }, end: { line: 4, column: 10 } },
+    },
+  },
+});
+
+const COBERTURA_CONTENT = [
+  '<?xml version="1.0"?>',
+  "<coverage>",
+  '  <class filename="src/foo.ts">',
+  '    <lines>',
+  '      <line number="2" hits="0"/>',
+  '      <line number="3" hits="1"/>',
+  '      <line number="4" hits="0"/>',
+  '    </lines>',
+  "  </class>",
+  "</coverage>",
+].join("\n");
+
+const COV_REQ = (overrides = {}) => ({
+  repoFullName: "owner/repo",
+  prNumber: 1,
+  headSha: "abc123",
+  githubToken: "tok",
+  files: [{ path: "src/foo.ts", patch: PATCH_WITH_ADDS }],
+  ...overrides,
+});
+
+const RUNS_RESP = { workflow_runs: [{ id: 42, conclusion: "success", created_at: "2026-06-01T00:00:00Z" }] };
+const ARTIFACTS_RESP = { artifacts: [{ id: 7, name: "coverage", size_in_bytes: 1000 }] };
+
+/** Slice a Buffer into a standalone ArrayBuffer (avoids Node pool byteOffset issues). */
+function toArrayBuffer(buf) {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+function makeCovFetch(lcovContent = LCOV_CONTENT) {
+  const zip = makeStoredZip([{ name: "lcov.info", data: lcovContent }]);
+  const zipAb = toArrayBuffer(zip);
+  return async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts")) return { ok: true, json: async () => ARTIFACTS_RESP };
+    if (u.includes("/actions/artifacts/7/zip"))
+      return { ok: true, arrayBuffer: async () => zipAb };
+    return { ok: false, json: async () => ({}) };
+  };
+}
+
+// ── extractChangedLines ───────────────────────────────────────────────────────
+
+test("extractChangedLines: tracks added lines by 1-indexed new-file position, skips removed/context", () => {
+  const lines = extractChangedLines(PATCH_WITH_ADDS);
+  assert.ok(lines.has(2), "line 2 added");
+  assert.ok(lines.has(4), "line 4 added");
+  assert.ok(!lines.has(1), "line 1 is context");
+  assert.ok(!lines.has(3), "line 3 is context");
+  assert.equal(lines.size, 2);
+});
+
+test("extractChangedLines: handles multiple hunks with correct line offsets", () => {
+  const patch = "@@ -1,0 +1,2 @@\n+a\n+b\n@@ -5,0 +7,1 @@\n+c";
+  const lines = extractChangedLines(patch);
+  assert.ok(lines.has(1));
+  assert.ok(lines.has(2));
+  assert.ok(lines.has(7));
+  assert.equal(lines.size, 3);
+});
+
+// ── parseLcov ─────────────────────────────────────────────────────────────────
+
+test("parseLcov: extracts uncovered lines (DA:line,0) per file, ignores covered", () => {
+  const map = parseLcov(LCOV_CONTENT);
+  const fooUncovered = map.get("src/foo.ts")!;
+  assert.ok(fooUncovered.has(2));
+  assert.ok(fooUncovered.has(4));
+  assert.ok(!fooUncovered.has(3));
+  assert.equal(map.get("src/bar.ts")?.size ?? 0, 0, "bar.ts has no uncovered lines");
+});
+
+test("parseLcov: returns empty map for empty content", () => {
+  assert.equal(parseLcov("").size, 0);
+});
+
+// ── parseIstanbulJson ─────────────────────────────────────────────────────────
+
+test("parseIstanbulJson: extracts uncovered statements by line; path preserved as key", () => {
+  const map = parseIstanbulJson(ISTANBUL_CONTENT);
+  const fooUncovered = map.get("/workspace/src/foo.ts")!;
+  assert.ok(fooUncovered.has(2));
+  assert.ok(fooUncovered.has(4));
+  assert.ok(!fooUncovered.has(3));
+});
+
+test("parseIstanbulJson: returns empty map for invalid JSON", () => {
+  assert.equal(parseIstanbulJson("not json").size, 0);
+});
+
+test("parseIstanbulJson: returns empty map for non-object root", () => {
+  assert.equal(parseIstanbulJson("[]").size, 0);
+});
+
+test("parseIstanbulJson: skips file entries missing s or statementMap", () => {
+  const content = JSON.stringify({ "a.ts": { path: "a.ts" } });
+  assert.equal(parseIstanbulJson(content).size, 0);
+});
+
+// ── parseCoberturaXml ─────────────────────────────────────────────────────────
+
+test("parseCoberturaXml: extracts zero-hit lines per class filename", () => {
+  const map = parseCoberturaXml(COBERTURA_CONTENT);
+  const fooUncovered = map.get("src/foo.ts")!;
+  assert.ok(fooUncovered.has(2));
+  assert.ok(fooUncovered.has(4));
+  assert.ok(!fooUncovered.has(3));
+});
+
+test("parseCoberturaXml: returns empty set for file with no zero-hit lines", () => {
+  const xml = '<class filename="a.ts"><lines><line number="1" hits="1"/></lines></class>';
+  const map = parseCoberturaXml(xml);
+  assert.equal(map.get("a.ts")?.size ?? 0, 0);
+});
+
+// ── readZipEntries ────────────────────────────────────────────────────────────
+
+test("readZipEntries: extracts stored entries by name and data", () => {
+  const zip = makeStoredZip([
+    { name: "lcov.info", data: "SF:a\nDA:1,0\nend_of_record" },
+    { name: "other.txt", data: "hello" },
+  ]);
+  const entries = readZipEntries(zip);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].name, "lcov.info");
+  assert.ok(entries[0].data.toString().includes("DA:1,0"));
+  assert.equal(entries[1].name, "other.txt");
+});
+
+test("readZipEntries: returns [] for a buffer that is not a ZIP", () => {
+  assert.deepEqual(readZipEntries(Buffer.from("not a zip")), []);
+});
+
+test("readZipEntries: returns [] for an empty buffer", () => {
+  assert.deepEqual(readZipEntries(Buffer.alloc(0)), []);
+});
+
+// ── scanCoverageDelta ─────────────────────────────────────────────────────────
+
+test("scanCoverageDelta: returns [] when githubToken is absent", async () => {
+  const findings = await scanCoverageDelta(
+    COV_REQ({ githubToken: undefined }),
+    async () => { throw new Error("no fetch"); },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when headSha is absent", async () => {
+  const findings = await scanCoverageDelta(
+    COV_REQ({ headSha: undefined }),
+    async () => { throw new Error("no fetch"); },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when no files have patches", async () => {
+  const findings = await scanCoverageDelta(
+    COV_REQ({ files: [{ path: "src/foo.ts" }] }),
+    async () => { throw new Error("no fetch"); },
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] on runs API non-ok response", async () => {
+  const findings = await scanCoverageDelta(
+    COV_REQ(),
+    async () => ({ ok: false, json: async () => ({}) }),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] on runs API network error (fail-safe)", async () => {
+  const findings = await scanCoverageDelta(COV_REQ(), async () => { throw new Error("down"); });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when no successful runs are found", async () => {
+  const findings = await scanCoverageDelta(
+    COV_REQ(),
+    async () => ({ ok: true, json: async () => ({ workflow_runs: [{ id: 1, conclusion: "failure", created_at: "2026-01-01" }] }) }),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when artifacts API fails for all runs", async () => {
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    return { ok: false, json: async () => ({}) };
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when no coverage artifact is found in the run", async () => {
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts"))
+      return { ok: true, json: async () => ({ artifacts: [{ id: 9, name: "build-output", size_in_bytes: 500 }] }) };
+    return { ok: false, json: async () => ({}) };
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when artifact ZIP download fails", async () => {
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts")) return { ok: true, json: async () => ARTIFACTS_RESP };
+    return { ok: false, json: async () => ({}) };
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: returns [] when ZIP contains no recognised coverage file", async () => {
+  const zip = makeStoredZip([{ name: "readme.txt", data: "no coverage here" }]);
+  const zipAb = toArrayBuffer(zip);
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts")) return { ok: true, json: async () => ARTIFACTS_RESP };
+    if (u.includes("/actions/artifacts/7/zip"))
+      return { ok: true, arrayBuffer: async () => zipAb };
+    return { ok: false };
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: detects uncovered changed lines via lcov artifact", async () => {
+  const findings = await scanCoverageDelta(COV_REQ(), makeCovFetch());
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "src/foo.ts");
+  // patch adds lines 2 and 4; lcov marks both as uncovered
+  assert.deepEqual(findings[0].uncoveredLines, [2, 4]);
+});
+
+test("scanCoverageDelta: detects uncovered changed lines via Istanbul JSON artifact", async () => {
+  const zip = makeStoredZip([{ name: "coverage-final.json", data: ISTANBUL_CONTENT }]);
+  const zipAb = toArrayBuffer(zip);
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts")) return { ok: true, json: async () => ARTIFACTS_RESP };
+    if (u.includes("/actions/artifacts/7/zip"))
+      return { ok: true, arrayBuffer: async () => zipAb };
+    return { ok: false };
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "src/foo.ts");
+  assert.deepEqual(findings[0].uncoveredLines, [2, 4]);
+});
+
+test("scanCoverageDelta: detects uncovered changed lines via Cobertura XML artifact", async () => {
+  const zip = makeStoredZip([{ name: "coverage.xml", data: COBERTURA_CONTENT }]);
+  const zipAb = toArrayBuffer(zip);
+  const findings = await scanCoverageDelta(COV_REQ(), async (url) => {
+    const u = String(url);
+    if (u.includes("/actions/runs?")) return { ok: true, json: async () => RUNS_RESP };
+    if (u.includes("/actions/runs/42/artifacts")) return { ok: true, json: async () => ARTIFACTS_RESP };
+    if (u.includes("/actions/artifacts/7/zip"))
+      return { ok: true, arrayBuffer: async () => zipAb };
+    return { ok: false };
+  });
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0].uncoveredLines, [2, 4]);
+});
+
+test("scanCoverageDelta: returns [] when all changed lines are covered", async () => {
+  // lcov reports all lines covered (hits > 0)
+  const lcov = "SF:src/foo.ts\nDA:2,5\nDA:4,3\nend_of_record\n";
+  const findings = await scanCoverageDelta(COV_REQ(), makeCovFetch(lcov));
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: skips files not present in coverage report", async () => {
+  // PR adds lines to a different file than what's in the lcov
+  const lcov = "SF:src/other.ts\nDA:1,0\nend_of_record\n";
+  const findings = await scanCoverageDelta(COV_REQ(), makeCovFetch(lcov));
+  assert.deepEqual(findings, []);
+});
+
+test("scanCoverageDelta: forwards abort signal to fetch calls", async () => {
+  const seenSignals: AbortSignal[] = [];
+  const controller = new AbortController();
+  await scanCoverageDelta(COV_REQ(), async (_url, init) => {
+    seenSignals.push(init.signal);
+    return { ok: true, json: async () => RUNS_RESP };
+  }, { signal: controller.signal });
+  assert.ok(seenSignals.length >= 1);
+  assert.ok(seenSignals.every((s) => s instanceof AbortSignal));
+});
+
+// ── renderBrief: coverage-delta ───────────────────────────────────────────────
+
+test("renderBrief: renders the coverage-delta block with file and line list", () => {
+  const r = renderBrief({
+    coverageDelta: [
+      { file: "src/foo.ts", uncoveredLines: [5, 12, 23] },
+    ],
+  });
+  assert.match(r.promptSection, /Changed lines not covered by tests/);
+  assert.match(r.promptSection, /`src\/foo\.ts`/);
+  assert.match(r.promptSection, /5, 12, 23/);
+});
+
+test("renderBrief: sanitizes file paths in coverage-delta block", () => {
+  const r = renderBrief({
+    coverageDelta: [
+      { file: "src/evil`\nnext", uncoveredLines: [1] },
+    ],
+  });
+  // The raw newline in the filename must be replaced (not injected as a real newline into the output).
+  assert.ok(!r.promptSection.includes("src/evil\nnext"), "raw newline must be escaped");
+  assert.match(r.promptSection, /`src\/evil/);
+});
+
+test("buildBrief: coverageDelta analyzer is wired into the orchestrator", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = makeCovFetch();
+  try {
+    const brief = await buildBrief({
+      repoFullName: "owner/repo",
+      prNumber: 1,
+      headSha: "abc123",
+      githubToken: "tok",
+      files: [{ path: "src/foo.ts", patch: PATCH_WITH_ADDS }],
+    });
+    assert.equal(brief.analyzerStatus.coverageDelta, "ok");
+    assert.equal(brief.findings.coverageDelta.length, 1);
+    assert.match(brief.promptSection, /Changed lines not covered/);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -30,6 +30,7 @@ import {
   readZipEntries,
   scanCoverageDelta,
 } from "../dist/analyzers/coverage-delta.js";
+import {
   findOwners,
   parseCodeowners,
   patternToRegex,
@@ -1497,6 +1498,11 @@ test("buildBrief: coverageDelta analyzer is wired into the orchestrator", async 
     assert.equal(brief.analyzerStatus.coverageDelta, "ok");
     assert.equal(brief.findings.coverageDelta.length, 1);
     assert.match(brief.promptSection, /Changed lines not covered/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("codeOnly: blanks string messages, keeps ${...} interpolation bodies", () => {
   assert.equal(codeOnly('"a secret here"'), " ");
   assert.equal(codeOnly("'plain'"), " ");

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { deflateRawSync } from "node:zlib";
 import {
   extractDependencyChanges,
   queryOsv,
@@ -1161,6 +1162,51 @@ test("readZipEntries: returns [] for a buffer that is not a ZIP", () => {
 
 test("readZipEntries: returns [] for an empty buffer", () => {
   assert.deepEqual(readZipEntries(Buffer.alloc(0)), []);
+});
+
+test("readZipEntries: skips DEFLATE entry whose decompressed size exceeds MAX_COVERAGE_BYTES (decompression bomb guard)", () => {
+  // 2 MB + 1 byte of repetitive data — compresses to a tiny payload but exceeds the cap on decompression.
+  const MAX_COVERAGE_BYTES = 2 * 1024 * 1024;
+  const uncompressed = Buffer.alloc(MAX_COVERAGE_BYTES + 1, 0x41);
+  const compressed = deflateRawSync(uncompressed);
+
+  // Build a minimal single-entry ZIP with compression method 8 (DEFLATE).
+  const name = Buffer.from("bomb.txt");
+  const lh = Buffer.alloc(30);
+  lh.writeUInt32LE(0x04034b50, 0); // local file header signature
+  lh.writeUInt16LE(0, 4); lh.writeUInt16LE(0, 6);
+  lh.writeUInt16LE(8, 8); // compression method = DEFLATE
+  lh.writeUInt16LE(0, 10); lh.writeUInt16LE(0, 12); lh.writeUInt32LE(0, 14);
+  lh.writeUInt32LE(compressed.length, 18);
+  lh.writeUInt32LE(uncompressed.length, 22);
+  lh.writeUInt16LE(name.length, 26); lh.writeUInt16LE(0, 28);
+
+  const cdStart = 30 + name.length + compressed.length;
+  const cd = Buffer.alloc(46);
+  cd.writeUInt32LE(0x02014b50, 0); // central directory entry signature
+  cd.writeUInt16LE(0, 4);  // version made by
+  cd.writeUInt16LE(0, 6);  // version needed
+  cd.writeUInt16LE(0, 8);  // general purpose bit flag
+  cd.writeUInt16LE(8, 10); // compression method = DEFLATE
+  cd.writeUInt16LE(0, 12); cd.writeUInt16LE(0, 14);
+  cd.writeUInt32LE(0, 16);
+  cd.writeUInt32LE(compressed.length, 20);
+  cd.writeUInt32LE(uncompressed.length, 24);
+  cd.writeUInt16LE(name.length, 28); cd.writeUInt16LE(0, 30); cd.writeUInt16LE(0, 32);
+  cd.writeUInt16LE(0, 34); cd.writeUInt16LE(0, 36); cd.writeUInt32LE(0, 38);
+  cd.writeUInt32LE(0, 42); // local header offset = 0
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(1, 8); eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(46 + name.length, 12); // central directory size
+  eocd.writeUInt32LE(cdStart, 16);           // central directory offset
+  eocd.writeUInt16LE(0, 20);
+
+  const zip = toArrayBuffer(Buffer.concat([lh, name, compressed, cd, name, eocd]));
+  const entries = readZipEntries(Buffer.from(zip));
+  assert.deepEqual(entries, [], "entry exceeding MAX_COVERAGE_BYTES must be skipped, not returned");
 });
 
 // ── scanCoverageDelta ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a `coverageDelta` analyzer to REES (#1516) that surfaces added/changed PR lines not covered by the project's own CI test suite, without requiring a repo checkout.

- Fetches recent successful GitHub Actions workflow runs for the PR's head SHA, finds the first artifact whose name matches a coverage-related pattern (`coverage`, `lcov`, `cov-report`, etc.), downloads its ZIP, and parses the first recognised coverage file inside it.
- Supports three formats: **lcov** (`lcov.info` / `*.lcov`), **Istanbul/NYC JSON** (`coverage-final.json`), and **Cobertura XML** (`coverage.xml` / `cobertura.xml`).
- ZIP extraction uses only Node.js built-in `zlib.inflateRawSync` (no new dependencies); the central-directory reader supports stored (method 0) and DEFLATE (method 8) entries.
- Cobertura XML is parsed line-by-line to avoid `[\s\S]*?` ReDoS patterns on attacker-influenced input.
- Fail-safe throughout: any network error, non-ok response, or unparseable artifact returns `[]` without throwing.
- Caps: 5 MB artifact ZIP, 2 MB per uncompressed file, 5 runs to search, 15 files reported, 20 uncovered lines per file.
- Findings are rendered in the `promptSection` as a `### Changed lines not covered by tests` block.

Resolves #1516.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:workers` — no Cloudflare Worker bindings touched; REES is a standalone Node.js service.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI changes — REES is a backend enrichment service; output appears only in the review engine's prompt section.

## Notes

- Path matching handles workspace-prefixed absolute paths (e.g. `/home/runner/work/repo/repo/src/foo.ts` matches PR file `src/foo.ts`) via a suffix check in `pathMatches`.
- The `makeStoredZip` test helper builds a minimal valid ZIP (stored compression, central directory + EOCD) entirely from `Buffer.alloc`/`writeUInt*` — no fixture files needed. `toArrayBuffer` slices the Buffer into a standalone `ArrayBuffer` to avoid Node.js pool `byteOffset` issues when passing to `Buffer.from(arrayBuffer)`.
