### PR TITLE
fix(observability): forward every console.error structured log to Sentry

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -115,7 +115,7 @@ function summarizeLogFields(obj: Record<string, unknown>): string {
  *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as JSON strings, often via console.error.
  *  No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal — routine logs
  *  (audit/info/no-level: job_complete, regate_sweep_throttled, …) are intentionally skipped. */
-export function forwardStructuredLogToSentry(line: unknown): void {
+export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = false): void {
   if (!active || !Sentry) return;
   if (typeof line !== "string" || line.charCodeAt(0) !== 123 /* "{" */) return;
   let obj: Record<string, unknown>;
@@ -125,7 +125,11 @@ export function forwardStructuredLogToSentry(line: unknown): void {
   } catch {
     return; // not JSON — an ordinary log line
   }
-  const level = obj.level;
+  // A console.error sink is error-level by DEFAULT even when the JSON omits an explicit level (many engine error
+  // logs do) — that's how those errors reach Sentry instead of printing to stderr and vanishing. An EXPLICIT level
+  // always wins, so a deliberate level:"warn" emitted via console.error is still skipped.
+  const explicitLevel = typeof obj.level === "string" ? obj.level : undefined;
+  const level = explicitLevel ?? (fromErrorSink ? "error" : undefined);
   if (level !== "error" && level !== "fatal") return;
   const severity = level === "fatal" ? "fatal" : "error";
   const event = typeof obj.event === "string" ? obj.event : undefined;
@@ -175,21 +179,24 @@ export function installStructuredLogForwarding(
   const baseConsoleLog = target.log.bind(target);
   const baseConsoleError = target.error.bind(target);
   let forwardingToSentry = false;
-  const forward = (line: unknown): void => {
+  const forward = (line: unknown, fromErrorSink: boolean): void => {
     if (forwardingToSentry) return;
     forwardingToSentry = true;
     try {
-      forwardStructuredLogToSentry(line);
+      forwardStructuredLogToSentry(line, fromErrorSink);
     } finally {
       forwardingToSentry = false;
     }
   };
+  // stdout (console.log): forward only an EXPLICIT level:error/fatal. stderr (console.error): forward as error by
+  // default (an explicit level still wins) — so EVERY console.error structured log reaches Sentry, not just the
+  // ones that happened to include a level field.
   target.log = (...args: unknown[]): void => {
     baseConsoleLog(...args);
-    forward(args[0]);
+    forward(args[0], false);
   };
   target.error = (...args: unknown[]): void => {
     baseConsoleError(...args);
-    forward(args[0]);
+    forward(args[0], true);
   };
 }

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -312,6 +312,38 @@ describe("installStructuredLogForwarding — central console sink instrumentatio
     expect(base.log).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards a NO-LEVEL structured log emitted through console.error (the error sink defaults to error)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target } = makeConsole();
+    installStructuredLogForwarding(target);
+    // No `level` field — previously dropped on the floor; now console.error forwards it as error (with field summary).
+    target.error(
+      JSON.stringify({ event: "selfhost_ai_provider_failed", repo: "o/r" }),
+    );
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      "selfhost_ai_provider_failed (repo=o/r)",
+      "error",
+    );
+  });
+
+  it("does NOT forward a no-level log through console.log (stdout is not error by default)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target } = makeConsole();
+    installStructuredLogForwarding(target);
+    target.log(JSON.stringify({ event: "job_complete" }));
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps skipping an EXPLICIT level:warn through console.error (explicit level wins over the sink default)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    const { target } = makeConsole();
+    installStructuredLogForwarding(target);
+    target.error(
+      JSON.stringify({ level: "warn", event: "orb_broker_degraded" }),
+    );
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
   it("does not recursively forward if the Sentry path logs while forwarding", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     const { target, base } = makeConsole();


### PR DESCRIPTION
## Summary

The structured-log → Sentry forwarder keyed on the JSON `level` field, so the many engine error logs emitted via `console.error` **without** an explicit `level:"error"` — `selfhost_ai_provider_failed`, `agent_maintenance_failed`, `sweep_rereview_failed`, `reputation_record_failed`, `rag_*`, … — printed to stderr but **never reached Sentry**. That's the systemic gap behind 'Sentry instrumentation across the entire engine.'

Fix: treat the `console.error` sink as **error-level by default**. An explicit level still wins (a deliberate `level:"warn"` via console.error is still skipped), and `console.log` is unchanged (only an explicit `level:error/fatal` forwards). One central change → every error log reaches Sentry, instead of per-log edits across the codebase.

## Scope
- [x] Conventional Commit; focused (`selfhost/sentry.ts` + its test).
- [x] No `site/`/`CNAME`/Pages.

## Validation
- [x] `npm run test:ci` green. New tests: no-level via console.error → forwarded as error (with field summary); no-level via console.log → not forwarded; explicit level:warn via console.error → skipped.
- [x] `npm audit --audit-level=moderate`

## Safety
- [x] Respects explicit levels (no over-forwarding of deliberate warnings). Still filters to JSON-object strings; the beforeSend scrubber still redacts secrets.
- [x] No public GitHub text change.