### PR TITLE
fix(scoring): exclude DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT and MAX_ISSUE_CLOSE_WINDOW_DAYS from unmodeled drift

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -254,6 +254,12 @@ const NON_SCORING_UPSTREAM_CONSTANT_NAMES = new Set([
   // this entry the parser (which reads exponent literals like `1e-9`, #992) flagged it as a permanent
   // false-positive unmodeled-scoring-drift warning (#809).
   "EMISSION_SHARE_TOLERANCE",
+  // Fallback weight applied by the validator's load_programming_language_weights() for extensions absent from
+  // the JSON file; gittensory reads the JSON directly and does not track this loader default (#1692).
+  "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT",
+  // Validator-side window (days) within which a linked issue's close timestamp must fall relative to the PR
+  // merge to count as a valid link; gittensory's scoring preview does not model this linkage constraint (#1692).
+  "MAX_ISSUE_CLOSE_WINDOW_DAYS",
 ]);
 
 /**

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -391,6 +391,24 @@ NOVELTY_BONUS_SCALAR = 3
     expect(withScoringGap).toEqual(["NOVELTY_BONUS_SCALAR"]);
   });
 
+  it("excludes DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT and MAX_ISSUE_CLOSE_WINDOW_DAYS from unmodeled drift (#1692)", () => {
+    // Both are numeric constants in the live upstream constants.py that the parser successfully reads, but
+    // neither is a scoring dimension gittensory models — excluding them prevents perpetual false-positive
+    // drift warnings on every refreshScoringModelSnapshot run (same pattern as EMISSION_SHARE_TOLERANCE #809).
+    const result = findUnmodeledUpstreamConstants(
+      "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT = 0.12\nMAX_ISSUE_CLOSE_WINDOW_DAYS = 1\n",
+    );
+    expect(result).toEqual([]);
+    expect(result).not.toContain("DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT");
+    expect(result).not.toContain("MAX_ISSUE_CLOSE_WINDOW_DAYS");
+
+    // A genuinely new upstream scoring dimension still surfaces alongside them.
+    const withNewDimension = findUnmodeledUpstreamConstants(
+      "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT = 0.12\nMAX_ISSUE_CLOSE_WINDOW_DAYS = 1\nNOVELTY_BONUS_SCALAR = 3\n",
+    );
+    expect(withNewDimension).toEqual(["NOVELTY_BONUS_SCALAR"]);
+  });
+
   it("truncates the unmodeled-constants warning when upstream defines more than 12 (#809)", async () => {
     const env = createTestEnv({
       GITTENSOR_UPSTREAM_REPO: "custom/upstream",


### PR DESCRIPTION
## Summary

- `DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT` (0.12) and `MAX_ISSUE_CLOSE_WINDOW_DAYS` (1) are numeric constants defined in the upstream `gittensor/constants.py` that `parsePythonNumberConstants` successfully parses but that are absent from both `DEFAULT_SCORING_CONSTANTS` and `NON_SCORING_UPSTREAM_CONSTANT_NAMES`. Every invocation of `findUnmodeledUpstreamConstants` — called on every `refreshScoringModelSnapshot` — flags both as "unmodeled scoring constants", generating perpetual false-positive drift warnings that drown out signals from genuinely new upstream scoring dimensions.
- Neither constant is a scoring dimension gittensory models: `DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT` is the validator loader's fallback weight for extensions absent from the JSON file (gittensory reads the JSON directly); `MAX_ISSUE_CLOSE_WINDOW_DAYS` is the validator-side linkage-window check that is not part of the scoring preview. Adding both to `NON_SCORING_UPSTREAM_CONSTANT_NAMES` suppresses the false positives — same fix as `EMISSION_SHARE_TOLERANCE` in #1329.

Fixes #1692

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. Full `npm run test:ci` passed locally (exit 0).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No UI changes.

## Notes

- The regression test in `test/unit/scoring.test.ts` verifies both constants are excluded from unmodeled drift and that a genuinely new upstream dimension (`NOVELTY_BONUS_SCALAR`) still surfaces when present alongside them.
- Change is pure metadata (no scoring logic altered, no constants values changed) — the `NON_SCORING_UPSTREAM_CONSTANT_NAMES` set is detection-only.
