### PR TITLE
fix(upstream): treat an unparseable ruleset generatedAt as stale, not current

### DIFF
--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -227,7 +227,16 @@ export async function loadUpstreamStatus(env: Env): Promise<UpstreamStatus> {
   const highest = highestSeverity(openReports.map((report) => report.severity));
   const registryHyperparameterDrift = summarizeRegistryHyperparameterDriftReports(openReports);
   const generatedAt = nowIso();
-  const stale = latestRuleset ? Date.parse(latestRuleset.generatedAt) + UPSTREAM_STALE_MS < Date.now() : false;
+  // generatedAt is a DB-sourced column; an empty/malformed value makes Date.parse return NaN, and
+  // `NaN + UPSTREAM_STALE_MS < Date.now()` is false -- silently reporting a stale/corrupted ruleset as fresh.
+  // Fail safe toward stale (mirror src/github/backfill.ts' Number.isFinite freshness guard). The absent-snapshot
+  // path stays explicitly false so `stale` never conflates "no row" with "stale row" (status is "unavailable" then).
+  const latestGeneratedAtMs = latestRuleset ? Date.parse(latestRuleset.generatedAt) : NaN;
+  const stale = latestRuleset
+    ? Number.isFinite(latestGeneratedAtMs)
+      ? latestGeneratedAtMs + UPSTREAM_STALE_MS < Date.now()
+      : true
+    : false;
   const affectedAreas = [...new Set(openReports.flatMap((report) => report.affectedAreas))].sort();
   return {
     generatedAt,

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -796,6 +796,20 @@ describe("upstream ruleset drift tracking", () => {
     await expect(loadUpstreamStatus(staleEnv)).resolves.toMatchObject({ status: "stale", latestRulesetId: "stale" });
   });
 
+  it("treats an unparseable ruleset generatedAt as stale (fail-safe), not current", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-30T04:00:00.000Z"));
+    // A malformed generatedAt would make Date.parse return NaN; pre-fix the staleness check silently
+    // evaluated false and the status was reported as "current". Fail-safe direction is stale.
+    const corruptEnv = createTestEnv();
+    await persistUpstreamRulesetSnapshot(corruptEnv, ruleset("corrupt", "corrupt-hash", "pending_saturation_model", 1, 0.01, "not-a-date"));
+    await expect(loadUpstreamStatus(corruptEnv)).resolves.toMatchObject({
+      status: "stale",
+      latestRulesetId: "corrupt",
+      latestRulesetGeneratedAt: "not-a-date",
+    });
+  });
+
   it("deduplicates unchanged semantic drift fingerprints and leaves issue filing disabled by default", async () => {
     const env = createTestEnv();
     const previous = ruleset("ruleset-old", "old-hash", "current_density_model", 1, 0.01, "2026-05-30T00:00:00.000Z");


### PR DESCRIPTION
## Summary

`loadUpstreamStatus` in `src/upstream/ruleset.ts` decided staleness with an unguarded `Date.parse(latestRuleset.generatedAt)`:

```ts
const stale = latestRuleset ? Date.parse(latestRuleset.generatedAt) + UPSTREAM_STALE_MS < Date.now() : false;
```

`latestRuleset.generatedAt` is a DB-sourced column read via `getLatestUpstreamRulesetSnapshot`. If it is ever empty or malformed, `Date.parse` returns `NaN`, so `NaN + UPSTREAM_STALE_MS < Date.now()` is `false`, and the status resolves to `current` -- a stale or corrupted upstream ruleset is silently reported as fresh. That fail-open hid staleness from every operator-facing consumer of `loadUpstreamStatus` (operator dashboard, weekly value report, `/v1/upstream/status`, the MCP `upstream_status` tool, and the readiness checks in `api/routes.ts`).

This is a freshness gate failing in the wrong direction -- it should fail safe toward **stale**, not silently claim freshness when it cannot even parse the timestamp.

## Fix

Guard with `Number.isFinite` and treat an unparseable timestamp as stale (fail-safe), mirroring the established freshness guard in `src/github/backfill.ts` (`Number.isFinite(ageMs)` before the comparison, treating an unparseable value as not-fresh). No behavior change for any well-formed row.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1685).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run db:migrations:check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/upstream-ruleset.test.ts` 38/38 pass; scoped coverage on `src/upstream/ruleset.ts` is 100% lines / 100% functions (changed lines fully covered, both ternary branches exercised).
- [x] New behavior has a regression test: a persisted snapshot with an unparseable `generatedAt` now reports `status: "stale"` (pre-fix it returned `"current"`).

Targeted run:

```sh
npx vitest run test/unit/upstream-ruleset.test.ts --coverage --coverage.include='src/upstream/ruleset.ts'
# 38/38 passed; ruleset.ts 100% lines / 100% functions
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- pure-function guard, no I/O.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend staleness guard with no visible UI, frontend, docs, or extension surface.

Closes #1685