### PR TITLE
fix(enrichment): detect npm alias dependency targets for typosquat/confusion

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -27,7 +27,9 @@ interface ScanOptions {
 
 // Per-manifest line parsers. Each returns [name, version] for a `+`/`-` diff line, or null. Heuristic (line-based,
 // not a full manifest parse) — good enough to flag the deps a PR adds/bumps without resolving the whole tree.
-const NPM_RE = /^"([^"]+)"\s*:\s*"([\^~>=<\s]*[0-9][^"]*)"/;
+const NPM_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;
+const NPM_ALIAS_RE = /^npm:(@[^/]+\/[^@]+|[^@]+)@(.+)$/;
+const NPM_VERSION_PREFIX_RE = /^[\^~>=<\s]+/;
 const PYPI_RE = /^([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s;]*)/;
 const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;
 
@@ -37,8 +39,13 @@ function parseLine(
 ): { name: string; version: string } | null {
   if (manifest === "package.json") {
     const m = NPM_RE.exec(body);
-    if (m)
-      return { name: m[1]!, version: m[2]!.replace(/^[\^~>=<\s]+/, "").trim() };
+    if (m) {
+      const spec = m[2]!.trim();
+      const alias = NPM_ALIAS_RE.exec(spec);
+      if (alias) return { name: alias[1]!, version: alias[2]!.replace(NPM_VERSION_PREFIX_RE, "").trim() };
+      if (/^[\^~>=<\s]*[0-9]/.test(spec))
+        return { name: m[1]!, version: spec.replace(NPM_VERSION_PREFIX_RE, "").trim() };
+    }
   } else if (manifest === "requirements.txt") {
     const m = PYPI_RE.exec(body);
     if (m) return { name: m[1]!, version: m[2]! };

--- a/review-enrichment/test/typosquat.test.ts
+++ b/review-enrichment/test/typosquat.test.ts
@@ -18,6 +18,12 @@ const npmAdd = (name, version = "1.0.0") => ({
   files: [{ path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "${name}": "^${version}"` }],
 });
 
+const npmAliasAdd = (alias, target, version = "1.0.0") => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "${alias}": "npm:${target}@${version}"` }],
+});
+
 // Fetch stubs returning a minimal Response-like shape (status + ok), matching the other analyzer tests.
 const status = (code) => async () => ({ status: code, ok: code >= 200 && code < 300 });
 const throwingFetch = async () => {
@@ -103,6 +109,27 @@ test("scanTyposquat flags dependency-confusion on a 404 unscoped name", async ()
   const findings = await scanTyposquat(npmAdd("acme-internal-utils"), status(404));
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "confusion");
+  assert.match(findings[0].reason, /publicly claimable/);
+});
+
+test("scanTyposquat scans npm alias targets for typosquats", async () => {
+  let called = false;
+  const findings = await scanTyposquat(npmAliasAdd("lodash", "l0dash", "^1.0.0"), async () => {
+    called = true;
+    return status(404)();
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "typosquat");
+  assert.equal(findings[0].package, "l0dash");
+  assert.equal(findings[0].version, "1.0.0");
+  assert.equal(called, false);
+});
+
+test("scanTyposquat scans npm alias targets for dependency-confusion", async () => {
+  const findings = await scanTyposquat(npmAliasAdd("react", "acme-internal-utils"), status(404));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "confusion");
+  assert.equal(findings[0].package, "acme-internal-utils");
   assert.match(findings[0].reason, /publicly claimable/);
 });
 


### PR DESCRIPTION
### Motivation
- Close a security-control bypass where npm alias dependency specifiers (e.g. `"foo": "npm:attacker@1.0.0"`) were not parsed, so the analyzer never saw the real registry package and skipped typosquat and dependency-confusion checks.
- Ensure the typosquat/dependency-confusion analyzer evaluates the actual package name and version that will be installed, preserving the existing semver parsing behavior.

### Description
- Change `review-enrichment/src/analyzers/dependency-scan.ts` to broaden the `NPM_RE` to capture the full package spec and add an `NPM_ALIAS_RE` to recognise `npm:target@version` alias specifiers and return the alias target name and version as the dependency entry.
- Preserve existing behaviour for ordinary semver specs by keeping the semver guard and stripping leading semver operators when appropriate.
- Add regression tests in `review-enrichment/test/typosquat.test.ts` including `npmAliasAdd` fixtures and tests that assert `scanTyposquat` now flags alias targets for both typosquat and dependency-confusion findings.

### Testing
- Ran the review-enrichment unit test suite with `npm run test --prefix review-enrichment`, which passed (all tests green, new alias-target tests included).
- Verified `git diff --check` returned clean results locally. 
- Attempted the full local gate with `npm run test:ci`, but it could not be completed due to an environment/network blocker in `actionlint` (WASM fallback reported a pre-existing custom runner label in `.github/workflows/self-host-nightly.yml`).
- Attempted `npm audit --audit-level=moderate`, which could not complete due to the npm registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4213d5264c832c94b9949de173304a)