### PR TITLE
feat(selfhost): add trace ids to logs and sentry

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -78,6 +78,11 @@ review_context_fetch_failed`}
         The observability profile starts Prometheus, Alertmanager, Loki, Promtail, and Grafana with
         dashboards for infra, review activity, and AI usage.
       </p>
+      <p>
+        When OpenTelemetry and Sentry are enabled, job audit logs and Sentry events include
+        trace_id/span_id fields so an operator can jump from a failed job or issue to the matching
+        trace in Grafana or Tempo.
+      </p>
       <CodeBlock lang="bash" code={`docker compose --profile observability up -d`} />
 
       <h2>Routine checks</h2>

--- a/src/selfhost/audit.ts
+++ b/src/selfhost/audit.ts
@@ -3,6 +3,8 @@
 // setup. Written to process.stdout so it is captured by Docker's default json-file log driver and is
 // accessible via `docker compose logs gittensory`.
 
+import { otelTraceLogFields } from "./otel";
+
 export type AuditEventType =
   | "job_complete"
   | "job_dead"
@@ -21,8 +23,8 @@ export interface AuditEvent {
 }
 
 /** Emit a single audit event as a JSON line on stdout. */
-export function logAudit(ev: AuditEvent): void {
-  process.stdout.write(JSON.stringify({ level: "audit", ...ev }) + "\n");
+export function logAudit(ev: AuditEvent, traceParent?: string): void {
+  process.stdout.write(JSON.stringify({ level: "audit", ...ev, ...otelTraceLogFields(traceParent) }) + "\n");
 }
 
 /** Extract a `type` label from a raw job payload string without fully parsing it. Returns undefined

--- a/src/selfhost/otel.ts
+++ b/src/selfhost/otel.ts
@@ -9,6 +9,8 @@ type OtelProvider = {
   shutdown(): Promise<void>;
 };
 type SpanOptions = { parentTraceParent?: string | undefined };
+export type OtelTraceIds = { trace_id: string; span_id: string };
+export type OtelTraceLogFields = { trace_id: string; span_id?: string };
 
 let Otel: OtelApi | undefined;
 let provider: OtelProvider | undefined;
@@ -145,24 +147,51 @@ function statusMessage(error: unknown): string {
   return exceptionFor(error).message.slice(0, MAX_ATTRIBUTE_LENGTH);
 }
 
-function activeContextFromTraceParent(traceParent: string | undefined): Context | undefined {
-  if (!traceParent || !Otel) return undefined;
+function parseTraceParent(traceParent: string | undefined): { traceId: string; spanId: string; traceFlags: number } | undefined {
+  if (!traceParent) return undefined;
   const match = TRACEPARENT_RE.exec(traceParent.trim());
   if (!match) return undefined;
-  return Otel.trace.setSpanContext(Otel.context.active(), {
+  return {
     traceId: match[1]!.toLowerCase(),
     spanId: match[2]!.toLowerCase(),
     traceFlags: Number.parseInt(match[3]!, 16) & 1,
+  };
+}
+
+function activeContextFromTraceParent(api: OtelApi, traceParent: string | undefined): Context | undefined {
+  const parsed = parseTraceParent(traceParent);
+  if (!parsed) return undefined;
+  return api.trace.setSpanContext(api.context.active(), {
+    traceId: parsed.traceId,
+    spanId: parsed.spanId,
+    traceFlags: parsed.traceFlags,
     isRemote: true,
   });
 }
 
-export function currentOtelTraceParent(): string | undefined {
+function currentOtelSpanContext() {
   if (!active || !Otel) return undefined;
-  const spanContext = Otel.trace.getSpanContext(contextStore.getStore() ?? Otel.context.active());
+  return Otel.trace.getSpanContext(contextStore.getStore() ?? Otel.context.active());
+}
+
+export function currentOtelTraceParent(): string | undefined {
+  const spanContext = currentOtelSpanContext();
   if (!spanContext) return undefined;
   const flags = (spanContext.traceFlags & 1).toString(16).padStart(2, "0");
   return `00-${spanContext.traceId}-${spanContext.spanId}-${flags}`;
+}
+
+export function currentOtelTraceIds(): OtelTraceIds | undefined {
+  const spanContext = currentOtelSpanContext();
+  if (!spanContext) return undefined;
+  return { trace_id: spanContext.traceId, span_id: spanContext.spanId };
+}
+
+export function otelTraceLogFields(fallbackTraceParent?: string): OtelTraceLogFields | undefined {
+  const activeTrace = currentOtelTraceIds();
+  if (activeTrace) return activeTrace;
+  const fallback = parseTraceParent(fallbackTraceParent);
+  return fallback ? { trace_id: fallback.traceId } : undefined;
 }
 
 export function setCurrentOtelSpanAttributes(attributes: Record<string, unknown>): void {
@@ -178,7 +207,7 @@ export async function withOtelSpan<T>(
   options?: SpanOptions,
 ): Promise<T> {
   if (!active || !Otel || !tracer) return await fn();
-  const parentContext = activeContextFromTraceParent(options?.parentTraceParent) ?? contextStore.getStore() ?? Otel.context.active();
+  const parentContext = activeContextFromTraceParent(Otel, options?.parentTraceParent) ?? contextStore.getStore() ?? Otel.context.active();
   const span = tracer.startSpan(name, { attributes: otelSafeAttributes(attributes) }, parentContext);
   const childContext = Otel.trace.setSpan(parentContext, span);
   return await contextStore.run(childContext, async () => {

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -339,6 +339,7 @@ export function createPgQueue(
         });
         return true;
       }
+      const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
       try {
         await withOtelSpan(
           "selfhost.queue.job",
@@ -355,7 +356,7 @@ export function createPgQueue(
           payload_type: extractPayloadType(job.payload),
           latency_ms: Date.now() - claimedAt,
           attempts: Number(job.attempts) + 1,
-        });
+        }, jobTraceParent);
       } catch (error) {
         const attempts = Number(job.attempts) + 1;
         const errMsg = error instanceof Error ? error.message : "unknown error";
@@ -394,7 +395,7 @@ export function createPgQueue(
             attempts,
             retry_after_ms: Math.max(0, retryAfter - Date.now()),
             error: errMsg,
-          });
+          }, jobTraceParent);
           return true;
         }
         await recordQueueMetric("gittensory_jobs_failed_total");
@@ -421,7 +422,7 @@ export function createPgQueue(
             latency_ms: Date.now() - claimedAt,
             attempts,
             error: errMsg,
-          });
+          }, jobTraceParent);
           captureError(error, {
             kind: "job_dead",
             reason: "max_retries_exhausted",
@@ -443,7 +444,7 @@ export function createPgQueue(
             latency_ms: Date.now() - claimedAt,
             attempts,
             error: errMsg,
-          });
+          }, jobTraceParent);
         }
       }
       return true;

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -2,7 +2,13 @@
 // env-gated, dynamically-imported selfhost-integration pattern (Redis/Qdrant/embed-provider in server.ts).
 // @sentry/node is NEVER imported at module top level — it loads lazily inside initSentry(), so it never enters
 // the Worker bundle (src/index.ts) and cloudflare:* stubbing stays clean. All helpers are safe to call when off.
+import { currentOtelTraceIds } from "./otel";
+
 type SentryNs = typeof import("@sentry/node");
+type SentryScope = {
+  setContext(name: string, context: Record<string, unknown>): void;
+  setTag(key: string, value: string): void;
+};
 let Sentry: SentryNs | undefined;
 let active = false;
 
@@ -12,6 +18,14 @@ const SECRET_KEY =
 function nonBlank(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function setOtelTraceScope(scope: SentryScope): void {
+  const trace = currentOtelTraceIds();
+  if (!trace) return;
+  scope.setTag("trace_id", trace.trace_id);
+  scope.setTag("span_id", trace.span_id);
+  scope.setContext("otel", { ...trace });
 }
 
 /** Resolve the Sentry release id from explicit override first, then the image-baked self-host version. */
@@ -70,6 +84,7 @@ export function captureError(
 ): void {
   if (!active || !Sentry) return;
   Sentry.withScope((scope) => {
+    setOtelTraceScope(scope);
     if (context) scope.setContext("gittensory", context);
     Sentry!.captureException(
       error instanceof Error ? error : new Error(String(error)),
@@ -86,6 +101,7 @@ export function captureReviewFailure(
   if (!active || !Sentry) return;
   Sentry.withScope((scope) => {
     scope.setLevel("error");
+    setOtelTraceScope(scope);
     if (context) {
       scope.setContext("review", context);
       for (const tag of ["owner", "repo", "pr", "head_sha"]) {
@@ -102,7 +118,7 @@ export function captureReviewFailure(
 
 // The structured-log fields worth indexing as Sentry tags — the dimensions operators filter + group by. Only
 // string|number values are tagged; everything else stays in the full "log" context.
-const SENTRY_LOG_TAG_KEYS = ["repo", "repository", "installationId", "installation_id", "pull", "pullNumber", "pr", "project", "kind", "deliveryId", "provider", "model", "effort", "timeoutMs"] as const;
+const SENTRY_LOG_TAG_KEYS = ["repo", "repository", "installationId", "installation_id", "pull", "pullNumber", "pr", "project", "kind", "deliveryId", "provider", "model", "effort", "timeoutMs", "trace_id", "span_id"] as const;
 
 /** A SHORT location suffix — " (repo#pr)" — for a no-message error title, so the issue list shows WHERE without
  *  dumping every scalar field (which made titles unreadably long, e.g. trailing a full deliveryId). The complete
@@ -211,6 +227,7 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
   errorEvent.name = event ?? "GittensoryLog";
   Sentry.withScope((scope) => {
     scope.setLevel(severity);
+    setOtelTraceScope(scope);
     scope.setContext("log", obj);
     if (event) scope.setTag("event", event);
     // Index the dimensions operators filter + group by, so issues are findable without digging into the context.

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -282,6 +282,7 @@ export function createSqliteQueue(
         });
         return true;
       }
+      const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
       try {
         await withOtelSpan(
           "selfhost.queue.job",
@@ -298,7 +299,7 @@ export function createSqliteQueue(
           payload_type: extractPayloadType(job.payload),
           latency_ms: Date.now() - claimedAt,
           attempts: job.attempts + 1,
-        });
+        }, jobTraceParent);
       } catch (error) {
         const attempts = job.attempts + 1;
         const errMsg = error instanceof Error ? error.message : "unknown error";
@@ -337,7 +338,7 @@ export function createSqliteQueue(
             attempts,
             retry_after_ms: Math.max(0, retryAfter - Date.now()),
             error: errMsg,
-          });
+          }, jobTraceParent);
           return true;
         }
         recordQueueMetric(driver, "gittensory_jobs_failed_total");
@@ -364,7 +365,7 @@ export function createSqliteQueue(
             latency_ms: Date.now() - claimedAt,
             attempts,
             error: errMsg,
-          });
+          }, jobTraceParent);
           captureError(error, {
             kind: "job_dead",
             reason: "max_retries_exhausted",
@@ -386,7 +387,7 @@ export function createSqliteQueue(
             latency_ms: Date.now() - claimedAt,
             attempts,
             error: errMsg,
-          });
+          }, jobTraceParent);
         }
       }
       return true;

--- a/test/unit/selfhost-audit.test.ts
+++ b/test/unit/selfhost-audit.test.ts
@@ -41,6 +41,16 @@ describe("logAudit", () => {
     logAudit({ event: "job_complete", ts: 0, job_id: 0, latency_ms: 0, attempts: 1 });
     expect(written[0]!).toMatch(/\n$/);
   });
+
+  it("adds a carried OTEL trace id without inventing a current span id", () => {
+    logAudit(
+      { event: "job_complete", ts: 4000, job_id: 3, latency_ms: 20, attempts: 1 },
+      "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    );
+    const parsed = JSON.parse(written[0]!) as Record<string, unknown>;
+    expect(parsed.trace_id).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(parsed.span_id).toBeUndefined();
+  });
 });
 
 describe("extractPayloadType", () => {

--- a/test/unit/selfhost-otel.test.ts
+++ b/test/unit/selfhost-otel.test.ts
@@ -21,10 +21,12 @@ vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
 }));
 
 import {
+  currentOtelTraceIds,
   currentOtelTraceParent,
   flushOpenTelemetry,
   initOpenTelemetry,
   otelSafeAttributes,
+  otelTraceLogFields,
   resetOpenTelemetryForTest,
   resolveOtelTraceEndpoint,
   selfHostHttpRequestAttributes,
@@ -63,6 +65,12 @@ describe("self-host OpenTelemetry", () => {
     await flushOpenTelemetry();
     await expect(withOtelSpan("off", { "job.type": "x" }, () => 42)).resolves.toBe(42);
     expect(currentOtelTraceParent()).toBeUndefined();
+    expect(currentOtelTraceIds()).toBeUndefined();
+    expect(otelTraceLogFields()).toBeUndefined();
+    expect(otelTraceLogFields("bad-traceparent")).toBeUndefined();
+    expect(otelTraceLogFields("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")).toEqual({
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
     setCurrentOtelSpanAttributes({ ignored: true });
     expect(otelMocks.OTLPTraceExporter).not.toHaveBeenCalled();
   });
@@ -152,16 +160,26 @@ describe("self-host OpenTelemetry", () => {
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://collector/v1/traces",
     }));
     expect(currentOtelTraceParent()).toBeUndefined();
+    expect(currentOtelTraceIds()).toBeUndefined();
     setCurrentOtelSpanAttributes({ ignored: true });
     let traceParent: string | undefined;
+    let traceIds: ReturnType<typeof currentOtelTraceIds>;
+    let logFields: ReturnType<typeof otelTraceLogFields>;
     await withOtelSpan("selfhost.http.request", undefined, () => {
       traceParent = currentOtelTraceParent();
+      traceIds = currentOtelTraceIds();
+      logFields = otelTraceLogFields("00-ffffffffffffffffffffffffffffffff-eeeeeeeeeeeeeeee-01");
       setCurrentOtelSpanAttributes({
         "http.response.status_code": 202,
         secretHeader: "drop",
       });
     });
     expect(traceParent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+    expect(traceIds).toEqual({
+      trace_id: traceParent!.split("-")[1],
+      span_id: traceParent!.split("-")[2],
+    });
+    expect(logFields).toEqual(traceIds);
 
     await withOtelSpan("selfhost.queue.job", { "job.type": "github-webhook" }, () => undefined, { parentTraceParent: traceParent });
     await withOtelSpan("invalid-parent", undefined, () => undefined, { parentTraceParent: "not-a-traceparent" });

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -292,6 +292,28 @@ describe("createPgQueue (durable #977)", () => {
     expect(seen).toEqual(["review"]);
   });
 
+  it("copies carried webhook trace ids into job audit logs", async () => {
+    const m = makePool();
+    const writes: string[] = [];
+    vi.mocked(process.stdout.write).mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    m.enqueueJob("1", {
+      type: "github-webhook",
+      traceParent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    });
+    const q = createPgQueue(m.pool, async () => undefined);
+
+    await q.init();
+    await q.drain();
+
+    const audit = writes.find((line) => line.includes('"event":"job_complete"'));
+    expect(JSON.parse(audit!) as Record<string, unknown>).toMatchObject({
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+  });
+
   it("claims foreground work before falling back to the capped background lane", async () => {
     const claimSql: string[] = [];
     const fn = vi.fn().mockImplementation(async (sql: unknown) => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -12,12 +12,18 @@ const mocks = vi.hoisted(() => {
     flush: vi.fn().mockResolvedValue(true),
   };
 });
+const otelMocks = vi.hoisted(() => ({
+  currentOtelTraceIds: vi.fn(),
+}));
 vi.mock("@sentry/node", () => ({
   init: mocks.init,
   withScope: mocks.withScope,
   captureException: mocks.captureException,
   captureMessage: mocks.captureMessage,
   flush: mocks.flush,
+}));
+vi.mock("../../src/selfhost/otel", () => ({
+  currentOtelTraceIds: otelMocks.currentOtelTraceIds,
 }));
 
 import {
@@ -35,6 +41,7 @@ import {
 beforeEach(() => {
   resetSentryForTest();
   vi.clearAllMocks();
+  otelMocks.currentOtelTraceIds.mockReturnValue(undefined);
 });
 
 // The structured-log forwarder captures a synthetic Error via captureException (name = event slug, message = the
@@ -195,6 +202,32 @@ describe("enabled when SENTRY_DSN is set", () => {
     expect(mocks.captureException).toHaveBeenCalledTimes(2);
   });
 
+  it("adds active OTEL trace ids to captured Sentry events", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    otelMocks.currentOtelTraceIds.mockReturnValue({
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      span_id: "bbbbbbbbbbbbbbbb",
+    });
+
+    captureError(new Error("boom"), { kind: "job_dead" });
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("span_id", "bbbbbbbbbbbbbbbb");
+    expect(mocks.scope.setContext).toHaveBeenCalledWith("otel", {
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      span_id: "bbbbbbbbbbbbbbbb",
+    });
+
+    mocks.scope.setTag.mockClear();
+    mocks.scope.setContext.mockClear();
+    captureReviewFailure(new Error("review"), { repo: "o/r", pr: 9 });
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("span_id", "bbbbbbbbbbbbbbbb");
+    expect(mocks.scope.setContext).toHaveBeenCalledWith("otel", {
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      span_id: "bbbbbbbbbbbbbbbb",
+    });
+  });
+
   it("flushSentry delegates to Sentry.flush with the timeout", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     await flushSentry(123);
@@ -299,6 +332,20 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.scope.setTag).toHaveBeenCalledWith("model", "gpt-5.5");
     expect(mocks.scope.setTag).toHaveBeenCalledWith("effort", "high");
     expect(mocks.scope.setTag).toHaveBeenCalledWith("timeoutMs", "240000");
+  });
+
+  it("indexes trace ids already present on structured error logs", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "selfhost_job_dead",
+        trace_id: "cccccccccccccccccccccccccccccccc",
+        span_id: "dddddddddddddddd",
+      }),
+    );
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("trace_id", "cccccccccccccccccccccccccccccccc");
+    expect(mocks.scope.setTag).toHaveBeenCalledWith("span_id", "dddddddddddddddd");
   });
 
   it("forwards a level:fatal log titled by message (no event ⇒ no tag)", async () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -56,6 +56,26 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.size()).toBe(0);
   });
 
+  it("copies carried webhook trace ids into job audit logs", async () => {
+    const driver = makeDriver();
+    const writes: string[] = [];
+    vi.mocked(process.stdout.write).mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const q = createSqliteQueue(driver, async () => undefined);
+    const traced = prWebhook("trace-a");
+    if (traced.type === "github-webhook") traced.traceParent = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+    await q.binding.send(traced);
+
+    await q.drain();
+
+    const audit = writes.find((line) => line.includes('"event":"job_complete"'));
+    expect(JSON.parse(audit!) as Record<string, unknown>).toMatchObject({
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+  });
+
   it("tags webhook and PR review refresh jobs with elevated priorities (#review-latency)", async () => {
     const driver = makeDriver();
     const q = createSqliteQueue(driver, async () => undefined);


### PR DESCRIPTION
Closes #1803

## Summary
- Add self-host trace id helpers for the active OpenTelemetry span and safe fallback traceparent parsing.
- Enrich audit logs, Sentry scopes, and forwarded structured error logs with trace_id/span_id fields.
- Carry webhook trace context into SQLite and Postgres job audit logs and document the operator workflow.

## What changed
- Audit logs now include trace_id for carried webhook context and active trace_id/span_id when a span is active.
- Sentry captures tag active trace ids and index trace fields already present on structured logs.
- Queue workers pass webhook trace context to job_complete, job_error, job_rate_limited, and job_dead audit events.
- Self-host operations docs explain log/Sentry-to-trace correlation for Grafana or Tempo.

## Why
Self-host operators need a simple way to jump from a failed job log line or Sentry issue to the matching distributed trace when debugging queue and webhook failures.

## Validation
- `npx vitest run test/unit/selfhost-otel.test.ts test/unit/selfhost-sentry.test.ts test/unit/selfhost-audit.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage`
- `npm run test:ci`
- `npm audit --audit-level=moderate`

## Notes
- OpenTelemetry-off behavior remains a no-op.
- Fallback traceparent parsing logs only trace_id, not a stale parent span_id as the current span.