### PR TITLE
fix(observability): redact secret fields in Sentry field-only log summaries

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -130,10 +130,16 @@ const SUMMARY_SKIP_KEYS = new Set([
 function summarizeLogFields(obj: Record<string, unknown>): string {
   return Object.entries(obj)
     .filter(([k, v]) => !SUMMARY_SKIP_KEYS.has(k) && v !== null)
-    .map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`)
+    .map(([k, v]) => `${k}=${summarizeLogFieldValue(k, v)}`)
     .filter((part) => part.length <= 90) // a long blob (id/body) belongs in the context, not the title
     .slice(0, 5) // a few salient fields, not a dump
     .join(", ");
+}
+
+function summarizeLogFieldValue(key: string, value: unknown): string {
+  if (SECRET_KEY.test(key)) return "[redacted]";
+  if (typeof value !== "object") return String(value);
+  return JSON.stringify(scrubEvent({ extra: structuredClone(value) }).extra);
 }
 
 /** Forward a structured console line to Sentry when it is an ERROR-level log. The engine logs operational

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -299,6 +299,25 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
       "project=JSONbored/gittensory, closePrecision=0.6, floor=0.8",
     );
   });
+
+  it("redacts secret-keyed values in field-only error summaries (regression)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "field_only_secret",
+        apiKey: "sensitive-value",
+        password: "sensitive-value",
+        project: "demo",
+        details: { authToken: "nested-sensitive", count: 2 },
+      }),
+    );
+
+    expect(lastCapturedError().name).toBe("field_only_secret");
+    expect(lastCapturedError().message).toBe(
+      'apiKey=[redacted], password=[redacted], project=demo, details={"authToken":"[redacted]","count":2}',
+    );
+  });
 });
 
 describe("installStructuredLogForwarding — central console sink instrumentation (#1468)", () => {


### PR DESCRIPTION
### Motivation
- Field-only structured logs were being summarized into the synthetic Sentry `Error.message` without applying the repository's secret-key redaction, which could expose short secrets (API keys, passwords, tokens) in issue titles/notifications.
- The existing `scrubEvent()` scrubber only covered `request.headers`, `contexts`, and `extra`, so the new summarization path duplicated unredacted scalar fields into the exception value and bypassed the privacy boundary.

### Description
- Route every summarized field through a new `summarizeLogFieldValue()` helper that applies `SECRET_KEY` checks and redacts top-level secret-like keys before formatting.
- For nested/object values, reuse the existing `scrubEvent()` on a `structuredClone` of the value and then `JSON.stringify()` the scrubbed result so nested secret keys are also redacted.
- Add a regression unit test that asserts scalar and nested secret-keyed fields are redacted in the synthesized Sentry message while safe fields remain visible.

### Testing
- Ran `npm run typecheck`, which completed successfully with no type errors.
- Ran the unit tests for the modified file with `npx vitest run test/unit/selfhost-sentry.test.ts`, and the suite passed (`27 tests` passed).
- Attempted coverage and full local gate runs: `npm run test:coverage` encountered a coverage-remapping provider error (`TypeError: jsTokens is not a function`) after tests completed, and `npm run test:ci` was blocked by `actionlint` setup network/fallback issues in this environment, while `npm audit --audit-level=moderate` was blocked by the registry audit endpoint returning `403`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40fe72e56c832c91027e27f331f07f)