### PR TITLE
feat: add native-build / install-cost dependency flag

### DIFF
--- a/review-enrichment/src/analyzers/native-build.ts
+++ b/review-enrichment/src/analyzers/native-build.ts
@@ -1,0 +1,104 @@
+// Native-build / install-cost dependency flag (#1512). Flags a newly added/changed dependency that triggers a
+// native compile on install (npm: `node-gyp` with no prebuilt binary) or has no pure-Python wheel (PyPI:
+// sdist-only) — hidden CI cold-start/install cost and a frequent cross-platform breakage source.
+//
+// Data sources: the npm registry packument (`versions[v].gypfile` + `versions[v].binary`) and the PyPI
+// per-release JSON (`urls[].packagetype`). Both are free; keyed on package@version from the shipped extractor
+// (`extractDependencyChanges`), so this analyzer never re-parses the diff.
+//
+// Distinct from #1474 (CVE scan) and the install-script auditor: those grade vulnerability/supply-chain risk;
+// this grades INSTALL COST. A pure-JS package with a malicious postinstall is an install-script finding; a
+// native module with no prebuilt that slows CI by 90s is a native-build finding.
+//
+// Fail-safe: returns [] on any network error or non-ok response (mirrors `queryOsv`). Forwards abort signals
+// so the orchestrator's timeout can cancel in-flight registry fetches.
+import type { EnrichRequest, NativeBuildFinding } from "../types.js";
+import { extractDependencyChanges } from "./dependency-scan.js";
+
+// Caps attacker-controlled input: a huge manifest diff cannot exhaust the shared registry budget. Matches the
+// OSV/license/install-script analyzers' per-dependency query cap.
+const MAX_DEPS_QUERIED = 25;
+
+const NPM_PACKAGE_RE =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
+const SEMVER_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+// PyPI normalized names: ASCII letters, digits, `.`, `_`, `-`; normalized to lowercase on the index.
+const PYPI_PACKAGE_RE = /^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$/i;
+
+interface NpmVersionManifest {
+  /** npm sets `gypfile: true` when the version ships a `binding.gyp` (a node-gyp native build). */
+  gypfile?: boolean;
+  /** A `binary` field is the node-pre-gyp / prebuild-install convention for hosting prebuilt binaries. */
+  binary?: unknown;
+}
+interface NpmPackument {
+  versions?: Record<string, NpmVersionManifest>;
+}
+interface PypiRelease {
+  /** Each url's `packagetype`: `sdist` (source), `bdist_wheel` (wheel), `bdist_egg`, … */
+  urls?: Array<{ packagetype: string }>;
+}
+
+/** True when an npm version manifest declares a native build (gypfile) with NO prebuilt binary host. Pure.
+ *  A `binary` field means prebuilt artifacts are fetched on install (no compile needed), so the cost is gone. */
+export function hasNpmNativeBuild(manifest: NpmVersionManifest | undefined): boolean {
+  if (!manifest) return false;
+  if (manifest.gypfile !== true) return false;
+  return manifest.binary == null;
+}
+
+/** True when a PyPI release ships ONLY an sdist (no `bdist_wheel`). Pure. An empty `urls` list is NOT flagged
+ *  (no signal) — only a release that published a source distribution but no wheel carries the install cost. */
+export function isPypiSdistOnly(release: PypiRelease | undefined): boolean {
+  const urls = release?.urls ?? [];
+  if (urls.length === 0) return false;
+  return !urls.some((url) => url.packagetype === "bdist_wheel");
+}
+
+async function fetchJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  signal?: AbortSignal,
+): Promise<T | undefined> {
+  const response = await fetchImpl(url, { signal });
+  if (!response.ok) return undefined;
+  return (await response.json()) as T;
+}
+
+type ScanOptions = { signal?: AbortSignal };
+
+/** Analyzer entrypoint: changed npm/PyPI deps → registry → only the deps that carry native-build install cost. */
+export async function scanNativeBuild(
+  req: EnrichRequest,
+  fetchImpl: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<NativeBuildFinding[]> {
+  const changes = extractDependencyChanges(req.files ?? []).slice(0, MAX_DEPS_QUERIED);
+  const findings: NativeBuildFinding[] = [];
+  for (const change of changes) {
+    if (options.signal?.aborted) break;
+    if (change.ecosystem === "npm" && NPM_PACKAGE_RE.test(change.package) && SEMVER_RE.test(change.to)) {
+      const data = await fetchJson<NpmPackument>(
+        fetchImpl,
+        `https://registry.npmjs.org/${encodeURIComponent(change.package)}`,
+        options.signal,
+      );
+      if (hasNpmNativeBuild(data?.versions?.[change.to])) {
+        findings.push({ package: change.package, version: change.to, ecosystem: "npm", reason: "node-gyp" });
+      }
+      continue;
+    }
+    if (change.ecosystem === "PyPI" && PYPI_PACKAGE_RE.test(change.package)) {
+      const data = await fetchJson<PypiRelease>(
+        fetchImpl,
+        `https://pypi.org/pypi/${encodeURIComponent(change.package)}/${encodeURIComponent(change.to)}/json`,
+        options.signal,
+      );
+      if (isPypiSdistOnly(data)) {
+        findings.push({ package: change.package, version: change.to, ecosystem: "PyPI", reason: "no-wheel" });
+      }
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -16,6 +16,7 @@ import { scanEol } from "./analyzers/eol-check.js";
 import { scanRedos } from "./analyzers/redos.js";
 import { scanCodeowners } from "./analyzers/codeowners.js";
 import { scanSecretLog } from "./analyzers/secret-log.js";
+import { scanNativeBuild } from "./analyzers/native-build.js";
 import { renderBrief } from "./render.js";
 
 type AnalyzerFn = (req: EnrichRequest, signal: AbortSignal) => Promise<unknown>;
@@ -31,6 +32,7 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   redos: (req) => scanRedos(req),
   codeowners: (req, signal) => scanCodeowners(req, fetch, { signal }),
   secretLog: (req, signal) => scanSecretLog(req, signal),
+  nativeBuild: (req, signal) => scanNativeBuild(req, fetch, { signal }),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -160,6 +160,22 @@ export function renderBrief(
     }
   }
 
+  const nativeBuilds = findings.nativeBuild ?? [];
+  if (nativeBuilds.length) {
+    lines.push(
+      "### Native-build / install-cost dependencies (slow CI install, cross-platform breakage risk)",
+    );
+    for (const item of nativeBuilds) {
+      const why =
+        item.reason === "node-gyp"
+          ? "compiles native code on install with no prebuilt binary"
+          : "ships source-only (no wheel) — needs a build toolchain";
+      lines.push(
+        `- \`${promptText(item.package)}@${promptText(item.version)}\` (${item.ecosystem}) ${why}`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -109,6 +109,18 @@ export interface SecretLogFinding {
   category: "secret" | "pii" | "request-object";
 }
 
+/** A newly added/changed dependency that triggers a native build on install (#1512) — hidden CI cold-start
+ *  cost and a frequent cross-platform breakage source. `package@version` + ecosystem + the reason only —
+ *  never any script body or registry payload (public-safe by construction). */
+export interface NativeBuildFinding {
+  package: string;
+  version: string;
+  ecosystem: "npm" | "PyPI";
+  /** Why this dep carries hidden install cost: `node-gyp` (npm — compiles native code, no prebuilt binary)
+   *  or `no-wheel` (PyPI — ships source-only, needs a build toolchain). */
+  reason: "node-gyp" | "no-wheel";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -120,6 +132,7 @@ export interface BriefFindings {
   redos?: RedosFinding[];
   codeowners?: CodeownersFinding[];
   secretLog?: SecretLogFinding[];
+  nativeBuild?: NativeBuildFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -33,6 +33,11 @@ import {
   scanPatchForSecretLog,
   scanSecretLog,
 } from "../dist/analyzers/secret-log.js";
+import {
+  hasNpmNativeBuild,
+  isPypiSdistOnly,
+  scanNativeBuild,
+} from "../dist/analyzers/native-build.js";
 
 const NOW = new Date("2026-06-26").getTime();
 const eolFetch =
@@ -1198,6 +1203,203 @@ test("buildBrief: secret-log analyzer runs (pure, no network)", async () => {
     assert.equal(brief.analyzerStatus.secretLog, "ok");
     assert.equal(brief.findings.secretLog.length, 1);
     assert.match(brief.promptSection, /Secrets \/ PII reaching a log/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// ── native-build analyzer (#1512) ─────────────────────────────────────────────
+
+const npmPatch = (name, version) => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "package.json", patch: `+    "${name}": "${version}",` }],
+});
+const pypiPatch = (name, version) => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "requirements.txt", patch: `+${name}==${version}` }],
+});
+
+test("hasNpmNativeBuild: gypfile + no binary => true; prebuilt binary or pure JS => false", () => {
+  assert.equal(hasNpmNativeBuild({ gypfile: true }), true);
+  assert.equal(hasNpmNativeBuild({ gypfile: true, binary: { host: "x" } }), false);
+  assert.equal(hasNpmNativeBuild({ binary: { host: "x" } }), false); // prebuilt, not native
+  assert.equal(hasNpmNativeBuild({ scripts: { install: "x" } }), false); // pure JS
+  assert.equal(hasNpmNativeBuild(undefined), false);
+  assert.equal(hasNpmNativeBuild({}), false);
+  assert.equal(hasNpmNativeBuild({ gypfile: false }), false);
+});
+
+test("isPypiSdistOnly: sdist-only => true; has wheel or empty => false", () => {
+  assert.equal(isPypiSdistOnly({ urls: [{ packagetype: "sdist" }] }), true);
+  assert.equal(
+    isPypiSdistOnly({ urls: [{ packagetype: "sdist" }, { packagetype: "bdist_wheel" }] }),
+    false,
+  );
+  assert.equal(
+    isPypiSdistOnly({ urls: [{ packagetype: "bdist_wheel" }] }),
+    false,
+  );
+  assert.equal(isPypiSdistOnly({ urls: [] }), false); // no signal
+  assert.equal(isPypiSdistOnly(undefined), false);
+});
+
+test("scanNativeBuild: flags npm node-gyp (no binary); skips prebuilt + pure JS", async () => {
+  const fetchImpl = async (url) => {
+    const u = String(url);
+    if (u.includes("/native-no-prebuild")) {
+      return {
+        ok: true,
+        json: async () => ({ versions: { "1.0.0": { gypfile: true } } }),
+      };
+    }
+    if (u.includes("/native-with-prebuild")) {
+      return {
+        ok: true,
+        json: async () => ({
+          versions: { "1.0.0": { gypfile: true, binary: { host: "x" } } },
+        }),
+      };
+    }
+    if (u.includes("/pure-js")) {
+      return { ok: true, json: async () => ({ versions: { "1.0.0": {} } }) };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  const findings = await scanNativeBuild(
+    {
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [
+        { path: "package.json", patch: [
+          '+    "native-no-prebuild": "1.0.0",',
+          '+    "native-with-prebuild": "1.0.0",',
+          '+    "pure-js": "1.0.0",',
+        ].join("\n") },
+      ],
+    },
+    fetchImpl,
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].package, "native-no-prebuild");
+  assert.equal(findings[0].version, "1.0.0");
+  assert.equal(findings[0].ecosystem, "npm");
+  assert.equal(findings[0].reason, "node-gyp");
+});
+
+test("scanNativeBuild: flags PyPI sdist-only; skips packages that ship a wheel", async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    json: async () => ({ urls: [{ packagetype: "sdist" }] }),
+  });
+  const wheelFetch = async () => ({
+    ok: true,
+    json: async () => ({
+      urls: [{ packagetype: "sdist" }, { packagetype: "bdist_wheel" }],
+    }),
+  });
+  const flagged = await scanNativeBuild(pypiPatch("source-only", "1.0.0"), fetchImpl);
+  assert.equal(flagged.length, 1);
+  assert.equal(flagged[0].ecosystem, "PyPI");
+  assert.equal(flagged[0].reason, "no-wheel");
+  const clean = await scanNativeBuild(pypiPatch("has-wheel", "1.0.0"), wheelFetch);
+  assert.equal(clean.length, 0);
+});
+
+test("scanNativeBuild: a non-ok registry response yields no finding (fail-safe)", async () => {
+  const fetchImpl = async () => ({ ok: false, json: async () => ({}) });
+  const findings = await scanNativeBuild(npmPatch("anything", "1.0.0"), fetchImpl);
+  assert.deepEqual(findings, []);
+});
+
+test("scanNativeBuild: rejects malformed package names + non-semver npm versions", async () => {
+  let calls = 0;
+  const fetchImpl = async () => { calls++; return { ok: true, json: async () => ({ versions: { "1.0.0": { gypfile: true } } }) }; };
+  await scanNativeBuild(
+    {
+      repoFullName: "o/r",
+      prNumber: 1,
+      files: [
+        { path: "package.json", patch: '+    "../bad-name": "1.0.0",' },
+        { path: "package.json", patch: '+    "good-name": "not-a-version",' },
+      ],
+    },
+    fetchImpl,
+  );
+  assert.equal(calls, 0);
+});
+
+test("scanNativeBuild: caps dependency queries and forwards abort signals", async () => {
+  const seenSignals = [];
+  const files = Array.from({ length: 5 }, (_, i) => ({
+    path: "package.json",
+    patch: `+    "pkg-${i}": "1.0.0",`,
+  }));
+  const controller = new AbortController();
+  const findings = await scanNativeBuild(
+    { repoFullName: "o/r", prNumber: 1, files },
+    async (_url, init) => {
+      seenSignals.push(init.signal);
+      return { ok: true, json: async () => ({ versions: {} }) };
+    },
+    { signal: controller.signal },
+  );
+  assert.equal(findings.length, 0);
+  assert.equal(seenSignals.length, 5); // default MAX_DEPS_QUERIED caps well above 5
+  assert.ok(seenSignals.every((s) => s instanceof AbortSignal));
+});
+
+test("renderBrief: renders the native-build block, escaping markdown in names", () => {
+  const r = renderBrief({
+    nativeBuild: [
+      { package: "native`pkg", version: "1.0.0", ecosystem: "npm", reason: "node-gyp" },
+      { package: "source-only", version: "2.1.3", ecosystem: "PyPI", reason: "no-wheel" },
+    ],
+  });
+  assert.match(r.promptSection, /Native-build \/ install-cost/);
+  assert.match(r.promptSection, /compiles native code on install with no prebuilt binary/);
+  assert.match(r.promptSection, /ships source-only \(no wheel\)/);
+  assert.doesNotMatch(r.promptSection, /native`pkg/); // backtick escaped
+});
+
+test("buildBrief: native-build analyzer runs alongside the others, marked ok", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes("registry.npmjs.org/native-pkg")) {
+      return { ok: true, json: async () => ({ versions: { "1.0.0": { gypfile: true } } }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  };
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 1,
+      analyzers: ["nativeBuild"],
+      files: [{ path: "package.json", patch: '+    "native-pkg": "1.0.0",' }],
+    });
+    assert.equal(brief.analyzerStatus.nativeBuild, "ok");
+    assert.equal(brief.findings.nativeBuild.length, 1);
+    assert.match(brief.promptSection, /Native-build \/ install-cost/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("buildBrief: native-build analyzer marks degraded + partial on a thrown fetch", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error("registry down"); };
+  try {
+    const brief = await buildBrief({
+      repoFullName: "o/r",
+      prNumber: 2,
+      analyzers: ["nativeBuild"],
+      files: [{ path: "package.json", patch: '+    "x": "1.0.0",' }],
+    });
+    assert.equal(brief.partial, true);
+    assert.equal(brief.analyzerStatus.nativeBuild, "degraded");
+    assert.equal(brief.promptSection, "");
   } finally {
     globalThis.fetch = realFetch;
   }


### PR DESCRIPTION
## Summary

Adds a REES analyzer that flags a newly added/changed dependency which triggers a **native build on install** — hidden CI cold-start/install cost and a frequent cross-platform breakage source. Two signals, one per ecosystem:

- **npm** — the version manifest declares `gypfile: true` (a `binding.gyp` → node-gyp native compile) AND has no `binary` field (no prebuilt-binary host, so the compile always runs). A native module that ships prebuilts (`binary` present) is NOT flagged.
- **PyPI** — the release is sdist-only (no `bdist_wheel`), so `pip install` must build it from source against the local toolchain.

Reuses `extractDependencyChanges` from `dependency-scan.ts` for the package@version key (no diff re-parse), then queries the npm registry packument and the PyPI per-release JSON. Distinct from #1474 (CVE scan) and the install-script auditor — those grade vulnerability/supply-chain risk; this grades install cost.

Follows the established analyzer pattern end-to-end: finding type → pure analyzer (inject `fetch` for tests) → brief registry → public-safe render block → `node:test` units against `dist/`. Fail-safe: returns `[]` on any non-ok response; forwards abort signals so the orchestrator's timeout can cancel in-flight fetches.

Closes #1512.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Verified against real registries before implementing: `node-expat@2.4.1` (`gypfile:true`, no `binary`) is the textbook flag; `bcrypt@5.1.1` (has `binary` prebuilds) and `lodash@4.17.21` (pure JS) correctly don't flag. On PyPI, packages shipping `bdist_wheel` entries are not flagged.
- The finding is public-safe by construction: `package@version` + ecosystem + a reason enum (`node-gyp` / `no-wheel`). No script bodies, registry payloads, or install logs ever leave the analyzer. The render block routes package/version through `promptText` (the same markdown-escape the install-script block uses).
- Pure helpers (`hasNpmNativeBuild`, `isPypiSdistOnly`) are exported and unit-tested independently — they take the registry shape directly, so the classifier is testable with no network.