### PR TITLE
fix(rees): default token forwarding off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,10 +54,10 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # REES_URL=https://enrichment.example.internal
 # REES_SHARED_SECRET=                       # bearer secret configured on the REES service
 # REES_TIMEOUT_MS=8000                      # optional; minimum 1000, default 8000
-# REES_FORWARD_GITHUB_TOKEN=true            # optional; default true. Sends a GitHub read token to REES so
-#                                            #   codeowners/assetWeight can read CODEOWNERS and blob sizes
-#                                            #   (installation token when available; otherwise GITHUB_PUBLIC_TOKEN).
-#                                            #   Set false if REES_URL is outside your trust boundary.
+# REES_FORWARD_GITHUB_TOKEN=false           # optional; default false. Set true only when REES_URL is inside
+#                                            #   your trust boundary and token-aware analyzers need a GitHub
+#                                            #   token for CODEOWNERS/blob-size reads (installation token when
+#                                            #   available; otherwise GITHUB_PUBLIC_TOKEN).
 # REES_ANALYZERS=all                        # all | comma-list of exact names:
 #                                            # dependency,lockfileDrift,secret,license,installScript,
 #                                            # actionPin,eol,redos,provenance,codeowners,secretLog,

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -110,7 +110,7 @@ export const REES_ANALYZERS: ReesAnalyzerDoc[] = [
     network:
       "Calls the GitHub API. Requires author plus GitHub token forwarding for private repos.",
     notes:
-      "Set REES_FORWARD_GITHUB_TOKEN=false to disable token forwarding; this analyzer will then skip when it cannot read CODEOWNERS.",
+      "Leave REES_FORWARD_GITHUB_TOKEN unset/false to disable token forwarding; this analyzer will then skip when it cannot read CODEOWNERS.",
   },
   {
     name: "secretLog",

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
@@ -79,7 +79,7 @@ GITTENSORY_REVIEW_ENRICHMENT=true
 REES_URL=https://enrichment.example.internal
 REES_SHARED_SECRET=<shared-secret>
 REES_TIMEOUT_MS=8000
-REES_FORWARD_GITHUB_TOKEN=true
+REES_FORWARD_GITHUB_TOKEN=false
 REES_ANALYZERS=all`}
       />
       <FeatureRow
@@ -104,7 +104,7 @@ REES_ANALYZERS=all`}
           {
             title: "REES_FORWARD_GITHUB_TOKEN",
             description:
-              "Defaults to true. Sends a GitHub read token so token-aware analyzers can read CODEOWNERS and blob sizes. Set false to keep tokens out of the REES request.",
+              "Defaults to false. Set true only when REES_URL is inside your trust boundary and token-aware analyzers need CODEOWNERS or blob-size reads.",
           },
         ]}
       />
@@ -113,16 +113,16 @@ REES_ANALYZERS=all`}
       <p>
         Set <code>GITTENSORY_REVIEW_ENRICHMENT=false</code> to turn off REES for the whole instance.
         To keep REES configured but prevent a repo from using it, remove that repo from{" "}
-        <code>GITTENSORY_REVIEW_REPOS</code>. To keep REES enabled but prevent token forwarding, set{" "}
-        <code>REES_FORWARD_GITHUB_TOKEN=false</code>.
+        <code>GITTENSORY_REVIEW_REPOS</code>. Token forwarding stays off unless you explicitly set{" "}
+        <code>REES_FORWARD_GITHUB_TOKEN=true</code>.
       </p>
       <CodeBlock
         filename=".env"
         code={`# Full REES off switch:
 GITTENSORY_REVIEW_ENRICHMENT=false
 
-# Keep REES on, but do not send a GitHub token to the service:
-REES_FORWARD_GITHUB_TOKEN=false`}
+# Keep REES on and explicitly allow token-aware analyzers:
+REES_FORWARD_GITHUB_TOKEN=true`}
       />
 
       <h2>Analyzer selection</h2>
@@ -144,11 +144,11 @@ REES_FORWARD_GITHUB_TOKEN=false`}
       <p>
         When enabled, the engine POSTs the repo name, PR number, head SHA, base SHA when GitHub
         supplies it, title, changed file paths, changed file patches, and review diff to{" "}
-        <code>REES_URL</code>. By default it also forwards a GitHub read token when one is
-        available, so GitHub API analyzers can read private CODEOWNERS and blob sizes. The engine
-        prefers a short-lived installation token and falls back to <code>GITHUB_PUBLIC_TOKEN</code>.
-        Set <code>REES_FORWARD_GITHUB_TOKEN=false</code> if the REES service is outside your trust
-        boundary.
+        <code>REES_URL</code>. It forwards no GitHub token by default. If{" "}
+        <code>REES_FORWARD_GITHUB_TOKEN=true</code>, the engine includes a GitHub read token so
+        GitHub API analyzers can read private CODEOWNERS and blob sizes. The engine prefers a
+        short-lived installation token and falls back to <code>GITHUB_PUBLIC_TOKEN</code>. Enable
+        forwarding only when the REES service is inside your trust boundary.
       </p>
       <Callout variant="safety">
         Do not point <code>REES_URL</code> at a service you do not trust with PR diffs. Token

--- a/review-enrichment/README.md
+++ b/review-enrichment/README.md
@@ -17,8 +17,9 @@ treats any timeout/error as "no brief" and proceeds.
 | `POST /v1/enrich` | `Authorization: Bearer <REES_SHARED_SECRET>` → `EnrichRequest` → `ReviewBrief`. |
 
 See `src/types.ts` for the `EnrichRequest` / `ReviewBrief` contract. When the engine is configured with
-`REES_FORWARD_GITHUB_TOKEN=true` (the default), requests can include a GitHub read token so token-aware analyzers can
-read CODEOWNERS and blob sizes. The engine prefers a short-lived installation token and falls back to
+`REES_FORWARD_GITHUB_TOKEN=true`, requests can include a GitHub read token so token-aware analyzers can read
+CODEOWNERS and blob sizes. Token forwarding is off by default and should be enabled only when the REES endpoint is
+inside the operator's trust boundary. The engine prefers a short-lived installation token and falls back to
 `GITHUB_PUBLIC_TOKEN`. The service must never log request bodies, diffs, or tokens.
 
 ## Analyzers

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -197,8 +197,8 @@ declare global {
     /** Review-enrichment service (REES): when truthy, the self-host review engine POSTs the PR diff/files to
      *  REES and splices any public-safe brief into the AI reviewer prompt. Requires REES_URL and the repo in
      *  GITTENSORY_REVIEW_REPOS. REES_ANALYZERS is an optional exact comma-list; unset/"all"/"*" lets REES run its
-     *  full registry. REES_FORWARD_GITHUB_TOKEN defaults on for token-aware analyzers and can be set false to keep
-     *  GitHub read tokens out of the REES request. REES_SHARED_SECRET is a bearer secret and must never be committed. */
+     *  full registry. REES_FORWARD_GITHUB_TOKEN defaults off and must be explicitly enabled before
+     *  GitHub read tokens are included in the REES request. REES_SHARED_SECRET is a bearer secret and must never be committed. */
     GITTENSORY_REVIEW_ENRICHMENT?: string;
     REES_URL?: string;
     REES_SHARED_SECRET?: string;

--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -57,11 +57,11 @@ export function isEnrichmentEnabled(env: Env): boolean {
   );
 }
 
-/** True unless explicitly disabled. REES already receives PR content when enabled; token forwarding lets
- *  token-aware analyzers read CODEOWNERS and blob sizes through the GitHub API. */
+/** True only when explicitly enabled. REES already receives PR content when enabled, but GitHub
+ *  token forwarding crosses a credential boundary and must remain opt-in. */
 export function isReesGithubTokenForwardingEnabled(env: Env): boolean {
-  return !/^(0|false|no|off)$/i.test(
-    (reesConfig(env).REES_FORWARD_GITHUB_TOKEN ?? "true").trim(),
+  return /^(1|true|yes|on)$/i.test(
+    (reesConfig(env).REES_FORWARD_GITHUB_TOKEN ?? "").trim(),
   );
 }
 

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -375,11 +375,16 @@ describe("buildReviewEnrichment", () => {
 });
 
 describe("isReesGithubTokenForwardingEnabled", () => {
-  it("defaults on and only turns off for explicit false-like values", () => {
-    expect(isReesGithubTokenForwardingEnabled(env({}))).toBe(true);
+  it("defaults off and only turns on for explicit truthy values", () => {
+    expect(isReesGithubTokenForwardingEnabled(env({}))).toBe(false);
     expect(
       isReesGithubTokenForwardingEnabled(
         env({ REES_FORWARD_GITHUB_TOKEN: "true" }),
+      ),
+    ).toBe(true);
+    expect(
+      isReesGithubTokenForwardingEnabled(
+        env({ REES_FORWARD_GITHUB_TOKEN: " YES " }),
       ),
     ).toBe(true);
     expect(

--- a/test/unit/enrichment-wiring.test.ts
+++ b/test/unit/enrichment-wiring.test.ts
@@ -81,6 +81,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
       GITTENSORY_REVIEW_ENRICHMENT: "true",
       REES_URL: "https://rees.example",
       REES_SHARED_SECRET: "sek",
+      REES_FORWARD_GITHUB_TOKEN: "true",
       REES_ANALYZERS: "secret,actionPin,redos",
     });
     await seedRepoFile(env, "acme/widgets");
@@ -182,7 +183,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
     }
   });
 
-  it("does not forward a GitHub token when REES_FORWARD_GITHUB_TOKEN is false", async () => {
+  it("does not forward a GitHub token unless REES_FORWARD_GITHUB_TOKEN is true", async () => {
     const run = vi.fn(async () => ({ response: notesJson }));
     const env = createTestEnv({
       AI: { run } as unknown as Ai,
@@ -195,7 +196,6 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
       GITTENSORY_REVIEW_ENRICHMENT: "true",
       REES_URL: "https://rees.example",
       REES_SHARED_SECRET: "sek",
-      REES_FORWARD_GITHUB_TOKEN: "false",
       REES_ANALYZERS: "codeowners,assetWeight",
     });
     await seedRepoFile(env, "acme/widgets");


### PR DESCRIPTION
### Motivation
- Close a credential-exposure hole where REES forwarded GitHub installation tokens by default, which could leak full installation-scoped tokens to an external REES endpoint.
- Make token forwarding opt-in to enforce a safer fail-closed default and reduce risk when operators configure REES_URL outside their trust boundary.

### Description
- Change the forwarding guard so `REES_FORWARD_GITHUB_TOKEN` is treated as opt-in: `isReesGithubTokenForwardingEnabled` now returns true only for explicit truthy values (`1|true|yes|on`) instead of defaulting to true.
- Update runtime typing, `.env` example, UI self-hosting docs, and the REES README to document that token forwarding defaults off and must be explicitly enabled for trusted endpoints.
- Adjust REES analyzer docs text to reflect the default-off behavior and small wording changes in analyzer notes.
- Add/adjust unit tests to cover the default-off behavior and the explicit opt-in path for forwarding.

### Testing
- Ran unit tests with `npx vitest run test/unit/enrichment-wire.test.ts test/unit/enrichment-wiring.test.ts` and all tests passed.
- Ran `npm run ui:lint` and `npm run typecheck` which completed (lint produced existing warnings only and typecheck passed).
- Attempted full gate `npm run test:ci` and `npm audit --audit-level=moderate`, but these were blocked by environment/network limitations (actionlint setup network fallback and npm audit registry access), so the full CI gate could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43050d03a8832cb4bb432c053f2e53)