### PR TITLE
feat(selfhost): trace webhook requests through queue jobs

### DIFF
--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -5,6 +5,7 @@ import { sha256Hex, verifyGitHubSignature } from "../utils/crypto";
 import { parsePositiveInt } from "../utils/json";
 import { relayVerify } from "../orb/relay";
 import { isSelfHostedReviewRuntime } from "../selfhost/review-runtime";
+import { getSelfHostRequestTraceParent } from "../selfhost/trace-context";
 import { isSelfAuthoredWebhookNoise } from "./self-authored";
 
 const DEFAULT_MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
@@ -38,7 +39,7 @@ export async function handleGitHubWebhook(c: Context<{ Bindings: Env }>): Promis
  *  webhook receiver above AND the Orb relay receiver below (they verify the body differently — GitHub's HMAC vs the
  *  Orb relay HMAC — then share everything after). */
 export async function enqueueVerifiedWebhook(c: Context<{ Bindings: Env }>, deliveryId: string, eventName: string, rawBody: string): Promise<Response> {
-  const result = await enqueueWebhookByEnv(c.env, deliveryId, eventName, rawBody);
+  const result = await enqueueWebhookByEnv(c.env, deliveryId, eventName, rawBody, getSelfHostRequestTraceParent(c.req.raw));
   switch (result) {
     case "review_unavailable":
       return c.json({ error: "selfhost_review_runtime_required" }, 410);
@@ -65,7 +66,7 @@ export type EnqueueWebhookResult = "queued" | "duplicate" | "ignored" | "invalid
  *  webhooks at /v1/orb/webhook and forwards/pends them for registered self-host engines. Direct review execution
  *  now requires the self-host runtime cache so stale Cloudflare review-webhook traffic fails loudly instead of being
  *  accepted into a Worker path that no longer performs reviews. */
-export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventName: string, rawBody: string): Promise<EnqueueWebhookResult> {
+export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventName: string, rawBody: string, traceParent?: string): Promise<EnqueueWebhookResult> {
   if (!isSelfHostedReviewRuntime(env)) return "review_unavailable";
 
   let payload: GitHubWebhookPayload;
@@ -104,7 +105,7 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
 
   await recordWebhookEvent(env, { ...eventRow, status: "queued" });
 
-  const message: JobMessage = { type: "github-webhook", deliveryId, eventName, payload };
+  const message: JobMessage = { type: "github-webhook", deliveryId, eventName, payload, ...(traceParent ? { traceParent } : {}) };
   try {
     // Send to the dedicated WEBHOOKS lane (not the shared JOBS queue) so a maintenance burst on JOBS can never
     // starve real GitHub events into the DLQ. (#audit-webhook-queue)

--- a/src/selfhost/otel.ts
+++ b/src/selfhost/otel.ts
@@ -8,6 +8,7 @@ type OtelProvider = {
   forceFlush(): Promise<void>;
   shutdown(): Promise<void>;
 };
+type SpanOptions = { parentTraceParent?: string | undefined };
 
 let Otel: OtelApi | undefined;
 let provider: OtelProvider | undefined;
@@ -18,6 +19,7 @@ const contextStore = new AsyncLocalStorage<Context>();
 const SECRET_KEY =
   /(token|secret|key|password|passwd|authorization|auth|dsn|cookie|bearer|credential|private)/i;
 const MAX_ATTRIBUTE_LENGTH = 160;
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i;
 
 function nonBlank(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -76,6 +78,42 @@ export function otelSafeAttributes(input: Record<string, unknown> | undefined): 
   return out;
 }
 
+const SELFHOST_STATIC_ROUTES = new Set([
+  "/mcp",
+  "/v1/github/webhook",
+  "/v1/orb/relay",
+  "/v1/orb/relay/pull",
+  "/v1/orb/webhook",
+]);
+
+function selfHostHttpRoute(path: string): string {
+  if (SELFHOST_STATIC_ROUTES.has(path)) return path;
+  if (path.startsWith("/v1/internal/")) return "/v1/internal/*";
+  return path.startsWith("/v1/") ? "/v1/*" : "other";
+}
+
+export function selfHostHttpRequestAttributes(request: Request, path = new URL(request.url).pathname): Record<string, unknown> {
+  const route = selfHostHttpRoute(path);
+  const attrs: Record<string, unknown> = {
+    "http.request.method": request.method,
+    "http.route": route,
+  };
+  const eventName = request.headers.get("x-github-event")?.trim();
+  if (eventName && (route === "/v1/github/webhook" || route === "/v1/orb/relay" || route === "/v1/orb/webhook"))
+    attrs["github.webhook.event"] = eventName;
+  if (route === "/v1/github/webhook") attrs["selfhost.webhook.transport"] = "github";
+  else if (route === "/v1/orb/relay") attrs["selfhost.webhook.transport"] = "orb-relay";
+  else if (route === "/v1/orb/webhook") attrs["selfhost.webhook.transport"] = "orb";
+  return attrs;
+}
+
+export function selfHostHttpResponseAttributes(status: number): Record<string, unknown> {
+  return {
+    "http.response.status_code": status,
+    "http.response.status_class": `${Math.floor(status / 100)}xx`,
+  };
+}
+
 /** Initialize self-host OTEL traces. No global provider registration: Sentry can coexist when both are enabled. */
 export async function initOpenTelemetry(env: NodeJS.ProcessEnv): Promise<boolean> {
   const endpoint = resolveOtelTraceEndpoint(env);
@@ -107,13 +145,40 @@ function statusMessage(error: unknown): string {
   return exceptionFor(error).message.slice(0, MAX_ATTRIBUTE_LENGTH);
 }
 
+function activeContextFromTraceParent(traceParent: string | undefined): Context | undefined {
+  if (!traceParent || !Otel) return undefined;
+  const match = TRACEPARENT_RE.exec(traceParent.trim());
+  if (!match) return undefined;
+  return Otel.trace.setSpanContext(Otel.context.active(), {
+    traceId: match[1]!.toLowerCase(),
+    spanId: match[2]!.toLowerCase(),
+    traceFlags: Number.parseInt(match[3]!, 16) & 1,
+    isRemote: true,
+  });
+}
+
+export function currentOtelTraceParent(): string | undefined {
+  if (!active || !Otel) return undefined;
+  const spanContext = Otel.trace.getSpanContext(contextStore.getStore() ?? Otel.context.active());
+  if (!spanContext) return undefined;
+  const flags = (spanContext.traceFlags & 1).toString(16).padStart(2, "0");
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${flags}`;
+}
+
+export function setCurrentOtelSpanAttributes(attributes: Record<string, unknown>): void {
+  if (!active || !Otel) return;
+  const span = Otel.trace.getSpan(contextStore.getStore() ?? Otel.context.active());
+  span?.setAttributes(otelSafeAttributes(attributes));
+}
+
 export async function withOtelSpan<T>(
   name: string,
   attributes: Record<string, unknown> | undefined,
   fn: () => T | Promise<T>,
+  options?: SpanOptions,
 ): Promise<T> {
   if (!active || !Otel || !tracer) return await fn();
-  const parentContext = contextStore.getStore() ?? Otel.context.active();
+  const parentContext = activeContextFromTraceParent(options?.parentTraceParent) ?? contextStore.getStore() ?? Otel.context.active();
   const span = tracer.startSpan(name, { attributes: otelSafeAttributes(attributes) }, parentContext);
   const childContext = Otel.trace.setSpan(parentContext, span);
   return await contextStore.run(childContext, async () => {

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -344,6 +344,7 @@ export function createPgQueue(
           "selfhost.queue.job",
           { "job.type": message.type, "queue.backend": "postgres", "job.attempt": Number(job.attempts) + 1 },
           () => consume(message),
+          { parentTraceParent: message.type === "github-webhook" ? message.traceParent : undefined },
         );
         await pool.query(`DELETE FROM ${TABLE} WHERE id=$1`, [job.id]);
         await recordQueueMetric("gittensory_jobs_processed_total");

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -287,6 +287,7 @@ export function createSqliteQueue(
           "selfhost.queue.job",
           { "job.type": message.type, "queue.backend": "sqlite", "job.attempt": job.attempts + 1 },
           () => consume(message),
+          { parentTraceParent: message.type === "github-webhook" ? message.traceParent : undefined },
         );
         driver.query(`DELETE FROM ${TABLE} WHERE id=?`, [job.id]);
         recordQueueMetric(driver, "gittensory_jobs_processed_total");

--- a/src/selfhost/trace-context.ts
+++ b/src/selfhost/trace-context.ts
@@ -1,0 +1,14 @@
+const requestTraceParents = new WeakMap<Request, string>();
+
+export function setSelfHostRequestTraceParent(request: Request, traceParent: string | undefined): void {
+  if (traceParent) requestTraceParents.set(request, traceParent);
+  else requestTraceParents.delete(request);
+}
+
+export function getSelfHostRequestTraceParent(request: Request): string | undefined {
+  return requestTraceParents.get(request);
+}
+
+export function clearSelfHostRequestTraceParent(request: Request): void {
+  requestTraceParents.delete(request);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,9 +59,18 @@ import {
   installStructuredLogForwarding,
 } from "./selfhost/sentry";
 import {
+  currentOtelTraceParent,
   initOpenTelemetry,
+  selfHostHttpRequestAttributes,
+  selfHostHttpResponseAttributes,
+  setCurrentOtelSpanAttributes,
   shutdownOpenTelemetry,
+  withOtelSpan,
 } from "./selfhost/otel";
+import {
+  clearSelfHostRequestTraceParent,
+  setSelfHostRequestTraceParent,
+} from "./selfhost/trace-context";
 import {
   setLocalManifestReader,
   setLocalReviewContextReader,
@@ -672,44 +681,56 @@ async function main(): Promise<void> {
             );
           }
         }
-        // Instrument real app traffic — status-class counter + latency histogram. (Infra endpoints
-        // /health /ready /metrics and the setup wizard already returned above and are not counted.)
-        const startedReq = Date.now();
-        const record = (status: number): void => {
-          incr("gittensory_http_requests_total", {
-            status: `${Math.floor(status / 100)}xx`,
-          });
-          observe(
-            "gittensory_http_request_duration_seconds",
-            (Date.now() - startedReq) / 1000,
-          );
-        };
-        // Webhook delivery dedup: return 204 immediately for already-processed delivery IDs.
-        // We mark only AFTER a successful response — failed/rejected webhooks must be retryable.
-        const isWebhook =
-          webhookCache &&
-          path === "/v1/github/webhook" &&
-          request.method === "POST";
-        const deliveryId = isWebhook
-          ? request.headers.get("x-github-delivery")
-          : null;
-        if (deliveryId) {
-          const seen = await webhookCache!.get(`delivery:${deliveryId}`);
-          if (seen) {
-            incr("gittensory_webhook_dedup_total");
-            record(204);
-            return new Response(null, { status: 204 });
-          }
-        }
-        const response = await worker.fetch(request, env, ctx);
-        if (deliveryId && response.ok) {
-          // Best-effort — never block the response on a cache write failure
-          void webhookCache!
-            .set(`delivery:${deliveryId}`, "1", 300)
-            .catch(() => undefined);
-        }
-        record(response.status);
-        return response;
+        return await withOtelSpan(
+          "selfhost.http.request",
+          selfHostHttpRequestAttributes(request, path),
+          async () => {
+            const traceParent = currentOtelTraceParent();
+            if (traceParent) setSelfHostRequestTraceParent(request, traceParent);
+            try {
+              // Instrument real app traffic — status-class counter + latency histogram. (Infra endpoints
+              // /health /ready /metrics and the setup wizard already returned above and are not counted.)
+              const startedReq = Date.now();
+              const finish = (response: Response): Response => {
+                incr("gittensory_http_requests_total", {
+                  status: `${Math.floor(response.status / 100)}xx`,
+                });
+                observe(
+                  "gittensory_http_request_duration_seconds",
+                  (Date.now() - startedReq) / 1000,
+                );
+                setCurrentOtelSpanAttributes(selfHostHttpResponseAttributes(response.status));
+                return response;
+              };
+              // Webhook delivery dedup: return 204 immediately for already-processed delivery IDs.
+              // We mark only AFTER a successful response — failed/rejected webhooks must be retryable.
+              const isWebhook =
+                webhookCache &&
+                path === "/v1/github/webhook" &&
+                request.method === "POST";
+              const deliveryId = isWebhook
+                ? request.headers.get("x-github-delivery")
+                : null;
+              if (deliveryId) {
+                const seen = await webhookCache!.get(`delivery:${deliveryId}`);
+                if (seen) {
+                  incr("gittensory_webhook_dedup_total");
+                  return finish(new Response(null, { status: 204 }));
+                }
+              }
+              const response = await worker.fetch(request, env, ctx);
+              if (deliveryId && response.ok) {
+                // Best-effort — never block the response on a cache write failure
+                void webhookCache!
+                  .set(`delivery:${deliveryId}`, "1", 300)
+                  .catch(() => undefined);
+              }
+              return finish(response);
+            } finally {
+              clearSelfHostRequestTraceParent(request);
+            }
+          },
+        );
       },
       port,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export type JobMessage =
       // Set when the DLQ consumer re-drives a dead-lettered webhook back onto the lane (#1276). Bounds the
       // self-heal to a single re-drive so a genuinely-poison payload cannot loop the webhook DLQ forever.
       redriven?: boolean;
+      /** Self-host OTEL trace context for connecting ingress → queued review work. */
+      traceParent?: string;
     }
   | {
       // Delayed self-poll to re-capture a PR's before/after preview once its preview deploy is live — the first

--- a/test/unit/selfhost-otel.test.ts
+++ b/test/unit/selfhost-otel.test.ts
@@ -21,13 +21,22 @@ vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
 }));
 
 import {
+  currentOtelTraceParent,
   flushOpenTelemetry,
   initOpenTelemetry,
   otelSafeAttributes,
   resetOpenTelemetryForTest,
   resolveOtelTraceEndpoint,
+  selfHostHttpRequestAttributes,
+  selfHostHttpResponseAttributes,
+  setCurrentOtelSpanAttributes,
   withOtelSpan,
 } from "../../src/selfhost/otel";
+import {
+  clearSelfHostRequestTraceParent,
+  getSelfHostRequestTraceParent,
+  setSelfHostRequestTraceParent,
+} from "../../src/selfhost/trace-context";
 
 const env = (values: Record<string, string>): NodeJS.ProcessEnv => values as unknown as NodeJS.ProcessEnv;
 
@@ -53,6 +62,8 @@ describe("self-host OpenTelemetry", () => {
     expect(await initOpenTelemetry(env({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318" }))).toBe(false);
     await flushOpenTelemetry();
     await expect(withOtelSpan("off", { "job.type": "x" }, () => 42)).resolves.toBe(42);
+    expect(currentOtelTraceParent()).toBeUndefined();
+    setCurrentOtelSpanAttributes({ ignored: true });
     expect(otelMocks.OTLPTraceExporter).not.toHaveBeenCalled();
   });
 
@@ -133,6 +144,101 @@ describe("self-host OpenTelemetry", () => {
     expect(child.events.map((event: { name: string }) => event.name)).toContain("exception");
     expect(child.attributes.secretToken).toBeUndefined();
     expect(child.parentSpanContext.spanId).toBe(parent.spanContext().spanId);
+  });
+
+  it("injects traceparent context and resumes later spans from it", async () => {
+    await initOpenTelemetry(env({
+      OTEL_TRACES_EXPORTER: "otlp",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://collector/v1/traces",
+    }));
+    expect(currentOtelTraceParent()).toBeUndefined();
+    setCurrentOtelSpanAttributes({ ignored: true });
+    let traceParent: string | undefined;
+    await withOtelSpan("selfhost.http.request", undefined, () => {
+      traceParent = currentOtelTraceParent();
+      setCurrentOtelSpanAttributes({
+        "http.response.status_code": 202,
+        secretHeader: "drop",
+      });
+    });
+    expect(traceParent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    await withOtelSpan("selfhost.queue.job", { "job.type": "github-webhook" }, () => undefined, { parentTraceParent: traceParent });
+    await withOtelSpan("invalid-parent", undefined, () => undefined, { parentTraceParent: "not-a-traceparent" });
+    await flushOpenTelemetry();
+
+    const root = otelMocks.exportedSpans.find((span) => span.name === "selfhost.http.request");
+    const child = otelMocks.exportedSpans.find((span) => span.name === "selfhost.queue.job");
+    const invalid = otelMocks.exportedSpans.find((span) => span.name === "invalid-parent");
+    expect(root.attributes).toMatchObject({ "http.response.status_code": 202 });
+    expect(root.attributes.secretHeader).toBeUndefined();
+    expect(child.parentSpanContext.spanId).toBe(root.spanContext().spanId);
+    expect(invalid.parentSpanContext).toBeUndefined();
+  });
+
+  it("builds low-cardinality self-host HTTP span attributes", () => {
+    expect(
+      selfHostHttpRequestAttributes(
+        new Request("https://self.example/v1/github/webhook", {
+          method: "POST",
+          headers: { "x-github-event": "pull_request" },
+        }),
+      ),
+    ).toEqual({
+      "http.request.method": "POST",
+      "http.route": "/v1/github/webhook",
+      "github.webhook.event": "pull_request",
+      "selfhost.webhook.transport": "github",
+    });
+    expect(
+      selfHostHttpRequestAttributes(
+        new Request("https://self.example/v1/orb/relay", {
+          method: "POST",
+          headers: { "x-github-event": "check_run" },
+        }),
+      ),
+    ).toMatchObject({
+      "http.route": "/v1/orb/relay",
+      "github.webhook.event": "check_run",
+      "selfhost.webhook.transport": "orb-relay",
+    });
+    expect(
+      selfHostHttpRequestAttributes(
+        new Request("https://self.example/v1/orb/webhook", {
+          method: "POST",
+          headers: { "x-github-event": "installation" },
+        }),
+      ),
+    ).toMatchObject({
+      "http.route": "/v1/orb/webhook",
+      "selfhost.webhook.transport": "orb",
+    });
+    expect(selfHostHttpRequestAttributes(new Request("https://self.example/v1/internal/jobs/refresh-registry"))).toMatchObject({
+      "http.route": "/v1/internal/*",
+    });
+    expect(selfHostHttpRequestAttributes(new Request("https://self.example/v1/repos/acme/widgets"))).toMatchObject({
+      "http.route": "/v1/*",
+    });
+    expect(selfHostHttpRequestAttributes(new Request("https://self.example/favicon.ico"))).toMatchObject({
+      "http.route": "other",
+    });
+    expect(selfHostHttpResponseAttributes(204)).toEqual({
+      "http.response.status_code": 204,
+      "http.response.status_class": "2xx",
+    });
+  });
+
+  it("stores request trace context only for the exact Request object", () => {
+    const request = new Request("https://self.example/v1/github/webhook");
+    const other = new Request("https://self.example/v1/github/webhook");
+    setSelfHostRequestTraceParent(request, "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01");
+    expect(getSelfHostRequestTraceParent(request)).toBe("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01");
+    expect(getSelfHostRequestTraceParent(other)).toBeUndefined();
+    setSelfHostRequestTraceParent(request, undefined);
+    expect(getSelfHostRequestTraceParent(request)).toBeUndefined();
+    setSelfHostRequestTraceParent(request, "00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01");
+    clearSelfHostRequestTraceParent(request);
+    expect(getSelfHostRequestTraceParent(request)).toBeUndefined();
   });
 
   it("uses safe defaults and captures non-Error failures", async () => {

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -3,6 +3,10 @@ import type { Context } from "hono";
 import { handleGitHubWebhook, handleOrbRelay } from "../../src/github/webhook";
 import { getWebhookEvent, recordWebhookEvent } from "../../src/db/repositories";
 import { relaySignature } from "../../src/orb/relay";
+import {
+  clearSelfHostRequestTraceParent,
+  setSelfHostRequestTraceParent,
+} from "../../src/selfhost/trace-context";
 import { createTestEnv } from "../helpers/d1";
 
 describe("github webhook body reader edge cases", () => {
@@ -214,6 +218,41 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     await expect(response.json()).resolves.toMatchObject({ status: "queued" });
     expect(webhookSends).toBe(1); // routed to the dedicated webhook lane
     expect(jobsSends).toBe(0); // never the shared maintenance queue
+  });
+
+  it("copies the internal self-host traceparent onto queued webhook jobs", async () => {
+    const env = createTestEnv();
+    const sent: import("../../src/types").JobMessage[] = [];
+    env.WEBHOOKS = { send: async (message: unknown) => void sent.push(message as import("../../src/types").JobMessage) } as unknown as Queue;
+    const rawBody = JSON.stringify({ action: "opened", repository: { full_name: "JSONbored/gittensory" }, installation: { id: 1 } });
+    const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
+    const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
+    const traceParent = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+    setSelfHostRequestTraceParent(request, traceParent);
+    const headers: Record<string, string> = {
+      "x-github-delivery": "traceparent-1",
+      "x-github-event": "pull_request",
+      "x-hub-signature-256": signature,
+    };
+    const context = {
+      req: {
+        raw: request,
+        header(name: string) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+      env,
+      json(payload: unknown, status?: number) {
+        return Response.json(payload, status === undefined ? undefined : { status });
+      },
+    } as unknown as Context<{ Bindings: Env }>;
+
+    const response = await handleGitHubWebhook(context);
+    clearSelfHostRequestTraceParent(request);
+
+    expect(response.status).toBe(202);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: "github-webhook", traceParent });
   });
 
   it("drops self-authored app comment webhooks before they add queue pressure", async () => {


### PR DESCRIPTION
## Summary
- Add self-host HTTP request root spans for non-health app traffic.
- Propagate internal traceparent context from webhook ingress into queued GitHub webhook jobs.
- Resume webhook queue spans from that context in both SQLite and Postgres self-host queues.

## What changed
- Added low-cardinality HTTP route/status attributes for self-host OTEL spans.
- Added request-scoped trace context storage keyed by the exact incoming Request.
- Copied internal trace context onto webhook queue messages and resumed it during queue consumption.
- Covered disabled-OTEL no-op behavior, traceparent continuation, HTTP attribute invariants, request context isolation, and webhook queue propagation.

## Why
Self-host operators who enable OTEL can now follow a webhook from inbound HTTP handling into async review processing, making Grafana/Tempo trace inspection and incident debugging much more direct without changing behavior when OTEL is disabled.

## Validation
- `npm run typecheck`
- `git diff --check`
- `npx vitest run test/unit/selfhost-otel.test.ts test/unit/webhook.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts`
- `npm run test:coverage`
- `npm run test:ci`
- `npm audit --audit-level=moderate`

## Notes
Closes #1778