### PR TITLE
perf(github): expose response cache ttl controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   pin production rollouts to a release tag such as :orb-v0.1.0
 #                                            #   or to an immutable @sha256 digest.
 # GITHUB_CACHE_TTL_SECONDS=20                # Short default Redis TTL for safe GitHub GET response caching. Set 0 to disable.
+# GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS=1200  # TTL for required-status branch protection reads.
+# GITHUB_METADATA_CACHE_TTL_SECONDS=600      # TTL for stable repo/user/installation metadata reads.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
 # DISCORD_WEBHOOK_URL=                        # one Discord channel for per-action notifications (merged/closed/

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -84,14 +84,20 @@ INTERNAL_JOB_TOKEN=<random-32-byte-token>`}
         identity and response-shaping headers, and cold misses are single-flighted so concurrent
         jobs do not stampede GitHub.
       </p>
-      <CodeBlock filename=".env" code={`GITHUB_CACHE_TTL_SECONDS=20`} />
+      <CodeBlock
+        filename=".env"
+        code={`GITHUB_CACHE_TTL_SECONDS=20
+GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS=1200
+GITHUB_METADATA_CACHE_TTL_SECONDS=600`}
+      />
       <Callout variant="note">
         <code>GITHUB_CACHE_TTL_SECONDS</code> is the short default for repeated safe GitHub GETs.
-        Stable repo/user metadata and branch-protection required-status reads use longer internal
-        TTLs. Live CI status, check-run, check-suite, pull/issue subresources, pull mergeability,
-        token minting, rate-limit, and collaborator-permission endpoints are never served from this
-        cache. Prometheus exports <code>gittensory_github_response_cache_total</code>, and the
-        bundled self-host Grafana dashboard includes the hit/miss/coalesced/error breakdown.
+        Stable repo/user metadata and branch-protection required-status reads use the per-class TTLs
+        above so operators can keep repeated policy reads hot without broadening stale cache risk.
+        Live CI status, check-run, check-suite, pull/issue subresources, pull mergeability, token
+        minting, rate-limit, and collaborator-permission endpoints are never served from this cache.
+        Prometheus exports <code>gittensory_github_response_cache_total</code>, and the bundled
+        self-host Grafana dashboard includes the hit/miss/coalesced/error breakdown.
       </Callout>
 
       <h2>Per-PR feature flags</h2>

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -19,8 +19,8 @@ import type { RepositorySettings } from "../types";
 const GITHUB_FETCH_TIMEOUT_MS = 12_000;
 const GITHUB_API_PREFIX = "https://api.github.com";
 const GITHUB_RESPONSE_CACHE_METRIC = "gittensory_github_response_cache_total";
-const BRANCH_PROTECTION_TTL_SECONDS = 20 * 60;
-const METADATA_TTL_SECONDS = 10 * 60;
+const DEFAULT_BRANCH_PROTECTION_TTL_SECONDS = 20 * 60;
+const DEFAULT_METADATA_TTL_SECONDS = 10 * 60;
 export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-gittensory-cache";
 
 /** A shared cache for safe GitHub GET responses (e.g. Redis on the self-host). Stores only status/body/
@@ -43,7 +43,8 @@ export function setGitHubResponseCache(cache: GitHubResponseCache | null): void 
   responseCache = cache;
 }
 
-type GitHubCacheClass = "branch_protection" | "metadata";
+export type GitHubCacheClass = "branch_protection" | "metadata";
+type EnvLookup = Record<string, string | undefined>;
 
 /** Only cache explicitly stable GitHub REST reads. PR/issue/comment/label/event/check/status reads are mutable
  * review inputs and must always reflect the current GitHub state. Exported for tests. */
@@ -69,9 +70,20 @@ function githubCacheClassForUrl(url: string): GitHubCacheClass | null {
   return null;
 }
 
-function githubCacheTtlSeconds(cls: GitHubCacheClass): number {
-  if (cls === "branch_protection") return BRANCH_PROTECTION_TTL_SECONDS;
-  return METADATA_TTL_SECONDS;
+function positiveEnvSeconds(env: EnvLookup, name: string, fallback: number): number {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return fallback;
+  const seconds = Math.floor(value);
+  return seconds >= 1 ? seconds : fallback;
+}
+
+export function githubResponseCacheTtlSeconds(cls: GitHubCacheClass, env: EnvLookup = process.env): number {
+  if (cls === "branch_protection") {
+    return positiveEnvSeconds(env, "GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS", DEFAULT_BRANCH_PROTECTION_TTL_SECONDS);
+  }
+  return positiveEnvSeconds(env, "GITHUB_METADATA_CACHE_TTL_SECONDS", DEFAULT_METADATA_TTL_SECONDS);
 }
 
 function hasConditionalRequestHeader(headers: Headers): boolean {
@@ -201,7 +213,7 @@ async function fetchAndMaybeCacheGitHubGet(
       ...(response.headers.get("etag") ? { etag: response.headers.get("etag")! } : {}),
       ...(response.headers.get("last-modified") ? { lastModified: response.headers.get("last-modified")! } : {}),
     };
-    await responseCache!.set(cacheKey, cached, githubCacheTtlSeconds(cls));
+    await responseCache!.set(cacheKey, cached, githubResponseCacheTtlSeconds(cls));
     recordGitHubCacheMetric("set", cls);
     return { response, cached };
   } catch {

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -3,6 +3,7 @@ import {
   clearGitHubResponseCacheForTest,
   forcedSelfhostMode,
   GITHUB_RESPONSE_CACHE_REPLAY_HEADER,
+  githubResponseCacheTtlSeconds,
   isCacheableGithubUrl,
   isRateLimitedResponse,
   makeInstallationOctokit,
@@ -36,6 +37,7 @@ function installMemoryResponseCache(): Map<string, CachedGitHubResponse> {
 afterEach(() => {
   clearGitHubResponseCacheForTest();
   resetMetrics();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -301,7 +303,21 @@ describe("timeoutFetch", () => {
     expect(await replay.json()).toEqual({ ok: true });
   });
 
-  it("uses longer TTL overrides for stable GitHub metadata and branch-protection reads", async () => {
+  it("resolves per-class cache TTL env overrides with safe fallbacks", () => {
+    expect(githubResponseCacheTtlSeconds("branch_protection", {})).toBe(20 * 60);
+    expect(githubResponseCacheTtlSeconds("metadata", {})).toBe(10 * 60);
+    expect(githubResponseCacheTtlSeconds("branch_protection", { GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS: "3600" })).toBe(3600);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "90.8" })).toBe(90);
+    expect(githubResponseCacheTtlSeconds("branch_protection", { GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS: "" })).toBe(20 * 60);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "0" })).toBe(10 * 60);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "0.5" })).toBe(10 * 60);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "not-a-number" })).toBe(10 * 60);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "Infinity" })).toBe(10 * 60);
+  });
+
+  it("uses configured TTL overrides for stable GitHub metadata and branch-protection reads", async () => {
+    vi.stubEnv("GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS", "3600");
+    vi.stubEnv("GITHUB_METADATA_CACHE_TTL_SECONDS", "900");
     const ttlByUrl = new Map<string, number | undefined>();
     setGitHubResponseCache({
       get: async () => null,
@@ -320,10 +336,10 @@ describe("timeoutFetch", () => {
     const userTtl = [...ttlByUrl].find(([key]) => key.endsWith("/users/alice"))?.[1];
     const installationTtl = [...ttlByUrl].find(([key]) => key.endsWith("/app/installations/123"))?.[1];
     const statusTtl = [...ttlByUrl].find(([key]) => key.includes("/commits/abc/status"))?.[1];
-    expect(branchTtl).toBe(20 * 60);
-    expect(repoTtl).toBe(10 * 60);
-    expect(userTtl).toBe(10 * 60);
-    expect(installationTtl).toBe(10 * 60);
+    expect(branchTtl).toBe(3600);
+    expect(repoTtl).toBe(900);
+    expect(userTtl).toBe(900);
+    expect(installationTtl).toBe(900);
     expect(statusTtl).toBeUndefined();
     expect([...ttlByUrl.keys()].some((key) => key.includes("/commits/abc/status"))).toBe(false);
   });
@@ -527,7 +543,9 @@ describe("timeoutFetch", () => {
     });
 
     const url = "https://api.github.com/repos/o/r/branches/main/protection/required_status_checks";
-    const first = timeoutFetch(url).catch((error: Error) => error.message);
+    const firstRequest = timeoutFetch(url);
+    void firstRequest.catch(() => undefined);
+    const first = firstRequest.catch((error: Error) => error.message);
     const second = timeoutFetch(url);
     await bothCacheReads;
     releaseFetch();


### PR DESCRIPTION
## Summary

- Adds env controls for the safe GitHub GET response cache TTLs so branch-protection required-status reads and stable metadata reads can be tuned independently.
- No issue because this is a small self-host operational tuning change for the existing Redis GitHub response cache.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. `npm run test:ci` passed end-to-end; `npm audit --audit-level=moderate` reported 0 vulnerabilities.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| Text-only configuration docs | Not applicable; this only updates self-hosting config copy and env examples, with `npm run ui:build` passing. |

## Notes

- Defaults preserve the existing 20 minute branch-protection TTL and 10 minute metadata TTL. Operators can raise branch-protection TTL independently without caching mutable CI, PR, issue, check-run, status, rate-limit, token, or collaborator-permission endpoints.
