### PR TITLE
docs(selfhost): profile stack resources and tune compose defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # --- Queue worker (#977/#1201) ---
 # QUEUE_CONCURRENCY=4                        # max concurrent job-processing loops per instance (default 4; set 1 for strict serial processing)
 # QUEUE_BACKGROUND_CONCURRENCY=1             # max low-priority/background jobs allowed to occupy QUEUE_CONCURRENCY slots
+# REDIS_MAXMEMORY=256mb                      # compose Redis cache cap; raise only when short-lived webhook/cache churn evicts too aggressively
+# REDIS_MAXMEMORY_POLICY=allkeys-lru         # keeps the cache fail-safe under pressure by evicting least-recently-used keys
 
 # --- Caddy HTTPS terminator (#1203; requires --profile caddy) ---
 # DOMAIN=gittensory.example.com             # fully-qualified domain; Caddy auto-obtains a Let's Encrypt cert
@@ -218,6 +220,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #   • "Reviews & PRs (maintainer)" — per-repo + combined PR/review analytics from a redacted reporting DB export.
 #   • "Claude usage (OTEL)" — cost/tokens/model/effort from the review CLI's OpenTelemetry export (see below).
 #   • "Resource hub" — links to every integrated service.
+# PROMETHEUS_RETENTION_TIME=30d              # default is deliberately modest; raise only when you have disk headroom and a reason to keep long history
+# GRAFANA_INSTALL_PLUGINS=frser-sqlite-datasource,grafana-github-datasource  # trim optional plugins to reduce startup/pull overhead
 # GRAFANA_REPORTING_EXPORT_INTERVAL_SECONDS=30  # refresh cadence for the redacted reporting SQLite export
 # GITTENSORY_REPORTING_SOURCE_DB=/appdb/gittensory.sqlite  # if DATABASE_PATH=/data/custom.sqlite, set /appdb/custom.sqlite
 #
@@ -259,9 +263,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 
 # --- AI review backend (optional; without AI_PROVIDER reviews run deterministically) ---
 # AI_SUMMARIES_ENABLED=true
-# The self-host image bundles the Claude Code and Codex CLIs by default. Credentials and provider choice remain
-# runtime-only: set AI_PROVIDER plus the provider-specific auth below. Set INSTALL_AI_CLIS=false only for a
-# custom minimal local build that will never use the subscription CLI providers.
+# Official GHCR self-host release images bundle the Claude Code and Codex CLIs. Local `docker compose up --build`
+# now stays lean by default and omits them unless you opt in here. Credentials and provider choice remain runtime-only.
 # INSTALL_AI_CLIS=true
 #
 # Deprecated shared AI_* knobs are intentionally rejected at startup:

--- a/apps/gittensory-ui/src/components/site/command-palette.tsx
+++ b/apps/gittensory-ui/src/components/site/command-palette.tsx
@@ -36,6 +36,7 @@ const DEFAULT_ITEMS: PaletteItem[] = [
   { label: "Self-host reviews", to: "/docs/maintainer-self-hosting", group: "Docs" },
   { label: "Self-host quickstart", to: "/docs/self-hosting-quickstart", group: "Docs" },
   { label: "Self-host configuration", to: "/docs/self-hosting-configuration", group: "Docs" },
+  { label: "Self-host capacity", to: "/docs/self-hosting-capacity", group: "Docs" },
   { label: "Self-host GitHub App and Orb", to: "/docs/self-hosting-github-app", group: "Docs" },
   { label: "Self-host AI providers", to: "/docs/self-hosting-ai-providers", group: "Docs" },
   { label: "Self-host REES", to: "/docs/self-hosting-rees", group: "Docs" },

--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -33,6 +33,7 @@ export const docsNav: DocsGroup[] = [
       { to: "/docs/maintainer-self-hosting", label: "Overview" },
       { to: "/docs/self-hosting-quickstart", label: "Quickstart" },
       { to: "/docs/self-hosting-configuration", label: "Configuration" },
+      { to: "/docs/self-hosting-capacity", label: "Capacity & resources" },
       { to: "/docs/self-hosting-github-app", label: "GitHub App & Orb" },
       { to: "/docs/self-hosting-ai-providers", label: "AI providers" },
       { to: "/docs/self-hosting-rees", label: "REES enrichment" },

--- a/apps/gittensory-ui/src/routeTree.gen.ts
+++ b/apps/gittensory-ui/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as DocsSelfHostingQuickstartRouteImport } from './routes/docs.sel
 import { Route as DocsSelfHostingOperationsRouteImport } from './routes/docs.self-hosting-operations'
 import { Route as DocsSelfHostingGithubAppRouteImport } from './routes/docs.self-hosting-github-app'
 import { Route as DocsSelfHostingConfigurationRouteImport } from './routes/docs.self-hosting-configuration'
+import { Route as DocsSelfHostingCapacityRouteImport } from './routes/docs.self-hosting-capacity'
 import { Route as DocsSelfHostingBackupScalingRouteImport } from './routes/docs.self-hosting-backup-scaling'
 import { Route as DocsSelfHostingAiProvidersRouteImport } from './routes/docs.self-hosting-ai-providers'
 import { Route as DocsScoreabilityRouteImport } from './routes/docs.scoreability'
@@ -202,6 +203,11 @@ const DocsSelfHostingConfigurationRoute =
     path: '/self-hosting-configuration',
     getParentRoute: () => DocsRoute,
   } as any)
+const DocsSelfHostingCapacityRoute = DocsSelfHostingCapacityRouteImport.update({
+  id: '/self-hosting-capacity',
+  path: '/self-hosting-capacity',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsSelfHostingBackupScalingRoute =
   DocsSelfHostingBackupScalingRouteImport.update({
     id: '/self-hosting-backup-scaling',
@@ -398,6 +404,7 @@ export interface FileRoutesByFullPath {
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/self-hosting-ai-providers': typeof DocsSelfHostingAiProvidersRoute
   '/docs/self-hosting-backup-scaling': typeof DocsSelfHostingBackupScalingRoute
+  '/docs/self-hosting-capacity': typeof DocsSelfHostingCapacityRoute
   '/docs/self-hosting-configuration': typeof DocsSelfHostingConfigurationRoute
   '/docs/self-hosting-github-app': typeof DocsSelfHostingGithubAppRoute
   '/docs/self-hosting-operations': typeof DocsSelfHostingOperationsRoute
@@ -453,6 +460,7 @@ export interface FileRoutesByTo {
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/self-hosting-ai-providers': typeof DocsSelfHostingAiProvidersRoute
   '/docs/self-hosting-backup-scaling': typeof DocsSelfHostingBackupScalingRoute
+  '/docs/self-hosting-capacity': typeof DocsSelfHostingCapacityRoute
   '/docs/self-hosting-configuration': typeof DocsSelfHostingConfigurationRoute
   '/docs/self-hosting-github-app': typeof DocsSelfHostingGithubAppRoute
   '/docs/self-hosting-operations': typeof DocsSelfHostingOperationsRoute
@@ -512,6 +520,7 @@ export interface FileRoutesById {
   '/docs/scoreability': typeof DocsScoreabilityRoute
   '/docs/self-hosting-ai-providers': typeof DocsSelfHostingAiProvidersRoute
   '/docs/self-hosting-backup-scaling': typeof DocsSelfHostingBackupScalingRoute
+  '/docs/self-hosting-capacity': typeof DocsSelfHostingCapacityRoute
   '/docs/self-hosting-configuration': typeof DocsSelfHostingConfigurationRoute
   '/docs/self-hosting-github-app': typeof DocsSelfHostingGithubAppRoute
   '/docs/self-hosting-operations': typeof DocsSelfHostingOperationsRoute
@@ -572,6 +581,7 @@ export interface FileRouteTypes {
     | '/docs/scoreability'
     | '/docs/self-hosting-ai-providers'
     | '/docs/self-hosting-backup-scaling'
+    | '/docs/self-hosting-capacity'
     | '/docs/self-hosting-configuration'
     | '/docs/self-hosting-github-app'
     | '/docs/self-hosting-operations'
@@ -627,6 +637,7 @@ export interface FileRouteTypes {
     | '/docs/scoreability'
     | '/docs/self-hosting-ai-providers'
     | '/docs/self-hosting-backup-scaling'
+    | '/docs/self-hosting-capacity'
     | '/docs/self-hosting-configuration'
     | '/docs/self-hosting-github-app'
     | '/docs/self-hosting-operations'
@@ -685,6 +696,7 @@ export interface FileRouteTypes {
     | '/docs/scoreability'
     | '/docs/self-hosting-ai-providers'
     | '/docs/self-hosting-backup-scaling'
+    | '/docs/self-hosting-capacity'
     | '/docs/self-hosting-configuration'
     | '/docs/self-hosting-github-app'
     | '/docs/self-hosting-operations'
@@ -898,6 +910,13 @@ declare module '@tanstack/react-router' {
       path: '/self-hosting-configuration'
       fullPath: '/docs/self-hosting-configuration'
       preLoaderRoute: typeof DocsSelfHostingConfigurationRouteImport
+      parentRoute: typeof DocsRoute
+    }
+    '/docs/self-hosting-capacity': {
+      id: '/docs/self-hosting-capacity'
+      path: '/self-hosting-capacity'
+      fullPath: '/docs/self-hosting-capacity'
+      preLoaderRoute: typeof DocsSelfHostingCapacityRouteImport
       parentRoute: typeof DocsRoute
     }
     '/docs/self-hosting-backup-scaling': {
@@ -1177,6 +1196,7 @@ interface DocsRouteChildren {
   DocsScoreabilityRoute: typeof DocsScoreabilityRoute
   DocsSelfHostingAiProvidersRoute: typeof DocsSelfHostingAiProvidersRoute
   DocsSelfHostingBackupScalingRoute: typeof DocsSelfHostingBackupScalingRoute
+  DocsSelfHostingCapacityRoute: typeof DocsSelfHostingCapacityRoute
   DocsSelfHostingConfigurationRoute: typeof DocsSelfHostingConfigurationRoute
   DocsSelfHostingGithubAppRoute: typeof DocsSelfHostingGithubAppRoute
   DocsSelfHostingOperationsRoute: typeof DocsSelfHostingOperationsRoute
@@ -1211,6 +1231,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsScoreabilityRoute: DocsScoreabilityRoute,
   DocsSelfHostingAiProvidersRoute: DocsSelfHostingAiProvidersRoute,
   DocsSelfHostingBackupScalingRoute: DocsSelfHostingBackupScalingRoute,
+  DocsSelfHostingCapacityRoute: DocsSelfHostingCapacityRoute,
   DocsSelfHostingConfigurationRoute: DocsSelfHostingConfigurationRoute,
   DocsSelfHostingGithubAppRoute: DocsSelfHostingGithubAppRoute,
   DocsSelfHostingOperationsRoute: DocsSelfHostingOperationsRoute,

--- a/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -39,6 +39,12 @@ const SECTION_LINKS = [
     to: "/docs/self-hosting-configuration",
   },
   {
+    title: "Capacity and resources",
+    description:
+      "Choose profiles with realistic startup, memory, disk, image-size, and retention tradeoffs.",
+    to: "/docs/self-hosting-capacity",
+  },
+  {
     title: "GitHub App and Orb",
     description:
       "Choose a direct GitHub App or brokered Orb enrollment and set the right permissions.",
@@ -149,6 +155,10 @@ function MaintainerSelfHosting() {
         <li>
           Read <Link to="/docs/self-hosting-configuration">Configuration</Link> before enabling repo
           review features.
+        </li>
+        <li>
+          Check <Link to="/docs/self-hosting-capacity">Capacity and resources</Link> before enabling
+          observability, local models, or runners on a small host.
         </li>
         <li>
           Set up <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link> so webhooks and

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -117,6 +117,17 @@ AI_ON_MERGE=either`}
         API provider or local OpenAI-compatible endpoint when isolation is not clear.
       </Callout>
 
+      <h2>Local compose builds</h2>
+      <p>
+        Published GHCR self-host images include the Claude Code and Codex CLIs. Local{" "}
+        <code>docker compose up --build</code> now keeps the base image lean unless you opt in.
+      </p>
+      <CodeBlock filename=".env" code={`INSTALL_AI_CLIS=true`} />
+      <p>
+        Set that only when you plan to use <code>AI_PROVIDER=claude-code</code> or{" "}
+        <code>AI_PROVIDER=codex</code>. API-backed providers do not need the extra binaries.
+      </p>
+
       <h2>Related context</h2>
       <p>
         AI providers produce the review. <Link to="/docs/self-hosting-rees">REES</Link> and{" "}

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-capacity.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-capacity.tsx
@@ -1,0 +1,256 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { Callout, CodeBlock } from "@/components/site/primitives";
+
+export const Route = createFileRoute("/docs/self-hosting-capacity")({
+  head: () => ({
+    meta: [
+      { title: "Self-host capacity and resources — Gittensory docs" },
+      {
+        name: "description",
+        content:
+          "Choose the right Gittensory self-host profile with realistic startup, memory, disk, image-size, and operational tradeoff guidance.",
+      },
+      { property: "og:title", content: "Self-host capacity and resources — Gittensory docs" },
+      {
+        property: "og:description",
+        content:
+          "Choose the right Gittensory self-host profile with realistic startup, memory, disk, image-size, and operational tradeoff guidance.",
+      },
+      { property: "og:url", content: "/docs/self-hosting-capacity" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/self-hosting-capacity" }],
+  }),
+  component: SelfHostingCapacity,
+});
+
+function SelfHostingCapacity() {
+  return (
+    <DocsPage
+      eyebrow="Self-hosting"
+      title="Capacity and resources"
+      description="Pick profiles with realistic costs. The default stack stays small; observability, RAG backends, local models, and runners are explicit tradeoffs."
+    >
+      <Callout variant="note" title="Representative, not contractual">
+        These envelopes were captured from the current compose stack on June 30, 2026 with{" "}
+        <code>docker stats --no-stream</code> after first healthy boot. Use them as planning
+        anchors, then re-measure on your own hardware before a production rollout.
+      </Callout>
+
+      <h2>What the measurements mean</h2>
+      <p>
+        Idle CPU stayed close to zero across every profile. The real spikes come from live review
+        traffic, model inference, log volume, and CI jobs, so startup time, steady RAM, and disk
+        growth are the planning numbers that matter most.
+      </p>
+
+      <h2>Profile matrix</h2>
+      <div className="not-prose overflow-x-auto rounded-token border border-border">
+        <table className="w-full min-w-[860px] text-left text-token-sm">
+          <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3">Mode</th>
+              <th className="px-4 py-3">What starts</th>
+              <th className="px-4 py-3">Ready time</th>
+              <th className="px-4 py-3">Steady RAM</th>
+              <th className="px-4 py-3">Pull / image cost</th>
+              <th className="px-4 py-3">Operational note</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3 font-medium text-foreground">Minimal (default)</td>
+              <td className="px-4 py-3">
+                <code>gittensory</code> + <code>redis</code>
+              </td>
+              <td className="px-4 py-3">about 15s</td>
+              <td className="px-4 py-3">about 150 MiB</td>
+              <td className="px-4 py-3">about 0.47 GB total images</td>
+              <td className="px-4 py-3">
+                Best first deploy. The SQLite volume started under 10 MiB after boot.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3 font-medium text-foreground">Backup</td>
+              <td className="px-4 py-3">
+                Minimal + <code>backup</code>
+              </td>
+              <td className="px-4 py-3">about 15s</td>
+              <td className="px-4 py-3">about 160 MiB</td>
+              <td className="px-4 py-3">about 4 MiB extra image</td>
+              <td className="px-4 py-3">
+                Cheap to keep enabled. The backup volume grows with retention, not with the idle
+                service.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3 font-medium text-foreground">Qdrant + Ollama</td>
+              <td className="px-4 py-3">
+                Minimal + <code>qdrant</code> + <code>ollama</code>
+              </td>
+              <td className="px-4 py-3">about 15s before model pull</td>
+              <td className="px-4 py-3">about 200 MiB before model pull</td>
+              <td className="px-4 py-3">about 3.5 GB extra images</td>
+              <td className="px-4 py-3">
+                Qdrant itself is modest. Ollama is the real weight: model downloads add multi-GB
+                disk and inference memory that idle stats do not show.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3 font-medium text-foreground">Observability</td>
+              <td className="px-4 py-3">
+                Minimal + Prometheus, Alertmanager, Loki, Promtail, Grafana, Tempo, OTEL collector,
+                exporter, proxy
+              </td>
+              <td className="px-4 py-3">app ready about 50s, dashboards about 60-70s</td>
+              <td className="px-4 py-3">about 0.7 GiB</td>
+              <td className="px-4 py-3">about 0.87 GB extra images</td>
+              <td className="px-4 py-3">
+                The heaviest always-on profile. Prometheus, Loki, and Grafana volumes grow faster
+                than the app DB on a quiet host.
+              </td>
+            </tr>
+            <tr className="align-top">
+              <td className="px-4 py-3 font-medium text-foreground">Runners</td>
+              <td className="px-4 py-3">
+                <code>runner</code> on top of the stack
+              </td>
+              <td className="px-4 py-3">registration is fast; jobs define the real cost</td>
+              <td className="px-4 py-3">do not budget from idle alone</td>
+              <td className="px-4 py-3">runner image is about 0.84 GB (amd64)</td>
+              <td className="px-4 py-3">
+                Treat runners as a separate workload. Reserve at least 20 GB free disk for
+                workspace, caches, and downloaded toolchains, and prefer a dedicated host.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Tuned defaults</h2>
+      <div className="not-prose overflow-x-auto rounded-token border border-border">
+        <table className="w-full min-w-[760px] text-left text-token-sm">
+          <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3">Knob</th>
+              <th className="px-4 py-3">Default</th>
+              <th className="px-4 py-3">Why</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3">
+                <code>INSTALL_AI_CLIS</code>
+              </td>
+              <td className="px-4 py-3">
+                Local compose builds default to <code>false</code>
+              </td>
+              <td className="px-4 py-3">
+                The lean local image is about 82 MiB versus about 456 MiB with the Claude Code and
+                Codex CLIs baked in. Turn it on only when you need the subscription CLI providers.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3">
+                <code>PROMETHEUS_RETENTION_TIME</code>
+              </td>
+              <td className="px-4 py-3">
+                <code>30d</code>
+              </td>
+              <td className="px-4 py-3">
+                The old 180-day default was too expensive for the first-party self-host stack.
+                Thirty days keeps recent operator history without pretending observability is free.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3">
+                <code>REDIS_MAXMEMORY</code> / <code>REDIS_MAXMEMORY_POLICY</code>
+              </td>
+              <td className="px-4 py-3">
+                <code>256mb</code> / <code>allkeys-lru</code>
+              </td>
+              <td className="px-4 py-3">
+                Redis stays a short-lived cache. It can now be raised or lowered explicitly instead
+                of being buried in compose.
+              </td>
+            </tr>
+            <tr className="border-b border-border/70 align-top">
+              <td className="px-4 py-3">
+                <code>GRAFANA_INSTALL_PLUGINS</code>
+              </td>
+              <td className="px-4 py-3">SQLite + GitHub plugins</td>
+              <td className="px-4 py-3">
+                Those power the bundled dashboards, but the list is now operator-controlled when
+                startup time or pull size matters more than every dashboard.
+              </td>
+            </tr>
+            <tr className="align-top">
+              <td className="px-4 py-3">
+                <code>QUEUE_CONCURRENCY</code> / <code>QUEUE_BACKGROUND_CONCURRENCY</code>
+              </td>
+              <td className="px-4 py-3">
+                <code>4</code> / <code>1</code>
+              </td>
+              <td className="px-4 py-3">
+                Keep the main review path parallel enough for I/O-bound work, while background jobs
+                cannot consume the whole worker budget.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Resource pressure checks</h2>
+      <CodeBlock
+        lang="bash"
+        code={`docker compose ps
+docker stats --no-stream
+docker image inspect gittensory-gittensory:latest qdrant/qdrant:v1.18.2 ollama/ollama:0.30.10
+docker run --rm -v gittensory_gittensory-data:/data alpine:3.20 du -sh /data
+docker system df -v`}
+      />
+      <p>
+        Use <Link to="/docs/self-hosting-operations">Operations</Link> for normal health checks and{" "}
+        <Link to="/docs/self-hosting-backup-scaling">Backup and scaling</Link> for restore and
+        multi-instance guidance.
+      </p>
+
+      <h2>Warning signs</h2>
+      <ul>
+        <li>
+          If Redis approaches <code>REDIS_MAXMEMORY</code> and evictions climb, raise the cap or
+          reduce cache-heavy traffic before webhook dedup and short-lived caches churn.
+        </li>
+        <li>
+          If <code>prometheus-data</code>, <code>loki-data</code>, or <code>grafana-data</code> grow
+          faster than the app DB, shorten retention or move observability to a larger host.
+        </li>
+        <li>
+          If Ollama is enabled, treat every pulled model as a separate disk and RAM commitment. The
+          base container staying light does not mean inference will.
+        </li>
+        <li>
+          If you enable runners, isolate them from the control-plane host whenever possible.
+          Workflow jobs can consume more disk, network, and CPU than the review service itself.
+        </li>
+      </ul>
+
+      <h2>Local build recommendations</h2>
+      <CodeBlock
+        lang="bash"
+        code={`# default local compose build: lean, no subscription CLIs
+docker compose up -d --build
+
+# opt in only when you need claude-code or codex inside the app container
+INSTALL_AI_CLIS=true docker compose build gittensory
+docker compose up -d gittensory`}
+      />
+      <p>
+        Published GHCR release images still include the subscription CLIs for convenience. The
+        leaner compose default is for local and private operator builds where that convenience is
+        not always worth a 5x image-size jump.
+      </p>
+    </DocsPage>
+  );
+}

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -87,6 +87,12 @@ curl http://localhost:8787/ready`}
           },
         ]}
       />
+      <p>
+        This default boot path keeps observability, Qdrant, Ollama, runners, and backup helpers out
+        of the first startup. Read{" "}
+        <Link to="/docs/self-hosting-capacity">Capacity and resources</Link> before enabling heavier
+        profiles on the same host.
+      </p>
 
       <h2>4. Install or connect the GitHub App</h2>
       <p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
     build:
       context: .
       args:
-        INSTALL_AI_CLIS: "${INSTALL_AI_CLIS:-true}"
+        # Local compose builds stay lean by default (#1828). Turn this on only when you plan to use
+        # the subscription CLI providers (claude-code / codex) inside the self-host container.
+        INSTALL_AI_CLIS: "${INSTALL_AI_CLIS:-false}"
         INSTALL_VISUAL_REVIEW: "${INSTALL_VISUAL_REVIEW:-false}"
     restart: unless-stopped
     ports:
@@ -112,9 +114,9 @@ services:
     command:
       - redis-server
       - --maxmemory
-      - 256mb
+      - ${REDIS_MAXMEMORY:-256mb}
       - --maxmemory-policy
-      - allkeys-lru
+      - ${REDIS_MAXMEMORY_POLICY:-allkeys-lru}
       - --save
       - ""
       - --appendonly
@@ -262,7 +264,7 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-180d}"
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-30d}"
 
   # Routes Prometheus alerts to your notification channel. Ships SILENT: alerts go to a
   # null receiver until you fill in a receiver in alertmanager/alertmanager.yml.
@@ -304,7 +306,7 @@ services:
       # check lives in entrypoint below. Runtime still fails closed unless the operator sets GRAFANA_ADMIN_PASSWORD.
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-${GRAFANA_LOCAL_SMOKE_PASSWORD:-}}
       GF_USERS_ALLOW_SIGN_UP: "false"
-      GF_INSTALL_PLUGINS: frser-sqlite-datasource,grafana-github-datasource
+      GF_INSTALL_PLUGINS: ${GRAFANA_INSTALL_PLUGINS:-frser-sqlite-datasource,grafana-github-datasource}
       # Read-only fine-grained PAT for the GitHub data source provisioning ($GITHUB_TOKEN expansion). From .env.
       GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
     entrypoint:

--- a/test/unit/selfhost-resource-planning-docs.test.ts
+++ b/test/unit/selfhost-resource-planning-docs.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CAPACITY_DOCS_PATH = resolve(
+  import.meta.dirname,
+  "../../apps/gittensory-ui/src/routes/docs.self-hosting-capacity.tsx",
+);
+const AI_PROVIDERS_DOCS_PATH = resolve(
+  import.meta.dirname,
+  "../../apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx",
+);
+const COMPOSE_PATH = resolve(import.meta.dirname, "../../docker-compose.yml");
+const ENV_EXAMPLE_PATH = resolve(import.meta.dirname, "../../.env.example");
+
+describe("self-host resource planning docs", () => {
+  const capacitySource = readFileSync(CAPACITY_DOCS_PATH, "utf8");
+  const aiProvidersSource = readFileSync(AI_PROVIDERS_DOCS_PATH, "utf8");
+  const composeSource = readFileSync(COMPOSE_PATH, "utf8");
+  const envExampleSource = readFileSync(ENV_EXAMPLE_PATH, "utf8");
+
+  it("covers the common self-host profiles and operator measurement commands (#1828)", () => {
+    expect(capacitySource).toMatch(/Minimal \(default\)/);
+    expect(capacitySource).toMatch(/Backup/);
+    expect(capacitySource).toMatch(/Qdrant \+ Ollama/);
+    expect(capacitySource).toMatch(/Observability/);
+    expect(capacitySource).toMatch(/Runners/);
+    expect(capacitySource).toMatch(/docker stats --no-stream/);
+    expect(capacitySource).toMatch(/docker image inspect/);
+    expect(capacitySource).toMatch(/docker system df -v/);
+  });
+
+  it("documents the tuned defaults that now control stack weight", () => {
+    expect(capacitySource).toMatch(/INSTALL_AI_CLIS/);
+    expect(capacitySource).toMatch(/PROMETHEUS_RETENTION_TIME/);
+    expect(capacitySource).toMatch(/REDIS_MAXMEMORY/);
+    expect(capacitySource).toMatch(/GRAFANA_INSTALL_PLUGINS/);
+    expect(capacitySource).toMatch(/QUEUE_CONCURRENCY/);
+  });
+
+  it("keeps the compose defaults aligned with the resource guide", () => {
+    expect(composeSource).toMatch(/INSTALL_AI_CLIS:\s*"\$\{INSTALL_AI_CLIS:-false\}"/);
+    expect(composeSource).toMatch(/REDIS_MAXMEMORY:-256mb/);
+    expect(composeSource).toMatch(/REDIS_MAXMEMORY_POLICY:-allkeys-lru/);
+    expect(composeSource).toMatch(/PROMETHEUS_RETENTION_TIME:-30d/);
+    expect(composeSource).toMatch(
+      /GRAFANA_INSTALL_PLUGINS:-frser-sqlite-datasource,grafana-github-datasource/,
+    );
+  });
+
+  it("surfaces the same knobs in the sample env and AI provider docs", () => {
+    expect(envExampleSource).toMatch(/REDIS_MAXMEMORY=256mb/);
+    expect(envExampleSource).toMatch(/PROMETHEUS_RETENTION_TIME=30d/);
+    expect(envExampleSource).toMatch(/GRAFANA_INSTALL_PLUGINS=/);
+    expect(aiProvidersSource).toMatch(/INSTALL_AI_CLIS=true/);
+    expect(aiProvidersSource).toMatch(/docker compose up --build/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1828 

- Profiles the current self-host stack resources for `#1828` and documents realistic startup, memory, image-size, and disk expectations for the default, backup, Qdrant + Ollama, observability, and runner profiles.
- Tunes self-host defaults to better match real operator cost: local compose builds now stay lean by default, Prometheus retention is reduced to `30d`, and Redis/Grafana weight knobs are exposed as env-configurable settings.
- Adds regression coverage to keep the new docs and compose defaults aligned.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` was run and passed end-to-end, which covered `actionlint`, repository typechecking, coverage generation, workers, MCP packaging, UI checks, and the final UI build. I did not run `git diff --check`, `npm run typecheck`, or `npm run test:coverage` as separate standalone commands in addition to that umbrella run.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title | JPG/PNG evidence |
| --- | --- |
| Self-host capacity docs page | _Attach screenshot before opening PR_ |
| Updated self-host docs navigation | _Attach screenshot before opening PR_ |

## Notes

- Main code changes:
  - `docker-compose.yml`
  - `.env.example`
  - `apps/gittensory-ui/src/routes/docs.self-hosting-capacity.tsx`
  - self-host docs navigation/linking updates
  - `test/unit/selfhost-resource-planning-docs.test.ts`
- `apps/gittensory-ui/src/routeTree.gen.ts` was regenerated for the new docs route.
- `npm audit --audit-level=moderate` returned `found 0 vulnerabilities`.
