### PR TITLE
fix(signals): preflight duplicate-work matches linked issues, not PR numbers (#1775)

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -900,6 +900,18 @@ export function isPullRequestInDuplicateCluster(collisions: CollisionReport, pul
   );
 }
 
+/**
+ * True when a collision item targets one of the planned contribution's linked issues. An issue item carries its
+ * own number in `linkedIssues` (`[issue.number]`); a PR / recent-merge item carries the issues that PR closes. The
+ * preflight duplicate-work check previously tested `plannedLinkedIssues.includes(item.number)`, which conflated a
+ * PR's NUMBER with an issue number — an unrelated open PR #42 then matched a plan linking issue #42, a routine
+ * GitHub numbering collision that minted a spurious `possible_duplicate_work` finding. Compare linked-issue SETS
+ * instead, mirroring the pairwise `sharedIssue` test `buildCollisionReport` already uses between items. (#1775)
+ */
+export function itemSharesPlannedLinkedIssue(item: CollisionItem, plannedLinkedIssues: number[]): boolean {
+  return (item.linkedIssues ?? []).some((issueNumber) => plannedLinkedIssues.includes(issueNumber));
+}
+
 export function buildQueueHealth(
   repo: RepositoryRecord | null,
   issues: IssueRecord[],
@@ -2478,7 +2490,7 @@ export function buildPreflightResult(
   const itemTerms = collisionReportTermCache.get(collisionReport) ?? new Map<string, CollisionTerms>();
   const collisions = collisionReport.clusters.filter((cluster) =>
     cluster.items.some((item) => {
-      if (linkedIssues.includes(item.number)) {
+      if (itemSharesPlannedLinkedIssue(item, linkedIssues)) {
         return true;
       }
       const overlap = termOverlap(plannedTerms, itemTerms.get(itemKey(item)) ?? collisionTerms(item));

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -24,9 +24,11 @@ import {
   buildQueueHealth,
   buildRoleContext,
   detectGittensorContributor,
+  itemSharesPlannedLinkedIssue,
   shouldPublishPrIntelligenceComment,
   unionScopedOverlapClusters,
   type CollisionCluster,
+  type CollisionItem,
   type CollisionReport,
   type QueueHealth,
 } from "../../src/signals/engine";
@@ -609,6 +611,41 @@ describe("signal coverage edge cases", () => {
     );
 
     expect(preflight.findings.map((finding) => finding.code)).toContain("possible_duplicate_work");
+  });
+
+  it("matches duplicate work by a shared linked issue, not a coincident PR number (#1775)", () => {
+    const directRepo = repo("owner/direct");
+    // A clustered issue (#7) and an open PR (#50) that closes it — the issue↔linking-PR collision cluster.
+    const sharedIssue = issue(directRepo.fullName, 7, "Token refresh race in the auth middleware");
+    const linkingPr = pr(directRepo.fullName, 50, "Guard the token refresh race", { linkedIssues: [7] });
+
+    // Plan links issue #50, which coincides with the open PR's NUMBER but not its linked issue (#7), and the
+    // planned title/paths do not overlap the cluster — so only the old number-conflation bug would flag it.
+    const coincidentNumber = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: "Add pagination to the labels export endpoint", body: "Fixes #50", changedFiles: ["src/api/labels.ts"], linkedIssues: [50] },
+      directRepo,
+      [sharedIssue],
+      [linkingPr],
+    );
+    expect(coincidentNumber.findings.map((finding) => finding.code)).not.toContain("possible_duplicate_work");
+
+    // Plan links the actually-shared issue (#7) → genuine overlap is still flagged.
+    const sharedLinkedIssue = buildPreflightResult(
+      { repoFullName: directRepo.fullName, title: "Add pagination to the labels export endpoint", body: "Fixes #7", changedFiles: ["src/api/labels.ts"], linkedIssues: [7] },
+      directRepo,
+      [sharedIssue],
+      [linkingPr],
+    );
+    expect(sharedLinkedIssue.findings.map((finding) => finding.code)).toContain("possible_duplicate_work");
+  });
+
+  it("itemSharesPlannedLinkedIssue intersects linked-issue sets and tolerates missing linkedIssues (#1775)", () => {
+    const prItemValue: CollisionItem = { type: "pull_request", number: 42, title: "Unrelated PR", linkedIssues: [9] };
+    // Shares issue #9 with the plan → match; only its number (42) overlapping the plan must NOT match.
+    expect(itemSharesPlannedLinkedIssue(prItemValue, [9])).toBe(true);
+    expect(itemSharesPlannedLinkedIssue(prItemValue, [42])).toBe(false);
+    // Defensive: an item without a linkedIssues array never matches (covers the nullish fallback).
+    expect(itemSharesPlannedLinkedIssue({ type: "pull_request", number: 9, title: "No links" }, [9])).toBe(false);
   });
 
   it("does not flag duplicate work for a short planned title that merely shares one word", () => {


### PR DESCRIPTION
## Summary

Fixes #1775.

`buildPreflightResult` raised `possible_duplicate_work` when a collision cluster item's `number` appeared in the planned contribution's linked issues (`linkedIssues.includes(item.number)`). For `pull_request` and `recent_merged_pull_request` items, `number` is the **PR number**, not an issue number. GitHub uses one shared sequence, so planning to fix issue `#42` falsely matched any unrelated open PR `#42` in a cluster — even when that PR closed a different issue and titles/paths did not overlap.

- `src/signals/engine.ts`: export `itemSharesPlannedLinkedIssue(item, plannedLinkedIssues)` to intersect the planned linked issues with each item's own `linkedIssues` set (issue items carry `[issue.number]`; PRs carry the issues they close), mirroring the pairwise `sharedIssue` test `buildCollisionReport` already uses between items.
- `buildPreflightResult`: call the helper instead of comparing `item.number`.
- `test/unit/signals-coverage.test.ts`: regression tests for the coincident-number false positive, a genuine shared-issue hit, and the `linkedIssues ?? []` fallback.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; both branches of the new helper and both preflight outcomes (coincident PR number vs shared linked issue) are covered.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (found 0 vulnerabilities)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped; `npm run test:coverage` and the other `test:ci` steps were run locally and are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/schema change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- The helper is exported so the `linkedIssues ?? []` nullish branch is directly unit-tested; collision items built by `issueItem` / `prItem` always populate `linkedIssues`, but the fallback is defensive and branch-covered.
