### PR TITLE
ci(runners): pin trusted jobs to gittensory pool

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   audit:
     name: audit
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: [self-hosted, gittensory]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   # On push to main everything runs regardless (keeps the coverage baseline solid).
   changes:
     name: changes
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -75,7 +75,7 @@ jobs:
     name: lint
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -117,7 +117,7 @@ jobs:
     name: test
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -200,7 +200,7 @@ jobs:
     name: coverage-upload
     needs: [changes, test]
     if: ${{ (github.event_name == 'push' || needs.changes.outputs.backend == 'true') && needs.test.result == 'success' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -258,7 +258,7 @@ jobs:
     name: workers
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -289,7 +289,7 @@ jobs:
     name: mcp
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -322,7 +322,7 @@ jobs:
     name: rees
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.rees == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -343,7 +343,7 @@ jobs:
     name: ui
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 15
     env:
       VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
@@ -387,7 +387,7 @@ jobs:
   security:
     name: security
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -408,7 +408,7 @@ jobs:
     name: validate
     needs: [changes, lint, test, coverage-upload, workers, mcp, rees, ui, security]
     if: ${{ always() }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
     timeout-minutes: 2
     steps:
       - name: All required jobs passed

--- a/test/unit/workflow-runner-labels.test.ts
+++ b/test/unit/workflow-runner-labels.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("workflow runner labels", () => {
+  it("keeps trusted CI jobs on the gittensory runner pool and fork PRs on GitHub-hosted runners", () => {
+    const workflow = read(".github/workflows/ci.yml");
+    const trustedRunnerExpression =
+      '${{ fromJSON((github.event_name == \'pull_request\' && github.event.pull_request.head.repo.fork == true) && \'["ubuntu-latest"]\' || \'["self-hosted","gittensory"]\') }}';
+
+    expect(workflow.match(new RegExp(escapeRegExp(trustedRunnerExpression), "g")) ?? []).toHaveLength(10);
+    expect(workflow).not.toContain("|| 'self-hosted'");
+    expect(workflow).not.toContain('"fork-ci"');
+  });
+
+  it("keeps scheduled audit work on the trusted self-hosted pool", () => {
+    const workflow = read(".github/workflows/audit.yml");
+
+    expect(workflow).toContain("runs-on: [self-hosted, gittensory]");
+    expect(workflow).not.toContain("|| 'self-hosted'");
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
No issue because this is an operational CI routing fix. Trusted CI jobs now require the `gittensory` self-hosted runner label instead of targeting the generic `self-hosted` pool, while fork PR jobs continue to run on GitHub-hosted runners.

## What changed
- Updated `.github/workflows/ci.yml` first-party and push jobs to resolve to `["self-hosted", "gittensory"]`.
- Kept fork PR jobs on `ubuntu-latest`.
- Moved the scheduled audit workflow to `[self-hosted, gittensory]`.
- Added a regression test that rejects bare `self-hosted` fallback routing.

## Validation
- `npm run actionlint`
- `npx vitest run test/unit/workflow-runner-labels.test.ts`
- `git diff --check`

## Notes
This should stop ephemeral `fork-ci` runners from stealing trusted same-repo CI jobs while preserving fork isolation on GitHub-hosted runners.