### PR TITLE
feat(enrichment): register docCommentDrift in engine REES_ANALYZER_NAMES

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -92,6 +92,7 @@ export const REES_ANALYZER_NAMES = [
   "iacMisconfig",
   "nativeBuild",
   "history",
+  "docCommentDrift",
 ] as const;
 
 const REES_ANALYZER_NAME_SET = new Set<string>(REES_ANALYZER_NAMES);

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -491,12 +491,18 @@ describe("resolveReesAnalyzers", () => {
     warnSpy.mockRestore();
   });
 
+  it("accepts docCommentDrift as a configured analyzer subset", () => {
+    expect(
+      resolveReesAnalyzers(env({ REES_ANALYZERS: "docCommentDrift" })),
+    ).toEqual(["docCommentDrift"]);
+  });
+
   it("accepts every REES analyzer currently registered by the service", () => {
     expect(
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift",
         }),
       ),
     ).toEqual([
@@ -518,6 +524,7 @@ describe("resolveReesAnalyzers", () => {
       "iacMisconfig",
       "nativeBuild",
       "history",
+      "docCommentDrift",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Add `docCommentDrift` to `REES_ANALYZER_NAMES` so self-host operators can enable the shipped REES analyzer via `REES_ANALYZERS=docCommentDrift`.

## Issue

> **Action:** Open upstream issue titled `feat(enrichment): register docCommentDrift in engine REES_ANALYZER_NAMES` and link it here (`Fixes #…`) before gate review.

## Validation

```
npx vitest run test/unit/enrichment-wire.test.ts -t "docCommentDrift|accepts every REES"
```

## Test plan

- [x] `REES_ANALYZERS=docCommentDrift` resolves successfully
- [x] Full allowlist acceptance test includes `docCommentDrift`

