### PR TITLE
fix(queue): reserve GitHub budget for foreground reviews

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { isOrbBrokerEnabled } from "./orb/broker";
 import { isOpsEnabled } from "./review/ops-wire";
 import { isRagEnabled } from "./review/rag-wire";
 import { isSelfTuneEnabled } from "./review/selftune-wire";
+import { isGitHubBudgetBackgroundJob } from "./selfhost/queue-common";
 import { isReviewExecutionJob, isSelfHostedReviewRuntime } from "./selfhost/review-runtime";
 import type { JobMessage } from "./types";
 
@@ -39,6 +40,21 @@ export default {
           );
           message.ack();
           continue;
+        }
+        if (isGitHubBudgetBackgroundJob(message.body)) {
+          const resetAt = await shouldWaitForGitHubRateLimit(env, MAINTENANCE_RESERVED_HEADROOM).catch(() => undefined);
+          if (resetAt) {
+            console.log(
+              JSON.stringify({
+                event: "github_background_job_throttled",
+                messageId: message.id,
+                jobType: message.body.type,
+                resetAt,
+              }),
+            );
+            message.retry({ delaySeconds: delayUntil(resetAt) });
+            continue;
+          }
         }
         await processJob(env, message.body);
         message.ack();

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -11,7 +11,9 @@ import {
   consumingRetryDelayMs,
   deterministicJitterMs,
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
+  githubBackgroundRateLimitDelayMs,
   githubRateLimitRetryDelayMs,
+  isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
@@ -340,6 +342,32 @@ export function createPgQueue(
         return true;
       }
       const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
+      const backgroundRateLimitDelay = isGitHubBudgetBackgroundJob(message)
+        ? await backgroundRateLimitDelayMs()
+        : null;
+      if (backgroundRateLimitDelay !== null) {
+        const now = Date.now();
+        const retryAfter = now + rateLimitRetryDelayWithJitter(
+          backgroundRateLimitDelay,
+          `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+        );
+        const update = await pool.query(
+          `UPDATE ${TABLE} SET status='pending', run_after=GREATEST(run_after, $1), last_error=COALESCE(last_error, $2) WHERE id=$3`,
+          [retryAfter, "github rate-limit background admission", job.id],
+        );
+        if (update.rowCount) {
+          await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total");
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              event: "selfhost_queue_background_admission_deferred",
+              jobType: message.type,
+              retry_after_ms: Math.max(0, retryAfter - now),
+            }),
+          );
+        }
+        return true;
+      }
       try {
         await withOtelSpan(
           "selfhost.queue.job",
@@ -575,6 +603,17 @@ export function createPgQueue(
       changed += update.rowCount ?? 0;
     }
     return changed;
+  }
+
+  async function backgroundRateLimitDelayMs(): Promise<number | null> {
+    const res = await pool.query(
+      `SELECT remaining, reset_at FROM github_rate_limit_observations
+        WHERE resource='rest' AND remaining IS NOT NULL
+        ORDER BY observed_at DESC
+        LIMIT 1`,
+    );
+    const row = res.rows[0] as { remaining?: number | string | null; reset_at?: string | null } | undefined;
+    return githubBackgroundRateLimitDelayMs(row);
   }
 
   async function mergeRescheduledJobIntoPending(

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -1,4 +1,6 @@
 import { retryableJobDelayMs } from "../queue/retryable";
+import type { JobMessage } from "../types";
+import { MAINTENANCE_RESERVED_HEADROOM } from "../github/rate-limit";
 import { extractPayloadType } from "./audit";
 
 const DEFAULT_RATE_LIMIT_JITTER_MS = 5 * 60_000;
@@ -13,6 +15,22 @@ export const FOREGROUND_QUEUE_PRIORITY_FLOOR = 8;
 // sit just below real webhooks, and sweep fan-out sits below those so stale surfaces are repaired during bursts.
 // Bot-generated comment edits are background noise; keeping them with real webhooks lets panel edits starve repair.
 const AGENT_REGATE_PRIORITY = 9;
+const GITHUB_BUDGET_BACKGROUND_TYPES = new Set<string>([
+  "agent-regate-sweep",
+  "backfill-registered-repos",
+  "backfill-repo-segment",
+  "backfill-pr-details",
+  "refresh-upstream-sources",
+  "build-upstream-ruleset",
+  "detect-upstream-drift",
+  "refresh-upstream-drift",
+  "file-upstream-drift-issues",
+  "build-contributor-evidence",
+  "build-contributor-decision-packs",
+  "refresh-contributor-activity",
+  "build-burden-forecasts",
+  "rag-index-repo",
+]);
 const PRIORITY_BY_TYPE = new Map([
   ["agent-regate-pr", AGENT_REGATE_PRIORITY],
   ["recapture-preview", 9],
@@ -58,6 +76,41 @@ export function queueBackgroundConcurrency(
       ? Math.floor(raw)
       : DEFAULT_BACKGROUND_CONCURRENCY;
   return Math.min(parsed, total);
+}
+
+export function isGitHubBudgetBackgroundJob(message: JobMessage): boolean {
+  if (message.type === "agent-regate-pr") {
+    if (typeof message.deliveryId !== "string") return false;
+    return !message.deliveryId.startsWith("manual-regate:");
+  }
+  return GITHUB_BUDGET_BACKGROUND_TYPES.has(message.type);
+}
+
+export function githubBackgroundRateLimitDelayMs(
+  observation:
+    | { remaining?: unknown; reset_at?: unknown; resetAt?: unknown }
+    | null
+    | undefined,
+  nowMs = Date.now(),
+): number | null {
+  const rawRemaining = observation?.remaining;
+  const remaining =
+    typeof rawRemaining === "number"
+      ? normalizedNumber(rawRemaining)
+      : typeof rawRemaining === "string"
+        ? normalizedNumber(Number(rawRemaining))
+        : null;
+  const resetAt =
+    typeof observation?.reset_at === "string"
+      ? observation.reset_at
+      : typeof observation?.resetAt === "string"
+        ? observation.resetAt
+        : null;
+  if (remaining === null || !resetAt) return null;
+  if (remaining > MAINTENANCE_RESERVED_HEADROOM) return null;
+  const ms = Date.parse(resetAt) - nowMs;
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  return Math.max(30_000, Math.min(900_000, (Math.ceil(ms / 1000) + 15) * 1000));
 }
 
 function githubWebhookPriority(payload: string): number {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -12,7 +12,9 @@ import {
   consumingRetryDelayMs,
   deterministicJitterMs,
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
+  githubBackgroundRateLimitDelayMs,
   githubRateLimitRetryDelayMs,
+  isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
@@ -283,6 +285,32 @@ export function createSqliteQueue(
         return true;
       }
       const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
+      const backgroundRateLimitDelay = isGitHubBudgetBackgroundJob(message)
+        ? backgroundRateLimitDelayMs(driver)
+        : null;
+      if (backgroundRateLimitDelay !== null) {
+        const now = Date.now();
+        const retryAfter = now + rateLimitRetryDelayWithJitter(
+          backgroundRateLimitDelay,
+          `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+        );
+        const { changes } = driver.query(
+          `UPDATE ${TABLE} SET status='pending', run_after=max(run_after, ?), last_error=coalesce(last_error, ?) WHERE id=?`,
+          [retryAfter, "github rate-limit background admission", job.id],
+        );
+        if (changes) {
+          recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total");
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              event: "selfhost_queue_background_admission_deferred",
+              jobType: message.type,
+              retry_after_ms: Math.max(0, retryAfter - now),
+            }),
+          );
+        }
+        return true;
+      }
       try {
         await withOtelSpan(
           "selfhost.queue.job",
@@ -572,6 +600,21 @@ function deferPendingJobsForRateLimit(
     changed += changes;
   }
   return changed;
+}
+
+function backgroundRateLimitDelayMs(driver: SqliteDriver): number | null {
+  try {
+    const row = driver.query(
+      `SELECT remaining, reset_at FROM github_rate_limit_observations
+        WHERE resource='rest' AND remaining IS NOT NULL
+        ORDER BY observed_at DESC
+        LIMIT 1`,
+      [],
+    ).rows[0] as { remaining?: number | null; reset_at?: string | null } | undefined;
+    return githubBackgroundRateLimitDelayMs(row);
+  } catch {
+    return null;
+  }
 }
 
 function reclaimExpiredProcessingJobs(

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -162,6 +162,58 @@ describe("worker entrypoint", () => {
     vi.useRealTimers();
   });
 
+  it("pre-yields GitHub-budget background queue jobs while preserving retry budget", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const env = createTestEnv();
+    await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 120, resetAt: "2026-06-24T12:10:00.000Z", observedAt: "2026-06-24T12:00:00.000Z" });
+    const acked: string[] = [];
+    const retries: Array<{ delaySeconds?: number } | undefined> = [];
+    const batch = {
+      messages: [
+        {
+          id: "background-regate",
+          body: { type: "agent-regate-pr", deliveryId: "sweep:owner/repo#7", repoFullName: "owner/repo", prNumber: 7, installationId: 123 },
+          ack: () => acked.push("background-regate"),
+          retry: (options?: { delaySeconds?: number }) => retries.push(options),
+        },
+      ],
+    } as unknown as MessageBatch<import("../../src/types").JobMessage>;
+
+    await worker.queue(batch, env);
+
+    expect(acked).toEqual([]);
+    expect(retries).toEqual([{ delaySeconds: 615 }]);
+    vi.useRealTimers();
+  });
+
+  it("continues GitHub-budget background queue jobs when the observation read fails", async () => {
+    const env = createTestEnv();
+    env.DB = {
+      ...env.DB,
+      prepare() {
+        throw new Error("rate-limit observation read failed");
+      },
+    } as unknown as D1Database;
+    const acked: string[] = [];
+    const retries: Array<{ delaySeconds?: number } | undefined> = [];
+    const batch = {
+      messages: [
+        {
+          id: "background-rag",
+          body: { type: "rag-index-repo", requestedBy: "schedule" },
+          ack: () => acked.push("background-rag"),
+          retry: (options?: { delaySeconds?: number }) => retries.push(options),
+        },
+      ],
+    } as unknown as MessageBatch<import("../../src/types").JobMessage>;
+
+    await worker.queue(batch, env);
+
+    expect(acked).toEqual(["background-rag"]);
+    expect(retries).toEqual([]);
+  });
+
   it("runs scheduled jobs through waitUntil", async () => {
     const env = createTestEnv();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -35,12 +35,22 @@ interface MockPool {
   enqueueResult(r: Partial<QueryResult>): void;
   /** Pre-load a job to be returned by the next RETURNING claim query. */
   enqueueJob(id: string, payload: object, attempts?: number, jobKey?: string | null): void;
+  setDeferUpdateRowCount(rowCount: number): void;
+  setRateLimitRows(rows: Array<{ remaining: number | string | null; reset_at: string | null }>): void;
 }
 
 function makePool(): MockPool {
   const results: Partial<QueryResult>[] = [];
+  let deferUpdateRowCount = 1;
+  let rateLimitRows: Array<{ remaining: number | string | null; reset_at: string | null }> = [];
   const fn = vi.fn().mockImplementation(async (sql: unknown) => {
     const q = String(sql);
+    if (q.includes("FROM github_rate_limit_observations")) {
+      return { rows: rateLimitRows, rowCount: rateLimitRows.length };
+    }
+    if (q.includes("SET status='pending', run_after=GREATEST")) {
+      return { rows: [], rowCount: deferUpdateRowCount };
+    }
     // Claim queries use RETURNING — pop from queue; fall through to empty default otherwise.
     if (q.includes("RETURNING")) {
       const next = results.shift();
@@ -59,13 +69,22 @@ function makePool(): MockPool {
     enqueueJob(id, payload, attempts = 0, jobKey = null) {
       results.push({ rows: [{ id, payload: JSON.stringify(payload), attempts, job_key: jobKey }], rowCount: 1 });
     },
+    setDeferUpdateRowCount(rowCount) {
+      deferUpdateRowCount = rowCount;
+    },
+    setRateLimitRows(rows) {
+      rateLimitRows = rows;
+    },
   };
 }
 
 describe("createPgQueue (durable #977)", () => {
   // Suppress audit log stdout noise in tests.
   beforeEach(() => { vi.spyOn(process.stdout, "write").mockImplementation(() => true); });
-  afterEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it("init() creates the table and recovers stuck-processing jobs", async () => {
     const m = makePool();
@@ -371,6 +390,73 @@ describe("createPgQueue (durable #977)", () => {
       expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
       ["background"],
     );
+  });
+
+  it("pre-yields GitHub-budget background jobs when the persisted REST budget is reserved", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+    process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
+    try {
+      const m = makePool();
+      m.setRateLimitRows([{ remaining: "120", reset_at: "2026-06-24T12:10:00.000Z" }]);
+      m.enqueueJob("background", {
+        type: "agent-regate-pr",
+        deliveryId: "sweep:owner/repo#7",
+        repoFullName: "owner/repo",
+        prNumber: 7,
+        installationId: 123,
+      });
+      const seen: string[] = [];
+      const q = createPgQueue(m.pool, async (j) => void seen.push(typeOf(j)));
+
+      await q.drain();
+
+      expect(seen).toEqual([]);
+      expect(m.pool.query).toHaveBeenCalledWith(
+        expect.stringContaining("SET status='pending', run_after=GREATEST"),
+        [Date.parse("2026-06-24T12:10:15.000Z"), "github rate-limit background admission", "background"],
+      );
+      expect(m.pool.query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO _selfhost_job_stats"),
+        ["gittensory_jobs_rate_limit_deferred_total", 1],
+      );
+    } finally {
+      if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+      else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
+    }
+  });
+
+  it("skips the background-admission metric when the defer update changes no rows", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+    process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
+    try {
+      const m = makePool();
+      m.setDeferUpdateRowCount(0);
+      m.setRateLimitRows([{ remaining: 120, reset_at: "2026-06-24T12:10:00.000Z" }]);
+      m.enqueueJob("background", {
+        type: "rag-index-repo",
+        requestedBy: "schedule",
+      });
+      const warned = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const seen: string[] = [];
+      const q = createPgQueue(m.pool, async (j) => void seen.push(typeOf(j)));
+
+      await q.drain();
+
+      expect(seen).toEqual([]);
+      expect(warned).not.toHaveBeenCalled();
+      expect(m.pool.query).not.toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO _selfhost_job_stats"),
+        ["gittensory_jobs_rate_limit_deferred_total", 1],
+      );
+    } finally {
+      if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+      else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
+      vi.useRealTimers();
+    }
   });
 
   it("dead-letters an unparseable payload (job_dead audit emitted)", async () => {

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   consumingRetryDelayMs,
+  githubBackgroundRateLimitDelayMs,
   githubRateLimitRetryDelayMs,
+  isGitHubBudgetBackgroundJob,
   isForegroundJobPriority,
   jobCoalesceKey,
   jobPriority,
@@ -14,6 +16,7 @@ import {
   queueStartupJitterMs,
 } from "../../src/selfhost/queue-common";
 import { RetryableJobError } from "../../src/queue/retryable";
+import type { JobMessage } from "../../src/types";
 
 const payload = (value: unknown): string => JSON.stringify(value);
 
@@ -43,6 +46,30 @@ describe("self-host queue common helpers", () => {
     expect(queueBackgroundConcurrency(Number.NaN, "3")).toBe(0);
     expect(queueBackgroundConcurrency(4, null)).toBe(1);
     expect(queueBackgroundConcurrency(4, "")).toBe(1);
+  });
+
+  it("identifies GitHub-budget background jobs without pre-yielding fresh webhooks or manual re-gates", () => {
+    expect(isGitHubBudgetBackgroundJob({ type: "github-webhook", deliveryId: "d1", eventName: "pull_request", payload: {} })).toBe(false);
+    expect(isGitHubBudgetBackgroundJob({ type: "recapture-preview", deliveryId: "r1", repoFullName: "owner/repo", prNumber: 1, installationId: 2, attempt: 1 })).toBe(false);
+    expect(isGitHubBudgetBackgroundJob({ type: "agent-regate-pr" } as unknown as JobMessage)).toBe(false);
+    expect(isGitHubBudgetBackgroundJob({ type: "agent-regate-pr", deliveryId: "manual-regate:owner/repo#1:1", repoFullName: "owner/repo", prNumber: 1, installationId: 2 })).toBe(false);
+    expect(isGitHubBudgetBackgroundJob({ type: "agent-regate-pr", deliveryId: "sweep:owner/repo#1", repoFullName: "owner/repo", prNumber: 1, installationId: 2 })).toBe(true);
+    expect(isGitHubBudgetBackgroundJob({ type: "agent-regate-sweep", requestedBy: "schedule" })).toBe(true);
+    expect(isGitHubBudgetBackgroundJob({ type: "backfill-repo-segment", requestedBy: "schedule", repoFullName: "owner/repo", segment: "open_pull_requests" })).toBe(true);
+    expect(isGitHubBudgetBackgroundJob({ type: "rag-index-repo", requestedBy: "schedule" })).toBe(true);
+    expect(isGitHubBudgetBackgroundJob({ type: "refresh-installation-health", requestedBy: "schedule" })).toBe(false);
+  });
+
+  it("computes background admission delays from persisted GitHub REST observations", () => {
+    const now = Date.parse("2026-06-24T12:00:00.000Z");
+    expect(githubBackgroundRateLimitDelayMs(null, now)).toBeNull();
+    expect(githubBackgroundRateLimitDelayMs({ remaining: 500, reset_at: "2026-06-24T12:10:00.000Z" }, now)).toBeNull();
+    expect(githubBackgroundRateLimitDelayMs({ remaining: 120, reset_at: "2026-06-24T11:59:00.000Z" }, now)).toBeNull();
+    expect(githubBackgroundRateLimitDelayMs({ remaining: null, reset_at: "2026-06-24T12:10:00.000Z" }, now)).toBeNull();
+    expect(githubBackgroundRateLimitDelayMs({ remaining: "soon", reset_at: "2026-06-24T12:10:00.000Z" }, now)).toBeNull();
+    expect(githubBackgroundRateLimitDelayMs({ remaining: "120", reset_at: "2026-06-24T12:10:00.000Z" }, now)).toBe(615_000);
+    expect(githubBackgroundRateLimitDelayMs({ remaining: 120, resetAt: "2026-06-24T12:00:05.000Z" }, now)).toBe(30_000);
+    expect(githubBackgroundRateLimitDelayMs({ remaining: 120, reset_at: "2026-06-24T14:00:00.000Z" }, now)).toBe(900_000);
   });
 
   it("demotes bot-authored issue-comment edit webhooks without demoting human reruns", () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -43,7 +43,10 @@ const typeOf = (m: JobMessage): string => (m as unknown as { type: string }).typ
 describe("createSqliteQueue (durable #980)", () => {
   // Suppress audit log stdout noise.
   beforeEach(() => { vi.spyOn(process.stdout, "write").mockImplementation(() => true); });
-  afterEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it("persists + drains FIFO through the consumer", async () => {
     const driver = makeDriver();
@@ -104,6 +107,118 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(prio(JSON.stringify(webhook({ login: "gittensory-orb[bot]", type: "Bot" })))).toBe(0);
     expect(prio(JSON.stringify(msg("rag-index-repo")))).toBe(0);
     expect(prio("{}")).toBe(0);
+  });
+
+  it("pre-yields GitHub-budget background jobs when the persisted REST budget is reserved", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+    process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
+    try {
+      const driver = makeDriver();
+      driver.query(
+        `CREATE TABLE github_rate_limit_observations (
+          id TEXT PRIMARY KEY,
+          repo_full_name TEXT NOT NULL,
+          resource TEXT NOT NULL,
+          path TEXT NOT NULL,
+          status_code INTEGER NOT NULL,
+          limit_value INTEGER,
+          remaining INTEGER,
+          reset_at TEXT,
+          observed_at TEXT NOT NULL
+        )`,
+        [],
+      );
+      driver.query(
+        `INSERT INTO github_rate_limit_observations (id, repo_full_name, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+         VALUES (?, ?, 'rest', ?, 200, 5000, 120, ?, ?)`,
+        ["rl-bg", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T12:00:00.000Z"],
+      );
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
+
+      await q.binding.send({ type: "agent-regate-pr", deliveryId: "sweep:owner/repo#7", repoFullName: "owner/repo", prNumber: 7, installationId: 123 });
+      await q.binding.send({ type: "rag-index-repo", requestedBy: "schedule" });
+      await q.binding.send({ type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: {} });
+      await q.drain();
+
+      expect(seen).toEqual(["github-webhook"]);
+      const row = driver.query(
+        "SELECT status, attempts, run_after, last_error FROM _selfhost_jobs WHERE payload LIKE ?",
+        ['%"agent-regate-pr"%'],
+      ).rows[0] as { status: string; attempts: number; run_after: number; last_error: string };
+      expect(row).toMatchObject({
+        status: "pending",
+        attempts: 0,
+        run_after: Date.parse("2026-06-24T12:10:15.000Z"),
+        last_error: "github rate-limit background admission",
+      });
+      const pendingBackground = driver.query(
+        "SELECT COUNT(*) AS c FROM _selfhost_jobs WHERE status='pending' AND last_error=?",
+        ["github rate-limit background admission"],
+      ).rows[0] as { c: number };
+      expect(pendingBackground.c).toBe(2);
+      expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limit_deferred_total: 2 });
+    } finally {
+      if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+      else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips the background-admission metric when the defer update changes no rows", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+    process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
+    try {
+      const base = makeDriver();
+      const driver = {
+        query(sql: string, params: unknown[]) {
+          if (sql.includes("SET status='pending', run_after=max")) {
+            return { rows: [], changes: 0, lastInsertRowid: 0 };
+          }
+          return base.query(sql, params);
+        },
+        exec(sql: string) {
+          base.exec(sql);
+        },
+      };
+      driver.query(
+        `CREATE TABLE github_rate_limit_observations (
+          id TEXT PRIMARY KEY,
+          repo_full_name TEXT NOT NULL,
+          resource TEXT NOT NULL,
+          path TEXT NOT NULL,
+          status_code INTEGER NOT NULL,
+          limit_value INTEGER,
+          remaining INTEGER,
+          reset_at TEXT,
+          observed_at TEXT NOT NULL
+        )`,
+        [],
+      );
+      driver.query(
+        `INSERT INTO github_rate_limit_observations (id, repo_full_name, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+         VALUES (?, ?, 'rest', ?, 200, 5000, 120, ?, ?)`,
+        ["rl-bg", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T12:00:00.000Z"],
+      );
+      const warned = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
+
+      await q.binding.send({ type: "rag-index-repo", requestedBy: "schedule" });
+      await q.drain();
+
+      expect(seen).toEqual([]);
+      expect(warned).not.toHaveBeenCalled();
+      expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+    } finally {
+      if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+      else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
+      vi.useRealTimers();
+    }
   });
 
   it("backfills stale priorities on startup so existing regate jobs are not buried", async () => {


### PR DESCRIPTION
## Summary
- defer GitHub-heavy background queue work when the persisted REST bucket is below maintenance headroom
- keep fresh webhooks and manual re-gates on the foreground path
- preserve retry attempts while delaying background jobs until reset plus margin

## What changed
- added a shared classifier for GitHub-budget background job types
- added Cloudflare queue pre-yielding before processing background jobs
- added SQLite and Postgres self-host queue admission checks using persisted REST observations
- added regression coverage for classification, delay calculation, Cloudflare fallback, durable-queue defer metrics, and zero-row update guards

## Why
Background sweeps, backfills, drift scans, and indexing jobs should not drain the shared GitHub REST budget ahead of review-critical webhook and manual work. This keeps foreground review work moving during webhook bursts and low-budget windows.

Closes #1840

## Validation
- npm run test -- test/unit/index.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts test/unit/selfhost-queue-common.test.ts
- npm run typecheck
- npm run test:coverage
- npm run test:ci
- npm audit --audit-level=moderate

## Notes
- UI lint/build warnings are pre-existing warning-only output from the full local gate.
- Patch line and branch coverage for the changed source lines was checked locally from the coverage report.