### PR TITLE
fix(enrichment): bound heavy dependency usage scan

### DIFF
--- a/review-enrichment/src/analyzers/heavy-dependency.ts
+++ b/review-enrichment/src/analyzers/heavy-dependency.ts
@@ -79,27 +79,48 @@ function moduleSpecifiers(text: string): string[] {
   return specs;
 }
 
-function specifierMatchesPackage(specifier: string, pkg: string): boolean {
-  return specifier === pkg || specifier.startsWith(`${pkg}/`);
+function packageNameFromSpecifier(specifier: string): string | null {
+  if (specifier.startsWith("@")) {
+    const [scope, name] = specifier.split("/", 3);
+    return scope && name ? `${scope}/${name}` : null;
+  }
+  const [name] = specifier.split("/", 1);
+  return name || null;
+}
+
+function countPatchUsagesByPackage(
+  files: NonNullable<EnrichRequest["files"]>,
+  packages: ReadonlySet<string>,
+): Map<string, Pick<HeavyDependencyFinding, "usageCount" | "usageLocations">> {
+  const usages = new Map<
+    string,
+    Pick<HeavyDependencyFinding, "usageCount" | "usageLocations">
+  >();
+  for (const line of addedPatchLines(files)) {
+    for (const specifier of moduleSpecifiers(line.text)) {
+      const pkg = packageNameFromSpecifier(specifier);
+      if (!pkg || !packages.has(pkg)) continue;
+      const usage = usages.get(pkg) ?? { usageCount: 0, usageLocations: [] };
+      usage.usageCount += 1;
+      if (usage.usageLocations.length < TRIVIAL_USAGE_MAX) {
+        usage.usageLocations.push({ file: line.file, line: line.line });
+      }
+      usages.set(pkg, usage);
+    }
+  }
+  return usages;
 }
 
 export function countPackagePatchUsages(
   files: NonNullable<EnrichRequest["files"]>,
   pkg: string,
 ): Pick<HeavyDependencyFinding, "usageCount" | "usageLocations"> {
-  const locations: HeavyDependencyFinding["usageLocations"] = [];
-  for (const line of addedPatchLines(files)) {
-    const matches = moduleSpecifiers(line.text).filter((specifier) =>
-      specifierMatchesPackage(specifier, pkg),
-    );
-    for (let i = 0; i < matches.length; i += 1) {
-      locations.push({ file: line.file, line: line.line });
+  return (
+    countPatchUsagesByPackage(files, new Set([pkg])).get(pkg) ?? {
+      usageCount: 0,
+      usageLocations: [],
     }
-  }
-  return {
-    usageCount: locations.length,
-    usageLocations: locations.slice(0, TRIVIAL_USAGE_MAX),
-  };
+  );
 }
 
 function numberOrNull(value: unknown): number | null {
@@ -154,13 +175,25 @@ export async function scanHeavyDependencies(
   const changes = extractDependencyChanges(req.files ?? []).filter(
     (change) => change.ecosystem === "npm",
   );
+  const safePackageNames = new Set(
+    changes
+      .filter((change) => isSafeNpmPackageVersion(change.package, change.to))
+      .map((change) => change.package),
+  );
+  const usagesByPackage = countPatchUsagesByPackage(
+    req.files ?? [],
+    safePackageNames,
+  );
   let weightLookups = 0;
 
   for (const change of changes) {
     if (options.signal?.aborted || findings.length >= MAX_FINDINGS) break;
     if (!isSafeNpmPackageVersion(change.package, change.to)) continue;
 
-    const usage = countPackagePatchUsages(req.files ?? [], change.package);
+    const usage = usagesByPackage.get(change.package) ?? {
+      usageCount: 0,
+      usageLocations: [],
+    };
     if (usage.usageCount < 1 || usage.usageCount > TRIVIAL_USAGE_MAX) continue;
     if (weightLookups >= MAX_WEIGHT_LOOKUPS) break;
     weightLookups += 1;

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -980,6 +980,26 @@ test("countPackagePatchUsages: line-cites import, require, dynamic import, and s
   ]);
 });
 
+test("countPackagePatchUsages: matches scoped package subpaths and ignores malformed scoped imports", () => {
+  const usage = countPackagePatchUsages(
+    [
+      {
+        path: "src/scoped.ts",
+        patch: [
+          "@@ -20,0 +20,3 @@",
+          '+import thing from "@scope/heavy/subpath";',
+          '+import bad from "@scope";',
+          '+import other from "@scope/other";',
+        ].join("\n"),
+      },
+    ],
+    "@scope/heavy",
+  );
+
+  assert.equal(usage.usageCount, 1);
+  assert.deepEqual(usage.usageLocations, [{ file: "src/scoped.ts", line: 20 }]);
+});
+
 test("queryPackageWeight: maps bundlephobia size fields and degrades on non-ok", async () => {
   const weight = await queryPackageWeight("lodash", "4.17.21", async () => ({
     ok: true,


### PR DESCRIPTION
### Motivation
- The newly-registered heavy-dependency analyzer performed repeated full-patch rescans for every changed npm dependency, yielding O(changed_dependencies * patch_lines) synchronous CPU work that can bypass the analyzer timeout and enable PR-triggered CPU exhaustion.
- Precompute usage counts once per request and restrict scanning to safe package names to ensure the lookup budget and timeout can take effect.

### Description
- Add `packageNameFromSpecifier` and `countPatchUsagesByPackage` to derive package names from bare and scoped module specifiers and compute usage counts in a single pass over added patch lines.
- Change `scanHeavyDependencies` to build a `safePackageNames` set and `usagesByPackage` map up-front and to consult that map when iterating dependency changes so each patch is scanned at most once per request instead of once per package.
- Make `countPackagePatchUsages` delegate to the shared counting path to preserve the exported API while avoiding duplicated work.
- Add a unit test to cover scoped package subpath matching and malformed scoped imports so scoped specifiers are handled correctly.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran targeted REES tests with `cd review-enrichment && npm run test -- --test-name-pattern='countPackagePatchUsages|scanHeavyDependencies'`, and all matching tests passed.
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate`, but these were blocked by network-dependent tooling: `actionlint` setup failed with `EAI_AGAIN` (WASM fallback reported a custom self-hosted runner label) and `npm audit` returned `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4304b2dbec832cb1a16267749493c7)