### PR TITLE
feat(signals): classify remaining config and manifest paths

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -57,6 +57,11 @@ const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([
   "build.gradle",
   "build.gradle.kts",
   "pom.xml",
+  "deno.json",
+  "deno.jsonc",
+  "pubspec.yaml",
+  "mix.exs",
+  "go.work",
 ]);
 
 const DOCS_EXTENSIONS: ReadonlySet<string> = new Set(["md", "mdx", "markdown", "rst", "adoc", "asciidoc"]);
@@ -88,8 +93,33 @@ const CONFIG_FILE_NAMES: ReadonlySet<string> = new Set([
   "lefthook.yml",
   "lefthook.yaml",
   ".pre-commit-config.yaml",
+  ".gitleaks.toml",
+  // Coverage service config.
+  ".codecov.yml",
+  ".codecov.yaml",
+  "codecov.yml",
+  "codecov.yaml",
+  // Task-runner config.
+  "taskfile.yml",
+  "taskfile.yaml",
+  "justfile",
+  // Docker Compose deploy config.
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  "compose.yml",
+  "compose.yaml",
+  "docker-compose.override.yml",
+  "docker-compose.override.yaml",
+  "compose.override.yml",
+  "compose.override.yaml",
+  // Hosted deploy config.
+  "caddyfile",
+  "netlify.toml",
+  "vercel.json",
+  "railway.json",
   // Hosted CI pipeline definitions (single-file basenames).
   ".gitlab-ci.yml",
+  "jenkinsfile",
   "azure-pipelines.yml",
   "buf.yaml",
   "buf.gen.yaml",

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -119,7 +119,19 @@ describe("defensive input handling", () => {
 
 describe("isDependencyManifestFile", () => {
   it("matches dependency manifests", () => {
-    for (const path of ["package.json", "Cargo.toml", "go.mod", "requirements.txt", "pyproject.toml", "build.gradle.kts"]) {
+    for (const path of [
+      "package.json",
+      "Cargo.toml",
+      "go.mod",
+      "requirements.txt",
+      "pyproject.toml",
+      "build.gradle.kts",
+      "deno.json",
+      "apps/web/deno.jsonc",
+      "pubspec.yaml",
+      "backend/mix.exs",
+      "go.work",
+    ]) {
       expect(isDependencyManifestFile(path)).toBe(true);
     }
   });
@@ -187,7 +199,28 @@ describe("isConfigFile", () => {
       "mise.toml",
       "lefthook.yml",
       ".pre-commit-config.yaml",
+      ".gitleaks.toml",
+      ".codecov.yml",
+      ".codecov.yaml",
+      "codecov.yml",
+      "codecov.yaml",
+      "Taskfile.yml",
+      "Taskfile.yaml",
+      "justfile",
+      "deploy/docker-compose.yml",
+      "docker-compose.yaml",
+      "compose.yml",
+      "compose.yaml",
+      "docker-compose.override.yml",
+      "docker-compose.override.yaml",
+      "compose.override.yml",
+      "compose.override.yaml",
+      "Caddyfile",
+      "netlify.toml",
+      "vercel.json",
+      "railway.json",
       ".gitlab-ci.yml",
+      "Jenkinsfile",
       "azure-pipelines.yml",
       "buf.yaml",
       "buf.gen.yaml",
@@ -199,8 +232,17 @@ describe("isConfigFile", () => {
     }
   });
 
-  it("does not treat renovate-like source names as config", () => {
-    for (const path of ["src/renovate-helpers.ts", "docs/dependabot-notes.md"]) {
+  it("does not treat source names or doc near-misses as config", () => {
+    for (const path of [
+      "src/renovate-helpers.ts",
+      "docs/dependabot-notes.md",
+      "src/compose.ts",
+      "docs/codecov.yml.md",
+      "docs/docker-compose.yml.md",
+      "src/justfile.ts",
+      "docs/Jenkinsfile.md",
+      "locks/deno.json.lock",
+    ]) {
       expect(isConfigFile(path)).toBe(false);
     }
   });
@@ -242,11 +284,34 @@ describe("classifyChangedFile", () => {
       ["pubspec.lock", "lockfile"],
       ["ios/Podfile.lock", "lockfile"],
       ["package.json", "dependency_manifest"],
+      ["deno.json", "dependency_manifest"],
+      ["apps/web/deno.jsonc", "dependency_manifest"],
+      ["pubspec.yaml", "dependency_manifest"],
+      ["mix.exs", "dependency_manifest"],
+      ["go.work", "dependency_manifest"],
       ["tsconfig.json", "config"],
       ["vitest.config.ts", "config"],
       ["wrangler.jsonc", "config"],
       ["turbo.json", "config"],
       ["renovate.json", "config"],
+      ["Taskfile.yml", "config"],
+      ["Taskfile.yaml", "config"],
+      ["justfile", "config"],
+      ["docker-compose.yml", "config"],
+      ["docker-compose.yaml", "config"],
+      ["compose.yml", "config"],
+      ["compose.yaml", "config"],
+      ["docker-compose.override.yml", "config"],
+      ["compose.override.yaml", "config"],
+      ["Caddyfile", "config"],
+      ["netlify.toml", "config"],
+      ["vercel.json", "config"],
+      ["railway.json", "config"],
+      [".codecov.yml", "config"],
+      ["codecov.yml", "config"],
+      ["codecov.yaml", "config"],
+      [".gitleaks.toml", "config"],
+      ["Jenkinsfile", "config"],
       [".github/workflows/ci.yml", "config"],
       ["test/unit/app.test.ts", "test"],
       ["README.md", "docs"],


### PR DESCRIPTION
## Summary
- classify the remaining #1421 dependency manifests: deno.json/jsonc, pubspec.yaml, mix.exs, and go.work
- classify the remaining repo policy, task-runner, deploy, and CI config basenames like .gitleaks.toml, codecov.yml/yaml, .codecov.yml/yaml, Taskfile.yml/yaml, justfile, docker-compose/compose entrypoints and overrides, Caddyfile, netlify.toml, vercel.json, railway.json, and Jenkinsfile
- add direct unit coverage through isDependencyManifestFile, isConfigFile, and classifyChangedFile for the new path groups, plus negative exact-basename cases

## Scope
This is a narrow follow-up after #1261 and #1458. Those PRs already landed the shared CI/toolchain and lockfile work; this PR covers the remaining examples from #1421 on top of current main and adds public classifier coverage for each newly added basename.

Fixes #1421

## Test plan
- npm run test -- --run test/unit/path-matchers.test.ts
- npm run typecheck