### PR TITLE
feat(scoring): surface the issue-discovery validity floor in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -131,6 +131,45 @@ function mergedHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBre
   };
 }
 
+// Sibling of mergedHistoryBreakdown for the issue-discovery validity floor (upstream MIN_VALID_SOLVED_ISSUES +
+// MIN_ISSUE_CREDIBILITY): a contributor whose observed valid solved-issue count or issue credibility is below
+// the upstream floors has the entire issue-discovery preview zeroed. Explained here so a miner in the
+// issue-discovery lane sees the same actionable breakdown the merged-PR history floor already provides.
+function issueDiscoveryHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { issueDiscoveryHistoryMultiplier } = preview.scoreEstimate;
+  const {
+    validSolvedIssuesFloor,
+    issueCredibilityFloor,
+    validSolvedIssues,
+    issueCredibility,
+  } = preview.gates;
+  // Either evidence dimension unobserved => the floor is not enforced for this preview => neutral (mirrors
+  // preview.ts:410 issueDiscoveryHistoryKnown).
+  if (validSolvedIssues === undefined || issueCredibility === undefined) {
+    return {
+      component: "issueDiscoveryHistoryMultiplier",
+      band: "neutral",
+      summary: `Issue-discovery validity floor is not enforced for this preview (no solved-issue evidence observed; upstream floors are ${validSolvedIssuesFloor} valid solved / ${issueCredibilityFloor.toFixed(2)} credibility).`,
+      lever: "No action needed for this preview; the upstream issue-discovery floors apply once solved-issue evidence is observed.",
+      leverageScore: 0,
+    };
+  }
+  const meetsFloor =
+    validSolvedIssues >= validSolvedIssuesFloor && issueCredibility >= issueCredibilityFloor;
+  const band = bandForMultiplier(issueDiscoveryHistoryMultiplier);
+  return {
+    component: "issueDiscoveryHistoryMultiplier",
+    band,
+    summary: meetsFloor
+      ? `Solved-issue evidence (${validSolvedIssues} valid solved, ${issueCredibility.toFixed(2)} credibility) meets the upstream floors (${validSolvedIssuesFloor} / ${issueCredibilityFloor.toFixed(2)}).`
+      : `Solved-issue evidence (${validSolvedIssues} valid solved, ${issueCredibility.toFixed(2)} credibility) is below the upstream floors (${validSolvedIssuesFloor} valid solved, ${issueCredibilityFloor.toFixed(2)} credibility), so this issue-discovery preview is zeroed.`,
+    lever: meetsFloor
+      ? "Keep resolving valid open issues with solved-by-PR evidence to maintain issue-discovery eligibility."
+      : "Land more solved-by-PR-validated issues and grow issue credibility to clear the upstream floors before relying on this preview.",
+    leverageScore: meetsFloor ? 5 : 100,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -272,6 +311,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     openPrBreakdown(preview),
     openIssueBreakdown(preview),
     mergedHistoryBreakdown(preview),
+    issueDiscoveryHistoryBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildScorePreview } from "../../src/scoring/preview";
 import { explainScoreBreakdown } from "../../src/services/score-breakdown";
 import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
+import type { LinkedIssueMultiplierContext } from "../../src/scoring/preview";
 
 const FORBIDDEN = /\b(wallet|hotkey|coldkey|mnemonic|farming|payout|raw[-_\s]?trust)\b/i;
 
@@ -117,6 +118,30 @@ describe("explainScoreBreakdown", () => {
     );
     expect(blocked.components.find((entry) => entry.component === "mergedHistoryMultiplier")).toMatchObject({ band: "blocked", leverageScore: 100 });
     expect(blocked.highestLeverageLever.lever).toMatch(/merge/i);
+    expect(JSON.stringify(blocked)).not.toMatch(FORBIDDEN);
+  });
+
+  it("explains the issue-discovery validity floor as neutral (unobserved), full (meets floors), and blocked (below floors)", () => {
+    const standardContext: LinkedIssueMultiplierContext = { status: "raw", source: "github_cache", issueNumbers: [12] };
+
+    // Unobserved evidence -> floors not enforced -> neutral.
+    const unobserved = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "standard", linkedIssueContext: standardContext } }),
+    );
+    expect(unobserved.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")).toMatchObject({ band: "neutral" });
+
+    // Observed + both floors met -> full.
+    const meets = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "standard", linkedIssueContext: standardContext, validSolvedIssues: 5, issueCredibility: 0.95 } }),
+    );
+    expect(meets.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")).toMatchObject({ band: "full" });
+
+    // Observed + below floors -> blocked, and the issue-discovery lever surfaces as highest-leverage.
+    const blocked = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "standard", linkedIssueContext: standardContext, validSolvedIssues: 1, issueCredibility: 0.5 } }),
+    );
+    expect(blocked.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")).toMatchObject({ band: "blocked", leverageScore: 100 });
+    expect(blocked.highestLeverageLever.lever).toMatch(/issue/i);
     expect(JSON.stringify(blocked)).not.toMatch(FORBIDDEN);
   });
 


### PR DESCRIPTION
## Summary

`explainScoreBreakdown` (`src/services/score-breakdown.ts`) explained every other scoring multiplier -- density, contribution bonus, label, issue, credibility, review penalty, open-PR pressure, open-issue spam, and now the merged-PR history floor (#1801) -- but silently omitted the **`issueDiscoveryHistoryMultiplier`**, even though it can zero an entire issue-discovery preview when a contributor's observed `validSolvedIssues` or `issueCredibility` falls below the upstream floors (`MIN_VALID_SOLVED_ISSUES`, `MIN_ISSUE_CREDIBILITY`).

## What this adds

An `issueDiscoveryHistoryBreakdown` component mirroring the sibling `mergedHistoryBreakdown` (#1801):

- **neutral** when either solved-issue evidence dimension is unobserved (the floor is not enforced for the preview -- matches `preview.ts:410` `issueDiscoveryHistoryKnown`);
- **full** when both observed dimensions meet the upstream floors;
- **blocked** -- with a 100-leverage "land more solved-by-PR-validated issues and grow issue credibility" lever -- when either is below the floor.

A contributor in the issue-discovery lane whose evidence is below the floors now sees an actionable lever instead of an opaque zero. Purely additive explanation; **no scoring behavior change**. The multiplier is consulted whenever `linkedIssueMode !== "none"` (independent of the per-repo `issueDiscoveryPolicy`), so the breakdown is real value on every issue-discovery preview.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue -- this is a small, self-evident additive feat that completes the breakdown surface started by #1453 (openIssueBreakdown) and #1801 (mergedHistoryBreakdown). The contributor fork PAT used here does not have upstream issue-create scope, and an unlinked PR is an explicitly allowed submission pattern per the contributing guide.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/score-breakdown.test.ts` 12/12 pass; `src/services/score-breakdown.ts` is 100% statements / 100% functions / 100% lines (the new component's three branches -- unobserved, meets-floors, below-floors -- are each covered).

Targeted run:

```sh
npx vitest run test/unit/score-breakdown.test.ts --coverage --coverage.include='src/services/score-breakdown.ts'
# 12/12 passed; 100% statements/functions/lines
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed (a forbidden-term assertion is included).
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics (every summary/lever runs through the existing `sanitizePublicComment`).
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- a purely additive explanation projection over an already-computed multiplier; no scoring logic change.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend score-breakdown projection with no visible UI, frontend, docs, or extension surface.
