### PR TITLE
feat(scoring): explain the merged-PR history floor in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -99,6 +99,31 @@ function openIssueBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdo
   };
 }
 
+// Upstream merged-PR history floor (#808): scoring is gated to zero until a contributor has at least the
+// minimum merged-PR count. Explained here so a miner whose preview is zeroed by the floor sees the same
+// actionable breakdown the open-PR / open-issue gates already provide. mergedPullRequests is absent when the
+// history is unknown — in that case the multiplier defaults to 1 (treated as eligible), so say so explicitly.
+function mergedHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { mergedHistoryMultiplier } = preview.scoreEstimate;
+  const { mergedPullRequests, mergedPrFloor } = preview.gates;
+  const band = bandForMultiplier(mergedHistoryMultiplier);
+  return {
+    component: "mergedHistoryMultiplier",
+    band,
+    summary:
+      mergedHistoryMultiplier >= 1
+        ? mergedPullRequests !== undefined
+          ? `Merged-PR history (${mergedPullRequests}) meets the upstream validity floor (${mergedPrFloor}).`
+          : `Merged-PR history is not yet observed, so it is treated as meeting the upstream validity floor (${mergedPrFloor}).`
+        : `Merged-PR history (${mergedPullRequests ?? 0}) is below the upstream validity floor (${mergedPrFloor}), so scoring is gated to zero.`,
+    lever:
+      mergedHistoryMultiplier >= 1
+        ? "Keep landing merged PRs in registered repos to stay above the upstream validity floor."
+        : "Build more merged-PR history in registered repos to clear the upstream merged-PR validity floor.",
+    leverageScore: mergedHistoryMultiplier >= 1 ? 8 : 90,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -239,6 +264,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     reviewPenaltyBreakdown(preview),
     openPrBreakdown(preview),
     openIssueBreakdown(preview),
+    mergedHistoryBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -83,6 +83,7 @@ describe("explainScoreBreakdown", () => {
         "reviewPenaltyMultiplier",
         "openPrMultiplier",
         "openIssueMultiplier",
+        "mergedHistoryMultiplier",
       ]),
     );
     for (const component of breakdown.components) {
@@ -95,6 +96,26 @@ describe("explainScoreBreakdown", () => {
     expect(JSON.stringify(breakdown)).not.toMatch(FORBIDDEN);
     // No open issues → within the allowance → full band on the open-issue gate.
     expect(breakdown.components.find((entry) => entry.component === "openIssueMultiplier")).toMatchObject({ band: "full" });
+    // No observed merged-PR history → treated as eligible (full), with an explicit "not yet observed" note.
+    const mergedHistory = breakdown.components.find((entry) => entry.component === "mergedHistoryMultiplier");
+    expect(mergedHistory).toMatchObject({ band: "full" });
+    expect(mergedHistory?.summary).toMatch(/not yet observed/i);
+  });
+
+  it("explains the merged-PR history floor: meets the floor when observed, blocks when below", () => {
+    const base = { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80 };
+    const eligible = explainScoreBreakdown(buildScorePreview({ repo, snapshot, input: { ...base, mergedPullRequests: 5 } }));
+    const below = explainScoreBreakdown(buildScorePreview({ repo, snapshot, input: { ...base, mergedPullRequests: 1 } }));
+    const eMerged = eligible.components.find((entry) => entry.component === "mergedHistoryMultiplier");
+    const bMerged = below.components.find((entry) => entry.component === "mergedHistoryMultiplier");
+    // 5 merged PRs clears the default MIN_VALID_MERGED_PRS (3) floor.
+    expect(eMerged).toMatchObject({ band: "full" });
+    expect(eMerged?.summary).toMatch(/meets the upstream validity floor/i);
+    // 1 merged PR is below the floor → scoring gated to zero.
+    expect(bMerged).toMatchObject({ band: "blocked" });
+    expect(bMerged?.summary).toMatch(/below the upstream validity floor/i);
+    expect(bMerged?.lever).toMatch(/build more merged-PR history/i);
+    expect(JSON.stringify(below)).not.toMatch(FORBIDDEN);
   });
 
   it("explains an over-threshold open-issue count as a blocked open-issue spam gate", () => {


### PR DESCRIPTION
## What

`explainScoreBreakdown` produces an improvement lever for every score multiplier — density, contribution bonus, label, issue, credibility, review penalty, open-PR, open-issue — **except** the upstream merged-PR history floor (#808). That floor zeroes a contributor's score until they have at least `MIN_VALID_MERGED_PRS` merged PRs; it is the eligibility sibling of the open-PR and open-issue gates, which already have breakdown rows. So a miner whose preview is gated to zero by the history floor gets no row explaining why or how to recover.

## How

Adds `mergedHistoryBreakdown`, mirroring `openIssueBreakdown`. It reads values the preview **already computes** — `scoreEstimate.mergedHistoryMultiplier` and the `gates.mergedPullRequests` / `mergedPrFloor` fields — and emits a full/blocked band with a concrete lever (build more merged-PR history). When the history is unobserved the multiplier defaults to 1 (treated as eligible), so the summary says so explicitly instead of printing a missing count. No new inputs, no score-math change, no schema change.

## Tests / coverage

- Unobserved history → `full` band with a 'not yet observed' summary (existing fixture).
- 5 merged PRs clears the default floor (3) → `full`, 'meets the upstream validity floor'.
- 1 merged PR is below the floor → `blocked`, 'below the upstream validity floor', with the build-history lever.
- Full branch coverage on every added line; output stays public-safe; OpenAPI unchanged.

No linked issue: a small, self-evident, self-contained enhancement to one internal explainer — no behavior change, no API/schema/DB change.