### PR TITLE
feat(enrichment): forward PR body to REES enrichment request

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3825,6 +3825,7 @@ export async function runAiReviewForAdvisory(
             headSha: args.advisory.headSha,
             baseSha: args.pr.baseSha ?? null,
             title: args.pr.title,
+            body: args.pr.body ?? undefined,
             author: args.author,
             githubToken: isReesGithubTokenForwardingEnabled(env)
               ? await resolveReviewEnrichmentGithubToken(

--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -141,6 +141,7 @@ interface EnrichmentInput {
   headSha: string | null;
   baseSha?: string | null;
   title?: string | undefined;
+  body?: string | undefined;
   author?: string | null | undefined;
   githubToken?: string | undefined;
   files: PullRequestFileRecord[];
@@ -232,6 +233,7 @@ export async function buildReviewEnrichment(
         headSha: input.headSha,
         baseSha: input.baseSha ?? null,
         title: input.title,
+        ...(input.body ? { body: input.body } : {}),
         author: input.author ?? undefined,
         ...(input.githubToken ? { githubToken: input.githubToken } : {}),
         files: input.files.map((file) => ({

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -83,6 +83,7 @@ describe("buildReviewEnrichment", () => {
       {
         ...input,
         baseSha: "baseabc",
+        body: "Fixes #12",
         author: "alice",
         githubToken: "gh-read-token",
       },
@@ -106,6 +107,7 @@ describe("buildReviewEnrichment", () => {
     const body = JSON.parse(calls[0]!.init.body as string);
     expect(body.repoFullName).toBe("o/r");
     expect(body.baseSha).toBe("baseabc");
+    expect(body.body).toBe("Fixes #12");
     expect(body.author).toBe("alice");
     expect(body.githubToken).toBe("gh-read-token");
     expect(body.analyzers).toBeUndefined();
@@ -126,6 +128,22 @@ describe("buildReviewEnrichment", () => {
       },
       { path: "b.ts", status: undefined, patch: undefined },
     ]);
+  });
+
+  it("omits body from the REES POST when the PR body is empty", async () => {
+    let posted: { body?: string } | undefined;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      posted = JSON.parse(String(init?.body ?? "{}")) as { body?: string };
+      return {
+        ok: true,
+        json: async () => ({ promptSection: "brief" }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    await buildReviewEnrichment(env({ REES_URL: "https://rees" }), {
+      ...input,
+      author: "alice",
+    });
+    expect(posted?.body).toBeUndefined();
   });
 
   it("sends an analyzer budget below the transport timeout and accepts partial degraded briefs", async () => {

--- a/test/unit/enrichment-wiring.test.ts
+++ b/test/unit/enrichment-wiring.test.ts
@@ -92,6 +92,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
         analyzers?: string[];
         baseSha?: string | null;
         author?: string;
+        body?: string;
         githubToken?: string;
       };
     } = {};
@@ -105,6 +106,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
             analyzers?: string[];
             baseSha?: string | null;
             author?: string;
+            body?: string;
             githubToken?: string;
           };
           return new Response(
@@ -141,6 +143,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
       ]);
       expect(reesRequest.body?.baseSha).toBe("base7");
       expect(reesRequest.body?.author).toBe("alice");
+      expect(reesRequest.body?.body).toBe("Implements the thing.");
       expect(reesRequest.body?.githubToken).toBe("public-read-token");
       // The brief's content flows into the user prompt, but the system prompt carries our FIXED
       // enrichment suffix — the REES-supplied systemSuffix is untrusted and is never spliced in.


### PR DESCRIPTION
## Summary

Forward `pr.body` through `runAiReviewForAdvisory` → `buildReviewEnrichment` so REES `history` can parse `Fixes #N` from the PR description.

## Issue

> **Action:** Open upstream issue `feat(enrichment): forward PR body to REES enrichment request` and link `Fixes #…` before gate review.

## Validation

```
npx vitest run test/unit/enrichment-wire.test.ts test/unit/enrichment-wiring.test.ts -t "body|FLAG-ON"
```

## Test plan

- [x] Non-empty PR body appears in REES POST
- [x] Missing body omits the field
- [x] Processor wiring test covers advisory → enrichment path

