### PR TITLE
fix(selfhost): bound webhook event span cardinality

### DIFF
--- a/src/selfhost/otel.ts
+++ b/src/selfhost/otel.ts
@@ -86,6 +86,77 @@ const SELFHOST_STATIC_ROUTES = new Set([
   "/v1/orb/webhook",
 ]);
 
+const GITHUB_WEBHOOK_EVENTS = new Set([
+  "branch_protection_configuration",
+  "branch_protection_rule",
+  "check_run",
+  "check_suite",
+  "code_scanning_alert",
+  "commit_comment",
+  "create",
+  "delete",
+  "dependabot_alert",
+  "deploy_key",
+  "deployment",
+  "deployment_protection_rule",
+  "deployment_review",
+  "deployment_status",
+  "discussion",
+  "discussion_comment",
+  "fork",
+  "github_app_authorization",
+  "gollum",
+  "installation",
+  "installation_repositories",
+  "installation_target",
+  "issue_comment",
+  "issues",
+  "label",
+  "marketplace_purchase",
+  "member",
+  "membership",
+  "merge_group",
+  "meta",
+  "milestone",
+  "org_block",
+  "organization",
+  "package",
+  "page_build",
+  "personal_access_token_request",
+  "ping",
+  "project",
+  "project_card",
+  "project_column",
+  "projects_v2_item",
+  "public",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "pull_request_review_thread",
+  "push",
+  "registry_package",
+  "release",
+  "repository",
+  "repository_advisory",
+  "repository_dispatch",
+  "repository_import",
+  "repository_ruleset",
+  "repository_vulnerability_alert",
+  "secret_scanning_alert",
+  "secret_scanning_alert_location",
+  "security_advisory",
+  "security_and_analysis",
+  "sponsorship",
+  "star",
+  "status",
+  "team",
+  "team_add",
+  "watch",
+  "workflow_dispatch",
+  "workflow_job",
+  "workflow_run",
+]);
+
 function selfHostHttpRoute(path: string): string {
   if (SELFHOST_STATIC_ROUTES.has(path)) return path;
   if (path.startsWith("/v1/internal/")) return "/v1/internal/*";
@@ -99,7 +170,7 @@ export function selfHostHttpRequestAttributes(request: Request, path = new URL(r
     "http.route": route,
   };
   const eventName = request.headers.get("x-github-event")?.trim();
-  if (eventName && (route === "/v1/github/webhook" || route === "/v1/orb/relay" || route === "/v1/orb/webhook"))
+  if (eventName && GITHUB_WEBHOOK_EVENTS.has(eventName) && (route === "/v1/github/webhook" || route === "/v1/orb/relay" || route === "/v1/orb/webhook"))
     attrs["github.webhook.event"] = eventName;
   if (route === "/v1/github/webhook") attrs["selfhost.webhook.transport"] = "github";
   else if (route === "/v1/orb/relay") attrs["selfhost.webhook.transport"] = "orb-relay";

--- a/test/unit/selfhost-otel.test.ts
+++ b/test/unit/selfhost-otel.test.ts
@@ -211,7 +211,30 @@ describe("self-host OpenTelemetry", () => {
       ),
     ).toMatchObject({
       "http.route": "/v1/orb/webhook",
+      "github.webhook.event": "installation",
       "selfhost.webhook.transport": "orb",
+    });
+    expect(
+      selfHostHttpRequestAttributes(
+        new Request("https://self.example/v1/github/webhook", {
+          method: "POST",
+          headers: { "x-github-event": "attacker_unique_event_1" },
+        }),
+      ),
+    ).toEqual({
+      "http.request.method": "POST",
+      "http.route": "/v1/github/webhook",
+      "selfhost.webhook.transport": "github",
+    });
+    expect(
+      selfHostHttpRequestAttributes(
+        new Request("https://self.example/v1/repos/acme/widgets", {
+          headers: { "x-github-event": "pull_request" },
+        }),
+      ),
+    ).toEqual({
+      "http.request.method": "GET",
+      "http.route": "/v1/*",
     });
     expect(selfHostHttpRequestAttributes(new Request("https://self.example/v1/internal/jobs/refresh-registry"))).toMatchObject({
       "http.route": "/v1/internal/*",


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated webhook requests from injecting arbitrary, high‑cardinality values into OTEL span attributes by restricting `github.webhook.event` to a known set of GitHub event names.  
- Keep low‑cardinality telemetry for self‑host deployments while preserving legitimate webhook event attributes for verified/known events.

### Description
- Add a finite `GITHUB_WEBHOOK_EVENTS` allowlist and check it before copying `x-github-event` into span attributes.  
- Update `selfHostHttpRequestAttributes` to only set `github.webhook.event` when the header value is in the allowlist and the route is a webhook route.  
- Preserve existing `selfhost.webhook.transport` tagging for the webhook routes.  
- Add unit test coverage asserting known events are kept, attacker-controlled event names are dropped, and non-webhook routes do not gain event attributes.

### Testing
- Ran `npx vitest run test/unit/selfhost-otel.test.ts --reporter=verbose` and all unit tests in that file passed.  
- Ran `npm run typecheck` (`tsc --noEmit`) and typecheck succeeded.  
- Attempted `npm run test:coverage` and `npm run test:ci` as the full local gate, but the environment ran into tool/network issues (actionlint / audit) so the end‑to‑end gate did not complete successfully in this environment.  
- The committed unit test for the otel helpers validates the regression and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43380992b8832c83a6b5d9d13f6e57)