### PR TITLE
feat(review): capture RAG attribution telemetry

### DIFF
--- a/migrations/0086_ai_review_cache_metadata.sql
+++ b/migrations/0086_ai_review_cache_metadata.sql
@@ -1,0 +1,3 @@
+-- Store structured, non-secret observability for cached AI reviews so cache hits retain the same RAG attribution
+-- metadata as the cold review that produced the notes/findings.
+ALTER TABLE ai_review_cache ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3335,14 +3335,15 @@ export async function putCachedAiReview(
   review: { notes: string; reviewerCount: number; findings?: AdvisoryFinding[]; metadata?: Record<string, unknown> | undefined },
 ): Promise<void> {
   if (!headSha) return;
+  const createdAt = nowIso();
   await env.DB
     .prepare(
-      `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo_full_name, pull_number, head_sha) DO UPDATE SET
-         ai_review_mode = excluded.ai_review_mode, notes = excluded.notes, reviewer_count = excluded.reviewer_count, findings_json = excluded.findings_json, metadata_json = excluded.metadata_json, created_at = CURRENT_TIMESTAMP`,
+         ai_review_mode = excluded.ai_review_mode, notes = excluded.notes, reviewer_count = excluded.reviewer_count, findings_json = excluded.findings_json, metadata_json = excluded.metadata_json, created_at = excluded.created_at`,
     )
-    .bind(repoFullName, pullNumber, headSha, mode, review.notes, review.reviewerCount, jsonString(review.findings ?? []), jsonString(review.metadata ?? {}))
+    .bind(repoFullName, pullNumber, headSha, mode, review.notes, review.reviewerCount, jsonString(review.findings ?? []), jsonString(review.metadata ?? {}), createdAt)
     .run();
 }
 

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3309,14 +3309,20 @@ export async function getCachedAiReview(
   pullNumber: number,
   headSha: string | null | undefined,
   mode: string,
-): Promise<{ notes: string; reviewerCount: number; findings: AdvisoryFinding[] } | null> {
+): Promise<{ notes: string; reviewerCount: number; findings: AdvisoryFinding[]; metadata?: Record<string, unknown> | undefined } | null> {
   if (!headSha) return null;
   const row = await env.DB
-    .prepare("SELECT notes, reviewer_count AS reviewerCount, ai_review_mode AS mode, findings_json AS findingsJson FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND head_sha = ?")
+    .prepare("SELECT notes, reviewer_count AS reviewerCount, ai_review_mode AS mode, findings_json AS findingsJson, metadata_json AS metadataJson FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND head_sha = ?")
     .bind(repoFullName, pullNumber, headSha)
-    .first<{ notes: string; reviewerCount: number; mode: string; findingsJson: string | null }>();
+    .first<{ notes: string; reviewerCount: number; mode: string; findingsJson: string | null; metadataJson: string | null }>();
   if (!row || row.mode !== mode) return null;
-  return { notes: row.notes, reviewerCount: row.reviewerCount, findings: parseJson<AdvisoryFinding[]>(row.findingsJson, []) };
+  const metadata = parseJson<Record<string, unknown>>(row.metadataJson, {});
+  return {
+    notes: row.notes,
+    reviewerCount: row.reviewerCount,
+    findings: parseJson<AdvisoryFinding[]>(row.findingsJson, []),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
 }
 
 /** Upsert the AI review for (repo, pull, head SHA). A nullish head SHA is a no-op. */
@@ -3326,17 +3332,17 @@ export async function putCachedAiReview(
   pullNumber: number,
   headSha: string | null | undefined,
   mode: string,
-  review: { notes: string; reviewerCount: number; findings?: AdvisoryFinding[] },
+  review: { notes: string; reviewerCount: number; findings?: AdvisoryFinding[]; metadata?: Record<string, unknown> | undefined },
 ): Promise<void> {
   if (!headSha) return;
   await env.DB
     .prepare(
-      `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO ai_review_cache (repo_full_name, pull_number, head_sha, ai_review_mode, notes, reviewer_count, findings_json, metadata_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo_full_name, pull_number, head_sha) DO UPDATE SET
-         ai_review_mode = excluded.ai_review_mode, notes = excluded.notes, reviewer_count = excluded.reviewer_count, findings_json = excluded.findings_json, created_at = CURRENT_TIMESTAMP`,
+         ai_review_mode = excluded.ai_review_mode, notes = excluded.notes, reviewer_count = excluded.reviewer_count, findings_json = excluded.findings_json, metadata_json = excluded.metadata_json, created_at = CURRENT_TIMESTAMP`,
     )
-    .bind(repoFullName, pullNumber, headSha, mode, review.notes, review.reviewerCount, jsonString(review.findings ?? []))
+    .bind(repoFullName, pullNumber, headSha, mode, review.notes, review.reviewerCount, jsonString(review.findings ?? []), jsonString(review.metadata ?? {}))
     .run();
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { index, integer, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { index, integer, primaryKey, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 // Timestamp columns use a drizzle $defaultFn so an insert that omits the column gets a real ISO-8601
 // timestamp. A static `.default("CURRENT_TIMESTAMP")` would make drizzle inject the literal STRING
 // "CURRENT_TIMESTAMP" (it applies static defaults client-side, never reaching SQLite's CURRENT_TIMESTAMP),
@@ -1136,5 +1136,23 @@ export const aiUsageEvents = sqliteTable(
     // Covers the daily-budget query (sumAiEstimatedNeuronsSince): WHERE status='ok' AND created_at >= ?.
     // Without it that aggregate full-scans ai_usage_events, which runs on every AI review/summary.
     statusCreated: index("ai_usage_events_status_created_idx").on(table.status, table.createdAt),
+  }),
+);
+
+export const aiReviewCache = sqliteTable(
+  "ai_review_cache",
+  {
+    repoFullName: text("repo_full_name").notNull(),
+    pullNumber: integer("pull_number").notNull(),
+    headSha: text("head_sha").notNull(),
+    aiReviewMode: text("ai_review_mode").notNull(),
+    notes: text("notes").notNull(),
+    reviewerCount: integer("reviewer_count").notNull(),
+    findingsJson: text("findings_json").notNull().default("[]"),
+    metadataJson: text("metadata_json").notNull().default("{}"),
+    createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
+  },
+  (table) => ({
+    primary: primaryKey({ columns: [table.repoFullName, table.pullNumber, table.headSha] }),
   }),
 );

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -248,15 +248,16 @@ export async function timeoutFetch(input: RequestInfo | URL, init?: RequestInit)
     if (replay) return responseFromCached(replay, "coalesced");
   }
 
-  const request = fetchAndMaybeCacheGitHubGet(input, init, url, cacheKey, cls);
-  const shared = request.then(
-    (result) => result.cached,
-    () => null,
+  const request = fetchAndMaybeCacheGitHubGet(input, init, url, cacheKey, cls).then(
+    (result) => ({ ok: true as const, result }),
+    (error: unknown) => ({ ok: false as const, error }),
   );
+  const shared = request.then((settled) => (settled.ok ? settled.result.cached : null));
   const sharedWithCleanup = shared.finally(() => inFlightCacheableGets.delete(cacheKey));
   inFlightCacheableGets.set(cacheKey, sharedWithCleanup);
   const result = await request;
-  return result.response;
+  if (!result.ok) throw result.error;
+  return result.result.response;
 }
 
 /** Test-only: reset shared GitHub response cache state between tests. */

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -325,7 +325,12 @@ import {
   checkSummaryText as checkFailureSummaryText,
   isGroundingEnabled,
 } from "../review/grounding-wire";
-import { buildReviewRagContext, isRagEnabled } from "../review/rag-wire";
+import {
+  attributeReviewRagTelemetry,
+  buildReviewRagContextWithMetrics,
+  emptyReviewRagTelemetry,
+  isRagEnabled,
+} from "../review/rag-wire";
 import {
   buildReviewEnrichment,
   isEnrichmentEnabled,
@@ -3675,6 +3680,7 @@ export async function runAiReviewForAdvisory(
       reviewerCount: number;
       inlineFindings: InlineFinding[];
       findings: AdvisoryFinding[];
+      metadata?: Record<string, unknown> | undefined;
       cacheable?: boolean | undefined;
     }
   | undefined
@@ -3791,8 +3797,8 @@ export async function runAiReviewForAdvisory(
     // semantically related to the changed files and append them as additive reference context — exactly like
     // grounding. Flag-OFF (default) → NO new branch: no adapter use, no vector query, and `ragContext` is left
     // undefined so the prompt is byte-identical to today. Fully fail-safe (a missing/cold index degrades to "").
-    const ragContext = ragActive
-      ? await buildReviewRagContext(env, {
+    const ragContextResult = ragActive
+      ? await buildReviewRagContextWithMetrics(env, {
           repoFullName: args.repoFullName,
           title: args.pr.title,
           files: files.map((file) => ({
@@ -3804,6 +3810,8 @@ export async function runAiReviewForAdvisory(
           })),
         })
       : undefined;
+    const ragTelemetry =
+      ragContextResult?.telemetry ?? emptyReviewRagTelemetry(false);
     // Review-enrichment (#1472, flag-gated by GITTENSORY_REVIEW_ENRICHMENT + REES_URL). POST the PR to the external
     // REES for the heavy/external analysis the reviewer can't run (dependency CVEs, secrets, license/EOL/supply-chain);
     // its public-safe brief splices into the prompt next to grounding + RAG. Flag-OFF (default) → no call, no branch,
@@ -3838,7 +3846,8 @@ export async function runAiReviewForAdvisory(
       mode: args.settings.aiReviewMode === "block" ? "block" : "advisory",
       providerKey,
       grounding,
-      ragContext,
+      ragContext: ragContextResult?.text,
+      observability: { rag: ragTelemetry },
       enrichment,
       profile: args.reviewProfile ?? null,
       // Inline comments (#inline-comments): ask the model for line-anchored findings only when the operator flag,
@@ -3917,12 +3926,23 @@ export async function runAiReviewForAdvisory(
       });
     }
     args.advisory.findings.push(...findings);
+    const metadataFor = (
+      notes: string | null | undefined,
+      inlineFindings: InlineFinding[],
+    ): Record<string, unknown> => ({
+      rag: attributeReviewRagTelemetry(ragTelemetry, {
+        notes,
+        findings,
+        inlineFindings,
+      }),
+    });
     if (result.inconclusive && hasPublicReviewAssessment(result.advisoryNotes)) {
       return {
         notes: result.advisoryNotes!,
         reviewerCount: result.reviewerCount,
         inlineFindings: [],
         findings,
+        metadata: metadataFor(result.advisoryNotes, []),
         cacheable: false,
       };
     }
@@ -3932,6 +3952,7 @@ export async function runAiReviewForAdvisory(
         reviewerCount: result.reviewerCount,
         inlineFindings: result.inlineFindings,
         findings,
+        metadata: metadataFor(result.advisoryNotes, result.inlineFindings),
       };
     }
     if (result.inconclusive) {
@@ -3941,6 +3962,7 @@ export async function runAiReviewForAdvisory(
         reviewerCount: result.reviewerCount,
         inlineFindings: [],
         findings,
+        metadata: metadataFor(null, []),
         cacheable: false,
       };
     }
@@ -3980,6 +4002,7 @@ export async function runAiReviewForAdvisory(
       reviewerCount: result.reviewerCount,
       inlineFindings: [],
       findings,
+      metadata: metadataFor(null, []),
       cacheable: false,
     };
   } catch (error) {
@@ -4462,6 +4485,7 @@ async function maybePublishPrPublicSurface(
         reviewerCount: number;
         inlineFindings?: InlineFinding[];
         findings?: AdvisoryFinding[];
+        metadata?: Record<string, unknown> | undefined;
         cacheable?: boolean | undefined;
       }
     | undefined;

--- a/src/review/rag-wire.ts
+++ b/src/review/rag-wire.ts
@@ -20,7 +20,7 @@
 // flag ON but a cold/empty index, `retrieveContext` returns "" — the capability activates once an index exists.
 
 import { createReviewAdapters } from "./adapters";
-import { type RagChunk, retrieveContext, upsertChunks } from "./rag";
+import { type RagChunk, retrieveContextWithMetrics, upsertChunks } from "./rag";
 
 /** True when RAG retrieval is enabled. Flag-OFF (default) → the caller takes no new branch, so no retrieval is
  *  performed and the reviewer prompt is unchanged. */
@@ -46,6 +46,92 @@ const RAG_RERANKER = "bm25" as const;
 
 /** The subset of a PR file record the query builder reads (filename + the patch text when present). */
 export type RagQueryFile = { path: string; patch?: string | undefined };
+
+export type ReviewRagTelemetry = {
+  enabled: boolean;
+  attempted: boolean;
+  injected: boolean;
+  candidates: number;
+  kept: number;
+  topScore: number;
+  minScore: number;
+  reranked: boolean;
+  injectedChars: number;
+  retrievedPathCount: number;
+  retrievedPaths: string[];
+  findingReferencedRetrievedPath: boolean;
+  notesReferencedRetrievedPath: boolean;
+  referencedRetrievedPathCount: number;
+  referencedRetrievedPaths: string[];
+};
+
+export type ReviewRagContextResult = {
+  text: string;
+  telemetry: ReviewRagTelemetry;
+};
+
+type ReviewRagAttributionInput = {
+  notes?: string | null | undefined;
+  findings?: Array<{ title?: string | undefined; detail?: string | undefined; action?: string | undefined }> | undefined;
+  inlineFindings?: Array<{ path?: string | undefined; body?: string | undefined }> | undefined;
+};
+
+export function emptyReviewRagTelemetry(enabled: boolean): ReviewRagTelemetry {
+  return {
+    enabled,
+    attempted: false,
+    injected: false,
+    candidates: 0,
+    kept: 0,
+    topScore: 0,
+    minScore: 0,
+    reranked: false,
+    injectedChars: 0,
+    retrievedPathCount: 0,
+    retrievedPaths: [],
+    findingReferencedRetrievedPath: false,
+    notesReferencedRetrievedPath: false,
+    referencedRetrievedPathCount: 0,
+    referencedRetrievedPaths: [],
+  };
+}
+
+function uniq(paths: string[]): string[] {
+  return [...new Set(paths.filter(Boolean))];
+}
+
+function textMentionsPath(text: string, path: string): boolean {
+  return text.toLowerCase().includes(path.toLowerCase());
+}
+
+export function attributeReviewRagTelemetry(
+  telemetry: ReviewRagTelemetry,
+  review: ReviewRagAttributionInput,
+): ReviewRagTelemetry {
+  if (!telemetry.retrievedPaths.length) return telemetry;
+  const findingText = [
+    ...(review.findings ?? []).flatMap((finding) => [
+      finding.title ?? "",
+      finding.detail ?? "",
+      finding.action ?? "",
+    ]),
+    ...(review.inlineFindings ?? []).flatMap((finding) => [
+      finding.path ?? "",
+      finding.body ?? "",
+    ]),
+  ].join("\n");
+  const notesText = review.notes ?? "";
+  const findingPaths = telemetry.retrievedPaths.filter((path) => textMentionsPath(findingText, path));
+  const notesPaths = telemetry.retrievedPaths.filter((path) => textMentionsPath(notesText, path));
+  const referencedRetrievedPaths = uniq([...findingPaths, ...notesPaths]);
+  return {
+    ...telemetry,
+    findingReferencedRetrievedPath: findingPaths.length > 0,
+    notesReferencedRetrievedPath: notesPaths.length > 0,
+    referencedRetrievedPathCount: referencedRetrievedPaths.length,
+    referencedRetrievedPaths,
+  };
+}
 
 /**
  * Compose the retrieval QUERY TEXT from the PR's TITLE + changed files. We PREPEND the PR title (intent in natural
@@ -88,17 +174,24 @@ export async function buildReviewRagContext(
   env: Env,
   args: { repoFullName: string; files: RagQueryFile[]; title?: string; reranker?: "off" | "bm25" },
 ): Promise<string> {
+  return (await buildReviewRagContextWithMetrics(env, args)).text;
+}
+
+export async function buildReviewRagContextWithMetrics(
+  env: Env,
+  args: { repoFullName: string; files: RagQueryFile[]; title?: string; reranker?: "off" | "bm25" },
+): Promise<ReviewRagContextResult> {
   try {
     const { queryText, excludePaths } = buildRagQuery(args.files, args.title);
-    if (!queryText) return "";
+    if (!queryText) return { text: "", telemetry: emptyReviewRagTelemetry(true) };
     const infra = createReviewAdapters(env);
     // No vector index or no AI binding → the adapters omit the member and retrieveContext returns "" (no RAG).
-    if (!infra.vector || !infra.inference) return "";
+    if (!infra.vector || !infra.inference) return { text: "", telemetry: emptyReviewRagTelemetry(true) };
     const [project, repo] = splitRepo(args.repoFullName);
     // Quality knobs match reviewbot's core config: drop low-relevance cosine matches (minScore) and BM25-rerank the
     // survivors (reranker) so only genuinely-related code reaches the prompt — low-relevance "neighbours" are noise
     // that themselves cause false positives. A caller-supplied reranker still wins (e.g. to force "off"). (#GAP-2)
-    return await retrieveContext(infra, {
+    const result = await retrieveContextWithMetrics(infra, {
       project,
       repo,
       queryText,
@@ -107,8 +200,24 @@ export async function buildReviewRagContext(
       minScore: RAG_MIN_SCORE,
       reranker: args.reranker ?? RAG_RERANKER,
     });
+    return {
+      text: result.context,
+      telemetry: {
+        ...emptyReviewRagTelemetry(true),
+        attempted: true,
+        injected: result.context.length > 0,
+        candidates: result.metrics.candidates,
+        kept: result.metrics.kept,
+        topScore: result.metrics.topScore,
+        minScore: result.metrics.minScore,
+        reranked: result.metrics.reranked,
+        injectedChars: result.metrics.injectedChars,
+        retrievedPathCount: result.metrics.paths.length,
+        retrievedPaths: result.metrics.paths,
+      },
+    };
   } catch {
-    return ""; // any error → review proceeds on the diff alone (fail-safe)
+    return { text: "", telemetry: emptyReviewRagTelemetry(true) }; // any error → review proceeds on the diff alone (fail-safe)
   }
 }
 

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -70,6 +70,21 @@ export interface RagInfra {
   inference?: InferenceAdapter;
 }
 
+export type RagRetrievalMetrics = {
+  candidates: number;
+  kept: number;
+  topScore: number;
+  minScore: number;
+  reranked: boolean;
+  injectedChars: number;
+  paths: string[];
+};
+
+export type RagRetrievalResult = {
+  context: string;
+  metrics: RagRetrievalMetrics;
+};
+
 /** bge-m3: large context window → a whole file/function embeds as one coherent chunk (fewer vectors
  *  than 512-token models, which helps both quality and the free-tier vector budget). */
 export const EMBED_MODEL = "@cf/baai/bge-m3";
@@ -337,6 +352,15 @@ export async function deleteChunksForPaths(infra: RagInfra, project: string, rep
 const MIN_QUERY_CHARS = 40;
 /** Hard cap on neighbours per query — bounds vector-index cost even if a caller passes a large topK. (#cloud-opt) */
 const RAG_MAX_TOPK = 20;
+const EMPTY_RAG_RETRIEVAL_METRICS: RagRetrievalMetrics = {
+  candidates: 0,
+  kept: 0,
+  topScore: 0,
+  minScore: 0,
+  reranked: false,
+  injectedChars: 0,
+  paths: [],
+};
 // Memoize the cold-index check briefly per isolate: a repo's "has any chunks" flips false→true ONCE (then
 // stays true until prune), so a short TTL safely skips the per-review storage COUNT on a hot repo. (#cloud-opt)
 const CHUNK_COUNT_TTL_MS = 60_000;
@@ -350,30 +374,41 @@ async function hasIndexedChunks(storage: StorageAdapter, project: string, repo: 
   return n > 0;
 }
 
-export async function retrieveContext(
+function emptyRagRetrievalResult(minScore = 0): RagRetrievalResult {
+  return {
+    context: "",
+    metrics: { ...EMPTY_RAG_RETRIEVAL_METRICS, minScore, paths: [] },
+  };
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths.filter(Boolean))];
+}
+
+export async function retrieveContextWithMetrics(
   infra: RagInfra,
   opts: { project: string; repo: string; queryText: string; topK?: number; minScore?: number; excludePaths?: string[]; reranker?: "off" | "bm25" },
-): Promise<string> {
+): Promise<RagRetrievalResult> {
   const { storage, vector: vectorAdapter, inference } = infra;
-  if (!vectorAdapter || !inference || opts.queryText.trim().length < MIN_QUERY_CHARS) return "";
+  const configuredMinScore = opts.minScore ?? 0;
+  if (!vectorAdapter || !inference || opts.queryText.trim().length < MIN_QUERY_CHARS) return emptyRagRetrievalResult(configuredMinScore);
   // Cold-index guard (memoized): when nothing is indexed yet for this repo, skip the embed + vector query
   // entirely — no point spending an inference call (and vector query budget) on an empty namespace. (#audit cost)
-  if (!(await hasIndexedChunks(storage, opts.project, opts.repo, Date.now()))) return "";
+  if (!(await hasIndexedChunks(storage, opts.project, opts.repo, Date.now()))) return emptyRagRetrievalResult(configuredMinScore);
   try {
     const embedded = await embedTexts(inference, [opts.queryText.slice(0, 16000)]);
     const vec = embedded?.[0];
-    if (!vec) return "";
+    if (!vec) return emptyRagRetrievalResult(configuredMinScore);
     const res = await vectorAdapter.query(vec, {
       topK: Math.min(opts.topK ?? 12, RAG_MAX_TOPK),
       namespace: ragNamespace(opts.project, opts.repo),
       returnMetadata: "all",
     });
     const exclude = new Set(opts.excludePaths ?? []);
-    const minScore = opts.minScore ?? 0;
     const all = res?.matches ?? [];
     const matches = all.filter((m) => {
       const p = (m.metadata?.path as string) ?? "";
-      return p && !exclude.has(p) && (typeof m.score !== "number" || m.score >= minScore);
+      return p && !exclude.has(p) && (typeof m.score !== "number" || m.score >= configuredMinScore);
     });
     const texts = matches.length > 0 ? await readChunkTexts(storage, matches.map((m) => m.id)) : new Map<string, string>();
     let chunks = matches
@@ -390,6 +425,16 @@ export async function retrieveContext(
     const reranked = opts.reranker === "bm25" && chunks.length > 1;
     if (reranked) chunks = bm25Rerank(opts.queryText, chunks);
     const out = chunks.length > 0 ? formatRetrievedContext(chunks) : "";
+    const paths = uniquePaths(chunks.map((chunk) => chunk.path));
+    const metrics: RagRetrievalMetrics = {
+      candidates: all.length,
+      kept: chunks.length,
+      topScore: Number((all[0]?.score ?? 0).toFixed(4)),
+      minScore: configuredMinScore,
+      reranked,
+      injectedChars: out.length,
+      paths,
+    };
     // Observability (#rag-observability): so we can SEE retrieval quality (score distribution, how much
     // context was injected) instead of flying blind — feeds tuning of minScore/topK + the /stats readout.
     console.log(
@@ -397,22 +442,30 @@ export async function retrieveContext(
         ev: "rag_retrieve",
         project: opts.project,
         repo: opts.repo,
-        candidates: all.length,
-        kept: chunks.length,
-        topScore: Number((all[0]?.score ?? 0).toFixed(4)),
-        minScore,
-        reranked, // #283: whether BM25 reordered the candidates
-        injectedChars: out.length,
+        candidates: metrics.candidates,
+        kept: metrics.kept,
+        topScore: metrics.topScore,
+        minScore: metrics.minScore,
+        reranked: metrics.reranked, // #283: whether BM25 reordered the candidates
+        injectedChars: metrics.injectedChars,
+        retrievedPathCount: paths.length,
       }),
     );
-    return out;
+    return { context: out, metrics };
   } catch (error) {
     // ERROR level (#5 review observability): emit so the central Sentry forwarder captures a broken RAG backend
     // (qdrant/embedder down) — retrieval degrades the review to diff-only, and this was previously a no-`level`
     // console.log invisible to Sentry. Keeps the `ev` tag for log continuity.
     console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_retrieve_error", message: String(error).slice(0, 200) }));
-    return "";
+    return emptyRagRetrievalResult(configuredMinScore);
   }
+}
+
+export async function retrieveContext(
+  infra: RagInfra,
+  opts: { project: string; repo: string; queryText: string; topK?: number; minScore?: number; excludePaths?: string[]; reranker?: "off" | "bm25" },
+): Promise<string> {
+  return (await retrieveContextWithMetrics(infra, opts)).context;
 }
 
 // ── BM25 reranking (#283): rescore the cosine top-K by exact-term overlap to demote vector-accident matches ──

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -136,6 +136,9 @@ export type GittensoryAiReviewInput = {
    * to today — no section is appended.
    */
   ragContext?: string | null | undefined;
+  /** Internal review observability metadata, stored with usage events. The caller must pass only public-safe,
+   *  non-secret counters/paths; provider keys and raw prompt text never belong here. */
+  observability?: Record<string, unknown> | null | undefined;
   /**
    * Review-enrichment service brief (#1472, flag-gated by GITTENSORY_REVIEW_ENRICHMENT). The caller POSTs the PR
    * to the external REES (see `review/enrichment-wire`), which runs heavy/external/historical analysis the
@@ -1289,6 +1292,7 @@ async function record(
     metadata: {
       repoFullName: input.repoFullName,
       pullNumber: input.prNumber,
+      ...(input.observability ?? {}),
       ...(metadata ?? {}),
     },
   });

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -34,4 +34,31 @@ describe("AI review cache (#1)", () => {
       findings: [{ code: "ai_review_split", severity: "critical", title: "Split", detail: "One reviewer blocked." }],
     });
   });
+
+  it("round-trips structured review metadata and replaces it on upsert", async () => {
+    const env = createTestEnv();
+    await putCachedAiReview(env, "o/r", 9, "sha1", "advisory", {
+      notes: "first",
+      reviewerCount: 1,
+      metadata: { rag: { enabled: true, injected: true, retrievedPaths: ["src/a.ts"] } },
+    });
+    expect(await getCachedAiReview(env, "o/r", 9, "sha1", "advisory")).toEqual({
+      notes: "first",
+      reviewerCount: 1,
+      findings: [],
+      metadata: { rag: { enabled: true, injected: true, retrievedPaths: ["src/a.ts"] } },
+    });
+
+    await putCachedAiReview(env, "o/r", 9, "sha1", "advisory", {
+      notes: "second",
+      reviewerCount: 2,
+      metadata: { rag: { enabled: true, injected: false, retrievedPaths: [] } },
+    });
+    expect(await getCachedAiReview(env, "o/r", 9, "sha1", "advisory")).toEqual({
+      notes: "second",
+      reviewerCount: 2,
+      findings: [],
+      metadata: { rag: { enabled: true, injected: false, retrievedPaths: [] } },
+    });
+  });
 });

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getCachedAiReview, putCachedAiReview } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
@@ -33,6 +33,31 @@ describe("AI review cache (#1)", () => {
       reviewerCount: 2,
       findings: [{ code: "ai_review_split", severity: "critical", title: "Split", detail: "One reviewer blocked." }],
     });
+  });
+
+  it("stores ISO created_at values on insert and conflict update", async () => {
+    const env = createTestEnv();
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-06-30T09:00:00.123Z"));
+      await putCachedAiReview(env, "o/r", 8, "sha1", "advisory", { notes: "first", reviewerCount: 1 });
+      const inserted = await env.DB.prepare("SELECT created_at AS createdAt FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND head_sha = ?")
+        .bind("o/r", 8, "sha1")
+        .first<{ createdAt: string }>();
+      expect(inserted?.createdAt).toBe("2026-06-30T09:00:00.123Z");
+      expect(inserted?.createdAt).not.toContain(" ");
+
+      vi.setSystemTime(new Date("2026-06-30T09:05:00.456Z"));
+      await putCachedAiReview(env, "o/r", 8, "sha1", "block", { notes: "second", reviewerCount: 2 });
+      const updated = await env.DB.prepare("SELECT created_at AS createdAt FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND head_sha = ?")
+        .bind("o/r", 8, "sha1")
+        .first<{ createdAt: string }>();
+      expect(updated?.createdAt).toBe("2026-06-30T09:05:00.456Z");
+      expect(updated?.createdAt).not.toContain(" ");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("round-trips structured review metadata and replaces it on upsert", async () => {

--- a/test/unit/rag-wiring.test.ts
+++ b/test/unit/rag-wiring.test.ts
@@ -3,7 +3,14 @@ import { runGittensoryAiReview } from "../../src/services/ai-review";
 import { runAiReviewForAdvisory } from "../../src/queue/processors";
 import * as ragModule from "../../src/review/rag";
 import { RAG_DIMENSIONS } from "../../src/review/rag";
-import { buildRagQuery, buildReviewRagContext, isRagEnabled } from "../../src/review/rag-wire";
+import {
+  attributeReviewRagTelemetry,
+  buildRagQuery,
+  buildReviewRagContext,
+  buildReviewRagContextWithMetrics,
+  emptyReviewRagTelemetry,
+  isRagEnabled,
+} from "../../src/review/rag-wire";
 import { createTestEnv } from "../helpers/d1";
 import type { Advisory, RepositorySettings } from "../../src/types";
 
@@ -68,6 +75,15 @@ const baseReviewInput = {
 };
 
 const changedFiles = [{ path: "src/a.ts", patch: "@@\n+export const A = helper();" }];
+const emptyRetrievalMetrics = {
+  candidates: 0,
+  kept: 0,
+  topScore: 0,
+  minScore: 0.4,
+  reranked: false,
+  injectedChars: 0,
+  paths: [],
+};
 
 // ── isRagEnabled ──────────────────────────────────────────────────────────────────────────────────
 
@@ -116,6 +132,16 @@ describe("buildRagQuery composes the retrieval query from the changed files", ()
     const { excludePaths } = buildRagQuery([{ path: "src/a.ts" }, { path: "src/a.ts" }, { path: "src/b.ts" }]);
     expect(excludePaths).toEqual(["src/a.ts", "src/b.ts"]);
   });
+
+  it("stops sampling patches after the bounded diff budget is reached", () => {
+    const largePatch = `@@\n+${"x".repeat(4100)}`;
+    const { queryText } = buildRagQuery([
+      { path: "src/large.ts", patch: largePatch },
+      { path: "src/skipped.ts", patch: "@@\n+SHOULD_NOT_APPEAR" },
+    ]);
+    expect(queryText).toContain("src/skipped.ts");
+    expect(queryText).not.toContain("SHOULD_NOT_APPEAR");
+  });
 });
 
 // ── buildReviewRagContext (retrieval, fail-safe) ───────────────────────────────────────────────────
@@ -132,6 +158,27 @@ describe("buildReviewRagContext: retrieval wiring + fail-safe", () => {
     // The query was embedded and the vector index was queried.
     expect(ai.run).toHaveBeenCalledWith("@cf/baai/bge-m3", expect.anything());
     expect(vec.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("FLAG-ON with a warm index: returns retrieval telemetry for later attribution", async () => {
+    const vec = vectorizeStub();
+    const ai = aiStub();
+    const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vec as unknown as Vectorize, AI: ai as unknown as Ai });
+    const out = await buildReviewRagContextWithMetrics(env, { repoFullName: "acme/rag-warm-metrics", files: changedFiles });
+    expect(out.text).toContain("RELEVANT EXISTING CODE / DOCS");
+    expect(out.telemetry).toMatchObject({
+      enabled: true,
+      attempted: true,
+      injected: true,
+      candidates: 1,
+      kept: 1,
+      topScore: 0.92,
+      minScore: 0.4,
+      reranked: false,
+      retrievedPathCount: 1,
+      retrievedPaths: ["src/helper.ts"],
+    });
+    expect(out.telemetry.injectedChars).toBeGreaterThan(0);
   });
 
   it("fail-safe: a MISSING Vectorize binding → empty context, NO vector query attempted", async () => {
@@ -181,7 +228,10 @@ describe("buildReviewRagContext passes the quality knobs into retrieveContext (#
   afterEach(() => vi.restoreAllMocks());
 
   it("invokes the retrieve call with minScore 0.4 + reranker 'bm25' and the title-led query (reviewbot parity)", async () => {
-    const spy = vi.spyOn(ragModule, "retrieveContext").mockResolvedValue("=== RELEVANT EXISTING CODE / DOCS ===");
+    const spy = vi.spyOn(ragModule, "retrieveContextWithMetrics").mockResolvedValue({
+      context: "=== RELEVANT EXISTING CODE / DOCS ===",
+      metrics: emptyRetrievalMetrics,
+    });
     const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
     const out = await buildReviewRagContext(env, { repoFullName: "acme/widgets", title: "Add a feature", files: changedFiles });
     expect(out).toContain("RELEVANT EXISTING CODE / DOCS");
@@ -194,10 +244,87 @@ describe("buildReviewRagContext passes the quality knobs into retrieveContext (#
   });
 
   it("a caller-supplied reranker still wins over the default (e.g. forcing it off), minScore unchanged", async () => {
-    const spy = vi.spyOn(ragModule, "retrieveContext").mockResolvedValue("");
+    const spy = vi.spyOn(ragModule, "retrieveContextWithMetrics").mockResolvedValue({
+      context: "",
+      metrics: emptyRetrievalMetrics,
+    });
     const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
     await buildReviewRagContext(env, { repoFullName: "acme/widgets", files: changedFiles, reranker: "off" });
     expect(spy.mock.calls[0]?.[1]).toMatchObject({ minScore: 0.4, reranker: "off" });
+  });
+
+  it("handles slashless repo names by using an empty project namespace", async () => {
+    const spy = vi.spyOn(ragModule, "retrieveContextWithMetrics").mockResolvedValue({
+      context: "",
+      metrics: emptyRetrievalMetrics,
+    });
+    const env = createTestEnv({ DB: ragDbStub(), VECTORIZE: vectorizeStub() as unknown as Vectorize, AI: aiStub() as unknown as Ai });
+    await buildReviewRagContext(env, { repoFullName: "widgets", files: changedFiles });
+    expect(spy.mock.calls[0]?.[1]).toMatchObject({ project: "", repo: "widgets" });
+  });
+});
+
+describe("RAG review attribution telemetry", () => {
+  it("marks findings and notes that reference retrieved paths", () => {
+    const telemetry = {
+      ...emptyReviewRagTelemetry(true),
+      attempted: true,
+      injected: true,
+      retrievedPathCount: 2,
+      retrievedPaths: ["src/helper.ts", "src/unused.ts"],
+    };
+    const out = attributeReviewRagTelemetry(telemetry, {
+      notes: "The existing convention in src/unused.ts is preserved.",
+      findings: [{ title: "Bug", detail: "src/helper.ts now returns the wrong value.", action: "Fix it." }],
+      inlineFindings: [{ path: "src/a.ts", body: "Compare against src/helper.ts." }],
+    });
+    expect(out.findingReferencedRetrievedPath).toBe(true);
+    expect(out.notesReferencedRetrievedPath).toBe(true);
+    expect(out.referencedRetrievedPathCount).toBe(2);
+    expect(out.referencedRetrievedPaths).toEqual(["src/helper.ts", "src/unused.ts"]);
+  });
+
+  it("returns unchanged telemetry when no paths were retrieved", () => {
+    const telemetry = emptyReviewRagTelemetry(true);
+    expect(attributeReviewRagTelemetry(telemetry, { notes: "No context." })).toBe(telemetry);
+  });
+
+  it("treats omitted attribution fields as empty text", () => {
+    const telemetry = {
+      ...emptyReviewRagTelemetry(true),
+      retrievedPathCount: 1,
+      retrievedPaths: ["src/helper.ts"],
+    };
+    expect(
+      attributeReviewRagTelemetry(telemetry, {
+        notes: null,
+        findings: [{}],
+        inlineFindings: [{}],
+      }),
+    ).toMatchObject({
+      findingReferencedRetrievedPath: false,
+      notesReferencedRetrievedPath: false,
+      referencedRetrievedPathCount: 0,
+      referencedRetrievedPaths: [],
+    });
+  });
+
+  it("handles omitted finding and inline arrays while still attributing notes", () => {
+    const telemetry = {
+      ...emptyReviewRagTelemetry(true),
+      retrievedPathCount: 1,
+      retrievedPaths: ["src/helper.ts"],
+    };
+    expect(
+      attributeReviewRagTelemetry(telemetry, {
+        notes: "The review followed src/helper.ts.",
+      }),
+    ).toMatchObject({
+      findingReferencedRetrievedPath: false,
+      notesReferencedRetrievedPath: true,
+      referencedRetrievedPathCount: 1,
+      referencedRetrievedPaths: ["src/helper.ts"],
+    });
   });
 });
 
@@ -260,6 +387,9 @@ describe("RAG wired into the AI reviewer (flag GITTENSORY_REVIEW_RAG)", () => {
     await env.DB.prepare(
       "INSERT INTO pull_request_files (repo_full_name, pull_number, path, status, additions, deletions, changes, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
     ).bind("acme/widgets", 3, "img/logo.png", "added", 0, 0, 0, JSON.stringify({})).run(); // no `patch` → undefined branch
+    await env.DB.prepare(
+      "INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).bind("v1", "acme", "widgets", "src/helper.ts", 0, "code", "export function helper() { return 1; }").run();
     const adv: Advisory = {
       id: "adv-rag", targetType: "pull_request", targetKey: "acme/widgets#3", repoFullName: "acme/widgets",
       pullNumber: 3, headSha: "sha3", conclusion: "neutral", severity: "info",
@@ -275,6 +405,14 @@ describe("RAG wired into the AI reviewer (flag GITTENSORY_REVIEW_RAG)", () => {
     });
     // The review still completes (RAG is additive + fail-safe); the map having run is what we're exercising.
     expect(result?.notes ?? "").toBeDefined();
+    expect(result?.metadata?.rag).toMatchObject({
+      enabled: true,
+      attempted: true,
+      injected: true,
+      retrievedPaths: ["src/helper.ts"],
+      notesReferencedRetrievedPath: false,
+      findingReferencedRetrievedPath: false,
+    });
   });
 
   it("FLAG-OFF (default): the prompt is byte-identical to the no-RAG prompt (ragContext undefined)", async () => {

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -17,6 +17,7 @@ import {
   ragNamespace,
   readChunkTexts,
   retrieveContext,
+  retrieveContextWithMetrics,
   type StorageAdapter,
   upsertChunks,
   type VectorAdapter,
@@ -169,6 +170,29 @@ describe("rag: fail-safe (never throws; degrades to no context)", () => {
     expect(await retrieveContext(infra, { project: "p", repo: "o/r", queryText: "x" })).toBe("");
   });
 
+  it("retrieveContextWithMetrics returns empty metrics when retrieval is skipped", async () => {
+    const infra: RagInfra = { storage: storageStub({ count: 5 }) };
+    await expect(
+      retrieveContextWithMetrics(infra, {
+        project: "p",
+        repo: "o/r",
+        queryText: "refactor the auth token verification and add coverage",
+        minScore: 0.7,
+      }),
+    ).resolves.toEqual({
+      context: "",
+      metrics: {
+        candidates: 0,
+        kept: 0,
+        topScore: 0,
+        minScore: 0.7,
+        reranked: false,
+        injectedChars: 0,
+        paths: [],
+      },
+    });
+  });
+
   it("retrieveContext returns '' when the vector query throws", async () => {
     const vector = { query: async () => { throw new Error("boom"); } } as unknown as VectorAdapter;
     const infra: RagInfra = { storage: storageStub({ count: 5 }), vector, inference: ai1024 }; // warm index → reaches the query
@@ -223,6 +247,42 @@ describe("rag: fail-safe (never throws; degrades to no context)", () => {
     expect(out).toContain("src/a.ts");
     expect(out).toContain("export const x = 1;");
     expect(out).not.toContain("src/changed.ts"); // the file under review is excluded → only RELATED code surfaces
+  });
+
+  it("retrieveContextWithMetrics reports candidates, injected chars, and unique retrieved paths", async () => {
+    const matches = [
+      { id: "src/a.ts::0", score: 0.9, metadata: { path: "src/a.ts" } },
+      { id: "src/a.ts::1", score: 0.8, metadata: { path: "src/a.ts" } },
+    ];
+    const vector = { query: async () => ({ matches }) } as unknown as VectorAdapter;
+    const infra: RagInfra = {
+      storage: storageStub({
+        count: 2,
+        rows: [
+          { id: "src/a.ts::0", text: "export const x = 1;" },
+          { id: "src/a.ts::1", text: "export const y = 2;" },
+        ],
+      }),
+      vector,
+      inference: ai1024,
+    };
+    const out = await retrieveContextWithMetrics(infra, {
+      project: "p",
+      repo: "o/r",
+      queryText: "refactor the auth token verification and add coverage",
+      minScore: 0.5,
+      reranker: "off",
+    });
+    expect(out.context).toContain("src/a.ts");
+    expect(out.metrics).toMatchObject({
+      candidates: 2,
+      kept: 2,
+      topScore: 0.9,
+      minScore: 0.5,
+      reranked: false,
+      paths: ["src/a.ts"],
+    });
+    expect(out.metrics.injectedChars).toBeGreaterThan(0);
   });
 
   it("minScore drops low-relevance matches (#rag-observability)", async () => {

--- a/test/unit/schema-timestamp-defaults.test.ts
+++ b/test/unit/schema-timestamp-defaults.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { getDb } from "../../src/db/client";
-import { orbRelayPending, repositorySettings, webhookEvents } from "../../src/db/schema";
+import { aiReviewCache, orbRelayPending, repositorySettings, webhookEvents } from "../../src/db/schema";
 import { createTestEnv } from "../helpers/d1";
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
@@ -52,6 +52,22 @@ describe("timestamp column defaults", () => {
       rawBody: "{}",
       coalesceKey,
     });
+    expect(row?.createdAt).toMatch(ISO);
+    expect(row?.createdAt).not.toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("applies the AI review cache createdAt default on omit", async () => {
+    const env = createTestEnv();
+    const db = getDb(env.DB);
+    await db.insert(aiReviewCache).values({
+      repoFullName: "acme/widgets",
+      pullNumber: 1,
+      headSha: "sha",
+      aiReviewMode: "advisory",
+      notes: "ok",
+      reviewerCount: 1,
+    });
+    const [row] = await db.select().from(aiReviewCache).where(eq(aiReviewCache.repoFullName, "acme/widgets")).limit(1);
     expect(row?.createdAt).toMatch(ISO);
     expect(row?.createdAt).not.toBe("CURRENT_TIMESTAMP");
   });


### PR DESCRIPTION
## Summary
- capture structured RAG retrieval and attribution telemetry for AI reviews without adding shadow review calls
- persist review metadata through the AI review cache so cache hits keep the same RAG context signals
- add migration/schema parity and focused regression coverage for retrieval metrics, attribution, cache metadata, and timestamp defaults

## What changed
- adds metrics-returning RAG helpers while preserving the existing string-returning wrappers
- records public-safe RAG counters, retrieved paths, injected context size, and final-review path references in review metadata
- adds `ai_review_cache.metadata_json` with a Drizzle schema definition
- extends unit coverage around RAG wiring, cache round-trips, migration schema parity, and timestamp defaults

## Why
We need real production signals before tuning Ollama/RAG cost and resource usage. This lets us measure whether retrieved context is being injected and whether final review notes/findings actually reference it, without spending extra review calls.

## Validation
- `npm run test:ci`
- `npm run db:migrations:check`
- `npm run typecheck`
- `npm audit --audit-level=moderate`
- `npm test -- --run test/unit/schema-timestamp-defaults.test.ts test/unit/rag-wiring.test.ts test/unit/rag.test.ts test/unit/ai-review-cache.test.ts`

## Notes
- no additional provider review calls are introduced
- migration adds a nullable-safe JSON metadata column with default `{}`