### PR TITLE
fix(queue): migrate sqlite priority before claim index

### DIFF
--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -20,8 +20,10 @@ CREATE TABLE IF NOT EXISTS ${TABLE} (
   created_at INTEGER NOT NULL,
   last_error TEXT,
   priority INTEGER NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after, priority);`;
+);`;
+const CLAIM_INDEX_DDL = `
+DROP INDEX IF EXISTS ${TABLE}_claim;
+CREATE INDEX ${TABLE}_claim ON ${TABLE}(status, run_after, priority);`;
 
 // Webhook-driven work (a fresh PR → its review) jumps ahead of heavy background jobs (rag-index ~4min, the regate
 // sweep) so a NEW PR is reviewed promptly instead of waiting behind them in the shared FIFO queue. Additive: every
@@ -72,7 +74,7 @@ export function createSqliteQueue(
 
   driver.exec(DDL);
   // Idempotent add for queues created before the priority column existed (#review-latency): the CREATE is skipped
-  // for a pre-existing table, so ALTER adds the column; on a later boot it throws "duplicate column" → swallowed.
+  // for a pre-existing table, so ALTER must run before any index references the new column.
   try {
     driver.exec(
       `ALTER TABLE ${TABLE} ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`,
@@ -80,6 +82,7 @@ export function createSqliteQueue(
   } catch {
     /* column already present */
   }
+  driver.exec(CLAIM_INDEX_DDL);
   // Recover jobs a crashed previous run left mid-flight → make them claimable again.
   const recovered = driver.query(
     `UPDATE ${TABLE} SET status='pending' WHERE status='processing'`,

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -46,6 +46,57 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(prio("{}")).toBe(0);
   });
 
+  it("migrates an old queue table without a priority column before creating the claim index", async () => {
+    const driver = makeDriver();
+    driver.exec(`
+      CREATE TABLE _selfhost_jobs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        payload TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        attempts INTEGER NOT NULL DEFAULT 0,
+        run_after INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        last_error TEXT
+      );
+    `);
+
+    expect(() => createSqliteQueue(driver, async () => undefined)).not.toThrow();
+
+    const { rows } = driver.query("PRAGMA table_info(_selfhost_jobs)", []);
+    expect(rows.map((row) => (row as { name: string }).name)).toContain(
+      "priority",
+    );
+    expect(
+      driver.query("PRAGMA index_info(_selfhost_jobs_claim)", []).rows.map(
+        (row) => (row as { name: string }).name,
+      ),
+    ).toEqual(["status", "run_after", "priority"]);
+  });
+
+  it("rebuilds an old claim index so priority participates in future claims", async () => {
+    const driver = makeDriver();
+    driver.exec(`
+      CREATE TABLE _selfhost_jobs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        payload TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        attempts INTEGER NOT NULL DEFAULT 0,
+        run_after INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        last_error TEXT
+      );
+      CREATE INDEX _selfhost_jobs_claim ON _selfhost_jobs(status, run_after);
+    `);
+
+    createSqliteQueue(driver, async () => undefined);
+
+    expect(
+      driver.query("PRAGMA index_info(_selfhost_jobs_claim)", []).rows.map(
+        (row) => (row as { name: string }).name,
+      ),
+    ).toEqual(["status", "run_after", "priority"]);
+  });
+
   it("claims a high-priority (github-webhook) job before an earlier low-priority one", async () => {
     const driver = makeDriver();
     const seen: string[] = [];


### PR DESCRIPTION
## Summary

No issue because this is maintainer-side self-host queue upgrade hardening. Existing SQLite-backed queues that predate the `priority` column should not fail startup while creating the claim index.

## What changed

- Adds the `priority` column before creating any claim index that references it.
- Rebuilds `_selfhost_jobs_claim` with `(status, run_after, priority)` so upgraded queues use the priority-aware index shape.
- Adds regression coverage for old queue tables without `priority` and for old claim indexes that omitted `priority`.

## Validation

- `npx vitest run test/unit/selfhost-sqlite-queue.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm audit --audit-level=moderate`
- `npm run test:ci`
- GitHub self-host workflow completed successfully