### PR TITLE
fix(upstream): fail-closed when ruleset generatedAt is unparseable

### DIFF
--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -36,6 +36,17 @@ const DEFAULT_DRIFT_ISSUE_REPO = "JSONbored/gittensory";
 const UPSTREAM_STALE_MS = 2 * 60 * 60 * 1000;
 const REGISTRY_HYPERPARAMETER_DRIFT_LIMIT = 100;
 
+/** True when a ruleset snapshot's `generatedAt` is missing/unparseable or older than the staleness window.
+ *  Unparseable timestamps fail closed (treated as stale) — mirrors the `Number.isFinite(ageMs)` guard in backfill. */
+export function isUpstreamRulesetStale(
+  generatedAt: string,
+  nowMs: number = Date.now(),
+): boolean {
+  const parsedMs = Date.parse(generatedAt);
+  if (!Number.isFinite(parsedMs)) return true;
+  return parsedMs + UPSTREAM_STALE_MS < nowMs;
+}
+
 const TRACKED_SOURCES = [
   { key: "constants", path: "gittensor/constants.py" },
   { key: "registry", path: "gittensor/validator/weights/master_repositories.json" },
@@ -227,7 +238,9 @@ export async function loadUpstreamStatus(env: Env): Promise<UpstreamStatus> {
   const highest = highestSeverity(openReports.map((report) => report.severity));
   const registryHyperparameterDrift = summarizeRegistryHyperparameterDriftReports(openReports);
   const generatedAt = nowIso();
-  const stale = latestRuleset ? Date.parse(latestRuleset.generatedAt) + UPSTREAM_STALE_MS < Date.now() : false;
+  const stale = latestRuleset
+    ? isUpstreamRulesetStale(latestRuleset.generatedAt)
+    : false;
   const affectedAreas = [...new Set(openReports.flatMap((report) => report.affectedAreas))].sort();
   return {
     generatedAt,

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -11,6 +11,7 @@ import {
   detectAndPersistUpstreamDrift,
   buildUpstreamDriftReport,
   fileUpstreamDriftIssues,
+  isUpstreamRulesetStale,
   loadUpstreamStatus,
   registryHyperparameterDriftWarningsForRepo,
   refreshUpstreamDrift,
@@ -794,6 +795,25 @@ describe("upstream ruleset drift tracking", () => {
     const staleEnv = createTestEnv();
     await persistUpstreamRulesetSnapshot(staleEnv, ruleset("stale", "stale-hash", "pending_saturation_model", 1, 0.01, "2026-05-30T00:00:00.000Z"));
     await expect(loadUpstreamStatus(staleEnv)).resolves.toMatchObject({ status: "stale", latestRulesetId: "stale" });
+  });
+
+  it("treats unparseable ruleset generatedAt as stale (fail-closed, #1695)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-30T01:00:00.000Z"));
+    const nowMs = Date.now();
+    expect(isUpstreamRulesetStale("not-a-date", nowMs)).toBe(true);
+    expect(isUpstreamRulesetStale("", nowMs)).toBe(true);
+    expect(isUpstreamRulesetStale("2026-05-30T00:30:00.000Z", nowMs)).toBe(false);
+
+    const badTsEnv = createTestEnv();
+    await persistUpstreamRulesetSnapshot(
+      badTsEnv,
+      ruleset("bad-ts", "bad-hash", "pending_saturation_model", 1, 0.01, "garbage-timestamp"),
+    );
+    await expect(loadUpstreamStatus(badTsEnv)).resolves.toMatchObject({
+      status: "stale",
+      latestRulesetId: "bad-ts",
+    });
   });
 
   it("deduplicates unchanged semantic drift fingerprints and leaves issue filing disabled by default", async () => {


### PR DESCRIPTION
## Summary
- Add `isUpstreamRulesetStale()` helper that treats unparseable `generatedAt` values as stale (fail-closed)
- Wire `loadUpstreamStatus` through the helper instead of raw `Date.parse` comparison
- Regression tests for garbage timestamps, empty strings, and valid recent timestamps

Fixes #1695

## Validation
```sh
npx vitest run test/unit/upstream-ruleset.test.ts -t "1695|stale and unavailable"
```

## Test plan
- [x] Malformed `generatedAt` resolves to `status: "stale"`
- [x] Valid recent timestamp resolves to `status: "current"`
- [x] Existing stale-window behavior unchanged
