### PR TITLE
fix(metrics): redact private repo labels

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5042,7 +5042,7 @@ async function maybePublishPrPublicSurface(
         ciState,
         aiCiRefutationActive(env, repoFullName),
       );
-      // Observability (#reviews-dashboard): record the would-be gate verdict per repo so the Grafana panel shows the
+      // Observability (#reviews-dashboard): record the would-be gate verdict so the Grafana panel shows the
       // merge/close/hold mix — the "are we rubber-stamping?" signal — even in advisory/dryRun (this is the rendered verdict).
       incr("gittensory_gate_decisions_total", {
         repo: repoFullName,

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -18,6 +18,19 @@ const counters = new Map<string, number>();
 const gauges = new Map<string, GaugeSample>();
 const histograms = new Map<string, HistogramState>();
 
+// These public counters are scraped without auth; redact repo labels at the counter call-site.
+const PRIVATE_REPO_LABEL_METRICS = new Set([
+  "gittensory_gate_decisions_total",
+  "gittensory_reviews_published_total",
+]);
+
+function publicLabelsForMetric(name: string, labels?: Labels): Labels | undefined {
+  if (!labels || !PRIVATE_REPO_LABEL_METRICS.has(name) || !("repo" in labels)) return labels;
+  const publicLabels = { ...labels };
+  delete publicLabels.repo;
+  return Object.keys(publicLabels).length > 0 ? publicLabels : undefined;
+}
+
 // Request-latency buckets in seconds (Prometheus convention). Covers sub-ms health checks through
 // multi-second webhook processing. Callers may pass their own buckets to observe().
 export const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
@@ -33,7 +46,7 @@ function seriesKey(name: string, labels?: Labels): string {
 
 /** Increment a monotonic counter (created on first use). */
 export function incr(name: string, labels?: Labels, by = 1): void {
-  const k = seriesKey(name, labels);
+  const k = seriesKey(name, publicLabelsForMetric(name, labels));
   counters.set(k, (counters.get(k) ?? 0) + by);
 }
 

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -20,6 +20,38 @@ describe("metrics registry (#982)", () => {
     expect((await renderMetrics())).toContain('m_total{a="1",b="2"} 1');
   });
 
+  it("redacts private repository labels from public review counters", async () => {
+    incr("gittensory_reviews_published_total", { repo: "private-owner/secret-repo" });
+
+    const out = await renderMetrics();
+    expect(out).toContain("gittensory_reviews_published_total 1");
+    expect(out).not.toContain("private-owner/secret-repo");
+    expect(out).not.toContain('repo="');
+  });
+
+  it("keeps non-sensitive gate labels after redacting the repository", async () => {
+    incr("gittensory_gate_decisions_total", {
+      repo: "private-owner/secret-repo",
+      conclusion: "success",
+    });
+
+    const out = await renderMetrics();
+    expect(out).toContain('gittensory_gate_decisions_total{conclusion="success"} 1');
+    expect(out).not.toContain("private-owner/secret-repo");
+    expect(out).not.toContain('repo="');
+  });
+
+  it("keeps sensitive metric labels when no repository label is present", async () => {
+    incr("gittensory_gate_decisions_total", { conclusion: "hold" });
+
+    expect(await renderMetrics()).toContain('gittensory_gate_decisions_total{conclusion="hold"} 1');
+  });
+
+  it("preserves repository labels for unrelated metrics", async () => {
+    incr("debug_total", { repo: "public-owner/public-repo" });
+    expect(await renderMetrics()).toContain('debug_total{repo="public-owner/public-repo"} 1');
+  });
+
   it("gauges sample at scrape time", async () => {
     let v = 5;
     gauge("g", () => v);


### PR DESCRIPTION
## Summary

No issue because this is maintainer-side hardening for the self-host `/metrics` endpoint. Public scrapes still need aggregate review/gate counters, but they should not expose repository identifiers on the sensitive review and gate series.

## What changed

- Strips the `repo` label from `gittensory_gate_decisions_total` and `gittensory_reviews_published_total` before counter series keys are generated.
- Keeps non-sensitive labels such as `conclusion` intact after redaction.
- Leaves unrelated metrics unchanged so public repository labels still render where explicitly intended.
- Adds regression coverage for repo redaction, repo-less sensitive metric labels, and unrelated metric pass-through.

## Validation

- `npx vitest run test/unit/selfhost-metrics.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run db:migrations:check`
- `npm run test:ci`