### PR TITLE
fix(review): engage the merge breaker on a real would-merge sample, not total decided

### DIFF
--- a/src/review/auto-tune.ts
+++ b/src/review/auto-tune.ts
@@ -80,6 +80,7 @@ export interface AutoTuneAction {
   project: string;
   mergePrecision: number;
   decided: number;
+  wouldMerge: number;
   message: string;
 }
 
@@ -87,13 +88,18 @@ export interface AutoTuneAction {
 export function planAutoTune(report: GateEvalReport): AutoTuneAction[] {
   const actions: AutoTuneAction[] = [];
   for (const r of report.rows) {
-    if (r.decided < AUTOTUNE_MIN_DECIDED || r.mergePrecision == null) continue;
+    // Gate on wouldMerge, NOT decided: precision is measured over WOULD-MERGE predictions, so a project with many
+    // holds/closes but few would-merges (e.g. 9 holds + 1 wrong would-merge) must not trip the breaker on a
+    // statistically meaningless sample. mergePrecision is non-null iff wouldMerge > 0, so check it FIRST to keep
+    // both arms of the guard reachable.
+    if (r.mergePrecision == null || r.wouldMerge < AUTOTUNE_MIN_DECIDED) continue;
     if (r.mergePrecision < AUTOTUNE_MERGE_PRECISION_FLOOR) {
       actions.push({
         project: r.project,
         mergePrecision: r.mergePrecision,
         decided: r.decided,
-        message: `Auto-merge DISABLED for ${r.project}: merge precision ${Math.round(r.mergePrecision * 100)}% over ${r.decided} decided PR(s) (< ${Math.round(AUTOTUNE_MERGE_PRECISION_FLOOR * 100)}%). Would-merges now HOLD for review. Investigate, then clear holdonly:${r.project}.`,
+        wouldMerge: r.wouldMerge,
+        message: `Auto-merge DISABLED for ${r.project}: merge precision ${Math.round(r.mergePrecision * 100)}% over ${r.wouldMerge} would-merge PR(s) (< ${Math.round(AUTOTUNE_MERGE_PRECISION_FLOOR * 100)}%). Would-merges now HOLD for review. Investigate, then clear holdonly:${r.project}.`,
       });
     }
   }
@@ -129,7 +135,7 @@ export function shouldAutoClear(report: GateEvalReport, project: string, setAtIs
   const setMs = Date.parse(hasZone ? t : `${t}Z`);
   if (!Number.isFinite(setMs) || nowMs - setMs < AUTOCLEAR_AFTER_MS) return false; // still in cooldown
   const row = report.rows.find((r) => r.project === project);
-  const stillFailing = !!row && row.mergePrecision != null && row.decided >= AUTOTUNE_MIN_DECIDED && row.mergePrecision < AUTOTUNE_MERGE_PRECISION_FLOOR;
+  const stillFailing = !!row && row.mergePrecision != null && row.wouldMerge >= AUTOTUNE_MIN_DECIDED && row.mergePrecision < AUTOTUNE_MERGE_PRECISION_FLOOR;
   return !stillFailing; // cooldown elapsed + precision recovered (or no signal) → clear and let it retry
 }
 

--- a/test/unit/auto-tune.test.ts
+++ b/test/unit/auto-tune.test.ts
@@ -60,6 +60,13 @@ describe("planAutoTune (#self-improve) — circuit-breaker is one-directional", 
   it("does NOT engage when precision is healthy (it only ever tightens, never loosens)", () => {
     expect(planAutoTune(report([row({ project: "p", decided: 30, wouldMerge: 30, mergeConfirmed: 29, mergePrecision: 0.97 })]))).toHaveLength(0);
   });
+  it("does NOT engage on a thin WOULD-MERGE sample even when total decided is high (gate on wouldMerge, not decided)", () => {
+    // 19 holds/closes + 1 wrong would-merge: decided=20 (over the floor) but only 1 would-merge — meaningless precision.
+    expect(planAutoTune(report([row({ project: "p", decided: 20, wouldMerge: 1, mergeConfirmed: 0, mergePrecision: 0 })]))).toHaveLength(0);
+  });
+  it("skips a project with no would-merge predictions (mergePrecision null → nothing to judge)", () => {
+    expect(planAutoTune(report([row({ project: "x", decided: 20, wouldMerge: 0, mergePrecision: null })]))).toHaveLength(0);
+  });
 });
 
 describe("applyAutoTune", () => {
@@ -104,6 +111,12 @@ describe("shouldAutoClear (#272 recovery-gated breaker auto-clear)", () => {
   });
   it("keeps the breaker engaged if precision is STILL failing after cooldown", () => {
     expect(shouldAutoClear(failing, "g", past, now)).toBe(false);
+  });
+  it("clears after cooldown when there's no would-merge signal (mergePrecision null → not still-failing)", () => {
+    expect(shouldAutoClear(report([row({ project: "g", decided: 20, wouldMerge: 0, mergePrecision: null })]), "g", past, now)).toBe(true);
+  });
+  it("clears after cooldown on a thin would-merge sample (undersampled → not still-failing)", () => {
+    expect(shouldAutoClear(report([row({ project: "g", decided: 20, wouldMerge: 1, mergeConfirmed: 0, mergePrecision: 0 })]), "g", past, now)).toBe(true);
   });
   it("parses a SQLite 'YYYY-MM-DD HH:MM:SS' (UTC, no zone) timestamp as UTC, not local (#272 tz-fix)", () => {
     const sqlite = new Date(now - AUTOCLEAR_AFTER_MS - 3_600_000).toISOString().slice(0, 19).replace("T", " "); // 25h ago, SQLite format


### PR DESCRIPTION
## Summary

The merge-side auto-tune circuit breaker gated on `r.decided` (= wouldMerge + wouldClose + hold) instead of `r.wouldMerge`, but merge precision is measured **over would-merge predictions**. So a project with many holds/closes but few would-merges (e.g. 9 holds + 1 wrong would-merge → `decided=20`, `mergePrecision=0/1=0`) would **trip the auto-merge-hold breaker on a single, statistically meaningless sample** — eroding trust in the self-tuning loop. The close side already gates correctly on `wouldClose`.

Fix: gate `planAutoTune` (engage) and `shouldAutoClear` (`stillFailing`) on `r.wouldMerge >= AUTOTUNE_MIN_DECIDED`. Since `mergePrecision` is non-null **iff** `wouldMerge > 0`, the engage guard is reordered to check `mergePrecision == null` first, so both arms stay reachable (gating on `wouldMerge` first would make the null-check unreachable → a dead branch). Added `wouldMerge` to `AutoTuneAction` + the alert message ("over N would-merge PR(s)").

Surfaced by the 2026-06-27 review-pipeline hardening audit (accuracy). (No fabricated commit reference — the close side is correct by construction, not a prior fix.)

## Scope

- [x] Conventional Commit title; focused (`auto-tune.ts` + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident accuracy fix (no separate issue needed).

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — both changed guards' arms covered: the **regression** (decided=20, wouldMerge=1 → does NOT engage), the null-precision skip (wouldMerge=0 → mergePrecision null), the thin-sample auto-clear, and the no-signal auto-clear; existing engage/heal/recover tests (wouldMerge ≥ 10) stay green.
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: pure logic + an interface field.

## Safety

- [x] No secrets/wallets/trust-scores exposed (the breaker governs auto-merge precision, not reward/scoring values).
- [x] No public GitHub text change. The breaker only ever tightens (engages a hold), never loosens.

## Notes

- Self-host engine code (the self-tune loop); ships on the next engine rebuild. The breaker is dormant in advisory mode (no auto-merge) — this hardens it for when auto-merge is enabled.
