### PR TITLE
fix(backfill): drop unparseable timestamps from the latestDate reduction

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2805,7 +2805,10 @@ function topItems(values: string[], limit: number): string[] {
 }
 
 function latestDate(values: Array<string | null | undefined>): string | undefined {
-  return values.filter(Boolean).sort().at(-1) ?? undefined;
+  // Drop unparseable values before the lexicographic max: a malformed/sentinel timestamp whose first char
+  // sorts after "2" (e.g. "bad-date", "pending") would otherwise outrank a real 2026-... ISO stamp and be
+  // persisted as lastActivityAt. Mirrors the guarded newest()/oldest() in signals/data-quality.ts.
+  return values.filter((value): value is string => Boolean(value && Number.isFinite(Date.parse(value)))).sort().at(-1) ?? undefined;
 }
 
 function daysSince(value: string): number {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -287,7 +287,7 @@ describe("GitHub backfill", () => {
     expect(await listContributorRepoStats(env, "jsonbored")).toEqual([
       expect.objectContaining({
         dominantLabels: ["alpha", "zeta"],
-        lastActivityAt: "bad-date",
+        lastActivityAt: "2026-05-24T00:00:00Z",
         unlinkedPullRequests: 1,
       }),
     ]);


### PR DESCRIPTION
## Summary

`latestDate` (`src/github/backfill.ts`) selects the contributor's latest activity timestamp with a lexicographic `.sort().at(-1)` and only a truthiness filter:

```ts
function latestDate(values: Array<string | null | undefined>): string | undefined {
  return values.filter(Boolean).sort().at(-1) ?? undefined;
}
```

A malformed/sentinel GitHub timestamp whose first character sorts after `2` (e.g. `bad-date`, `pending`, `not-a-date`) therefore wins over a real `2026-...` ISO stamp and is persisted into `contributor_repo_stats.last_activity_at`. Every downstream freshness check then does `Date.parse(bad-date) -> NaN` and treats a genuinely active repo as stale/missing.

## Fix

Mirror the guarded canonical form already in `src/signals/data-quality.ts` (`newest()`/`oldest()`):

```ts
return values?.filter((value): value is string => Boolean(value && Number.isFinite(Date.parse(value)))).sort().at(-1);
```

Also require `Number.isFinite(Date.parse(value))` in `latestDate`'s filter, so unparseable values are dropped from the reduction. No behavior change when every value is a well-formed ISO timestamp.

## Regression proof

An existing test (`test/unit/backfill.test.ts`) feeds a fixture mixing `updatedAt: bad-date` with valid ISO stamps and previously asserted `lastActivityAt: bad-date` -- encoding the bug. That assertion is corrected to the real latest stamp (`2026-05-24T00:00:00Z`); the flip is the regression proof (pre-fix the malformed value won the lexicographic max; post-fix it is dropped).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1714).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run db:migrations:check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/backfill.test.ts` 94/94 pass; the changed filter is covered (both arms: the malformed `bad-date` is dropped, the valid ISO stamps are kept).

Targeted run:

```sh
npx vitest run test/unit/backfill.test.ts
# 94/94 passed
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- a pure-helper timestamp reduction on the contributor-activity ingestion path, using a guard pattern already established in the same codebase.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend timestamp-reduction helper with no visible UI, frontend, docs, or extension surface.

Closes #1714