### PR TITLE
fix(signals): compare freshness SLO in milliseconds, not floored seconds

### DIFF
--- a/src/signals/data-quality.ts
+++ b/src/signals/data-quality.ts
@@ -71,8 +71,12 @@ export function buildFreshnessSloReport(args: {
   const add = (area: keyof typeof FRESHNESS_SLO_MS, targetKey: string, observedAt: string | null | undefined, forced?: "blocked" | "degraded" | "missing") => {
     const observedMs = observedAt ? Date.parse(observedAt) : NaN;
     const validObservedAt = observedAt && Number.isFinite(observedMs) ? observedAt : null;
-    const ageSeconds = validObservedAt ? Math.max(0, Math.floor((nowMs - observedMs) / 1000)) : undefined;
-    const status = forced ?? (!validObservedAt ? "missing" : ageSeconds !== undefined && ageSeconds * 1000 > FRESHNESS_SLO_MS[area] ? "stale" : "fresh");
+    // Compare staleness in milliseconds (matching isStale below), not on the floored-to-seconds age:
+    // `ageSeconds * 1000 > SLO_MS` drops the sub-second remainder, so an age up to 999ms past the SLO is
+    // wrongly reported "fresh". ageSeconds stays floored for display; the threshold check uses raw ms.
+    const ageMs = validObservedAt ? Math.max(0, nowMs - observedMs) : undefined;
+    const ageSeconds = ageMs !== undefined ? Math.floor(ageMs / 1000) : undefined;
+    const status = forced ?? (!validObservedAt ? "missing" : ageMs !== undefined && ageMs > FRESHNESS_SLO_MS[area] ? "stale" : "fresh");
     const launchBlocking = status !== "fresh" && LAUNCH_BLOCKING_FRESHNESS_AREAS.has(area);
     items.push({ area, targetKey, status, launchBlocking, ...(ageSeconds !== undefined ? { ageSeconds, breachSeconds: Math.max(0, ageSeconds - Math.floor(FRESHNESS_SLO_MS[area] / 1000)) } : {}), sloSeconds: Math.floor(FRESHNESS_SLO_MS[area] / 1000), observedAt: validObservedAt, summary: `${area}:${targetKey} is ${status}` });
   };

--- a/test/unit/data-quality.test.ts
+++ b/test/unit/data-quality.test.ts
@@ -250,6 +250,28 @@ describe("sync data quality", () => {
     expect(report.items.map((item) => item.area).sort()).toEqual(["bounty_data", "decision_pack", "github_totals", "registry", "repo_segments", "scoring_model", "signal_snapshot"]);
   });
 
+  it("compares freshness against the SLO in milliseconds, not floored seconds", () => {
+    const fetchedAt = "2026-05-25T00:00:00.000Z";
+    const sloMs = 7 * 24 * 60 * 60 * 1000; // scoring_model uses DEFAULT_STALE_MS (7 days)
+    const scoringSnapshot = {
+      id: "scoring",
+      sourceKind: "test" as const,
+      sourceUrl: "fixture://scoring",
+      fetchedAt,
+      activeModel: "current_density_model" as const,
+      constants: {},
+      programmingLanguages: {},
+      warnings: [],
+      payload: {},
+    };
+    // 1ms past the SLO must be stale — the old floored-seconds compare wrongly reported it fresh.
+    const stale = buildFreshnessSloReport({ scoringSnapshot, nowMs: Date.parse(fetchedAt) + sloMs + 1 });
+    expect(stale.items.find((item) => item.area === "scoring_model")?.status).toBe("stale");
+    // Exactly at the SLO stays fresh — the threshold is strictly greater-than.
+    const fresh = buildFreshnessSloReport({ scoringSnapshot, nowMs: Date.parse(fetchedAt) + sloMs });
+    expect(fresh.items.find((item) => item.area === "scoring_model")?.status).toBe("fresh");
+  });
+
   it("degrades freshness when repo segments are active and totals are missing", () => {
     const report = buildFreshnessSloReport({
       repoCount: 1,


### PR DESCRIPTION
## The bug

`buildFreshnessSloReport` (src/signals/data-quality.ts) decides staleness from the **floored-to-seconds** age:

```ts
const ageSeconds = Math.floor((nowMs - observedMs) / 1000);
const status = ... ageSeconds * 1000 > FRESHNESS_SLO_MS[area] ? "stale" : "fresh";
```

Flooring drops the sub-second remainder, so an observation **up to 999ms past its SLO is wrongly reported `fresh`**. This diverges from `isStale()` in the *same module*, which compares raw milliseconds: `nowMs - parsed > staleMs`. Two staleness checks in one file, two different precisions.

## The fix

Compute the age in milliseconds and compare that against the SLO; keep `ageSeconds` floored for display only. Now a source 1ms past its SLO is `stale`, matching `isStale` and the documented intent.

## Tests

The existing tests all use day-granularity gaps, so the millisecond boundary was never exercised — which is why the drift went unnoticed. Added a regression test: at SLO+1ms the area is `stale`; exactly at the SLO it stays `fresh` (threshold is strictly greater-than). Day-granularity cases are unaffected; full local gate green, codecov patch covers the changed lines, OpenAPI unchanged.

No linked issue: a small, self-evident correctness fix to one threshold comparison — no behavior change beyond the sub-second boundary, no API/schema/DB change.