### PR TITLE
fix(selfhost): split migration SQL safely

### DIFF
--- a/src/selfhost/migrate.ts
+++ b/src/selfhost/migrate.ts
@@ -6,6 +6,73 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { errorMessage } from "../utils/json";
 
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let start = 0;
+  let quote: "'" | '"' | "`" | null = null;
+  let lineComment = false;
+  let blockComment = false;
+  let triggerBody = false;
+
+  for (let i = 0; i < sql.length; i += 1) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        if (next === quote) {
+          i += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+
+    if (char === "-" && next === "-") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    const partial = sql.slice(start, i + 1);
+    if (/^\s*CREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\b[\s\S]*\bBEGIN\b/i.test(partial)) {
+      triggerBody = true;
+    }
+
+    if (char === ";" && (!triggerBody || /\bEND\s*;\s*$/i.test(partial))) {
+      const statement = sql.slice(start, i + 1).trim();
+      if (statement) statements.push(statement);
+      start = i + 1;
+      triggerBody = false;
+    }
+  }
+
+  const tail = sql.slice(start).trim();
+  if (tail) statements.push(tail);
+  return statements;
+}
+
 export async function runSelfHostMigrations(db: D1Database, dir: string): Promise<number> {
   await db.exec("CREATE TABLE IF NOT EXISTS _selfhost_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL)");
   const existing = await db.prepare("SELECT name FROM _selfhost_migrations").all<{ name: string }>();
@@ -14,10 +81,10 @@ export async function runSelfHostMigrations(db: D1Database, dir: string): Promis
   let count = 0;
   for (const file of files) {
     if (applied.has(file)) continue;
-    const sql = readFileSync(join(dir, file), "utf8").replace(/--.*$/gm, "");
-    for (const statement of sql.split(";").map((part) => part.trim()).filter(Boolean)) {
+    const sql = readFileSync(join(dir, file), "utf8");
+    for (const statement of splitSqlStatements(sql)) {
       try {
-        await db.exec(`${statement};`);
+        await db.exec(statement);
       } catch (error) {
         // Idempotency (#migrate-drift): tolerate duplicate DDL per statement so a drifted multi-step migration
         // still executes the remaining schema changes before the file is recorded as applied.

--- a/test/unit/selfhost-migrate.test.ts
+++ b/test/unit/selfhost-migrate.test.ts
@@ -48,4 +48,55 @@ describe("runSelfHostMigrations (#980)", () => {
     expect(await runSelfHostMigrations(db, dir)).toBe(0);
   });
 
+  it("applies valid SQL containing semicolons and comment markers inside strings", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gtmig-"));
+    writeFileSync(
+      join(dir, "0001_strings.sql"),
+      "CREATE TABLE notes (body TEXT); INSERT INTO notes (body) VALUES ('semi;colon -- literal');",
+    );
+    const db = createD1Adapter(nodeSqliteDriver(new DatabaseSync(":memory:") as never));
+
+    expect(await runSelfHostMigrations(db, dir)).toBe(1);
+    await expect(db.prepare("SELECT body FROM notes").first<{ body: string }>()).resolves.toEqual({
+      body: "semi;colon -- literal",
+    });
+  });
+
+  it("preserves SQL comments outside strings without treating their semicolons as delimiters", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gtmig-"));
+    writeFileSync(
+      join(dir, "0001_comments.sql"),
+      `-- leading comment; ignored by SQLite
+/* block comment; ignored by SQLite */
+CREATE TABLE "quoted;table" (\`body;column\` TEXT);
+INSERT INTO "quoted;table" (\`body;column\`) VALUES ('it''s; ok')`,
+    );
+    const db = createD1Adapter(nodeSqliteDriver(new DatabaseSync(":memory:") as never));
+
+    expect(await runSelfHostMigrations(db, dir)).toBe(1);
+    await expect(db.prepare('SELECT `body;column` AS body FROM "quoted;table"').first<{ body: string }>()).resolves.toEqual({
+      body: "it's; ok",
+    });
+  });
+
+  it("applies trigger bodies that contain internal statement semicolons", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gtmig-"));
+    writeFileSync(
+      join(dir, "0001_trigger.sql"),
+      `CREATE TABLE notes (body TEXT);
+CREATE TABLE audit (body TEXT);
+CREATE TRIGGER notes_ai AFTER INSERT ON notes
+BEGIN
+  INSERT INTO audit (body) VALUES (NEW.body);
+END;
+INSERT INTO notes (body) VALUES ('triggered');`,
+    );
+    const db = createD1Adapter(nodeSqliteDriver(new DatabaseSync(":memory:") as never));
+
+    expect(await runSelfHostMigrations(db, dir)).toBe(1);
+    await expect(db.prepare("SELECT body FROM audit").first<{ body: string }>()).resolves.toEqual({
+      body: "triggered",
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

No issue because this is maintainer-side self-host migration hardening. The startup migrator should not split valid SQLite migration SQL at semicolons or comment markers that appear inside strings, comments, or trigger bodies.

## What changed

- Adds a SQL-aware statement splitter for self-host migration execution.
- Preserves line comments, block comments, quoted strings, quoted identifiers, escaped quotes, and trigger bodies while finding statement boundaries.
- Keeps existing duplicate-column / already-exists drift tolerance per statement.
- Adds unit coverage for string literals, comments, quoted identifiers, escaped quotes, and trigger bodies with internal semicolons.

## Validation

- `npm run typecheck`
- `npx vitest run test/unit/selfhost-migrate.test.ts`
- GitHub CI completed successfully
- GitHub self-host workflow completed successfully