### PR TITLE
fix(scoring): report issue close-window drift

### DIFF
--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -257,9 +257,6 @@ const NON_SCORING_UPSTREAM_CONSTANT_NAMES = new Set([
   // Fallback weight applied by the validator's load_programming_language_weights() for extensions absent from
   // the JSON file; gittensory reads the JSON directly and does not track this loader default (#1692).
   "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT",
-  // Validator-side window (days) within which a linked issue's close timestamp must fall relative to the PR
-  // merge to count as a valid link; gittensory's scoring preview does not model this linkage constraint (#1692).
-  "MAX_ISSUE_CLOSE_WINDOW_DAYS",
 ]);
 
 /**

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -391,22 +391,20 @@ NOVELTY_BONUS_SCALAR = 3
     expect(withScoringGap).toEqual(["NOVELTY_BONUS_SCALAR"]);
   });
 
-  it("excludes DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT and MAX_ISSUE_CLOSE_WINDOW_DAYS from unmodeled drift (#1692)", () => {
-    // Both are numeric constants in the live upstream constants.py that the parser successfully reads, but
-    // neither is a scoring dimension gittensory models — excluding them prevents perpetual false-positive
-    // drift warnings on every refreshScoringModelSnapshot run (same pattern as EMISSION_SHARE_TOLERANCE #809).
+  it("keeps linked-issue close-window constants visible as unmodeled drift (#1692)", () => {
+    // DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT is loader fallback metadata, but MAX_ISSUE_CLOSE_WINDOW_DAYS
+    // controls linked-issue eligibility; keep it visible until the preview models that scoring rule.
     const result = findUnmodeledUpstreamConstants(
       "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT = 0.12\nMAX_ISSUE_CLOSE_WINDOW_DAYS = 1\n",
     );
-    expect(result).toEqual([]);
+    expect(result).toEqual(["MAX_ISSUE_CLOSE_WINDOW_DAYS"]);
     expect(result).not.toContain("DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT");
-    expect(result).not.toContain("MAX_ISSUE_CLOSE_WINDOW_DAYS");
 
-    // A genuinely new upstream scoring dimension still surfaces alongside them.
+    // A genuinely new upstream scoring dimension still surfaces alongside the close-window gap.
     const withNewDimension = findUnmodeledUpstreamConstants(
       "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT = 0.12\nMAX_ISSUE_CLOSE_WINDOW_DAYS = 1\nNOVELTY_BONUS_SCALAR = 3\n",
     );
-    expect(withNewDimension).toEqual(["NOVELTY_BONUS_SCALAR"]);
+    expect(withNewDimension).toEqual(["MAX_ISSUE_CLOSE_WINDOW_DAYS", "NOVELTY_BONUS_SCALAR"]);
   });
 
   it("truncates the unmodeled-constants warning when upstream defines more than 12 (#809)", async () => {


### PR DESCRIPTION
### Motivation
- Restore reporting of `MAX_ISSUE_CLOSE_WINDOW_DAYS` as an unmodeled upstream constant because it controls linked-issue close-window eligibility and was mistakenly excluded, which hid a real scoring-model gap.

### Description
- Remove `MAX_ISSUE_CLOSE_WINDOW_DAYS` from `NON_SCORING_UPSTREAM_CONSTANT_NAMES` in `src/scoring/model.ts` so the constant surfaces in unmodeled-drift detection.
- Update the unit test in `test/unit/scoring.test.ts` to assert that `MAX_ISSUE_CLOSE_WINDOW_DAYS` is reported by `findUnmodeledUpstreamConstants` while `DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT` remains ignored.

### Testing
- Ran `npx vitest run test/unit/scoring.test.ts -t "close-window"`, which passed (1 passed, 73 skipped).
- Ran `npm run typecheck` (`tsc --noEmit`), which passed.
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate`, but those could not be completed locally due to environment/network limitations (actionlint setup retries / npm audit 403), so the full CI gate was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42162f3624832c98d81e059d2300ee)