### PR TITLE
fix(enrichment): bound secret-log patch scanning

### DIFF
--- a/review-enrichment/src/analyzers/secret-log.ts
+++ b/review-enrichment/src/analyzers/secret-log.ts
@@ -94,13 +94,33 @@ export function detectSecretLog(
 }
 
 /** Scan one file patch's added lines for sensitive-data-into-a-sink, line-cited via hunk headers. Pure. */
+type SecretLogScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  // Stream by patch line so large diffs do not require an intermediate split array; abort is sampled per line below.
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
 export function scanPatchForSecretLog(
   path: string,
   patch: string,
+  limits: SecretLogScanLimits = {},
 ): SecretLogFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
   const findings: SecretLogFinding[] = [];
   let newLine = 0;
-  for (const line of patch.split("\n")) {
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
     if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
@@ -118,6 +138,7 @@ export function scanPatchForSecretLog(
             sink: hit.sink,
             category: hit.category,
           });
+          if (findings.length >= maxFindings) return findings;
         }
       }
       newLine++;
@@ -131,12 +152,18 @@ export function scanPatchForSecretLog(
 /** Analyzer entrypoint: scan every changed file's added lines for secrets/PII reaching a log or stdout sink. */
 export async function scanSecretLog(
   req: EnrichRequest,
+  signal?: AbortSignal,
 ): Promise<SecretLogFinding[]> {
   const findings: SecretLogFinding[] = [];
   for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
     if (!file.patch) continue;
-    for (const finding of scanPatchForSecretLog(file.path, file.patch)) {
+    for (const finding of scanPatchForSecretLog(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
       findings.push(finding);
+      // The per-file scan is capped to the remaining budget; keep this as a final invariant if that scanner changes.
       if (findings.length >= MAX_FINDINGS) return findings;
     }
   }

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -30,7 +30,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   eol: (req) => scanEol(req),
   redos: (req) => scanRedos(req),
   codeowners: (req, signal) => scanCodeowners(req, fetch, { signal }),
-  secretLog: (req) => scanSecretLog(req),
+  secretLog: (req, signal) => scanSecretLog(req, signal),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -1043,6 +1043,62 @@ test("scanSecretLog: scans every changed file's added lines, caps to its budget"
   assert.equal(findings[0].file, "a.ts");
 });
 
+test("scanPatchForSecretLog: stops scanning once the finding budget is exhausted", () => {
+  // Fixture patch lines are intentionally scanner-triggering inputs.
+  const patch = [
+    "@@ -1,0 +1,4 @@",
+    "+console.log(user.password);",
+    "+console.log(user.apiKey);",
+    "+console.log(user.secret);",
+    "+console.log(user.accessToken);",
+  ].join("\n");
+
+  const findings = scanPatchForSecretLog("src/a.ts", patch, {
+    maxFindings: 2,
+  });
+
+  assert.deepEqual(
+    findings.map(({ line, category }) => ({ line, category })),
+    [
+      { line: 1, category: "secret" },
+      { line: 2, category: "secret" },
+    ],
+  );
+});
+
+test("scanPatchForSecretLog: returns no findings when the budget is exhausted", () => {
+  const findings = scanPatchForSecretLog(
+    "src/a.ts",
+    "@@ -1,0 +1,1 @@\n+console.log(user.password);",
+    { maxFindings: 0 },
+  );
+
+  assert.deepEqual(findings, []);
+});
+
+test("scanSecretLog: forwards abort signals to the per-file scanner", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  await assert.rejects(
+    () =>
+      scanSecretLog(
+        {
+          repoFullName: "o/r",
+          prNumber: 1,
+          files: [
+            {
+              path: "a.ts",
+              patch: "@@ -1,0 +1,1 @@\n+console.log(user.password);",
+            },
+          ],
+        },
+        controller.signal,
+      ),
+    /analyzer_aborted/,
+  );
+});
+
 test("renderBrief: renders the secret-log block, code-spanning + sanitizing", () => {
   const r = renderBrief({
     secretLog: [


### PR DESCRIPTION
## Summary

No issue because this is maintainer-side availability hardening for the review-enrichment service. The secret-log analyzer should stop once its finding budget is exhausted and should respect the orchestrator timeout signal instead of continuing through attacker-sized patches.

## What changed

- Adds per-file finding limits to the secret-log patch scanner.
- Streams patch lines instead of materializing the whole split array up front.
- Threads `AbortSignal` from the brief orchestrator into the secret-log analyzer and checks it during scanning.
- Adds regression coverage for budget exhaustion, zero-budget behavior, and abort propagation.
- Adds short comments around scanner-triggering fixtures and the final cap invariant.

## Validation

- `npm test` from `review-enrichment/`
- `npm audit --audit-level=moderate` from `review-enrichment/`
- `git diff --check`