### PR TITLE
fix(selfhost): default deploy release to current head

### DIFF
--- a/scripts/deploy-selfhost-prebuilt.sh
+++ b/scripts/deploy-selfhost-prebuilt.sh
@@ -200,7 +200,9 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-SENTRY_RELEASE="${SENTRY_RELEASE:-$(env_get SENTRY_RELEASE || true)}"
+# Default to the current checkout on every deploy. Do not reuse a persisted .env value here:
+# that value is written by the previous deploy and would make future updates report stale
+# release/version metadata unless the operator remembered to override it manually.
 SENTRY_RELEASE="${SENTRY_RELEASE:-gittensory-selfhost@$(git rev-parse --short=8 HEAD)}"
 export SENTRY_RELEASE
 

--- a/test/unit/selfhost-sentry-release.test.ts
+++ b/test/unit/selfhost-sentry-release.test.ts
@@ -23,6 +23,10 @@ describe("self-host Sentry release wiring", () => {
     expect(edgeDeployScript).toContain(
       'SENTRY_CLI_PACKAGE="${SENTRY_CLI_PACKAGE:-@sentry/cli@3.6.0}"',
     );
+    expect(edgeDeployScript).toContain(
+      'SENTRY_RELEASE="${SENTRY_RELEASE:-gittensory-selfhost@$(git rev-parse --short=8 HEAD)}"',
+    );
+    expect(edgeDeployScript).not.toContain('env_get SENTRY_RELEASE');
     expect(edgeDeployScript).not.toContain("@sentry/cli@latest");
     expect(releaseWorkflow).toContain("target: runtime-prebuilt");
     expect(releaseWorkflow).toContain(


### PR DESCRIPTION
## Summary
- Make the self-host prebuilt deploy script default release metadata to the current checkout head on every run.
- Keep explicit `SENTRY_RELEASE=...` overrides working for operators who need a custom release name.
- Add a regression check so the script does not read stale `SENTRY_RELEASE` values back out of `.env`.

## Why
The deploy script writes `SENTRY_RELEASE` and `GITTENSORY_VERSION` into `.env` after each deploy. Reusing that persisted value on the next run makes a later deployment report the previous release unless the operator remembers to pass an override manually. The default deploy path should produce correct release/version metadata from the checked-out commit.

## Validation
- `npx vitest run test/unit/selfhost-sentry-release.test.ts`
- `bash -n scripts/deploy-selfhost-prebuilt.sh`
- `git diff --check`

## Notes
- This does not change secret handling. `.env` is still only updated for `SENTRY_RELEASE` and `GITTENSORY_VERSION` by the deploy script.