### PR TITLE
test(reviewability): cover the likely_duplicate action branch and its precedence

### DIFF
--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -1603,11 +1603,32 @@ describe("v2 signal builders", () => {
       repoFullName: repo.fullName,
       pullNumber: 10,
     });
+    // Two open PRs linking the same issue form a collision cluster. This uses the SAME high-quality inputs as
+    // `clean` (which yields review_now on score) to also pin precedence: the collision check runs before the
+    // score thresholds, so a duplicate cluster routes to likely_duplicate even when the score would say review_now.
+    const duplicateTarget = { ...cleanPr, state: "open" as const };
+    const duplicate = buildPullRequestReviewability({
+      repo,
+      pullRequest: duplicateTarget,
+      issues: [],
+      pullRequests: [duplicateTarget, { ...duplicateTarget, number: 11 }],
+      files: [
+        { repoFullName: repo.fullName, pullNumber: 10, path: "src/github/webhook.ts", additions: 20, deletions: 2, changes: 22, payload: {} },
+        { repoFullName: repo.fullName, pullNumber: 10, path: "test/unit/webhook.test.ts", additions: 25, deletions: 0, changes: 25, payload: {} },
+      ],
+      reviews: [{ id: "approved", repoFullName: repo.fullName, pullNumber: 10, state: "APPROVED", payload: {} }],
+      checks: [{ id: "ok", repoFullName: repo.fullName, pullNumber: 10, name: "test", status: "completed", conclusion: "success", payload: {} }],
+      recentMergedPullRequests: [],
+      repoFullName: repo.fullName,
+      pullNumber: 10,
+    });
 
     expect(clean.action).toBe("review_now");
     expect(closed.action).toBe("close_or_redirect");
     expect(maintainer.action).toBe("maintainer_lane");
     expect(watch.action).toBe("watch");
+    expect(duplicate.action).toBe("likely_duplicate");
+    expect(duplicate.whyThisHelps).toContain("Checking overlap first prevents maintainers from reviewing duplicate or soon-obsolete work.");
     expect(clean.maintainerNextSteps[0]).toContain("Review");
     expect(closed.maintainerNextSteps[0]).toContain("Redirect");
     expect(maintainer.maintainerNextSteps[0]).toContain("stewardship");


### PR DESCRIPTION
## Summary

`buildPullRequestReviewability` (`src/signals/reward-risk.ts`) routes a PR through a 6-way `action` classifier. Five of the six outcomes had dedicated assertions (`review_now`, `close_or_redirect`, `maintainer_lane`, `watch`, `needs_author`), but the **`likely_duplicate`** arm -- taken when `collisionClusters > 0` -- was only loosely regex-matched, never affirmatively asserted. A future refactor that reordered the ternary (e.g. scoring the PR before the duplicate check) could silently downgrade a duplicate cluster to `review_now` with no failing test.

## What this adds

A dedicated `likely_duplicate` case: two open PRs linking the same issue form a collision cluster and route to `likely_duplicate`. It is built from the **same high-quality inputs** as the existing `review_now` case, so it also pins **precedence** -- the collision check runs before the score thresholds, so a duplicate cluster routes to `likely_duplicate` even when the score alone would say `review_now`.

It also asserts the matching `whyThisHelps` line so the contributor-facing guidance for the duplicate arm is pinned alongside the routing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue -- this is a small, self-evident test-coverage addition over a routing-classifier branch.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/signals-v2.test.ts` 33/33 pass.

Targeted run:

```sh
npx vitest run test/unit/signals-v2.test.ts
# 33/33 passed
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- test-only.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- test-only change with no visible UI, frontend, docs, or extension surface.