### PR TITLE
fix(observability): give detail-less error logs a real reason for Sentry

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -83,13 +83,13 @@ export async function fetchBrokeredInstallationToken(
 export async function registerOrbRelayTarget(
   env: { ORB_ENROLLMENT_SECRET?: string | undefined; ORB_BROKER_URL?: string | undefined; PUBLIC_API_ORIGIN?: string | undefined; ORB_RELAY_MODE?: string | undefined },
   fetchImpl: typeof fetch = fetch,
-): Promise<"registered" | "skipped" | "failed"> {
-  if (!isOrbBrokerMode(env)) return "skipped";
+): Promise<{ status: "registered" | "skipped" | "failed"; reason?: string }> {
+  if (!isOrbBrokerMode(env)) return { status: "skipped" };
   // Pull mode (#secure-relay): the engine DRAINS events outbound from the Orb, so NO inbound endpoint is exposed —
   // the right fit for a NAT/tailnet self-host (a public push URL would otherwise be unreachable). Push mode needs a
   // public relay URL the Orb can reach.
   const mode = env.ORB_RELAY_MODE === "pull" ? "pull" : "push";
-  if (mode === "push" && !env.PUBLIC_API_ORIGIN) return "skipped";
+  if (mode === "push" && !env.PUBLIC_API_ORIGIN) return { status: "skipped" };
   const relayUrl = mode === "push" ? `${env.PUBLIC_API_ORIGIN!.replace(/\/+$/, "")}/v1/orb/relay` : "";
   try {
     const base = orbBrokerBaseUrl(env);
@@ -99,9 +99,15 @@ export async function registerOrbRelayTarget(
       body: JSON.stringify({ relayUrl, mode }),
       signal: AbortSignal.timeout(10_000),
     });
-    return res.ok ? "registered" : "failed";
-  } catch {
-    return "failed";
+    // Carry WHY it failed (HTTP status) so the caller's log — and Sentry — show a real reason, not "(no message)".
+    return res.ok
+      ? { status: "registered" }
+      : { status: "failed", reason: `http_${res.status}` };
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: error instanceof Error ? error.message : "fetch_threw",
+    };
   }
 }
 

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -158,7 +158,7 @@ async function pruneRelayPending(env: Env): Promise<number> {
   // Make pull-mode loss VISIBLE too (parity with the push-path drop): a pruned row is a webhook a long-down tailnet
   // container never drained — emit an alertable error-level log (distinct event name) so it leaves a Sentry trace.
   if (pruned.meta.changes > 0) {
-    console.error(JSON.stringify({ level: "error", event: "orb_relay_pending_dropped", count: pruned.meta.changes }));
+    console.error(JSON.stringify({ level: "error", event: "orb_relay_pending_dropped", message: `${pruned.meta.changes} pull-mode webhook(s) expired undrained after ${RELAY_PENDING_TTL_HOURS}h`, count: pruned.meta.changes }));
   }
   return pruned.meta.changes;
 }
@@ -249,7 +249,7 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
   // retries exhausted) — e.g. a container down for over an hour. Emit an alertable structured log so the loss
   // leaves a trace instead of vanishing silently.
   if (pruned.meta.changes > 0) {
-    console.error(JSON.stringify({ level: "error", event: "orb_relay_events_dropped", count: pruned.meta.changes }));
+    console.error(JSON.stringify({ level: "error", event: "orb_relay_events_dropped", message: `${pruned.meta.changes} relay event(s) dropped after ${RELAY_RETRY_MAX_ATTEMPTS} retries or 1h TTL`, count: pruned.meta.changes }));
   }
   const { results } = await env.DB
     .prepare(

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4075,7 +4075,7 @@ async function auditGateCheckPermissionMissing(
   });
   // Surface the install-wide Checks:write gap to Sentry — until the scope is granted the required gate check-run
   // silently never posts on ANY PR for this install; an operator must SEE this config fault, not just the ledger.
-  console.error(JSON.stringify({ level: "error", event: "gate_check_permission_missing", repository: repoFullName, pullNumber, deliveryId }));
+  console.error(JSON.stringify({ level: "error", event: "gate_check_permission_missing", message: warning, repository: repoFullName, pullNumber, deliveryId }));
 }
 
 /**
@@ -4905,7 +4905,7 @@ async function maybePublishPrPublicSurface(
           detail: checkRunResult.warning,
           metadata: { deliveryId: webhook.deliveryId, repoFullName },
         });
-        console.error(JSON.stringify({ level: "error", event: "check_run_permission_missing", repository: repoFullName, pullNumber: pr.number, deliveryId: webhook.deliveryId }));
+        console.error(JSON.stringify({ level: "error", event: "check_run_permission_missing", message: checkRunResult.warning, repository: repoFullName, pullNumber: pr.number, deliveryId: webhook.deliveryId }));
       } else if (checkRunResult?.kind === "published") {
         publishedOutputs.push("check_run");
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -745,12 +745,22 @@ async function main(): Promise<void> {
     ORB_RELAY_MODE: process.env.ORB_RELAY_MODE,
   })
     .then((r) => {
-      if (r === "registered") {
-        console.log(JSON.stringify({ event: "selfhost_orb_relay_register", result: r }));
-      } else if (r === "failed") {
-        // A failed registration means the central Orb won't forward this install's webhooks here — the container
-        // looks alive but reviews NOTHING. Surface at error level so the operator sees a deaf container.
-        console.error(JSON.stringify({ level: "error", event: "selfhost_orb_relay_register_failed" }));
+      if (r.status === "registered") {
+        console.log(JSON.stringify({ event: "selfhost_orb_relay_register", result: r.status }));
+      } else if (r.status === "failed") {
+        // A failed registration is fatal for PUSH mode (the Orb can't reach our public relay URL → the container
+        // looks alive but reviews NOTHING → error). In PULL mode the outbound drain loop below delivers events
+        // regardless, so a failed announce is only degraded telemetry → warn (not paged as a deaf container).
+        // Either way carry the reason (HTTP status / fetch error) in `error` so Sentry shows WHY, not "(no message)".
+        const pull = process.env.ORB_RELAY_MODE === "pull";
+        console.error(
+          JSON.stringify({
+            level: pull ? "warn" : "error",
+            event: "selfhost_orb_relay_register_failed",
+            mode: pull ? "pull" : "push",
+            error: r.reason ?? "unknown",
+          }),
+        );
       }
     })
     .catch((error) => captureError(error, { kind: "orb_relay_register" }));

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -97,13 +97,13 @@ describe("fetchBrokeredInstallationToken", () => {
 
 describe("registerOrbRelayTarget", () => {
   it("skips unless broker mode AND a public origin are configured", async () => {
-    expect(await registerOrbRelayTarget({})).toBe("skipped"); // not broker mode
-    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s" })).toBe("skipped"); // no PUBLIC_API_ORIGIN
+    expect(await registerOrbRelayTarget({})).toEqual({ status: "skipped" }); // not broker mode
+    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s" })).toEqual({ status: "skipped" }); // no PUBLIC_API_ORIGIN
   });
 
   it("POSTs the relay URL (origin + /v1/orb/relay) to the broker with the enrollment secret; trailing slashes stripped", async () => {
     const { fetchImpl, calls } = captureFetch(new Response("ok"));
-    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "orbsec_x", PUBLIC_API_ORIGIN: "https://me.example/", ORB_BROKER_URL: "https://broker.example/" }, fetchImpl)).toBe("registered");
+    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "orbsec_x", PUBLIC_API_ORIGIN: "https://me.example/", ORB_BROKER_URL: "https://broker.example/" }, fetchImpl)).toEqual({ status: "registered" });
     expect(calls[0]?.url).toBe("https://broker.example/v1/orb/relay/register"); // ORB_BROKER_URL trailing slash stripped
     expect((calls[0]?.init?.headers as Record<string, string>).authorization).toBe("Bearer orbsec_x");
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ relayUrl: "https://me.example/v1/orb/relay", mode: "push" }); // PUBLIC_API_ORIGIN trailing slash stripped
@@ -120,19 +120,19 @@ describe("registerOrbRelayTarget", () => {
       throw new Error("fetch should not be called for an unsafe broker URL");
     }) as typeof fetch;
 
-    await expect(registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example", ORB_BROKER_URL: "http://broker.example" }, fetchImpl)).resolves.toBe("failed");
+    await expect(registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example", ORB_BROKER_URL: "http://broker.example" }, fetchImpl)).resolves.toMatchObject({ status: "failed" });
   });
 
   it("returns failed on a non-ok response or a thrown fetch (never blocks boot)", async () => {
     const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
-    expect(await registerOrbRelayTarget(cfg, (async () => new Response("no", { status: 403 })) as typeof fetch)).toBe("failed");
-    expect(await registerOrbRelayTarget(cfg, (async () => { throw new Error("down"); }) as typeof fetch)).toBe("failed");
+    expect(await registerOrbRelayTarget(cfg, (async () => new Response("no", { status: 403 })) as typeof fetch)).toEqual({ status: "failed", reason: "http_403" });
+    expect(await registerOrbRelayTarget(cfg, (async () => { throw new Error("down"); }) as typeof fetch)).toEqual({ status: "failed", reason: "down" });
   });
 
   it("pull mode (ORB_RELAY_MODE=pull) registers with NO relay URL and works without a public origin (NAT/tailnet)", async () => {
     const { fetchImpl, calls } = captureFetch(new Response("ok"));
     // No PUBLIC_API_ORIGIN — push would skip, but pull doesn't need an inbound URL.
-    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", ORB_RELAY_MODE: "pull" }, fetchImpl)).toBe("registered");
+    expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", ORB_RELAY_MODE: "pull" }, fetchImpl)).toEqual({ status: "registered" });
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ relayUrl: "", mode: "pull" });
   });
 });


### PR DESCRIPTION
## Summary
Five structured error logs reached Sentry with no `message`/`error` field, so they rendered as **"(no message — see the log context)"**. Each now carries its real reason:

- **`selfhost_orb_relay_register_failed`** — `registerOrbRelayTarget` now returns `{status, reason}`; server.ts logs the cause (`http_NNN` / fetch error). A **PULL-mode** register failure drops to `warn` (the outbound drain delivers events regardless — not a deaf container); only **PUSH-mode** stays `error`.
- **`gate_check_permission_missing` / `check_run_permission_missing`** — now carry the permission `warning` already in scope.
- **`orb_relay_pending_dropped` / `orb_relay_events_dropped`** — now state the drop reason (TTL elapsed / retry budget exhausted).

Audit also confirmed **no silent catches** in src/.

## Validation
- `npm run test:ci` green; broker-client tests assert the new `{status, reason}` shape incl. both `http_403` and the thrown-error branches.