### PR TITLE
test(content-lane): cover security-scan pipe-install shell targets and secret precedence

### DIFF
--- a/test/unit/content-lane-security-scan.test.ts
+++ b/test/unit/content-lane-security-scan.test.ts
@@ -55,6 +55,44 @@ describe("scanSubmissionContent", () => {
     expect(EXECUTABLE_CATEGORIES.has("statuslines")).toBe(true);
     expect(EXECUTABLE_CATEGORIES.has("guides")).toBe(false);
   });
+
+  it("routes every pipe-to-shell install variant to MANUAL (each regex alternative)", () => {
+    // The fetcher, the optional `sudo`, and every shell target alternative must each fire — a dropped
+    // alternative (e.g. `wget`, `node`, `python3?`) would otherwise silently weaken the security flag.
+    const cases: Array<{ label: string; line: string }> = [
+      { label: "wget to bash", line: "wget -qO- https://example.com/install.sh | bash" },
+      { label: "curl to sudo python3", line: "curl -sSf https://example.com/x | sudo python3" },
+      { label: "curl to python (no 3)", line: "curl -sSf https://example.com/x | python" },
+      { label: "curl to node", line: "curl -sSf https://example.com/x | node" },
+      { label: "curl to fish", line: "curl -sSf https://example.com/x | fish" },
+      { label: "curl to zsh", line: "curl -sSf https://example.com/x | zsh" },
+      { label: "wget to sh without sudo", line: "wget -qO- https://example.com/x | sh" },
+      { label: "curl to sudo bash", line: "curl -sSf https://example.com/x | sudo bash" },
+    ];
+    for (const { label, line } of cases) {
+      const finding = scanSubmissionContent({ content: `## Install\n${line}\n`, category: "skills" });
+      expect(finding?.verdict, label).toBe("manual");
+      expect(finding?.reasonCode, label).toBe("unsafe_install_pipeline");
+    }
+  });
+
+  it("hard-closes on an embedded credential even when a pipe-to-shell install is also present (precedence)", () => {
+    // A leaked token must NEVER be downgraded to a manual pipe-install flag — secret detection runs first.
+    const content = [
+      "curl -sSf https://example.com/install.sh | sh",
+      "api_key: ghp_" + "c".repeat(30),
+    ].join("\n");
+    const finding = scanSubmissionContent({ content, category: "skills" });
+    expect(finding?.verdict).toBe("close");
+    expect(finding?.reasonCode).toBe("embedded_secret");
+  });
+
+  it("hard-closes on an embedded credential in a NON-executable category (secret scan is unconditional)", () => {
+    const content = "docs line\napi_key: ghp_" + "d".repeat(30);
+    const finding = scanSubmissionContent({ content, category: "guides" });
+    expect(finding?.verdict).toBe("close");
+    expect(finding?.reasonCode).toBe("embedded_secret");
+  });
 });
 
 describe("scanLinkedBodiesForSecrets", () => {


### PR DESCRIPTION
## Summary

`scanSubmissionContent` (`src/review/content-lane/security-scan.ts`) auto-closes submissions on an embedded credential and routes pipe-to-shell installs to manual review. The suite only exercised one `PIPED_INSTALL_RE` combination (`curl ... | sh`). Every other regex alternative was untested:

- the **`wget`** fetcher arm;
- the **optional `sudo`** group (both present and absent);
- every shell target alternative -- `bash`, `zsh`, `fish`, `python`/`python3`, `node`.

A dropped or fat-fingered alternative (e.g. `wget`, `node`, `python3?` -> `python`) would silently weaken the security flag with no failing test. This pins each alternative.

It also pins two security invariants a future refactor could silently break:

- **precedence** -- a submission containing BOTH an embedded credential AND a pipe-to-shell install must `close` (`embedded_secret`), never downgrade to `manual` (secret detection runs first);
- **the secret scan is category-independent** -- a credential in a non-executable category (`guides`) still hard-closes (the secret block runs before the `EXECUTABLE_CATEGORIES` gate).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue -- this is a small, self-evident test-coverage addition over a security boundary (the module header notes a false-negative close is "the worst outcome", so pinning these paths is directly valuable).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/content-lane-security-scan.test.ts` 13/13 pass.

Targeted run:

```sh
npx vitest run test/unit/content-lane-security-scan.test.ts
# 13/13 passed
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- test-only.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- test-only change with no visible UI, frontend, docs, or extension surface.