### PR TITLE
fix(review): prune duplicate sticky review comments

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -58,8 +58,8 @@ async function createOrUpdateIssueCommentWithMarker(
     const octokit = makeInstallationOctokit(env, token, options.mode ?? "live");
     const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
     const markers = markerAliases(marker);
-    let existing: IssueComment | undefined;
-    for (let page = 1; !existing && page <= COMMENT_SEARCH_PAGE_LIMIT; page += 1) {
+    const existing: IssueComment[] = [];
+    for (let page = 1; page <= COMMENT_SEARCH_PAGE_LIMIT; page += 1) {
       const response = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", {
         owner,
         repo,
@@ -68,21 +68,26 @@ async function createOrUpdateIssueCommentWithMarker(
         page,
       });
       const batch = response.data as IssueComment[];
-      existing = batch.find((comment) => isGittensoryBotComment(comment, botLogin) && markers.some((candidate) => comment.body?.includes(candidate)));
+      existing.push(...batch.filter((comment) => isGittensoryBotComment(comment, botLogin) && markers.some((candidate) => comment.body?.includes(candidate))));
       if (batch.length < 100) break;
     }
-    if (existing) {
+    const canonical = canonicalMarkerComment(existing);
+    if (canonical) {
       // Idempotency (#4): skip the PATCH when the rendered body is byte-identical to what's already posted. The
       // re-gate sweep re-renders the same surface every cycle for an unchanged PR; without this, every cycle PATCHes
       // GitHub (a write + rate-limit cost) for no visible change. Defense-in-depth alongside the head_sha publish
       // marker — also collapses a duplicate webhook delivery for the same commit.
-      if (existing.body === body) return { id: existing.id, ...(existing.html_url !== undefined ? { html_url: existing.html_url } : {}) };
+      if (canonical.body === body) {
+        await deleteDuplicateMarkerComments(octokit, owner, repo, existing, canonical.id);
+        return { id: canonical.id, ...(canonical.html_url !== undefined ? { html_url: canonical.html_url } : {}) };
+      }
       const response = await octokit.request("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}", {
         owner,
         repo,
-        comment_id: existing.id,
+        comment_id: canonical.id,
         body,
       });
+      await deleteDuplicateMarkerComments(octokit, owner, repo, existing, canonical.id);
       return response.data as { id: number; html_url?: string };
     }
     if (options.createIfMissing === false) return null;
@@ -98,6 +103,30 @@ async function createOrUpdateIssueCommentWithMarker(
 
 function isGittensoryBotComment(comment: IssueComment, botLogin: string): boolean {
   return comment.user?.type === "Bot" && comment.user.login?.toLowerCase() === botLogin.toLowerCase();
+}
+
+function canonicalMarkerComment(comments: IssueComment[]): IssueComment | undefined {
+  return comments.reduce<IssueComment | undefined>((best, comment) => (best === undefined || comment.id < best.id ? comment : best), undefined);
+}
+
+async function deleteDuplicateMarkerComments(
+  octokit: ReturnType<typeof makeInstallationOctokit>,
+  owner: string,
+  repo: string,
+  comments: IssueComment[],
+  canonicalId: number,
+): Promise<void> {
+  await Promise.allSettled(
+    comments
+      .filter((comment) => comment.id !== canonicalId)
+      .map((comment) =>
+        octokit.request("DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}", {
+          owner,
+          repo,
+          comment_id: comment.id,
+        }),
+      ),
+  );
 }
 
 function markerAliases(_marker: string): string[] {

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -107,6 +107,47 @@ describe("GitHub PR intelligence comments", () => {
     expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/101"))).toBe(true);
   });
 
+  it("prunes duplicate bot marker comments while updating the canonical sticky comment", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/12/comments") && (init?.method ?? "GET") === "GET") {
+        return Response.json([
+          { id: 202, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\n\nreviewing placeholder`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
+          { id: 101, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nold final`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
+          { id: 303, body: `${PR_INTELLIGENCE_COMMENT_MARKER}\nsecond duplicate`, user: { login: "gittensory-orb[bot]", type: "Bot" } },
+        ]);
+      }
+      if (url.includes("/issues/comments/202") && init?.method === "DELETE") return new Response(null, { status: 204 });
+      if (url.includes("/issues/comments/303") && init?.method === "DELETE") return new Response(null, { status: 204 });
+      if (url.includes("/issues/comments/101") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body)) as { body: string };
+        expect(body.body).toContain("new final");
+        return Response.json({ id: 101, html_url: "https://github.com/comment/101" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await createOrUpdatePrIntelligenceComment(
+      createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey, GITHUB_APP_SLUG: "gittensory-orb" }),
+      123,
+      "JSONbored/gittensory",
+      12,
+      `${PR_INTELLIGENCE_COMMENT_MARKER}\nnew final`,
+    );
+
+    expect(result?.id).toBe(101);
+    expect(calls.filter((call) => call.startsWith("DELETE ") && call.includes("/issues/comments/")).sort()).toEqual([
+      "DELETE https://api.github.com/repos/JSONbored/gittensory/issues/comments/202",
+      "DELETE https://api.github.com/repos/JSONbored/gittensory/issues/comments/303",
+    ]);
+    expect(calls.some((call) => call.startsWith("PATCH ") && call.includes("/issues/comments/101"))).toBe(true);
+    expect(calls.some((call) => call.startsWith("POST ") && call.includes("/issues/12/comments"))).toBe(false);
+  });
+
   it("finds the existing bot comment on page 2 and updates it rather than creating a duplicate", async () => {
     const privateKey = await generatePrivateKeyPem();
     const calls: string[] = [];

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
+import { PR_PANEL_COMMENT_MARKER } from "../../src/github/comments";
 import * as repositoriesModule from "../../src/db/repositories";
 import * as sentryModule from "../../src/selfhost/sentry";
 import {
@@ -1106,8 +1107,10 @@ describe("queue processors", () => {
       aiReviewMode: "block",
       gatePack: "oss-anti-slop",
     });
-    const commentBodies: string[] = [];
-    let firstCommentWasPlaceholder = false;
+    const stickyComment: { current: { id: number; body: string } | null } = { current: null };
+    let firstWriteWasPlaceholder = false;
+    let postCount = 0;
+    let patchCount = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
@@ -1117,12 +1120,21 @@ describe("queue processors", () => {
       if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
-      if (url.includes("/issues/7/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/7/comments") && method === "GET") {
+        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+      }
       if (url.includes("/issues/7/comments") && method === "POST") {
         const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
-        if (commentBodies.length === 0) firstCommentWasPlaceholder = body.includes("is reviewing");
-        commentBodies.push(body);
+        postCount += 1;
+        if (postCount === 1) firstWriteWasPlaceholder = body.includes("is reviewing");
+        stickyComment.current = { id: 1, body };
         return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/issues/comments/1") && method === "PATCH") {
+        const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        patchCount += 1;
+        stickyComment.current = { id: 1, body };
+        return Response.json({ id: 1 }, { status: 200 });
       }
       if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
       return Response.json({});
@@ -1140,13 +1152,13 @@ describe("queue processors", () => {
       },
     });
 
-    // The transient purple placeholder was posted FIRST (before the final verdict comment), proving the
-    // pre-review placeholder glue in maybePublishPrPublicSurface runs when a comment + AI review are due.
-    expect(commentBodies.length).toBeGreaterThanOrEqual(2);
-    expect(firstCommentWasPlaceholder).toBe(true);
-    expect(commentBodies[0]).toContain("🟪");
-    // A later comment carries the real verdict, not the placeholder prose.
-    expect(commentBodies.some((body) => !body.includes("is reviewing"))).toBe(true);
+    // The transient purple placeholder is the first write, then the final verdict updates the same sticky comment.
+    expect(postCount).toBe(1);
+    expect(patchCount).toBeGreaterThanOrEqual(1);
+    expect(firstWriteWasPlaceholder).toBe(true);
+    expect(stickyComment.current?.body).toContain(PR_PANEL_COMMENT_MARKER);
+    expect(stickyComment.current?.body).toContain("Thanks for the contribution");
+    expect(stickyComment.current?.body).not.toContain("is reviewing");
   });
 
   it("continues to final verdict when the reviewing placeholder audit write fails", async () => {
@@ -1240,7 +1252,9 @@ describe("queue processors", () => {
     await persistRegistrySnapshot(env, normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"));
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", gateCheckMode: "enabled", aiReviewMode: "advisory" });
-    const commentBodies: string[] = [];
+    const stickyComment: { current: { id: number; body: string } | null } = { current: null };
+    let postCount = 0;
+    let patchCount = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
@@ -1250,10 +1264,20 @@ describe("queue processors", () => {
       if (url.includes("/commits/a8/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/a8/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
-      if (url.includes("/issues/8/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/8/comments") && method === "GET") {
+        return Response.json(stickyComment.current ? [{ ...stickyComment.current, user: { login: "gittensory[bot]", type: "Bot" } }] : []);
+      }
       if (url.includes("/issues/8/comments") && method === "POST") {
-        commentBodies.push(String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? ""));
+        const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        postCount += 1;
+        stickyComment.current = { id: 1, body };
         return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/issues/comments/1") && method === "PATCH") {
+        const body = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        patchCount += 1;
+        stickyComment.current = { id: 1, body };
+        return Response.json({ id: 1 }, { status: 200 });
       }
       if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
       return Response.json({});
@@ -1272,10 +1296,11 @@ describe("queue processors", () => {
     });
 
     expect(aiCalls).toBe(0);
-    expect(commentBodies.length).toBeGreaterThanOrEqual(2);
-    expect(commentBodies[0]).toContain("is reviewing");
-    expect(commentBodies[0]).toContain("🟪");
-    expect(commentBodies.some((body) => !body.includes("is reviewing"))).toBe(true);
+    expect(postCount).toBe(1);
+    expect(patchCount).toBeGreaterThanOrEqual(1);
+    expect(stickyComment.current?.body).toContain(PR_PANEL_COMMENT_MARKER);
+    expect(stickyComment.current?.body).toContain("Thanks for the contribution");
+    expect(stickyComment.current?.body).not.toContain("is reviewing");
   });
 
   it("keeps the PR comment in 🟪 reviewing state and retries when the final comment update is rate-limited", async () => {


### PR DESCRIPTION
## Summary
- Fix sticky PR review-comment upserts so duplicate bot-owned marker comments are collapsed back to one canonical comment.
- Preserve the oldest sticky review comment and best-effort delete later duplicate marker comments created by webhook races.
- Strengthen queue tests so the reviewing placeholder must be replaced via PATCH instead of a second POST.

## Why
A webhook race can create a final review comment and then a separate `Gittensory is reviewing...` placeholder with the same sticky marker. Later refreshes update the older final comment and leave the newer placeholder visible. The review surface is supposed to be a single comment that updates in place.

## Validation
- `npx vitest run test/unit/github-comments.test.ts`
- `npx vitest run test/unit/queue.test.ts -t "reviewing placeholder"`
- `npm run typecheck`
- `git diff --check`
- `npm run test:coverage`