### PR TITLE
fix(selfhost): restore conservative queue concurrency default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,7 +187,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # LITESTREAM_REGION=us-east-1
 
 # --- Queue worker (#977/#1201) ---
-# QUEUE_CONCURRENCY=4                        # max concurrent job-processing loops per instance (default 4; set 1 for strict serial processing)
+# QUEUE_CONCURRENCY=1                        # max concurrent job-processing loops per instance (default 1; raise only after profiling your host)
 # QUEUE_BACKGROUND_CONCURRENCY=1             # max low-priority/background jobs allowed to occupy QUEUE_CONCURRENCY slots
 
 # --- Caddy HTTPS terminator (#1203; requires --profile caddy) ---

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -17,6 +17,7 @@ import {
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
+  queueConcurrency,
   queueProcessingTimeoutMs,
   queueRecoveryJitterMs,
   queueStartupJitterMinJobs,
@@ -72,9 +73,9 @@ export interface PgQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
-   *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster; FOR UPDATE SKIP LOCKED
-   *  keeps claims race-free across the pool (and across replicas). Set QUEUE_CONCURRENCY=1 to force strict serial. */
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 1 — keep the out-of-the-box
+   *  self-host profile conservative on small hosts (#1828). Invalid env values fail closed to 1; operators who
+   *  have profiled their stack can raise QUEUE_CONCURRENCY explicitly. FOR UPDATE SKIP LOCKED keeps claims safe. */
   concurrency?: number;
   /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to QUEUE_BACKGROUND_CONCURRENCY or 1. */
   backgroundConcurrency?: number;
@@ -90,9 +91,7 @@ export function createPgQueue(
   const backoff =
     opts.backoffMs ??
     ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
-  const concurrency =
-    opts.concurrency ??
-    Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "4"));
+  const concurrency = opts.concurrency ?? queueConcurrency();
   const backgroundConcurrency = queueBackgroundConcurrency(
     concurrency,
     opts.backgroundConcurrency,

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -9,6 +9,7 @@ const DEFAULT_STARTUP_JITTER_MS = 3 * 60_000;
 const DEFAULT_RECOVERY_JITTER_MS = 60_000;
 const DEFAULT_STARTUP_JITTER_MIN_JOBS = 8;
 const DEFAULT_PROCESSING_TIMEOUT_MS = 30 * 60_000;
+const DEFAULT_QUEUE_CONCURRENCY = 1;
 const DEFAULT_BACKGROUND_CONCURRENCY = 1;
 export const FOREGROUND_QUEUE_PRIORITY_FLOOR = 8;
 
@@ -59,6 +60,18 @@ function agentRegatePriority(payload: string): number {
 
 export function isForegroundJobPriority(priority: number): boolean {
   return priority >= FOREGROUND_QUEUE_PRIORITY_FLOOR;
+}
+
+export function queueConcurrency(
+  configured: unknown = process.env.QUEUE_CONCURRENCY,
+): number {
+  const raw =
+    configured === undefined || configured === null || configured === ""
+      ? DEFAULT_QUEUE_CONCURRENCY
+      : Number(configured);
+  return Number.isFinite(raw) && raw >= 1
+    ? Math.floor(raw)
+    : DEFAULT_QUEUE_CONCURRENCY;
 }
 
 export function queueBackgroundConcurrency(

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -18,6 +18,7 @@ import {
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
+  queueConcurrency,
   queueProcessingTimeoutMs,
   queueRecoveryJitterMs,
   queueStartupJitterMinJobs,
@@ -74,9 +75,9 @@ export interface SqliteQueueOptions {
   maxRetries?: number;
   pollIntervalMs?: number;
   backoffMs?: (attempt: number) => number;
-  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 4 — review jobs are I/O-bound
-   *  (GitHub + AI awaits dominate), so overlapping a handful drains a PR burst far faster while SQLite's WAL +
-   *  busy_timeout absorb the short serialized write windows. Set QUEUE_CONCURRENCY=1 to force strict serial. */
+  /** Max concurrent `processOne()` loops. Defaults to QUEUE_CONCURRENCY env var or 1 — the beginner-friendly
+   *  minimal self-host profile should stay serial until an operator has profiled their own box (#1828). Invalid
+   *  env values fail closed to 1; raise QUEUE_CONCURRENCY explicitly when the host has headroom. */
   concurrency?: number;
   /** Max background jobs (priority < 8) allowed to consume concurrent slots. Defaults to QUEUE_BACKGROUND_CONCURRENCY or 1. */
   backgroundConcurrency?: number;
@@ -92,9 +93,7 @@ export function createSqliteQueue(
   const backoff =
     opts.backoffMs ??
     ((attempt: number) => Math.min(60_000, 1000 * 2 ** attempt));
-  const concurrency =
-    opts.concurrency ??
-    Math.max(1, Number(process.env.QUEUE_CONCURRENCY ?? "4"));
+  const concurrency = opts.concurrency ?? queueConcurrency();
   const backgroundConcurrency = queueBackgroundConcurrency(
     concurrency,
     opts.backgroundConcurrency,

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -772,6 +772,99 @@ describe("createPgQueue (durable #977)", () => {
     expect(maxConcurrent).toBe(2);
   });
 
+  it("defaults QUEUE_CONCURRENCY to 1 when the env var is unset (#1828)", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    delete process.env.QUEUE_CONCURRENCY;
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const m = makePool();
+      m.enqueueJob("1", { type: "a" });
+      m.enqueueJob("2", { type: "b" });
+      const q = createPgQueue(
+        m.pool,
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.init();
+      await q.binding.send(msg("a"));
+      await q.binding.send(msg("b"));
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(1);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
+  it("uses the QUEUE_CONCURRENCY env override when options.concurrency is absent", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    process.env.QUEUE_CONCURRENCY = "2";
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const m = makePool();
+      m.enqueueJob("1", { type: "a" });
+      m.enqueueJob("2", { type: "b" });
+      const q = createPgQueue(
+        m.pool,
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.init();
+      await q.binding.send(msg("a"));
+      await q.binding.send(msg("b"));
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(2);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
+  it("fails closed to QUEUE_CONCURRENCY=1 when the env var is invalid", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    process.env.QUEUE_CONCURRENCY = "not-a-number";
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const m = makePool();
+      m.enqueueJob("1", { type: "a" });
+      m.enqueueJob("2", { type: "b" });
+      const q = createPgQueue(
+        m.pool,
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.init();
+      await q.binding.send(msg("a"));
+      await q.binding.send(msg("b"));
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(1);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
   it("start() and stop() run the poll loop", async () => {
     const m = makePool();
     m.enqueueJob("1", { type: "ticked" });

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1076,7 +1076,10 @@ describe("createSqliteQueue (durable #980)", () => {
         },
         { pollIntervalMs: 100_000 },
       );
-      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await q.binding.sendBatch([
+        { body: msg("github-webhook") },
+        { body: msg("github-webhook") },
+      ]);
       await new Promise((r) => setTimeout(r, 60));
       await q.stop();
       expect(maxConcurrent).toBe(1);
@@ -1102,7 +1105,10 @@ describe("createSqliteQueue (durable #980)", () => {
         },
         { pollIntervalMs: 100_000 },
       );
-      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await q.binding.sendBatch([
+        { body: msg("github-webhook") },
+        { body: msg("github-webhook") },
+      ]);
       await new Promise((r) => setTimeout(r, 60));
       await q.stop();
       expect(maxConcurrent).toBe(2);
@@ -1128,7 +1134,10 @@ describe("createSqliteQueue (durable #980)", () => {
         },
         { pollIntervalMs: 100_000 },
       );
-      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await q.binding.sendBatch([
+        { body: msg("github-webhook") },
+        { body: msg("github-webhook") },
+      ]);
       await new Promise((r) => setTimeout(r, 60));
       await q.stop();
       expect(maxConcurrent).toBe(1);

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1060,6 +1060,84 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.size()).toBe(0);
   });
 
+  it("defaults QUEUE_CONCURRENCY to 1 when the env var is unset (#1828)", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    delete process.env.QUEUE_CONCURRENCY;
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const q = createSqliteQueue(
+        makeDriver(),
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(1);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
+  it("uses the QUEUE_CONCURRENCY env override when options.concurrency is absent", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    process.env.QUEUE_CONCURRENCY = "2";
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const q = createSqliteQueue(
+        makeDriver(),
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(2);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
+  it("fails closed to QUEUE_CONCURRENCY=1 when the env var is invalid", async () => {
+    const previous = process.env.QUEUE_CONCURRENCY;
+    process.env.QUEUE_CONCURRENCY = "not-a-number";
+    try {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      const q = createSqliteQueue(
+        makeDriver(),
+        async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 15));
+          concurrent--;
+        },
+        { pollIntervalMs: 100_000 },
+      );
+      await q.binding.sendBatch([{ body: msg("a") }, { body: msg("b") }]);
+      await new Promise((r) => setTimeout(r, 60));
+      await q.stop();
+      expect(maxConcurrent).toBe(1);
+    } finally {
+      if (previous === undefined) delete process.env.QUEUE_CONCURRENCY;
+      else process.env.QUEUE_CONCURRENCY = previous;
+    }
+  });
+
   it("start() is idempotent and stop() waits for an in-flight pump", async () => {
     let done = false;
     const q = createSqliteQueue(makeDriver(), async () => {


### PR DESCRIPTION
## Summary

- Restore the self-host queue runtime default to `QUEUE_CONCURRENCY=1` for both SQLite and Postgres queues so the default stack stays resource-conservative again.
- Add regression tests covering the unset-env fallback and env override paths.
- Document resource-sensitive self-host defaults, profile planning, and operator checks for issue #1828.

Fixes #1828

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable. This PR has no visible UI, frontend, docs-site, or extension review surface that requires screenshots.

## Notes

- This issue is part of the self-host profiling/tuning follow-up. The concrete fix here is to make the default worker concurrency conservative again unless operators explicitly raise it after profiling their host.
- Added docs now describe the default stack, optional profiles, retention defaults, and simple pressure-check commands for operators.
