### PR TITLE
fix(enrichment): cap native-build registry JSON

### DIFF
--- a/review-enrichment/src/analyzers/native-build.ts
+++ b/review-enrichment/src/analyzers/native-build.ts
@@ -7,6 +7,7 @@ import type { EnrichRequest, NativeBuildFinding } from "../types.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
 
 const MAX_QUERIES = 25;
+const MAX_REGISTRY_JSON_BYTES = 2 * 1024 * 1024;
 const INSTALL_HOOKS = ["preinstall", "install", "postinstall"];
 // Tokens in an install-lifecycle script that indicate a native toolchain runs on install.
 const NATIVE_TOOL_RE = /\b(node-gyp|node-pre-gyp|prebuild|prebuild-install|cmake-js|node-addon-api|nan)\b/;
@@ -78,9 +79,45 @@ async function fetchJson(
   try {
     const response = await fetchImpl(url, { signal });
     if (!response.ok) return null;
-    return await response.json();
+    const text = await readJsonText(response);
+    return text === null ? null : JSON.parse(text);
   } catch {
     return null;
+  }
+}
+
+async function readJsonText(response: Response): Promise<string | null> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsedLength = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_REGISTRY_JSON_BYTES) return null;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_REGISTRY_JSON_BYTES) return null;
+    return new TextDecoder().decode(buffer);
+  }
+
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_REGISTRY_JSON_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/review-enrichment/test/native-build.test.ts
+++ b/review-enrichment/test/native-build.test.ts
@@ -19,9 +19,10 @@ const pypiAdd = (name, version = "1.0.0") => ({
   prNumber: 1,
   files: [{ path: "requirements.txt", patch: `@@ -1,0 +1,1 @@\n+${name}==${version}` }],
 });
-const npmFetch = (meta) => async () => ({ ok: true, json: async () => ({ versions: { "1.0.0": meta } }) });
-const pypiFetch = (urls) => async () => ({ ok: true, json: async () => ({ urls }) });
-const status = (code) => async () => ({ ok: code >= 200 && code < 300, status: code, json: async () => ({}) });
+const jsonResponse = (body, init) => new Response(JSON.stringify(body), init);
+const npmFetch = (meta) => async () => jsonResponse({ versions: { "1.0.0": meta } });
+const pypiFetch = (urls) => async () => jsonResponse({ urls });
+const status = (code) => async () => jsonResponse({}, { status: code });
 const throwingFetch = async () => {
   throw new Error("network down");
 };
@@ -128,6 +129,34 @@ test("scanNativeBuild: a PyPI PEP 440 (non-semver) sdist-only version is flagged
 test("scanNativeBuild fails safe on a non-ok or throwing fetch", async () => {
   assert.deepEqual(await scanNativeBuild(npmAdd("bcrypt"), status(404)), []);
   assert.deepEqual(await scanNativeBuild(npmAdd("bcrypt"), throwingFetch), []);
+});
+
+test("scanNativeBuild fails safe before parsing registry JSON with an oversized Content-Length", async () => {
+  let bodyRead = false;
+  const findings = await scanNativeBuild(npmAdd("bcrypt"), async () => ({
+    ok: true,
+    headers: new Headers({ "content-length": String(2 * 1024 * 1024 + 1) }),
+    body: {
+      getReader() {
+        bodyRead = true;
+        throw new Error("body should not be read");
+      },
+    },
+    arrayBuffer: async () => {
+      bodyRead = true;
+      return new ArrayBuffer(0);
+    },
+  }));
+
+  assert.deepEqual(findings, []);
+  assert.equal(bodyRead, false);
+});
+
+test("scanNativeBuild fails safe when streamed registry JSON exceeds the byte cap", async () => {
+  const bigMetadata = `${" ".repeat(2 * 1024 * 1024)}{"versions":{"1.0.0":{"gypfile":true}}}`;
+  const findings = await scanNativeBuild(npmAdd("bcrypt"), async () => new Response(bigMetadata));
+
+  assert.deepEqual(findings, []);
 });
 
 test("scanNativeBuild stops on an already-aborted signal", async () => {


### PR DESCRIPTION
### Motivation
- The native-build analyzer previously called `response.json()` on npm/PyPI registry responses without any size bound, allowing an attacker to supply very large registry JSON (packument) and cause excessive memory/CPU use or process failure.

### Description
- Add a per-response byte cap `MAX_REGISTRY_JSON_BYTES = 2 * 1024 * 1024` and replace ungated `response.json()` with a bounded reader that checks `Content-Length` and aborts parsing when the streamed body exceeds the cap in `review-enrichment/src/analyzers/native-build.ts`.
- Implement `readJsonText(response: Response)` to safely read or reject oversized responses, then `JSON.parse` the bounded text only when safe.
- Update tests in `review-enrichment/test/native-build.test.ts` to use `Response`-based stubs and add regression tests that verify oversized `Content-Length` responses are rejected without reading the body and that streamed bodies exceeding the cap fail safe.
- Preserve the analyzer’s existing behavior on normal-sized registry responses and keep fail-safe `null` semantics when fetches are non-ok, throwing, or oversized.

### Testing
- Ran `git diff --check` which passed locally. 
- Ran `npm --prefix review-enrichment test` and the whole REES test suite passed (all added and existing tests green).
- Attempted `npm run test:ci` but it could not complete in this environment due to external `actionlint` setup/download DNS failures, so CI-level run was blocked. 
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403` and that step was blocked by network/registry access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4302c009b4832c879e769a15a7a3a2)