### PR TITLE
fix(db): preserve legacy digest subscriptions

### DIFF
--- a/migrations/0083_normalize_digest_subscription_logins.sql
+++ b/migrations/0083_normalize_digest_subscription_logins.sql
@@ -1,0 +1,26 @@
+CREATE TEMP TABLE digest_subscriptions_canonical AS
+SELECT id, lower(login) AS login, lower(email) AS email, status, source, created_at, updated_at
+FROM (
+  SELECT
+    id,
+    login,
+    email,
+    status,
+    source,
+    created_at,
+    updated_at,
+    row_number() OVER (
+      PARTITION BY lower(login), lower(email)
+      ORDER BY updated_at DESC, created_at DESC, id DESC
+    ) AS rn
+  FROM digest_subscriptions
+)
+WHERE rn = 1;
+
+DELETE FROM digest_subscriptions;
+
+INSERT INTO digest_subscriptions (id, login, email, status, source, created_at, updated_at)
+SELECT id, login, email, status, source, created_at, updated_at
+FROM digest_subscriptions_canonical;
+
+DROP TABLE digest_subscriptions_canonical;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1361,7 +1361,12 @@ export async function upsertDigestSubscription(
 
 export async function listDigestSubscriptionsForLogin(env: Env, login: string): Promise<DigestSubscriptionRecord[]> {
   const db = getDb(env.DB);
-  const rows = await db.select().from(digestSubscriptions).where(eq(digestSubscriptions.login, login.toLowerCase())).orderBy(desc(digestSubscriptions.updatedAt)).limit(20);
+  const rows = await db
+    .select()
+    .from(digestSubscriptions)
+    .where(sql`lower(${digestSubscriptions.login}) = ${login.toLowerCase()}`)
+    .orderBy(desc(digestSubscriptions.updatedAt))
+    .limit(20);
   return rows.map(toDigestSubscriptionRecord);
 }
 

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import {
   getContributorScoringProfile,
@@ -340,6 +342,39 @@ describe("product usage events", () => {
     await upsertDigestSubscription(env, { login: "OKTOFEESH1", email: "digest@example.com", status: "paused" });
     await expect(listDigestSubscriptionsForLogin(env, "Oktofeesh1")).resolves.toEqual([
       expect.objectContaining({ login: "oktofeesh1", email: "digest@example.com", status: "paused" }),
+    ]);
+  });
+
+  it("normalizes legacy digest subscription rows during migration", () => {
+    const db = new DatabaseSync(":memory:");
+    for (const migrationFile of readdirSync("migrations")
+      .filter((file) => file.endsWith(".sql") && file < "0083_")
+      .sort()) {
+      db.exec(readFileSync(`migrations/${migrationFile}`, "utf8"));
+    }
+    db.exec(`
+      INSERT INTO digest_subscriptions (id, login, email, status, source, created_at, updated_at)
+      VALUES
+        ('legacy-active', 'OktoFeesh1', 'Digest@Example.com', 'active', 'app', '2026-05-29T00:00:00.000Z', '2026-05-29T00:00:00.000Z'),
+        ('legacy-paused', 'oktofeesh1', 'digest@example.com', 'paused', 'app', '2026-05-30T00:00:00.000Z', '2026-05-30T00:00:00.000Z')
+    `);
+
+    db.exec(readFileSync("migrations/0083_normalize_digest_subscription_logins.sql", "utf8"));
+
+    expect(db.prepare("SELECT login, email, status FROM digest_subscriptions").all()).toEqual([
+      { login: "oktofeesh1", email: "digest@example.com", status: "paused" },
+    ]);
+  });
+
+  it("keeps legacy mixed-case digest subscriptions visible during lookup", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      `INSERT INTO digest_subscriptions (id, login, email, status, source, created_at, updated_at)
+       VALUES ('legacy-digest', 'OktoFeesh1', 'legacy@example.com', 'active', 'app', '2026-05-30T00:00:00.000Z', '2026-05-30T00:00:00.000Z')`,
+    ).run();
+
+    await expect(listDigestSubscriptionsForLogin(env, "oktofeesh1")).resolves.toEqual([
+      expect.objectContaining({ login: "OktoFeesh1", email: "legacy@example.com", status: "active" }),
     ]);
   });
 


### PR DESCRIPTION
### Motivation

- Recent changes normalized newly-inserted digest subscription `login`/`email` to lowercase but did not make legacy mixed-case rows discoverable, which caused duplicate rows and lookup/visibility regressions for existing subscriptions. 
- The intent is to preserve existing subscriptions and avoid introducing duplicate case-variant rows while keeping new-case normalization in place.

### Description

- Add migration `migrations/0083_normalize_digest_subscription_logins.sql` that canonicalizes existing `digest_subscriptions` by collapsing case-variant duplicates using `lower(login), lower(email)` and keeping the newest row per logical subscription. 
- Make lookup case-insensitive by changing `listDigestSubscriptionsForLogin` to compare `lower(login)` against the lowercased lookup key so legacy mixed-case rows remain visible prior to/after migration. 
- Add unit/regression tests in `test/unit/product-usage.test.ts` that exercise migration normalization and that a legacy mixed-case row is visible via the lookup API. 

### Testing

- Ran the focused unit test group with `npx vitest run test/unit/product-usage.test.ts -t "digest subscription"`, which executed the new tests and passed. 
- Ran migration guard `npm run db:migrations:check`, which reported the migration set is contiguous and OK. 
- Ran typecheck `npm run typecheck`, which passed with no TypeScript errors. 
- Attempted coverage `npm run test:coverage -- test/unit/product-usage.test.ts`: the tests executed but coverage remapping failed with `TypeError: jsTokens is not a function` during V8 coverage processing. 
- Attempted full gate `npm run test:ci`: it stopped early in `actionlint` due to network resolution failure (fallback flagged a custom self-hosted runner label), and `npm audit --audit-level=moderate` failed to reach the audit endpoint (HTTP 403), so those CI-level steps did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4194b50b50832c87546f0ed141bec9)