### PR TITLE
feat(enrichment): typosquat & dependency-confusion analyzer

### DIFF
--- a/review-enrichment/src/analyzers/typosquat.ts
+++ b/review-enrichment/src/analyzers/typosquat.ts
@@ -1,0 +1,200 @@
+// Typosquat + dependency-confusion analyzer (#1501). For each dependency a PR newly ADDS, flags two supply-chain
+// risks the no-checkout `claude --print` reviewer cannot: (1) a name that is a near-miss of a popular package
+// (edit-distance / homoglyph / separator / scope-swap) — a likely typosquat; (2) an unscoped name that is NOT
+// published on the public registry and is therefore publicly claimable — a dependency-confusion vector. Pure
+// name analysis runs offline against a bundled popular-package list; the confusion check uses an injected fetch.
+import type { EnrichRequest, TyposquatFinding } from "../types.js";
+import { extractDependencyChanges } from "./dependency-scan.js";
+
+const MAX_DEPS = 50;
+const MAX_CONFUSION_QUERIES = 15;
+// Short names have too many distance-1 neighbours to flag reliably; require some length before an edit-distance hit.
+const MIN_LEN_DISTANCE_1 = 4;
+
+interface ScanLimits {
+  maxDeps?: number;
+  maxConfusionQueries?: number;
+}
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  limits?: ScanLimits;
+}
+
+// Bundled top popular packages per ecosystem — the high-traffic names typosquatters impersonate. Not exhaustive;
+// the near-miss compare only needs the most-squatted targets. Lowercased. An exact match here is the REAL package.
+const POPULAR: Record<string, readonly string[]> = {
+  npm: [
+    "react", "react-dom", "lodash", "express", "axios", "chalk", "commander", "request", "async", "debug",
+    "moment", "vue", "webpack", "typescript", "jest", "eslint", "prettier", "dotenv", "uuid", "classnames",
+    "next", "tailwindcss", "redux", "rxjs", "mongoose", "bcrypt", "jsonwebtoken", "cors", "body-parser",
+    "node-fetch", "yargs", "glob", "semver", "minimist", "colors", "underscore", "bluebird", "fs-extra", "ws",
+  ],
+  PyPI: [
+    "requests", "numpy", "pandas", "flask", "django", "setuptools", "urllib3", "boto3", "scipy", "pytest",
+    "pillow", "six", "click", "pyyaml", "cryptography", "jinja2", "sqlalchemy", "beautifulsoup4", "matplotlib",
+    "torch", "scikit-learn", "certifi", "idna", "wheel", "python-dateutil", "tqdm", "aiohttp", "fastapi", "pydantic",
+  ],
+};
+
+// Well-known legitimate packages that sit a near-miss away from a popular name but are NOT typosquats — exempt
+// from all name flagging so they don't false-positive (e.g. `preact` is one edit from `react`). Extensible.
+const KNOWN_LEGIT: Record<string, readonly string[]> = {
+  npm: ["preact", "lodash-es", "vuex", "react-router", "react-scripts", "babel-jest"],
+  PyPI: ["requests-oauthlib", "djangorestframework", "pytest-django"],
+};
+
+const REGISTRY_URL: Record<string, (name: string) => string> = {
+  npm: (name) => `https://registry.npmjs.org/${encodeURIComponent(name)}`,
+  PyPI: (name) => `https://pypi.org/pypi/${encodeURIComponent(name)}/json`,
+};
+
+/** Damerau-Levenshtein (optimal string alignment) distance — counts insert/delete/substitute + adjacent
+ *  transposition. Bounded: returns `max + 1` as soon as the whole row exceeds `max`, so callers can early-reject. */
+export function damerauLevenshtein(a: string, b: string, max = Infinity): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  const prev2 = new Array<number>(b.length + 1);
+  let prev = new Array<number>(b.length + 1);
+  let curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    let rowMin = curr[0]!;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      let v = Math.min(prev[j]! + 1, curr[j - 1]! + 1, prev[j - 1]! + cost);
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        v = Math.min(v, prev2[j - 2]! + 1);
+      }
+      curr[j] = v;
+      if (v < rowMin) rowMin = v;
+    }
+    if (rowMin > max) return max + 1;
+    for (let j = 0; j <= b.length; j++) prev2[j] = prev[j]!;
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length]!;
+}
+
+const HOMOGLYPH: Record<string, string> = { "0": "o", "1": "l", "3": "e", "4": "a", "5": "s", "6": "b", "7": "t", "9": "g" };
+
+/** Canonical form for confusable-name detection: lowercase, map digit homoglyphs to letters, and strip the
+ *  interchangeable separators `-`, `_`, `.`. Two distinct raw names with the same canonical form differ only by a
+ *  confusable substitution (e.g. `lodash` vs `l0dash`, `lo-dash`, `lo_dash`). Pure. */
+export function canonicalize(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[013456789]/g, (d) => HOMOGLYPH[d] ?? d)
+    .replace(/[-_.]/g, "");
+}
+
+/** Pure near-miss classifier for an UNSCOPED dependency name: is it a likely typosquat of a bundled popular
+ *  `ecosystem` package? Returns the matched popular name + reason, or null.
+ *
+ *  SCOPED names (`@scope/x`) are deliberately never classified: an npm scope is namespace-protected (you cannot
+ *  publish under `@types`/`@acme` without owning it), so a scoped package whose tail merely matches a popular
+ *  name — `@types/react`, `@acme/express` — is not impersonation. Restricting to unscoped names removes that
+ *  whole false-positive class while still covering the real typosquat surface (the public flat namespace).
+ *
+ *  Checks (in order): exact (safe → null), known-legit near-neighbour (safe → null), homoglyph/separator
+ *  (canonical-form equal), then a distance-1 edit. */
+export function classifyTyposquat(
+  ecosystem: string,
+  rawName: string,
+): { similarTo: string; distance?: number; reason: string } | null {
+  const popular = POPULAR[ecosystem];
+  if (!popular) return null;
+  if (rawName.startsWith("@")) return null; // scoped names are namespace-protected — not a typosquat surface
+  const name = rawName.toLowerCase();
+  if (popular.includes(name)) return null; // it IS the popular package
+  if (KNOWN_LEGIT[ecosystem]?.includes(name)) return null; // a known-legitimate near-neighbour, not a squat
+
+  const canon = canonicalize(name);
+  for (const target of popular) {
+    if (name === target) continue;
+    if (canonicalize(target) === canon) {
+      return { similarTo: target, distance: 0, reason: `homoglyph/separator variant of '${target}'` };
+    }
+  }
+
+  let best: { target: string; distance: number } | null = null;
+  for (const target of popular) {
+    if (Math.min(name.length, target.length) < MIN_LEN_DISTANCE_1) continue;
+    if (damerauLevenshtein(name, target, 1) === 1 && !best) best = { target, distance: 1 };
+  }
+  if (best) {
+    return { similarTo: best.target, distance: best.distance, reason: `edit distance ${best.distance} from '${best.target}'` };
+  }
+  return null;
+}
+
+/** Is `name` published on the public registry for `ecosystem`? `true`/`false` on a definitive 200/404, or `null`
+ *  when undeterminable (unsupported ecosystem, network error, or any non-200/404 status) — callers fail safe on null. */
+export async function isPublished(
+  ecosystem: string,
+  name: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<boolean | null> {
+  const toUrl = REGISTRY_URL[ecosystem];
+  if (!toUrl || signal?.aborted) return null;
+  try {
+    const response = await fetchImpl(toUrl(name), { signal });
+    if (response.status === 404) return false;
+    if (response.ok) return true;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Analyzer entrypoint: newly-added deps → typosquat near-miss (pure) + dependency-confusion (registry 404). */
+export async function scanTyposquat(
+  req: EnrichRequest,
+  fetchImpl: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<TyposquatFinding[]> {
+  const maxDeps = options.limits?.maxDeps ?? MAX_DEPS;
+  const maxConfusion = options.limits?.maxConfusionQueries ?? MAX_CONFUSION_QUERIES;
+  // Only names the PR INTRODUCES (from === null) carry name-novelty risk; a version bump keeps an existing name.
+  const added = extractDependencyChanges(req.files ?? [])
+    .filter((change) => change.from === null)
+    .slice(0, maxDeps);
+
+  const findings: TyposquatFinding[] = [];
+  let confusionQueries = 0;
+  for (const dep of added) {
+    if (options.signal?.aborted) break;
+    const match = classifyTyposquat(dep.ecosystem, dep.package);
+    if (match) {
+      findings.push({
+        ecosystem: dep.ecosystem,
+        package: dep.package,
+        version: dep.to,
+        kind: "typosquat",
+        similarTo: match.similarTo,
+        ...(match.distance !== undefined ? { distance: match.distance } : {}),
+        reason: match.reason,
+      });
+      continue;
+    }
+    // Dependency-confusion: an UNSCOPED name (scoped names are namespace-protected) absent from the public
+    // registry is publicly claimable. Only a definitive 404 flags it; transient/unknown states fail safe.
+    const isScoped = dep.package.startsWith("@");
+    if (!isScoped && confusionQueries < maxConfusion && REGISTRY_URL[dep.ecosystem]) {
+      confusionQueries += 1;
+      const published = await isPublished(dep.ecosystem, dep.package, fetchImpl, options.signal);
+      if (published === false) {
+        findings.push({
+          ecosystem: dep.ecosystem,
+          package: dep.package,
+          version: dep.to,
+          kind: "confusion",
+          reason: `not published on the public ${dep.ecosystem} registry — an unscoped name that is publicly claimable (dependency-confusion)`,
+        });
+      }
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -18,6 +18,7 @@ import { scanProvenance } from "./analyzers/provenance.js";
 import { scanCodeowners } from "./analyzers/codeowners.js";
 import { scanSecretLog } from "./analyzers/secret-log.js";
 import { scanAssetWeight } from "./analyzers/asset-weight.js";
+import { scanTyposquat } from "./analyzers/typosquat.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest, signal: AbortSignal) => Promise<unknown>;
@@ -35,6 +36,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   codeowners: (req, signal) => scanCodeowners(req, fetch, { signal }),
   secretLog: (req, signal) => scanSecretLog(req, signal),
   assetWeight: (req, signal) => scanAssetWeight(req, fetch, { signal }),
+  typosquat: (req, signal) => scanTyposquat(req, fetch, { signal }),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -215,6 +215,22 @@ export function renderBrief(
     }
   }
 
+  const typosquats = findings.typosquat ?? [];
+  if (typosquats.length) {
+    lines.push(
+      "### Typosquat / dependency-confusion risks (verify the package name before merging)",
+    );
+    for (const item of typosquats) {
+      const detail =
+        item.kind === "typosquat"
+          ? `${item.reason} — likely typosquat of ${safeCodeSpan(item.similarTo ?? "")}`
+          : item.reason;
+      lines.push(
+        `- ${safeCodeSpan(`${item.package}@${item.version}`)} (${item.ecosystem}): ${detail}`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -133,6 +133,22 @@ export interface AssetWeightFinding {
   status: "added" | "grown";
 }
 
+/** A newly-added dependency whose name is a near-miss of a popular package (typosquat) or an unscoped name that
+ *  is not published on the public registry and is therefore publicly claimable (dependency-confusion). Reports
+ *  the package name + the reason only — never the manifest contents. (#1501) */
+export interface TyposquatFinding {
+  ecosystem: string;
+  package: string;
+  version: string;
+  kind: "typosquat" | "confusion";
+  /** The popular package the name is a near-miss of — set for `typosquat` findings. */
+  similarTo?: string;
+  /** Damerau-Levenshtein distance to `similarTo` — set for edit-distance `typosquat` findings (0 = homoglyph/separator). */
+  distance?: number;
+  /** Short, public-safe explanation of why the name was flagged. */
+  reason: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -146,6 +162,7 @@ export interface BriefFindings {
   codeowners?: CodeownersFinding[];
   secretLog?: SecretLogFinding[];
   assetWeight?: AssetWeightFinding[];
+  typosquat?: TyposquatFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/typosquat.test.ts
+++ b/review-enrichment/test/typosquat.test.ts
@@ -1,0 +1,153 @@
+// Units for the typosquat + dependency-confusion analyzer (#1501). Kept in its own file (not enrichment.test.ts)
+// so concurrent analyzer PRs don't collide on a shared test file. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  damerauLevenshtein,
+  canonicalize,
+  classifyTyposquat,
+  isPublished,
+  scanTyposquat,
+} from "../dist/analyzers/typosquat.js";
+import { renderBrief } from "../dist/render.js";
+
+// A package.json diff that ADDS one dependency (a single `+` line → from === null).
+const npmAdd = (name, version = "1.0.0") => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "${name}": "^${version}"` }],
+});
+
+// Fetch stubs returning a minimal Response-like shape (status + ok), matching the other analyzer tests.
+const status = (code) => async () => ({ status: code, ok: code >= 200 && code < 300 });
+const throwingFetch = async () => {
+  throw new Error("network down");
+};
+
+test("damerauLevenshtein: substitution, indel, transposition, and bounded early-exit", () => {
+  assert.equal(damerauLevenshtein("expres", "express"), 1); // one insertion
+  assert.equal(damerauLevenshtein("lodahs", "lodash"), 1); // adjacent transposition
+  assert.equal(damerauLevenshtein("axios", "axios"), 0);
+  assert.equal(damerauLevenshtein("abc", "xyz"), 3);
+  assert.equal(damerauLevenshtein("kitten", "sitting", 2), 3); // exceeds bound → max + 1
+  assert.equal(damerauLevenshtein("react", "preact-compat", 2), 3); // length gap > bound short-circuits
+});
+
+test("canonicalize maps digit homoglyphs and strips separators", () => {
+  assert.equal(canonicalize("l0dash"), "lodash");
+  assert.equal(canonicalize("lo-dash"), "lodash");
+  assert.equal(canonicalize("LO_DASH"), "lodash");
+  assert.equal(canonicalize("expr3ss"), "express");
+});
+
+test("classifyTyposquat: exact match is safe", () => {
+  assert.equal(classifyTyposquat("npm", "react"), null);
+  assert.equal(classifyTyposquat("npm", "React"), null); // case-insensitive
+});
+
+test("classifyTyposquat: homoglyph / separator variants", () => {
+  assert.deepEqual(classifyTyposquat("npm", "l0dash"), {
+    similarTo: "lodash",
+    distance: 0,
+    reason: "homoglyph/separator variant of 'lodash'",
+  });
+  assert.equal(classifyTyposquat("npm", "lo-dash")?.similarTo, "lodash");
+});
+
+test("classifyTyposquat: scoped names are intentionally not classified (namespace-protected)", () => {
+  // Scope-swap is deliberately out of scope: an npm scope cannot be published to without owning it, so a popular
+  // tail under any scope is not claimable impersonation. Crucially, the offline tail-vs-popular heuristic cannot
+  // tell a legitimate `@chakra-ui/react` / `@types/react` from a hypothetical `@evil/react` without an
+  // authoritative scope-ownership source, so it would only manufacture false positives. We flag none.
+  assert.equal(classifyTyposquat("npm", "@types/react"), null); // DefinitelyTyped mirrors the name by design
+  assert.equal(classifyTyposquat("npm", "@chakra-ui/react"), null); // a real, published, legitimate scoped package
+  assert.equal(classifyTyposquat("npm", "@acme/express"), null); // an arbitrary first-party scope
+  assert.equal(classifyTyposquat("npm", "@evil/react"), null); // an unfamiliar scope is indistinguishable offline
+});
+
+test("classifyTyposquat: known-legitimate near-neighbours are not flagged", () => {
+  assert.equal(classifyTyposquat("npm", "preact"), null); // one edit from `react`, but a real package
+});
+
+test("classifyTyposquat: edit distance with short-name guard", () => {
+  assert.equal(classifyTyposquat("npm", "expres")?.distance, 1); // express, len ok
+  assert.equal(classifyTyposquat("PyPI", "reqests")?.similarTo, "requests");
+  assert.equal(classifyTyposquat("npm", "ws"), null); // too short to flag a distance-1 neighbour
+  assert.equal(classifyTyposquat("npm", "totally-unrelated-name"), null);
+  assert.equal(classifyTyposquat("Go", "anything"), null); // unsupported ecosystem
+});
+
+test("isPublished: definitive 404/200, undeterminable otherwise", async () => {
+  assert.equal(await isPublished("npm", "x", status(404)), false);
+  assert.equal(await isPublished("npm", "x", status(200)), true);
+  assert.equal(await isPublished("npm", "x", status(500)), null);
+  assert.equal(await isPublished("npm", "x", throwingFetch), null);
+  assert.equal(await isPublished("Go", "x", status(404)), null); // unsupported ecosystem
+  assert.equal(await isPublished("npm", "x", status(404), AbortSignal.abort()), null);
+});
+
+test("scanTyposquat flags a typosquat without any registry call", async () => {
+  let called = false;
+  const findings = await scanTyposquat(npmAdd("expres"), async () => {
+    called = true;
+    return status(404)();
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "typosquat");
+  assert.equal(findings[0].similarTo, "express");
+  assert.equal(findings[0].package, "expres");
+  assert.equal(called, false); // a name match never needs the registry
+});
+
+test("scanTyposquat flags dependency-confusion on a 404 unscoped name", async () => {
+  const findings = await scanTyposquat(npmAdd("acme-internal-utils"), status(404));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "confusion");
+  assert.match(findings[0].reason, /publicly claimable/);
+});
+
+test("scanTyposquat: a published unscoped name is not flagged", async () => {
+  const findings = await scanTyposquat(npmAdd("acme-internal-utils"), status(200));
+  assert.deepEqual(findings, []);
+});
+
+test("scanTyposquat: scoped names are never confusion-checked", async () => {
+  let called = false;
+  const findings = await scanTyposquat(npmAdd("@acme/internal"), async () => {
+    called = true;
+    return status(404)();
+  });
+  assert.deepEqual(findings, []);
+  assert.equal(called, false);
+});
+
+test("scanTyposquat: a version bump (existing name) is ignored", async () => {
+  const bump = {
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [{ path: "package.json", patch: `@@ -1,1 +1,1 @@\n-  "expres": "^1.0.0"\n+  "expres": "^2.0.0"` }],
+  };
+  assert.deepEqual(await scanTyposquat(bump, status(404)), []);
+});
+
+test("scanTyposquat fails safe when the registry fetch throws", async () => {
+  assert.deepEqual(await scanTyposquat(npmAdd("acme-internal-utils"), throwingFetch), []);
+});
+
+test("scanTyposquat stops on an already-aborted signal", async () => {
+  const findings = await scanTyposquat(npmAdd("expres"), status(404), { signal: AbortSignal.abort() });
+  assert.deepEqual(findings, []);
+});
+
+test("renderBrief emits a public-safe typosquat block", () => {
+  const { promptSection } = renderBrief({
+    typosquat: [
+      { ecosystem: "npm", package: "expres", version: "1.0.0", kind: "typosquat", similarTo: "express", distance: 1, reason: "edit distance 1 from 'express'" },
+      { ecosystem: "npm", package: "acme-internal", version: "0.0.1", kind: "confusion", reason: "not published on the public npm registry — an unscoped name that is publicly claimable (dependency-confusion)" },
+    ],
+  });
+  assert.match(promptSection, /Typosquat \/ dependency-confusion risks/);
+  assert.match(promptSection, /likely typosquat of/);
+  assert.match(promptSection, /expres@1\.0\.0/);
+  assert.match(promptSection, /publicly claimable/);
+});


### PR DESCRIPTION
## Summary

Adds a REES analyzer (#1501) that flags two supply-chain risks for the dependencies a PR **newly adds** — the heavy/external name analysis the no-checkout `claude --print` reviewer cannot do. Additive + fail-safe: it fills its own `typosquat` findings key and degrades independently like every other analyzer.

**Detects (unscoped names only)**
- **Typosquat** — a newly-added *unscoped* dep whose name is a near-miss of a bundled popular package:
  - homoglyph / separator variant (canonical-form match, e.g. `l0dash`, `lo-dash` → `lodash`),
  - distance-1 **Damerau-Levenshtein** edit (e.g. `expres` → `express`), with a short-name guard and a known-legitimate near-neighbour allowlist (e.g. `preact` is not flagged as a near-miss of `react`). Pure + offline.
- **Dependency-confusion** — an **unscoped** name that returns a definitive **404** on the public registry is publicly claimable (namespace-takeover). Transient/unknown registry states **fail safe** (no finding).

**Scope note — scoped packages are intentionally not analyzed.** An npm scope is namespace-protected (it cannot be published to without owning it), so a popular tail under any scope — `@types/react`, `@chakra-ui/react`, `@acme/express` — is **not** claimable impersonation. There is no offline source of truth that distinguishes a legitimate scoped package from a hypothetical malicious one, so classifying scoped names would only manufacture false positives. The analyzer therefore restricts to the unscoped flat namespace, which is the real typosquat/confusion surface. (This deliberately narrows the issue's "scope-swap" idea to keep the analyzer precise.)

## Implementation (established `review-enrichment/` pattern)
1. `TyposquatFinding` type + `typosquat?` key in `src/types.ts`
2. `src/analyzers/typosquat.ts` — pure helpers (`damerauLevenshtein`, `canonicalize`, `classifyTyposquat`, `isPublished`) + `scanTyposquat(req, fetch, opts)`; reuses `extractDependencyChanges` to read added (not bumped) deps
3. Registered in the `src/brief.ts` ANALYZERS registry
4. Public-safe block in `src/render.ts` (renders `package@version` + reason only — never manifest contents)
5. `node:test` units in a **separate `test/typosquat.test.ts`** (avoids colliding with concurrent analyzer PRs on `enrichment.test.ts`)

## Validation
From `review-enrichment/` (Node 24):

```sh
npm test   # build + node --test: 132 pass / 0 fail
```

Covers edit-distance/transposition/bounded early-exit, homoglyph + separator canonicalization, short-name guard, known-legit exemption, scoped-name non-classification (incl. `@chakra-ui/react`), registry 404/200/5xx/throw/abort, version-bump-ignored, scoped-name skipped, fail-safe, and the rendered public-safe block.

Closes #1501