### PR TITLE
fix(github): repost cross-app check-runs + handle transient rate limits

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -80,6 +80,48 @@ export function isCacheableGithubUrl(url: string): boolean {
   );
 }
 
+// Transient GitHub rate-limit handling (#ratelimit-resilience). A primary (x-ratelimit-remaining:0) or secondary
+// (Retry-After / "secondary rate limit" body) limit returns 403/429. Instead of surfacing it as a failure — or
+// MISCLASSIFYING a 403 as a permission gap — back off a few times and retry. A sustained limit exhausts the
+// retries and the response is returned so the caller (and the queue) handles it. Bounded so a review never stalls.
+const GITHUB_RATE_LIMIT_MAX_RETRIES = 3;
+const GITHUB_RATE_LIMIT_MAX_DELAY_MS = 8_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Does this GitHub response signal a rate limit (primary or secondary)? 403/429 with a Retry-After header, an
+ *  exhausted x-ratelimit-remaining, or a secondary-limit/abuse body. A 403 with NONE of these is a real
+ *  permission/other error and must surface — not retry, not be mistaken for a rate limit. Exported for tests. */
+export async function isRateLimitedResponse(
+  response: Response,
+): Promise<boolean> {
+  if (response.status !== 403 && response.status !== 429) return false;
+  if (response.headers.get("retry-after") != null) return true;
+  if (response.headers.get("x-ratelimit-remaining") === "0") return true;
+  try {
+    return /secondary rate limit|\babuse\b|api rate limit exceeded/i.test(
+      await response.clone().text(),
+    );
+    /* v8 ignore next 3 -- defensive: a cloned Response body that fails to read isn't reachable in practice */
+  } catch {
+    return false;
+  }
+}
+
+/** How long to wait before the next rate-limit retry: honor a valid Retry-After (seconds), else exponential
+ *  backoff — each capped so a review can never stall on one call. A sustained PRIMARY limit (reset up to an hour
+ *  out) simply exhausts the few inline retries and the queue retries the job later. Exported for tests. */
+export function rateLimitRetryMs(response: Response, attempt: number): number {
+  const retryAfterHeader = response.headers.get("retry-after");
+  if (retryAfterHeader != null) {
+    const retryAfter = Number(retryAfterHeader);
+    if (Number.isFinite(retryAfter) && retryAfter >= 0)
+      return Math.min(retryAfter * 1000, GITHUB_RATE_LIMIT_MAX_DELAY_MS);
+  }
+  return Math.min(500 * 2 ** attempt, GITHUB_RATE_LIMIT_MAX_DELAY_MS);
+}
+
 async function timeoutFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -96,12 +138,22 @@ async function timeoutFetch(
         headers: { "content-type": hit.contentType },
       });
   }
-  const response = init?.signal
-    ? await fetch(input, init)
-    : await fetch(input, {
-        ...(init ?? {}),
-        signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
-      });
+  let response: Response;
+  for (let attempt = 0; ; attempt += 1) {
+    response = init?.signal
+      ? await fetch(input, init)
+      : await fetch(input, {
+          ...(init ?? {}),
+          signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
+        });
+    // Retry a transient rate-limit (with backoff) instead of surfacing it; stop once exhausted or it's not a limit.
+    if (
+      attempt >= GITHUB_RATE_LIMIT_MAX_RETRIES ||
+      !(await isRateLimitedResponse(response))
+    )
+      break;
+    await sleep(rateLimitRetryMs(response, attempt));
+  }
   if (useCache && response.status === 200) {
     try {
       const body = await response.clone().text(); // clone leaves the returned response readable
@@ -564,6 +616,8 @@ async function createOrUpdateNamedCheckRun(
   },
 ): Promise<CheckRunOutcome | null> {
   if (!advisory.headSha) return null;
+  // Narrow once into a const so the postNewCheckRun closure below sees a string, not string | undefined.
+  const headSha = advisory.headSha;
   const [owner, repo] = repoFullName.split("/");
   if (!owner || !repo)
     throw new Error(`Invalid repository full name: ${repoFullName}`);
@@ -577,72 +631,80 @@ async function createOrUpdateNamedCheckRun(
   const detailsUrl = maintainerControlPanelUrl(env, repoFullName);
   const detailsUrlBody = detailsUrl ? { details_url: detailsUrl } : {};
 
-  try {
-    if (check.checkRunId) {
-      const response = await octokit.request(
-        "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
-        {
-          owner,
-          repo,
-          check_run_id: check.checkRunId,
-          name: check.name,
-          /* v8 ignore next 2 -- Exported check helpers always provide status/conclusion for known-id finalization. */
-          status: check.status ?? "completed",
-          ...(check.conclusion ? { conclusion: check.conclusion } : {}),
-          output: outputForCheckRunUpdate(check.output),
-          ...detailsUrlBody,
-        },
-      );
-      const data = response.data as CheckRunResponse;
-      return publishedOutcome(data);
-    }
-
-    const existing = await octokit.request(
-      "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
-      {
-        owner,
-        repo,
-        ref: advisory.headSha,
-        check_name: check.name,
-        filter: "latest",
-        per_page: 1,
-      },
-    );
-    const existingCheckRun = (existing.data as CheckRunListResponse)
-      .check_runs?.[0];
-    if (existingCheckRun) {
-      const response = await octokit.request(
-        "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
-        {
-          owner,
-          repo,
-          check_run_id: existingCheckRun.id,
-          name: check.name,
-          status: check.status ?? "completed",
-          ...(check.conclusion ? { conclusion: check.conclusion } : {}),
-          output: outputForCheckRunUpdate(check.output),
-          ...detailsUrlBody,
-        },
-      );
-      const data = response.data as CheckRunResponse;
-      return publishedOutcome(data);
-    }
-
+  // POST a fresh check-run THIS App owns. Used for a brand-new run AND as the cross-app fallback below.
+  const postNewCheckRun = async (): Promise<CheckRunOutcome> => {
     const response = await octokit.request(
       "POST /repos/{owner}/{repo}/check-runs",
       {
         owner,
         repo,
         name: check.name,
-        head_sha: advisory.headSha,
+        head_sha: headSha,
         status: check.status ?? "completed",
         ...(check.conclusion ? { conclusion: check.conclusion } : {}),
         output: check.output,
         ...detailsUrlBody,
       },
     );
-    const data = response.data as CheckRunResponse;
-    return publishedOutcome(data);
+    return publishedOutcome(response.data as CheckRunResponse);
+  };
+  // PATCH an existing run by id. If that run was created by a PRIOR GitHub App (install migrated / reinstalled under a
+  // new app_id), GitHub 403s "can only be modified by the GitHub App that created it" — that stale run is unreachable,
+  // so fall through (null) to POST a fresh one this App owns instead of failing the gate forever. (#cross-app-checkrun)
+  const patchCheckRun = async (id: number): Promise<CheckRunOutcome | null> => {
+    try {
+      const response = await octokit.request(
+        "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+        {
+          owner,
+          repo,
+          check_run_id: id,
+          name: check.name,
+          status: check.status ?? "completed",
+          ...(check.conclusion ? { conclusion: check.conclusion } : {}),
+          output: outputForCheckRunUpdate(check.output),
+          ...detailsUrlBody,
+        },
+      );
+      return publishedOutcome(response.data as CheckRunResponse);
+    } catch (error) {
+      if (!isCrossAppCheckRunError(error)) throw error;
+      console.log(
+        JSON.stringify({
+          level: "info",
+          event: "check_run_cross_app_repost",
+          repository: `${owner}/${repo}`,
+          staleCheckRunId: id,
+        }),
+      );
+      return null;
+    }
+  };
+
+  try {
+    if (check.checkRunId) {
+      const out = await patchCheckRun(check.checkRunId);
+      if (out) return out;
+    } else {
+      const existing = await octokit.request(
+        "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+        {
+          owner,
+          repo,
+          ref: advisory.headSha,
+          check_name: check.name,
+          filter: "latest",
+          per_page: 1,
+        },
+      );
+      const existingCheckRun = (existing.data as CheckRunListResponse)
+        .check_runs?.[0];
+      if (existingCheckRun) {
+        const out = await patchCheckRun(existingCheckRun.id);
+        if (out) return out;
+      }
+    }
+    return await postNewCheckRun();
   } catch (error) {
     if (isCheckRunPermissionError(error)) {
       // Capture the ACTUAL response (status + body). A 403 here is often NOT a real permission gap (the App has
@@ -687,10 +749,51 @@ function publishedOutcome(data: CheckRunResponse): CheckRunOutcome {
   return outcome;
 }
 
-function isCheckRunPermissionError(error: unknown): boolean {
+/** A check-run created by a PRIOR GitHub App (the install was migrated / reinstalled under a new app_id) cannot be
+ *  PATCHed by THIS App — GitHub 403s "Invalid app_id N - check run can only be modified by the GitHub App that
+ *  created it". That stale run is unreachable, so the caller reposts a fresh one this App owns. (#cross-app-checkrun) */
+export function isCrossAppCheckRunError(error: unknown): boolean {
   /* v8 ignore next -- Octokit wraps thrown fetch values in HttpError objects before this helper sees them. */
   if (typeof error !== "object" || error === null) return false;
-  const e = error as { status?: number; message?: string };
+  const e = error as { message?: string };
+  return (
+    typeof e.message === "string" &&
+    /can only be modified by the GitHub App that created it|invalid app_id/i.test(
+      e.message,
+    )
+  );
+}
+
+/** Mirror of {@link isRateLimitedResponse} for a THROWN Octokit error (has .status, .message, .response.headers).
+ *  A rate-limit 403/429 is not a permission gap — used to keep it out of isCheckRunPermissionError. */
+function isRateLimitedError(error: {
+  status?: number;
+  message?: string;
+  response?: { headers?: Record<string, unknown> };
+}): boolean {
+  if (error.status !== 403 && error.status !== 429) return false;
+  const headers = error.response?.headers ?? {};
+  if (headers["retry-after"] != null) return true;
+  if (headers["x-ratelimit-remaining"] === "0") return true;
+  return (
+    typeof error.message === "string" &&
+    /secondary rate limit|\babuse\b|api rate limit exceeded/i.test(error.message)
+  );
+}
+
+/** Exported for tests. */
+export function isCheckRunPermissionError(error: unknown): boolean {
+  /* v8 ignore next -- Octokit wraps thrown fetch values in HttpError objects before this helper sees them. */
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as {
+    status?: number;
+    message?: string;
+    response?: { headers?: Record<string, unknown> };
+  };
+  // A rate-limit / secondary-limit 403 is NOT a permission gap — never record it as one (the App has Checks:write;
+  // a 403 under burst load is the abuse limit). timeoutFetch already retries these inline; an EXHAUSTED one surfaces
+  // here and must PROPAGATE (→ queue retry), not be swallowed as a permanent permission_missing. (#ratelimit-resilience)
+  if (isRateLimitedError(e)) return false;
   if (e.status === 403) return true;
   return (
     typeof e.message === "string" &&

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -4,6 +4,7 @@ import {
   clearInstallationTokenCacheForTest,
   createInstallationToken,
   createOrUpdateCheckRun,
+  isCrossAppCheckRunError,
   createOrUpdateGateCheckRun,
   createOrUpdatePendingGateCheckRun,
   createOrUpdateSkippedGateCheckRun,
@@ -11,7 +12,10 @@ import {
   getInstallationId,
   getRepositoryCollaboratorPermission,
   isCacheableGithubUrl,
+  isCheckRunPermissionError,
   isForeignAppInstallation,
+  isRateLimitedResponse,
+  rateLimitRetryMs,
   setGitHubResponseCache,
   setInstallationTokenStore,
 } from "../../src/github/app";
@@ -489,6 +493,88 @@ describe("GitHub check runs", () => {
       }),
     ).toBe(true);
     errSpy.mockRestore();
+  });
+
+  it("reposts a fresh check-run when an existing one was created by a PRIOR App (cross-app 403)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/access_tokens"))
+          return Response.json({ token: "installation-token" });
+        // An existing run (created by the OLD app) is found on the commit...
+        if (url.includes("/commits/") && url.includes("/check-runs"))
+          return Response.json({ total_count: 1, check_runs: [{ id: 99 }] });
+        // ...PATCHing it 403s because a different app_id created it...
+        if (method === "PATCH" && url.includes("/check-runs/"))
+          return new Response(
+            JSON.stringify({
+              message:
+                "Invalid app_id 3824093 - check run can only be modified by the GitHub App that created it.",
+            }),
+            { status: 403 },
+          );
+        // ...so the engine POSTs a fresh run THIS app owns instead of failing the gate.
+        if (method === "POST" && url.includes("/check-runs"))
+          return Response.json({ id: 4242 });
+        return new Response("not found", { status: 404 });
+      },
+    );
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const advisory: Advisory = {
+      id: "advisory-crossapp",
+      targetType: "pull_request",
+      targetKey: "JSONbored/gittensory#7",
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 7,
+      headSha: "crossapp123",
+      conclusion: "neutral",
+      severity: "info",
+      title: "Gittensory advisory",
+      summary: "ok",
+      findings: [],
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    };
+
+    const result = await createOrUpdateCheckRun(
+      env,
+      123,
+      "JSONbored/gittensory",
+      advisory,
+    );
+    // Reposted as a fresh run (NOT permission_missing) — the stale prior-App run is unreachable.
+    expect(result).toMatchObject({ kind: "published", id: 4242 });
+    expect(
+      logSpy.mock.calls.some((c) => {
+        const line = String(c[0]);
+        return (
+          line.includes("check_run_cross_app_repost") &&
+          line.includes('"staleCheckRunId":99')
+        );
+      }),
+    ).toBe(true);
+    logSpy.mockRestore();
+  });
+
+  it("isCrossAppCheckRunError detects a prior-App check-run 403, not other errors", () => {
+    expect(
+      isCrossAppCheckRunError({
+        message:
+          "Invalid app_id 3824093 - check run can only be modified by the GitHub App that created it.",
+      }),
+    ).toBe(true);
+    expect(
+      isCrossAppCheckRunError({
+        status: 403,
+        message: "Resource not accessible by integration",
+      }),
+    ).toBe(false);
+    expect(isCrossAppCheckRunError({})).toBe(false); // no message
+    expect(isCrossAppCheckRunError(null)).toBe(false); // non-object
   });
 
   it("creates a failing opt-in Gittensory Gate check for merge blockers", async () => {
@@ -1501,5 +1587,118 @@ describe("self-host Redis token store + GitHub GET response cache", () => {
     expect(store.has("https://api.github.com/app/installations/99")).toBe(
       false,
     ); // non-200 not cached
+  });
+});
+
+describe("GitHub rate-limit handling (#ratelimit-resilience)", () => {
+  describe("isRateLimitedResponse", () => {
+    it("is false for a 200 and for a non-rate 403 (real permission error)", async () => {
+      expect(await isRateLimitedResponse(new Response("ok", { status: 200 }))).toBe(false);
+      expect(
+        await isRateLimitedResponse(
+          new Response("Resource not accessible by integration", { status: 403 }),
+        ),
+      ).toBe(false);
+    });
+    it("detects a primary limit (x-ratelimit-remaining:0) and a Retry-After (secondary/429)", async () => {
+      expect(
+        await isRateLimitedResponse(
+          new Response("", { status: 403, headers: { "x-ratelimit-remaining": "0" } }),
+        ),
+      ).toBe(true);
+      expect(
+        await isRateLimitedResponse(
+          new Response("", { status: 429, headers: { "retry-after": "1" } }),
+        ),
+      ).toBe(true);
+    });
+    it("detects a secondary limit from the body when headers are absent", async () => {
+      expect(
+        await isRateLimitedResponse(
+          new Response("You have exceeded a secondary rate limit", { status: 403 }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("rateLimitRetryMs", () => {
+    it("honors a valid Retry-After (seconds), capped, including 0", () => {
+      expect(rateLimitRetryMs(new Response("", { headers: { "retry-after": "2" } }), 0)).toBe(2000);
+      expect(rateLimitRetryMs(new Response("", { headers: { "retry-after": "9999" } }), 0)).toBe(8000);
+      expect(rateLimitRetryMs(new Response("", { headers: { "retry-after": "0" } }), 0)).toBe(0);
+    });
+    it("falls back to exponential backoff when Retry-After is absent or invalid", () => {
+      expect(rateLimitRetryMs(new Response("", {}), 2)).toBe(2000); // 500 * 2^2, no header
+      expect(rateLimitRetryMs(new Response("", { headers: { "retry-after": "soon" } }), 0)).toBe(500); // invalid → 500 * 2^0
+    });
+  });
+
+  describe("isCheckRunPermissionError — a rate-limit 403 is NOT a permission gap", () => {
+    it("classifies a genuine permission error as permission_missing", () => {
+      expect(isCheckRunPermissionError({ status: 403, message: "nope" })).toBe(true);
+      expect(
+        isCheckRunPermissionError({ status: 404, message: "Resource not accessible by integration" }),
+      ).toBe(true);
+    });
+    it("does NOT classify a rate-limit 403/429 as permission_missing", () => {
+      expect(
+        isCheckRunPermissionError({ status: 403, response: { headers: { "retry-after": "30" } } }),
+      ).toBe(false);
+      expect(
+        isCheckRunPermissionError({ status: 403, response: { headers: { "x-ratelimit-remaining": "0" } } }),
+      ).toBe(false);
+      expect(
+        isCheckRunPermissionError({ status: 429, message: "You have exceeded a secondary rate limit" }),
+      ).toBe(false);
+    });
+    it("is false for a non-object and for a non-permission, non-rate error", () => {
+      expect(isCheckRunPermissionError(null)).toBe(false);
+      expect(isCheckRunPermissionError({ status: 500, message: "boom" })).toBe(false);
+    });
+  });
+
+  it("timeoutFetch retries a transient rate-limit, then succeeds (via the token mint)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    clearInstallationTokenCacheForTest();
+    let calls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        calls += 1;
+        if (calls === 1)
+          return new Response("secondary rate limit", {
+            status: 403,
+            headers: { "retry-after": "0" }, // 0 → instant retry (fast test)
+          });
+        return Response.json({
+          token: "tok-after-retry",
+          expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    expect(await createInstallationToken(env, 5151)).toBe("tok-after-retry");
+    expect(calls).toBe(2); // one rate-limited attempt + one success
+  });
+
+  it("timeoutFetch gives up after the retry budget so a sustained limit surfaces (→ queue retry)", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    clearInstallationTokenCacheForTest();
+    let calls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        calls += 1;
+        return new Response("secondary rate limit", {
+          status: 403,
+          headers: { "retry-after": "0" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    await expect(createInstallationToken(env, 5252)).rejects.toThrow();
+    expect(calls).toBe(4); // initial + GITHUB_RATE_LIMIT_MAX_RETRIES (3)
   });
 });


### PR DESCRIPTION
## Summary
Two GitHub App resilience fixes in the check-run path.

**Cross-app check-run repost (ends recurring Sentry noise).** A check-run created by a *prior* GitHub App (install migrated/reinstalled under a new app_id) can't be PATCHed by the current App — GitHub 403s `can only be modified by the GitHub App that created it`. The engine was recording this as a bogus `permission_missing` (the `check_run_post_denied` / `gate_check_permission_missing` noise on awesome-claude under the retired app_id 3824093). Now it falls through to **POST a fresh run this App owns** (`isCrossAppCheckRunError` + `patchCheckRun`→`postNewCheckRun` fall-through).

**Transient rate-limit handling (re-applied).** `timeoutFetch` retries a primary/secondary (abuse) rate-limit 403/429 with bounded backoff (Retry-After or capped exponential, ≤8s, ≤3 tries); `isCheckRunPermissionError` no longer misclassifies a rate-limit 403 as a permission gap (an exhausted limit propagates → queue retry).

## Validation
- `npm run test:ci` green; 52 github-app tests incl. the cross-app repost path + the re-applied rate-limit suite.