### PR TITLE
fix(orb): coalesce pending relay webhooks

### DIFF
--- a/migrations/0085_orb_relay_pending_coalesce_key.sql
+++ b/migrations/0085_orb_relay_pending_coalesce_key.sql
@@ -1,0 +1,6 @@
+-- Pull-mode relay backlog coalescing: keep only the newest pending row for webhook classes where later delivery
+-- supersedes earlier equivalent work (CI completion / PR refresh), while preserving terminal lifecycle events.
+ALTER TABLE orb_relay_pending ADD COLUMN coalesce_key TEXT;
+CREATE INDEX IF NOT EXISTS idx_orb_relay_pending_coalesce
+  ON orb_relay_pending (installation_id, coalesce_key)
+  WHERE coalesce_key IS NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { index, integer, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 // Timestamp columns use a drizzle $defaultFn so an insert that omits the column gets a real ISO-8601
 // timestamp. A static `.default("CURRENT_TIMESTAMP")` would make drizzle inject the literal STRING
@@ -692,6 +693,24 @@ export const webhookEvents = sqliteTable("webhook_events", {
   receivedAt: text("received_at").notNull().$defaultFn(() => nowIso()),
   processedAt: text("processed_at"),
 });
+
+export const orbRelayPending = sqliteTable(
+  "orb_relay_pending",
+  {
+    deliveryId: text("delivery_id").primaryKey(),
+    installationId: integer("installation_id").notNull(),
+    eventName: text("event_name").notNull(),
+    rawBody: text("raw_body").notNull(),
+    createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
+    coalesceKey: text("coalesce_key"),
+  },
+  (table) => ({
+    installation: index("idx_orb_relay_pending_install").on(table.installationId, table.createdAt),
+    coalesce: index("idx_orb_relay_pending_coalesce")
+      .on(table.installationId, table.coalesceKey)
+      .where(sql`coalesce_key IS NOT NULL`),
+  }),
+);
 
 export const syncRuns = sqliteTable("sync_runs", {
   id: text("id").primaryKey(),

--- a/src/github/webhook-coalesce.ts
+++ b/src/github/webhook-coalesce.ts
@@ -1,0 +1,89 @@
+import type { GitHubWebhookPayload } from "../types";
+
+const COALESCABLE_PULL_REQUEST_ACTIONS = new Set([
+  "opened",
+  "synchronize",
+  "edited",
+  "ready_for_review",
+  "labeled",
+  "unlabeled",
+]);
+
+export function githubWebhookCoalesceKey(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+): string | null {
+  const action =
+    typeof payload.action === "string" ? payload.action : "";
+  const repo = normalizedRepo(payload.repository?.full_name);
+  if (!repo) return null;
+  if (
+    (eventName === "check_suite" || eventName === "check_run") &&
+    action === "completed"
+  ) {
+    const node = webhookNode(eventName, payload);
+    const headSha = normalizedSha(
+      node?.head_sha ??
+        (eventName === "check_run" ? node?.check_suite?.head_sha : undefined),
+    );
+    if (!headSha) return null;
+    const pullNumbers = (node?.pull_requests ?? [])
+      .map((entry) => normalizedNumber(entry?.number))
+      .filter((value): value is number => value !== null)
+      .sort((a, b) => a - b)
+      .join(",");
+    return `github-webhook:ci-completed:${repo}@${headSha}${pullNumbers ? `#${pullNumbers}` : ""}`;
+  }
+  if (eventName === "pull_request" && isCoalescablePullRequestAction(action)) {
+    const pr =
+      normalizedNumber(payload.pull_request?.number) ??
+      normalizedNumber((payload as { number?: unknown }).number);
+    const headSha = normalizedSha(payload.pull_request?.head?.sha);
+    return pr !== null
+      ? `github-webhook:pr-refresh:${repo}#${pr}${headSha ? `@${headSha}` : ""}`
+      : null;
+  }
+  return null;
+}
+
+function webhookNode(
+  eventName: string,
+  payload: GitHubWebhookPayload,
+):
+  | {
+      head_sha?: unknown;
+      check_suite?: { head_sha?: unknown } | null;
+      pull_requests?: Array<{ number?: unknown } | null> | null;
+    }
+  | undefined {
+  const record = payload as Record<string, unknown>;
+  return record[eventName] as
+    | {
+        head_sha?: unknown;
+        check_suite?: { head_sha?: unknown } | null;
+        pull_requests?: Array<{ number?: unknown } | null> | null;
+      }
+    | undefined;
+}
+
+function normalizedRepo(value: unknown): string | null {
+  return typeof value === "string" && value.includes("/")
+    ? value.trim().toLowerCase()
+    : null;
+}
+
+function normalizedNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.floor(value)
+    : null;
+}
+
+function normalizedSha(value: unknown): string | null {
+  return typeof value === "string" && /^[a-f0-9]{7,40}$/i.test(value.trim())
+    ? value.trim().toLowerCase()
+    : null;
+}
+
+function isCoalescablePullRequestAction(action: string): boolean {
+  return COALESCABLE_PULL_REQUEST_ACTIONS.has(action);
+}

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -5,7 +5,9 @@
 // Per-enrollment isolation (one container's secret can never forge to another), and a DB-only leak can't forge
 // (the encryption key is a separate secret).
 import { hashToken } from "../auth/security";
+import { githubWebhookCoalesceKey } from "../github/webhook-coalesce";
 import { isSafeHttpUrl } from "../review/content-lane/safe-url";
+import type { GitHubWebhookPayload } from "../types";
 import { decryptSecret, encryptSecret } from "../utils/crypto";
 
 // The events a brokered container needs to review/act on. Installation-lifecycle + other Orb-internal events are
@@ -171,12 +173,21 @@ export async function enqueueRelayPending(
   args: { deliveryId: string; installationId: number; eventName: string; rawBody: string },
 ): Promise<void> {
   await pruneRelayPending(env);
-  await env.DB
+  const coalesceKey = relayPendingCoalesceKey(args.eventName, args.rawBody);
+  const inserted = await env.DB
     .prepare(
-      "INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body) VALUES (?, ?, ?, ?) ON CONFLICT(delivery_id) DO NOTHING",
+      "INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body, coalesce_key) VALUES (?, ?, ?, ?, ?) ON CONFLICT(delivery_id) DO NOTHING",
     )
-    .bind(args.deliveryId, args.installationId, args.eventName, args.rawBody)
+    .bind(args.deliveryId, args.installationId, args.eventName, args.rawBody, coalesceKey)
     .run();
+  if (coalesceKey && inserted.meta.changes > 0) {
+    await env.DB
+      .prepare(
+        "DELETE FROM orb_relay_pending WHERE installation_id = ? AND coalesce_key = ? AND delivery_id <> ?",
+      )
+      .bind(args.installationId, coalesceKey, args.deliveryId)
+      .run();
+  }
   await env.DB
     .prepare(
       `DELETE FROM orb_relay_pending
@@ -190,6 +201,17 @@ export async function enqueueRelayPending(
     )
     .bind(args.installationId, args.installationId, RELAY_PENDING_MAX_PER_INSTALLATION)
     .run();
+}
+
+function relayPendingCoalesceKey(eventName: string, rawBody: string): string | null {
+  try {
+    return githubWebhookCoalesceKey(
+      eventName,
+      JSON.parse(rawBody) as GitHubWebhookPayload,
+    );
+  } catch {
+    return null;
+  }
 }
 
 /** Drain pending pull-mode events for an installation. The engine calls this outbound (it can't be pushed to):

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -183,7 +183,10 @@ export async function enqueueRelayPending(
   if (coalesceKey && inserted.meta.changes > 0) {
     await env.DB
       .prepare(
-        "DELETE FROM orb_relay_pending WHERE installation_id = ? AND coalesce_key = ? AND delivery_id <> ?",
+        `DELETE FROM orb_relay_pending
+         WHERE installation_id = ?
+           AND coalesce_key = ?
+           AND rowid < (SELECT rowid FROM orb_relay_pending WHERE delivery_id = ?)`,
       )
       .bind(args.installationId, coalesceKey, args.deliveryId)
       .run();

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -1,6 +1,7 @@
 import { retryableJobDelayMs } from "../queue/retryable";
-import type { JobMessage } from "../types";
 import { MAINTENANCE_RESERVED_HEADROOM } from "../github/rate-limit";
+import { githubWebhookCoalesceKey } from "../github/webhook-coalesce";
+import type { GitHubWebhookPayload, JobMessage } from "../types";
 import { extractPayloadType } from "./audit";
 
 const DEFAULT_RATE_LIMIT_JITTER_MS = 5 * 60_000;
@@ -238,20 +239,7 @@ export function jobCoalesceKey(payload: string): string | null {
       repoFullName?: unknown;
       prNumber?: unknown;
       attempt?: unknown;
-      payload?: {
-        action?: unknown;
-        repository?: { full_name?: unknown } | null;
-        pull_request?: { number?: unknown; head?: { sha?: unknown } | null } | null;
-        check_suite?: {
-          head_sha?: unknown;
-          pull_requests?: Array<{ number?: unknown } | null> | null;
-        } | null;
-        check_run?: {
-          head_sha?: unknown;
-          check_suite?: { head_sha?: unknown } | null;
-          pull_requests?: Array<{ number?: unknown } | null> | null;
-        } | null;
-      } | null;
+      payload?: GitHubWebhookPayload | null;
     };
     const type = typeof message.type === "string" ? message.type : "";
     if (type === "agent-regate-pr") {
@@ -274,37 +262,9 @@ export function jobCoalesceKey(payload: string): string | null {
     if (type !== "github-webhook") return null;
     const eventName =
       typeof message.eventName === "string" ? message.eventName : "";
-    const action =
-      typeof message.payload?.action === "string" ? message.payload.action : "";
-    const repo = normalizedRepo(message.payload?.repository?.full_name);
-    if (!repo) return null;
-    if (
-      (eventName === "check_suite" || eventName === "check_run") &&
-      action === "completed"
-    ) {
-      const node = eventName === "check_suite" ? message.payload?.check_suite : message.payload?.check_run;
-      const headSha = normalizedSha(
-        node?.head_sha ??
-          (eventName === "check_run" ? message.payload?.check_run?.check_suite?.head_sha : undefined),
-      );
-      if (!headSha) return null;
-      const pullNumbers = (node?.pull_requests ?? [])
-        .map((entry) => normalizedNumber(entry?.number))
-        .filter((value): value is number => value !== null)
-        .sort((a, b) => a - b)
-        .join(",");
-      return `github-webhook:ci-completed:${repo}@${headSha}${pullNumbers ? `#${pullNumbers}` : ""}`;
-    }
-    if (eventName === "pull_request" && isCoalescablePullRequestAction(action)) {
-      const pr =
-        normalizedNumber(message.payload?.pull_request?.number) ??
-        normalizedNumber((message.payload as { number?: unknown } | null | undefined)?.number);
-      const headSha = normalizedSha(message.payload?.pull_request?.head?.sha);
-      return pr !== null
-        ? `github-webhook:pr-refresh:${repo}#${pr}${headSha ? `@${headSha}` : ""}`
-        : null;
-    }
-    return null;
+    return message.payload
+      ? githubWebhookCoalesceKey(eventName, message.payload)
+      : null;
   } catch {
     return null;
   }
@@ -334,23 +294,6 @@ function normalizedNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.floor(value)
     : null;
-}
-
-function normalizedSha(value: unknown): string | null {
-  return typeof value === "string" && /^[a-f0-9]{7,40}$/i.test(value.trim())
-    ? value.trim().toLowerCase()
-    : null;
-}
-
-function isCoalescablePullRequestAction(action: string): boolean {
-  return (
-    action === "opened" ||
-    action === "synchronize" ||
-    action === "edited" ||
-    action === "ready_for_review" ||
-    action === "labeled" ||
-    action === "unlabeled"
-  );
 }
 
 function numberHeader(

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -476,6 +476,81 @@ describe("enqueueRelayPending", () => {
     expect(other ?? null).not.toBeNull();
   });
 
+  it("keeps the newer coalesced delivery when an older enqueue prunes after a newer insert", async () => {
+    const e = brokeredEnv();
+    const realDb = db(e);
+    type TestStatement = ReturnType<TestD1Database["prepare"]>;
+    let releaseOldPrune!: () => void;
+    let oldInserted!: () => void;
+    const oldMayPrune = new Promise<void>((resolve) => {
+      releaseOldPrune = resolve;
+    });
+    const oldInsertedPromise = new Promise<void>((resolve) => {
+      oldInserted = resolve;
+    });
+    e.DB = {
+      prepare(sql: string) {
+        const statement = realDb.prepare(sql);
+        let bound: unknown[] = [];
+        let wrapped: TestStatement;
+        wrapped = {
+          bind(...values: Parameters<TestStatement["bind"]>) {
+            bound = values;
+            statement.bind(...values);
+            return wrapped;
+          },
+          first<T = unknown>() {
+            return statement.first<T>();
+          },
+          all<T = unknown>() {
+            return statement.all<T>();
+          },
+          raw<T = unknown[]>() {
+            return statement.raw<T>();
+          },
+          async run() {
+            const result = await statement.run();
+            if (
+              sql.includes("INSERT INTO orb_relay_pending") &&
+              bound[0] === "ci-race-old"
+            ) {
+              oldInserted();
+              await oldMayPrune;
+            }
+            return result;
+          },
+        };
+        return wrapped;
+      },
+      batch(statements: TestStatement[]) {
+        return realDb.batch(statements);
+      },
+    } as unknown as D1Database;
+    const body = (marker: string) =>
+      JSON.stringify({
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_suite: {
+          head_sha: "d".repeat(40),
+          pull_requests: [{ number: 1838 }],
+        },
+        marker,
+      });
+
+    const older = enqueueRelayPending(e, { deliveryId: "ci-race-old", installationId: 9607, eventName: "check_suite", rawBody: body("old") });
+    await oldInsertedPromise;
+    await enqueueRelayPending(e, { deliveryId: "ci-race-new", installationId: 9607, eventName: "check_suite", rawBody: body("new") });
+    releaseOldPrune();
+    await older;
+
+    const rows = await db(e)
+      .prepare("SELECT delivery_id, raw_body FROM orb_relay_pending WHERE installation_id=9607 ORDER BY delivery_id")
+      .all<{ delivery_id: string; raw_body: string }>();
+    expect(rows.results).toHaveLength(1);
+    expect(rows.results[0]?.delivery_id).toBe("ci-race-new");
+    expect(JSON.parse(rows.results[0]?.raw_body ?? "{}")).toMatchObject({ marker: "new" });
+  });
+
   it("keeps exact duplicate coalescible delivery IDs idempotent", async () => {
     const e = brokeredEnv();
     const body = (marker: string) =>

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -445,6 +445,82 @@ describe("enqueueRelayPending", () => {
     expect(after?.n).toBe(1);
     expect(after?.body).toBe('{"n":1}'); // original retained
   });
+
+  it("coalesces duplicate pending CI completions per installation while retaining the newest delivery", async () => {
+    const e = brokeredEnv();
+    const body = (marker: string) =>
+      JSON.stringify({
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_suite: {
+          head_sha: "b".repeat(40),
+          pull_requests: [{ number: 1629 }],
+        },
+        marker,
+      });
+
+    await enqueueRelayPending(e, { deliveryId: "ci-old", installationId: 9603, eventName: "check_suite", rawBody: body("old") });
+    await enqueueRelayPending(e, { deliveryId: "ci-new", installationId: 9603, eventName: "check_suite", rawBody: body("new") });
+    await enqueueRelayPending(e, { deliveryId: "ci-other-install", installationId: 9604, eventName: "check_suite", rawBody: body("other") });
+
+    const rows = await db(e)
+      .prepare("SELECT delivery_id, raw_body, coalesce_key FROM orb_relay_pending WHERE installation_id=9603 ORDER BY delivery_id")
+      .all<{ delivery_id: string; raw_body: string; coalesce_key: string | null }>();
+    expect(rows.results).toHaveLength(1);
+    expect(rows.results[0]).toMatchObject({
+      delivery_id: "ci-new",
+      coalesce_key: `github-webhook:ci-completed:jsonbored/gittensory@${"b".repeat(40)}#1629`,
+    });
+    expect(JSON.parse(rows.results[0]?.raw_body ?? "{}")).toMatchObject({ marker: "new" });
+    const other = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='ci-other-install'").first();
+    expect(other ?? null).not.toBeNull();
+  });
+
+  it("keeps exact duplicate coalescible delivery IDs idempotent", async () => {
+    const e = brokeredEnv();
+    const body = (marker: string) =>
+      JSON.stringify({
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_suite: {
+          head_sha: "c".repeat(40),
+          pull_requests: [{ number: 1807 }],
+        },
+        marker,
+      });
+
+    await enqueueRelayPending(e, { deliveryId: "ci-same", installationId: 9606, eventName: "check_suite", rawBody: body("first") });
+    await enqueueRelayPending(e, { deliveryId: "ci-same", installationId: 9606, eventName: "check_suite", rawBody: body("second") });
+
+    const row = await db(e)
+      .prepare("SELECT raw_body, coalesce_key FROM orb_relay_pending WHERE delivery_id='ci-same'")
+      .first<{ raw_body: string; coalesce_key: string | null }>();
+    expect(row?.coalesce_key).toBe(`github-webhook:ci-completed:jsonbored/gittensory@${"c".repeat(40)}#1807`);
+    expect(JSON.parse(row?.raw_body ?? "{}")).toMatchObject({ marker: "first" });
+  });
+
+  it("does not coalesce terminal events or malformed payloads", async () => {
+    const e = brokeredEnv();
+    await enqueueRelayPending(e, {
+      deliveryId: "closed-1",
+      installationId: 9605,
+      eventName: "pull_request",
+      rawBody: JSON.stringify({ action: "closed", repository: { full_name: "JSONbored/gittensory" }, pull_request: { number: 1 } }),
+    });
+    await enqueueRelayPending(e, {
+      deliveryId: "closed-2",
+      installationId: 9605,
+      eventName: "pull_request",
+      rawBody: JSON.stringify({ action: "closed", repository: { full_name: "JSONbored/gittensory" }, pull_request: { number: 1 } }),
+    });
+    await enqueueRelayPending(e, { deliveryId: "bad-json", installationId: 9605, eventName: "pull_request", rawBody: "{bad" });
+
+    const rows = await db(e)
+      .prepare("SELECT delivery_id, coalesce_key FROM orb_relay_pending WHERE installation_id=9605 ORDER BY delivery_id")
+      .all<{ delivery_id: string; coalesce_key: string | null }>();
+    expect(rows.results.map((row) => row.delivery_id)).toEqual(["bad-json", "closed-1", "closed-2"]);
+    expect(rows.results.every((row) => row.coalesce_key === null)).toBe(true);
+  });
 });
 
 describe("pullRelayPending", () => {

--- a/test/unit/github-webhook-coalesce.test.ts
+++ b/test/unit/github-webhook-coalesce.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { githubWebhookCoalesceKey } from "../../src/github/webhook-coalesce";
+import type { GitHubWebhookPayload } from "../../src/types";
+
+describe("githubWebhookCoalesceKey", () => {
+  it("coalesces CI completions by repo, head sha, and sorted pull numbers", () => {
+    expect(
+      githubWebhookCoalesceKey("check_suite", {
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_suite: {
+          head_sha: "ABC1234",
+          pull_requests: [{ number: 12 }, { number: 3 }, { number: 7 }],
+        },
+      } as never),
+    ).toBe("github-webhook:ci-completed:jsonbored/gittensory@abc1234#3,7,12");
+
+    expect(
+      githubWebhookCoalesceKey("check_run", {
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_run: { check_suite: { head_sha: "DEF5678" }, pull_requests: [] },
+      } as never),
+    ).toBe("github-webhook:ci-completed:jsonbored/gittensory@def5678");
+  });
+
+  it("coalesces refresh-like pull request events and ignores terminal actions", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "synchronize",
+        repository: { full_name: "JSONbored/Gittensory" },
+        number: 99,
+        pull_request: {},
+      } as never),
+    ).toBe("github-webhook:pr-refresh:jsonbored/gittensory#99");
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "opened",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 100, head: { sha: "BEEF123" } },
+      } as GitHubWebhookPayload),
+    ).toBe("github-webhook:pr-refresh:jsonbored/gittensory#100@beef123");
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "closed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 100, head: { sha: "BEEF123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+  });
+
+  it("returns null for malformed or non-coalescible webhook shapes", () => {
+    expect(githubWebhookCoalesceKey("issues", { action: "closed", repository: { full_name: "JSONbored/Gittensory" } } as never)).toBeNull();
+    expect(githubWebhookCoalesceKey("check_suite", { action: "requested", repository: { full_name: "JSONbored/Gittensory" } } as never)).toBeNull();
+    expect(
+      githubWebhookCoalesceKey("check_suite", {
+        action: "completed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        check_suite: { pull_requests: [{ number: 7 }] },
+      } as never),
+    ).toBeNull();
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "edited",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { head: { sha: "BEEF123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+    expect(githubWebhookCoalesceKey("pull_request", { action: "edited" } as GitHubWebhookPayload)).toBeNull();
+  });
+});

--- a/test/unit/schema-timestamp-defaults.test.ts
+++ b/test/unit/schema-timestamp-defaults.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { getDb } from "../../src/db/client";
-import { repositorySettings, webhookEvents } from "../../src/db/schema";
+import { orbRelayPending, repositorySettings, webhookEvents } from "../../src/db/schema";
 import { createTestEnv } from "../helpers/d1";
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
@@ -25,6 +25,34 @@ describe("timestamp column defaults", () => {
     const [row] = await db.select().from(repositorySettings).where(eq(repositorySettings.repoFullName, "acme/widgets")).limit(1);
     expect(row?.createdAt).toMatch(ISO);
     expect(row?.updatedAt).toMatch(ISO);
+    expect(row?.createdAt).not.toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("keeps orb relay pending coalesce keys wired through the drizzle schema", async () => {
+    const env = createTestEnv();
+    const db = getDb(env.DB);
+    const coalesceKey = `github-webhook:ci-completed:jsonbored/gittensory@${"a".repeat(40)}#1838`;
+    await db.insert(orbRelayPending).values({
+      deliveryId: "relay-schema-1",
+      installationId: 1838,
+      eventName: "check_suite",
+      rawBody: "{}",
+      coalesceKey,
+    });
+
+    const [row] = await db
+      .select()
+      .from(orbRelayPending)
+      .where(eq(orbRelayPending.deliveryId, "relay-schema-1"))
+      .limit(1);
+    expect(row).toMatchObject({
+      deliveryId: "relay-schema-1",
+      installationId: 1838,
+      eventName: "check_suite",
+      rawBody: "{}",
+      coalesceKey,
+    });
+    expect(row?.createdAt).toMatch(ISO);
     expect(row?.createdAt).not.toBe("CURRENT_TIMESTAMP");
   });
 });


### PR DESCRIPTION
## Summary
- Coalesces duplicate pull-mode relay webhook backlog entries before self-hosted containers drain them.
- Reuses the existing semantic webhook coalescing rules for CI completion and PR refresh events.
- No issue because this is a narrow correctness fix for the existing pull-mode relay coalescing path.

## What changed
- Added a shared GitHub webhook coalescing helper for CI completion and PR refresh keys.
- Stored nullable coalescing keys on `orb_relay_pending` with an installation-scoped partial index.
- Updated Orb relay enqueueing to retain only the newest accepted pending row for safe coalescible webhook classes.
- Made coalesced-row pruning delete only rows older than the row that was just inserted, so stale concurrent prunes cannot remove newer deliveries.
- Kept terminal lifecycle events, malformed payloads, and exact duplicate delivery IDs idempotent.
- Added a deterministic regression test for the insert/insert/prune/prune interleaving.

## Why
- Pull-mode installs can accumulate repeated CI and PR refresh webhook deliveries during bursts or offline windows.
- Collapsing superseded relay backlog entries earlier reduces duplicate queue work and avoidable downstream GitHub calls without changing terminal event behavior.
- The prune must be ordered by the inserted row, otherwise concurrent enqueueing can drop the newer pending payload.

## Validation
- `npx vitest run test/integration/orb-relay.test.ts -t "older enqueue"`
- `npx vitest run test/integration/orb-relay.test.ts`
- `npm run typecheck`
- `npm run db:migrations:check`
- `git diff --check`
- `npm run test:ci`
- `npm audit --audit-level=moderate`