### PR TITLE
fix(review): withhold malformed ai output

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -539,7 +539,6 @@ async function runWorkersOpinion(
   // Track the last provider error so we can fail-LOUD once ALL models × attempts are exhausted (below). Per-attempt
   // logs are warn (noisy retries, skipped by the central Sentry forwarder); the exhausted summary is error (#26).
   let lastError: unknown;
-  let lastUnstructuredText = "";
   let lastUnparseable:
     | { model: string; attempt: number; responseChars: number; hasJsonObject: boolean }
     | undefined;
@@ -570,7 +569,6 @@ async function runWorkersOpinion(
         const status = text.trim() ? "unparseable_output" : "empty_output";
         diagnostics.push({ model, attempt, status, responseChars: text.length, hasJsonObject });
         if (text.trim()) {
-          lastUnstructuredText = text;
           lastUnparseable = { model, attempt, responseChars: text.length, hasJsonObject };
           console.warn(
             JSON.stringify({
@@ -629,10 +627,7 @@ async function runWorkersOpinion(
       }),
     );
   }
-  return {
-    review: null,
-    ...(lastUnstructuredText ? { fallbackNote: lastUnstructuredText } : {}),
-  };
+  return { review: null };
 }
 
 const PROVIDER_DEFAULT_MODEL: Record<AiReviewProviderKey["provider"], string> =
@@ -740,7 +735,6 @@ async function runProviderReview(
   const review = textValue ? parseModelReview(textValue) : null;
   return {
     review,
-    ...(textValue && !review ? { fallbackNote: textValue } : {}),
     diagnostic: {
       model,
       attempt: 0,
@@ -1206,7 +1200,11 @@ export async function runGittensoryAiReview(
   const reviewsForNotes = [advisoryReview, secondReview].filter(
     (r): r is ModelReview => Boolean(r),
   );
-  if (fallbackNotes.length > 0 && reviewsForNotes.length === 0)
+  if (
+    reviewsForNotes.length === 0 &&
+    (fallbackNotes.length > 0 ||
+      reviewDiagnostics.some((diagnostic) => diagnostic.status === "unparseable_output"))
+  )
     inconclusive = true;
   const advisoryNotes =
     reviewsForNotes.length > 0

--- a/test/unit/ai-review-advisory.test.ts
+++ b/test/unit/ai-review-advisory.test.ts
@@ -524,7 +524,7 @@ describe("runAiReviewForAdvisory", () => {
     expect(adv.findings.map((f) => f.code)).toEqual(["ai_review_inconclusive"]);
   });
 
-  it("preserves public-safe unstructured AI text while holding the PR for manual review", async () => {
+  it("withholds unstructured AI text while holding the PR for manual review", async () => {
     const adv = advisory();
     const result = await runAiReviewForAdvisory(aiEnv(async () => ({ response: "Looks coherent, but please verify the new cache branch before merging." })), {
       settings: { aiReviewMode: "advisory" } as RepositorySettings,
@@ -534,9 +534,9 @@ describe("runAiReviewForAdvisory", () => {
       author: "alice",
       confirmedContributor: true,
     });
-    expect(result?.reviewerCount).toBe(1);
-    expect(result?.notes).toContain("returned public review text but not the expected structured verdict");
-    expect(result?.notes).toContain("Looks coherent");
+    expect(result?.reviewerCount).toBe(0);
+    expect(result?.notes).toContain("AI review could not be completed for this PR head");
+    expect(result?.notes).not.toContain("Looks coherent");
     expect(adv.findings.map((f) => f.code)).toEqual(["ai_review_inconclusive"]);
   });
 

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -571,7 +571,7 @@ describe("BYOK provider dispatch", () => {
     expect(run).not.toHaveBeenCalled(); // advisory mode + BYOK → no Workers AI call
   });
 
-  it("preserves public unstructured BYOK text as manual-review fallback diagnostics", async () => {
+  it("withholds unstructured BYOK text while recording diagnostics", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -600,9 +600,7 @@ describe("BYOK provider dispatch", () => {
       providerKey: { provider: "anthropic", key: "sk-ant-secret" },
     });
     expect(result.status === "ok" && result.inconclusive).toBe(true);
-    expect(result.status === "ok" && result.advisoryNotes).toContain(
-      "queue cache branch",
-    );
+    expect(result.status === "ok" && result.advisoryNotes).toBeNull();
     expect(result.status === "ok" && result.reviewDiagnostics).toEqual([
       expect.objectContaining({
         status: "unparseable_output",
@@ -734,7 +732,7 @@ describe("BYOK provider dispatch", () => {
 });
 
 describe("Workers AI fallback + degraded output", () => {
-  it("tries the per-slot fallback model then preserves public fallback notes when every opinion is unparseable", async () => {
+  it("tries the per-slot fallback model then withholds unparseable output from public notes", async () => {
     const run = vi.fn(async (_model: string) => ({
       response: "this is not json at all",
     }));
@@ -745,7 +743,7 @@ describe("Workers AI fallback + degraded output", () => {
       AI_DAILY_NEURON_BUDGET: "100000",
     });
     const result = await runGittensoryAiReview(env, baseInput);
-    expect(result.status === "ok" && result.advisoryNotes).toContain("this is not json at all");
+    expect(result.status === "ok" && result.advisoryNotes).toBeNull();
     expect(result.status === "ok" && result.inconclusive).toBe(true);
     // primary 3× + fallback 3× retries, all unparseable.
     expect(run).toHaveBeenCalledTimes(6);
@@ -861,7 +859,7 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
     expect(seen).toEqual(["claude-code"]); // the decision reviewer ran once; the advisory came from BYOK (fetch)
   });
 
-  it("single + BYOK: drops unsafe provider fallback text but keeps public reviewer fallback text", async () => {
+  it("single + BYOK: withholds unsafe provider and reviewer fallback text", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -892,8 +890,21 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
     });
     if (result.status !== "ok") throw new Error("expected ok");
     expect(result.inconclusive).toBe(true);
-    expect(result.advisoryNotes).toContain("recommends manual review");
-    expect(result.advisoryNotes).not.toContain("wallet");
+    expect(result.advisoryNotes).toBeNull();
+    expect(result.reviewDiagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          model: "claude-3-5-sonnet-latest",
+          status: "unparseable_output",
+        }),
+        expect.objectContaining({
+          model: "claude-code",
+          status: "unparseable_output",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(result)).not.toContain("wallet secret");
+    expect(JSON.stringify(result)).not.toContain("recommends manual review");
   });
 
   it("explicit input.reviewers/combine/onMerge override the env plan", async () => {
@@ -1324,7 +1335,7 @@ describe("pure helpers", () => {
     const run = vi.fn(async () => ({ response: "not json at all" }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
     const result = await runWorkersOpinion(env, "primary-model", "", "sys", "user", 256);
-    expect(result).toEqual({ review: null, fallbackNote: "not json at all" });
+    expect(result).toEqual({ review: null });
     expect(
       logSpy.mock.calls
         .map((c) => c[0])

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1516,7 +1516,8 @@ describe("queue processors", () => {
     expect(commentBodies[0]).toContain("is reviewing");
     const finalComment = commentBodies.find((body) => !body.includes("is reviewing"));
     expect(finalComment).toContain("Gittensory review needs maintainer review");
-    expect(finalComment).toContain("The AI reviewer returned public review text but not the expected structured verdict");
+    expect(finalComment).toContain("AI review could not be completed for this PR head");
+    expect(finalComment).not.toContain("The AI reviewer returned public review text but not the expected structured verdict");
     const cached = await env.DB.prepare("select count(*) as n from ai_review_cache where repo_full_name = ? and pull_number = ?")
       .bind("JSONbored/gittensory", 48)
       .first<{ n: number }>();


### PR DESCRIPTION
## Summary
- Withhold malformed model output from public AI review notes while preserving diagnostics.

## What changed
- Stops unparseable Workers AI and BYOK provider text from becoming fallback advisory notes.
- Keeps `reviewDiagnostics` and fail-closed inconclusive behavior when no parsed reviewer output is available.
- Updates review and queue tests to assert diagnostic-only handling for malformed output.

## Why
- Raw malformed model text can contain prompt-visible private context or unsafe content, so it should never be copied into public PR comments.

## Validation
- `git diff --check`
- `npx vitest run test/unit/ai-review.test.ts test/unit/ai-review-advisory.test.ts test/unit/queue.test.ts`
- `npm run typecheck`
- `npm run validate`