### PR TITLE
feat(scoring): surface the merged-PR history floor in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -99,6 +99,38 @@ function openIssueBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdo
   };
 }
 
+// Sibling of openIssueBreakdown/openPrBreakdown for the merged-PR history floor (upstream MIN_VALID_MERGED_PRS):
+// a contributor whose observed merged-PR count on this repo is below the floor has the entire preview zeroed.
+// Explained here so a miner sees the same actionable breakdown the open-PR / open-issue gates already provide.
+function mergedHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { mergedHistoryMultiplier } = preview.scoreEstimate;
+  const { mergedPrFloor, mergedPullRequests } = preview.gates;
+  // mergedPullRequests is optional: when unobserved the floor is not enforced (the multiplier stays 1).
+  if (mergedPullRequests === undefined) {
+    return {
+      component: "mergedHistoryMultiplier",
+      band: "neutral",
+      summary: `Merged-PR history floor is not enforced for this preview (no contributor history observed; upstream floor is ${mergedPrFloor}).`,
+      lever: "No action needed for this preview; the upstream merged-PR floor applies once contributor history is observed.",
+      leverageScore: 0,
+    };
+  }
+  const band = bandForMultiplier(mergedHistoryMultiplier);
+  return {
+    component: "mergedHistoryMultiplier",
+    band,
+    summary:
+      mergedPullRequests >= mergedPrFloor
+        ? `Merged PR history (${mergedPullRequests}) meets the upstream floor (${mergedPrFloor}).`
+        : `Merged PR history (${mergedPullRequests}) is below the upstream floor (${mergedPrFloor}), so this preview is zeroed.`,
+    lever:
+      mergedPullRequests >= mergedPrFloor
+        ? "Keep landing merged PRs in this repo to maintain contributor history."
+        : "Land more merged PRs in this repo to clear the contributor-history floor before relying on this preview.",
+    leverageScore: mergedPullRequests >= mergedPrFloor ? 5 : 100,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -239,6 +271,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     reviewPenaltyBreakdown(preview),
     openPrBreakdown(preview),
     openIssueBreakdown(preview),
+    mergedHistoryBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -83,6 +83,7 @@ describe("explainScoreBreakdown", () => {
         "reviewPenaltyMultiplier",
         "openPrMultiplier",
         "openIssueMultiplier",
+        "mergedHistoryMultiplier",
       ]),
     );
     for (const component of breakdown.components) {
@@ -95,6 +96,28 @@ describe("explainScoreBreakdown", () => {
     expect(JSON.stringify(breakdown)).not.toMatch(FORBIDDEN);
     // No open issues → within the allowance → full band on the open-issue gate.
     expect(breakdown.components.find((entry) => entry.component === "openIssueMultiplier")).toMatchObject({ band: "full" });
+  });
+
+  it("explains the merged-PR history floor as neutral (unobserved), full (meets floor), and blocked (below floor)", () => {
+    // Unobserved history -> floor not enforced -> neutral.
+    const unobserved = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none" } }),
+    );
+    expect(unobserved.components.find((entry) => entry.component === "mergedHistoryMultiplier")).toMatchObject({ band: "neutral" });
+
+    // Observed >= upstream floor (MIN_VALID_MERGED_PRS = 3) -> full.
+    const meets = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none", mergedPullRequests: 5 } }),
+    );
+    expect(meets.components.find((entry) => entry.component === "mergedHistoryMultiplier")).toMatchObject({ band: "full" });
+
+    // Observed < floor -> blocked, and the merged-PR lever is the top-leverage one.
+    const blocked = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none", mergedPullRequests: 1 } }),
+    );
+    expect(blocked.components.find((entry) => entry.component === "mergedHistoryMultiplier")).toMatchObject({ band: "blocked", leverageScore: 100 });
+    expect(blocked.highestLeverageLever.lever).toMatch(/merge/i);
+    expect(JSON.stringify(blocked)).not.toMatch(FORBIDDEN);
   });
 
   it("explains an over-threshold open-issue count as a blocked open-issue spam gate", () => {


### PR DESCRIPTION
## Summary

`explainScoreBreakdown` (`src/services/score-breakdown.ts`) explains every other scoring multiplier -- density, contribution bonus, label, issue, credibility, review penalty, open-PR pressure, open-issue spam -- but silently omits the **mergedHistoryMultiplier**, even though it can zero the entire preview. The multiplier is already computed in `src/scoring/preview.ts` (a contributor's observed merged-PR count below the upstream floor `MIN_VALID_MERGED_PRS` zeroes it), feeds the final score, and has its own gate blocker (`merged_pr_history_floor`), yet had no entry in the `components` list.

## What this adds

A `mergedHistoryBreakdown` component mirroring the existing `openIssueBreakdown` that #1453 added for the sibling open-issue gate:

- **neutral** when no contributor history is observed (the floor is not enforced for the preview);
- **full** when the observed merged-PR count meets the upstream floor;
- **blocked** -- with a 100-leverage "land more merged PRs in this repo to clear the contributor-history floor" lever -- when the count is below the floor.

A contributor whose merged-PR history is below the upstream floor now sees an actionable lever instead of an opaque zero. Purely additive explanation; **no scoring behavior change**.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1798).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/score-breakdown.test.ts` 11/11 pass; `src/services/score-breakdown.ts` is 100% statements / 100% functions / 100% lines (the new component's three branches -- unobserved, meets-floor, below-floor -- are each covered).

Targeted run:

```sh
npx vitest run test/unit/score-breakdown.test.ts --coverage --coverage.include='src/services/score-breakdown.ts'
# 11/11 passed; 100% statements/functions/lines
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed (a forbidden-term assertion is included).
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics (every summary/lever runs through the existing `sanitizePublicComment`).
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- a purely additive explanation projection over an already-computed multiplier; no scoring logic change.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend score-breakdown projection with no visible UI, frontend, docs, or extension surface.

Closes #1798
