### PR TITLE
fix(enrichment): harden CODEOWNERS glob matching

### DIFF
--- a/review-enrichment/src/analyzers/codeowners.ts
+++ b/review-enrichment/src/analyzers/codeowners.ts
@@ -2,7 +2,7 @@
 // docs/CODEOWNERS), matches each changed file against the glob rules using last-match-wins semantics (per GitHub),
 // and reports files where the PR author is absent from the owner list — plus the blast radius derived at render
 // time from the unique set of ownership domains (users/teams) crossed by the PR.
-// Glob-to-regex conversion uses only atomic `[^/]*`, `.*`, and literal escapes — no catastrophic backtracking.
+// CODEOWNERS matching uses a bounded, linear glob matcher instead of repository-controlled regular expressions.
 // Fail-safe: returns [] on any network error, non-ok response, or missing/unreadable CODEOWNERS file.
 import type { EnrichRequest, CodeownersFinding } from "../types.js";
 
@@ -14,17 +14,29 @@ const CODEOWNERS_PATHS = [
 ] as const;
 const MAX_FILES_REPORTED = 20;
 
+type GlobToken =
+  | { kind: "literal"; value: string }
+  | { kind: "star" }
+  | { kind: "question" }
+  | { kind: "globstar" };
+
 interface ParsedRule {
-  regex: RegExp;
+  tokens: GlobToken[];
+  anchored: boolean;
   owners: string[];
 }
 
+const MAX_CODEOWNERS_BYTES = 64 * 1024;
+const MAX_CODEOWNERS_RULES = 1000;
+const MAX_CODEOWNERS_PATTERN_LENGTH = 512;
+
 // ── Glob matching ─────────────────────────────────────────────────────────────
 
-/** Convert a CODEOWNERS glob pattern to a RegExp that matches repo-root-relative file paths.
- *  `*` matches any non-`/` characters; `**` matches across separators; `?` matches one non-`/` char.
- *  A leading `/` or interior `/` anchors the pattern to the repo root; a leading glob does not. */
-export function patternToRegex(pattern: string): RegExp {
+/** Normalize a CODEOWNERS pattern and determine whether GitHub treats it as root-anchored. */
+function normalizePattern(pattern: string): {
+  pattern: string;
+  anchored: boolean;
+} {
   let p = pattern;
 
   const leadingSlash = p.startsWith("/");
@@ -34,19 +46,87 @@ export function patternToRegex(pattern: string): RegExp {
   if (p.endsWith("/")) p += "**";
 
   // Anchored when explicitly rooted, or when a path separator appears outside a leading `**/`.
-  const anchored = leadingSlash || (p.includes("/") && !p.startsWith("**/"));
+  return {
+    pattern: p,
+    anchored: leadingSlash || (p.includes("/") && !p.startsWith("**/")),
+  };
+}
 
-  let re = "";
+function compilePattern(pattern: string): { tokens: GlobToken[]; anchored: boolean } {
+  const { pattern: p, anchored } = normalizePattern(pattern);
+  const tokens: GlobToken[] = [];
   let i = 0;
   while (i < p.length) {
     const c = p[i]!;
     if (c === "*" && i + 1 < p.length && p[i + 1] === "*") {
       i += 2;
       if (p[i] === "/") i++; // consume the `/` that follows `**`
-      re += ".*";
+      if (tokens.at(-1)?.kind !== "globstar") tokens.push({ kind: "globstar" });
     } else if (c === "*") {
-      re += "[^/]*";
       i++;
+      if (tokens.at(-1)?.kind !== "star") tokens.push({ kind: "star" });
+    } else if (c === "?") {
+      tokens.push({ kind: "question" });
+      i++;
+    } else {
+      tokens.push({ kind: "literal", value: c });
+      i++;
+    }
+  }
+  return { tokens, anchored };
+}
+
+function matchTokens(tokens: GlobToken[], filePath: string, start = 0): boolean {
+  let states = new Set<number>([start]);
+  for (const token of tokens) {
+    const next = new Set<number>();
+    for (const pos of states) {
+      if (token.kind === "literal") {
+        if (filePath[pos] === token.value) next.add(pos + 1);
+      } else if (token.kind === "question") {
+        if (pos < filePath.length && filePath[pos] !== "/") next.add(pos + 1);
+      } else if (token.kind === "star") {
+        next.add(pos);
+        for (let j = pos; j < filePath.length && filePath[j] !== "/"; j++) {
+          next.add(j + 1);
+        }
+      } else {
+        for (let j = pos; j <= filePath.length; j++) next.add(j);
+      }
+    }
+    if (next.size === 0) return false;
+    states = next;
+  }
+  return states.has(filePath.length);
+}
+
+function matchesRule(rule: ParsedRule, filePath: string): boolean {
+  if (rule.anchored) return matchTokens(rule.tokens, filePath);
+  if (matchTokens(rule.tokens, filePath)) return true;
+  for (let i = 0; i < filePath.length; i++) {
+    if (filePath[i] === "/" && matchTokens(rule.tokens, filePath, i + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Convert a CODEOWNERS glob pattern to a RegExp that matches repo-root-relative file paths.
+ *  Kept for compatibility with callers that only need a display/debug regex; matching uses the
+ *  linear token matcher above so repository-controlled glob input cannot trigger regex backtracking. */
+export function patternToRegex(pattern: string): RegExp {
+  const { pattern: p, anchored } = normalizePattern(pattern);
+  let re = "";
+  let i = 0;
+  while (i < p.length) {
+    const c = p[i]!;
+    if (c === "*" && i + 1 < p.length && p[i + 1] === "*") {
+      i += 2;
+      if (p[i] === "/") i++;
+      if (!re.endsWith(".*")) re += ".*";
+    } else if (c === "*") {
+      i++;
+      if (!re.endsWith("[^/]*")) re += "[^/]*";
     } else if (c === "?") {
       re += "[^/]";
       i++;
@@ -55,7 +135,6 @@ export function patternToRegex(pattern: string): RegExp {
       i++;
     }
   }
-
   return new RegExp(anchored ? `^${re}$` : `(^|/)${re}$`);
 }
 
@@ -64,19 +143,21 @@ export function patternToRegex(pattern: string): RegExp {
 /** Parse CODEOWNERS text into ordered rules. Lines are returned in source order; last match wins at query time. */
 export function parseCodeowners(content: string): ParsedRule[] {
   const rules: ParsedRule[] = [];
-  for (const rawLine of content.split("\n")) {
+  const boundedContent = content.slice(0, MAX_CODEOWNERS_BYTES);
+  for (const rawLine of boundedContent.split("\n")) {
+    if (rules.length >= MAX_CODEOWNERS_RULES) break;
     const line = rawLine.trim();
     if (!line || line.startsWith("#")) continue;
     const parts = line.split(/\s+/);
     const pattern = parts[0];
-    if (!pattern) continue;
+    if (!pattern || pattern.length > MAX_CODEOWNERS_PATTERN_LENGTH) continue;
     // Accept @handle and @org/team; also plain email (contains `@` but no leading `@`).
     const owners = parts
       .slice(1)
       .filter((o) => o.startsWith("@") || (o.includes("@") && !o.startsWith("#")));
     if (owners.length === 0) continue; // no owners → unowned pattern, skip
     try {
-      rules.push({ regex: patternToRegex(pattern), owners });
+      rules.push({ ...compilePattern(pattern), owners });
     } catch {
       // malformed pattern — skip
     }
@@ -88,7 +169,7 @@ export function parseCodeowners(content: string): ParsedRule[] {
 export function findOwners(rules: ParsedRule[], filePath: string): string[] {
   let owners: string[] = [];
   for (const rule of rules) {
-    if (rule.regex.test(filePath)) owners = rule.owners;
+    if (matchesRule(rule, filePath)) owners = rule.owners;
   }
   return owners;
 }

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -22,6 +22,12 @@ import {
   scanRedos,
 } from "../dist/analyzers/redos.js";
 import {
+  findOwners,
+  parseCodeowners,
+  patternToRegex,
+  scanCodeowners,
+} from "../dist/analyzers/codeowners.js";
+import {
   codeOnly,
   detectSecretLog,
   scanPatchForSecretLog,
@@ -815,6 +821,70 @@ test("buildBrief: timeout aborts dependency scan so OSV work stops", async () =>
   } finally {
     globalThis.fetch = realFetch;
   }
+});
+
+test("findOwners: uses linear CODEOWNERS glob matching for adversarial wildcard patterns", () => {
+  const rules = parseCodeowners(`${"**".repeat(30)}Z @team/security`);
+  const start = performance.now();
+
+  assert.deepEqual(findOwners(rules, "a".repeat(400)), []);
+
+  assert.ok(
+    performance.now() - start < 100,
+    "adversarial non-match stays bounded",
+  );
+});
+
+test("parseCodeowners: caps repository-controlled size, rule count, and pattern length", () => {
+  const oversizedPattern = `${"a".repeat(513)} @too/long`;
+  const manyRules = Array.from(
+    { length: 1005 },
+    (_, index) => `file-${index} @owner/${index}`,
+  );
+  const rules = parseCodeowners([oversizedPattern, ...manyRules].join("\n"));
+
+  assert.equal(rules.length, 1000);
+  assert.deepEqual(findOwners(rules, "file-0"), ["@owner/0"]);
+  assert.deepEqual(findOwners(rules, "file-1001"), []);
+});
+
+test("findOwners: preserves CODEOWNERS anchoring and last-match-wins semantics", () => {
+  const rules = parseCodeowners([
+    "*.ts @global/ts",
+    "/src/*.ts @root/src",
+    "docs/ @docs/team",
+    "src/special.ts @last/match",
+  ].join("\n"));
+
+  assert.deepEqual(findOwners(rules, "nested/file.ts"), ["@global/ts"]);
+  assert.deepEqual(findOwners(rules, "src/file.ts"), ["@root/src"]);
+  assert.deepEqual(findOwners(rules, "nested/src/file.ts"), ["@global/ts"]);
+  assert.deepEqual(findOwners(rules, "docs/guide/intro.md"), ["@docs/team"]);
+  assert.deepEqual(findOwners(rules, "src/special.ts"), ["@last/match"]);
+});
+
+test("scanCodeowners: reports files not owned by the PR author", async () => {
+  const findings = await scanCodeowners(
+    {
+      repoFullName: "owner/repo",
+      prNumber: 1,
+      githubToken: "token",
+      author: "alice",
+      files: [{ path: "src/app.ts" }, { path: "README.md" }],
+    },
+    async () => ({
+      ok: true,
+      text: async () => "src/** @team/reviewers\nREADME.md @alice",
+    }),
+  );
+
+  assert.deepEqual(findings, [
+    { file: "src/app.ts", owners: ["@team/reviewers"] },
+  ]);
+});
+
+test("patternToRegex: collapses adjacent wildcards in compatibility regex output", () => {
+  assert.equal(patternToRegex("******Z").source, "(^|\\/)\.\*Z$");
 });
 
 test("extractVersionPins: Dockerfile FROM + .nvmrc + go.mod; latest skipped", () => {


### PR DESCRIPTION
## Summary

No issue because this is maintainer-side availability hardening for review enrichment. Repository-controlled CODEOWNERS patterns should not be able to compile into expensive regular expressions or exhaust parser work.

## What changed

- Replaces CODEOWNERS rule matching with a bounded token matcher instead of repository-controlled regular expressions.
- Caps CODEOWNERS file size, rule count, and pattern length before parsing.
- Keeps `patternToRegex` only as a compatibility/display helper and collapses adjacent wildcards there.
- Adds regression coverage for adversarial wildcard patterns, parser caps, anchoring and last-match semantics, analyzer output, and compatibility regex output.

## Validation

- `cd review-enrichment && npm test`
- `git diff --check`
- GitHub CI completed successfully