### PR TITLE
fix(signals): match contributor opportunities repos case-insensitively

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1353,7 +1353,7 @@ export function buildContributorOpportunities(
   issueQualityByRepo?: Map<string, IssueQualityReport>,
 ): ContributorOpportunity[] {
   const opportunities: ContributorOpportunity[] = [];
-  const touchedRepos = new Set(profile.registeredRepoActivity.reposTouched);
+  const touchedRepos = new Set(profile.registeredRepoActivity.reposTouched.map((repoFullName) => repoFullName.toLowerCase()));
   const labelHistory = new Set(profile.registeredRepoActivity.dominantLabels);
   const bountyByIssue = indexBountiesByIssue(bounties);
   const qualityByKey = issueQualityByRepo
@@ -1362,8 +1362,8 @@ export function buildContributorOpportunities(
 
   for (const repo of repositories.filter((candidate) => candidate.isRegistered)) {
     const lane = buildLaneAdvice(repo, repo.fullName);
-    const repoIssues = issues.filter((issue) => issue.repoFullName === repo.fullName && issue.state === "open");
-    const repoPullRequests = pullRequests.filter((pr) => pr.repoFullName === repo.fullName && pr.state === "open");
+    const repoIssues = issues.filter((issue) => sameRepo(issue.repoFullName, repo.fullName) && issue.state === "open");
+    const repoPullRequests = pullRequests.filter((pr) => sameRepo(pr.repoFullName, repo.fullName) && pr.state === "open");
     const linkedIssueNumbers = new Set(repoPullRequests.flatMap((pr) => pr.linkedIssues));
     const availableIssues = repoIssues.filter((issue) => issue.linkedPrs.length === 0 && !linkedIssueNumbers.has(issue.number));
     const queuePenalty = Math.min(20, repoPullRequests.length * 2);
@@ -1404,7 +1404,7 @@ export function buildContributorOpportunities(
       const maintainerWipPenalty = maintainerWip ? 45 : 0;
       const score = clamp(
         50 +
-          (touchedRepos.has(repo.fullName) ? 20 : 0) +
+          (touchedRepos.has(repo.fullName.toLowerCase()) ? 20 : 0) +
           labelFit * 5 +
           (lane.lane === "split" ? 8 : 0) +
           (lane.lane === "direct_pr" ? 5 : 0) -
@@ -1431,7 +1431,7 @@ export function buildContributorOpportunities(
         reasons: [
           lane.summary,
           ...(maintainerAuthored && !maintainerWip ? ["Maintainer-created issue — typically the highest contribution multiplier on Gittensor."] : []),
-          ...(touchedRepos.has(repo.fullName) ? ["Contributor has prior activity in this registered repo."] : []),
+          ...(touchedRepos.has(repo.fullName.toLowerCase()) ? ["Contributor has prior activity in this registered repo."] : []),
           ...(labelFit > 0 ? [`Issue labels overlap contributor history: ${issue.labels.filter((label) => labelHistory.has(label)).join(", ")}.`] : []),
           ...(bountyLifecycle === "active" ? ["An active bounty is attached as contribution context (not guaranteed payout)."] : []),
           ...(quality?.status === "ready" ? ["Issue quality report rates this issue as ready."] : []),

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -153,6 +153,31 @@ describe("world-class backend signals", () => {
     }
   });
 
+  it("matches contributor prior-activity and repo issues case-insensitively (regression for #1787)", () => {
+    const mixedRepo: RepositoryRecord = {
+      ...repo,
+      fullName: "Entrius/Allways-UI",
+      registryConfig: { ...repo.registryConfig!, repo: "Entrius/Allways-UI" },
+    };
+    const mixedIssue: IssueRecord = {
+      ...issues[0]!,
+      repoFullName: "entrius/allways-ui",
+      number: 99,
+      title: "Case-variant repo issue",
+      linkedPrs: [],
+    };
+    const profile = buildContributorProfile(
+      "oktofeesh1",
+      { login: "oktofeesh1", topLanguages: ["TypeScript"], source: "github" },
+      [{ ...pullRequests[0]!, repoFullName: "entrius/allways-ui", linkedIssues: [] }],
+      [],
+    );
+    const opportunities = buildContributorOpportunities(profile, [mixedRepo], [mixedIssue], []);
+    expect(opportunities).toHaveLength(1);
+    expect(opportunities[0]?.reasons).toContain("Contributor has prior activity in this registered repo.");
+    expect(opportunities[0]?.score).toBeGreaterThanOrEqual(70);
+  });
+
   it("ranks grabbable maintainer-created issues above community issues and downgrades maintainer WIP (#699/#186)", () => {
     const profile = buildContributorProfile("scout", { login: "scout", topLanguages: ["TypeScript"], source: "github" }, [], []);
     const maintainerOpen: IssueRecord = {


### PR DESCRIPTION
## Summary

Fixes #1787. `buildContributorOpportunities` checked prior repo activity with case-sensitive `touchedRepos.has(repo.fullName)` and filtered issues/PRs with exact `repoFullName === repo.fullName`. Registry sync and `buildRoleContext` already compare repo names case-insensitively, so a casing mismatch (e.g. profile `jsonbored/gittensory` vs registered `JSONbored/Gittensory`) dropped the +20 prior-activity score and could exclude open issues from opportunity ranking.

Normalize `touchedRepos` to lowercase and use `sameRepo` for issue/PR filtering.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] I linked issue #1787.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/signals.test.ts -t "regression for #1787"`
- [x] New regression test for case-variant repo full names

Skipped full `test:ci` on Windows (environment-only `spawn claude/codex ENOENT` failures); Linux CI is authoritative.

## Safety

- [x] No secrets or private scoring terms in code or PR text.
- [x] No auth/CORS/UI changes.

## UI Evidence

N/A — backend signal logic only.

## Notes

Replaces closed duplicate PR #1782 (same area as open #1776). Regression test in `test/unit/signals.test.ts`.