### PR TITLE
fix(observability): short (repo#pr) Sentry titles + capture the real check-run 403

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -645,6 +645,23 @@ async function createOrUpdateNamedCheckRun(
     return publishedOutcome(data);
   } catch (error) {
     if (isCheckRunPermissionError(error)) {
+      // Capture the ACTUAL response (status + body). A 403 here is often NOT a real permission gap (the App has
+      // Checks:write) — it can be a per-PR access quirk (e.g. a fork-head commit the App can't write to) — and this
+      // log is the only way to tell why, instead of an opaque "permission missing". Surfaces to Sentry with a real
+      // message via console.error (#review-403-context).
+      const e = error as { status?: number; message?: string };
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "check_run_post_denied",
+          repository: `${owner}/${repo}`,
+          status: e.status ?? null,
+          message: (e.message ?? "Resource not accessible by integration").slice(
+            0,
+            300,
+          ),
+        }),
+      );
       return {
         kind: "permission_missing",
         warning:

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -91,24 +91,20 @@ export function captureReviewFailure(
 // string|number values are tagged; everything else stays in the full "log" context.
 const SENTRY_LOG_TAG_KEYS = ["repo", "repository", "installationId", "installation_id", "pull", "pullNumber", "pr", "project", "kind", "deliveryId"] as const;
 
-// Fields already represented in the title/level (or non-scalar) — excluded from the field-summary below so a
-// no-message title isn't padded with redundant or unrenderable values.
-const SENTRY_LOG_META_FIELDS = new Set(["level", "event", "ev", "message", "error", "err", "stack"]);
-
-/** Build a one-line `(key=value, …)` summary of a structured log's SCALAR fields. Many engine error logs carry
- *  only an event slug + structured context (no `message`/`error`) — without this they'd land in Sentry as a bare
- *  slug ("gate_check_permission_missing") with no hint of WHERE. This folds the context into the title instead:
- *  `gate_check_permission_missing (repository=owner/repo, pullNumber=42)`. Empty when there's no scalar context
- *  beyond the meta fields; capped so a fat log can't blow up the issue title. */
-function summarizeLogFields(obj: Record<string, unknown>): string {
-  const parts: string[] = [];
-  for (const [key, value] of Object.entries(obj)) {
-    if (SENTRY_LOG_META_FIELDS.has(key)) continue;
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-      parts.push(`${key}=${value}`);
-    }
-  }
-  return parts.length > 0 ? ` (${parts.join(", ").slice(0, 180)})` : "";
+/** A SHORT location suffix — " (repo#pr)" — for a no-message error title, so the issue list shows WHERE without
+ *  dumping every scalar field (which made titles unreadably long, e.g. trailing a full deliveryId). The complete
+ *  field set is still indexed as Sentry tags + kept in the "log" context. Empty when the log carries no repo. */
+function logLocation(obj: Record<string, unknown>): string {
+  const repo =
+    typeof obj.repository === "string"
+      ? obj.repository
+      : typeof obj.repo === "string"
+        ? obj.repo
+        : undefined;
+  if (!repo) return "";
+  // The standard pullNumber locates the PR in the title; other pr aliases stay in the tags/context (not the title).
+  const pr = obj.pullNumber;
+  return typeof pr === "number" ? ` (${repo}#${pr})` : ` (${repo})`;
 }
 
 /** Forward a structured console line to Sentry when it is an ERROR-level log. The engine logs operational
@@ -136,10 +132,10 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
   // Lead the Sentry title with the real failure detail (message → error), not just the event slug, so an operator
   // sees WHAT broke straight from the issue list instead of having to open the context blob.
   const detail = typeof obj.message === "string" ? obj.message : typeof obj.error === "string" ? obj.error : undefined;
-  // Title preference: "event: detail" (real failure text) → "event (key=value, …)" (context-only logs, so the
-  // issue list is never a bare slug) → detail alone → "error". The forwarder can't invent a sentence, but it can
-  // always surface WHERE from the structured fields.
-  const title = event ? (detail ? `${event}: ${detail}` : `${event}${summarizeLogFields(obj)}`) : (detail ?? "error");
+  // Title preference: "event: detail" (the real failure text, from message/error) → "event (repo#pr)" (a short
+  // location for context-only logs, not a dump of every field) → detail alone → "error". Real legibility comes
+  // from each log carrying a `message`/`error`; this keeps the no-message fallback short + identifying.
+  const title = event ? (detail ? `${event}: ${detail}` : `${event}${logLocation(obj)}`) : (detail ?? "error");
   Sentry.withScope((scope) => {
     scope.setLevel(severity);
     scope.setContext("log", obj);

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -463,6 +463,7 @@ describe("GitHub check runs", () => {
       generatedAt: "2026-05-22T00:00:00.000Z",
     };
 
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await createOrUpdateCheckRun(
       env,
       123,
@@ -474,6 +475,20 @@ describe("GitHub check runs", () => {
     expect((result as { kind: string; warning: string }).warning).toMatch(
       /Checks: write/i,
     );
+    // The ACTUAL 403 is logged (check_run_post_denied) with repo + status + GitHub's message, so a denied
+    // gate-check is diagnosable in Sentry instead of an opaque "permission missing". (#review-403-context)
+    expect(
+      errSpy.mock.calls.some((c) => {
+        const line = String(c[0]);
+        return (
+          line.includes("check_run_post_denied") &&
+          line.includes('"status":403') &&
+          line.includes("JSONbored/gittensory") &&
+          line.includes("Resource not accessible")
+        );
+      }),
+    ).toBe(true);
+    errSpy.mockRestore();
   });
 
   it("creates a failing opt-in Gittensory Gate check for merge blockers", async () => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -187,28 +187,25 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.captureMessage).not.toHaveBeenCalled();
   });
 
-  it("titles a no-message error log with event + a (key=value) summary of its scalar context", async () => {
+  it("titles a no-message error log with event + a SHORT (repo#pr) location, not a field dump", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(
       JSON.stringify({
         level: "error",
-        event: "orb_broker_unavailable",
-        installationId: 1,
+        event: "gate_check_permission_missing",
+        repository: "JSONbored/awesome-claude",
+        pullNumber: 4240,
+        deliveryId: "regate-sweep:JSONbored/awesome-claude#4240",
       }),
     );
     expect(mocks.scope.setLevel).toHaveBeenCalledWith("error");
-    expect(mocks.scope.setContext).toHaveBeenCalledWith("log", {
-      level: "error",
-      event: "orb_broker_unavailable",
-      installationId: 1,
-    });
     expect(mocks.scope.setTag).toHaveBeenCalledWith(
       "event",
-      "orb_broker_unavailable",
+      "gate_check_permission_missing",
     );
-    // No message/error → the title still surfaces WHERE from the structured fields (not a bare slug).
+    // No message/error → a SHORT location (repo#pr), NOT every field — the long deliveryId stays in tags/context only.
     expect(mocks.captureMessage).toHaveBeenCalledWith(
-      "orb_broker_unavailable (installationId=1)",
+      "gate_check_permission_missing (JSONbored/awesome-claude#4240)",
       "error",
     );
   });
@@ -249,7 +246,7 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.captureMessage).toHaveBeenCalledWith("error", "error");
   });
 
-  it("uses a bare event title when a no-message error log has no scalar context (empty field-summary)", async () => {
+  it("uses a bare event title when a no-message error log has no repo to locate it", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(
       JSON.stringify({ level: "error", event: "relay_drained_error" }),
@@ -257,18 +254,22 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.captureMessage).toHaveBeenCalledWith("relay_drained_error", "error");
   });
 
-  it("field-summary includes scalar fields but skips non-scalar (array/object) values", async () => {
+  it("uses (repo) without a pull number, and never dumps other fields into the title", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(
       JSON.stringify({
         level: "error",
         event: "closehold_backlog",
+        repo: "JSONbored/gittensory",
         count: 2,
         projects: ["a", "b"],
       }),
     );
-    // count (scalar) is folded into the title; projects (array) stays in the context blob only.
-    expect(mocks.captureMessage).toHaveBeenCalledWith("closehold_backlog (count=2)", "error");
+    // Only the repo locates it (no pullNumber); count/projects stay in the context blob, NOT crammed in the title.
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      "closehold_backlog (JSONbored/gittensory)",
+      "error",
+    );
   });
 });
 
@@ -292,7 +293,7 @@ describe("installStructuredLogForwarding — central console sink instrumentatio
     );
 
     expect(mocks.captureMessage).toHaveBeenCalledWith(
-      "orb_broker_unavailable (installationId=1)",
+      "orb_broker_unavailable",
       "error",
     );
     expect(base.error).toHaveBeenCalledTimes(1);
@@ -316,12 +317,12 @@ describe("installStructuredLogForwarding — central console sink instrumentatio
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     const { target } = makeConsole();
     installStructuredLogForwarding(target);
-    // No `level` field — previously dropped on the floor; now console.error forwards it as error (with field summary).
+    // No `level` field — previously dropped on the floor; now console.error forwards it as error (short location).
     target.error(
       JSON.stringify({ event: "selfhost_ai_provider_failed", repo: "o/r" }),
     );
     expect(mocks.captureMessage).toHaveBeenCalledWith(
-      "selfhost_ai_provider_failed (repo=o/r)",
+      "selfhost_ai_provider_failed (o/r)",
       "error",
     );
   });


### PR DESCRIPTION
## Summary

Two observability fixes:

1. **Sentry titles were unreadably long.** The forwarder's no-message fallback dumped *every* scalar field into the title (e.g. a full `deliveryId=regate-sweep:...`). Replaced with a short location suffix — `event (repo#pr)` — keeping the complete field set in the Sentry **tags + log context** (where it belongs), not the title. Real legibility still comes from each log carrying a `message`/`error`; this just keeps the fallback short + identifying.

2. **A denied gate-check logged an opaque slug, never the real 403.** `createOrUpdateCheckRun` now logs the **actual** response (status + body) as `check_run_post_denied` before returning `permission_missing`, so we can finally see *why* a check-run is denied (a genuine permission gap vs a per-PR access quirk) instead of guessing.

## Scope
- [x] Conventional Commit; focused (`selfhost/sentry.ts` + `github/app.ts` + tests).
- [x] No `site/`/`CNAME`/Pages.

## Validation
- [x] `npm run test:ci` green; tests cover the new `(repo#pr)` / `(repo)` / bare-event title branches.
- [x] `npm audit --audit-level=moderate`

## Safety
- [x] No secrets in logs (the 403 log carries repo + status + GitHub's message, not the token; the beforeSend scrubber still runs).
- [x] No public GitHub text change.