### PR TITLE
fix(signals): redact /root/ and forward-slash Windows paths in the manifest public-safe guard

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -289,7 +289,10 @@ const EMPTY_MANIFEST: FocusManifest = {
  * text must not leak reward, wallet/key, ranking, or local filesystem path material.
  */
 export function isFocusManifestPublicSafe(text: string): boolean {
-  return !/\b(reward\w*|score\w*|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|farming|payouts?|rankings?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|private[-\s]?reviewability|reviewability(?:[-\s]?internals?)?|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)s?|estimated[-\s]?scores?|score[-\s]?(?:estimate|prediction|preview)s?)\b|\/Users\/|\/home\/|\/tmp\/|[A-Z]:\\Users\\/i.test(text);
+  // Local filesystem path alternatives mirror the canonical PUBLIC_UNSAFE_PATTERN in redaction.ts: include
+  // `/root/` (container/CI home) and accept the forward-slash Windows form (`C:/Users/`), not only the
+  // backslash one — otherwise a `/root/...` or `C:/Users/...` path leaks through this public-safe guard.
+  return !/\b(reward\w*|score\w*|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|farming|payouts?|rankings?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|private[-\s]?reviewability|reviewability(?:[-\s]?internals?)?|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)s?|estimated[-\s]?scores?|score[-\s]?(?:estimate|prediction|preview)s?)\b|\/Users\/|\/home\/|\/root\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i.test(text);
 }
 
 function emptyManifest(source: FocusManifestSource, warnings: string[] = []): FocusManifest {

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -713,6 +713,19 @@ describe("public-safe invariant", () => {
     expect(isFocusManifestPublicSafe("paste your hotkey")).toBe(false);
   });
 
+  it("rejects local filesystem paths, matching the canonical redaction guard", () => {
+    // Unix homes + container/CI `/root/` + tmp.
+    expect(isFocusManifestPublicSafe("see /Users/me/repo/src")).toBe(false);
+    expect(isFocusManifestPublicSafe("see /home/dev/repo/src")).toBe(false);
+    expect(isFocusManifestPublicSafe("see /root/repo/src")).toBe(false);
+    expect(isFocusManifestPublicSafe("see /tmp/build/out")).toBe(false);
+    // Windows, both backslash and forward-slash forms.
+    expect(isFocusManifestPublicSafe("see C:\\Users\\me\\repo")).toBe(false);
+    expect(isFocusManifestPublicSafe("see C:/Users/me/repo")).toBe(false);
+    // A relative path with none of these roots stays safe.
+    expect(isFocusManifestPublicSafe("see src/signals/focus-manifest.ts")).toBe(true);
+  });
+
   it("never emits public next steps that contain forbidden language for generated manifests", () => {
     // Deterministic property-style check (seeded LCG, no external generator dependency):
     // build a wide range of manifests/changed-paths from a fixture pool that deliberately


### PR DESCRIPTION
## The bug

`isFocusManifestPublicSafe` is the public-output safety gate used by contributor-issue drafts (`src/services/contributor-issue-draft.ts`) and decision packs (`src/services/decision-pack.ts`). Its local-filesystem-path alternatives have drifted from the canonical `PUBLIC_UNSAFE_PATTERN` in `src/signals/redaction.ts`:

| Path form | redaction.ts (canonical) | isFocusManifestPublicSafe |
|---|---|---|
| `/Users/` `/home/` `/tmp/` | redacted | redacted |
| **`/root/`** | **redacted** | ❌ **leaks** |
| **`C:/Users/`** (forward slash) | **redacted** | ❌ **leaks** |
| `C:\Users\` (backslash) | redacted | redacted |

So a manifest string containing `/root/<path>` — the home/CWD on containers and most CI runners — or the forward-slash Windows form `C:/Users/<path>` passes as public-safe and leaks a local filesystem path into public output, even though the function's own doc comment says such text "must not leak ... local filesystem path material".

## The fix

Sync the path alternatives with the canonical guard: add `/root/` and accept both slash forms (`[A-Z]:[\\/]Users[\\/]`). One-line regex change; the forbidden-term list is untouched.

## Tests

The existing public-safe invariant test only covered reward/secret terms, never paths — which is why the drift went unnoticed. Added a regression test asserting `/Users/`, `/home/`, `/root/`, `/tmp/`, and both Windows forms are rejected, plus a relative-path (`src/signals/...`) safe case. Full local gate green; codecov patch covers the changed line; OpenAPI unchanged.

No linked issue: a small, self-evident, self-contained security fix to one guard — no behavior change beyond closing the leak, no API/schema/DB change.