### PR TITLE
fix(rag): support configured embedding dimensions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,8 +171,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   Collection and schema are auto-created at startup. Off when unset.
 # QDRANT_API_KEY=                            # Bearer token for an authenticated Qdrant (cloud / on-prem). Omit for
 #                                            #   the local --profile qdrant container (unauthenticated).
-# QDRANT_DIM=1024                            # vector dimension of the collection (default 1024 = bge-m3); set to
-#                                            #   match your AI_EMBED_MODEL if it differs.
+# QDRANT_DIM=768                             # vector dimension of the collection (768 = nomic-embed-text:latest;
+#                                            #   1024 = bge-m3/mxbai-embed-large). Must match AI_EMBED_MODEL;
+#                                            #   recreate the Qdrant collection when changing this after startup.
 # MIGRATIONS_DIR=/app/migrations
 # CRON_INTERVAL_MS=120000                    # maintain/sweep + sync cadence (default ~2 min)
 
@@ -315,9 +316,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # CODEX_AI_EFFORT=high                       # low | medium | high | xhigh. `max` is accepted and maps to xhigh.
 # CODEX_AI_TIMEOUT_MS=                       # override CLI timeout in ms; unset scales by effort (low/medium 120s, high 240s, xhigh 360s)
 #                                            # Codex service speed is standard by default. No fast/priority tier is requested by this stack.
-# AI_EMBED_MODEL=bge-m3                      # embedding model for RAG (openai-compatible /embeddings). MUST be
-#                                            #   1024-dimensional (e.g. bge-m3 or mxbai-embed-large via Ollama).
-#                                            #   Used only when RAG is enabled (GITTENSORY_REVIEW_RAG + allowlist).
+# AI_EMBED_MODEL=nomic-embed-text:latest     # embedding model for RAG (openai-compatible /embeddings). Its output
+#                                            #   dimension must match QDRANT_DIM. Used only when RAG is enabled
+#                                            #   (GITTENSORY_REVIEW_RAG + allowlist).
 
 # --- Gittensory Orb (#1255; ALWAYS-ON fleet-calibration telemetry) ---
 # TELEMETRY NOTICE: running this self-hosted image contributes anonymized gate-calibration data to

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
@@ -59,15 +59,20 @@ function SelfHostingRag() {
         code={`GITTENSORY_REVIEW_RAG=true
 GITTENSORY_REVIEW_REPOS=owner/repo
 QDRANT_URL=http://qdrant:6333
-QDRANT_DIM=1024
+QDRANT_DIM=768
 AI_EMBED_BASE_URL=http://ollama:11434/v1
-AI_EMBED_MODEL=bge-m3`}
+AI_EMBED_MODEL=nomic-embed-text:latest`}
       />
       <CodeBlock
         lang="bash"
         code={`docker compose --profile qdrant --profile ollama up -d
-docker compose exec ollama ollama pull bge-m3`}
+docker compose exec ollama ollama pull nomic-embed-text:latest`}
       />
+      <p>
+        Use <code>QDRANT_DIM=1024</code> for 1024-dimensional models such as <code>bge-m3</code> or{" "}
+        <code>mxbai-embed-large</code>. If a Qdrant collection already exists, recreate it before
+        changing dimensions.
+      </p>
 
       <h2>Indexing</h2>
       <p>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,6 +15,8 @@ declare global {
      *  injects Qdrant/sqlite/pg adapters here when configured. Absent ⇒ no RAG, review proceeds with no retrieved
      *  context. */
     VECTORIZE?: Vectorize;
+    /** Self-host RAG vector width. Must match the configured embedding model and vector backend. */
+    QDRANT_DIM?: string;
     /** Optional self-host review audit + visual-capture blob store. The Node runtime injects a filesystem-backed
      *  store when REVIEW_AUDIT_DIR is set; the Cloudflare API worker no longer binds the review R2 bucket. */
     REVIEW_AUDIT?: R2Bucket;

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -249,6 +249,9 @@ export async function timeoutFetch(input: RequestInfo | URL, init?: RequestInit)
   }
 
   const request = fetchAndMaybeCacheGitHubGet(input, init, url, cacheKey, cls);
+  // Followers can recover with a fresh request when the leader fails; keep the internal leader promise observed
+  // while still letting the leader caller receive the original rejection from `await request` below.
+  void request.catch(() => undefined);
   const shared = request.then(
     (result) => result.cached,
     () => null,

--- a/src/review/adapters.ts
+++ b/src/review/adapters.ts
@@ -13,7 +13,7 @@
 // fail-safe on a missing vector/inference adapter ("no vector index → no RAG", "no AI → no context"), so the
 // modules NEVER throw — they degrade to no-context. Storage (D1 `DB`) is always present (the Worker cannot run
 // without it); its wrapper is a thin pass-through with the prepare→bind→all/first/run + batch surface RAG uses.
-import type { InferenceAdapter, RagInfra, StorageAdapter, VectorAdapter } from "./rag";
+import { ragDimensionsFromEnv, type InferenceAdapter, type RagInfra, type StorageAdapter, type VectorAdapter } from "./rag";
 
 // ── Storage (D1 → StorageAdapter). Always present. A thin pass-through over `env.DB` — structurally the
 //    prepare→bind→{all,first,run} + batch surface the ported modules use. Byte-faithful to reviewbot's
@@ -68,6 +68,7 @@ export function reviewInferenceAdapter(ai: Ai): InferenceAdapter {
  *  is satisfied by only assigning a member when its binding is present (never `vector: undefined`). */
 export function createReviewAdapters(env: Env): RagInfra {
   const infra: RagInfra = { storage: reviewStorageAdapter(env) };
+  if (env.QDRANT_DIM !== undefined) infra.embeddingDimensions = ragDimensionsFromEnv(env.QDRANT_DIM);
   if (env.VECTORIZE) infra.vector = reviewVectorAdapter(env.VECTORIZE);
   // Embeddings use the DEDICATED embed provider (env.AI_EMBED) when configured — keeping the review chat chain
   // frontier-only — and fall back to env.AI otherwise (byte-identical to before).

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -68,12 +68,13 @@ export interface RagInfra {
   storage: StorageAdapter;
   vector?: VectorAdapter;
   inference?: InferenceAdapter;
+  embeddingDimensions?: number;
 }
 
 /** bge-m3: large context window → a whole file/function embeds as one coherent chunk (fewer vectors
  *  than 512-token models, which helps both quality and the free-tier vector budget). */
 export const EMBED_MODEL = "@cf/baai/bge-m3";
-/** bge-m3 output dimension — the vector index MUST be created with `--dimensions=1024`. */
+/** Default bge-m3 output dimension. Self-host can override this when QDRANT_DIM selects another model width. */
 export const RAG_DIMENSIONS = 1024;
 
 const CHUNK_CHARS = 16000; // per-file chunk budget; only files larger than this are split
@@ -91,6 +92,11 @@ export type RagChunk = { id: string; path: string; chunkIndex: number; kind: Rag
 
 export function ragNamespace(project: string, repo: string): string {
   return `${project}:${repo}`.toLowerCase().slice(0, 64);
+}
+
+export function ragDimensionsFromEnv(value: string | undefined): number {
+  const dim = Number(value);
+  return Number.isFinite(dim) && dim > 0 ? Math.floor(dim) : RAG_DIMENSIONS;
 }
 
 // ── Filtering: index CODE, not content/data corpora (the primary free-tier cost guard) ───────────
@@ -251,7 +257,7 @@ export async function countRepoChunks(storage: StorageAdapter, project: string, 
 }
 
 // ── Embedding (fail-safe: null on any failure) ────────────────────────────────────────────────────
-export async function embedTexts(inference: InferenceAdapter | undefined, texts: string[]): Promise<number[][] | null> {
+export async function embedTexts(inference: InferenceAdapter | undefined, texts: string[], expectedDimensions = RAG_DIMENSIONS): Promise<number[][] | null> {
   if (!inference || texts.length === 0) return null;
   try {
     const out: number[][] = [];
@@ -260,9 +266,9 @@ export async function embedTexts(inference: InferenceAdapter | undefined, texts:
       const res = (await inference.run(EMBED_MODEL, { text: batch })) as { data?: number[][] } | null;
       const data = res?.data;
       // Validate COUNT and DIMENSION: a self-host embedding endpoint can return a structurally-valid response
-      // with a missing/empty/wrong-width vector (e.g. a non-1024-d model) — without the dim check a bad vector
+      // with a missing/empty/wrong-width vector — without the dim check a bad vector
       // slips through and later fails Vectorize.upsert, dropping the whole batch. Fail the batch early. (#abc-verify)
-      if (!Array.isArray(data) || data.length !== batch.length || data.some((v) => !Array.isArray(v) || v.length !== RAG_DIMENSIONS)) return null;
+      if (!Array.isArray(data) || data.length !== batch.length || data.some((v) => !Array.isArray(v) || v.length !== expectedDimensions)) return null;
       out.push(...data.map((v) => Array.from(v)));
     }
     return out;
@@ -279,7 +285,7 @@ export async function upsertChunks(infra: RagInfra, project: string, repo: strin
   const { storage: db, vector: vec, inference } = infra;
   if (!vec || !inference || chunks.length === 0) return 0;
   const namespace = ragNamespace(project, repo);
-  const vectors = await embedTexts(inference, chunks.map((c) => c.text));
+  const vectors = await embedTexts(inference, chunks.map((c) => c.text), infra.embeddingDimensions ?? RAG_DIMENSIONS);
   if (!vectors) return 0;
   try {
     await vec.upsert(
@@ -360,7 +366,7 @@ export async function retrieveContext(
   // entirely — no point spending an inference call (and vector query budget) on an empty namespace. (#audit cost)
   if (!(await hasIndexedChunks(storage, opts.project, opts.repo, Date.now()))) return "";
   try {
-    const embedded = await embedTexts(inference, [opts.queryText.slice(0, 16000)]);
+    const embedded = await embedTexts(inference, [opts.queryText.slice(0, 16000)], infra.embeddingDimensions ?? RAG_DIMENSIONS);
     const vec = embedded?.[0];
     if (!vec) return "";
     const res = await vectorAdapter.query(vec, {

--- a/src/selfhost/qdrant-vectorize.ts
+++ b/src/selfhost/qdrant-vectorize.ts
@@ -34,6 +34,9 @@ interface Match {
 interface QdrantSearchResult {
   result: Array<{ id: string; score: number; payload: Record<string, unknown> }>;
 }
+interface QdrantCollectionInfo {
+  result: { config: { params: { vectors: { size: number } } } };
+}
 
 /** Maps an arbitrary string ID to a UUID that Qdrant accepts as a point ID. Deterministic. */
 function idToUuid(id: string): string {
@@ -60,7 +63,7 @@ export function qdrantDimensionFromEnv(value: string | undefined): number {
 
 /**
  * Ensures the Qdrant collection exists. Safe to call on every startup — a 409 (already exists)
- * is silently ignored. Call this before createQdrantVectorize() when QDRANT_URL is set.
+ * verifies the existing collection width. Call this before createQdrantVectorize() when QDRANT_URL is set.
  */
 export async function initQdrantCollection(
   url: string,
@@ -75,6 +78,15 @@ export async function initQdrantCollection(
   });
   if (!res.ok && res.status !== 409) {
     throw new Error(`Qdrant collection init failed: HTTP ${res.status}`);
+  }
+  if (res.status === 409) {
+    const existing = await fetch(`${base}/collections/${collection}`, { headers: qdrantHeaders() });
+    if (!existing.ok) throw new Error(`Qdrant collection lookup failed: HTTP ${existing.status}`);
+    const info = (await existing.json()) as QdrantCollectionInfo;
+    const existingDim = info.result.config.params.vectors.size;
+    if (existingDim !== dim) {
+      throw new Error(`Qdrant collection dimension mismatch: existing ${existingDim}, configured ${dim}`);
+    }
   }
 }
 

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -484,16 +484,14 @@ describe("timeoutFetch", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const octokit = makeInstallationOctokit(createTestEnv(), "tok");
-    const first = octokit
-      .request("GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", { owner: "o", repo: "r", branch: "main" })
-      .catch((error: { status?: number }) => error.status);
-    const second = octokit.request("GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", { owner: "o", repo: "r", branch: "main" });
+    const url = "https://api.github.com/repos/o/r/branches/main/protection/required_status_checks";
+    const first = timeoutFetch(url).then((response) => response.status);
+    const second = timeoutFetch(url);
     await bothCacheReads;
     releaseFetch();
 
     await expect(first).resolves.toBe(500);
-    await expect(second).resolves.toEqual(expect.objectContaining({ data: { contexts: ["after-fallback"] } }));
+    await expect(second.then((response) => response.json())).resolves.toEqual({ contexts: ["after-fallback"] });
     expect(getFetches).toBe(2);
   });
 
@@ -528,16 +526,14 @@ describe("timeoutFetch", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const octokit = makeInstallationOctokit(createTestEnv(), "tok");
-    const first = octokit
-      .request("GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", { owner: "o", repo: "r", branch: "main" })
-      .catch((error: Error) => error.message);
-    const second = octokit.request("GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks", { owner: "o", repo: "r", branch: "main" });
+    const url = "https://api.github.com/repos/o/r/branches/main/protection/required_status_checks";
+    const first = timeoutFetch(url).catch((error: Error) => error.message);
+    const second = timeoutFetch(url);
     await bothCacheReads;
     releaseFetch();
 
     await expect(first).resolves.toContain("network down");
-    await expect(second).resolves.toEqual(expect.objectContaining({ data: { contexts: ["after-throw"] } }));
+    await expect(second.then((response) => response.json())).resolves.toEqual({ contexts: ["after-throw"] });
     expect(getFetches).toBe(2);
   });
 

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -14,6 +14,8 @@ import {
   isIndexablePath,
   type RagChunk,
   type RagInfra,
+  RAG_DIMENSIONS,
+  ragDimensionsFromEnv,
   ragNamespace,
   readChunkTexts,
   retrieveContext,
@@ -26,6 +28,7 @@ import {
 // ── Adapter stub helpers (the injected infra replaces reviewbot's raw env bindings) ───────────────
 const aiThatReturns = (data: unknown): InferenceAdapter => ({ run: async () => ({ data }) });
 const ai1024: InferenceAdapter = aiThatReturns([Array(1024).fill(0.1)]);
+const ai768: InferenceAdapter = aiThatReturns([Array(768).fill(0.1)]);
 
 /** A storage stub whose COUNT(*) returns `n` (warm vs cold index) and whose chunk-text SELECT returns rows. */
 function storageStub(opts: { count?: number; rows?: Array<{ id: string; text: string }> } = {}): StorageAdapter {
@@ -63,6 +66,21 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
 
   it("namespaces per repo (bounded to 64 bytes, lowercased)", () => {
     expect(ragNamespace("gittensory", "JSONbored/gittensory")).toBe("gittensory:jsonbored/gittensory");
+  });
+});
+
+describe("ragDimensionsFromEnv", () => {
+  it("uses a positive integer dimension from configuration", () => {
+    expect(ragDimensionsFromEnv("768")).toBe(768);
+    expect(ragDimensionsFromEnv("1536.9")).toBe(1536);
+  });
+
+  it("falls back to the bge-m3 default for unset, invalid, or non-positive values", () => {
+    expect(ragDimensionsFromEnv(undefined)).toBe(RAG_DIMENSIONS);
+    expect(ragDimensionsFromEnv("")).toBe(RAG_DIMENSIONS);
+    expect(ragDimensionsFromEnv("not-a-number")).toBe(RAG_DIMENSIONS);
+    expect(ragDimensionsFromEnv("0")).toBe(RAG_DIMENSIONS);
+    expect(ragDimensionsFromEnv("-5")).toBe(RAG_DIMENSIONS);
   });
 });
 
@@ -164,6 +182,11 @@ describe("rag: fail-safe (never throws; degrades to no context)", () => {
     expect((await embedTexts(ai1024, ["hi"]))?.[0]?.length).toBe(1024);
   });
 
+  it("embedTexts accepts a configured 768-dimension embedder without weakening the default guard", async () => {
+    expect(await embedTexts(ai768, ["hi"])).toBeNull();
+    expect((await embedTexts(ai768, ["hi"], 768))?.[0]?.length).toBe(768);
+  });
+
   it("retrieveContext returns '' when the vector index / AI are unbound", async () => {
     const infra: RagInfra = { storage: storageStub({ count: 5 }) };
     expect(await retrieveContext(infra, { project: "p", repo: "o/r", queryText: "x" })).toBe("");
@@ -225,6 +248,29 @@ describe("rag: fail-safe (never throws; degrades to no context)", () => {
     expect(out).not.toContain("src/changed.ts"); // the file under review is excluded → only RELATED code surfaces
   });
 
+  it("retrieves context with a configured 768-dimension self-host embedder", async () => {
+    let queryVectorLength = 0;
+    const vector = {
+      query: async (vec: number[]) => {
+        queryVectorLength = vec.length;
+        return { matches: [{ id: "src/dim.ts::0", score: 0.9, metadata: { path: "src/dim.ts" } }] };
+      },
+    } as unknown as VectorAdapter;
+    const infra: RagInfra = {
+      storage: storageStub({ count: 1, rows: [{ id: "src/dim.ts::0", text: "export const dim = 768;" }] }),
+      vector,
+      inference: ai768,
+      embeddingDimensions: 768,
+    };
+    const out = await retrieveContext(infra, {
+      project: "dim-proj",
+      repo: "o/dim-repo",
+      queryText: "refactor the embedding pipeline while keeping vector dimensions consistent across providers",
+    });
+    expect(queryVectorLength).toBe(768);
+    expect(out).toContain("export const dim = 768;");
+  });
+
   it("minScore drops low-relevance matches (#rag-observability)", async () => {
     const matches = [
       { id: "src/hit.ts::0", score: 0.82, metadata: { path: "src/hit.ts" } },
@@ -262,6 +308,18 @@ describe("rag: upsertChunks (embed + vector upsert + chunk-text store)", () => {
     expect(upserted[0]?.[0]).toMatchObject({ id: "ns|src/a.ts::0", namespace: ragNamespace("gittensory", "o/r"), metadata: { path: "src/a.ts", chunkIndex: 0, kind: "code" } });
     expect((upserted[0]?.[0]?.values ?? []).length).toBe(1024);
     expect(batched).toBe(1); // one INSERT statement per chunk handed to db.batch
+  });
+
+  it("upserts configured 768-dimension self-host embedding vectors", async () => {
+    const upserted: VectorUpsert[][] = [];
+    const vector = { upsert: async (v: VectorUpsert[]) => { upserted.push(v); } } as unknown as VectorAdapter;
+    const storage = {
+      prepare: () => ({ bind: () => ({ run: async () => undefined }) as unknown as BoundStatement }),
+      batch: async () => undefined,
+    } as unknown as StorageAdapter;
+    const n = await upsertChunks({ storage, vector, inference: ai768, embeddingDimensions: 768 }, "gittensory", "o/r", chunks);
+    expect(n).toBe(1);
+    expect((upserted[0]?.[0]?.values ?? []).length).toBe(768);
   });
 
   it("returns 0 with no vector / no inference / empty chunks (the fail-safe guard)", async () => {

--- a/test/unit/review-adapters.test.ts
+++ b/test/unit/review-adapters.test.ts
@@ -62,6 +62,12 @@ describe("createReviewAdapters: bundle assembly + graceful degradation", () => {
     expect(infra.inference).toBeDefined();
   });
 
+  it("carries the configured RAG vector dimension into the infra bundle", () => {
+    const { DB } = dbStub();
+    const infra = createReviewAdapters({ DB, VECTORIZE: vectorizeStub(), AI: aiStub(), QDRANT_DIM: "768" } as unknown as Env);
+    expect(infra.embeddingDimensions).toBe(768);
+  });
+
   it("prefers the dedicated AI_EMBED provider for inference, keeping the review chain frontier-only", async () => {
     const { DB } = dbStub();
     const reviewAi = { run: vi.fn(async () => ({ response: "review text" })) }; // would NOT return embed data
@@ -105,6 +111,7 @@ describe("createReviewAdapters: bundle assembly + graceful degradation", () => {
     const infra = createReviewAdapters({ DB } as unknown as Env);
     expect("vector" in infra).toBe(false);
     expect("inference" in infra).toBe(false);
+    expect("embeddingDimensions" in infra).toBe(false);
   });
 });
 

--- a/test/unit/selfhost-qdrant-vectorize.test.ts
+++ b/test/unit/selfhost-qdrant-vectorize.test.ts
@@ -9,6 +9,10 @@ function mockFetch(status: number, body: unknown = {}) {
   return vi.fn(async () => new Response(JSON.stringify(body), { status }));
 }
 
+function collectionInfo(size: number) {
+  return { result: { config: { params: { vectors: { size } } } } };
+}
+
 describe("qdrantReadyzUrl (#1482 regression)", () => {
   it("points readiness probes at Qdrant's unauthenticated /readyz endpoint", () => {
     expect(qdrantReadyzUrl(BASE)).toBe(`${BASE}/readyz`);
@@ -50,9 +54,33 @@ describe("initQdrantCollection (#1217)", () => {
     expect(body.vectors.size).toBe(1024);
   });
 
-  it("ignores a 409 (collection already exists)", async () => {
-    vi.stubGlobal("fetch", mockFetch(409));
+  it("accepts a 409 when the existing collection dimension matches", async () => {
+    const fake = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "exists" }), { status: 409 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(collectionInfo(1024)), { status: 200 }));
+    vi.stubGlobal("fetch", fake);
     await expect(initQdrantCollection(BASE)).resolves.not.toThrow();
+    expect(fake).toHaveBeenCalledTimes(2);
+    expect(fake.mock.calls[1]?.[0]).toBe(`${BASE}/collections/gittensory`);
+  });
+
+  it("throws on a 409 when the existing collection dimension is wrong", async () => {
+    const fake = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "exists" }), { status: 409 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(collectionInfo(1024)), { status: 200 }));
+    vi.stubGlobal("fetch", fake);
+    await expect(initQdrantCollection(BASE, "gittensory", 768)).rejects.toThrow(/existing 1024, configured 768/);
+  });
+
+  it("throws when an existing collection cannot be inspected after a 409", async () => {
+    const fake = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "exists" }), { status: 409 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }));
+    vi.stubGlobal("fetch", fake);
+    await expect(initQdrantCollection(BASE)).rejects.toThrow(/lookup failed: HTTP 503/);
   });
 
   it("throws on any other non-OK status", async () => {


### PR DESCRIPTION
## Summary

- Adds configured RAG embedding dimensions so self-host deployments can use 768-dimensional Ollama embeddings without weakening the default 1024-dimensional guard.
- No linked issue: this is a focused self-host configuration fix needed for the new embedding service path.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran focused unit tests for RAG dimensions, adapter wiring, Qdrant startup validation, and GitHub GET single-flight fallback behavior. Also ran the full local gate with `npm run test:ci`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Not applicable | Docs/config text only; no rendered layout behavior changed. |

## Notes

- `QDRANT_DIM` now flows into RAG embedding validation instead of forcing all self-host embedding providers to 1024 dimensions.
- Existing Qdrant collections are inspected after an already-exists response; a stale collection fails startup with a clear dimension mismatch instead of failing later during vector writes.