### PR TITLE
fix(observability): summarize field-only error logs in the Sentry value

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -107,6 +107,35 @@ function logLocation(obj: Record<string, unknown>): string {
   return typeof pr === "number" ? ` (${repo}#${pr})` : ` (${repo})`;
 }
 
+/** When a log carries no message/error, summarize its SALIENT scalar fields (project, counts, precisions, …) into the
+ *  Sentry value so a field-only log — e.g. close_breaker_engaged{project,closePrecision,floor} or closehold_backlog
+ *  {count,projects} — shows real data instead of "(no message)". Skips meta + the location keys logLocation already
+ *  used + long blobs (IDs/bodies stay in the indexed tags + the "log" context); caps to a few fields so the title
+ *  stays readable. This is the STRUCTURAL fix for field-only error logs (current + future), not per-log message-adding. */
+const SUMMARY_SKIP_KEYS = new Set([
+  "level",
+  "event",
+  "ts",
+  "time",
+  "timestamp",
+  "msg",
+  "ev",
+  "message",
+  "error",
+  "repo",
+  "repository",
+  "pullNumber",
+  "deliveryId",
+]);
+function summarizeLogFields(obj: Record<string, unknown>): string {
+  return Object.entries(obj)
+    .filter(([k, v]) => !SUMMARY_SKIP_KEYS.has(k) && v !== null)
+    .map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`)
+    .filter((part) => part.length <= 90) // a long blob (id/body) belongs in the context, not the title
+    .slice(0, 5) // a few salient fields, not a dump
+    .join(", ");
+}
+
 /** Forward a structured console line to Sentry when it is an ERROR-level log. The engine logs operational
  *  failures (orb_broker_unavailable, gate-check errors, relay drops, …) as JSON strings, often via console.error.
  *  No-op when Sentry is off, the line isn't a JSON object string, or its level isn't error/fatal — routine logs
@@ -138,8 +167,13 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
   //   message (value) = the failure detail (message/error) → else the PR location → else a pointer to the context
   // So the issue list always shows a legible "event: detail", never a bare slug or "(No error message)". The
   // fingerprint (by event) still groups recurrences, so the synthetic stack doesn't fragment grouping. (#1468)
+  // value = the real detail (message/error) → else the PR location + a summary of salient fields (so a field-only log
+  // like close_breaker_engaged shows "project=x, closePrecision=0.6, floor=0.8") → else a context pointer.
   const value =
-    detail ?? (logLocation(obj).trim() || "(no message — see the log context)");
+    detail ??
+    ([logLocation(obj).trim(), summarizeLogFields(obj)]
+      .filter(Boolean)
+      .join(" ") || "(no message — see the log context)");
   const errorEvent = new Error(value);
   errorEvent.name = event ?? "GittensoryLog";
   Sentry.withScope((scope) => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -246,11 +246,11 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(lastCapturedError().message).toBe("boom");
   });
 
-  it("falls back to a generic title when neither event nor message is present", async () => {
+  it("summarizes salient fields when neither event nor message is present", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(JSON.stringify({ level: "error", code: 500 }));
     expect(lastCapturedError().name).toBe("GittensoryLog");
-    expect(lastCapturedError().message).toBe("(no message — see the log context)");
+    expect(lastCapturedError().message).toBe("code=500");
   });
 
   it("uses a bare event title when a no-message error log has no repo to locate it", async () => {
@@ -262,7 +262,7 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(lastCapturedError().message).toBe("(no message — see the log context)");
   });
 
-  it("uses (repo) without a pull number, and never dumps other fields into the title", async () => {
+  it("summarizes salient fields (count/projects) alongside the repo location", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(
       JSON.stringify({
@@ -273,9 +273,31 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
         projects: ["a", "b"],
       }),
     );
-    // Only the repo locates it (no pullNumber); count/projects stay in the context, NOT crammed in the value.
+    // The repo locates it AND its salient fields are summarized, so the issue shows real data, not "(no message)".
     expect(lastCapturedError().name).toBe("closehold_backlog");
-    expect(lastCapturedError().message).toBe("(JSONbored/gittensory)");
+    expect(lastCapturedError().message).toBe(
+      '(JSONbored/gittensory) count=2, projects=["a","b"]',
+    );
+  });
+
+  it("summarizes a field-only error log (close_breaker_engaged), skipping nulls + long blobs", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "close_breaker_engaged",
+        project: "JSONbored/gittensory",
+        closePrecision: 0.6,
+        floor: 0.8,
+        extra: null,
+        note: "x".repeat(100),
+      }),
+    );
+    // project/closePrecision/floor are summarized; the null `extra` and the 100-char `note` are skipped.
+    expect(lastCapturedError().name).toBe("close_breaker_engaged");
+    expect(lastCapturedError().message).toBe(
+      "project=JSONbored/gittensory, closePrecision=0.6, floor=0.8",
+    );
   });
 });
 
@@ -299,7 +321,7 @@ describe("installStructuredLogForwarding — central console sink instrumentatio
     );
 
     expect(lastCapturedError().name).toBe("orb_broker_unavailable");
-    expect(lastCapturedError().message).toBe("(no message — see the log context)");
+    expect(lastCapturedError().message).toBe("installationId=1");
     expect(base.error).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
Field-only error logs (`close_breaker_engaged`, `closehold_backlog`, `breaker_engaged`, …) carry their detail in **fields** (project, closePrecision, count) with no `message`/`error`, so the forwarder rendered them as **"(no message — see the log context)"**. Rather than adding a `message` to each log one-by-one (whack-a-mole), the forwarder now **summarizes a log's salient scalar fields into the Sentry value** — e.g. `close_breaker_engaged: project=x, closePrecision=0.6, floor=0.8`. Skips meta + location keys (logLocation already uses them) + the long `deliveryId`/>90-char blobs (still indexed as tags + kept in the log context); caps to 5 fields.

**Structural** — covers every current AND future field-only error log, not just the two that surfaced.

## Validation
- `npm run test:ci` green; 26 selfhost-sentry tests incl. breaker-style field summary + null/long-blob skips.