### PR TITLE
fix(export): redact cached Orb token envelopes

### DIFF
--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -16,12 +16,13 @@ export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_m
 //   • submission_user_tokens.encrypted_token   — short-lived GitHub OAuth token envelopes, cloud-scoped.
 //   • orb_enrollments.secret_hash              — one-time enrollment secret hashes.
 //   • orb_enrollments.relay_secret_*           — encrypted relay webhook signing secret material.
+//   • orb_enrollments.cached_token_json         — encrypted GitHub installation-token cache envelope.
 export const REDACTED_COLUMNS = {
   auth_sessions: ["token_hash"],
   webhook_events: ["payload_hash"],
   repository_ai_keys: ["ciphertext"],
   submission_user_tokens: ["encrypted_token"],
-  orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"],
+  orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt", "cached_token_json"],
 };
 
 // A table name is only ever interpolated into SQL (`SELECT * FROM "<name>"`) after passing this allowlist, so a

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -38,7 +38,7 @@ describe("export-d1-core redaction (#selfhost-migration)", () => {
       webhook_events: ["payload_hash"],
       repository_ai_keys: ["ciphertext"],
       submission_user_tokens: ["encrypted_token"],
-      orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"],
+      orb_enrollments: ["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt", "cached_token_json"],
     });
     expect(redactRow("webhook_events", { delivery_id: "d1", payload_hash: "h" })).toEqual({ delivery_id: "d1" });
     expect(redactRow("repository_ai_keys", { repo_full_name: "o/r", ciphertext: "ENCRYPTED" })).toEqual({ repo_full_name: "o/r" });
@@ -59,9 +59,10 @@ describe("export-d1-core redaction (#selfhost-migration)", () => {
         relay_secret_enc: "LEAK_RELAY_SECRET",
         relay_secret_iv: "LEAK_RELAY_IV",
         relay_secret_salt: "LEAK_RELAY_SALT",
+        cached_token_json: "LEAK_CACHED_ORB_TOKEN_ENVELOPE",
       },
     ]);
-    expect(orbExport?.redactedColumns).toEqual(["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt"]);
+    expect(orbExport?.redactedColumns).toEqual(["secret_hash", "relay_secret_enc", "relay_secret_iv", "relay_secret_salt", "cached_token_json"]);
     expect(orbExport?.rows).toEqual([{ enroll_id: "e1", installation_id: 42 }]);
 
     expect(JSON.stringify([draftExport, orbExport])).not.toMatch(/LEAK_/);


### PR DESCRIPTION
## Summary

- No issue because this is a small maintainer-side confidentiality hardening for the self-host export boundary.
- Adds `orb_enrollments.cached_token_json` to the D1 export redaction list so encrypted Orb installation-token cache envelopes stay out of migration export artifacts.
- Extends the existing export regression test to prove the cache envelope is omitted together with the other Orb secret material.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Nothing was skipped. Also ran `npx vitest run test/unit/export-d1-core.test.ts` for the focused regression.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A: export redaction only.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. N/A: no API/OpenAPI/MCP surface change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. N/A: no docs/changelog change.

## UI Evidence

Not applicable. This is export tooling only, with no visible UI, frontend, docs, or extension change.

## Notes

- The vulnerable path was reproduced in the existing export unit boundary: `buildTableExport("orb_enrollments", ...)` previously preserved `cached_token_json`; after this change, the serialized export rows omit it and the regression asserts the `LEAK_` sentinel never appears.
