### PR TITLE
feat(mcp): suggest the closest command on an unknown command

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1404,7 +1404,10 @@ async function runCli(args) {
   if (command === "init-client") return initClient(options);
   if (command === "decision-pack") return decisionPackCli(options);
   if (command === "repo-decision") return repoDecisionCli(options);
-  if (command !== "analyze-branch" && command !== "preflight") throw new Error(`Unknown command: ${command}. Run \`gittensory-mcp --help\` to list commands.`);
+  if (command !== "analyze-branch" && command !== "preflight") {
+    const suggestion = suggestCommand(command);
+    throw new Error(`Unknown command: ${command}.${suggestion ? ` Did you mean \`${suggestion}\`?` : ""} Run \`gittensory-mcp --help\` to list commands.`);
+  }
   const contributorLogin = options.login ?? process.env.GITTENSORY_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!contributorLogin) throw new Error("Pass --login <github-login> or set GITTENSORY_LOGIN.");
   const result = await analyzeCurrentBranch({
@@ -1683,6 +1686,38 @@ function buildCompletionScript(shell) {
   if (shell === "zsh") return buildZshCompletion(topLevel, withSubcommands);
   if (shell === "fish") return buildFishCompletion(topLevel, withSubcommands);
   return buildPowershellCompletion(topLevel, withSubcommands);
+}
+
+// Suggest the closest known command for a typo, so an unknown command can offer a "did you mean".
+// Only suggests within a small edit-distance budget that scales with input length, so unrelated
+// input gets no (misleading) suggestion.
+function suggestCommand(input) {
+  let best = null;
+  let bestDistance = Infinity;
+  for (const candidate of Object.keys(CLI_COMMAND_SPEC)) {
+    const distance = levenshteinDistance(input, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  const budget = Math.max(2, Math.floor(input.length / 3));
+  return best !== null && bestDistance > 0 && bestDistance <= budget ? best : null;
+}
+
+function levenshteinDistance(a, b) {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(current[j - 1] + 1, previous[j] + 1, previous[j - 1] + cost);
+    }
+    previous = current;
+  }
+  return previous[b.length];
 }
 
 function buildBashCompletion(topLevel, withSubcommands) {

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -161,6 +161,15 @@ describe("gittensory-mcp CLI — basics", () => {
     expect(() => run(["bogus-command"])).toThrow(/gittensory-mcp --help/);
   });
 
+  it("suggests the closest command for a near-miss typo", () => {
+    // The suggestion is interpolated into the message, so matching `status` (not the literal
+    // template token) confirms it ran rather than just matching the throw's printed source line.
+    expect(() => run(["staus"])).toThrow(/Unknown command: staus\. Did you mean `status`\?/);
+    expect(() => run(["verison"])).toThrow(/Did you mean `version`\?/);
+    expect(() => run(["confi"])).toThrow(/Did you mean `config`\?/);
+    expect(() => run(["doctr"])).toThrow(/Did you mean `doctor`\?/);
+  });
+
   it("prints shell completion scripts for bash, zsh, and fish", () => {
     const bash = run(["completion", "bash"]);
     expect(bash).toContain("_gittensory_mcp()");


### PR DESCRIPTION
## Summary

When a command is mistyped, the CLI now offers a "did you mean" hint — the ergonomic that `git`, `npm`, and `cargo` all have:

```
$ gittensory-mcp staus
Error: Unknown command: staus. Did you mean `status`? Run `gittensory-mcp --help` to list commands.
```

The suggestion is the nearest known top-level command by Levenshtein distance, within a small edit-distance budget that scales with input length (`max(2, floor(len/3))`), so unrelated input gets **no** misleading suggestion and the base `Run --help` guidance is unchanged.

## Behavior / compatibility

- Additive: the existing `Unknown command: … Run --help` message is preserved; the `Did you mean …?` clause is only inserted when a close match exists.
- Unrelated input (e.g. `bogus-command`) gets only the `--help` guidance, exactly as before.

## Scope

- `packages/gittensory-mcp/bin/gittensory-mcp.js` — `suggestCommand()` + a small `levenshteinDistance()` helper (driven by the existing `CLI_COMMAND_SPEC`), wired into the unknown-command throw.
- `test/unit/mcp-cli-basics.test.ts` — near-miss typos resolving to `status`/`version`/`config`/`doctor`, plus the unchanged unrelated-input case.

Packages-only; no `src/**`, UI, schema, migration, or OpenAPI changes. No README change — this refines an error message, not a command surface.

## Validation

Run locally on Node v24.18.0 (engine floor is 22):

- `npm run build:mcp` → pass
- `npm run typecheck` → pass, 0 errors (full project)
- `npx vitest run test/unit/mcp-cli-basics.test.ts` → 20/20 pass, including the new `suggests the closest command for a near-miss typo` and the unchanged `guides unknown commands to --help`
- `npm pack --workspace @jsonbored/gittensory-mcp --dry-run` → package file list unchanged (allowed set; no new files, no secrets)
- Smoke: `staus`→`status`, `verison`→`version`, `confi`→`config`, `doctr`→`doctor`; `bogus-command` → no suggestion

Note: `npm run test:mcp-pack` can't run on my Windows box (its harness `spawnSync("npm", …)` can't resolve `npm.cmd` without a shell) — verified package contents with `npm pack --dry-run` instead. It passes on CI.

## Safety

No auth, cookie, CORS, GitHub App output, identity, contributor-evidence, or scoring changes. No secrets/wallets/hotkeys/trust/reward terms. The suggestion is drawn only from the static known-command list.

## Why no issue

This is an intentional no-issue PR: a small, self-contained CLI error-message refinement (a "did you mean" hint on an unknown command) with no public-behavior, auth, schema, deploy, or API-contract change. Per CONTRIBUTING this class of change does not require a tracking issue; happy to file one if maintainers prefer.
