### PR TITLE
ci(release): add image-based self-host deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,9 @@ GITTENSORY_REVIEW_DRAFT=false
 #                                            #   SQLite (shared DB → multi-instance). Overrides DATABASE_PATH.
 REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review runtime. The default compose stack
 #                                            #   starts Redis automatically; override for an external Redis.
+# GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost:latest  # image used by scripts/deploy-selfhost-image.sh;
+#                                            #   pin production rollouts to a release tag such as :orb-v0.1.0
+#                                            #   or to an immutable @sha256 digest.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
 # DISCORD_WEBHOOK_URL=                        # one Discord channel for per-action notifications (merged/closed/

--- a/scripts/deploy-selfhost-image.sh
+++ b/scripts/deploy-selfhost-image.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Pull and deploy a published self-host image without rebuilding on the host.
+#
+# Defaults to the latest official image:
+#   ./scripts/deploy-selfhost-image.sh
+#
+# Pin production rollouts to a release tag or digest:
+#   ./scripts/deploy-selfhost-image.sh ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0
+#   GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/deploy-selfhost-image.sh
+#
+# The image itself carries official release metadata. Set SENTRY_RELEASE only for custom images whose
+# source maps were uploaded under that exact id.
+set -euo pipefail
+
+ENV_FILE="${SELFHOST_ENV_FILE:-.env}"
+SERVICE="${SELFHOST_SERVICE:-gittensory}"
+HEALTH_TIMEOUT_SECONDS="${SELFHOST_HEALTH_TIMEOUT_SECONDS:-180}"
+DEFAULT_IMAGE="ghcr.io/jsonbored/gittensory-selfhost:latest"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+env_get() {
+  local key="$1"
+  local file="${2:-$ENV_FILE}"
+
+  [ -f "$file" ] || return 1
+
+  awk -v key="$key" '
+    /^[[:space:]]*(#|$)/ { next }
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (line !~ "^" key "[[:space:]]*=") {
+        next
+      }
+      sub(/^[^=]*=/, "", line)
+      sub(/^[[:space:]]*/, "", line)
+      sub(/[[:space:]]*$/, "", line)
+      if (length(line) >= 2) {
+        first = substr(line, 1, 1)
+        last = substr(line, length(line), 1)
+        if ((first == "\"" && last == "\"") || (first == "'\''" && last == "'\''")) {
+          line = substr(line, 2, length(line) - 2)
+        }
+      }
+      print line
+      found = 1
+      exit
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+}
+
+env_put() {
+  local key="$1"
+  local value="$2"
+  local file="${3:-$ENV_FILE}"
+  local dir base tmp
+
+  touch "$file"
+  dir="$(dirname "$file")"
+  base="$(basename "$file")"
+  tmp="$(mktemp "$dir/.${base}.tmp.XXXXXX")"
+  awk -v key="$key" -v value="$value" '
+    BEGIN { written = 0 }
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (line ~ "^" key "[[:space:]]*=") {
+        print key "=" value
+        written = 1
+      } else {
+        print $0
+      }
+    }
+    END {
+      if (!written) {
+        print key "=" value
+      }
+    }
+  ' "$file" >"$tmp"
+  cat "$tmp" >"$file"
+  rm -f "$tmp"
+}
+
+compose_file_args() {
+  local files=()
+  local file
+
+  if [ -n "${SELFHOST_COMPOSE_FILES:-}" ]; then
+    # shellcheck disable=SC2206
+    files=(${SELFHOST_COMPOSE_FILES})
+  else
+    files=(docker-compose.yml)
+    [ -f docker-compose.override.yml ] && files+=(docker-compose.override.yml)
+  fi
+
+  for file in "${files[@]}"; do
+    if [ ! -f "$file" ]; then
+      echo "error: compose file not found: $file" >&2
+      exit 1
+    fi
+    printf '%s\n' -f "$file"
+  done
+}
+
+resolve_image() {
+  local env_file_image
+
+  if [ "$#" -gt 1 ]; then
+    echo "error: expected at most one image argument" >&2
+    exit 1
+  fi
+
+  env_file_image="$(env_get GITTENSORY_IMAGE || true)"
+  printf '%s' "${1:-${GITTENSORY_IMAGE:-${env_file_image:-$DEFAULT_IMAGE}}}"
+}
+
+validate_inputs() {
+  local image="$1"
+
+  if [ -z "$image" ]; then
+    echo "error: image must not be empty" >&2
+    exit 1
+  fi
+  case "$image" in
+    *[[:space:]\"\'\\]*)
+      echo "error: image contains unsupported whitespace, quote, or backslash characters" >&2
+      exit 1
+      ;;
+  esac
+  if ! [[ "$SERVICE" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "error: SELFHOST_SERVICE contains unsupported characters" >&2
+    exit 1
+  fi
+  if ! [[ "$HEALTH_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+    echo "error: SELFHOST_HEALTH_TIMEOUT_SECONDS must be a non-negative integer" >&2
+    exit 1
+  fi
+}
+
+wait_for_healthy() {
+  local deadline container_id status
+
+  deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+  while [ "$SECONDS" -le "$deadline" ]; do
+    container_id="$(docker compose "${compose_args[@]}" ps -q "$SERVICE" 2>/dev/null || true)"
+    if [ -n "$container_id" ]; then
+      status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)"
+      if [ "$status" = "healthy" ]; then
+        echo "selfhost image deploy: $SERVICE is healthy"
+        return 0
+      fi
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      break
+    fi
+    sleep 2
+  done
+
+  echo "error: $SERVICE did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s" >&2
+  docker compose "${compose_args[@]}" ps "$SERVICE" >&2 || true
+  docker compose "${compose_args[@]}" logs --tail=80 "$SERVICE" >&2 || true
+  exit 1
+}
+
+require_cmd docker
+docker compose version >/dev/null
+
+IMAGE="$(resolve_image "$@")"
+validate_inputs "$IMAGE"
+
+override_file="$(mktemp)"
+SELFHOST_GENERATED_COMPOSE_FILE="$override_file"
+trap 'rm -f "${SELFHOST_GENERATED_COMPOSE_FILE:-}"' EXIT
+
+cat >"$override_file" <<YAML
+services:
+  $SERVICE:
+    image: "$IMAGE"
+YAML
+
+mapfile -t compose_args < <(compose_file_args)
+compose_args+=(-f "$override_file")
+
+echo "selfhost image deploy: pulling $IMAGE"
+docker compose "${compose_args[@]}" pull --policy always "$SERVICE"
+
+echo "selfhost image deploy: restarting $SERVICE"
+docker compose "${compose_args[@]}" up -d --no-build --no-deps "$SERVICE"
+
+wait_for_healthy
+env_put GITTENSORY_IMAGE "$IMAGE"
+
+echo "selfhost image deploy: complete ($IMAGE)"

--- a/test/unit/selfhost-image-deploy.test.ts
+++ b/test/unit/selfhost-image-deploy.test.ts
@@ -1,0 +1,195 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = resolve("scripts/deploy-selfhost-image.sh");
+const defaultImage = "ghcr.io/jsonbored/gittensory-selfhost:latest";
+
+interface RunOptions {
+  args?: string[];
+  env?: Record<string, string>;
+  envFile?: string;
+  dockerStatus?: string;
+  timeoutSeconds?: string;
+}
+
+function createHarness() {
+  const dir = mkdtempSync(join(tmpdir(), "gittensory-selfhost-image-"));
+  const binDir = join(dir, "bin");
+  const dockerCalls = join(dir, "docker-calls.log");
+  const dockerImages = join(dir, "docker-images.log");
+  const envPath = join(dir, ".env");
+
+  mkdirSync(binDir);
+  writeFileSync(join(dir, "docker-compose.yml"), "services:\n  gittensory:\n    image: old\n");
+  writeFileSync(
+    join(binDir, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_CALLS"
+
+if [ "$1" = "compose" ]; then
+  case "$*" in
+    *" pull --policy always "*)
+      last_file=""
+      prev=""
+      for arg in "$@"; do
+        if [ "$prev" = "-f" ]; then
+          last_file="$arg"
+        fi
+        prev="$arg"
+      done
+      if [ -n "$last_file" ]; then
+        grep 'image:' "$last_file" >> "$DOCKER_IMAGES"
+      fi
+      exit 0
+      ;;
+    *" version"*|*" up -d --no-build --no-deps "*|*" ps "*|*" logs "*)
+      if [[ "$*" == *" ps -q "* ]]; then
+        printf 'container-id\\n'
+      fi
+      exit 0
+      ;;
+  esac
+fi
+
+if [ "$1" = "inspect" ]; then
+  if grep -q '^GITTENSORY_IMAGE=' "$SELFHOST_ENV_FILE" 2>/dev/null; then
+    printf '%s\\n' persisted-before-health >> "$DOCKER_CALLS"
+  else
+    printf '%s\\n' not-persisted-before-health >> "$DOCKER_CALLS"
+  fi
+  printf '%s\\n' "\${DOCKER_INSPECT_STATUS:-healthy}"
+  exit 0
+fi
+
+printf 'unexpected docker invocation: %s\\n' "$*" >&2
+exit 1
+`,
+  );
+  chmodSync(join(binDir, "docker"), 0o755);
+
+  return {
+    dir,
+    envPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    readCalls: () => readOptional(dockerCalls),
+    readImages: () => readOptional(dockerImages),
+    run(options: RunOptions = {}) {
+      if (options.envFile !== undefined) writeFileSync(envPath, options.envFile);
+      const result = spawnSync("bash", [scriptPath, ...(options.args ?? [])], {
+        cwd: dir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          SELFHOST_ENV_FILE: envPath,
+          SELFHOST_HEALTH_TIMEOUT_SECONDS: options.timeoutSeconds ?? "10",
+          DOCKER_CALLS: dockerCalls,
+          DOCKER_IMAGES: dockerImages,
+          DOCKER_INSPECT_STATUS: options.dockerStatus ?? "healthy",
+          ...(options.env ?? {}),
+        },
+      });
+      return result;
+    },
+  };
+}
+
+function readOptional(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function runHarness(options: RunOptions = {}) {
+  const harness = createHarness();
+  const result = harness.run(options);
+  return { harness, result };
+}
+
+describe("self-host image deploy script", () => {
+  it.each([
+    {
+      name: "CLI argument",
+      args: ["ghcr.io/jsonbored/gittensory-selfhost:cli"],
+      env: { GITTENSORY_IMAGE: "ghcr.io/jsonbored/gittensory-selfhost:env" },
+      envFile: "GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost:file\n",
+      expected: "ghcr.io/jsonbored/gittensory-selfhost:cli",
+    },
+    {
+      name: "environment variable",
+      env: { GITTENSORY_IMAGE: "ghcr.io/jsonbored/gittensory-selfhost:env" },
+      envFile: "GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost:file\n",
+      expected: "ghcr.io/jsonbored/gittensory-selfhost:env",
+    },
+    {
+      name: ".env value",
+      envFile: "GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost:file\n",
+      expected: "ghcr.io/jsonbored/gittensory-selfhost:file",
+    },
+    {
+      name: "default image",
+      expected: defaultImage,
+    },
+  ])("uses image precedence from $name", ({ args, env, envFile, expected }) => {
+    const options: RunOptions = {};
+    if (args) options.args = args;
+    if (env) options.env = env;
+    if (envFile !== undefined) options.envFile = envFile;
+    const { harness, result } = runHarness(options);
+    try {
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(harness.envPath, "utf8")).toContain(`GITTENSORY_IMAGE=${expected}`);
+      expect(harness.readImages()).toContain(`image: "${expected}"`);
+      expect(harness.readCalls()).toContain("up -d --no-build --no-deps gittensory");
+      expect(harness.readCalls()).not.toContain(" build ");
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("persists the image only after the service reports healthy", () => {
+    const image = "ghcr.io/jsonbored/gittensory-selfhost:ordered";
+    const { harness, result } = runHarness({ args: [image], envFile: "EXISTING=1\n" });
+    try {
+      expect(result.status, result.stderr).toBe(0);
+      const calls = harness.readCalls().trim().split("\n");
+      expect(calls).toContain("not-persisted-before-health");
+      expect(calls).not.toContain("persisted-before-health");
+      expect(readFileSync(harness.envPath, "utf8")).toContain(`GITTENSORY_IMAGE=${image}`);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it("does not persist the image when health times out", () => {
+    const image = "ghcr.io/jsonbored/gittensory-selfhost:bad-health";
+    const { harness, result } = runHarness({
+      args: [image],
+      envFile: "EXISTING=1\n",
+      dockerStatus: "starting",
+      timeoutSeconds: "0",
+    });
+    try {
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("did not become healthy within 0s");
+      expect(readFileSync(harness.envPath, "utf8")).toBe("EXISTING=1\n");
+      expect(harness.readImages()).toContain(`image: "${image}"`);
+      expect(harness.readCalls()).not.toContain(" build ");
+    } finally {
+      harness.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Add an image-based self-host deploy script for rolling out published GHCR images without rebuilding the app on the VPS.

## What changed
- Add `scripts/deploy-selfhost-image.sh` for pull-and-recreate deploys from `GITTENSORY_IMAGE`, an explicit image argument, or the default official image.
- Wait for the app container to report healthy before the deploy succeeds.
- Persist the deployed image tag in `.env` only after a successful rollout.
- Document the `GITTENSORY_IMAGE` env knob and add regression coverage for the no-build/no-source-map deploy path.

## Why
Official Orb releases should deploy by pulling the exact published image tag or digest. Rebuilding on the VPS is slower, harder to reproduce, and keeps release rollout coupled to local host build tooling.

## Validation
- `bash -n scripts/deploy-selfhost-image.sh`
- `npx vitest run test/unit/selfhost-image-deploy.test.ts`
- `npm run typecheck`
- `git diff --check`