### PR TITLE
fix(signals): rank issue-quality report before capping to 100

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -2898,7 +2898,7 @@ export function buildIssueQualityReport(
   const lane = buildLaneAdvice(repo, fullName);
   const collisions = prebuiltCollisions ?? buildCollisionReport(fullName, issues, pullRequests, recentMergedPullRequests);
   const bountyByIssue = indexBountiesByIssue(bounties);
-  // Build per-issue indexes ONCE: the loop below runs over up to 100 open issues, and each previously re-scanned
+  // Build per-issue indexes ONCE: the loop below scores every open issue, and each previously re-scanned
   // the full PR list (up to 10k) twice plus every collision cluster. O(issues·PRs) → O(issues + PRs).
   const prsByLinkedIssue = indexPullRequestsByLinkedIssue(pullRequests);
   const prByNumber = new Map(pullRequests.map((pr) => [pr.number, pr] as const));
@@ -2908,7 +2908,6 @@ export function buildIssueQualityReport(
   const lifecycleByIssue = new Map(buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests).states.map((entry) => [entry.number, entry]));
   const reports = issues
     .filter((issue) => issue.state === "open")
-    .slice(0, 100)
     .map((issue) => {
       const linkedPrs = resolveLinkedPullRequests(issue, pullRequests, prsByLinkedIssue, prByNumber);
       const linkedMergedPrs = resolveLinkedPullRequests(issue, recentMergedPullRequests, mergedPrsByLinkedIssue, mergedPrByNumber);
@@ -2964,7 +2963,11 @@ export function buildIssueQualityReport(
               : "ready";
       return { number: issue.number, title: issue.title, lifecycle, linkage, bounty: bountyContext, status, score, reasons, warnings };
     })
-    .sort((left, right) => right.score - left.score || left.number - right.number);
+    // Rank-before-cap (#1773): score and sort EVERY open issue, then keep the top 100. Callers pass issues in
+    // updatedAt-desc order, so the old pre-score `.slice(0, 100)` silently dropped high-quality issues that were
+    // not among the 100 most-recently-updated — understating readyCount on repos with more than 100 open issues.
+    .sort((left, right) => right.score - left.score || left.number - right.number)
+    .slice(0, 100);
   return {
     repoFullName: fullName,
     generatedAt: nowIso(),

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -1062,6 +1062,48 @@ describe("world-class backend signals", () => {
     expect(quality.issues.length).toBeLessThanOrEqual(100);
   });
 
+  it("scores and ranks every open issue before capping to 100, keeping a high-quality issue past the first 100 (regression for #1773)", () => {
+    const discoveryRepo: RepositoryRecord = {
+      ...repo,
+      fullName: "owner/issue-quality-rank",
+      registryConfig: { ...repo.registryConfig!, repo: "owner/issue-quality-rank", issueDiscoveryShare: 1 },
+    };
+    const recent = new Date().toISOString();
+    // 100 thin, lower-scoring filler issues come first in caller order (callers pass open issues updatedAt-desc)...
+    const fillers: IssueRecord[] = Array.from({ length: 100 }, (_, index) => ({
+      repoFullName: discoveryRepo.fullName,
+      number: index + 1,
+      title: `Filler issue ${index + 1}`,
+      state: "open" as const,
+      authorLogin: "reporter",
+      authorAssociation: "NONE" as const,
+      labels: ["bug"],
+      linkedPrs: [],
+      body: "thin",
+      updatedAt: recent,
+    }));
+    // ...and one genuinely high-quality issue sits AFTER the first 100 (least-recently-updated position).
+    const strongIssue: IssueRecord = {
+      repoFullName: discoveryRepo.fullName,
+      number: 500,
+      title: "High-quality discovery candidate beyond the first hundred",
+      state: "open",
+      authorLogin: "reporter",
+      authorAssociation: "NONE",
+      labels: ["bug", "feature"],
+      linkedPrs: [],
+      body: "x".repeat(240),
+      updatedAt: recent,
+    };
+    const report = buildIssueQualityReport(discoveryRepo, [...fillers, strongIssue], [], discoveryRepo.fullName);
+    // The cap still bounds output to 100, but it now keeps the top-ranked issues rather than the first 100 by order.
+    expect(report.issues.length).toBe(100);
+    const strong = report.issues.find((entry) => entry.number === 500);
+    expect(strong?.status).toBe("ready");
+    // The highest-quality issue ranks first even though it was last in caller order (pre-cap it was dropped).
+    expect(report.issues[0]?.number).toBe(500);
+  });
+
   it("covers contributor fit and label audit warning boundaries", () => {
     const noUsageAudit = buildLabelAudit(
       { ...repo, registryConfig: { ...repo.registryConfig!, labelMultipliers: { feature: 1 } } },


### PR DESCRIPTION
## Summary

Fixes #1773. `buildIssueQualityReport` capped open issues with `.slice(0, 100)` before scoring and sorting, so on repos with more than 100 open issues only the 100 most-recently-updated issues were evaluated. High-quality issues outside that window were silently dropped, understating `ready` counts used by decision-pack and reward-risk guidance.

The pipeline now scores every open issue, sorts by quality score (then issue number), and only then caps to the top 100 — matching the rank-before-cap pattern used elsewhere in the signal pipeline.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers` (no worker changes)
- [ ] `npm run build:mcp` (no MCP changes)
- [ ] `npm run test:mcp-pack` (no MCP changes)
- [ ] `npm run ui:openapi:check` (no API schema changes)
- [ ] `npm run ui:lint` (no UI changes)
- [ ] `npm run ui:typecheck` (no UI changes)
- [ ] `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Skipped UI/MCP/workers/actionlint checks — backend-only `src/signals` change with no OpenAPI, workflow, or UI surface. Full `npm run test:ci` was run locally; 20 failures are Windows-environment-only (`spawn claude/codex ENOENT`, MCP CLI profile timeouts) and do not reproduce on Linux CI. Targeted vitest for the regression test and issue-quality tests passed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend signal logic only; no visible UI change.

## Notes

Regression test: `scores and ranks every open issue before capping to 100, keeping a high-quality issue past the first 100 (regression for #1773)` in `test/unit/signals.test.ts`.