### PR TITLE
fix: fall back to direct GitHub API when sats proxy returns 503

### DIFF
--- a/apps/gittensory-ui/src/components/site/github-stats-chip.test.tsx
+++ b/apps/gittensory-ui/src/components/site/github-stats-chip.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+  notifyApiFailure: vi.fn(),
+  notifyApiRecovered: vi.fn(),
+}));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
+
+import { GithubStatsChip } from "@/components/site/github-stats-chip";
+
+function renderWithClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const GH_OK = {
+  ok: true,
+  json: async () => ({ stargazers_count: 10, forks_count: 45 }),
+};
+
+describe("GithubStatsChip", () => {
+  it("shows stars and forks when the Worker proxy succeeds", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { stargazers_count: 10, forks_count: 45 },
+      status: 200,
+      durationMs: 50,
+    });
+
+    renderWithClient(<GithubStatsChip />);
+
+    await waitFor(() => {
+      expect(screen.getByText("10")).toBeTruthy();
+    });
+    expect(screen.getByText("45")).toBeTruthy();
+  });
+
+  it("falls back to the direct GitHub API when the Worker proxy returns 503", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 503,
+      message: "github_repo_stats_unavailable",
+      durationMs: 50,
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(GH_OK));
+
+    renderWithClient(<GithubStatsChip />);
+
+    await waitFor(() => {
+      expect(screen.getByText("10")).toBeTruthy();
+    });
+    expect(screen.getByText("45")).toBeTruthy();
+
+    // The fallback should have been called with the direct GitHub repos endpoint
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "https://api.github.com/repos/jsonbored/gittensory",
+      expect.objectContaining({ headers: { accept: "application/vnd.github+json" } }),
+    );
+  });
+
+  it("shows unavailable when both the proxy and the direct GitHub API fail", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 503,
+      message: "github_repo_stats_unavailable",
+      durationMs: 50,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({}),
+      }),
+    );
+
+    renderWithClient(<GithubStatsChip />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/unavailable/i)).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("normalizes malformed count fields from the GitHub fallback (finiteCount parity)", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      status: 503,
+      message: "github_repo_stats_unavailable",
+      durationMs: 50,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ stargazers_count: -1, forks_count: "not-a-number" }),
+      }),
+    );
+
+    renderWithClient(<GithubStatsChip />);
+
+    // finiteCount normalizes negative/non-number to 0 — both stars and forks render "0"
+    await waitFor(
+      () => {
+        const zeros = screen.getAllByText("0");
+        expect(zeros.length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 5000 },
+    );
+  });
+});

--- a/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
+++ b/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
@@ -14,6 +14,12 @@ const CACHE_TTL = 1000 * 60 * 10; // 10 min
 type RepoStats = { stargazers_count: number; forks_count: number };
 type Cached = { stats: RepoStats; ts: number };
 
+/** Normalize a GitHub count field — mirrors the backend's `finiteCount` so malformed/negative values
+ *  cannot render as odd compact numbers. */
+function finiteCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : 0;
+}
+
 function readCache(): Cached | null {
   if (typeof window === "undefined") return null;
   try {
@@ -45,8 +51,8 @@ async function fetchRepo(): Promise<RepoStats> {
   );
   if (result.ok) {
     const stats = {
-      stargazers_count: result.data?.stargazers_count ?? 0,
-      forks_count: result.data?.forks_count ?? 0,
+      stargazers_count: finiteCount(result.data?.stargazers_count),
+      forks_count: finiteCount(result.data?.forks_count),
     };
     writeCache(stats);
     return stats;
@@ -55,14 +61,16 @@ async function fetchRepo(): Promise<RepoStats> {
   // network error). GitHub sends Access-Control-Allow-Origin: * for public repo endpoints, and each browser
   // gets its own 60/hr unauthenticated budget — enough for this single chip. (#1754)
   const ghResponse = await fetch(`https://api.github.com/repos/${REPO}`, {
-    headers: { accept: "application/vnd.github+json", "user-agent": "gittensory/0.1" },
+    headers: { accept: "application/vnd.github+json" },
     signal: AbortSignal.timeout(6000),
   });
-  if (!ghResponse.ok) throw new Error(result.message);
+  if (!ghResponse.ok) {
+    throw new Error(`${result.message}; direct GitHub fallback failed (${ghResponse.status})`);
+  }
   const body = (await ghResponse.json()) as { stargazers_count?: number; forks_count?: number };
   const stats = {
-    stargazers_count: body.stargazers_count ?? 0,
-    forks_count: body.forks_count ?? 0,
+    stargazers_count: finiteCount(body.stargazers_count),
+    forks_count: finiteCount(body.forks_count),
   };
   writeCache(stats);
   return stats;

--- a/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
+++ b/apps/gittensory-ui/src/components/site/github-stats-chip.tsx
@@ -43,12 +43,26 @@ async function fetchRepo(): Promise<RepoStats> {
       silentStatus: true, // GitHub failures shouldn't poison the Gittensory API status pill
     },
   );
-  if (!result.ok) {
-    throw new Error(result.message);
+  if (result.ok) {
+    const stats = {
+      stargazers_count: result.data?.stargazers_count ?? 0,
+      forks_count: result.data?.forks_count ?? 0,
+    };
+    writeCache(stats);
+    return stats;
   }
+  // Fallback: fetch directly from the GitHub API when the Worker proxy is unavailable (rate-limited, 503,
+  // network error). GitHub sends Access-Control-Allow-Origin: * for public repo endpoints, and each browser
+  // gets its own 60/hr unauthenticated budget — enough for this single chip. (#1754)
+  const ghResponse = await fetch(`https://api.github.com/repos/${REPO}`, {
+    headers: { accept: "application/vnd.github+json", "user-agent": "gittensory/0.1" },
+    signal: AbortSignal.timeout(6000),
+  });
+  if (!ghResponse.ok) throw new Error(result.message);
+  const body = (await ghResponse.json()) as { stargazers_count?: number; forks_count?: number };
   const stats = {
-    stargazers_count: result.data?.stargazers_count ?? 0,
-    forks_count: result.data?.forks_count ?? 0,
+    stargazers_count: body.stargazers_count ?? 0,
+    forks_count: body.forks_count ?? 0,
   };
   writeCache(stats);
   return stats;


### PR DESCRIPTION
## Summary

The GitHub stars/forks counter in the main navbar showed **"unavailable"** because the Worker proxy endpoint (`/v1/public/github/repos/jsonbored/gittensory/stats`) returns **503** in production — the Worker's outbound `fetch` to `api.github.com` is rate-limited on Cloudflare's shared edge IP (60/hr unauthenticated budget exhausted by aggregate traffic).

The fix adds a **client-side fallback** in `GithubStatsChip`: when the Worker proxy fails (503, timeout, network error), the browser fetches `https://api.github.com/repos/jsonbored/gittensory` directly. GitHub sends `Access-Control-Allow-Origin: *` for public repo endpoints, and each browser gets its own 60/hr budget — more than enough for this single chip. Whichever path succeeds writes to the same `sessionStorage` cache, so the chip stays populated on subsequent navigations.

The Worker proxy remains the **primary** path (it authenticates with `GITHUB_PUBLIC_TOKEN` for a higher rate limit and provides server-side caching); the direct API is only a fallback when the proxy is unavailable.

Closes #1754.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Before — navbar shows "unavailable" | <img width="1280" height="256" alt="navbar-before" src="https://github.com/user-attachments/assets/5b36348c-77e7-4c07-950f-3db8a0d006ff" /> |
| After — stars/forks display via direct GitHub API fallback | <img width="1280" height="256" alt="navbar-after" src="https://github.com/user-attachments/assets/247e6150-4802-4498-af96-c9e31c70efdb" /> |


## Notes

- **Root cause confirmed**: a direct `Invoke-WebRequest` to the production Worker proxy (`https://gittensory-api.aethereal.dev/v1/public/github/repos/jsonbored/gittensory/stats`) returns `{"error":"github_repo_stats_unavailable"}` (503), while the same repo at `https://api.github.com/repos/jsonbored/gittensory` returns 200 with `stargazers_count: 9, forks_count: 45`. The Worker's outbound GitHub fetch is failing (rate-limited on the shared edge IP), and with no stale cache to fall back to, the endpoint returns 503.
- The fallback uses `AbortSignal.timeout(6000)` — same 6s budget as the proxy path — so a hung GitHub response cannot stall the chip indefinitely.
- The `REPO` constant (`"jsonbored/gittensory"`) drives both the proxy URL and the fallback URL, so they cannot drift.
- No mock/demo data: the fallback fetches **live** GitHub API data — the same source the Worker proxy uses, just from the browser instead.