### PR TITLE
fix(webhooks): drop non-actionable webhook noise

### DIFF
--- a/src/github/self-authored.ts
+++ b/src/github/self-authored.ts
@@ -4,6 +4,11 @@ type GitHubAppRef = {
   slug?: string | null;
 };
 
+type GitHubActorRef = {
+  login?: string | null;
+  type?: string | null;
+};
+
 type CheckRunWebhookNode = {
   app?: GitHubAppRef | null;
   check_suite?: {
@@ -26,6 +31,12 @@ function ownAppSlug(env: Env): string {
 function appSlugMatches(env: Env, app: GitHubAppRef | null | undefined): boolean {
   const expected = ownAppSlug(env);
   return expected !== "" && normalizeGitHubSlug(app?.slug) === expected;
+}
+
+function isBotActor(actor: GitHubActorRef | null | undefined): boolean {
+  const login = actor?.login?.toLowerCase() ?? "";
+  const type = actor?.type?.toLowerCase() ?? "";
+  return type === "bot" || login.endsWith("[bot]");
 }
 
 function ciCompletionApp(
@@ -68,6 +79,22 @@ export function isSelfAuthoredCiCompletionWebhook(
   return appSlugMatches(env, ciCompletionApp(eventName, payload));
 }
 
+export function isNonCompletedCiWebhook(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): boolean {
+  if (eventName !== "check_run" && eventName !== "check_suite") return false;
+  return payload.action !== "completed";
+}
+
+export function isBotAuthoredIssueCommentEditWebhook(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): boolean {
+  if (eventName !== "issue_comment" || payload.action !== "edited") return false;
+  return isBotActor(payload.sender);
+}
+
 export function isSelfAuthoredWebhookNoise(
   env: Env,
   eventName: string,
@@ -76,5 +103,17 @@ export function isSelfAuthoredWebhookNoise(
   return (
     isSelfAuthoredAppCommentWebhook(env, eventName, payload) ||
     isSelfAuthoredCiCompletionWebhook(env, eventName, payload)
+  );
+}
+
+export function isNonActionableWebhookNoise(
+  env: Env,
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): boolean {
+  return (
+    isSelfAuthoredWebhookNoise(env, eventName, payload) ||
+    isNonCompletedCiWebhook(eventName, payload) ||
+    isBotAuthoredIssueCommentEditWebhook(eventName, payload)
   );
 }

--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -6,7 +6,7 @@ import { parsePositiveInt } from "../utils/json";
 import { relayVerify } from "../orb/relay";
 import { isSelfHostedReviewRuntime } from "../selfhost/review-runtime";
 import { getSelfHostRequestTraceParent } from "../selfhost/trace-context";
-import { isSelfAuthoredWebhookNoise } from "./self-authored";
+import { isNonActionableWebhookNoise } from "./self-authored";
 
 const DEFAULT_MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
@@ -94,7 +94,7 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     repositoryFullName: payload.repository?.full_name,
     payloadHash,
   };
-  if (isSelfAuthoredWebhookNoise(env, eventName, payload)) {
+  if (isNonActionableWebhookNoise(env, eventName, payload)) {
     await recordWebhookEvent(env, { ...eventRow, status: "processed" });
     return "ignored";
   }

--- a/test/unit/github-self-authored.test.ts
+++ b/test/unit/github-self-authored.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  isBotAuthoredIssueCommentEditWebhook,
+  isNonActionableWebhookNoise,
+  isNonCompletedCiWebhook,
   isSelfAuthoredAppCommentWebhook,
   isSelfAuthoredCiCompletionWebhook,
   isSelfAuthoredWebhookNoise,
@@ -15,12 +18,15 @@ describe("self-authored GitHub webhook detection", () => {
       sender: { login: "gittensory-orb[bot]", type: "Bot" },
       comment: { user: { login: "gittensory-orb[bot]", type: "Bot" } },
     } as GitHubWebhookPayload;
+    const missingSlugEnv = createTestEnv();
+    delete (missingSlugEnv as { GITHUB_APP_SLUG?: string }).GITHUB_APP_SLUG;
 
     expect(isSelfAuthoredAppCommentWebhook(env, "issue_comment", payload)).toBe(true);
     expect(isSelfAuthoredWebhookNoise(env, "issue_comment", payload)).toBe(true);
     expect(isSelfAuthoredAppCommentWebhook(env, "pull_request", payload)).toBe(false);
     expect(isSelfAuthoredAppCommentWebhook(env, "issue_comment", { ...payload, action: "deleted" })).toBe(false);
     expect(isSelfAuthoredAppCommentWebhook(createTestEnv({ GITHUB_APP_SLUG: "" }), "issue_comment", payload)).toBe(false);
+    expect(isSelfAuthoredAppCommentWebhook(missingSlugEnv, "issue_comment", payload)).toBe(false);
     expect(
       isSelfAuthoredAppCommentWebhook(env, "issue_comment", {
         ...payload,
@@ -64,5 +70,61 @@ describe("self-authored GitHub webhook detection", () => {
     ).toBe(false);
     expect(isSelfAuthoredCiCompletionWebhook(env, "pull_request", { action: "completed" })).toBe(false);
     expect(isSelfAuthoredWebhookNoise(env, "pull_request", { action: "completed" })).toBe(false);
+  });
+
+  it("classifies non-completed CI lifecycle events as non-actionable noise only until completion", () => {
+    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+
+    expect(isNonCompletedCiWebhook("check_suite", { action: "requested" })).toBe(true);
+    expect(isNonCompletedCiWebhook("check_run", { action: "rerequested" })).toBe(true);
+    expect(isNonActionableWebhookNoise(env, "check_suite", { action: "requested" })).toBe(true);
+    expect(
+      isNonActionableWebhookNoise(env, "check_suite", {
+        action: "completed",
+        check_suite: { app: { slug: "github-actions" } },
+      } as never),
+    ).toBe(false);
+    expect(isNonCompletedCiWebhook("pull_request", { action: "opened" })).toBe(false);
+  });
+
+  it("drops bot-sender issue comment edits while preserving human panel edits", () => {
+    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const humanPanelEdit = {
+      action: "edited",
+      sender: { login: "maintainer", type: "User" },
+      comment: { user: { login: "gittensory-orb[bot]", type: "Bot" } },
+    } as GitHubWebhookPayload;
+
+    expect(
+      isBotAuthoredIssueCommentEditWebhook("issue_comment", {
+        action: "edited",
+        sender: { login: "codecov[bot]", type: "User" },
+      } as GitHubWebhookPayload),
+    ).toBe(true);
+    expect(
+      isBotAuthoredIssueCommentEditWebhook("issue_comment", {
+        action: "edited",
+        sender: { login: "external-bot", type: "Bot" },
+      } as GitHubWebhookPayload),
+    ).toBe(true);
+    expect(isBotAuthoredIssueCommentEditWebhook("issue_comment", humanPanelEdit)).toBe(false);
+    expect(isNonActionableWebhookNoise(env, "issue_comment", humanPanelEdit)).toBe(false);
+    expect(
+      isBotAuthoredIssueCommentEditWebhook("issue_comment", {
+        action: "edited",
+      } as GitHubWebhookPayload),
+    ).toBe(false);
+    expect(
+      isBotAuthoredIssueCommentEditWebhook("issue_comment", {
+        action: "edited",
+        sender: { login: "external-bot", type: "bot" },
+      } as GitHubWebhookPayload),
+    ).toBe(true);
+    expect(
+      isBotAuthoredIssueCommentEditWebhook("issue_comment", {
+        action: "created",
+        sender: { login: "codecov[bot]", type: "Bot" },
+      } as GitHubWebhookPayload),
+    ).toBe(false);
   });
 });

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -336,6 +336,131 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     const event = await getWebhookEvent(env, "self-check-suite-ignore-1");
     expect(event?.status).toBe("processed");
   });
+
+  it("drops non-completed CI lifecycle webhooks before they add queue pressure", async () => {
+    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    let webhookSends = 0;
+    env.WEBHOOKS = { send: async () => void (webhookSends += 1) } as unknown as Queue;
+    const rawBody = JSON.stringify({
+      action: "requested",
+      repository: { full_name: "JSONbored/gittensory" },
+      installation: { id: 1 },
+      check_suite: {
+        head_sha: "abc123",
+        pull_requests: [{ number: 1832 }],
+        app: { slug: "github-actions" },
+      },
+    });
+    const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
+    const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
+    const headers: Record<string, string> = {
+      "x-github-delivery": "requested-check-suite-ignore-1",
+      "x-github-event": "check_suite",
+      "x-hub-signature-256": signature,
+    };
+    const context = {
+      req: {
+        raw: request,
+        header(name: string) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+      env,
+      json(payload: unknown, status?: number) {
+        return Response.json(payload, status === undefined ? undefined : { status });
+      },
+    } as unknown as Context<{ Bindings: Env }>;
+
+    const response = await handleGitHubWebhook(context);
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ status: "ignored" });
+    expect(webhookSends).toBe(0);
+    const event = await getWebhookEvent(env, "requested-check-suite-ignore-1");
+    expect(event?.status).toBe("processed");
+  });
+
+  it("keeps third-party CI completion webhooks queued for review finalization", async () => {
+    const env = createTestEnv({ GITHUB_APP_SLUG: "gittensory-orb" });
+    const sent: unknown[] = [];
+    env.WEBHOOKS = { send: async (message: unknown) => void sent.push(message) } as unknown as Queue;
+    const rawBody = JSON.stringify({
+      action: "completed",
+      repository: { full_name: "JSONbored/gittensory" },
+      installation: { id: 1 },
+      check_suite: {
+        head_sha: "abc123",
+        pull_requests: [{ number: 1832 }],
+        app: { slug: "github-actions" },
+      },
+    });
+    const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
+    const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
+    const headers: Record<string, string> = {
+      "x-github-delivery": "third-party-check-suite-queue-1",
+      "x-github-event": "check_suite",
+      "x-hub-signature-256": signature,
+    };
+    const context = {
+      req: {
+        raw: request,
+        header(name: string) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+      env,
+      json(payload: unknown, status?: number) {
+        return Response.json(payload, status === undefined ? undefined : { status });
+      },
+    } as unknown as Context<{ Bindings: Env }>;
+
+    const response = await handleGitHubWebhook(context);
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ status: "queued" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: "github-webhook", eventName: "check_suite" });
+    const event = await getWebhookEvent(env, "third-party-check-suite-queue-1");
+    expect(event?.status).toBe("queued");
+  });
+
+  it("drops bot-authored issue comment edits but keeps them auditable", async () => {
+    const env = createTestEnv();
+    let webhookSends = 0;
+    env.WEBHOOKS = { send: async () => void (webhookSends += 1) } as unknown as Queue;
+    const rawBody = JSON.stringify({
+      action: "edited",
+      repository: { full_name: "JSONbored/gittensory" },
+      installation: { id: 1 },
+      issue: { number: 1701, pull_request: {} },
+      comment: { id: 123, body: "coverage updated", user: { login: "codecov[bot]", type: "User" } },
+      sender: { login: "codecov[bot]", type: "User" },
+    });
+    const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
+    const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
+    const headers: Record<string, string> = {
+      "x-github-delivery": "bot-comment-edit-ignore-1",
+      "x-github-event": "issue_comment",
+      "x-hub-signature-256": signature,
+    };
+    const context = {
+      req: {
+        raw: request,
+        header(name: string) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+      env,
+      json(payload: unknown, status?: number) {
+        return Response.json(payload, status === undefined ? undefined : { status });
+      },
+    } as unknown as Context<{ Bindings: Env }>;
+
+    const response = await handleGitHubWebhook(context);
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ status: "ignored" });
+    expect(webhookSends).toBe(0);
+    const event = await getWebhookEvent(env, "bot-comment-edit-ignore-1");
+    expect(event?.status).toBe("processed");
+  });
 });
 
 describe("handleOrbRelay (brokered self-host relay receiver)", () => {


### PR DESCRIPTION
## Summary
- Drop non-actionable webhook deliveries before they enter the self-host WEBHOOKS queue.

## What changed
- Treat non-completed `check_suite`/`check_run` lifecycle events as processed noise because review finalization only acts on CI completion.
- Treat bot-sender `issue_comment.edited` deliveries as processed noise while preserving human edits to bot panel comments.
- Added classifier and enqueue-path regression tests for the ignored cases and the third-party CI completion path.

## Why
Webhook bursts were adding queue pressure even for deliveries the processor does not act on. Filtering these before enqueue reduces self-host backlog without touching GitHub GET caching or the broader response-cache work happening separately.

## Validation
- `npm run test -- test/unit/github-self-authored.test.ts test/unit/webhook.test.ts`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run test:ci`
- `npm audit --audit-level=moderate`