### PR TITLE
fix(observability): synthesize a field summary for no-message error logs

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -91,6 +91,26 @@ export function captureReviewFailure(
 // string|number values are tagged; everything else stays in the full "log" context.
 const SENTRY_LOG_TAG_KEYS = ["repo", "repository", "installationId", "installation_id", "pull", "pullNumber", "pr", "project", "kind", "deliveryId"] as const;
 
+// Fields already represented in the title/level (or non-scalar) — excluded from the field-summary below so a
+// no-message title isn't padded with redundant or unrenderable values.
+const SENTRY_LOG_META_FIELDS = new Set(["level", "event", "ev", "message", "error", "err", "stack"]);
+
+/** Build a one-line `(key=value, …)` summary of a structured log's SCALAR fields. Many engine error logs carry
+ *  only an event slug + structured context (no `message`/`error`) — without this they'd land in Sentry as a bare
+ *  slug ("gate_check_permission_missing") with no hint of WHERE. This folds the context into the title instead:
+ *  `gate_check_permission_missing (repository=owner/repo, pullNumber=42)`. Empty when there's no scalar context
+ *  beyond the meta fields; capped so a fat log can't blow up the issue title. */
+function summarizeLogFields(obj: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (SENTRY_LOG_META_FIELDS.has(key)) continue;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      parts.push(`${key}=${value}`);
+    }
+  }
+  return parts.length > 0 ? ` (${parts.join(", ").slice(0, 180)})` : "";
+}
+
 /** Forward a structured console line to Sentry when it is an ERROR-level log. The engine logs operational
  *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as JSON strings, often via console.error.
  *  No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal — routine logs
@@ -112,7 +132,10 @@ export function forwardStructuredLogToSentry(line: unknown): void {
   // Lead the Sentry title with the real failure detail (message → error), not just the event slug, so an operator
   // sees WHAT broke straight from the issue list instead of having to open the context blob.
   const detail = typeof obj.message === "string" ? obj.message : typeof obj.error === "string" ? obj.error : undefined;
-  const title = event ? (detail ? `${event}: ${detail}` : event) : (detail ?? "error");
+  // Title preference: "event: detail" (real failure text) → "event (key=value, …)" (context-only logs, so the
+  // issue list is never a bare slug) → detail alone → "error". The forwarder can't invent a sentence, but it can
+  // always surface WHERE from the structured fields.
+  const title = event ? (detail ? `${event}: ${detail}` : `${event}${summarizeLogFields(obj)}`) : (detail ?? "error");
   Sentry.withScope((scope) => {
     scope.setLevel(severity);
     scope.setContext("log", obj);

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -187,7 +187,7 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.captureMessage).not.toHaveBeenCalled();
   });
 
-  it("forwards a level:error log titled by event, with context + an event tag", async () => {
+  it("titles a no-message error log with event + a (key=value) summary of its scalar context", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(
       JSON.stringify({
@@ -206,8 +206,9 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
       "event",
       "orb_broker_unavailable",
     );
+    // No message/error → the title still surfaces WHERE from the structured fields (not a bare slug).
     expect(mocks.captureMessage).toHaveBeenCalledWith(
-      "orb_broker_unavailable",
+      "orb_broker_unavailable (installationId=1)",
       "error",
     );
   });
@@ -247,6 +248,28 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     forwardStructuredLogToSentry(JSON.stringify({ level: "error", code: 500 }));
     expect(mocks.captureMessage).toHaveBeenCalledWith("error", "error");
   });
+
+  it("uses a bare event title when a no-message error log has no scalar context (empty field-summary)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "relay_drained_error" }),
+    );
+    expect(mocks.captureMessage).toHaveBeenCalledWith("relay_drained_error", "error");
+  });
+
+  it("field-summary includes scalar fields but skips non-scalar (array/object) values", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "closehold_backlog",
+        count: 2,
+        projects: ["a", "b"],
+      }),
+    );
+    // count (scalar) is folded into the title; projects (array) stays in the context blob only.
+    expect(mocks.captureMessage).toHaveBeenCalledWith("closehold_backlog (count=2)", "error");
+  });
 });
 
 describe("installStructuredLogForwarding — central console sink instrumentation (#1468)", () => {
@@ -269,7 +292,7 @@ describe("installStructuredLogForwarding — central console sink instrumentatio
     );
 
     expect(mocks.captureMessage).toHaveBeenCalledWith(
-      "orb_broker_unavailable",
+      "orb_broker_unavailable (installationId=1)",
       "error",
     );
     expect(base.error).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Investigating the live Sentry issues (`jsonbored/gittensory`) showed the "no error message" symptom: many engine error logs emit `{level:"error", event:"X", ...context}` with **no `message`/`error` field**, so the forwarder titled them with just the event slug — e.g. `gate_check_permission_missing` — giving the operator no description and no *where*.

The forwarder can't invent a sentence, but it can surface the *where*. When there's no `message`/`error`, it now folds the log's **scalar** fields into the title:

```
gate_check_permission_missing (repository=owner/repo, pullNumber=42, deliveryId=…)
```

Non-scalar values (arrays/objects) stay in the full `log` context; the summary is capped so a fat log can't blow up the issue title. Logs that *do* carry a `message`/`error` are unchanged (still `event: detail`).

## Scope

- [x] Conventional Commit; focused (`selfhost/sentry.ts` + its test).
- [x] No `site/`/`CNAME`/Pages; follows `CONTRIBUTING.md`.

## Validation

- [x] `git diff --check` · `actionlint` · `typecheck`
- [x] `test:coverage` — both `summarizeLogFields` branches covered: scalar fields present (title gets the summary), no scalar context (bare event title), and a non-scalar value skipped (array left in context); updated the existing event-titled + console.error regression tests to the new title.
- [x] `test:workers` · `build:mcp` · `test:mcp-pack` · `ui:*` · `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration/OpenAPI/cf-typegen: pure forwarder logic + tests.

## Safety

- [x] The `beforeSend` scrubber still runs — secret-like keys are redacted before send; the field-summary only reads already-emitted structured-log scalars (no new data source).
- [x] No public GitHub text change (Sentry-internal title only).

## Notes

- Self-host observability. The highest-leverage half of the "real error messages in Sentry" work: one central change makes *every* slug-only error log legible without touching each call site. Per-log `message` polish can follow incrementally.
