### PR TITLE
fix(upstream): match registry drift repos case-insensitively (#1792)

### DIFF
--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -697,14 +697,20 @@ const REGISTRY_DRIFT_FIELD_METADATA: Record<RegistryHyperparameterDriftField, { 
 };
 
 function buildRegistryHyperparameterDrift(previous: RulesetRegistryRepo[], current: RulesetRegistryRepo[]): RegistryHyperparameterDriftPayload {
-  const previousByRepo = new Map(previous.map((repo) => [repo.repo, repo]));
-  const currentByRepo = new Map(current.map((repo) => [repo.repo, repo]));
+  // Repo identity is case-insensitive upstream: registryHyperparameterDriftWarningsForRepo compares names with
+  // toLowerCase and the registry normalizer dedupes by lowercased name. Keying these maps by the raw,
+  // case-sensitive `repo` string made a casing-only rename (e.g. `Owner/Repo` -> `owner/repo`) surface as a
+  // spurious high-severity `added` + `removed` pair even when every hyperparameter was unchanged. Match by the
+  // lowercased name so a casing-only change resolves to the same repo (its comparable fields then diff to zero
+  // events), while genuine additions, removals, and field changes are still detected. (#1792)
+  const previousByRepo = new Map(previous.map((repo) => [registryRepoKey(repo), repo]));
+  const currentByRepo = new Map(current.map((repo) => [registryRepoKey(repo), repo]));
   const events = [
     ...current.flatMap((repo) => {
-      const old = previousByRepo.get(repo.repo);
+      const old = previousByRepo.get(registryRepoKey(repo));
       return old ? changedRegistryRepoEvents(old, repo) : [registryHyperparameterDriftEvent(repo.repo, "repo", null, "added", "added")];
     }),
-    ...previous.flatMap((repo) => (currentByRepo.has(repo.repo) ? [] : [registryHyperparameterDriftEvent(repo.repo, "repo", "present", null, "removed")])),
+    ...previous.flatMap((repo) => (currentByRepo.has(registryRepoKey(repo)) ? [] : [registryHyperparameterDriftEvent(repo.repo, "repo", "present", null, "removed")])),
   ].sort(compareRegistryHyperparameterDriftEvents);
   const capped = events.slice(0, REGISTRY_HYPERPARAMETER_DRIFT_LIMIT);
   return {
@@ -714,6 +720,12 @@ function buildRegistryHyperparameterDrift(previous: RulesetRegistryRepo[], curre
     unidentifiedAffectedRepoCount: 0,
     omittedEvents: Math.max(events.length - capped.length, 0),
   };
+}
+
+// Case-insensitive identity key for matching the same registry repo across two ruleset snapshots, mirroring the
+// lowercasing in registryHyperparameterDriftWarningsForRepo and the registry normalizer. (#1792)
+function registryRepoKey(repo: RulesetRegistryRepo): string {
+  return repo.repo.toLowerCase();
 }
 
 function changedRegistryRepoEvents(previous: RulesetRegistryRepo, current: RulesetRegistryRepo): RegistryHyperparameterDriftEvent[] {

--- a/test/unit/upstream-ruleset.test.ts
+++ b/test/unit/upstream-ruleset.test.ts
@@ -647,6 +647,24 @@ describe("upstream ruleset drift tracking", () => {
     });
     expect(membership!.payload.repoChanges).toEqual(["owner/added: added", "owner/removed: removed"]);
 
+    // (#1792) A casing-only registry rename with identical hyperparameters must NOT surface as add + remove.
+    const casingPrevious = rulesetWithRegistry("casing-previous", [registryRepo("Owner/Repo")]);
+    const casingCurrent = rulesetWithRegistry("casing-current", [registryRepo("owner/repo")]);
+    const casingOnly = await buildUpstreamDriftReport(casingCurrent, casingPrevious);
+    // No registry drift events at all → the report degrades to the source-only signal, not a registry membership change.
+    expect(registryDriftPayload(casingOnly!).events).toEqual([]);
+    expect(casingOnly!.payload.repoChanges).toEqual([]);
+    expect(casingOnly!.affectedAreas).not.toContain("registry");
+
+    // (#1792) A casing change that ALSO changes a hyperparameter still reports the field change (under the new
+    // casing) and never a spurious repo add/remove.
+    const fieldChangePrevious = rulesetWithRegistry("casing-field-previous", [registryRepo("Owner/Repo", { maintainerCut: 0.3 })]);
+    const fieldChangeCurrent = rulesetWithRegistry("casing-field-current", [registryRepo("owner/repo", { maintainerCut: 0.5 })]);
+    const casingWithFieldChange = await buildUpstreamDriftReport(fieldChangeCurrent, fieldChangePrevious);
+    const fieldDrift = registryDriftPayload(casingWithFieldChange!);
+    expect(fieldDrift.affectedFields).toEqual(["maintainerCut"]);
+    expect(fieldDrift.events.map((event) => ({ repoFullName: event.repoFullName, field: event.field }))).toEqual([{ repoFullName: "owner/repo", field: "maintainerCut" }]);
+
     const env = createTestEnv();
     await persistUpstreamRulesetSnapshot(env, ruleset("current", "current-hash", "pending_saturation_model", 1, 0.01, new Date().toISOString()));
     await upsertUpstreamDriftReport(env, driftReport("bad-registry-payload", { affectedAreas: ["registry"], payload: { registryHyperparameterDrift: "bad" } }));


### PR DESCRIPTION
## Summary

Fixes #1792.

`buildRegistryHyperparameterDrift` in `src/upstream/ruleset.ts` diffed the previous and current ruleset registries by keying repos with their **raw, case-sensitive** `repo` string. A casing-only upstream rename (e.g. `Owner/Repo` → `owner/repo`) with otherwise-identical hyperparameters therefore surfaced as a spurious high-severity `repo` **added** event (new casing) plus a `repo` **removed** event (old casing).

Repo identity is treated as case-insensitive everywhere else in the same module (`registryHyperparameterDriftWarningsForRepo` compares names with `.toLowerCase()`) and in the registry normalizer (which dedupes by lowercased name); the normalizer preserves the original `repo` casing, so two snapshots can legitimately differ in key casing only, making this reachable.

- `src/upstream/ruleset.ts`: add a `registryRepoKey` helper that lowercases the repo name and key both the previous/current maps (and the membership lookups) through it. A casing-only change now resolves to the same repo, so its comparable fields diff to zero events; genuine additions, removals, and field changes are unaffected (the events still carry the canonical current casing).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; both new branches (casing-only no-op vs casing change with a real field change) are covered, plus the existing genuine add/remove membership test.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (found 0 vulnerabilities)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped; the full `npm run test:ci` gate was run locally and is green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal drift-diff logic only; no API/schema change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- The fix is consistent with the module's existing case-insensitive repo-identity handling, so it removes an internal inconsistency rather than introducing new semantics.
