### PR TITLE
fix(review): enforce blocker-first PR verdicts

### DIFF
--- a/migrations/0084_pull_request_linked_issue_claimed_at.sql
+++ b/migrations/0084_pull_request_linked_issue_claimed_at.sql
@@ -1,0 +1,7 @@
+ALTER TABLE pull_requests ADD COLUMN linked_issue_claimed_at TEXT;
+
+UPDATE pull_requests
+SET linked_issue_claimed_at = COALESCE(json_extract(payload_json, '$.updated_at'), updated_at, created_at)
+WHERE linked_issues_json IS NOT NULL
+  AND linked_issues_json != '[]'
+  AND linked_issues_json != '';

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -304,7 +304,21 @@ export async function upsertPullRequestFromGitHub(
 ): Promise<PullRequestRecord> {
   const record = toPullRequestRecord(repoFullName, pr);
   const db = getDb(env.DB);
-  const lastSeenOpenAt = pr.state === "open" ? (options.seenOpenAt ?? nowIso()) : null;
+  const syncedAt = nowIso();
+  const lastSeenOpenAt = pr.state === "open" ? (options.seenOpenAt ?? syncedAt) : null;
+  const linkedIssuesJson = jsonString(record.linkedIssues);
+  const observedLinkedIssueClaimedAt = record.linkedIssues.length > 0 ? syncedAt : null;
+  const existingClaimRows = await db
+    .select({ linkedIssuesJson: pullRequests.linkedIssuesJson, linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt })
+    .from(pullRequests)
+    .where(and(eq(pullRequests.repoFullName, repoFullName), eq(pullRequests.number, pr.number)))
+    .limit(1);
+  const linkedIssueClaimedAt =
+    record.linkedIssues.length === 0
+      ? null
+      : existingClaimRows[0]?.linkedIssuesJson === linkedIssuesJson
+        ? (existingClaimRows[0].linkedIssueClaimedAt ?? observedLinkedIssueClaimedAt)
+        : observedLinkedIssueClaimedAt;
   await db
     .insert(pullRequests)
     .values({
@@ -321,10 +335,11 @@ export async function upsertPullRequestFromGitHub(
       mergedAt: pr.merged_at ?? undefined,
       htmlUrl: pr.html_url,
       labelsJson: jsonString(record.labels),
-      linkedIssuesJson: jsonString(record.linkedIssues),
+      linkedIssuesJson,
+      linkedIssueClaimedAt,
       lastSeenOpenAt,
       payloadJson: jsonString(compactGitHubPayload(pr)),
-      updatedAt: nowIso(),
+      updatedAt: syncedAt,
     })
     .onConflictDoUpdate({
       target: [pullRequests.repoFullName, pullRequests.number],
@@ -339,13 +354,17 @@ export async function upsertPullRequestFromGitHub(
         mergedAt: pr.merged_at ?? undefined,
         htmlUrl: pr.html_url,
         labelsJson: jsonString(record.labels),
-        linkedIssuesJson: jsonString(record.linkedIssues),
+        linkedIssuesJson,
+        linkedIssueClaimedAt:
+          record.linkedIssues.length === 0
+            ? null
+            : sql`CASE WHEN ${pullRequests.linkedIssuesJson} = ${linkedIssuesJson} THEN COALESCE(${pullRequests.linkedIssueClaimedAt}, ${observedLinkedIssueClaimedAt}) ELSE ${observedLinkedIssueClaimedAt} END`,
         lastSeenOpenAt,
         payloadJson: jsonString(compactGitHubPayload(pr)),
-        updatedAt: nowIso(),
+        updatedAt: syncedAt,
       },
     });
-  return record;
+  return { ...record, linkedIssueClaimedAt };
 }
 
 export async function upsertIssueFromGitHub(env: Env, repoFullName: string, issue: GitHubIssuePayload, options: { seenOpenAt?: string } = {}): Promise<IssueRecord> {
@@ -4201,6 +4220,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     createdAt: payload.created_at,
     updatedAt: payload.updated_at ?? row.updatedAt,
     closedAt: payload.closed_at,
+    linkedIssueClaimedAt: row.linkedIssueClaimedAt,
     labels: parseJson<string[]>(row.labelsJson, []),
     linkedIssues: parseJson<number[]>(row.linkedIssuesJson, []),
     slopRisk: row.slopRisk,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -283,6 +283,7 @@ export const pullRequests = sqliteTable(
     htmlUrl: text("html_url"),
     labelsJson: text("labels_json").notNull().default("[]"),
     linkedIssuesJson: text("linked_issues_json").notNull().default("[]"),
+    linkedIssueClaimedAt: text("linked_issue_claimed_at"),
     lastSeenOpenAt: text("last_seen_open_at"),
     payloadJson: text("payload_json").notNull().default("{}"),
     // Latest deterministic slop assessment (gittensory-computed; written separately from the GitHub sync).

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -65,6 +65,7 @@ import {
   GITTENSORY_GATE_CHECK_NAME,
   GITTENSORY_LEGACY_GATE_CHECK_NAME,
 } from "../review/check-names";
+import { buildReviewThreadBlocker, type ReviewThreadBlocker } from "../review/review-thread-findings";
 import { delayUntil, shouldWaitForGitHubRateLimit } from "./rate-limit";
 
 type GitHubLabelPayload = {
@@ -1943,13 +1944,10 @@ export type LiveCiAggregate = {
   // than ciState: a non-required pending check must not fail the gate, but review execution should still wait
   // until every visible CI signal has settled.
   hasPending: boolean;
-  // Checks that FAIL the gate: every failing check when required contexts are unknown, else only the failing
-  // REQUIRED contexts. These drive ciState === "failed" and the disposition (no-merge / close / request-changes).
+  // Checks that FAIL the gate. Any completed red check/status is adverse, required or not; required contexts are
+  // still used for absent/pending detection so missing required CI cannot silently pass.
   failingDetails: Array<{ name: string; summary?: string; detailsUrl?: string }>;
-  // RC2: checks that are RED but NOT in branch-protection's required set (e.g. codecov/patch, codecov/project).
-  // Surfaced to the contributor but they do NOT fail the gate, block merge/approve, or force request_changes.
-  // Empty when required contexts are unknown (best-effort fetch failed / no protection) — then every red check
-  // stays in failingDetails (byte-identical to pre-RC2).
+  // Historical compatibility: non-required red checks are now folded into failingDetails so this stays empty.
   nonRequiredFailingDetails: Array<{ name: string; summary?: string; detailsUrl?: string }>;
 };
 
@@ -1985,20 +1983,17 @@ export async function fetchRequiredStatusContexts(env: Env, repoFullName: string
  * reviewbot `getAllChecksState` parity that the converged auto-maintain path needs: codecov (codecov/patch,
  * codecov/project) and many other tools post a classic COMMIT-STATUS, not a check-run — fetching only
  * `/check-runs` (what the backfill sync does) misses them entirely, which is why a red codecov was reported as
- * "CI green". When branch-protection required contexts are known, only those trusted contexts gate review or
- * automation; non-required failures are reported separately. When required contexts cannot be determined, we
- * conservatively fold all checks/statuses into the gate so required red checks are not silently ignored.
- * Best-effort: a fetch error degrades that source to empty.
+ * "CI green". Any completed red check/status is adverse and fails the aggregate, required or not. Branch
+ * protection contexts are still used for required-context absence/pending detection. Best-effort: a fetch error
+ * degrades that source to empty.
  */
 export async function fetchLiveCiAggregate(
   env: Env,
   repoFullName: string,
   headSha: string | null | undefined,
   token: string | undefined,
-  // Branch-protection REQUIRED contexts are the trust boundary for CI gate authority. Non-required checks may be
-  // influenced by PR authors or third-party actors, so they are surfaced as advisory details but must not defer
-  // review, fail the merge gate, or drive automated close decisions. If required contexts are unavailable, fall
-  // back to gating on all contexts to avoid silently passing an unknown required failure.
+  // Branch-protection REQUIRED contexts are the trust boundary for required-context absence/pending detection.
+  // Completed red checks/statuses still fail the aggregate even when they are not branch-protection-required.
   requiredContexts?: ReadonlySet<string> | null,
 ): Promise<LiveCiAggregate> {
   if (!headSha) return { ciState: "unverified", hasPending: false, failingDetails: [], nonRequiredFailingDetails: [] };
@@ -2046,8 +2041,7 @@ export async function fetchLiveCiAggregate(
       const status = (run.status ?? "").toLowerCase();
       if (conclusion ? CI_FAILING_CONCLUSIONS.has(conclusion) : false) {
         const summary = [run.output?.title, run.output?.summary].find((value): value is string => typeof value === "string" && value.trim().length > 0)?.trim().slice(0, 200);
-        const detail = { name: run.name, ...(summary ? { summary } : {}), ...(run.details_url ? { detailsUrl: run.details_url } : {}) };
-        (isRequired(run.name) ? failingDetails : nonRequiredFailingDetails).push(detail);
+        failingDetails.push({ name: run.name, ...(summary ? { summary } : {}), ...(run.details_url ? { detailsUrl: run.details_url } : {}) });
       } else if (conclusion ? CI_PASSING_CONCLUSIONS.has(conclusion) : status === "completed") {
         // concluded and not failing → passing
       } else {
@@ -2085,8 +2079,7 @@ export async function fetchLiveCiAggregate(
     const state = (ctx.state ?? "").toLowerCase();
     if (state === "failure" || state === "error") {
       const summary = typeof ctx.description === "string" ? ctx.description.trim().slice(0, 200) : "";
-      const detail = { name, ...(summary ? { summary } : {}), ...(ctx.target_url ? { detailsUrl: ctx.target_url } : {}) };
-      (isRequired(name) ? failingDetails : nonRequiredFailingDetails).push(detail);
+      failingDetails.push({ name, ...(summary ? { summary } : {}), ...(ctx.target_url ? { detailsUrl: ctx.target_url } : {}) });
     } else if (state === "success") {
       // passing
     } else {
@@ -2136,9 +2129,8 @@ export async function fetchLiveCiAggregate(
     }
   }
 
-  // ciState reflects ONLY gate-failing (required, or all-when-unknown) checks. A repo whose only red check is a
-  // non-required codecov/* therefore reports "passed" and is eligible to merge/approve, with the codecov
-  // failure riding along in nonRequiredFailingDetails for the contributor to see.
+  // ciState reflects every completed red check/status. Required contexts additionally prevent absent or pending
+  // required checks from being treated as passed.
   let ciState: LiveCiAggregate["ciState"] = failingDetails.length > 0 ? "failed" : anyPending ? "pending" : total > 0 ? "passed" : "unverified";
   // Fail CLOSED on incomplete visibility: if either CI source could not be fully read, we cannot certify the
   // commit as passed/clean — hold (pending) so the gate waits and re-evaluates on the next sweep instead of
@@ -2229,6 +2221,91 @@ export async function fetchLivePullRequestReviewDecision(env: Env, repoFullName:
   const query = `query { repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) { pullRequest(number: ${prNumber}) { reviewDecision } } }`;
   const result = await githubGraphQl<{ data?: { repository?: { pullRequest?: { reviewDecision?: string | null } | null } | null } }>(env, query, token).catch(() => undefined);
   return result?.data?.repository?.pullRequest?.reviewDecision ?? undefined;
+}
+
+type GitHubReviewThreadResponse = {
+  data?: {
+    repository?: {
+      pullRequest?: {
+        reviewThreads?: {
+          nodes?: Array<{
+            isResolved?: boolean | null;
+            isOutdated?: boolean | null;
+            path?: string | null;
+            line?: number | null;
+            comments?: {
+              nodes?: Array<{
+                body?: string | null;
+                url?: string | null;
+                author?: { login?: string | null } | null;
+              } | null> | null;
+            } | null;
+          } | null> | null;
+        } | null;
+      } | null;
+    } | null;
+  };
+};
+
+/** Fetch unresolved GitHub review threads that should block merge readiness. GraphQL is required because REST
+ *  review comments do not expose thread resolution; if GraphQL is unavailable this fails open to [] rather than
+ *  guessing. Own gittensory-authored inline-comment threads are ignored so the bot never blocks on itself. */
+export async function fetchLiveReviewThreadBlockers(env: Env, repoFullName: string, prNumber: number, token: string | undefined): Promise<ReviewThreadBlocker[]> {
+  if (!token) return [];
+  const [owner, name] = repoFullName.split("/");
+  if (!owner || !name) return [];
+  const query = `query GittensoryPullRequestReviewThreads {
+    repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+      pullRequest(number: ${prNumber}) {
+        reviewThreads(first: 50) {
+          nodes {
+            isResolved
+            isOutdated
+            path
+            line
+            comments(first: 20) {
+              nodes {
+                body
+                url
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+  const result = await githubGraphQl<GitHubReviewThreadResponse>(env, query, token).catch(() => undefined);
+  const threads = result?.data?.repository?.pullRequest?.reviewThreads?.nodes;
+  if (!threads) return [];
+  const blockers: ReviewThreadBlocker[] = [];
+  for (const thread of threads) {
+    if (!thread || thread.isResolved !== false || thread.isOutdated === true) continue;
+    const comments = (thread.comments?.nodes ?? [])
+      .flatMap((comment) =>
+        comment
+          ? [
+              {
+                body: comment.body,
+                url: comment.url,
+                authorLogin: comment.author?.login,
+              },
+            ]
+          : [],
+      )
+      .filter((comment) => !isOwnReviewThreadAuthor(comment.authorLogin));
+    const blocker = buildReviewThreadBlocker({
+      path: thread.path,
+      line: thread.line,
+      comments,
+    });
+    if (blocker) blockers.push(blocker);
+  }
+  return blockers;
+}
+
+function isOwnReviewThreadAuthor(login: string | null | undefined): boolean {
+  return /\bgittensory[-\w]*\[bot\]$/i.test(login ?? "") || /^(gittensory|gittensory-orb)$/i.test(login ?? "");
 }
 
 /** The deterministic linked-issue facts the hard-rule evaluator needs (labels / assignees / open-state). */

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -79,6 +79,7 @@ import {
   fetchLivePullRequestHeadSha,
   fetchLivePullRequestMergeState,
   fetchLivePullRequestReviewDecision,
+  fetchLiveReviewThreadBlockers,
   fetchLivePullRequestState,
   fetchOpenPullRequestNumbersForCommit,
   fetchRequiredStatusContexts,
@@ -262,7 +263,7 @@ import {
   unionScopedOverlapClusters,
   type ContributorProfile,
 } from "../signals/engine";
-import { isDuplicateClusterWinner } from "../signals/duplicate-winner";
+import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
 import { buildUnifiedReviewDiff } from "../review/review-diff";
 import { buildUnifiedCommentBody } from "../review/unified-comment-bridge";
 import { isRetryableJobError, RetryableJobError } from "./retryable";
@@ -320,7 +321,6 @@ import {
   isPlannerEnabled,
 } from "../review/planner";
 import {
-  aiCiRefutationActive,
   buildReviewGroundingText,
   checkSummaryText as checkFailureSummaryText,
   isGroundingEnabled,
@@ -333,6 +333,7 @@ import {
 } from "../review/enrichment-wire";
 import { captureReviewFailure } from "../selfhost/sentry";
 import { evaluateWithSurfaceLane } from "../review/content-lane-wire";
+import { reviewThreadBlockerFinding } from "../review/review-thread-findings";
 import { indexRepo, reindexChangedPaths } from "../review/rag-index";
 import {
   isReputationEnabled,
@@ -1204,10 +1205,9 @@ export function applyPrecisionBreakers(
 }
 
 /**
- * #1177: a red CI may bypass the hard-guardrail manual hold (#ci-fail-closes-guarded) ONLY when we proved the
- * failing checks are required branch-protection contexts. A null fetch (unreadable branch protection) or an
- * EMPTY required set means `fetchLiveCiAggregate` may have folded an optional / third-party red into `failed`,
- * which must keep a guarded PR held for a human rather than auto-close it.
+ * Historical compatibility helper for callers/tests that still need to know whether branch-protection contexts
+ * were readable. The disposition planner no longer uses this to soften red CI: any visible completed red
+ * check/status is adverse, while required contexts still matter for missing/pending detection.
  */
 export function hasVerifiedRequiredContexts(
   requiredContexts: Set<string> | null,
@@ -1364,15 +1364,9 @@ async function maybeRunAgentMaintenance(
   const planned = planAgentMaintenanceActions({
     conclusion: gate.conclusion,
     blockerTitles: gate.blockers.map((blocker) => blocker.title),
-    // CI-refutation (#ai-ci-refutation): thread the blocker CODES + the active gate so the planner suppresses an
-    // AI-judgment-only failure (ai_consensus_defect / ai_review_split) on a green-CI PR — the deterministic
-    // validator overrules the model hallucination, so a clean+green PR MERGES instead of being false-closed.
-    // `aiCiRefutationEnabled` is the SAME grounding+convergence gate the public-comment reconciliation uses, passed
-    // as a single boolean so the refutation condition is unit-tested in the planner and this site carries no branch.
-    // Enabled=false (non-convergence / grounding-off) ⇒ the refutation is a no-op ⇒ byte-identical verdict. The
-    // codes are public-safe finding identifiers (no rubric/scoring/reward terms).
+    // Public-safe finding identifiers retained for telemetry/action reasons. They no longer refute a blocker on
+    // green CI; once the gate says failure, the close/hold decision follows that verdict.
     gateBlockerCodes: gate.blockers.map((blocker) => blocker.code),
-    aiCiRefutationEnabled: aiCiRefutationActive(env, repoFullName),
     autonomy: settings.autonomy,
     autoMaintain: settings.autoMaintain,
     slopGateMinScore: settings.slopGateMinScore,
@@ -1405,10 +1399,11 @@ async function maybeRunAgentMaintenance(
       // reason ("duplicate of another open PR" via agent-actions when count > 0). When the flag is ON and this
       // PR is the cluster winner, force the count to 0 so the winner's close reason OMITS the duplicate cause
       // (it can still close on its own merits — CI/conflict/blockers). Flag-OFF short-circuits ⇒ the real
-      // count is used (byte-identical). The sibling numbers are open-only, so the lowest is the open winner.
+      // count is used (byte-identical). Unknown claim time keeps the duplicate cause.
       linkedDuplicateCount: dupWinnerLinkedDuplicateCount(
-        linkedIssueDuplicatePullRequestsForGate(pr, otherOpenPullRequests),
+        linkedIssueDuplicatePullRequestRecordsForGate(pr, otherOpenPullRequests),
         pr.number,
+        pr.linkedIssueClaimedAt,
         env.GITTENSORY_DUPLICATE_WINNER === "true",
       ),
       headSha: pr.headSha,
@@ -3050,7 +3045,7 @@ async function processGitHubWebhook(
       }
       if (
         installationId &&
-        shouldProcessPullRequestPublicSurface(payload.action)
+        shouldProcessPullRequestPublicSurface(eventName, payload.action)
       ) {
         if (
           shouldCollectSlopEvidence(settings) ||
@@ -3373,8 +3368,18 @@ export function shouldRunSlopAiAdvisory(
 }
 
 function shouldProcessPullRequestPublicSurface(
+  eventName: string,
   action: string | undefined,
 ): boolean {
+  if (eventName === "pull_request_review_comment") {
+    return action === "created" || action === "edited" || action === "deleted";
+  }
+  if (eventName === "pull_request_review_thread") {
+    return action === "resolved" || action === "unresolved";
+  }
+  if (eventName === "pull_request_review") {
+    return action === "submitted" || action === "edited" || action === "dismissed";
+  }
   return (
     PR_PUBLIC_SURFACE_ACTIONS.has(action ?? "") ||
     PR_GATE_CLOSED_ACTIONS.has(action ?? "")
@@ -3421,7 +3426,7 @@ export function gateCheckPolicy(
     slopRisk: slopRisk ?? null,
     confirmedContributor: confirmedContributorForPack,
     // PR-size + guardrail manual-review HOLD (#gate-size / #gate-guardrail): the MODE comes from config; the
-    // thresholds default to 10 files / 500 lines (advisory.ts constants); the live counts + guardrail-hit come from
+    // thresholds default to 10 files / 1000 lines (advisory.ts constants); the live counts + guardrail-hit come from
     // the per-PR sizeContext threaded by the caller.
     sizeGateMode: settings.sizeGateMode,
     changedFileCount: sizeContext?.changedFileCount ?? null,
@@ -3699,7 +3704,7 @@ export async function runAiReviewForAdvisory(
   // block, falling back to the `convergedRepoAllowed` allowlist when unset (byte-identical default). The (cached)
   // manifest is loaded once and shared, and ONLY when at least one of the two features is globally enabled — so a
   // deploy with both flags off does no extra read (preserves the no-op default). Grounding deliberately stays on
-  // `convergedRepoAllowed` here so it remains coherent with the disposition-side CI-refutation gate (#deferred).
+  // `convergedRepoAllowed` here so prompt grounding remains tied to the converged review allowlist.
   const featureManifest =
     isReputationEnabled(env) || isRagEnabled(env)
       ? await loadRepoFocusManifest(env, args.repoFullName).catch(() => null)
@@ -4113,16 +4118,17 @@ export async function runAiSlopForAdvisory(
  * when count > 0). Flag-OFF (default) returns the real sibling count — byte-identical to today.
  */
 export function dupWinnerLinkedDuplicateCount(
-  openSiblingNumbers: number[],
+  openSiblings: Pick<PullRequestRecord, "number" | "linkedIssueClaimedAt">[],
   prNumber: number,
+  linkedIssueClaimedAt: string | null | undefined,
   duplicateWinnerEnabled: boolean,
 ): number {
   if (
     duplicateWinnerEnabled &&
-    isDuplicateClusterWinner(prNumber, openSiblingNumbers)
+    isDuplicateClusterWinnerByClaim({ number: prNumber, linkedIssueClaimedAt }, openSiblings)
   )
     return 0;
-  return openSiblingNumbers.length;
+  return openSiblings.length;
 }
 
 /**
@@ -4185,18 +4191,23 @@ export function linkedIssueDuplicatePullRequestsForGate(
   pr: PullRequestRecord,
   pullRequests: PullRequestRecord[],
 ): number[] {
+  return linkedIssueDuplicatePullRequestRecordsForGate(pr, pullRequests).map((otherPr) => otherPr.number);
+}
+
+export function linkedIssueDuplicatePullRequestRecordsForGate(
+  pr: PullRequestRecord,
+  pullRequests: PullRequestRecord[],
+): PullRequestRecord[] {
   const linkedIssues = new Set(pr.linkedIssues);
   if (linkedIssues.size === 0) return [];
   return [
-    ...new Set(
+    ...new Map(
       pullRequests.flatMap((otherPr) => {
         if (otherPr.number === pr.number || otherPr.state !== "open") return [];
-        return otherPr.linkedIssues.some((issue) => linkedIssues.has(issue))
-          ? [otherPr.number]
-          : [];
+        return otherPr.linkedIssues.some((issue) => linkedIssues.has(issue)) ? [[otherPr.number, otherPr] as const] : [];
       }),
-    ),
-  ].sort((left, right) => left - right);
+    ).values(),
+  ].sort((left, right) => left.number - right.number);
 }
 
 async function auditGateCheckPermissionMissing(
@@ -4514,19 +4525,19 @@ async function maybePublishPrPublicSurface(
     // penalty (below), and the public panel builders (further down) so they agree by construction. Flag-OFF
     // (default) ⇒ duplicateWinnerEnabled is false and isDupWinner is false ⇒ every guard short-circuits
     // (byte-identical).
-    const linkedDuplicatePrsForGate = linkedIssueDuplicatePullRequestsForGate(
+    const linkedDuplicatePrsForGate = linkedIssueDuplicatePullRequestRecordsForGate(
       pr,
       repoPullRequests,
     );
     const duplicateWinnerEnabled = env.GITTENSORY_DUPLICATE_WINNER === "true";
     const isDupWinner =
       duplicateWinnerEnabled &&
-      isDuplicateClusterWinner(pr.number, linkedDuplicatePrsForGate);
+      isDuplicateClusterWinnerByClaim(pr, linkedDuplicatePrsForGate);
     const readiness = buildPublicReadinessScore({
       pr,
       preflight,
       queueHealth,
-      linkedDuplicatePrs: isDupWinner ? [] : linkedDuplicatePrsForGate,
+      linkedDuplicatePrs: isDupWinner ? [] : linkedDuplicatePrsForGate.map((otherPr) => otherPr.number),
       scopedOverlapCount: unionScopedOverlapClusters(
         collisions,
         pr,
@@ -4826,6 +4837,24 @@ async function maybePublishPrPublicSurface(
       pullNumber: pr.number,
       files: await getReviewFiles(),
     });
+
+    // Unresolved GitHub review threads (for example external security scanner inline findings) are blocking
+    // review facts. Fetch them before gate evaluation so the normal blocker path drives the check-run, comment,
+    // and disposition consistently. Fail-open on GitHub/GraphQL errors: a transient thread-read failure should not
+    // invent a blocker, but any thread we can see must be resolved before approval/merge.
+    if (gateEnabled) {
+      const reviewThreadToken =
+        (await createInstallationToken(env, installationId).catch(
+          () => undefined,
+        )) ?? env.GITHUB_PUBLIC_TOKEN;
+      const reviewThreadBlockers = await fetchLiveReviewThreadBlockers(
+        env,
+        repoFullName,
+        pr.number,
+        reviewThreadToken,
+      ).catch(() => []);
+      advisory.findings.push(...reviewThreadBlockers.map(reviewThreadBlockerFinding));
+    }
 
     // First-time-contributor grace (#552): compute the author's complete per-repo PR history
     // (excluding this PR) with an aggregate DB query. Do not derive policy-enforcement history from
@@ -5172,7 +5201,8 @@ async function maybePublishPrPublicSurface(
       const ciToken = await createInstallationToken(env, installationId).catch(
         () => undefined,
       );
-      // RC2: only branch-protection-required checks gate the PR; a red codecov/* is surfaced but never blocks.
+      // Required contexts still detect missing/pending required CI, but every visible completed red check/status is
+      // adverse and blocks the PR.
       const requiredContexts = await fetchRequiredStatusContexts(
         env,
         repoFullName,
@@ -5220,8 +5250,7 @@ async function maybePublishPrPublicSurface(
           : {}),
         ...(failingDetails.length > 0 ? { failingDetails } : {}),
       };
-      // The public comment must match the authoritative Gate check-run conclusion. Planner-level CI refutation can
-      // affect auto-actions, but it must never recolor the review comment green while the posted Gate is red.
+      // The public comment must match the authoritative Gate check-run conclusion.
       const commentGate = gateEvaluation;
       // Observability (#reviews-dashboard): record the would-be gate verdict so the Grafana panel shows the
       // merge/close/hold mix — the "are we rubber-stamping?" signal — even in advisory/dryRun (this is the rendered verdict).

--- a/src/review/content-lane-wire.ts
+++ b/src/review/content-lane-wire.ts
@@ -24,9 +24,8 @@ import { METAGRAPHED_LANE_SPEC } from "./content-lane/registry-logic";
 import { isConvergenceRepoAllowed } from "./cutover-gate";
 import { makeGithubFileFetcher } from "./grounding-wire";
 
-// Deterministic surface-lane finding codes. DELIBERATELY NOT in AI_JUDGMENT_BLOCKER_CODES — a deterministic
-// surface close is a FACT, so the green-CI refutation (reconcileGateEvaluationForGreenCi) must never flip it to
-// a merge. Regression-asserted in the test suite.
+// Deterministic surface-lane finding codes. DELIBERATELY NOT in AI_JUDGMENT_BLOCKER_CODES; surface closes are
+// facts, and blocker findings must never be flipped to merge by green CI.
 const SURFACE_REJECT_CODE = "surface_lane_reject";
 const SURFACE_MANUAL_CODE = "surface_lane_manual";
 const SURFACE_TITLE = "Registry surface review";

--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -30,12 +30,8 @@ export function isGroundingEnabled(env: { GITTENSORY_REVIEW_GROUNDING?: string |
   return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_GROUNDING ?? "");
 }
 
-/** True when the AI CI-refutation (#ai-ci-refutation) is ACTIVE for this repo: grounding is ON (the converged AI
- *  review feeds the finished CI status to the reviewer, so enforcing that ground truth is coherent) AND the repo
- *  is convergence-allowlisted. Centralized so the disposition refutation (agent-actions) and the public-comment
- *  reconciliation gate on the SAME condition — the merge/close action and the rendered comment can never disagree.
- *  A single call (not an inline `&&` at the call sites) so the processor carries no branch and this is the one
- *  place the condition is unit-tested. */
+/** Historical compatibility helper for the removed AI CI-refutation path. Grounding still feeds CI/full-file truth
+ *  into the reviewer prompt, but green CI no longer rewrites a configured AI blocker into success. */
 export function aiCiRefutationActive(env: Env, repoFullName: string): boolean {
   return isGroundingEnabled(env) && isConvergenceRepoAllowed(env, repoFullName);
 }

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -1,4 +1,5 @@
-// Per-repo hard-guardrail path globs (paths that force MANUAL review — no auto-merge / no auto-close).
+// Per-repo hard-guardrail path globs. These force MANUAL review only for otherwise-ready PRs: no auto-merge /
+// no auto-approve, but blockers, red CI, and base conflicts still close for close-eligible contributors.
 //
 // Self-host note: hosted reviews and hosted policy storage are retired. Review execution uses the container-private
 // `.gittensory.yml` path for repo policy; these hard guardrails remain built-in invariants so a missing private
@@ -7,7 +8,7 @@ export const DEFAULT_CRUCIAL_GUARDRAIL_GLOBS = [".github/workflows/**", "scripts
 
 // The gate's OWN policy files, guarded for EVERY repo regardless of private config. A PR that edits the
 // config-as-code that defines the gate or coverage policy (the `.gittensory.*` focus manifest the loader
-// reads, or `codecov.yml`) must always be HELD for the owner — otherwise one auto-merged config-only PR
+// reads, or `codecov.yml`) must always be HELD when otherwise-ready — otherwise one auto-merged config-only PR
 // could weaken the gate repo-wide before any subsequent PR is evaluated against the new policy. The
 // manifest filenames mirror signals/focus-manifest-loader's candidates; this only ever WIDENS the guard.
 export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
@@ -25,7 +26,7 @@ export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
 // The review engine's OWN decision + safety code — its crown jewels — guarded for EVERY repo regardless of
 // private config. A contributor PR that edits how the gate decides a verdict, how a merge or close executes, the
 // action-mode kill-switch, scoring, auth, the CI aggregate the gate reads, or the guardrail itself must be HELD
-// for the owner: the engine must never auto-merge a change to the very code that governs its own autonomy.
+// when otherwise-ready: the engine must never auto-merge a change to the very code that governs its own autonomy.
 // These are gittensory engine-specific paths, so they never match an unrelated reviewed repo's PR (e.g.
 // metagraphed has no src/rules/** or agent-action-executor.ts); like the config-as-code set above, this only
 // ever WIDENS the guard.

--- a/src/review/review-thread-findings.ts
+++ b/src/review/review-thread-findings.ts
@@ -1,0 +1,97 @@
+import type { AdvisoryFinding } from "../types";
+
+export const REVIEW_THREAD_BLOCKER_CODE = "review_thread_unresolved";
+
+const SCANNER_FINDING_MARKER = /<!--\s*(?:brin-pr-finding|superagent-finding-fingerprint:)/i;
+const MARKDOWN_PRIORITY_TITLE = /\*\*\s*(P[0-3])\s*:\s*\*\*\s*([^\n\r]+)/i;
+const XML_PRIORITY = /<priority>\s*(P[0-3])\s*<\/priority>/i;
+const XML_TITLE = /<title>\s*([^<]+?)\s*<\/title>/i;
+
+export type ReviewThreadCommentInput = {
+  body?: string | null | undefined;
+  authorLogin?: string | null | undefined;
+  url?: string | null | undefined;
+};
+
+export type ReviewThreadBlocker = {
+  title: string;
+  priority?: "P0" | "P1" | "P2" | "P3" | undefined;
+  path?: string | null | undefined;
+  line?: number | null | undefined;
+  authorLogin?: string | null | undefined;
+  url?: string | null | undefined;
+  scannerFinding: boolean;
+};
+
+export function buildReviewThreadBlocker(input: {
+  path?: string | null | undefined;
+  line?: number | null | undefined;
+  comments: ReviewThreadCommentInput[];
+}): ReviewThreadBlocker | null {
+  const comments = input.comments.filter((comment) => (comment.body ?? "").trim().length > 0);
+  if (comments.length === 0) return null;
+  const scannerComment = comments.find((comment) => SCANNER_FINDING_MARKER.test(comment.body ?? ""));
+  const comment = scannerComment ?? comments[0]!;
+  const body = comment.body ?? "";
+  const title = reviewThreadTitle(body);
+  const priority = reviewThreadPriority(body);
+  return {
+    title,
+    ...(priority ? { priority } : {}),
+    path: input.path,
+    line: input.line,
+    authorLogin: comment.authorLogin,
+    url: comment.url,
+    scannerFinding: scannerComment !== undefined,
+  };
+}
+
+export function reviewThreadBlockerFinding(blocker: ReviewThreadBlocker): AdvisoryFinding {
+  const location = reviewThreadLocation(blocker);
+  const actor = blocker.authorLogin ? `${blocker.authorLogin} ` : "";
+  const priority = blocker.priority ? `${blocker.priority} ` : "";
+  const title = `${actor}review thread unresolved: ${priority}${blocker.title}${location ? ` (${location})` : ""}`;
+  return {
+    code: REVIEW_THREAD_BLOCKER_CODE,
+    severity: "critical",
+    title,
+    detail: `GitHub reports an unresolved review thread${location ? ` at ${location}` : ""}. The PR should not be approved or merged until the thread is resolved.`,
+    action: "Resolve the review thread or push a fix, then re-run the gate.",
+  };
+}
+
+function reviewThreadLocation(blocker: Pick<ReviewThreadBlocker, "path" | "line">): string {
+  const path = blocker.path?.trim();
+  if (!path) return "";
+  return typeof blocker.line === "number" && Number.isFinite(blocker.line) && blocker.line > 0 ? `${path}:${blocker.line}` : path;
+}
+
+function reviewThreadPriority(body: string): ReviewThreadBlocker["priority"] | undefined {
+  const markdown = MARKDOWN_PRIORITY_TITLE.exec(body)?.[1];
+  const xml = XML_PRIORITY.exec(body)?.[1];
+  const priority = (markdown ?? xml)?.toUpperCase();
+  return priority === "P0" || priority === "P1" || priority === "P2" || priority === "P3" ? priority : undefined;
+}
+
+function reviewThreadTitle(body: string): string {
+  const markdown = MARKDOWN_PRIORITY_TITLE.exec(body)?.[2];
+  const xml = XML_TITLE.exec(body)?.[1];
+  const direct = markdown ?? xml ?? firstMeaningfulLine(body) ?? "review thread";
+  return cleanTitle(direct);
+}
+
+function firstMeaningfulLine(body: string): string | undefined {
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith("<!--") && !line.startsWith("<details") && !line.startsWith("<summary") && !line.startsWith("```"));
+}
+
+function cleanTitle(value: string): string {
+  return value
+    .replace(/<\/?[^>]+>/g, "")
+    .replace(/[`*~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -277,12 +277,11 @@ export function deriveUnifiedStatus(input: UnifiedReviewInput, ctx: UnifiedComme
   // PR that won't actually merge). Applied LAST so it only ever downgrades an otherwise-ready status — a real
   // CI / merge-state / gate block above still wins. (#guarded-hold-comment)
   if (status === "ready" && ctx.heldForReview) return "held";
-  // Held-vs-closed disposition parity (#8/#9): a gate "close" verdict does NOT always close the PR. An
-  // owner/automation-bot author is NEVER auto-closed, and a guarded-path PR is held for owner review. Failed CI
-  // returned the red blocked status above, so the remaining close/held cases are green-or-pending manual holds.
+  // Held-vs-closed disposition parity (#8/#9): owner/automation-bot authors may be exempt from auto-close, so a
+  // close verdict on those authors is rendered as held. Guardrail holds are handled above only for otherwise-ready
+  // PRs; they must not downgrade a blocker/close verdict to manual review.
   if (input.decision === "close") {
     if (ctx.neverClosed) return "held";
-    if (ctx.heldForReview) return "held";
   }
   return status;
 }

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -10,9 +10,10 @@ import type {
   RepositoryRecord,
 } from "../types";
 import type { CollisionCluster, CollisionReport } from "../signals/engine";
-import { isDuplicateClusterWinner } from "../signals/duplicate-winner";
+import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
 import { nowIso } from "../utils/json";
 import { GITTENSORY_GATE_CHECK_NAME } from "../review/check-names";
+import { REVIEW_THREAD_BLOCKER_CODE } from "../review/review-thread-findings";
 
 export type GateCheckConclusion = "success" | "failure" | "action_required" | "neutral" | "skipped";
 
@@ -26,11 +27,9 @@ export type GateCheckPolicy = {
   /** When `block`, a dual-model AI consensus defect (`ai_consensus_defect` finding) becomes a hard
    *  blocker. Defaults to advisory — AI never blocks unless the maintainer opts in. */
   aiReviewGateMode?: GateRuleMode | undefined;
-  /** Minimum calibrated confidence (0-1) for an AI-judgment defect (`ai_consensus_defect` / `ai_review_split`) to
-   *  BLOCK under `aiReviewGateMode: block` (#7). The finding blocks only when its `confidence >= this`; below-threshold
-   *  AI defects hold for human review instead of passing or auto-closing. `null`/undefined ⇒ the 0.93 default. A finding
-   *  with no confidence (deterministic, or a graceful-fallback AI defect) is treated as 1.0 and always clears the floor
-   *  — matching the historical always-block behavior. */
+  /** Minimum calibrated confidence (0-1) configured for AI close calibration. AI defect findings still block under
+   *  `aiReviewGateMode: block` even when below this floor; the floor remains configurable context, never a guardrail
+   *  that downgrades a blocker to manual review. `null`/undefined ⇒ the 0.93 default. */
   aiReviewCloseConfidence?: number | null | undefined;
   readinessScore?: number | null | undefined;
   /** When `block`, the deterministic slop score becomes a hard blocker once `slopRisk >= slopGateMinScore`
@@ -67,7 +66,7 @@ export type GateCheckPolicy = {
   /** PR-size HOLD (#gate-size). When set (advisory/block), a PR with >= sizeGateMaxFiles changed files OR
    *  >= sizeGateMaxLines changed (added+deleted) lines that would OTHERWISE pass is HELD for manual review — a
    *  neutral gate → "manual" verdict, never auto-merged and never a hard failure. Defaults off; thresholds default
-   *  to 10 files / 500 lines. This is a HOLD (advisory dry-run friendly), not a close. */
+   *  to 10 files / 1000 lines. This is a HOLD (advisory dry-run friendly), not a close. */
   sizeGateMode?: GateRuleMode | undefined;
   /** Aggregate change size, threaded from the resolved file list (changedLineCount = additions + deletions). */
   changedFileCount?: number | null | undefined;
@@ -95,38 +94,26 @@ export type GateCheckEvaluation = {
   warnings: AdvisoryFinding[];
 };
 
-// AI-JUDGMENT blocker codes (#ai-ci-refutation): a gate failure driven SOLELY by these is the dual-model AI
-// reviewer's OPINION, not a deterministic fact. Shared by the disposition refutation (agent-actions) and the
-// public-comment reconciliation so the merge/close ACTION and the rendered comment always agree.
+// AI-JUDGMENT blocker codes. Kept distinct from deterministic blockers for telemetry and regression tests; the old
+// green-CI refutation path is intentionally disabled, so these still block when `aiReviewGateMode` is `block`.
 // `ai_review_inconclusive` is deliberately EXCLUDED — that is a "could not review" HOLD, not a false defect.
 export const AI_JUDGMENT_BLOCKER_CODES = new Set<string>(["ai_consensus_defect", "ai_review_split"]);
 
 /** True when the gate FAILED *solely* because of AI-judgment blockers (every blocker is an AI-judgment code).
- *  An empty blocker list is NOT an AI-judgment-only failure (there is nothing to refute). PURE. */
+ *  An empty blocker list is NOT an AI-judgment-only failure. PURE. */
 export function isAiJudgmentOnlyFailure(evaluation: GateCheckEvaluation): boolean {
   return evaluation.conclusion === "failure" && evaluation.blockers.length > 0 && evaluation.blockers.every((blocker) => AI_JUDGMENT_BLOCKER_CODES.has(blocker.code));
 }
 
 /**
- * Reconcile a gate evaluation with the deterministic CI for the PUBLIC review comment (#ai-ci-refutation).
- * When the gate FAILED solely on an AI-judgment blocker (ai_consensus_defect / ai_review_split) but the real CI
- * is GREEN, the AI claim is refuted by the validator — so the comment must render SUCCESS (advisory), matching
- * the disposition (planAgentMaintenanceActions merges such a PR) instead of a contradictory red "blocked/closed"
- * headline + Gate row. The AI concern stays VISIBLE without double-listing: the specific consensus defect still
- * surfaces from the advisory findings as a raised concern under the green verdict, so we only clear the gate's
- * hard blockers here. `enabled` is the caller's grounding+convergence gate (passed in so this stays a PURE,
- * unit-testable function and the processor carries no branch); `enabled` false, `ciState !== "passed"`, or a
- * non-AI-only failure ⇒ the evaluation is returned UNCHANGED.
+ * Historical compatibility shim for the old green-CI AI refutation path. The gate verdict is now authoritative:
+ * if an AI review finding is configured as blocking, green CI cannot rewrite it to success. This keeps the public
+ * comment, check-run, and disposition aligned with the "blockers always block" rule.
  */
 export function reconcileGateEvaluationForGreenCi(evaluation: GateCheckEvaluation, ciState: "passed" | "failed" | "unverified", enabled: boolean): GateCheckEvaluation {
-  if (!enabled || ciState !== "passed" || !isAiJudgmentOnlyFailure(evaluation)) return evaluation;
-  return {
-    ...evaluation,
-    conclusion: "success",
-    title: `${GITTENSORY_GATE_CHECK_NAME} passed`,
-    summary: "The AI review raised a concern, but the deterministic checks (CI) are green — the concern is advisory, not blocking.",
-    blockers: [],
-  };
+  void ciState;
+  void enabled;
+  return evaluation;
 }
 
 export function buildRepositoryAdvisory(repo: RepositoryRecord | null, fullName: string): Advisory {
@@ -408,7 +395,7 @@ export function formatCheckRunOutput(
 }
 
 const SIZE_HOLD_DEFAULT_MAX_FILES = 10;
-const SIZE_HOLD_DEFAULT_MAX_LINES = 500;
+const SIZE_HOLD_DEFAULT_MAX_LINES = 1000;
 
 /** Oversized-PR manual-review HOLD finding (#gate-size), or null when the size gate is off or the PR is within both
  *  thresholds. A HOLD (→ neutral gate → "manual" verdict), never a hard blocker, so it is dry-run/advisory friendly. */
@@ -463,8 +450,8 @@ function buildManifestBlockedPathHoldFinding(
 }
 
 /** Dry-run disposition (#gate-dryrun): promote every `advisory` sub-gate mode to `block` so the core eval yields the
- *  would-be conclusion. `off`/`block`/unset modes are untouched; non-mode policy (grace, size HOLD, guardrail) is
- *  preserved as-is, so the would-be verdict still honours newcomer grace and the manual-review holds. PURE. */
+ *  would-be conclusion. `off`/`block`/unset modes are untouched; non-mode policy (size HOLD, guardrail) is
+ *  preserved as-is, so the would-be verdict still honours manual-review holds. PURE. */
 function promoteAdvisoryToBlock(policy: GateCheckPolicy): GateCheckPolicy {
   // #disposition-redesign: the dry-run "would-be" verdict must reflect the REAL disposition model — a CLOSE is driven by
   // the AI reviewer's confidence + genuine hard blockers (secret/CI/banned) ONLY. The advisory signals — missing linked
@@ -512,42 +499,14 @@ function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy
   const slopBlocker = buildSlopGateBlocker(effective);
   const blockers = [...configuredBlockers, ...(slopBlocker ? [slopBlocker] : [])];
   const gateWarnings = qualityWarning ? [...warnings, qualityWarning] : warnings;
-  const lowConfidenceAiHolds = advisoryResult.findings.filter((finding) => isLowConfidenceAiReviewHold(finding, effective));
   // Non-confirmed contributors are gated NORMALLY (real blockers → failure → one-shot close; clean → success →
   // merge), the SAME as confirmed contributors: the review + CI + guardrail vet every PR, and confirmed-status
   // affects only on-chain SCORING, never the merge/close decision. (#gate-nonconfirmed) The old blanket
   // "never block a non-confirmed contributor" forced every non-confirmed PR with a blocker to a neutral → HELD
-  // state, burying the maintainer in manual review. Genuine newcomers stay protected by the opt-in first-time-
-  // contributor grace immediately below; everyone else is auto-merged/closed so the queue stays automated.
-  // First-time-contributor grace (#552): when the maintainer opted in, a genuine newcomer (0 merged PRs in
-  // this repo) who is NOT a repeat offender (< 3 closed-unmerged PRs) gets a neutral, non-blocking gate even
-  // when blockers fired — they keep the advisory findings without the hard block. Repeat offenders, authors
-  // with merge history, and repos with the setting off are gated normally below. Public-safe: this only
-  // expresses advisory-vs-block, never any reward/trust internals.
-  const isNewcomer = (effective.authorMergedPrCount ?? 0) === 0;
-  const isRepeatOffender = (effective.authorClosedUnmergedPrCount ?? 0) >= 3;
-  const graceApplies = effective.firstTimeContributorGrace === true && isNewcomer && !isRepeatOffender;
-  if (graceApplies && blockers.length > 0) {
-    return {
-      enabled: true,
-      conclusion: "neutral",
-      title: `${GITTENSORY_GATE_CHECK_NAME} — first-contribution grace`,
-      summary: "This is a first-time contribution to this repo, so the gate stays advisory rather than blocking. The findings remain visible, and the gate will apply normally once this author has merge history here.",
-      blockers: [],
-      warnings: gateWarnings,
-    };
-  }
+  // state, burying the maintainer in manual review. The old first-time-contributor grace path also softened
+  // blockers; that is intentionally no longer applied because blocker findings must remain closure/rejection
+  // outcomes for normal contributors. Owner/automation close exemptions live in the disposition planner instead.
   if (blockers.length === 0) {
-    if (lowConfidenceAiHolds.length > 0) {
-      return {
-        enabled: true,
-        conclusion: "neutral",
-        title: `${GITTENSORY_GATE_CHECK_NAME} — held for human review`,
-        summary: "The AI review flagged a possible must-fix defect below the automatic close-confidence floor, so the gate is held for a human reviewer instead of passed automatically.",
-        blockers: [],
-        warnings: [...gateWarnings, ...lowConfidenceAiHolds],
-      };
-    }
     // Fail-CLOSED AI hold (#ai-fail-closed, #audit-3.5): with NO deterministic blocker, a block-mode AI review
     // that could not return a usable verdict HOLDS the gate (neutral) for a human rather than passing
     // automatically — NEVER a failure, so a contributor PR is never auto-CLOSED because a model hiccupped. This
@@ -715,12 +674,11 @@ function addPullRequestFindings(
     const overlappingPrs = otherOpenPullRequests.filter((otherPr) =>
       otherPr.linkedIssues.some((issueNumber) => pr.linkedIssues.includes(issueNumber)),
     );
-    // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the cluster winner (the
-    // lowest open sibling number), SKIP the duplicate finding — suppressing it suppresses the gate failure, so
-    // the winner survives while the losers (which still see overlap > 0 and a lower sibling) keep the finding.
-    // `overlappingPrs` is derived from the OPEN-only `otherOpenPullRequests`, so the numbers are open siblings.
+    // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the earliest observed
+    // linked-issue claimant, SKIP the duplicate finding — suppressing it suppresses the gate failure, so the
+    // winner survives while later claimants keep the finding. Unknown claim time keeps the blocker.
     // Flag-OFF (default) short-circuits ⇒ the finding is pushed exactly as before (byte-identical).
-    if (overlappingPrs.length > 0 && !(duplicateWinnerEnabled && isDuplicateClusterWinner(pr.number, overlappingPrs.map((otherPr) => otherPr.number)))) {
+    if (overlappingPrs.length > 0 && !(duplicateWinnerEnabled && isDuplicateClusterWinnerByClaim(pr, overlappingPrs))) {
       findings.push({
         code: "duplicate_pr_risk",
         severity: "warning",
@@ -856,8 +814,8 @@ function isEvaluationBlocker(code: string): boolean {
   return code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached" || code === "pre_merge_check_unresolved";
 }
 
-// Default minimum calibrated confidence for an AI defect to BLOCK (#7) — used when the repo set `aiReview: block`
-// without a `closeConfidence`. 0.93 = block only on a high-confidence AI defect; below that stays advisory.
+// Default configured close-confidence floor (#7) retained for settings compatibility and public calibration text.
+// It must not be used to downgrade an AI defect blocker into manual review.
 const DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE = 0.93;
 
 function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPolicy): boolean {
@@ -870,15 +828,13 @@ function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPoli
   // most conservative AI signal (two independent models) but still confirmed-contributor gated by
   // evaluateGateCheck, and advisory by default.
   // A consensus defect (both reviewers) OR a SPLIT (one reviewer flagged a blocker the other did not) both block
-  // when aiReviewGateMode is `block` AND the finding's CALIBRATED confidence clears the close-confidence floor (#7).
-  // Below-floor AI defects are handled as a neutral human-review HOLD in evaluateGateCheckCore: the LLM-provided
-  // confidence must never turn a concrete AI defect into an auto-mergeable passing gate. A finding with no confidence
-  // (graceful fallback) is treated as 1.0 and always clears the floor — byte-identical to today's behavior. (#ai-review-split)
+  // when aiReviewGateMode is `block`. The configured close-confidence floor remains calibration context; it does
+  // not turn a blocker into a manual hold for normal contributors. (#ai-review-split)
   if (code === "ai_consensus_defect" || code === "ai_review_split") {
-    if (gateMode(policy.aiReviewGateMode ?? "advisory") !== "block") return false;
-    const confidence = finding.confidence ?? 1;
-    return confidence >= (policy.aiReviewCloseConfidence ?? DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE);
+    void (policy.aiReviewCloseConfidence ?? DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE);
+    return gateMode(policy.aiReviewGateMode ?? "advisory") === "block";
   }
+  if (code === REVIEW_THREAD_BLOCKER_CODE) return true;
   // A leaked-secret finding (`secret_leak`) ALWAYS hard-blocks: a committed credential must be removed and
   // rotated before merge, with no opt-in. This finding is produced ONLY by the flag-gated safety scan
   // (GITTENSORY_REVIEW_SAFETY); when the flag is off the finding never exists, so this branch is unreachable and the
@@ -899,13 +855,6 @@ function isConfiguredGateBlocker(finding: AdvisoryFinding, policy: GateCheckPoli
   // advisory — the finding surfaces in the panel without ever closing the PR unless explicitly configured.
   if (code === "self_authored_linked_issue") return gateMode(policy.selfAuthoredLinkedIssueGateMode ?? "advisory") === "block";
   return false;
-}
-
-function isLowConfidenceAiReviewHold(finding: AdvisoryFinding, policy: GateCheckPolicy): boolean {
-  if (!AI_JUDGMENT_BLOCKER_CODES.has(finding.code)) return false;
-  if (gateMode(policy.aiReviewGateMode ?? "advisory") !== "block") return false;
-  const confidence = finding.confidence ?? 1;
-  return confidence < (policy.aiReviewCloseConfidence ?? DEFAULT_AI_REVIEW_CLOSE_CONFIDENCE);
 }
 
 function buildQualityGateWarning(policy: GateCheckPolicy): AdvisoryFinding | null {

--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -222,8 +222,8 @@ export function buildPredictedGateVerdict(args: {
   const pack: GatePolicyPack = gate.pack ?? "gittensor";
   const effectiveConfirmedContributor = pack === "oss-anti-slop" ? undefined : args.confirmedContributor;
 
-  // Case-insensitive author match so the PREDICTOR agrees with the live gate (which matches case-insensitively);
-  // otherwise a contributor could see false first-time-grace optimism before a one-shot loss. (#audit-§4)
+  // Case-insensitive author match so the PREDICTOR agrees with the live gate (which matches case-insensitively).
+  // First-time grace is retained as compatibility context, but blocker findings are no longer softened by it.
   const contributorLoginLc = input.contributorLogin?.toLowerCase();
   const authorHistory = pullRequests.filter((pr) => pr.repoFullName === input.repoFullName && pr.authorLogin?.toLowerCase() === contributorLoginLc);
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -1,5 +1,5 @@
 import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyPolicy } from "../types";
-import { AI_JUDGMENT_BLOCKER_CODES, type GateCheckConclusion } from "../rules/advisory";
+import type { GateCheckConclusion } from "../rules/advisory";
 import { DEFAULT_AUTO_MAINTAIN_POLICY, autonomyRequiresApproval, isActingAutonomyLevel, resolveAutonomy } from "./autonomy";
 import { isGuardrailHit } from "../signals/change-guardrail";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../review/linked-issue-hard-rules";
@@ -68,21 +68,19 @@ export type PlannedAgentAction = {
 export type AgentActionPlanInput = {
   conclusion: GateCheckConclusion;
   blockerTitles: string[];
-  // The gate's blocking finding CODES (parallel to blockerTitles). Used by the CI-refutation rule
-  // (#ai-ci-refutation): when the gate FAILED solely because of AI-judgment blockers and CI is green, the
-  // AI claim is refuted by the deterministic validator. Optional/absent ⇒ the refutation is a no-op.
+  // The gate's blocking finding CODES (parallel to blockerTitles). Retained for compatibility/telemetry; blocker
+  // findings remain blocking and are not refuted by green CI in the disposition planner.
   gateBlockerCodes?: string[] | undefined;
-  // Whether the AI CI-refutation is ACTIVE for this repo (the caller's grounding + convergence gate, passed as a
-  // single boolean so the refutation condition is fully unit-testable here and the processor carries no branch).
-  // Absent/false ⇒ the refutation never fires and the verdict is byte-identical to the raw gate.
+  // Historical compatibility flag for the removed green-CI AI refutation path. Ignored by the planner; a configured
+  // blocker remains a blocker regardless of this value.
   aiCiRefutationEnabled?: boolean | undefined;
   autonomy: AutonomyPolicy | null | undefined;
   // Optional so the trigger can pass raw repo settings; both fall back to conservative defaults here.
   autoMaintain?: AutoMaintainPolicy | undefined;
   slopGateMinScore?: number | null | undefined;
   // Convergence safety (hard-guardrail port, #4196 incident class): the PR's changed paths + the repo's
-  // hard-guardrail globs. Any changed path matching a guardrail glob forces MANUAL review — gittensory will
-  // neither auto-merge, auto-approve, nor auto-close such a PR; it falls through to a human.
+  // hard-guardrail globs. Any changed path matching a guardrail glob forces MANUAL review only for otherwise
+  // review-good PRs; blockers, red CI, and base conflicts still close for close-eligible contributors.
   changedPaths: string[];
   hardGuardrailGlobs: string[];
   // True when the PR author is the repo owner (e.g. JSONbored). Standing rule: owner PRs are NEVER
@@ -107,9 +105,8 @@ export type AgentActionPlanInput = {
   // The names of the failing checks, surfaced in the close/request-changes reason so the contributor knows
   // WHY (e.g. "codecov/patch"). Empty unless ciState === "failed".
   failingCheckNames?: string[] | undefined;
-  // True only when the caller proved the failing CI names are required branch-protection contexts. When required
-  // contexts are unavailable, ciState conservatively folds in all red checks; that fallback must not bypass hard
-  // guardrails because an optional or third-party check may be the only red signal.
+  // Historical compatibility field. Red CI now closes close-eligible contributors regardless of branch-protection
+  // membership because any visible completed red check/status is adverse.
   ciRequiredContextsVerified?: boolean | undefined;
   // Linked-issue HARD-RULE result (#linked-issue-hard-rules). A DETERMINISTIC verdict about the issue(s) this PR
   // links (owner-assigned / missing point-label / maintainer-only), pre-computed by the trigger. When
@@ -121,7 +118,7 @@ export type AgentActionPlanInput = {
   // Contributor blacklist (#1425, anti-abuse): when the PR author is on the resolved blacklist (per-repo ∪
   // global), the disposition SHORT-CIRCUITS to a deterministic close ahead of ALL merit/CI/AI analysis — the
   // banned account never gets merit-reviewed or auto-merged. Zero-hallucination (not an AI judgment), so its
-  // close is EXEMPT from the AI-refutation breaker (closeKind "blacklist"). Fires for a CONTRIBUTOR only
+  // close is tagged separately (closeKind "blacklist"). Fires for a CONTRIBUTOR only
   // (owner/automation bots are never auto-closed). `reason` is private maintainer metadata used only for matching
   // context; the public close comment intentionally uses static copy. Absent / not-matched ⇒ no effect.
   blacklistMatch?: { matched: boolean; reason: string | null | undefined } | undefined;
@@ -260,8 +257,8 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // Contributor blacklist (#1425): a banned author's PR is a DETERMINISTIC short-circuit — it SHORT-CIRCUITS to a
   // label + close AHEAD of all merit/CI/gate/AI analysis (this returns before any of it), so a blocked account is
   // never merit-reviewed or auto-merged. Fires for a CONTRIBUTOR only (owner/automation bots are NEVER auto-closed,
-  // the standing rule). Zero-hallucination, so its close is `closeKind: "blacklist"` — exempt from the AI-refutation
-  // breaker like the linked-issue hard rule. The `acting`/`approval` gates here + the executor's pause/dry-run/
+  // the standing rule). Zero-hallucination, so its close is `closeKind: "blacklist"`, separate from heuristic
+  // closes. The `acting`/`approval` gates here + the executor's pause/dry-run/
   // kill-switch gate make it dry-run-able and approval-gated exactly like every other action. The close comment is
   // static by construction so private maintainer metadata from the blacklist entry cannot leak.
   const blacklistContributor = !input.authorIsOwner && !input.authorIsAutomationBot;
@@ -287,30 +284,16 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // Settle-before-decide: never approve / merge / close on a half-finished CI run.
   if (input.ciState === "pending") return actions;
 
-  // CI-refutation of an AI-judgment-only failure (#ai-ci-refutation). When the gate FAILED *solely* because the
-  // dual-model AI reviewer flagged a defect (ai_consensus_defect / ai_review_split) but the deterministic CI is
-  // GREEN, the AI claim is refuted by the real validator → downgrade the verdict to SUCCESS for the disposition so
-  // a clean+green PR MERGES instead of being false-closed on a model hallucination. Requires EVERY blocker to be an
-  // AI-judgment code (a mixed failure with any deterministic blocker — duplicate / secret / slop / missing-issue /
-  // manifest — keeps `failure` and still closes) AND CI === passed (a red/unverified CI is the real signal and is
-  // never overridden). Empty/absent codes (the rule gated OFF at the boundary, or a non-AI failure) ⇒ no-op, so the
-  // verdict is byte-identical. The effective `conclusion` drives every gate-verdict decision below; the AI concern
-  // still surfaces in the review comment (an advisory finding), it just no longer auto-closes a green PR.
-  // Resolve the blocker codes ONCE (so the nullish fallback is exercised for both a present and an absent list,
-  // and the checks below carry no further `??` branch). Absent ⇒ [] ⇒ no AI-judgment-only failure.
-  const gateBlockerCodes = input.gateBlockerCodes ?? [];
-  const aiJudgmentOnlyFailure =
-    input.aiCiRefutationEnabled === true && input.conclusion === "failure" && gateBlockerCodes.length > 0 && gateBlockerCodes.every((code) => AI_JUDGMENT_BLOCKER_CODES.has(code));
-  // The refutation only fires on a GREEN CI (the deterministic validator that overrules the AI). A red/unverified
-  // CI is the real signal and is never overridden, so the verdict stays as the raw gate `failure`.
-  const refuteAiFailureOnGreenCi = aiJudgmentOnlyFailure && ciPassed;
-  const conclusion: GateCheckConclusion = refuteAiFailureOnGreenCi ? "success" : input.conclusion;
+  // The gate verdict is authoritative. Green CI is still required for merge/approve, but it does not rewrite an AI
+  // or review-thread blocker into success once the gate has classified it as blocking.
+  const conclusion: GateCheckConclusion = input.conclusion;
 
   // Only SUCCESS earns the review-good auto-merge. A NEUTRAL gate flows (no longer silently returns []) but is
   // NOT auto-merged — it falls through to a HELD + labeled state for review. (Auto-merging a neutral / grace
   // PR is a separate trust/policy decision, deliberately NOT bundled into the harm-stop.) (#harm-stop)
   const gatePassing = conclusion === "success";
-  // A changed path matching a hard guardrail forces manual review (suppresses auto-MERGE / auto-approve / auto-close).
+  // A changed path matching a hard guardrail forces manual review only when the PR is otherwise review-good
+  // (suppresses auto-MERGE / auto-approve). It must never downgrade blockers/conflicts/red CI to manual review.
   // Fail SAFE on UNKNOWN paths (#1062): when guardrails are configured but the changed-file set is empty (cache
   // not yet / no longer populated), we cannot prove the PR doesn't touch a guarded path, so treat it as a hit —
   // never auto-merge, auto-approve, or auto-close a PR whose diff we don't know. Repos with no guardrails
@@ -326,7 +309,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // with high accuracy; manual review is the RARE exception. A PR is "review-good" when the gate passes AND CI is
   // green — that's the only thing that earns an auto-merge or an approve. Everything else, for a CONTRIBUTOR, is a
   // one-shot CLOSE (taopedia model: resolve + open a fresh PR). The guardrail is handled SEPARATELY: it converts
-  // every would-approve/would-merge/would-close disposition into a manual hold (owner safety review).
+  // would-approve/would-merge dispositions into a manual hold.
   const ciUnverified = input.ciState === "unverified";
   const reviewGood = gatePassing && ciPassed;
   const isContributor = !input.authorIsOwner && !input.authorIsAutomationBot;
@@ -346,21 +329,13 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // approve may fire again. Absent approved-head SHA (never approved by the bot) ⇒ not idempotent-skipped.
   const alreadyApprovedThisHead = input.pr.approvedHeadSha != null && input.pr.headSha != null && input.pr.approvedHeadSha === input.pr.headSha;
   const canMerge = reviewGood && !heldForManualReview && acting("merge") && mergeableClean && approvalsSatisfied && !mergeTerminallyBlocked;
-  // A guarded/CRUCIAL path (CI, the review engine, visual) → ALWAYS held for the owner, never auto-actioned —
-  // not auto-approved, not auto-merged, AND not auto-closed. Operator decision (#hold-crucial-on-reject): a
-  // hallucinated reject on a crucial PR must NOT auto-close a good change (the #1528 near-miss); the owner
-  // verifies and closes/merges. The BULK (non-guarded) contributor PRs still auto-close one-shot on a bad
-  // verdict / conflict — only the small crucial set is held. Owner/automation PRs are never closed regardless.
-  // CLOSE a contributor PR ONLY on a REAL adverse signal — a confirmed gate FAILURE, a red required CI, or a base
+  // CLOSE a contributor PR ONLY on a REAL adverse signal — a confirmed gate FAILURE, red CI, or a base
   // CONFLICT. NEVER close merely because CI is UNVERIFIED (a fork whose Actions await approval, or unreadable
   // checks) or otherwise not-yet-mergeable — those are HELD for review, not killed (#harm-stop fork-false-close).
-  // Owner/automation PRs are never closed (isContributor). A guarded path is HELD for the AI/gate VERDICT and for
-  // a base conflict (don't kill a crucial change on an AI call or a rebaseable conflict). A red CI may close a
-  // guarded path only after the caller proves required-context data was available; otherwise the live aggregate may
-  // have folded in optional / third-party checks and must keep the hard-guardrail manual hold.
+  // Owner/automation PRs are never closed unless owner-close is explicitly enabled. Guardrails do not soften
+  // blockers/conflicts/red CI; they hold only otherwise-ready PRs for manual review.
   // (Rebase-if-behind already ran above, so a red CI here is on the latest base — not a stale-base artifact.) (#ci-fail-closes-guarded)
-  const redVerifiedRequiredCi = ciFailed && input.ciRequiredContextsVerified === true;
-  const willClose = closeEligible && acting("close") && (redVerifiedRequiredCi || (!guardrailHit && (ciFailed || conclusion === "failure" || isConflict)));
+  const willClose = closeEligible && acting("close") && (ciFailed || conclusion === "failure" || isConflict);
   // Linked-issue HARD-RULE close (#linked-issue-hard-rules). A DETERMINISTIC verdict about the LINKED ISSUE
   // (owner-assigned / missing point-label / maintainer-only) — NOT an AI verdict, so there is no hallucination
   // to guard against: this close fires REGARDLESS of `guardrailHit`. It still only ever closes a CONTRIBUTOR
@@ -495,8 +470,8 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
     });
   } else if (willClose) {
-    // Contributor PR that is NOT review-good (gate blockers / red / unverified CI) OR conflicts with base →
-    // CLOSE one-shot when no hard guardrail requires manual review. Cite the concrete reasons.
+    // Contributor PR that is NOT review-good (gate blockers / red CI) OR conflicts with base → CLOSE one-shot.
+    // Guardrails hold otherwise-ready changes only; they do not downgrade blockers into manual review.
     const closeReasons: string[] = [];
     if (ciFailed) closeReasons.push(ciReason);
     if (isConflict) closeReasons.push("conflicts with the base branch — resolve and open a fresh PR");

--- a/src/signals/duplicate-winner.ts
+++ b/src/signals/duplicate-winner.ts
@@ -3,28 +3,58 @@
  *
  * When several OPEN PRs link the same issue (a duplicate cluster), the legacy behavior gate-blocks +
  * auto-closes EVERY sibling as a duplicate — no winner survives. With the flag ON, exactly ONE winner is
- * spared: the EARLIEST opened = the LOWEST PR number among the OPEN siblings. Only the LOSERS are
- * blocked/closed; the winner still must pass CI / conflict / gate / linked-issue / slop on its OWN merits.
+ * spared: the earliest observed linked-issue claimant. Only the LOSERS are blocked/closed; the winner still
+ * must pass CI / conflict / gate / linked-issue / slop on its OWN merits.
  *
  * This module is PURE — no IO, no Date, no random — so the same inputs always yield the same verdict and the
  * caller can compute the winner ONCE per review run and thread the result boolean consistently into every
  * surface (advisory finding, close reason, slop, panels), so they agree by construction.
  *
  * INVARIANT (the caller MUST honor it): {@link openSiblingNumbers} carries OPEN-only sibling PR numbers. The
- * existing sources (advisory `overlappingPrs`, gate `linkedIssueDuplicatePullRequestsForGate`, engine
- * `linkedIssueDuplicatePullRequests`) already exclude closed/merged PRs, so the lowest number is the lowest
- * OPEN number. Once the winner closes (e.g. red CI), it leaves the open set and the next-lowest OPEN sibling
- * becomes the winner on re-eval — no permanently-orphaned cluster.
+ * existing sources already exclude closed/merged PRs. Once the winner closes (e.g. red CI), it leaves the open
+ * set and the next-earliest OPEN claimant becomes the winner on re-eval — no permanently-orphaned cluster.
  */
+
+export type DuplicateClaimMember = {
+  number: number;
+  linkedIssueClaimedAt?: string | null | undefined;
+};
 
 /**
  * True iff `prNumber` is the cluster winner: the minimum of `{prNumber} ∪ openSiblingNumbers`. An empty
  * sibling list ⇒ the PR is alone in (or out of) the cluster ⇒ winner. A sibling list that happens to contain
  * `prNumber` itself is harmless — the comparison is still min-based.
+ *
+ * @deprecated Use {@link isDuplicateClusterWinnerByClaim}. PR-number election is retained only for legacy
+ * compatibility callers that do not have claim timestamps.
  */
 export function isDuplicateClusterWinner(prNumber: number, openSiblingNumbers: number[]): boolean {
   for (const sibling of openSiblingNumbers) {
     if (sibling < prNumber) return false;
   }
   return true;
+}
+
+/**
+ * True iff `pr` is the earliest known linked-issue claimant in the open duplicate cluster. Unknown or invalid
+ * claim times fail closed: the caller should keep the duplicate finding/blocker instead of accidentally sparing
+ * the wrong PR. Ties fall back to PR number only after the claim time is known for every compared sibling.
+ */
+export function isDuplicateClusterWinnerByClaim(pr: DuplicateClaimMember, openSiblings: DuplicateClaimMember[]): boolean {
+  if (openSiblings.length === 0) return true;
+  const prClaim = claimTimeMs(pr.linkedIssueClaimedAt);
+  if (prClaim === null) return false;
+  for (const sibling of openSiblings) {
+    const siblingClaim = claimTimeMs(sibling.linkedIssueClaimedAt);
+    if (siblingClaim === null) return false;
+    if (siblingClaim < prClaim) return false;
+    if (siblingClaim === prClaim && sibling.number < pr.number) return false;
+  }
+  return true;
+}
+
+function claimTimeMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -27,7 +27,7 @@ import { nowIso } from "../utils/json";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { labelMatchesPattern, projectLinkedIssueMultiplierForPlannedSolve, type LinkedIssueMultiplierStatus } from "../scoring/preview";
 import { hasLocalTestEvidence } from "./test-evidence";
-import { isDuplicateClusterWinner } from "./duplicate-winner";
+import { isDuplicateClusterWinnerByClaim } from "./duplicate-winner";
 import { PREFLIGHT_LIMITS } from "./preflight-limits";
 import type { UnifiedCollapsible } from "../review/unified-comment";
 import { splitAiReviewNits } from "../review/ai-notes";
@@ -54,6 +54,7 @@ export type CollisionItem = {
   htmlUrl?: string | null | undefined;
   labels?: string[] | undefined;
   linkedIssues?: number[] | undefined;
+  linkedIssueClaimedAt?: string | null | undefined;
   changedFiles?: string[] | undefined;
   body?: string | null | undefined;
 };
@@ -4186,14 +4187,15 @@ export function buildPublicPrIntelligenceComment(args: {
   review?: FocusManifestReviewConfig | undefined;
   /** Optional AI maintainer-review notes (already public-safe). Rendered as an advisory section. */
   aiReview?: { notes: string } | undefined;
-  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest open
-   *  sibling number among `linkedDuplicatePrs`), the hard-duplicate panel block is suppressed so the winner's
-   *  panel does not show a blocking duplicate. Default/false ⇒ byte-identical to today. */
+  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the earliest observed linked-issue
+   *  claimant among `linkedDuplicatePrs`, the hard-duplicate panel block is suppressed so the winner's panel
+   *  does not show a blocking duplicate. Default/false ⇒ byte-identical to today. */
   duplicateWinnerEnabled?: boolean | undefined;
 }): string {
   const publicFindings = publicSafePreflightFindings(args.preflight, args.settings);
   const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
-  const linkedDuplicatePrs = linkedIssueDuplicatePullRequests(args.pr, prCollisionClusters);
+  const linkedDuplicatePrItems = linkedIssueDuplicatePullRequestItems(args.pr, prCollisionClusters);
+  const linkedDuplicatePrs = linkedDuplicatePrItems.map((item) => item.number);
   const scopedOverlapClusters = unionScopedOverlapClusters(args.collisions, args.pr, args.preflight.collisions);
   const scopedOverlapCount = scopedOverlapClusters.length;
   const hasRelatedWork = linkedDuplicatePrs.length > 0 || scopedOverlapCount > 0;
@@ -4217,13 +4219,13 @@ export function buildPublicPrIntelligenceComment(args: {
   const gateEnabled = args.settings.gateCheckMode === "enabled";
   const hardLinkedIssueBlock =
     args.settings.linkedIssueGateMode === "block" && args.pr.linkedIssues.length === 0 && !hasClearNoIssueRationale(args.pr);
-  // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the cluster winner (the
-  // lowest open sibling number), do NOT hard-block it as a duplicate — only the losers block. `linkedDuplicatePrs`
-  // is open-only (collision clusters exclude closed PRs). Flag-OFF (default) short-circuits ⇒ byte-identical.
+  // Duplicate-winner adjudication (#dup-winner): when the flag is ON and this PR is the earliest observed
+  // linked-issue claimant, do NOT hard-block it as a duplicate — only the losers block. `linkedDuplicatePrs` is
+  // open-only (collision clusters exclude closed PRs). Unknown claim time keeps the blocker.
   const hardDuplicateBlock =
     args.settings.duplicatePrGateMode === "block" &&
     linkedDuplicatePrs.length > 0 &&
-    !(args.duplicateWinnerEnabled && isDuplicateClusterWinner(args.pr.number, linkedDuplicatePrs));
+    !(args.duplicateWinnerEnabled && isDuplicateClusterWinnerByClaim(args.pr, linkedDuplicatePrItems));
   const fallbackGateConclusion = !gateEnabled
     ? "success"
     : !args.repo
@@ -4437,13 +4439,14 @@ export function buildPublicPrPanelSignalRows(args: {
   preflight: PreflightResult;
   settings: RepositorySettings;
   gate?: PublicPrPanelGateEvaluation | undefined;
-  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the cluster winner (the lowest open
-   *  sibling number among `linkedDuplicatePrs`), the hard-duplicate block is suppressed. Default/false ⇒
-   *  byte-identical to today. Matches `buildPublicPrIntelligenceComment` so both panels agree. */
+  /** Duplicate-winner adjudication (#dup-winner). When true AND this PR is the earliest observed linked-issue
+   *  claimant among `linkedDuplicatePrs`, the hard-duplicate block is suppressed. Default/false ⇒ byte-identical
+   *  to today. Matches `buildPublicPrIntelligenceComment` so both panels agree. */
   duplicateWinnerEnabled?: boolean | undefined;
 }): { rows: PublicPrPanelSignalRow[]; readinessTotal: number } {
   const prCollisionClusters = pullRequestSpecificCollisionClusters(args.collisions, args.pr);
-  const linkedDuplicatePrs = linkedIssueDuplicatePullRequests(args.pr, prCollisionClusters);
+  const linkedDuplicatePrItems = linkedIssueDuplicatePullRequestItems(args.pr, prCollisionClusters);
+  const linkedDuplicatePrs = linkedDuplicatePrItems.map((item) => item.number);
   const scopedOverlapClusters = unionScopedOverlapClusters(args.collisions, args.pr, args.preflight.collisions);
   const scopedOverlapCount = scopedOverlapClusters.length;
   const readiness = buildPublicReadinessScore({ pr: args.pr, preflight: args.preflight, queueHealth: args.queueHealth, linkedDuplicatePrs, scopedOverlapCount });
@@ -4451,12 +4454,12 @@ export function buildPublicPrPanelSignalRows(args: {
   const relatedWorkResult = relatedWorkPanelResult(linkedDuplicatePrs, scopedOverlapCount);
   const gateEnabled = args.settings.gateCheckMode === "enabled";
   const hardLinkedIssueBlock = args.settings.linkedIssueGateMode === "block" && args.pr.linkedIssues.length === 0 && !hasClearNoIssueRationale(args.pr);
-  // Duplicate-winner adjudication (#dup-winner): suppress the winner's hard-duplicate block (see the comment
-  // builder). `linkedDuplicatePrs` is open-only; flag-OFF (default) short-circuits ⇒ byte-identical to today.
+  // Duplicate-winner adjudication (#dup-winner): suppress the earliest known claimant's hard-duplicate block
+  // (see the comment builder). Unknown claim time keeps the blocker; flag-OFF keeps legacy behavior.
   const hardDuplicateBlock =
     args.settings.duplicatePrGateMode === "block" &&
     linkedDuplicatePrs.length > 0 &&
-    !(args.duplicateWinnerEnabled && isDuplicateClusterWinner(args.pr.number, linkedDuplicatePrs));
+    !(args.duplicateWinnerEnabled && isDuplicateClusterWinnerByClaim(args.pr, linkedDuplicatePrItems));
   const fallbackGateConclusion = !gateEnabled ? "success" : !args.repo ? "neutral" : hardLinkedIssueBlock || hardDuplicateBlock ? "failure" : "success";
   const gateConclusion = args.gate?.conclusion ?? fallbackGateConclusion;
   const confirmedMiner = isOfficialContributorDetection(args.detection);
@@ -4496,15 +4499,19 @@ export function unionScopedOverlapClusters(
 }
 
 function linkedIssueDuplicatePullRequests(pr: PullRequestRecord, clusters: CollisionCluster[]): number[] {
+  return linkedIssueDuplicatePullRequestItems(pr, clusters).map((item) => item.number);
+}
+
+function linkedIssueDuplicatePullRequestItems(pr: PullRequestRecord, clusters: CollisionCluster[]): CollisionItem[] {
   const linkedIssues = new Set(pr.linkedIssues);
   if (linkedIssues.size === 0) return [];
   const duplicates = clusters.flatMap((cluster) =>
     cluster.items.flatMap((item) => {
       if (item.type !== "pull_request" || item.number === pr.number) return [];
-      return (item.linkedIssues ?? []).some((issue) => linkedIssues.has(issue)) ? [item.number] : [];
+      return (item.linkedIssues ?? []).some((issue) => linkedIssues.has(issue)) ? [item] : [];
     }),
   );
-  return [...new Set(duplicates)].sort((left, right) => left - right);
+  return [...new Map(duplicates.map((item) => [item.number, item])).values()].sort((left, right) => left.number - right.number);
 }
 
 function linkedIssuePanelResult(pr: PullRequestRecord): { result: string; evidence: string; action: string } {
@@ -5034,6 +5041,7 @@ function prItem(pr: PullRequestRecord): CollisionItem {
     htmlUrl: pr.htmlUrl,
     labels: pr.labels,
     linkedIssues: pr.linkedIssues,
+    linkedIssueClaimedAt: pr.linkedIssueClaimedAt,
     body: pr.body,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -433,6 +433,9 @@ export type PullRequestRecord = {
   createdAt?: string | null | undefined;
   updatedAt?: string | null | undefined;
   closedAt?: string | null | undefined;
+  /** First time Gittensory observed this PR claiming one or more linked issues. Used to elect same-issue
+   * duplicate winners by claim order instead of PR number. */
+  linkedIssueClaimedAt?: string | null | undefined;
   labels: string[];
   linkedIssues: number[];
   /** Latest deterministic slop assessment (0-100) and band, persisted by the public-surface processor when
@@ -517,7 +520,7 @@ export type RepositorySettings = {
    *  only, applies to every author like every blocker). Default `off` — opt-in via .gittensory.yml. */
   slopGateMode: GateRuleMode;
   /** PR-size manual-review HOLD (#gate-size). `off` (default/absent) = no size hold; `advisory`/`block` = a PR with
-   *  >= 10 changed files OR >= 500 changed (added+deleted) lines that would otherwise pass is HELD for manual review
+   *  >= 10 changed files OR >= 1000 changed (added+deleted) lines that would otherwise pass is HELD for manual review
    *  (neutral gate → "manual" verdict), never auto-merged and never a hard failure. Opt-in via `gate.size.mode`. */
   sizeGateMode?: GateRuleMode | undefined;
   /** Dry-run disposition (#gate-dryrun). When true, the gate renders the would-be merge/close/manual verdict (every
@@ -567,11 +570,11 @@ export type RepositorySettings = {
    *  AI themselves. Default false — opt-in via `.gittensory.yml gate.aiReview.allAuthors`. Independent of
    *  `aiReviewMode`: `off` still means no AI; this only widens WHO an enabled review covers. */
   aiReviewAllAuthors: boolean;
-  /** Minimum calibrated AI-reviewer confidence (0-1) for an AI defect to BLOCK under `aiReviewMode: block` (#7).
-   *  A dual-model consensus defect / split blocks only when its finding `confidence >= aiReviewCloseConfidence`;
-   *  below-threshold AI defects hold for human review rather than passing. Config-as-code only — set via
-   *  `.gittensory.yml gate.aiReview.closeConfidence` (no dashboard/DB column); unset ⇒ the gate uses the 0.93
-   *  default. Clamped to [0,1] at parse time. */
+  /** Configured AI-reviewer confidence floor (0-1) for close calibration (#7). Under `aiReviewMode: block`, AI
+   *  defect findings remain blockers even when their confidence is below this floor; the floor is retained as
+   *  configurable context, not a manual-review downgrade. Config-as-code only — set via `.gittensory.yml
+   *  gate.aiReview.closeConfidence` (no dashboard/DB column); unset ⇒ the gate uses the 0.93 default. Clamped to
+   *  [0,1] at parse time. */
   aiReviewCloseConfidence?: number | null | undefined;
   /** When TRUE, the repo OWNER's (and maintainer's) own PRs are eligible for auto-CLOSE like a contributor's
    *  (still subject to the `close` autonomy class + the same adverse-signal conditions). Default FALSE — owner

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -198,33 +198,24 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan).not.toContain("merge");
     });
 
-    it("does NOT auto-close a failing contributor PR on a guarded path — holds it for the owner (#hold-crucial-on-reject)", () => {
-      // Operator decision: a crucial/guarded PR is NEVER auto-closed, even on a reject — a hallucinated reject
-      // must not auto-close a good crucial PR (the #1528 near-miss). The owner verifies + closes/merges. The
-      // BULK (non-guarded) still auto-closes on reject; only the small crucial set is held.
+    it("auto-closes a failing contributor PR on a guarded path; guardrails hold only otherwise-ready PRs", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], ...guarded, pr: { labels: [], slopRisk: 95 } })));
-      expect(plan).not.toContain("close");
+      expect(plan).toContain("close");
     });
 
-    it("DOES auto-close a guarded contributor PR with red REQUIRED CI — a broken change can't merge regardless (#ci-fail-closes-guarded)", () => {
-      // The guardrail holds a crucial PR against the AI/gate VERDICT (the test above), but a red required CI is an
-      // OBJECTIVE failure: the change cannot merge no matter what, so it closes even on a guarded path. The
-      // contributor fixes CI and resubmits; a GREEN guarded resubmission is then held for review. conclusion is
-      // 'neutral' here to prove it is the CI — not a verdict — driving the close.
+    it("auto-closes a guarded contributor PR with red CI — a broken change can't merge regardless (#ci-fail-closes-guarded)", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", ciRequiredContextsVerified: true, pr: { labels: [] } })));
       expect(plan).toContain("close");
     });
 
-    it("does NOT auto-close a guarded contributor PR when red CI comes from the unknown-required fallback", () => {
-      // When branch-protection required contexts cannot be fetched, ciState=failed may be caused by an optional
-      // or third-party status. Preserve the hard-guardrail hold unless required contexts were verified.
+    it("auto-closes a guarded contributor PR even when red CI comes from an optional check", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ...guarded, ciState: "failed", failingCheckNames: ["attacker/non-required-status"], ciRequiredContextsVerified: false, pr: { labels: [] } })));
-      expect(plan).not.toContain("close");
+      expect(plan).toContain("close");
     });
 
-    it("does NOT auto-close unknown changed paths with guardrails when red CI is not verified-required", () => {
+    it("auto-closes unknown changed paths with guardrails when CI is red", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, changedPaths: [], hardGuardrailGlobs: ["src/scoring/**"], ciState: "failed", pr: { labels: [] } })));
-      expect(plan).not.toContain("close");
+      expect(plan).toContain("close");
     });
 
     it("does NOT approve or auto-merge a passing PR on a guarded path", () => {
@@ -290,69 +281,66 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
-  describe("CI-refutation: an AI-judgment-only gate failure does NOT close a green-CI PR (#ai-ci-refutation)", () => {
+  describe("AI/review blockers remain blocking even when CI is green", () => {
     const merging = { aiCiRefutationEnabled: true, autonomy: { merge: "auto" as const, approve: "auto" as const, close: "auto" as const, label: "auto" as const }, ciState: "passed" as const, pr: { labels: [], mergeableState: "clean" as const, reviewDecision: "APPROVED" as const } };
 
-    it("a consensus-defect failure on a green, clean PR MERGES instead of closing (the validator overrules the model)", () => {
+    it("a consensus-defect failure on a green, clean PR closes instead of merging", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["AI reviewers agree on a likely critical defect"], gateBlockerCodes: ["ai_consensus_defect"], ...merging }));
       const cls = classes(plan);
-      expect(cls).toContain("merge");
-      expect(cls).not.toContain("close");
-      // Never routed to manual review — the guardrail path is the ONLY manual hold.
-      expect(plan.find((a) => a.actionClass === "label")?.label).not.toBe(AGENT_LABEL_NEEDS_REVIEW);
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
 
-    it("a review-split failure on a green PR is refuted too (a single minority model opinion never closes a green PR)", () => {
+    it("a review-split failure on a green PR closes too", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["An AI reviewer flagged a likely blocking defect"], gateBlockerCodes: ["ai_review_split"], ...merging })));
-      expect(cls).toContain("merge");
-      expect(cls).not.toContain("close");
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
     });
 
-    it("the refutation reports the EFFECTIVE verdict (verdict=success; CI green), not the contradictory raw failure", () => {
+    it("the label reports the raw failure verdict, not a refuted success", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { label: "auto" }, ciState: "passed", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const label = plan.find((a) => a.actionClass === "label");
-      expect(label?.label).toBe(AGENT_LABEL_READY);
-      expect(label?.reason).toBe("verdict=success; CI green");
+      expect(label?.label).toBe(AGENT_LABEL_CHANGES);
+      expect(label?.reason).toBe("verdict=failure");
     });
 
-    it("is GATED by aiCiRefutationEnabled — enabled=false (the converged AI review off) still CLOSES the same PR", () => {
+    it("ignores aiCiRefutationEnabled — enabled=false still closes the same PR", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: false, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("does NOT refute when CI is RED — a real failing check is the ground truth and still CLOSES", () => {
+    it("closes when CI is red", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "failed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("does NOT refute a MIXED failure — any deterministic blocker alongside the AI one still CLOSES", () => {
+    it("closes a mixed failure", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect", "duplicate_open_pr"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("does NOT refute a deterministic-only failure (e.g. slop/duplicate) — those close normally on green CI", () => {
+    it("closes a deterministic-only failure", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["slop_high"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("does NOT refute ai_review_inconclusive — a 'could not review' hold is not a false defect", () => {
-      // inconclusive isn't a `failure` conclusion in practice (it HOLDS neutral), but even if a failure carried
-      // the code, it must NOT be treated as a refutable false positive.
+    it("closes ai_review_inconclusive when it is represented as a failure", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_review_inconclusive"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("is a no-op when codes are omitted (no AI blockers to refute) — byte-identical close", () => {
+    it("closes when codes are omitted too", () => {
       const cls = classes(planAgentMaintenanceActions(input({ conclusion: "failure", blockerTitles: ["AI reviewers agree on a likely critical defect"], aiCiRefutationEnabled: true, autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } })));
       expect(cls).toContain("close");
     });
 
-    it("a guardrail-touching AI-refuted PR is still HELD for the owner (refutation never overrides the guardrail hold)", () => {
+    it("a guardrail-touching blocker still closes for a contributor", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "failure", gateBlockerCodes: ["ai_consensus_defect"], aiCiRefutationEnabled: true, autonomy: { merge: "auto", approve: "auto", close: "auto", label: "auto" }, hardGuardrailGlobs: ["src/**"], changedPaths: ["src/index.ts"], ciState: "passed", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);
       expect(cls).not.toContain("merge");
-      expect(cls).not.toContain("close");
-      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
     });
   });
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -33,6 +33,7 @@ import {
   enrichInstallationHealth,
   fetchAndStorePullRequestFilesForReview,
   fetchLiveCiAggregate,
+  fetchLiveReviewThreadBlockers,
   fetchRequiredStatusContexts,
   isRateLimitedGitHubFailure,
   refreshContributorActivity,
@@ -2839,7 +2840,7 @@ describe("GitHub backfill", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("keeps non-required failing and pending statuses advisory when required contexts are known", async () => {
+    it("fails completed non-required red checks while still reporting optional pending visibility", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         const url = input.toString();
@@ -2866,10 +2867,10 @@ describe("GitHub backfill", () => {
 
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["trusted-required-ci"]));
 
-      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.ciState).toBe("failed");
       expect(aggregate.hasPending).toBe(true);
-      expect(aggregate.failingDetails).toEqual([]);
-      expect(aggregate.nonRequiredFailingDetails.map((detail) => detail.name).sort()).toEqual(["attacker/non-required-check", "attacker/non-required-status"]);
+      expect(aggregate.failingDetails.map((detail) => detail.name).sort()).toEqual(["attacker/non-required-check", "attacker/non-required-status"]);
+      expect(aggregate.nonRequiredFailingDetails).toEqual([]);
     });
 
     it("treats a visible required classic status that is still pending as pending CI", async () => {
@@ -3284,6 +3285,99 @@ describe("GitHub backfill", () => {
       expect(aggregate.failingDetails).toEqual([expect.objectContaining({ name: "ci/overflow" })]);
     });
 
+  });
+
+  describe("fetchLiveReviewThreadBlockers", () => {
+    it("returns unresolved non-outdated scanner review threads as blockers", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        if (input.toString() === "https://api.github.com/graphql") {
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: [
+                      {
+                        isResolved: false,
+                        isOutdated: false,
+                        path: "src/signals/redaction.ts",
+                        line: 30,
+                        comments: {
+                          nodes: [
+                            {
+                              body: "<!-- brin-pr-finding -->\n**P1:** PUBLIC_LOCAL_PATH_INLINE regex fails to match Windows backslash paths",
+                              url: "https://github.example/thread",
+                              author: { login: "superagent-security[bot]" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const blockers = await fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1748, "public-token");
+
+      expect(blockers).toEqual([
+        expect.objectContaining({
+          title: "PUBLIC_LOCAL_PATH_INLINE regex fails to match Windows backslash paths",
+          priority: "P1",
+          path: "src/signals/redaction.ts",
+          line: 30,
+          authorLogin: "superagent-security[bot]",
+          url: "https://github.example/thread",
+          scannerFinding: true,
+        }),
+      ]);
+    });
+
+    it("ignores resolved, outdated, own-bot, and empty review threads", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        if (input.toString() === "https://api.github.com/graphql") {
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: [
+                      { isResolved: true, isOutdated: false, path: "a.ts", line: 1, comments: { nodes: [{ body: "resolved", author: { login: "scanner[bot]" } }] } },
+                      { isResolved: false, isOutdated: true, path: "b.ts", line: 2, comments: { nodes: [{ body: "outdated", author: { login: "scanner[bot]" } }] } },
+                      { isResolved: false, isOutdated: false, path: "c.ts", line: 3, comments: { nodes: [{ body: "own bot", author: { login: "gittensory-orb[bot]" } }] } },
+                      { isResolved: false, isOutdated: false, path: "d.ts", line: 4, comments: { nodes: [{ body: "   ", author: { login: "scanner[bot]" } }, null] } },
+                      null,
+                    ],
+                  },
+                },
+              },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      await expect(fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1, "public-token")).resolves.toEqual([]);
+    });
+
+    it("fails open without a token, malformed repo name, or GraphQL response", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      const fetchSpy = vi.fn(async () => new Response("boom", { status: 500 }));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await expect(fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1, undefined)).resolves.toEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      await expect(fetchLiveReviewThreadBlockers(env, "malformed", 1, "public-token")).resolves.toEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      await expect(fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1, "public-token")).resolves.toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("fetchRequiredStatusContexts", () => {

--- a/test/unit/content-lane-wire.test.ts
+++ b/test/unit/content-lane-wire.test.ts
@@ -41,7 +41,7 @@ describe("surfaceVerdictToGate", () => {
     expect(evaluation.blockers).toHaveLength(1);
     expect(evaluation.blockers[0]?.severity).toBe("critical");
     expect(finding?.code).toBe("surface_lane_reject");
-    // Regression guard: a deterministic surface close must never be refutable by green CI.
+    // Regression guard: deterministic surface blockers remain outside AI-judgment telemetry.
     expect(AI_JUDGMENT_BLOCKER_CODES.has(evaluation.blockers[0]!.code)).toBe(false);
   });
 

--- a/test/unit/duplicate-winner.test.ts
+++ b/test/unit/duplicate-winner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isDuplicateClusterWinner } from "../../src/signals/duplicate-winner";
+import { isDuplicateClusterWinner, isDuplicateClusterWinnerByClaim } from "../../src/signals/duplicate-winner";
 import { dupWinnerLinkedDuplicateCount, linkedIssueDuplicatePullRequestsForGate } from "../../src/queue/processors";
 import type { PullRequestRecord } from "../../src/types";
 import { listOtherOpenPullRequests, upsertPullRequestFromGitHub } from "../../src/db/repositories";
@@ -35,22 +35,74 @@ describe("isDuplicateClusterWinner (#dup-winner)", () => {
   });
 });
 
+describe("isDuplicateClusterWinnerByClaim (#dup-winner claim election)", () => {
+  const claim = (number: number, linkedIssueClaimedAt: string | null) => ({ number, linkedIssueClaimedAt });
+
+  it("elects the earliest observed linked-issue claimant, not the lowest PR number", () => {
+    expect(isDuplicateClusterWinnerByClaim(claim(13, "2026-06-29T10:00:00.000Z"), [claim(12, "2026-06-29T10:05:00.000Z")])).toBe(true);
+  });
+
+  it("blocks an older PR that edits in the same issue after a newer PR already claimed it", () => {
+    expect(isDuplicateClusterWinnerByClaim(claim(12, "2026-06-29T10:05:00.000Z"), [claim(13, "2026-06-29T10:00:00.000Z")])).toBe(false);
+  });
+
+  it("falls back to PR number only for equal known claim timestamps", () => {
+    expect(isDuplicateClusterWinnerByClaim(claim(12, "2026-06-29T10:00:00.000Z"), [claim(13, "2026-06-29T10:00:00.000Z")])).toBe(true);
+    expect(isDuplicateClusterWinnerByClaim(claim(13, "2026-06-29T10:00:00.000Z"), [claim(12, "2026-06-29T10:00:00.000Z")])).toBe(false);
+  });
+
+  it("fails closed when any duplicate claimant has an unknown or invalid claim timestamp", () => {
+    expect(isDuplicateClusterWinnerByClaim(claim(12, null), [claim(13, "2026-06-29T10:00:00.000Z")])).toBe(false);
+    expect(isDuplicateClusterWinnerByClaim(claim(12, "2026-06-29T10:00:00.000Z"), [claim(13, "not-a-date")])).toBe(false);
+  });
+});
+
 describe("dupWinnerLinkedDuplicateCount (#dup-winner close-reason seam)", () => {
   it("winner + flag ON ⇒ 0 (close reason omits the duplicate cause)", () => {
-    expect(dupWinnerLinkedDuplicateCount([13, 14], 12, true)).toBe(0);
+    expect(
+      dupWinnerLinkedDuplicateCount(
+        [
+          { number: 13, linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" },
+          { number: 14, linkedIssueClaimedAt: "2026-06-29T10:02:00.000Z" },
+        ],
+        12,
+        "2026-06-29T10:00:00.000Z",
+        true,
+      ),
+    ).toBe(0);
   });
 
   it("loser + flag ON ⇒ real sibling count (close reason includes the duplicate cause)", () => {
-    expect(dupWinnerLinkedDuplicateCount([12, 13], 14, true)).toBe(2);
+    expect(
+      dupWinnerLinkedDuplicateCount(
+        [
+          { number: 12, linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z" },
+          { number: 13, linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" },
+        ],
+        14,
+        "2026-06-29T10:02:00.000Z",
+        true,
+      ),
+    ).toBe(2);
   });
 
   it("flag OFF ⇒ real sibling count even for a would-be winner (byte-identical)", () => {
-    expect(dupWinnerLinkedDuplicateCount([13, 14], 12, false)).toBe(2);
+    expect(
+      dupWinnerLinkedDuplicateCount(
+        [
+          { number: 13, linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" },
+          { number: 14, linkedIssueClaimedAt: "2026-06-29T10:02:00.000Z" },
+        ],
+        12,
+        "2026-06-29T10:00:00.000Z",
+        false,
+      ),
+    ).toBe(2);
   });
 
   it("no siblings ⇒ 0 regardless of the flag", () => {
-    expect(dupWinnerLinkedDuplicateCount([], 12, true)).toBe(0);
-    expect(dupWinnerLinkedDuplicateCount([], 12, false)).toBe(0);
+    expect(dupWinnerLinkedDuplicateCount([], 12, "2026-06-29T10:00:00.000Z", true)).toBe(0);
+    expect(dupWinnerLinkedDuplicateCount([], 12, "2026-06-29T10:00:00.000Z", false)).toBe(0);
   });
 });
 

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -5,6 +5,7 @@ import { buildAuthorizedPrActionAdvisory, gateCheckPolicy, resolveLinkedIssueAut
 import { createTestEnv } from "../helpers/d1";
 import { upsertIssueFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { evaluateGateCheck } from "../../src/rules/advisory";
+import { REVIEW_THREAD_BLOCKER_CODE } from "../../src/review/review-thread-findings";
 import { parseFocusManifest, resolveEffectiveSettings } from "../../src/signals/focus-manifest";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import type { Advisory, PullRequestRecord, RepositorySettings } from "../../src/types";
@@ -87,11 +88,11 @@ describe(".gittensory.yml settings override (resolveEffectiveSettings)", () => {
     expect(evaluateGateCheck(missingIssueAdvisory(), gateCheckPolicy(eff, null, true)).conclusion).toBe("failure");
   });
 
-  it("end-to-end: manifest gate.firstTimeContributorGrace:true softens a newcomer's block to advisory (#822/#552)", () => {
+  it("end-to-end: manifest gate.firstTimeContributorGrace:true no longer softens a newcomer's blocker (#822/#552)", () => {
     const eff = resolveEffectiveSettings(settings({ linkedIssueGateMode: "block", firstTimeContributorGrace: false }), parseFocusManifest({ gate: { firstTimeContributorGrace: true } }));
     expect(eff.firstTimeContributorGrace).toBe(true);
     const newcomerPolicy = gateCheckPolicy(eff, null, true, null, { mergedPrCount: 0, closedUnmergedPrCount: 0 });
-    expect(evaluateGateCheck(missingIssueAdvisory(), newcomerPolicy).conclusion).toBe("neutral");
+    expect(evaluateGateCheck(missingIssueAdvisory(), newcomerPolicy).conclusion).toBe("failure");
   });
 
   it("blocks a non-confirmed contributor identically to a confirmed one (#gate-nonconfirmed)", () => {
@@ -229,33 +230,30 @@ describe("AI close-confidence threshold gate (#7)", () => {
     expect(out.blockers.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
   });
 
-  it("holds for human review when mode=block but confidence < the floor (#7 regression)", () => {
+  it("blocks when mode=block even when confidence is below the configured floor (#7 regression)", () => {
     const out = evaluateGateCheck(aiDefectWith(0.92), gateCheckPolicy(settings({ aiReviewMode: "block" }), null, true));
-    expect(out.conclusion).toBe("neutral"); // below 0.93 → manual hold, not an auto-mergeable pass
-    expect(out.title).toBe("Gittensory Orb Review Agent — held for human review");
-    expect(out.blockers).toEqual([]);
-    expect(out.warnings.map((f) => f.code)).toContain("ai_consensus_defect");
+    expect(out.conclusion).toBe("failure");
+    expect(out.blockers.map((f) => f.code)).toEqual(["ai_consensus_defect"]);
   });
 
-  it("blocks exactly AT the floor (>= boundary) and not just below it", () => {
+  it("threads a custom floor but does not use it to downgrade below-floor defects", () => {
     // policy.aiReviewCloseConfidence is threaded onto the policy from settings.
     const policy = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.7 }), null, true);
-    expect(evaluateGateCheck(aiDefectWith(0.7), policy).conclusion).toBe("failure"); // == threshold → blocks
-    expect(evaluateGateCheck(aiDefectWith(0.69), policy).conclusion).toBe("neutral"); // just below → manual hold
+    expect(policy.aiReviewCloseConfidence).toBe(0.7);
+    expect(evaluateGateCheck(aiDefectWith(0.7), policy).conclusion).toBe("failure");
+    expect(evaluateGateCheck(aiDefectWith(0.69), policy).conclusion).toBe("failure");
   });
 
-  it("honors a custom aiReviewCloseConfidence (the `?? 0.93` default is NOT used when set) (#7)", () => {
-    // A high custom floor of 0.99 holds a 0.95 defect for human review (the 0.93 default would have blocked it).
+  it("keeps custom aiReviewCloseConfidence as calibration context without softening blockers (#7)", () => {
     const strict = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.99 }), null, true);
-    expect(evaluateGateCheck(aiDefectWith(0.95), strict).conclusion).toBe("neutral");
-    // A low custom floor of 0.3 blocks a 0.5 defect that the 0.93 default would have left advisory.
+    expect(evaluateGateCheck(aiDefectWith(0.95), strict).conclusion).toBe("failure");
     const lenient = gateCheckPolicy(settings({ aiReviewMode: "block", aiReviewCloseConfidence: 0.3 }), null, true);
     expect(evaluateGateCheck(aiDefectWith(0.5), lenient).conclusion).toBe("failure");
   });
 
-  it("a finding WITHOUT a confidence degrades to 1.0 and blocks under the default floor (graceful fallback) (#7)", () => {
+  it("a finding WITHOUT a confidence still blocks under aiReview:block (#7)", () => {
     const out = evaluateGateCheck(aiDefectWith(undefined), gateCheckPolicy(settings({ aiReviewMode: "block" }), null, true));
-    expect(out.conclusion).toBe("failure"); // no confidence → treated as 1.0 → always clears 0.93
+    expect(out.conclusion).toBe("failure");
   });
 
   it("never blocks when mode=advisory, regardless of a high confidence (#7)", () => {
@@ -264,15 +262,14 @@ describe("AI close-confidence threshold gate (#7)", () => {
 
   it("applies the same confidence floor to an ai_review_split finding (#7)", () => {
     const policy = gateCheckPolicy(settings({ aiReviewMode: "block" }), null, true);
-    expect(evaluateGateCheck(splitDefectWith(0.95), policy).conclusion).toBe("failure"); // clears 0.93 → blocks
-    expect(evaluateGateCheck(splitDefectWith(0.92), policy).conclusion).toBe("neutral"); // below 0.93 → manual hold
+    expect(evaluateGateCheck(splitDefectWith(0.95), policy).conclusion).toBe("failure");
+    expect(evaluateGateCheck(splitDefectWith(0.92), policy).conclusion).toBe("failure");
   });
 
   it("resolveEffectiveSettings maps gate.aiReview.closeConfidence (clamped) into the policy floor (#7)", () => {
     const eff = resolveEffectiveSettings(settings({ aiReviewMode: "off" }), parseFocusManifest({ gate: { aiReview: { mode: "block", closeConfidence: 0.4 } } }));
     expect(eff.aiReviewCloseConfidence).toBe(0.4);
     expect(eff.aiReviewMode).toBe("block");
-    // a 0.5 defect clears the configured 0.4 floor → blocks (it would NOT under the 0.93 default).
     expect(evaluateGateCheck(aiDefectWith(0.5), gateCheckPolicy(eff, null, true)).conclusion).toBe("failure");
   });
 });
@@ -405,20 +402,19 @@ describe("merge-readiness composite gate (#551)", () => {
   });
 });
 
-describe("first-time-contributor grace (#552)", () => {
+describe("first-time-contributor grace compatibility (#552)", () => {
   // A would-be hard blocker for a confirmed contributor (linked-issue: block trips on the missing-issue PR).
   const blockingPolicy = { linkedIssueGateMode: "block" as const, confirmedContributor: true };
 
-  it("(a) softens the block to a neutral/advisory gate for a genuine newcomer (0 merged, 0 closed-unmerged)", () => {
+  it("(a) does not soften blockers for a genuine newcomer (0 merged, 0 closed-unmerged)", () => {
     const result = evaluateGateCheck(missingIssueAdvisory(), {
       ...blockingPolicy,
       firstTimeContributorGrace: true,
       authorMergedPrCount: 0,
       authorClosedUnmergedPrCount: 0,
     });
-    expect(result.conclusion).toBe("neutral");
-    expect(result.blockers).toEqual([]);
-    expect(result.title).toContain("first-contribution grace");
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.map((finding) => finding.code)).toEqual(["missing_linked_issue"]);
   });
 
   it("(b) still blocks a repeat offender (0 merged, >= 3 closed-unmerged) — grace does not apply", () => {
@@ -459,7 +455,19 @@ describe("first-time-contributor grace (#552)", () => {
     expect(policy.firstTimeContributorGrace).toBe(true);
     expect(policy.authorMergedPrCount).toBe(0);
     expect(policy.authorClosedUnmergedPrCount).toBe(1);
-    expect(evaluateGateCheck(missingIssueAdvisory(), { ...policy, linkedIssueGateMode: "block" }).conclusion).toBe("neutral");
+    expect(evaluateGateCheck(missingIssueAdvisory(), { ...policy, linkedIssueGateMode: "block" }).conclusion).toBe("failure");
+  });
+});
+
+describe("review-thread blocker gate", () => {
+  it("always blocks unresolved review-thread findings", () => {
+    const advisory: Advisory = {
+      ...missingIssueAdvisory(),
+      findings: [{ code: REVIEW_THREAD_BLOCKER_CODE, severity: "critical", title: "review thread unresolved", detail: "Resolve it." }],
+    };
+    const result = evaluateGateCheck(advisory);
+    expect(result.conclusion).toBe("failure");
+    expect(result.blockers.map((finding) => finding.code)).toEqual([REVIEW_THREAD_BLOCKER_CODE]);
   });
 });
 
@@ -693,8 +701,8 @@ describe("size + guardrail manual-review HOLD (#gate-size / #gate-guardrail)", (
   const clean = (): Advisory => ({ ...missingIssueAdvisory(), findings: [] });
   it("holds (neutral) an oversized PR; passes under thresholds; off/unset = no hold", () => {
     expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory", changedFileCount: 12, changedLineCount: 10 }).conclusion).toBe("neutral"); // > 10 files
-    expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory", changedFileCount: 2, changedLineCount: 600 }).conclusion).toBe("neutral"); // > 500 lines
-    expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory", changedFileCount: 9, changedLineCount: 499 }).conclusion).toBe("success"); // under both thresholds
+    expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory", changedFileCount: 2, changedLineCount: 1000 }).conclusion).toBe("neutral"); // >= 1000 lines
+    expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory", changedFileCount: 9, changedLineCount: 999 }).conclusion).toBe("success"); // under both thresholds
     expect(evaluateGateCheck(clean(), { sizeGateMode: "off", changedFileCount: 50, changedLineCount: 9000 }).conclusion).toBe("success"); // gate off ⇒ no hold
     expect(evaluateGateCheck(clean(), { changedFileCount: 50, changedLineCount: 9000 }).conclusion).toBe("success"); // mode unset ⇒ no hold
     expect(evaluateGateCheck(clean(), { sizeGateMode: "advisory" }).conclusion).toBe("success"); // no counts ⇒ 0 ⇒ no hold

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -88,7 +88,7 @@ describe("isGroundingEnabled", () => {
   });
 });
 
-describe("aiCiRefutationActive (#ai-ci-refutation gate)", () => {
+describe("aiCiRefutationActive compatibility helper", () => {
   const env = (grounding: string, repos: string) => ({ GITTENSORY_REVIEW_GROUNDING: grounding, GITTENSORY_REVIEW_REPOS: repos }) as unknown as Env;
   const REPO = "JSONbored/metagraphed";
 

--- a/test/unit/maintainer-activation.test.ts
+++ b/test/unit/maintainer-activation.test.ts
@@ -171,8 +171,11 @@ describe("buildMaintainerActivationPreview", () => {
       repoFullName: repo.fullName,
       repo,
       settings: settings(),
-      // Two OPEN PRs link the same issue (#42) → a duplicate cluster. Winner = lowest open number = #1.
-      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { linkedIssues: [42] })],
+      // Two OPEN PRs link the same issue (#42) → a duplicate cluster. Winner = earliest observed claim = #1.
+      pullRequests: [
+        pr(1, { linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:00:00.000Z" }),
+        pr(2, { linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:01:00.000Z" }),
+      ],
       generatedAt: "2026-06-14T00:00:00.000Z",
       duplicateWinnerEnabled: true,
     });
@@ -187,7 +190,10 @@ describe("buildMaintainerActivationPreview", () => {
       repoFullName: repo.fullName,
       repo,
       settings: settings(),
-      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { linkedIssues: [42] })],
+      pullRequests: [
+        pr(1, { linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:00:00.000Z" }),
+        pr(2, { linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:01:00.000Z" }),
+      ],
       generatedAt: "2026-06-14T00:00:00.000Z",
     });
     expect(preview.findingCodeCounts).toContainEqual({ code: "duplicate_pr_risk", count: 2 });
@@ -199,7 +205,10 @@ describe("buildMaintainerActivationPreview", () => {
       repo,
       settings: settings(),
       // The only other PR linking #42 is CLOSED → not a live duplicate, so the open winner stays clean.
-      pullRequests: [pr(1, { linkedIssues: [42] }), pr(2, { state: "closed", linkedIssues: [42] })],
+      pullRequests: [
+        pr(1, { linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:00:00.000Z" }),
+        pr(2, { state: "closed", linkedIssues: [42], linkedIssueClaimedAt: "2026-06-14T00:01:00.000Z" }),
+      ],
       generatedAt: "2026-06-14T00:00:00.000Z",
       duplicateWinnerEnabled: true,
     });

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -142,13 +142,13 @@ describe("buildPredictedGateVerdict", () => {
     expect(noGate.blockers.some((b) => b.code === "missing_linked_issue")).toBe(false);
   });
 
-  it("honors public gate.firstTimeContributorGrace with predicted author history", () => {
+  it("does not let public gate.firstTimeContributorGrace soften duplicate blockers", () => {
     const newcomer = verdict({
       gate: { duplicates: "block", firstTimeContributorGrace: true },
       pullRequests: [openPr(42, "Retry uploads on 5xx responses", [7], "someone-else")],
     });
-    expect(newcomer.conclusion).toBe("neutral");
-    expect(newcomer.blockers).toHaveLength(0);
+    expect(newcomer.conclusion).toBe("failure");
+    expect(newcomer.blockers.some((b) => b.code === "duplicate_pr_risk")).toBe(true);
 
     const returning = verdict({
       gate: { duplicates: "block", firstTimeContributorGrace: true },
@@ -162,8 +162,8 @@ describe("buildPredictedGateVerdict", () => {
   });
 
   it("matches author history case-insensitively, like the live gate (#audit-§4)", () => {
-    // The merged PR's author is "MINER1" (different case from the contributor "miner1"). The predictor must
-    // count it as history — otherwise it would falsely predict newcomer grace (neutral) while the live gate fails.
+    // The merged PR's author is "MINER1" (different case from the contributor "miner1"). The predictor still
+    // counts it as history, but blocker disposition no longer depends on first-time grace.
     const mixedCase = verdict({
       gate: { duplicates: "block", firstTimeContributorGrace: true },
       pullRequests: [
@@ -174,9 +174,9 @@ describe("buildPredictedGateVerdict", () => {
     expect(mixedCase.conclusion).toBe("failure");
   });
 
-  it("denies first-contribution grace to a repeat offender via the closed-unmerged author-count path", () => {
-    // The author has 3 prior CLOSED-unmerged PRs (state === "closed" && !mergedAt) in this repo, so
-    // authorClosedUnmergedPrCount === 3 → isRepeatOffender → grace does NOT apply and the gate blocks.
+  it("keeps duplicate blockers for repeat offenders via the closed-unmerged author-count path", () => {
+    // The author has 3 prior CLOSED-unmerged PRs (state === "closed" && !mergedAt) in this repo. Blocker
+    // disposition no longer depends on first-time grace, so the gate blocks either way.
     const closedUnmerged = (number: number, title: string): PullRequestRecord => ({
       ...openPr(number, title, [], "miner1"),
       state: "closed",
@@ -195,8 +195,8 @@ describe("buildPredictedGateVerdict", () => {
   });
 
   it("counts a closed-but-merged PR as merge history via the mergedAt fallback (not state === merged)", () => {
-    // The prior PR has state "closed" yet carries a mergedAt timestamp, so it is only counted as merge
-    // history through the `|| pr.mergedAt` fallback → authorMergedPrCount >= 1 → not a newcomer → no grace.
+    // The prior PR has state "closed" yet carries a mergedAt timestamp, so it is still counted as merge history.
+    // Blocker disposition no longer depends on first-time grace, so the gate blocks either way.
     const result = verdict({
       gate: { duplicates: "block", firstTimeContributorGrace: true },
       pullRequests: [

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7310,6 +7310,7 @@ describe("queue processors", () => {
     });
     // The shared issue + the HIGHER-numbered open sibling (#92) → forms the same-issue duplicate cluster.
     await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 1, title: "Cache the registry sync", state: "open", user: { login: "maintainer" }, author_association: "OWNER", body: "We should cache the registry fetch." });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 91, title: "Fix the cache", state: "open", user: { login: "contributor" }, author_association: "CONTRIBUTOR", head: { sha: "win91" }, labels: [], body: "Fixes #1\n\nValidation: npm test" });
     await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 92, title: "Also fix the cache", state: "open", user: { login: "other" }, author_association: "CONTRIBUTOR", head: { sha: "sib92" }, labels: [], body: "Fixes #1" });
 
     let gatePatchBody: { conclusion?: string; output?: { title?: string; text?: string } } = {};

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -133,8 +133,9 @@ describe("advisory rules", () => {
       headSha: "abc123",
       labels: [],
       linkedIssues: [4],
+      linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z",
     };
-    const higherSibling: PullRequestRecord = { ...winner, number: 13, title: "Alternative registry sync" };
+    const higherSibling: PullRequestRecord = { ...winner, number: 13, title: "Alternative registry sync", linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" };
 
     const advisory = buildPullRequestAdvisory(repo, winner, { otherOpenPullRequests: [higherSibling], duplicateWinnerEnabled: true });
 
@@ -152,8 +153,9 @@ describe("advisory rules", () => {
       headSha: "abc123",
       labels: [],
       linkedIssues: [4],
+      linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z",
     };
-    const lowerSibling: PullRequestRecord = { ...loser, number: 12, title: "Add registry sync" };
+    const lowerSibling: PullRequestRecord = { ...loser, number: 12, title: "Add registry sync", linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z" };
 
     const advisory = buildPullRequestAdvisory(repo, loser, { otherOpenPullRequests: [lowerSibling], duplicateWinnerEnabled: true });
 
@@ -171,8 +173,9 @@ describe("advisory rules", () => {
       headSha: "abc123",
       labels: [],
       linkedIssues: [4],
+      linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z",
     };
-    const higherSibling: PullRequestRecord = { ...wouldBeWinner, number: 13, title: "Alternative registry sync" };
+    const higherSibling: PullRequestRecord = { ...wouldBeWinner, number: 13, title: "Alternative registry sync", linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" };
 
     const advisory = buildPullRequestAdvisory(repo, wouldBeWinner, { otherOpenPullRequests: [higherSibling], duplicateWinnerEnabled: false });
 
@@ -190,8 +193,9 @@ describe("advisory rules", () => {
       headSha: "abc123",
       labels: [],
       linkedIssues: [4],
+      linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z",
     };
-    const unrelated: PullRequestRecord = { ...lonePr, number: 13, title: "Unrelated change", linkedIssues: [99] };
+    const unrelated: PullRequestRecord = { ...lonePr, number: 13, title: "Unrelated change", linkedIssues: [99], linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z" };
 
     const advisory = buildPullRequestAdvisory(repo, lonePr, { otherOpenPullRequests: [unrelated], duplicateWinnerEnabled: true });
 
@@ -1078,7 +1082,7 @@ describe("firstAddedLineFromPatch", () => {
     });
   });
 
-describe("CI-refutation of the public comment gate (#ai-ci-refutation)", () => {
+describe("green-CI compatibility reconciliation of the public comment gate", () => {
   const finding = (code: string): import("../../src/types").AdvisoryFinding => ({ code, severity: "critical", title: `t:${code}`, detail: `d:${code}` });
   const failure = (codes: string[]): import("../../src/rules/advisory").GateCheckEvaluation => ({
     enabled: true,
@@ -1096,22 +1100,20 @@ describe("CI-refutation of the public comment gate (#ai-ci-refutation)", () => {
     expect(isAiJudgmentOnlyFailure(failure(["ai_consensus_defect", "duplicate_open_pr"]))).toBe(false);
     expect(isAiJudgmentOnlyFailure(failure(["slop_high"]))).toBe(false);
     expect(isAiJudgmentOnlyFailure(failure(["ai_review_inconclusive"]))).toBe(false);
-    // An empty blocker list is not a refutable AI-only failure.
+    // An empty blocker list is not an AI-only failure.
     expect(isAiJudgmentOnlyFailure({ ...failure([]), conclusion: "failure" })).toBe(false);
     // A non-failure conclusion is never AI-only-failure.
     expect(isAiJudgmentOnlyFailure({ ...failure(["ai_consensus_defect"]), conclusion: "success" })).toBe(false);
   });
 
-  it("enabled + green CI + AI-judgment-only failure → SUCCESS with cleared blockers (matches the merge disposition)", () => {
-    const out = reconcileGateEvaluationForGreenCi(failure(["ai_consensus_defect"]), "passed", true);
-    expect(out.conclusion).toBe("success");
-    expect(out.blockers).toEqual([]);
-    expect(out.title).toBe("Gittensory Orb Review Agent passed");
-    expect(out.summary).toContain("advisory, not blocking");
+  it("enabled + green CI + AI-judgment-only failure stays a failure", () => {
+    const fail = failure(["ai_consensus_defect"]);
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true)).toBe(fail);
   });
 
-  it("enabled + green CI + split-only failure → SUCCESS too", () => {
-    expect(reconcileGateEvaluationForGreenCi(failure(["ai_review_split"]), "passed", true).conclusion).toBe("success");
+  it("enabled + green CI + split-only failure stays a failure too", () => {
+    const fail = failure(["ai_review_split"]);
+    expect(reconcileGateEvaluationForGreenCi(fail, "passed", true)).toBe(fail);
   });
 
   it("is GATED by `enabled` — enabled=false returns the failure UNCHANGED even on green CI", () => {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -773,9 +773,19 @@ describe("signal coverage edge cases", () => {
   it("#dup-winner: panel hard-duplicate block is suppressed for the winner, kept for the loser, byte-identical when flag OFF", () => {
     const directRepo = repo("owner/dupwin");
     const dupIssue = issue(directRepo.fullName, 42, "Cache invalidation race");
-    // Two open PRs on the same issue: 70 is the lowest open number (the winner), 88 is the loser.
-    const winnerPr = pr(directRepo.fullName, 70, "Fix the cache race", { authorLogin: "miner", linkedIssues: [42], body: "Fixes #42" });
-    const loserPr = pr(directRepo.fullName, 88, "Also fixes the cache race", { authorLogin: "other", linkedIssues: [42], body: "Fixes #42" });
+    // Two open PRs on the same issue: 70 claimed the issue first (the winner), 88 is the later claimant.
+    const winnerPr = pr(directRepo.fullName, 70, "Fix the cache race", {
+      authorLogin: "miner",
+      linkedIssues: [42],
+      linkedIssueClaimedAt: "2026-06-29T10:00:00.000Z",
+      body: "Fixes #42",
+    });
+    const loserPr = pr(directRepo.fullName, 88, "Also fixes the cache race", {
+      authorLogin: "other",
+      linkedIssues: [42],
+      linkedIssueClaimedAt: "2026-06-29T10:01:00.000Z",
+      body: "Fixes #42",
+    });
     const collisions = buildCollisionReport(directRepo.fullName, [dupIssue], [winnerPr, loserPr]);
     const queueHealth = buildQueueHealth(directRepo, [dupIssue], [winnerPr, loserPr], collisions);
     const blockSettings = { ...repoSettings(directRepo.fullName), gateCheckMode: "enabled" as const, duplicatePrGateMode: "block" as const };

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -74,8 +74,7 @@ describe("deriveUnifiedStatus", () => {
   it("a guarded-path hold downgrades a would-be-ready PR to held — never 'safe to merge' (#guarded-hold-comment)", () => {
     // A clean+green PR that touches a hard-guardrail path is HELD for owner review, so the comment says held.
     expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed" } }, { heldForReview: true })).toBe("held");
-    // A guarded close with RED required CI still closes (the red check overrides the guardrail hold), so the
-    // headline stays "blocked"/Closed. The held-vs-closed nuance for non-red guarded closes is covered below.
+    // A guarded close still closes; guardrails hold only otherwise-ready PRs.
     expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "failed" } }, { heldForReview: true })).toBe("blocked");
     // Without the hold flag, the same clean+green PR is ready.
     expect(deriveUnifiedStatus({ ...base, decision: "merge", readiness: { ciState: "passed" } }, { heldForReview: false })).toBe("ready");
@@ -85,10 +84,10 @@ describe("deriveUnifiedStatus", () => {
     // #9: an owner / automation-bot author is NEVER auto-closed → a gate "close" verdict renders held while CI is green/unknown.
     expect(deriveUnifiedStatus({ ...base, decision: "close" }, { neverClosed: true })).toBe("held");
     expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "failed" } }, { neverClosed: true })).toBe("blocked");
-    // #8: a guarded-path close is the disposition's HOLD (owner review) unless a red required check forces it.
-    expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "passed" } }, { heldForReview: true })).toBe("held");
-    expect(deriveUnifiedStatus({ ...base, decision: "close" }, { heldForReview: true })).toBe("held"); // CI not yet reported → held
-    expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "failed" } }, { heldForReview: true })).toBe("blocked"); // red required CI → real close
+    // Guardrails do not downgrade a close/blocker verdict to held.
+    expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "passed" } }, { heldForReview: true })).toBe("blocked");
+    expect(deriveUnifiedStatus({ ...base, decision: "close" }, { heldForReview: true })).toBe("blocked");
+    expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "failed" } }, { heldForReview: true })).toBe("blocked");
     // A genuine contributor close (no guard, not owner/bot) still headlines Closed/blocked.
     expect(deriveUnifiedStatus({ ...base, decision: "close" })).toBe("blocked");
     expect(deriveUnifiedStatus({ ...base, decision: "close", readiness: { ciState: "failed" } })).toBe("blocked");


### PR DESCRIPTION
## Summary
- Keep blockers authoritative: blockers, red CI, base conflicts, and unresolved review threads stay close/reject paths instead of being downgraded to manual review.
- Treat guardrail and size holds as manual review only for otherwise-ready PRs.
- Block on visible failed CI checks/statuses and unresolved GitHub review threads, including scanner threads with P0-P3 findings.
- Elect same-linked-issue duplicate winners by first observed linked-issue claim time instead of PR number.
- Make the maintainer Reviews & PRs Grafana dashboard honor the selected time range.

## What changed
- Added review-thread blocker ingestion through the PR review path and webhook triggers for review comments/threads.
- Persisted `linked_issue_claimed_at` for PRs and threaded claim-aware duplicate winner logic through gate, comments, and planner paths.
- Removed green-CI/manual-review downgrades for configured AI/gate blockers.
- Updated the default large-PR manual-review line threshold to 1000 LOC.
- Added focused regression coverage for blocker-first verdicts, review threads, claim-time duplicate election, and dashboard-safe paths.

## Why
Blocked PRs were sometimes rendered as manual review when a guardrail/size hold was also present. Same-linked-issue duplicate handling also used PR creation order, which let older PRs that edited in a claim later suppress the real first claimant.

## Validation
- `npm run validate` — 5,166 tests passed, 4 skipped; coverage completed successfully.
- `npm run db:migrations:check` — migrations contiguous through 0084.
- `npm audit --audit-level=moderate` — 0 vulnerabilities.
- `git diff --check`
- Parsed `grafana/dashboards/maintainer-reviews.json` with Node.
