### PR TITLE
fix(review): surface a non-2xx REES enrichment response to Sentry

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -92,7 +92,20 @@ export async function buildReviewEnrichment(
       }),
       signal: AbortSignal.timeout(timeoutMs),
     });
-    if (!response.ok) return undefined;
+    if (!response.ok) {
+      // A non-2xx from REES (auth/5xx/bad-gateway) silently degraded the review to no-enrichment with no signal.
+      // Surface it at ERROR level (same event as the catch below) so the Sentry forwarder catches a broken REES.
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "review_context_fetch_failed",
+          repository: input.repoFullName,
+          contextType: "enrichment",
+          message: `REES /v1/enrich returned ${response.status}`,
+        }),
+      );
+      return undefined;
+    }
     const brief = (await response.json()) as {
       promptSection?: string;
       systemSuffix?: string;

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -90,13 +90,24 @@ describe("buildReviewEnrichment", () => {
     expect(await buildReviewEnrichment(env({}), input)).toBeUndefined();
   });
 
-  it("undefined on a non-200 response", async () => {
+  it("undefined on a non-200 response, and surfaces it at ERROR for Sentry (was a silent skip)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     globalThis.fetch = vi.fn(
-      async () => ({ ok: false, json: async () => ({}) }) as Response,
+      async () =>
+        ({ ok: false, status: 502, json: async () => ({}) }) as Response,
     ) as unknown as typeof fetch;
     expect(
       await buildReviewEnrichment(env({ REES_URL: "https://r" }), input),
     ).toBeUndefined();
+    // A non-2xx REES response now logs at error level (was a silent skip) so a broken backend is visible in Sentry.
+    expect(
+      errSpy.mock.calls.some(
+        (c) =>
+          String(c[0]).includes("review_context_fetch_failed") &&
+          String(c[0]).includes("502"),
+      ),
+    ).toBe(true);
+    errSpy.mockRestore();
   });
 
   it("undefined on a fetch error (network/timeout) and surfaces it at ERROR for Sentry (#5)", async () => {


### PR DESCRIPTION
## Summary

`buildReviewEnrichment` returned `undefined` on a non-200 from the REES `/v1/enrich` endpoint with **no log** — so a broken or auth-failing enrichment backend silently degraded the review to no-enrichment with no signal (only network/timeout errors were logged). It now logs the non-2xx at error level (the same `review_context_fetch_failed` event as the network-error catch, with the status code) so the Sentry forwarder captures a broken REES backend.

Verified live: `/v1/enrich` currently returns 200 — this closes the observability gap for when it doesn't.

## Scope
- [x] Conventional Commit; focused (`enrichment-wire.ts` + its test).
- [x] No `site/`/`CNAME`/Pages.

## Validation
- [x] `npm run test:ci` green; the non-200 test now asserts the error log fires (status 502).
- [x] `npm audit --audit-level=moderate`

## Safety
- [x] No secrets in code/logs (logs the status code + repo, not the shared secret).
- [x] No behavior change beyond the added log (still returns undefined → review proceeds un-enriched).