### PR TITLE
fix(signals): redact /var/ paths in the manifest public-safe guard

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -289,10 +289,11 @@ const EMPTY_MANIFEST: FocusManifest = {
  * text must not leak reward, wallet/key, ranking, or local filesystem path material.
  */
 export function isFocusManifestPublicSafe(text: string): boolean {
-  // Local filesystem path alternatives mirror the canonical PUBLIC_UNSAFE_PATTERN in redaction.ts: include
-  // `/root/` (container/CI home) and accept the forward-slash Windows form (`C:/Users/`), not only the
-  // backslash one — otherwise a `/root/...` or `C:/Users/...` path leaks through this public-safe guard.
-  return !/\b(reward\w*|score\w*|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|farming|payouts?|rankings?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|private[-\s]?reviewability|reviewability(?:[-\s]?internals?)?|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)s?|estimated[-\s]?scores?|score[-\s]?(?:estimate|prediction|preview)s?)\b|\/Users\/|\/home\/|\/root\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i.test(text);
+  // Local filesystem path alternatives mirror the canonical PUBLIC_UNSAFE_PATTERN in redaction.ts: the full
+  // set is `/Users/`, `/home/`, `/root/` (container/CI home), `/var/` (logs, temp, CI workspaces), `/tmp/`,
+  // and the Windows `[A-Z]:[\/]Users[\/]` form (both slash directions). Any omission leaks that path prefix
+  // through this public-safe guard.
+  return !/\b(reward\w*|score\w*|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|farming|payouts?|rankings?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|private[-\s]?reviewability|reviewability(?:[-\s]?internals?)?|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)s?|estimated[-\s]?scores?|score[-\s]?(?:estimate|prediction|preview)s?)\b|\/Users\/|\/home\/|\/root\/|\/var\/|\/tmp\/|[A-Z]:[\\/]Users[\\/]/i.test(text);
 }
 
 function emptyManifest(source: FocusManifestSource, warnings: string[] = []): FocusManifest {

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -718,6 +718,7 @@ describe("public-safe invariant", () => {
     expect(isFocusManifestPublicSafe("see /Users/me/repo/src")).toBe(false);
     expect(isFocusManifestPublicSafe("see /home/dev/repo/src")).toBe(false);
     expect(isFocusManifestPublicSafe("see /root/repo/src")).toBe(false);
+    expect(isFocusManifestPublicSafe("see /var/log/build.log")).toBe(false);
     expect(isFocusManifestPublicSafe("see /tmp/build/out")).toBe(false);
     // Windows, both backslash and forward-slash forms.
     expect(isFocusManifestPublicSafe("see C:\\Users\\me\\repo")).toBe(false);


### PR DESCRIPTION
## The bug

`isFocusManifestPublicSafe` — the public-output safety gate used by contributor-issue drafts (`src/services/contributor-issue-draft.ts`) and decision packs (`src/services/decision-pack.ts`) — lists local-filesystem path prefixes that must mirror the canonical `PUBLIC_UNSAFE_PATTERN` in `src/signals/redaction.ts`:

| Path prefix | redaction.ts (canonical) | isFocusManifestPublicSafe |
|---|---|---|
| `/Users/` `/home/` `/root/` `/tmp/` | redacted | redacted |
| **`/var/`** | **redacted** | ❌ **leaks** |

So a manifest string containing a `/var/` path — `/var/log/...`, `/var/folders/...` (macOS temp), or a CI workspace under `/var/` — passes as public-safe and leaks a local filesystem path into public output.

## The fix

Add `/var/` to the path alternatives so the guard matches the canonical set exactly. One-line regex change; the forbidden-term list is untouched. This completes the canonical path parity for this guard.

## Tests

Extends the existing path regression test with a `/var/log/build.log` case (the test previously covered `/Users/`, `/home/`, `/root/`, `/tmp/`, and both Windows forms). Full local gate green; codecov patch covers the changed line; OpenAPI unchanged.

No linked issue: a one-line, self-evident security fix — no behavior change beyond closing the leak, no API/schema/DB change.