### PR TITLE
fix(orb): prefer the newest relay enrollment when forwarding events

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -291,8 +291,14 @@ export async function forwardOrbEvent(
   fetchImpl: typeof fetch = fetch,
 ): Promise<"forwarded" | "queued" | "skipped" | "failed"> {
   if (!args.installationId || !RELAY_FORWARD_EVENTS.has(args.eventName)) return "skipped";
+  // issueOrbEnrollment INSERTs a new row per enrollment without revoking prior enrolled rows for the same
+  // installation_id. Without ORDER BY, .first() is nondeterministic — a stale row (no relay / old URL) can win
+  // after re-enrollment (#1783). Prefer enrollments with a registered relay (SQLite sorts NULL first on DESC),
+  // then the newest relay registration, then the newest enrollment.
   const row = await env.DB
-    .prepare("SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL")
+    .prepare(
+      "SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL ORDER BY (relay_registered_at IS NOT NULL) DESC, relay_registered_at DESC, enrolled_at DESC",
+    )
     .bind(args.installationId)
     .first<{ relay_mode: string; relay_url: string | null; relay_secret_enc: string | null; relay_secret_iv: string | null; relay_secret_salt: string | null }>();
   if (!row) return "skipped"; // not a brokered self-host (or revoked) — nothing to relay to

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -294,11 +294,12 @@ export async function forwardOrbEvent(
   // issueOrbEnrollment INSERTs a new row per enrollment without revoking prior enrolled rows for the same
   // installation_id. Without ORDER BY, .first() is nondeterministic — a stale row (no relay / old URL) can win
   // after re-enrollment (#1783). Prefer enrollments with a registered relay (SQLite sorts NULL first on DESC),
-  // then the newest relay registration, then the newest enrollment, with created_at/enroll_id tie-breakers when
-  // SQLite CURRENT_TIMESTAMP ties at second resolution (#1783).
+  // then the newest relay registration, then the newest enrollment. The final tie-break is the implicit rowid
+  // (monotonic insertion order) — enroll_id is a random opaque token, and CURRENT_TIMESTAMP ties at second
+  // resolution, so rowid is the only stable "most recently inserted" key when those collide (#1783).
   const row = await env.DB
     .prepare(
-      "SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL ORDER BY (relay_registered_at IS NOT NULL) DESC, relay_registered_at DESC, enrolled_at DESC, created_at DESC, enroll_id DESC",
+      "SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL ORDER BY (relay_registered_at IS NOT NULL) DESC, relay_registered_at DESC, enrolled_at DESC, rowid DESC",
     )
     .bind(args.installationId)
     .first<{ relay_mode: string; relay_url: string | null; relay_secret_enc: string | null; relay_secret_iv: string | null; relay_secret_salt: string | null }>();

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -294,10 +294,11 @@ export async function forwardOrbEvent(
   // issueOrbEnrollment INSERTs a new row per enrollment without revoking prior enrolled rows for the same
   // installation_id. Without ORDER BY, .first() is nondeterministic — a stale row (no relay / old URL) can win
   // after re-enrollment (#1783). Prefer enrollments with a registered relay (SQLite sorts NULL first on DESC),
-  // then the newest relay registration, then the newest enrollment.
+  // then the newest relay registration, then the newest enrollment, with created_at/enroll_id tie-breakers when
+  // SQLite CURRENT_TIMESTAMP ties at second resolution (#1783).
   const row = await env.DB
     .prepare(
-      "SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL ORDER BY (relay_registered_at IS NOT NULL) DESC, relay_registered_at DESC, enrolled_at DESC",
+      "SELECT relay_mode, relay_url, relay_secret_enc, relay_secret_iv, relay_secret_salt FROM orb_enrollments WHERE installation_id = ? AND state = 'enrolled' AND revoked_at IS NULL ORDER BY (relay_registered_at IS NOT NULL) DESC, relay_registered_at DESC, enrolled_at DESC, created_at DESC, enroll_id DESC",
     )
     .bind(args.installationId)
     .first<{ relay_mode: string; relay_url: string | null; relay_secret_enc: string | null; relay_secret_iv: string | null; relay_secret_salt: string | null }>();

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -181,6 +181,21 @@ describe("forwardOrbEvent", () => {
     expect(calls[0]?.init?.body).toBe(body);
   });
 
+  it("FORWARDS via the newest enrollment when multiple enrolled rows exist for one installation (regression for #1783)", async () => {
+    const e = brokeredEnv();
+    await seedInstall(e, 804);
+    const staleSecret = ((await issueOrbEnrollment(e, 804)) as { secret: string }).secret; // row A — enrolled, no relay
+    const freshSecret = ((await issueOrbEnrollment(e, 804)) as { secret: string }).secret; // row B — stays enrolled too
+    await registerOrbRelay(e, freshSecret, "https://new-host.example/v1/orb/relay");
+    const { fetchImpl, calls } = capture(new Response("ok"));
+    const body = '{"action":"opened","number":9}';
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 804, deliveryId: "del-1783", rawBody: body }, fetchImpl)).toBe("forwarded");
+    expect(calls[0]?.url).toBe("https://new-host.example/v1/orb/relay");
+    const h = calls[0]?.init?.headers as Record<string, string>;
+    expect(h["x-orb-signature-256"]).toBe(`sha256=${await relaySignature(freshSecret, body)}`);
+    expect(staleSecret).not.toBe(freshSecret);
+  });
+
   it("returns FAILED (never throws) on a non-ok response or a thrown fetch — the Orb 202 always stands", async () => {
     const e = brokeredEnv();
     const secret = await enroll(e, 802);

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -196,6 +196,22 @@ describe("forwardOrbEvent", () => {
     expect(staleSecret).not.toBe(freshSecret);
   });
 
+  it("prefers the newest registered relay when two enrolled rows tie on relay_registered_at (regression for #1783 tie-break)", async () => {
+    const e = brokeredEnv();
+    await seedInstall(e, 805);
+    const staleSecret = ((await issueOrbEnrollment(e, 805)) as { secret: string }).secret;
+    await registerOrbRelay(e, staleSecret, "https://stale-host.example/v1/orb/relay");
+    const freshSecret = ((await issueOrbEnrollment(e, 805)) as { secret: string }).secret;
+    await registerOrbRelay(e, freshSecret, "https://new-host.example/v1/orb/relay");
+    await db(e).prepare("UPDATE orb_enrollments SET relay_registered_at = '2026-06-30T00:00:00Z' WHERE installation_id = 805").run();
+    const { fetchImpl, calls } = capture(new Response("ok"));
+    const body = '{"action":"opened","number":10}';
+    expect(await forwardOrbEvent(e, { eventName: "pull_request", installationId: 805, deliveryId: "del-tie", rawBody: body }, fetchImpl)).toBe("forwarded");
+    expect(calls[0]?.url).toBe("https://new-host.example/v1/orb/relay");
+    const h = calls[0]?.init?.headers as Record<string, string>;
+    expect(h["x-orb-signature-256"]).toBe(`sha256=${await relaySignature(freshSecret, body)}`);
+  });
+
   it("returns FAILED (never throws) on a non-ok response or a thrown fetch — the Orb 202 always stands", async () => {
     const e = brokeredEnv();
     const secret = await enroll(e, 802);


### PR DESCRIPTION
## Summary

Fixes #1783. `forwardOrbEvent` loaded the brokered self-host relay target with a `.first()` query on `orb_enrollments` that had no `ORDER BY`. Because `issueOrbEnrollment` inserts a new `enrolled` row on every enrollment without revoking prior rows for the same `installation_id`, re-enrollment left multiple active rows. The lookup could return a stale enrollment (no relay URL → `skipped`, or an old push URL → mis-delivered HMAC-signed payload).

The enrollment lookup now orders by registered-relay presence, then `relay_registered_at DESC`, then `enrolled_at DESC`, so the current self-host container wins after re-enrollment.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow changes)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally for changed integration tests; full suite spot-checked via `npx vitest run test/integration/orb-relay.test.ts` (63/63 pass).
- [ ] `npm run test:workers` (no worker changes)
- [ ] `npm run build:mcp` (no MCP changes)
- [ ] `npm run test:mcp-pack` (no MCP changes)
- [ ] `npm run ui:openapi:check` (no API schema changes)
- [ ] `npm run ui:lint` (no UI changes)
- [ ] `npm run ui:typecheck` (no UI changes)
- [ ] `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Skipped UI/MCP/workers/actionlint — orb relay-only change. Full `test:ci` on Windows hits environment-only failures (`spawn claude/codex ENOENT`); Linux CI is authoritative.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — orb relay backend only.

## Notes

Regression test: `FORWARDS via the newest enrollment when multiple enrolled rows exist for one installation (regression for #1783)` in `test/integration/orb-relay.test.ts`.