### PR TITLE
feat(mcp): add VS Code host to init-client config

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -46,6 +46,7 @@ gittensory-mcp cache clear
 gittensory-mcp init-client --print codex
 gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
+gittensory-mcp init-client --print vscode
 gittensory-mcp init-client --print codex --agent-profile miner-planner
 gittensory-mcp completion bash
 gittensory-mcp completion zsh
@@ -153,6 +154,10 @@ The same capabilities are exposed to MCP clients as:
 - `gittensory_agent_get_run`
 - `gittensory_agent_explain_next_action`
 - `gittensory_agent_prepare_pr_packet`
+
+### Client config
+
+`init-client --print <host>` prints the stdio MCP config for a host: `codex` (TOML), `claude`, `cursor`, and `mcp` (the shared `mcpServers` JSON shape), and `vscode` (VS Code's native `servers` map with `"type": "stdio"`, for `.vscode/mcp.json`). It prints config only; it never edits client files.
 
 ### Agent profiles
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1779,7 +1779,7 @@ function printHelp() {
   gittensory-mcp changelog [--json]
   gittensory-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   gittensory-mcp cache status|clear [--json]
-  gittensory-mcp init-client --print codex|claude|cursor|mcp [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
+  gittensory-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
   gittensory-mcp decision-pack --login <github-login> [--json]
   gittensory-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   gittensory-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--json]
@@ -2319,7 +2319,7 @@ function shellArg(value) {
 
 function initClient(options) {
   const client = String(options.print ?? options.client ?? "").toLowerCase();
-  if (!client) throw new Error("Pass --print codex, --print claude, --print cursor, or --print mcp.");
+  if (!client) throw new Error("Pass --print codex, --print claude, --print cursor, --print mcp, or --print vscode.");
   const command = options.command ?? "gittensory-mcp";
   const snippet = clientSnippet(client, command);
   const agentProfile = resolveAgentProfile(options.agentProfile);
@@ -2725,7 +2725,24 @@ function clientSnippet(client, command) {
       2,
     );
   }
-  throw new Error(`Unsupported client: ${client}. Use codex, claude, cursor, or mcp.`);
+  // VS Code's native MCP support uses a `servers` map with an explicit transport type, not the
+  // `mcpServers` shape the other JSON hosts use, so it needs its own snippet (see .vscode/mcp.json).
+  if (client === "vscode") {
+    return JSON.stringify(
+      {
+        servers: {
+          gittensory: {
+            type: "stdio",
+            command,
+            args: ["--stdio"],
+          },
+        },
+      },
+      null,
+      2,
+    );
+  }
+  throw new Error(`Unsupported client: ${client}. Use codex, claude, cursor, mcp, or vscode.`);
 }
 
 async function getDecisionPackWithCache(login) {

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -27,6 +27,13 @@ describe("gittensory-mcp CLI — basics", () => {
 
     const generic = JSON.parse(run(["init-client", "--print", "mcp", "--json"])) as { snippet: string };
     expect(generic.snippet).toBe(claude.snippet);
+
+    const vscode = JSON.parse(run(["init-client", "--print", "vscode", "--json"])) as { snippet: string };
+    // VS Code uses a `servers` map with an explicit transport type, not the `mcpServers` shape.
+    expect(vscode.snippet).toContain('"servers"');
+    expect(vscode.snippet).toContain('"type": "stdio"');
+    expect(vscode.snippet).toContain('"gittensory"');
+    expect(vscode.snippet).not.toContain('"mcpServers"');
   });
 
   it("prints human-approved agent profile instructions for supported MCP clients", () => {


### PR DESCRIPTION
## Summary

Adds `vscode` to `gittensory-mcp init-client --print`. VS Code has native MCP support, but its config uses a `servers` map with an explicit `"type": "stdio"` transport (for `.vscode/mcp.json`) — which is **different** from the shared `mcpServers` JSON shape that `claude`/`cursor`/`mcp` emit. So it gets its own snippet rather than reusing the generic one:

```json
{
  "servers": {
    "gittensory": {
      "type": "stdio",
      "command": "gittensory-mcp",
      "args": ["--stdio"]
    }
  }
}
```

This fills a real gap — VS Code is a primary MCP host and was previously rejected as an unsupported client.

## Scope

- `packages/gittensory-mcp/bin/gittensory-mcp.js` — `vscode` branch in `clientSnippet()` (the VS Code `servers`/`type` shape), plus the `init-client` "missing arg" error, the `clientSnippet` "unsupported" error, and the `--help` usage line.
- `test/unit/mcp-cli-basics.test.ts` — assert the VS Code snippet uses the `servers`/`type` shape and not `mcpServers`.
- `packages/gittensory-mcp/README.md` — list `vscode` and add a short "Client config" note on the per-host shapes.

Packages-only; no `src/**`, no UI, no schema/migration/OpenAPI changes. The agent-profile option composes with `vscode` automatically (no extra wiring).

## Validation

Run locally on Node v24.18.0 (engine floor is 22):

- `npm run build:mcp` → pass
- `npm run typecheck` → **pass, 0 errors** (full project, deps installed)
- `npx vitest run test/unit/mcp-cli-basics.test.ts` → **19/19 pass**, including the updated `prints MCP client snippets` case
- `npm pack --workspace @jsonbored/gittensory-mcp --dry-run` → package file list unchanged (only the already-allowed files; no new files, no secrets)
- Smoke: `init-client --print vscode` emits the shape above; `--print other` still errors as unsupported

Note: `npm run test:mcp-pack` couldn't run on my Windows box (its harness calls `spawnSync("npm", …)`, which can't resolve `npm.cmd` without a shell) — verified the package contents directly with `npm pack --dry-run` instead. It passes on CI (Linux).

## Safety

No auth, cookie, CORS, GitHub App output, identity, contributor-evidence, or scoring changes. No secrets/wallets/hotkeys/trust/reward terms anywhere. The generated snippet contains only the static command/args already documented for the other hosts.
