### PR TITLE
feat(mcp): support targeted cache clear by login

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -44,6 +44,7 @@ gittensory-mcp profile switch work
 gittensory-mcp cache status
 gittensory-mcp cache list
 gittensory-mcp cache clear
+gittensory-mcp cache clear --login jsonbored
 gittensory-mcp init-client --print codex
 gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
@@ -244,7 +245,8 @@ Successful `decision-pack` and MCP `gittensory_get_decision_pack` calls store a 
 The cache excludes source contents and local paths, is bounded, and can be removed with:
 
 ```sh
-gittensory-mcp cache clear
+gittensory-mcp cache clear                       # clear all entries
+gittensory-mcp cache clear --login jsonbored     # clear only that contributor's entries
 ```
 
-`gittensory-mcp cache list` shows the cached entries (newest first) with the login, when each was cached, and its API/package version and size — never the cached payload or the auth-cache key. `gittensory-mcp cache status` reports the aggregate entry count.
+`gittensory-mcp cache list` shows the cached entries (newest first) with the login, when each was cached, and its API/package version and size — never the cached payload or the auth-cache key. `gittensory-mcp cache status` reports the aggregate entry count. `gittensory-mcp cache clear` removes all entries, or pass `--login <github-login>` to evict only that contributor's cached pack.

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1472,9 +1472,9 @@ function runCacheCli(args) {
   if (subcommand === "--help" || subcommand === "help") return printCacheHelp();
   const options = parseOptions(args.slice(1));
   if (subcommand === "clear") {
-    const payload = clearDecisionPackCache();
+    const payload = clearDecisionPackCache(typeof options.login === "string" ? options.login : undefined);
     if (options.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-    else process.stdout.write(`Cleared ${payload.removed} decision-pack cache entr${payload.removed === 1 ? "y" : "ies"}.\n`);
+    else process.stdout.write(`Cleared ${payload.removed} decision-pack cache entr${payload.removed === 1 ? "y" : "ies"}${payload.login ? ` for ${payload.login}` : ""}.\n`);
     return;
   }
   if (subcommand === "status") {
@@ -1785,7 +1785,7 @@ function printHelp() {
   gittensory-mcp profile list|create|switch|remove [name] [--json]
   gittensory-mcp changelog [--json]
   gittensory-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
-  gittensory-mcp cache status|list|clear [--json]
+  gittensory-mcp cache status|list|clear [--login <github-login>] [--json]
   gittensory-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
   gittensory-mcp decision-pack --login <github-login> [--json]
   gittensory-mcp repo-decision --login <github-login> --repo owner/repo [--json]
@@ -1813,9 +1813,10 @@ function printCacheHelp() {
   process.stdout.write(`Usage:
   gittensory-mcp cache status [--json]
   gittensory-mcp cache list [--json]
-  gittensory-mcp cache clear [--json]
+  gittensory-mcp cache clear [--login <github-login>] [--json]
 
 Decision-pack cache entries are local-only stale fallbacks for temporary API/network outages.
+Pass --login to clear only that contributor's cached entries; omit it to clear all.
 Source upload remains disabled.
 `);
 }
@@ -2959,18 +2960,34 @@ function pruneDecisionPackCache() {
   for (const file of files.slice(decisionPackCacheMaxEntries)) rmSync(file.path, { force: true });
 }
 
-function clearDecisionPackCache() {
-  const removed = decisionPackCacheFiles().length;
-  rmSync(decisionPackCacheDir, { recursive: true, force: true });
-  return {
-    status: "cleared",
-    removed,
-    cache: {
-      source: "local_cache",
-      maxEntries: decisionPackCacheMaxEntries,
-      clearCommand: "gittensory-mcp cache clear",
-    },
+function clearDecisionPackCache(loginFilter) {
+  const cache = {
+    source: "local_cache",
+    maxEntries: decisionPackCacheMaxEntries,
+    clearCommand: "gittensory-mcp cache clear",
   };
+  if (!loginFilter) {
+    const removed = decisionPackCacheFiles().length;
+    rmSync(decisionPackCacheDir, { recursive: true, force: true });
+    return { status: "cleared", removed, cache };
+  }
+  // Targeted eviction: remove only the entries whose stored login matches, leaving other logins'
+  // cached packs intact. Match the cache's own lowercased login key.
+  const target = loginFilter.toLowerCase();
+  let removed = 0;
+  for (const file of decisionPackCacheFiles()) {
+    let entryLogin = null;
+    try {
+      entryLogin = JSON.parse(readFileSync(file.path, "utf8")).login;
+    } catch {
+      entryLogin = null;
+    }
+    if (typeof entryLogin === "string" && entryLogin.toLowerCase() === target) {
+      rmSync(file.path, { force: true });
+      removed += 1;
+    }
+  }
+  return { status: "cleared", removed, login: target, cache };
 }
 
 function inspectDecisionPackCache() {

--- a/test/unit/mcp-cli-packets.test.ts
+++ b/test/unit/mcp-cli-packets.test.ts
@@ -131,6 +131,31 @@ describe("gittensory-mcp CLI — packets", () => {
     expect(human).toContain("jsonbored");
   });
 
+  it("clears only the targeted login's cached decision pack", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_CONFIG_DIR: tempDir,
+      GITTENSORY_API_TIMEOUT_MS: "1000",
+    };
+    await runAsync(["decision-pack", "--login", "JSONbored", "--json"], env);
+
+    // Clearing a different login leaves the cached entry intact.
+    const other = JSON.parse(run(["cache", "clear", "--login", "someone-else", "--json"], env)) as { status: string; removed: number; login: string };
+    expect(other).toMatchObject({ status: "cleared", removed: 0, login: "someone-else" });
+    expect((JSON.parse(run(["cache", "status", "--json"], env)) as { entries: number }).entries).toBe(1);
+
+    // Clearing the matching login (case-insensitive) evicts only that entry.
+    const matched = JSON.parse(run(["cache", "clear", "--login", "JSONbored", "--json"], env)) as { status: string; removed: number; login: string };
+    expect(matched).toMatchObject({ status: "cleared", removed: 1, login: "jsonbored" });
+    expect((JSON.parse(run(["cache", "status", "--json"], env)) as { entries: number }).entries).toBe(0);
+
+    const human = run(["cache", "clear", "--login", "JSONbored"], env);
+    expect(human).toContain("for jsonbored");
+  });
+
   it("does not use stale decision-pack cache created by a different local token", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
     const fixtureOptions: { decisionPackStatus?: number } = {};


### PR DESCRIPTION
## Summary

`gittensory-mcp cache clear` could only wipe the *entire* offline decision-pack cache. Now that `cache list` shows per-login entries, there was no way to drop a single stale one without re-fetching everything. Adds an optional `--login`:

```
$ gittensory-mcp cache clear --login jsonbored
Cleared 1 decision-pack cache entry for jsonbored.

$ gittensory-mcp cache clear --login jsonbored --json
{ "status": "cleared", "removed": 1, "login": "jsonbored", "cache": { ... } }
```

It evicts only that contributor's cached entries (case-insensitive against the cache's stored login key), leaving other logins' packs intact.

## Behavior / compatibility

- **Additive.** Without `--login`, `cache clear` still wipes the whole cache — existing behavior and the existing test are unchanged.
- Returns the same `{ status, removed, cache }` shape, plus a `login` field (and a `… for <login>` suffix in human output) when targeted.

## Scope

- `packages/gittensory-mcp/bin/gittensory-mcp.js` — `clearDecisionPackCache(loginFilter)` gains the targeted path; the `cache clear` dispatch passes `--login`; cache + main help text.
- `test/unit/mcp-cli-packets.test.ts` — covers the no-match case (entry survives), the matching case (only it is evicted, case-insensitive), and the `for <login>` human output.
- `packages/gittensory-mcp/README.md` — document the flag.

Packages-only; no `src/**`, UI, schema, migration, or OpenAPI changes.

## Validation

Run locally on Node v24.18.0 (engine floor is 22):

- `npm run build:mcp` → pass
- `npm run typecheck` → pass, 0 errors (full project)
- `npx vitest run test/unit/mcp-cli-packets.test.ts` → 18/18 pass, including the new `clears only the targeted login's cached decision pack` and the unchanged `cache clear` test
- `npm pack --workspace @jsonbored/gittensory-mcp --dry-run` → package file list unchanged (allowed set; no new files, no secrets)
- Smoke: `cache clear --login <x>` on an empty cache (removed 0) and the human/JSON output verified

Note: `npm run test:mcp-pack` can't run on my Windows box (its harness `spawnSync("npm", …)` can't resolve `npm.cmd` without a shell) — verified package contents with `npm pack --dry-run` instead. It passes on CI.

## Safety

No auth, cookie, CORS, GitHub App output, identity, contributor-evidence, or scoring changes. No secrets/wallets/hotkeys/trust/reward terms. Reads only the cache's stored `login` field to match; never logs the token or auth-cache key.
