### PR TITLE
fix(queue): coalesce recurring maintenance jobs (#1844)

### DIFF
--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -402,8 +402,14 @@ function normalizedDate(value: unknown): string | null {
 
 function normalizedPathScope(value: unknown): string | null {
   if (!Array.isArray(value)) return null;
-  const paths = [...new Set(value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0).map((entry) => entry.trim()))].sort();
-  return paths.length > 0 ? paths.join(",") : null;
+  const paths = [
+    ...new Set(
+      value
+        .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+        .map((entry) => entry.trim()),
+    ),
+  ].sort();
+  return paths.length > 0 ? JSON.stringify(paths) : null;
 }
 
 function boolFlag(value: unknown): string {

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -236,9 +236,20 @@ export function jobCoalesceKey(payload: string): string | null {
     const message = JSON.parse(payload) as {
       type?: unknown;
       eventName?: unknown;
+      requestedBy?: unknown;
       repoFullName?: unknown;
       prNumber?: unknown;
       attempt?: unknown;
+      force?: unknown;
+      mode?: unknown;
+      segment?: unknown;
+      cursor?: unknown;
+      login?: unknown;
+      day?: unknown;
+      days?: unknown;
+      dryRun?: unknown;
+      variant?: unknown;
+      paths?: unknown;
       payload?: GitHubWebhookPayload | null;
     };
     const type = typeof message.type === "string" ? message.type : "";
@@ -258,6 +269,76 @@ export function jobCoalesceKey(payload: string): string | null {
       return repo && pr !== null && attempt !== null
         ? `recapture-preview:${repo}#${pr}:${attempt}`
         : null;
+    }
+    switch (type) {
+      case "refresh-registry":
+      case "refresh-installation-health":
+      case "refresh-scoring-model":
+      case "refresh-upstream-sources":
+      case "build-upstream-ruleset":
+      case "detect-upstream-drift":
+      case "refresh-upstream-drift":
+      case "file-upstream-drift-issues":
+      case "repair-data-fidelity":
+      case "ops-alerts":
+      case "selftune":
+      case "retry-orb-relay":
+        return type;
+      case "backfill-registered-repos":
+        return keyOf(
+          type,
+          normalizedRepo(message.repoFullName) ?? "all",
+          normalizedEnum(message.mode) ?? "default",
+          boolFlag(message.force),
+        );
+      case "backfill-repo-segment":
+        return keyOf(
+          type,
+          normalizedRepo(message.repoFullName) ?? "unknown",
+          normalizedEnum(message.segment) ?? "unknown",
+          normalizedEnum(message.mode) ?? "default",
+          boolFlag(message.force),
+          normalizedCursor(message.cursor) ?? "start",
+        );
+      case "backfill-pr-details":
+        return keyOf(
+          type,
+          normalizedRepo(message.repoFullName) ?? "unknown",
+          normalizedEnum(message.mode) ?? "default",
+          normalizedCursor(message.cursor) ?? "start",
+        );
+      case "generate-signal-snapshots":
+      case "build-burden-forecasts":
+        return keyOf(type, normalizedRepo(message.repoFullName) ?? "all");
+      case "build-contributor-evidence":
+      case "build-contributor-decision-packs":
+        return keyOf(type, normalizedLogin(message.login) ?? "all");
+      case "refresh-contributor-activity":
+        return keyOf(
+          type,
+          normalizedLogin(message.login) ?? "unknown",
+          normalizedRepo(message.repoFullName) ?? "all",
+        );
+      case "rollup-product-usage":
+        return keyOf(
+          type,
+          normalizedDate(message.day) ?? "latest",
+          normalizedCursor(message.days) ?? "default",
+        );
+      case "prune-retention":
+        return keyOf(type, boolFlag(message.dryRun));
+      case "generate-weekly-value-report":
+        return keyOf(
+          type,
+          normalizedEnum(message.variant) ?? "operator",
+          normalizedCursor(message.days) ?? "default",
+        );
+      case "rag-index-repo":
+        return keyOf(
+          type,
+          normalizedRepo(message.repoFullName) ?? "all",
+          normalizedPathScope(message.paths) ?? "full",
+        );
     }
     if (type !== "github-webhook") return null;
     const eventName =
@@ -294,6 +375,43 @@ function normalizedNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.floor(value)
     : null;
+}
+
+function normalizedLogin(value: unknown): string | null {
+  return typeof value === "string" && value.trim()
+    ? value.trim().toLowerCase()
+    : null;
+}
+
+function normalizedEnum(value: unknown): string | null {
+  return typeof value === "string" && value.trim()
+    ? value.trim().toLowerCase()
+    : null;
+}
+
+function normalizedCursor(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) return String(Math.floor(value));
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizedDate(value: unknown): string | null {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim())
+    ? value.trim()
+    : null;
+}
+
+function normalizedPathScope(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const paths = [...new Set(value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0).map((entry) => entry.trim()))].sort();
+  return paths.length > 0 ? paths.join(",") : null;
+}
+
+function boolFlag(value: unknown): string {
+  return value === true ? "1" : "0";
+}
+
+function keyOf(type: string, ...parts: string[]): string {
+  return `${type}:${parts.join(":")}`;
 }
 
 function numberHeader(

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -301,6 +301,103 @@ describe("createPgQueue (durable #977)", () => {
     );
   });
 
+  it("coalesces recurring maintenance jobs by semantic scope and preserves distinct scopes", async () => {
+    const m = makePool();
+    const q = createPgQueue(m.pool, async () => undefined);
+    await q.init();
+
+    m.fn.mockResolvedValueOnce({ rows: [{ id: "existing-backfill" }], rowCount: 1 });
+    await q.binding.send({
+      type: "backfill-registered-repos",
+      requestedBy: "schedule",
+      repoFullName: "JSONbored/gittensory",
+      mode: "resume",
+      force: true,
+    });
+
+    m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await q.binding.send({
+      type: "backfill-registered-repos",
+      requestedBy: "api",
+      repoFullName: "JSONbored/gittensory",
+      mode: "light",
+      force: true,
+    });
+
+    m.fn.mockResolvedValueOnce({ rows: [{ id: "existing-report" }], rowCount: 1 });
+    await q.binding.send({
+      type: "generate-weekly-value-report",
+      requestedBy: "schedule",
+      variant: "operator",
+      days: 7,
+    });
+
+    m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await q.binding.send({
+      type: "generate-weekly-value-report",
+      requestedBy: "api",
+      variant: "public",
+      days: 7,
+    });
+
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE status='pending' AND job_key=$1"),
+      ["backfill-registered-repos:jsonbored/gittensory:resume:1"],
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE status='pending' AND job_key=$1"),
+      ["backfill-registered-repos:jsonbored/gittensory:light:1"],
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE status='pending' AND job_key=$1"),
+      ["generate-weekly-value-report:operator:7"],
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE status='pending' AND job_key=$1"),
+      ["generate-weekly-value-report:public:7"],
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("SET payload=$1, run_after=GREATEST"),
+      expect.arrayContaining([
+        expect.stringContaining('"type":"backfill-registered-repos"'),
+        expect.any(Number),
+        expect.any(Number),
+        0,
+        "existing-backfill",
+      ]),
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("SET payload=$1, run_after=GREATEST"),
+      expect.arrayContaining([
+        expect.stringContaining('"type":"generate-weekly-value-report"'),
+        expect.any(Number),
+        expect.any(Number),
+        0,
+        "existing-report",
+      ]),
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO _selfhost_jobs (payload"),
+      expect.arrayContaining([
+        expect.stringContaining('"mode":"light"'),
+        expect.any(Number),
+        expect.any(Number),
+        0,
+        "backfill-registered-repos:jsonbored/gittensory:light:1",
+      ]),
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO _selfhost_jobs (payload"),
+      expect.arrayContaining([
+        expect.stringContaining('"variant":"public"'),
+        expect.any(Number),
+        expect.any(Number),
+        0,
+        "generate-weekly-value-report:public:7",
+      ]),
+    );
+  });
+
   it("processes a job successfully (job_complete audit emitted)", async () => {
     const m = makePool();
     m.enqueueJob("1", { type: "review" });

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -260,7 +260,7 @@ describe("self-host queue common helpers", () => {
           segment: "labels",
           mode: "resume",
           force: true,
-          cursor: "page-2",
+          cursor: "  page-2  ",
         }),
       ),
     ).toBe("backfill-repo-segment:jsonbored/gittensory:labels:resume:1:page-2");
@@ -303,7 +303,27 @@ describe("self-host queue common helpers", () => {
           paths: ["README.md", "src/a.ts", "README.md"],
         }),
       ),
-    ).toBe("rag-index-repo:jsonbored/gittensory:README.md,src/a.ts");
+    ).toBe('rag-index-repo:jsonbored/gittensory:["README.md","src/a.ts"]');
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "rag-index-repo",
+          requestedBy: "webhook",
+          repoFullName: "JSONbored/Gittensory",
+          paths: ["a,b", "c"],
+        }),
+      ),
+    ).toBe('rag-index-repo:jsonbored/gittensory:["a,b","c"]');
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "rag-index-repo",
+          requestedBy: "schedule",
+          repoFullName: "JSONbored/Gittensory",
+          paths: ["a", "b,c"],
+        }),
+      ),
+    ).toBe('rag-index-repo:jsonbored/gittensory:["a","b,c"]');
     expect(jobCoalesceKey(payload({ type: "prune-retention", requestedBy: "schedule", dryRun: true }))).toBe(
       "prune-retention:1",
     );

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -234,6 +234,84 @@ describe("self-host queue common helpers", () => {
     ).toBeNull();
   });
 
+  it("coalesces recurring maintenance jobs while preserving their semantic scope", () => {
+    expect(
+      jobCoalesceKey(
+        payload({ type: "backfill-registered-repos", requestedBy: "schedule" }),
+      ),
+    ).toBe("backfill-registered-repos:all:default:0");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "backfill-registered-repos",
+          requestedBy: "api",
+          repoFullName: "JSONbored/Gittensory",
+          mode: "resume",
+          force: true,
+        }),
+      ),
+    ).toBe("backfill-registered-repos:jsonbored/gittensory:resume:1");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "backfill-repo-segment",
+          requestedBy: "schedule",
+          repoFullName: "JSONbored/Gittensory",
+          segment: "labels",
+          mode: "resume",
+          force: true,
+          cursor: "page-2",
+        }),
+      ),
+    ).toBe("backfill-repo-segment:jsonbored/gittensory:labels:resume:1:page-2");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "refresh-contributor-activity",
+          requestedBy: "schedule",
+          login: "OktoFeesh1",
+          repoFullName: "JSONbored/Gittensory",
+        }),
+      ),
+    ).toBe("refresh-contributor-activity:oktofeesh1:jsonbored/gittensory");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "rollup-product-usage",
+          requestedBy: "schedule",
+          day: "2026-06-30",
+          days: 7,
+        }),
+      ),
+    ).toBe("rollup-product-usage:2026-06-30:7");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "generate-weekly-value-report",
+          requestedBy: "schedule",
+          variant: "public",
+          days: 31,
+        }),
+      ),
+    ).toBe("generate-weekly-value-report:public:31");
+    expect(
+      jobCoalesceKey(
+        payload({
+          type: "rag-index-repo",
+          requestedBy: "webhook",
+          repoFullName: "JSONbored/Gittensory",
+          paths: ["README.md", "src/a.ts", "README.md"],
+        }),
+      ),
+    ).toBe("rag-index-repo:jsonbored/gittensory:README.md,src/a.ts");
+    expect(jobCoalesceKey(payload({ type: "prune-retention", requestedBy: "schedule", dryRun: true }))).toBe(
+      "prune-retention:1",
+    );
+    expect(jobCoalesceKey(payload({ type: "ops-alerts", requestedBy: "schedule" }))).toBe(
+      "ops-alerts",
+    );
+  });
+
   it("returns no coalesce key for malformed payloads", () => {
     expect(jobCoalesceKey("not-json")).toBeNull();
   });

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -387,8 +387,8 @@ describe("createSqliteQueue (durable #980)", () => {
       "backfill-registered-repos:jsonbored/gittensory:light:1",
       "generate-weekly-value-report:operator:7",
       "generate-weekly-value-report:public:7",
-      "rag-index-repo:jsonbored/gittensory:src/a.ts,src/b.ts",
-      "rag-index-repo:jsonbored/gittensory:src/c.ts",
+      'rag-index-repo:jsonbored/gittensory:["src/a.ts","src/b.ts"]',
+      'rag-index-repo:jsonbored/gittensory:["src/c.ts"]',
     ]);
     expect(rows.map((row) => JSON.parse(row.payload).requestedBy)).toEqual([
       "api",

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -314,6 +314,96 @@ describe("createSqliteQueue (durable #980)", () => {
     });
   });
 
+  it("coalesces recurring maintenance jobs by semantic scope and keeps distinct scopes separate", async () => {
+    const driver = makeDriver();
+    const q = createSqliteQueue(driver, async () => undefined);
+
+    await q.binding.send({
+      type: "backfill-registered-repos",
+      requestedBy: "schedule",
+      repoFullName: "JSONbored/gittensory",
+      mode: "resume",
+      force: true,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "backfill-registered-repos",
+      requestedBy: "api",
+      repoFullName: "JSONbored/gittensory",
+      mode: "resume",
+      force: true,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "backfill-registered-repos",
+      requestedBy: "api",
+      repoFullName: "JSONbored/gittensory",
+      mode: "light",
+      force: true,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "generate-weekly-value-report",
+      requestedBy: "schedule",
+      variant: "operator",
+      days: 7,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "generate-weekly-value-report",
+      requestedBy: "api",
+      variant: "operator",
+      days: 7,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "generate-weekly-value-report",
+      requestedBy: "api",
+      variant: "public",
+      days: 7,
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "rag-index-repo",
+      requestedBy: "webhook",
+      repoFullName: "JSONbored/gittensory",
+      paths: ["src/b.ts", "src/a.ts"],
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "rag-index-repo",
+      requestedBy: "schedule",
+      repoFullName: "JSONbored/gittensory",
+      paths: ["src/a.ts", "src/b.ts"],
+    }, { delaySeconds: 60 });
+    await q.binding.send({
+      type: "rag-index-repo",
+      requestedBy: "schedule",
+      repoFullName: "JSONbored/gittensory",
+      paths: ["src/c.ts"],
+    }, { delaySeconds: 60 });
+
+    const rows = driver.query(
+      "SELECT payload, job_key FROM _selfhost_jobs ORDER BY id",
+      [],
+    ).rows as Array<{ payload: string; job_key: string }>;
+
+    expect(rows).toHaveLength(6);
+    expect(rows.map((row) => row.job_key)).toEqual([
+      "backfill-registered-repos:jsonbored/gittensory:resume:1",
+      "backfill-registered-repos:jsonbored/gittensory:light:1",
+      "generate-weekly-value-report:operator:7",
+      "generate-weekly-value-report:public:7",
+      "rag-index-repo:jsonbored/gittensory:src/a.ts,src/b.ts",
+      "rag-index-repo:jsonbored/gittensory:src/c.ts",
+    ]);
+    expect(rows.map((row) => JSON.parse(row.payload).requestedBy)).toEqual([
+      "api",
+      "api",
+      "api",
+      "api",
+      "schedule",
+      "schedule",
+    ]);
+    expect(q.stats()).toMatchObject({
+      gittensory_jobs_enqueued_total: 6,
+      gittensory_jobs_coalesced_total: 3,
+    });
+  });
+
   it("does not coalesce terminal pull_request events that carry distinct lifecycle side effects", async () => {
     const driver = makeDriver();
     const q = createSqliteQueue(driver, async () => undefined);


### PR DESCRIPTION
## Summary
This PR adds stable semantic coalescing keys for recurring maintenance queue jobs so duplicate jobs with the same effective scope collapse into one pending job instead of being enqueued repeatedly.
## Related Issue
Fixes: #1844 
## Change Type
- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## What Changed
- Added semantic coalescing keys for recurring maintenance jobs in `src/selfhost/queue-common.ts`
- Covered repo-scoped, contributor-scoped, cursor-scoped, date-scoped, and path-scoped maintenance jobs
- Preserved distinct jobs when their effective scope differs
- Added regression tests for shared queue-key behavior
- Added queue-level tests for both SQLite and Postgres implementations

## Real Behavior Proof
- `npm run test:ci` ✅
- `npm audit --audit-level=moderate` ✅
- Focused regression coverage confirms:
  - duplicate maintenance jobs with the same semantic scope are coalesced
  - different scopes remain separate
  - both SQLite and Postgres queue paths preserve correct behavior

## Checklist
- [x] Fix is implemented
- [x] Regression tests added
- [x] Existing behavior preserved for distinct scopes
- [x] Full local CI passed
- [x] Audit check passed
- [x] Branch pushed

## Notes
- This change targets issue `#1844`
- Branch: `fix-1844-maintenance-job-coalescing`
- Commit: `276c8b6`