### PR TITLE
fix(observability): surface circuit-breaker engagement to Sentry at error level

### DIFF
--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -466,9 +466,10 @@ export async function runSelfTuneBreaker(env: Env): Promise<void> {
     const flags = createFlagStore(env);
     const engaged = await applyAutoTune(flags, report);
     for (const action of engaged) {
-      console.warn(
+      console.error(
         JSON.stringify({
-          ev: "breaker_engaged",
+          level: "error",
+          event: "breaker_engaged",
           project: action.project,
           mergePrecision: action.mergePrecision,
           decided: action.decided,
@@ -479,9 +480,10 @@ export async function runSelfTuneBreaker(env: Env): Promise<void> {
     // CLOSE-side breaker: engage closehold for any repo whose close precision dropped below the floor.
     const closeEngaged = await applyCloseAutoTune(flags, report);
     for (const action of closeEngaged) {
-      console.warn(
+      console.error(
         JSON.stringify({
-          ev: "close_breaker_engaged",
+          level: "error",
+          event: "close_breaker_engaged",
           project: action.project,
           closePrecision: action.closePrecision,
           decided: action.decided,
@@ -492,9 +494,10 @@ export async function runSelfTuneBreaker(env: Env): Promise<void> {
     // OBSERVABILITY: a single summary line of the engaged close-hold backlog so a human can see, at a glance,
     // how many (and which) repos are currently holding would-closes for review. Only emitted when ≥1 engaged.
     if (closeEngaged.length > 0) {
-      console.warn(
+      console.error(
         JSON.stringify({
-          ev: "closehold_backlog",
+          level: "error",
+          event: "closehold_backlog",
           count: closeEngaged.length,
           projects: closeEngaged.map((a) => a.project),
         }),

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -653,9 +653,13 @@ describe("runSelfTuneBreaker — reads recorded pr_outcome ground truth + engage
     for (let i = 4; i < 12; i += 1)
       await seedDecisionAndOutcome(env, "owner/repo", i, "merge", "closed");
 
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     await runSelfTuneBreaker(env);
 
     expect(await isHoldOnly(env, "owner/repo")).toBe(true);
+    // The bot self-disabling its own auto-merge now surfaces to Sentry at error level (not a hidden warn).
+    expect(err.mock.calls.some(([l]) => String(l).includes("breaker_engaged") && String(l).includes('"level":"error"'))).toBe(true);
+    err.mockRestore();
   });
 
   it("ENGAGES the CLOSE breaker when recorded outcomes show close precision below the floor", async () => {


### PR DESCRIPTION
## Summary

When the self-tune loop disables its own auto-merge / auto-close (precision dropped below the floor over a real sample), it logged `breaker_engaged` / `close_breaker_engaged` / `closehold_backlog` via `console.warn` with **no level** — so the self-disable never reached the Sentry forwarder (which only forwards `level:"error"/"fatal"`). The operator who relies on Sentry never learned the bot had self-corrected — exactly the kind of event that must surface.

Promote those three engagement logs to `console.error` + `level:"error"` (and `ev`→`event` so the forwarder tags them). The `*_auto_cleared` logs stay `console.log` — recovery is good news, not an alert.

## Scope

- [x] Conventional Commit; focused (`outcomes-wire.ts` + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — the existing engagement tests already exercise all three lines (a merge-precision drop engages the breaker, a close-precision drop engages close + emits the backlog line); added a spy asserting the merge engagement now fires `console.error` with `"level":"error"` + `breaker_engaged`.
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: log-level change + a test assertion.

## Safety

- [x] No secrets/wallets/trust-scores exposed (the log carries project + precision + the floor — no reward/scoring values).
- [x] No public GitHub text change (operator-facing log only).

## Notes

- Self-host observability; pairs with the forwarder field-summary work so a breaker engagement lands in Sentry as a legible, alertable issue.
