### PR TITLE
feat(enrichment): package maintenance-health / deprecated-dep scorer

### DIFF
--- a/review-enrichment/src/analyzers/dep-maintenance-health.ts
+++ b/review-enrichment/src/analyzers/dep-maintenance-health.ts
@@ -1,0 +1,201 @@
+// Package maintenance-health / deprecated-dep analyzer (#1511). For each dependency a PR newly ADDS or UPGRADES,
+// flags the ones a maintainer would want to know about but the no-checkout reviewer cannot derive: a package that
+// is DEPRECATED, or STALE (no release in roughly N years). Two deterministic registry signals only — no flaky
+// "archived"/sole-maintainer/Scorecard probes. Reports package@version + a short factual reason from the metadata.
+//   - npm: the packument `deprecated` field (non-empty string ⇒ deprecated, surface a short reason) and the `time`
+//     map (the newest version's publish date — stale when the most recent publish is older than the threshold).
+//   - PyPI: `info.yanked` (+ `yanked_reason`) for the queried version, and the newest release's upload date for
+//     staleness (same threshold).
+import type { EnrichRequest, DepMaintenanceHealthFinding } from "../types.js";
+import { extractDependencyChanges } from "./dependency-scan.js";
+
+const MAX_QUERIES = 25;
+// Staleness threshold: flag a package whose most recent release is older than this. Two years in ms.
+const STALE_AGE_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+
+const NPM_PACKAGE_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
+const PYPI_PACKAGE_RE = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+const SEMVER_RE = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+// PyPI versions are PEP 440, not semver: `1.0`, `24.1`, `1.0rc1`, `1.0.post1`, `1!2.0`. Validate only that the
+// string is non-empty and URL-path-safe (it goes into the version JSON URL) rather than imposing semver.
+const PYPI_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+!-]{0,63}$/;
+
+/** Is this dependency change one we can query a registry for (supported ecosystem + URL-safe name/version)? */
+function isQueryable(change: { ecosystem: string; package: string; to: string }): boolean {
+  if (change.ecosystem === "npm") return NPM_PACKAGE_RE.test(change.package) && SEMVER_RE.test(change.to);
+  if (change.ecosystem === "PyPI") return PYPI_PACKAGE_RE.test(change.package) && PYPI_VERSION_RE.test(change.to);
+  return false;
+}
+
+interface ScanLimits {
+  maxQueries?: number;
+  staleAgeMs?: number;
+}
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  limits?: ScanLimits;
+}
+
+/** A maintenance signal derived from registry metadata: `deprecated`/`yanked`, or `stale`. */
+type Health = { kind: "deprecated" | "yanked" | "stale"; reason: string };
+
+/** Collapse whitespace and cap the length of a registry-supplied reason so the rendered line stays short + safe. */
+function tidyReason(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 140);
+}
+
+/** Pure: the most recent publish date (ms epoch) from an npm `time` map, ignoring the `created`/`modified`
+ *  pseudo-entries and any unparseable timestamp. Returns null when no real, parseable publish date exists. */
+export function newestNpmPublishMs(time: Record<string, string> | undefined): number | null {
+  if (!time) return null;
+  let newest: number | null = null;
+  for (const [version, iso] of Object.entries(time)) {
+    if (version === "created" || version === "modified") continue;
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) continue; // garbage timestamp → ignore this entry (fail safe, don't flag)
+    if (newest === null || ms > newest) newest = ms;
+  }
+  return newest;
+}
+
+/** npm packument subset that carries the maintenance signals. `deprecated` is a string (the reason) when set, but
+ *  registries have historically also emitted `true`/`false` — both non-string forms are handled defensively. */
+export interface NpmPackument {
+  deprecated?: unknown;
+  time?: Record<string, string>;
+}
+
+/** Pure: classify an npm package from its packument. A non-empty `deprecated` STRING ⇒ deprecated (with its
+ *  reason); otherwise stale when the newest real publish is older than `staleAgeMs`. `now` injected for tests. */
+export function npmHealth(
+  meta: NpmPackument,
+  staleAgeMs: number,
+  now: number,
+): Health | null {
+  // `deprecated` is the reason string; a boolean/empty/whitespace value is NOT a deprecation (fail safe).
+  if (typeof meta.deprecated === "string" && meta.deprecated.trim() !== "") {
+    return { kind: "deprecated", reason: `deprecated by maintainer — ${tidyReason(meta.deprecated)}` };
+  }
+  const newest = newestNpmPublishMs(meta.time);
+  if (newest !== null && now - newest > staleAgeMs) {
+    const years = Math.floor((now - newest) / (365 * 24 * 60 * 60 * 1000));
+    return { kind: "stale", reason: `no release in ~${years}y (last publish ${new Date(newest).toISOString().slice(0, 10)})` };
+  }
+  return null;
+}
+
+/** PyPI version JSON subset: the queried version's `info` (yanked flag/reason) and the `releases` map (upload
+ *  dates per version) used for the staleness signal. */
+export interface PypiVersionJson {
+  info?: { yanked?: boolean; yanked_reason?: string | null };
+  releases?: Record<string, Array<{ upload_time_iso_8601?: string; upload_time?: string }>>;
+}
+
+/** Pure: the most recent upload date (ms epoch) across all releases, ignoring unparseable timestamps. Null when
+ *  no parseable upload date exists. */
+export function newestPypiUploadMs(releases: PypiVersionJson["releases"]): number | null {
+  if (!releases) return null;
+  let newest: number | null = null;
+  for (const files of Object.values(releases)) {
+    for (const file of files ?? []) {
+      const iso = file.upload_time_iso_8601 ?? file.upload_time;
+      if (!iso) continue;
+      const ms = Date.parse(iso);
+      if (!Number.isFinite(ms)) continue; // garbage timestamp → ignore (fail safe)
+      if (newest === null || ms > newest) newest = ms;
+    }
+  }
+  return newest;
+}
+
+/** Pure: classify a PyPI release from its version JSON. The queried version being `yanked` ⇒ yanked (with its
+ *  reason when present); otherwise stale when the newest upload is older than `staleAgeMs`. `now` injected. */
+export function pypiHealth(
+  data: PypiVersionJson,
+  staleAgeMs: number,
+  now: number,
+): Health | null {
+  if (data.info?.yanked === true) {
+    const why = typeof data.info.yanked_reason === "string" && data.info.yanked_reason.trim() !== ""
+      ? ` — ${tidyReason(data.info.yanked_reason)}`
+      : "";
+    return { kind: "yanked", reason: `release yanked from PyPI${why}` };
+  }
+  const newest = newestPypiUploadMs(data.releases);
+  if (newest !== null && now - newest > staleAgeMs) {
+    const years = Math.floor((now - newest) / (365 * 24 * 60 * 60 * 1000));
+    return { kind: "stale", reason: `no release in ~${years}y (last upload ${new Date(newest).toISOString().slice(0, 10)})` };
+  }
+  return null;
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  signal?: AbortSignal,
+): Promise<unknown | null> {
+  if (signal?.aborted) return null;
+  try {
+    const response = await fetchImpl(url, { signal });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Analyzer entrypoint: added/upgraded deps → registry metadata → only the deps that are deprecated/yanked or stale. */
+export async function scanDepMaintenanceHealth(
+  req: EnrichRequest,
+  fetchImpl: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<DepMaintenanceHealthFinding[]> {
+  const staleAgeMs = options.limits?.staleAgeMs ?? STALE_AGE_MS;
+  const now = Date.now();
+  // Filter to queryable (supported, URL-safe) changes BEFORE applying the cap, so unsupported/invalid entries
+  // can't consume the budget and starve a later real dependency.
+  const changes = extractDependencyChanges(req.files ?? [])
+    .filter(isQueryable)
+    .slice(0, options.limits?.maxQueries ?? MAX_QUERIES);
+  const findings: DepMaintenanceHealthFinding[] = [];
+  for (const change of changes) {
+    if (options.signal?.aborted) break;
+
+    if (change.ecosystem === "npm") {
+      const data = (await fetchJson(
+        fetchImpl,
+        `https://registry.npmjs.org/${encodeURIComponent(change.package)}`,
+        options.signal,
+      )) as NpmPackument | null;
+      const health = data && npmHealth(data, staleAgeMs, now);
+      if (health) {
+        findings.push({
+          ecosystem: change.ecosystem,
+          package: change.package,
+          version: change.to,
+          kind: health.kind,
+          reason: health.reason,
+        });
+      }
+    } else {
+      // PyPI — the only other ecosystem isQueryable admits.
+      const data = (await fetchJson(
+        fetchImpl,
+        `https://pypi.org/pypi/${encodeURIComponent(change.package)}/${encodeURIComponent(change.to)}/json`,
+        options.signal,
+      )) as PypiVersionJson | null;
+      const health = data && pypiHealth(data, staleAgeMs, now);
+      if (health) {
+        findings.push({
+          ecosystem: change.ecosystem,
+          package: change.package,
+          version: change.to,
+          kind: health.kind,
+          reason: health.reason,
+        });
+      }
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -24,6 +24,7 @@ import { scanTyposquat } from "./analyzers/typosquat.js";
 import { scanCommitSignature } from "./analyzers/commit-signature.js";
 import { scanIacMisconfig } from "./analyzers/iac-misconfig.js";
 import { scanNativeBuild } from "./analyzers/native-build.js";
+import { scanDepMaintenanceHealth } from "./analyzers/dep-maintenance-health.js";
 import { renderBrief } from "./render.js";
 import { captureAnalyzerDegradation } from "./sentry.js";
 
@@ -50,6 +51,8 @@ const ANALYZERS: Record<keyof BriefFindings, AnalyzerFn> = {
   commitSignature: (req, signal) => scanCommitSignature(req, fetch, { signal }),
   iacMisconfig: (req, signal) => scanIacMisconfig(req, signal),
   nativeBuild: (req, signal) => scanNativeBuild(req, fetch, { signal }),
+  depMaintenanceHealth: (req, signal) =>
+    scanDepMaintenanceHealth(req, fetch, { signal }),
 };
 
 function runWithTimeout<T>(

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -350,6 +350,20 @@ export function renderBrief(
     }
   }
 
+  const depHealth = findings.depMaintenanceHealth ?? [];
+  if (depHealth.length) {
+    lines.push(
+      "### Deprecated / stale dependencies (maintenance-health — prefer a maintained alternative)",
+    );
+    for (const item of depHealth) {
+      // `reason` can embed registry-supplied text (npm `deprecated` / PyPI `yanked_reason`), so it is escaped
+      // through promptText before splicing — never spliced raw into the prompt block.
+      lines.push(
+        `- ${safeCodeSpan(`${item.package}@${item.version}`)} (${item.ecosystem}): ${promptText(item.reason)}`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -225,6 +225,19 @@ export interface NativeBuildFinding {
   reason: string;
 }
 
+/** A newly-added/upgraded direct dependency (npm/PyPI) that is DEPRECATED/yanked by its maintainer, or STALE
+ *  (no release in roughly N years) — maintenance-health risks the no-checkout reviewer cannot derive from the
+ *  registry. Reports package@version + a short factual reason from the metadata only. (#1511) */
+export interface DepMaintenanceHealthFinding {
+  ecosystem: string;
+  package: string;
+  version: string;
+  /** `deprecated` (npm), `yanked` (PyPI), or `stale` (no recent release in either ecosystem). */
+  kind: "deprecated" | "yanked" | "stale";
+  /** Short, public-safe explanation of the maintenance signal. */
+  reason: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -244,6 +257,7 @@ export interface BriefFindings {
   commitSignature?: CommitSignatureFinding[];
   iacMisconfig?: IacMisconfigFinding[];
   nativeBuild?: NativeBuildFinding[];
+  depMaintenanceHealth?: DepMaintenanceHealthFinding[];
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped";

--- a/review-enrichment/test/dep-maintenance-health.test.ts
+++ b/review-enrichment/test/dep-maintenance-health.test.ts
@@ -1,0 +1,269 @@
+// Units for the maintenance-health / deprecated-dep analyzer (#1511). Own file (not enrichment.test.ts) so
+// concurrent analyzer PRs don't collide. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  newestNpmPublishMs,
+  newestPypiUploadMs,
+  npmHealth,
+  pypiHealth,
+  scanDepMaintenanceHealth,
+} from "../dist/analyzers/dep-maintenance-health.js";
+import { renderBrief } from "../dist/render.js";
+
+const NOW = Date.parse("2026-06-29T00:00:00Z");
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+const STALE_MS = 2 * YEAR_MS;
+const iso = (ms) => new Date(ms).toISOString();
+
+// A package.json diff that ADDS one dependency (a single `+` line → from === null).
+const npmAdd = (name, version = "1.0.0") => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "${name}": "^${version}"` }],
+});
+const pypiAdd = (name, version = "1.0.0") => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [{ path: "requirements.txt", patch: `@@ -1,0 +1,1 @@\n+${name}==${version}` }],
+});
+const npmFetch = (packument) => async () => ({ ok: true, json: async () => packument });
+const pypiFetch = (data) => async () => ({ ok: true, json: async () => data });
+const status = (code) => async () => ({ ok: code >= 200 && code < 300, status: code, json: async () => ({}) });
+const throwingFetch = async () => {
+  throw new Error("network down");
+};
+// A fresh npm `time` map whose newest publish is `recent` — used as the healthy/non-stale baseline.
+const freshNpmTime = { "1.0.0": iso(NOW - 30 * 24 * 60 * 60 * 1000) };
+const freshPypiReleases = { "1.0.0": [{ upload_time_iso_8601: iso(NOW - 30 * 24 * 60 * 60 * 1000) }] };
+
+test("npmHealth: a non-empty deprecated STRING is flagged deprecated with its reason", () => {
+  const hit = npmHealth({ deprecated: "use foo instead", time: freshNpmTime }, STALE_MS, NOW);
+  assert.equal(hit?.kind, "deprecated");
+  assert.match(hit.reason, /use foo instead/);
+});
+
+test("npmHealth: deprecated false/boolean/empty/whitespace is NOT a deprecation (fail safe)", () => {
+  assert.equal(npmHealth({ deprecated: false, time: freshNpmTime }, STALE_MS, NOW), null);
+  assert.equal(npmHealth({ deprecated: true, time: freshNpmTime }, STALE_MS, NOW), null);
+  assert.equal(npmHealth({ deprecated: "", time: freshNpmTime }, STALE_MS, NOW), null);
+  assert.equal(npmHealth({ deprecated: "   ", time: freshNpmTime }, STALE_MS, NOW), null);
+});
+
+test("npmHealth: a package with no release in >2y is flagged stale", () => {
+  const hit = npmHealth({ time: { "1.0.0": iso(NOW - 3 * YEAR_MS) } }, STALE_MS, NOW);
+  assert.equal(hit?.kind, "stale");
+  assert.match(hit.reason, /no release in ~3y/);
+});
+
+test("npmHealth: a recently-published healthy package yields no finding", () => {
+  assert.equal(npmHealth({ time: freshNpmTime }, STALE_MS, NOW), null);
+});
+
+test("npmHealth: missing time / no parseable date fails safe (no stale finding)", () => {
+  assert.equal(npmHealth({}, STALE_MS, NOW), null);
+  assert.equal(npmHealth({ time: { "1.0.0": "not-a-date" } }, STALE_MS, NOW), null);
+});
+
+test("newestNpmPublishMs: ignores created/modified and unparseable timestamps", () => {
+  const ms = newestNpmPublishMs({
+    created: iso(NOW),
+    modified: iso(NOW),
+    "1.0.0": iso(NOW - 5 * YEAR_MS),
+    "1.1.0": "garbage",
+    "2.0.0": iso(NOW - 3 * YEAR_MS),
+  });
+  assert.equal(ms, NOW - 3 * YEAR_MS); // newest real publish, not the created/modified pseudo-entries
+});
+
+test("pypiHealth: a yanked version is flagged with its reason", () => {
+  const hit = pypiHealth(
+    { info: { yanked: true, yanked_reason: "security issue" }, releases: freshPypiReleases },
+    STALE_MS,
+    NOW,
+  );
+  assert.equal(hit?.kind, "yanked");
+  assert.match(hit.reason, /security issue/);
+});
+
+test("pypiHealth: a yanked version with no/null reason still flags (no reason appended)", () => {
+  const hit = pypiHealth({ info: { yanked: true, yanked_reason: null }, releases: freshPypiReleases }, STALE_MS, NOW);
+  assert.equal(hit?.kind, "yanked");
+  assert.match(hit.reason, /release yanked from PyPI$/);
+});
+
+test("pypiHealth: yanked false / no info is not flagged yanked", () => {
+  assert.equal(pypiHealth({ info: { yanked: false }, releases: freshPypiReleases }, STALE_MS, NOW), null);
+  assert.equal(pypiHealth({ releases: freshPypiReleases }, STALE_MS, NOW), null);
+});
+
+test("pypiHealth: no upload in >2y is flagged stale; falls back to upload_time", () => {
+  const hit = pypiHealth({ releases: { "1.0.0": [{ upload_time: iso(NOW - 4 * YEAR_MS) }] } }, STALE_MS, NOW);
+  assert.equal(hit?.kind, "stale");
+  assert.match(hit.reason, /no release in ~4y/);
+});
+
+test("pypiHealth: missing releases / unparseable upload date fails safe", () => {
+  assert.equal(pypiHealth({}, STALE_MS, NOW), null);
+  assert.equal(pypiHealth({ releases: { "1.0.0": [{ upload_time_iso_8601: "nope" }] } }, STALE_MS, NOW), null);
+});
+
+test("newestPypiUploadMs: handles missing/empty file lists and picks the newest", () => {
+  assert.equal(newestPypiUploadMs(undefined), null);
+  assert.equal(newestPypiUploadMs({ "1.0.0": [] }), null);
+  const ms = newestPypiUploadMs({
+    "1.0.0": [{ upload_time_iso_8601: iso(NOW - 5 * YEAR_MS) }],
+    "2.0.0": [{ upload_time_iso_8601: iso(NOW - 1 * YEAR_MS) }],
+  });
+  assert.equal(ms, NOW - 1 * YEAR_MS);
+});
+
+test("scanDepMaintenanceHealth: npm deprecated dependency is flagged", async () => {
+  const findings = await scanDepMaintenanceHealth(
+    npmAdd("request"),
+    npmFetch({ deprecated: "no longer supported", time: freshNpmTime }),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "deprecated");
+  assert.equal(findings[0].package, "request");
+  assert.equal(findings[0].version, "1.0.0");
+});
+
+test("scanDepMaintenanceHealth: PyPI yanked release is flagged", async () => {
+  const findings = await scanDepMaintenanceHealth(
+    pypiAdd("badpkg"),
+    pypiFetch({ info: { yanked: true, yanked_reason: "broken" }, releases: freshPypiReleases }),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "yanked");
+  assert.equal(findings[0].ecosystem, "PyPI");
+});
+
+test("scanDepMaintenanceHealth: a healthy, recently-released dependency is not flagged", async () => {
+  assert.deepEqual(
+    await scanDepMaintenanceHealth(npmAdd("lodash"), npmFetch({ time: freshNpmTime })),
+    [],
+  );
+  assert.deepEqual(
+    await scanDepMaintenanceHealth(pypiAdd("requests"), pypiFetch({ info: { yanked: false }, releases: freshPypiReleases })),
+    [],
+  );
+});
+
+test("scanDepMaintenanceHealth: a scoped npm name is URL-encoded and still queryable", async () => {
+  let requested = "";
+  const findings = await scanDepMaintenanceHealth(npmAdd("@scope/pkg"), async (url) => {
+    requested = url;
+    return { ok: true, json: async () => ({ deprecated: "gone", time: freshNpmTime }) };
+  });
+  assert.equal(findings.length, 1);
+  assert.match(requested, /%40scope%2Fpkg/); // encodeURIComponent applied to the scoped name
+});
+
+test("scanDepMaintenanceHealth: malformed package names and unsupported ecosystems are never queried", async () => {
+  const req = {
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      { path: "go.mod", patch: `@@ -1,0 +1,1 @@\n+require example.com/x v1.0.0` }, // Go — unsupported
+      { path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "BadCaps": "^1.0.0"` }, // invalid npm name
+    ],
+  };
+  let called = false;
+  const out = await scanDepMaintenanceHealth(req, async () => {
+    called = true;
+    return status(200)();
+  });
+  assert.deepEqual(out, []);
+  assert.equal(called, false); // nothing queryable → no registry call
+});
+
+test("scanDepMaintenanceHealth: only DIRECT added/upgraded deps are scanned (an upgrade is queried)", async () => {
+  const upgrade = {
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      {
+        path: "package.json",
+        patch: `@@ -1,1 +1,1 @@\n-  "request": "^1.0.0"\n+  "request": "^2.0.0"`,
+      },
+    ],
+  };
+  let requestedVersion = "";
+  const findings = await scanDepMaintenanceHealth(upgrade, async () => ({
+    ok: true,
+    json: async () => ({ deprecated: "use a maintained fork", time: freshNpmTime }),
+  }));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].version, "2.0.0"); // the upgraded-to version is reported
+  void requestedVersion;
+});
+
+test("scanDepMaintenanceHealth: the query cap counts only queryable changes (skips don't starve a real dep)", async () => {
+  const goLines = Array.from({ length: 25 }, (_, i) => `+require example.com/m${i} v1.0.0`).join("\n");
+  const req = {
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      { path: "go.mod", patch: `@@ -1,0 +1,25 @@\n${goLines}` },
+      { path: "package.json", patch: `@@ -1,0 +1,1 @@\n+  "request": "^1.0.0"` },
+    ],
+  };
+  const findings = await scanDepMaintenanceHealth(
+    req,
+    npmFetch({ deprecated: "gone", time: freshNpmTime }),
+    { limits: { maxQueries: 25 } },
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].package, "request");
+});
+
+test("scanDepMaintenanceHealth: the query cap bounds total fetches", async () => {
+  const lines = Array.from({ length: 5 }, (_, i) => `+  "pkg${i}": "^1.0.0"`).join("\n");
+  const req = {
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [{ path: "package.json", patch: `@@ -1,0 +1,5 @@\n${lines}` }],
+  };
+  let calls = 0;
+  await scanDepMaintenanceHealth(
+    req,
+    async () => {
+      calls += 1;
+      return { ok: true, json: async () => ({ time: freshNpmTime }) };
+    },
+    { limits: { maxQueries: 2 } },
+  );
+  assert.equal(calls, 2); // capped at maxQueries even though 5 deps were added
+});
+
+test("scanDepMaintenanceHealth fails safe on a non-ok or throwing fetch", async () => {
+  assert.deepEqual(await scanDepMaintenanceHealth(npmAdd("request"), status(404)), []);
+  assert.deepEqual(await scanDepMaintenanceHealth(npmAdd("request"), throwingFetch), []);
+});
+
+test("scanDepMaintenanceHealth fails safe on malformed registry JSON", async () => {
+  const malformed = async () => ({ ok: true, json: async () => ({ unexpected: "shape" }) });
+  assert.deepEqual(await scanDepMaintenanceHealth(npmAdd("request"), malformed), []);
+  assert.deepEqual(await scanDepMaintenanceHealth(pypiAdd("requests"), malformed), []);
+});
+
+test("scanDepMaintenanceHealth stops on an already-aborted signal", async () => {
+  const findings = await scanDepMaintenanceHealth(npmAdd("request"), npmFetch({ deprecated: "gone", time: freshNpmTime }), {
+    signal: AbortSignal.abort(),
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("renderBrief emits a public-safe deprecated/stale block and escapes registry-supplied reasons", () => {
+  const { promptSection } = renderBrief({
+    depMaintenanceHealth: [
+      { ecosystem: "npm", package: "request", version: "2.88.2", kind: "deprecated", reason: "deprecated by maintainer — use `axios`*injected*" },
+      { ecosystem: "PyPI", package: "oldpkg", version: "0.1.0", kind: "stale", reason: "no release in ~5y (last upload 2020-01-01)" },
+    ],
+  });
+  assert.match(promptSection, /Deprecated \/ stale dependencies/);
+  assert.match(promptSection, /request@2\.88\.2/);
+  assert.match(promptSection, /oldpkg@0\.1\.0/);
+  assert.doesNotMatch(promptSection, /\*injected\*/); // markdown metacharacters from registry text are escaped
+});


### PR DESCRIPTION
## What

A new REES analyzer that flags newly-added or upgraded direct dependencies that are deprecated or yanked by their maintainer, or stale (no release in roughly two years) — maintenance-health and future supply-chain risks the no-checkout reviewer cannot derive.

## Data source

Public registry metadata, fetched with an injected fetch. npm: the packument `deprecated` field (a non-empty string means deprecated, and the maintainer reason is surfaced) and the `time` map for the newest publish date. PyPI: `info.yanked` (plus `yanked_reason` when present) and the newest release upload date. Output is public-safe: package@version plus a short factual reason only, with the registry-supplied reason markdown-escaped before it reaches the prompt block. No tokens, paths, or manifest contents.

## Behavior

Additive and fail-safe: it reuses the existing `extractDependencyChanges` to act only on direct added/upgraded deps, bounds the number of registry queries, and returns no finding on a malformed or empty registry response, an unparseable date, or any fetch error. A healthy dependency produces no finding. It follows the established analyzer pattern entirely within `review-enrichment/` (finding type in `types.ts`, a pure analyzer with injected `fetch` in `analyzers/dep-maintenance-health.ts`, registration in `brief.ts`, a public-safe block in `render.ts`), outside the engine scope. Scorecard, archived, and sole-maintainer signals are intentionally left out to keep this to the two deterministic registry signals.

## Tests

24 `node:test` cases with a mocked `fetch` cover deprecated/yanked/stale detection for npm and PyPI, the healthy no-finding case, and the fail-safe edge cases: package-name and ecosystem validation, scoped-name URL encoding, malformed or missing registry JSON, a boolean or empty `deprecated` value, unparseable dates (Number.isFinite guard), query bounding, and direct-only dependency scope. Full suite: rees build clean, 227 of 227 tests pass.

Closes #1511
