### PR TITLE
ci(selfhost): pin sentry release cli

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -72,11 +72,12 @@ jobs:
           test -n "$SENTRY_AUTH_TOKEN"
           test -n "$SENTRY_ORG"
           test -n "$SENTRY_PROJECT"
-          npx -y @sentry/cli@latest releases new "$SENTRY_RELEASE"
-          npx -y @sentry/cli@latest releases set-commits "$SENTRY_RELEASE" --auto
-          npx -y @sentry/cli@latest sourcemaps inject dist
+          SENTRY_CLI=(npx -y --package @sentry/cli@2.58.2 sentry-cli)
+          "${SENTRY_CLI[@]}" releases new "$SENTRY_RELEASE"
+          "${SENTRY_CLI[@]}" releases set-commits "$SENTRY_RELEASE" --auto
+          "${SENTRY_CLI[@]}" sourcemaps inject dist
           node scripts/validate-selfhost-sourcemap.mjs
-          npx -y @sentry/cli@latest sourcemaps upload --release="$SENTRY_RELEASE" dist
+          "${SENTRY_CLI[@]}" sourcemaps upload --release="$SENTRY_RELEASE" dist
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -122,7 +123,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           SENTRY_RELEASE: ${{ steps.version.outputs.release }}
-        run: npx -y @sentry/cli@latest releases finalize "$SENTRY_RELEASE"
+        run: npx -y --package @sentry/cli@2.58.2 sentry-cli releases finalize "$SENTRY_RELEASE"
 
       - name: GitHub Release
         if: github.event_name == 'push'


### PR DESCRIPTION
### Motivation
- Remove a CI/CD supply-chain risk where unpinned `npx @sentry/cli@latest` was executed during the self-host release flow before the Docker `runtime-prebuilt` image build, which allowed a floating npm executable to modify the built `dist/server.mjs` that is later copied into the image.

### Description
- Replace floating invocations of `npx -y @sentry/cli@latest` in `.github/workflows/release-selfhost.yml` with a pinned, exact invocation using `@sentry/cli@2.58.2` via `npx -y --package @sentry/cli@2.58.2 sentry-cli` and reuse that command for release creation, commit association, source-map injection, upload, and finalization.

### Testing
- `git diff --check` was run and passed locally.
- `npm run actionlint` was attempted but the environment could not reach GitHub for the official setup and the WASM fallback reported an unrelated custom runner-label warning, so actionlint could not be fully validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4227c6cea0832c9e6041f23b189fc8)