### PR TITLE
fix(github): single-flight installation-token mint to stop the cold-start herd

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -162,6 +162,12 @@ async function writeCachedToken(
   else installationTokenCache.set(installationId, value);
 }
 
+// Single-flight the mint: on a cold cache, N concurrent jobs for the SAME install would each mint a token (a
+// thundering herd — in broker mode the Orb re-mints N times → GitHub secondary-rate-limits the token endpoint →
+// orb_broker_unavailable). Coalesce concurrent callers onto ONE in-flight mint, so a cold start / restart costs a
+// single mint, not one-per-job. Keyed by installation; the entry self-deletes on settle (success OR failure).
+const inFlightMints = new Map<number, Promise<string>>();
+
 export async function createInstallationToken(
   env: Env,
   installationId: number,
@@ -169,6 +175,23 @@ export async function createInstallationToken(
   const cached = await readCachedToken(installationId);
   if (cached && cached.expiresAtMs - TOKEN_SAFETY_MARGIN_MS > Date.now())
     return cached.token;
+  const existing = inFlightMints.get(installationId);
+  if (existing) return existing; // a concurrent caller is already minting for this install — join it
+  const mint = mintInstallationToken(env, installationId, cached).finally(() => {
+    inFlightMints.delete(installationId);
+  });
+  inFlightMints.set(installationId, mint);
+  return mint;
+}
+
+/** Mint a fresh installation token (broker or local App-JWT) and cache it. `cached` is the expired/absent prior
+ *  entry, consulted only for the brokered stale-token grace. Extracted from createInstallationToken so that
+ *  function can single-flight concurrent cold-cache callers onto one mint (see inFlightMints). */
+async function mintInstallationToken(
+  env: Env,
+  installationId: number,
+  cached: { token: string; expiresAtMs: number } | null,
+): Promise<string> {
   // Self-host broker mode: a brokered self-host holds no App private key, so source the installation token from
   // the central Orb (enrollment secret → short-lived token) instead of minting locally. Cloud sets no enrollment
   // secret, so this branch is inert there → byte-identical. The token caches the same way (the install id is the

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -142,6 +142,31 @@ describe("GitHub check runs", () => {
     expect(mints).toBe(1);
   });
 
+  it("single-flights concurrent cold-cache mints for one install (no thundering herd)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mints = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mints += 1;
+        return Response.json({
+          token: `installation-token-${mints}`,
+          expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    // Ten concurrent callers on a COLD cache → exactly ONE mint (single-flight); all share the same token. Without
+    // coalescing this would be ten mints — the herd that secondary-rate-limits the Orb broker on a cold start.
+    const tokens = await Promise.all(
+      Array.from({ length: 10 }, () => createInstallationToken(env, 4242)),
+    );
+    expect(new Set(tokens)).toEqual(new Set(["installation-token-1"]));
+    expect(mints).toBe(1);
+  });
+
   it("re-mints an installation token once the cached one is within the expiry safety margin", async () => {
     const privateKey = await generatePrivateKeyPem();
     let mints = 0;


### PR DESCRIPTION
## Summary

`createInstallationToken` checked the (Redis/in-isolate) token cache and, on a miss, minted immediately — with **no single-flight**. On a cold cache (container restart / deploy, or the very first review after a token expires) the engine drains its job queue concurrently, so **N concurrent jobs for the same installation each mint a token**. In broker mode that means N back-to-back `/v1/orb/token` calls → the Orb re-mints from GitHub N times → GitHub **secondary-rate-limits the token endpoint** → `orb_broker_unavailable`. This is the verified root cause of the recurring broker-throttle warnings (Sentry GITTENSORY-3).

Fix: coalesce concurrent cold-cache callers onto **one in-flight mint** per installation (`inFlightMints` map; the entry self-deletes on settle, success or failure). A cold start now costs a single mint instead of one-per-job. The Redis token cache (`redis-token-cache.ts`) already prevents *steady-state* re-minting; this closes the *cold-start herd* it can't.

Extracted the mint body into `mintInstallationToken(env, installationId, cached)` so `createInstallationToken` can wrap it with the single-flight; the brokered stale-token grace + local-mint paths are byte-identical.

## Scope

- [x] Conventional Commit; focused (`github/app.ts` + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.
- [x] Small self-evident reliability fix.

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — new test: **10 concurrent cold-cache callers ⇒ exactly 1 mint**, all sharing the token (covers the `if (existing) return existing` join branch, the create+`.finally(delete)` branch); existing sequential cache / re-mint-on-margin / broker / stale-grace tests stay green (single-flight doesn't change sequential behavior).
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: pure logic, no schema/binding change.

## Safety

- [x] No secrets/tokens in code, comments, tests, or logs.
- [x] Eligibility unchanged: each mint still runs the full broker/JWT path; coalescing only dedups concurrent *identical* mints. A failed mint rejects all joined callers (self-deletes, so the next call retries).
- [x] No public GitHub text change.

## Notes

- Self-host engine reliability; ships on the next engine rebuild. Inert on cloud (the in-isolate Map already dedups within one isolate, and the single-flight is per-process — behavior is byte-identical there).
