### PR TITLE
perf(queue): prioritize webhook/review jobs over background work to cut review latency

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -17,9 +17,19 @@ CREATE TABLE IF NOT EXISTS ${TABLE} (
   attempts INTEGER NOT NULL DEFAULT 0,
   run_after BIGINT NOT NULL DEFAULT 0,
   created_at BIGINT NOT NULL,
-  last_error TEXT
+  last_error TEXT,
+  priority INTEGER NOT NULL DEFAULT 0
 );
-CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after);`;
+ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after, priority);`;
+
+// Webhook-driven work (a fresh PR → its review) jumps ahead of heavy background jobs (rag-index, the regate sweep)
+// so a NEW PR is reviewed promptly instead of waiting behind them in the shared FIFO queue. Additive: all other
+// jobs stay priority 0 (today's FIFO order). Mirrors sqlite-queue. (#review-latency)
+const HIGH_PRIORITY_TYPES = new Set(["github-webhook"]);
+function jobPriority(payload: string): number {
+  return HIGH_PRIORITY_TYPES.has(extractPayloadType(payload) ?? "") ? 10 : 0;
+}
 
 export interface PgDurableQueue {
   binding: Queue;
@@ -84,9 +94,10 @@ export function createPgQueue(
     delaySeconds: number,
   ): Promise<void> {
     const now = Date.now();
+    const payload = JSON.stringify(message);
     await pool.query(
-      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at) VALUES ($1,'pending',0,$2,$3)`,
-      [JSON.stringify(message), now + delaySeconds * 1000, now],
+      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority) VALUES ($1,'pending',0,$2,$3,$4)`,
+      [payload, now + delaySeconds * 1000, now, jobPriority(payload)],
     );
     incr("gittensory_jobs_enqueued_total");
     void pump();
@@ -96,7 +107,7 @@ export function createPgQueue(
     // Atomic, multi-instance-safe: lock + claim one due job, skipping rows another instance already locked.
     const res = await pool.query(
       `UPDATE ${TABLE} SET status='processing'
-       WHERE id = (SELECT id FROM ${TABLE} WHERE status='pending' AND run_after<=$1 ORDER BY id FOR UPDATE SKIP LOCKED LIMIT 1)
+       WHERE id = (SELECT id FROM ${TABLE} WHERE status='pending' AND run_after<=$1 ORDER BY priority DESC, id FOR UPDATE SKIP LOCKED LIMIT 1)
        RETURNING id, payload, attempts`,
       [Date.now()],
     );

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -18,9 +18,18 @@ CREATE TABLE IF NOT EXISTS ${TABLE} (
   attempts INTEGER NOT NULL DEFAULT 0,
   run_after INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL,
-  last_error TEXT
+  last_error TEXT,
+  priority INTEGER NOT NULL DEFAULT 0
 );
-CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after);`;
+CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after, priority);`;
+
+// Webhook-driven work (a fresh PR → its review) jumps ahead of heavy background jobs (rag-index ~4min, the regate
+// sweep) so a NEW PR is reviewed promptly instead of waiting behind them in the shared FIFO queue. Additive: every
+// other job stays priority 0 (today's FIFO order), so only github-webhook moves. (#review-latency)
+const HIGH_PRIORITY_TYPES = new Set(["github-webhook"]);
+function jobPriority(payload: string): number {
+  return HIGH_PRIORITY_TYPES.has(extractPayloadType(payload) ?? "") ? 10 : 0;
+}
 
 export interface DurableQueue {
   binding: Queue;
@@ -62,6 +71,15 @@ export function createSqliteQueue(
     Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "4"));
 
   driver.exec(DDL);
+  // Idempotent add for queues created before the priority column existed (#review-latency): the CREATE is skipped
+  // for a pre-existing table, so ALTER adds the column; on a later boot it throws "duplicate column" → swallowed.
+  try {
+    driver.exec(
+      `ALTER TABLE ${TABLE} ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    /* column already present */
+  }
   // Recover jobs a crashed previous run left mid-flight → make them claimable again.
   const recovered = driver.query(
     `UPDATE ${TABLE} SET status='pending' WHERE status='processing'`,
@@ -78,9 +96,10 @@ export function createSqliteQueue(
 
   function enqueue(message: JobMessage, delaySeconds: number): void {
     const now = Date.now();
+    const payload = JSON.stringify(message);
     driver.query(
-      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, ?, ?)`,
-      [JSON.stringify(message), now + delaySeconds * 1000, now],
+      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, ?, ?, ?)`,
+      [payload, now + delaySeconds * 1000, now, jobPriority(payload)],
     );
     incr("gittensory_jobs_enqueued_total");
     void pump();
@@ -88,7 +107,7 @@ export function createSqliteQueue(
 
   function claimNext(): JobRow | null {
     const { rows } = driver.query(
-      `SELECT id, payload, attempts FROM ${TABLE} WHERE status='pending' AND run_after<=? ORDER BY id LIMIT 1`,
+      `SELECT id, payload, attempts FROM ${TABLE} WHERE status='pending' AND run_after<=? ORDER BY priority DESC, id LIMIT 1`,
       [Date.now()],
     );
     const row = rows[0] as JobRow | undefined;

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -26,6 +26,46 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.size()).toBe(0);
   });
 
+  it("tags github-webhook with priority 10, other jobs 0, untyped 0 (#review-latency)", async () => {
+    const driver = makeDriver();
+    const q = createSqliteQueue(driver, async () => undefined);
+    // delaySeconds keeps them pending (not claimed) so we can read the stored priority.
+    await q.binding.send(msg("github-webhook"), { delaySeconds: 60 });
+    await q.binding.send(msg("rag-index-repo"), { delaySeconds: 60 });
+    await q.binding.send({} as unknown as JobMessage, { delaySeconds: 60 }); // no type → priority 0 fallback
+    const { rows } = driver.query(
+      "SELECT payload, priority FROM _selfhost_jobs",
+      [],
+    );
+    const prio = (p: string): number | undefined =>
+      (rows as Array<{ payload: string; priority: number }>).find(
+        (r) => r.payload === p,
+      )?.priority;
+    expect(prio(JSON.stringify(msg("github-webhook")))).toBe(10);
+    expect(prio(JSON.stringify(msg("rag-index-repo")))).toBe(0);
+    expect(prio("{}")).toBe(0);
+  });
+
+  it("claims a high-priority (github-webhook) job before an earlier low-priority one", async () => {
+    const driver = makeDriver();
+    const seen: string[] = [];
+    const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)), {
+      concurrency: 1, // serial so the claim order is deterministic
+    });
+    // Inserted directly so BOTH are pending before any claim; the low one has the smaller id (enqueued earlier).
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 0)",
+      [JSON.stringify(msg("rag-index-repo"))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
+      [JSON.stringify(msg("github-webhook"))],
+    );
+    await q.drain();
+    // github-webhook (priority 10, inserted LATER) is processed BEFORE the earlier rag-index-repo (priority 0).
+    expect(seen).toEqual(["github-webhook", "rag-index-repo"]);
+  });
+
   it("retries then dead-letters after maxRetries", async () => {
     const driver = makeDriver();
     let calls = 0;


### PR DESCRIPTION
## Summary

The self-host queue (sqlite + pg) claimed **FIFO** at concurrency 4, so a fresh PR's `github-webhook` job waited behind 4-minute `rag-index-repo` jobs — ~6 min just to *start* a review (well over the 5–10 min target).

Add a `priority` column (idempotent `ALTER` for already-deployed queue tables): `github-webhook` jobs get priority 10, **everything else stays 0 (today's FIFO order — purely additive)**, and the claim orders by `priority DESC, id`. New PRs jump ahead of RAG-index/sweep **without** raising concurrency (which would re-starve the claude review subprocess, the bug we just fixed).

## Scope
- [x] Conventional Commit; focused (`sqlite-queue.ts` + `pg-queue.ts` + test).
- [x] No `site/`/`CNAME`/Pages.

## Validation
- [x] `npm run test:ci` green; tests: enqueue tags github-webhook=10 / other=0 / untyped=0, and a high-priority job inserted LATER is claimed BEFORE an earlier low-priority one (concurrency 1).
- [x] `npm audit --audit-level=moderate`

## Safety
- [x] Additive + backward-compatible: existing rows default to priority 0 (unchanged FIFO); the ALTER is idempotent.
- [x] No secrets; no public GitHub text change. Concurrency unchanged (claude not re-starved).