### PR TITLE
feat(scoring): surface the time-decay multiplier in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -131,6 +131,31 @@ function mergedHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBre
   };
 }
 
+// Upstream time-decay (#703), env-gated by SCORING_TIME_DECAY_ENABLED (default OFF) and opted into per-preview
+// via input.applyTimeDecay. When the flag is off (the common case) or the PR is fresh, the multiplier is 1 and
+// the breakdown reads as "not enabled" / "fresh" — surfacing the value is a no-op for those previews but
+// surfaces the aged-PR decay lever cleanly when time-decay IS applied.
+function timeDecayBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { timeDecayMultiplier } = preview.scoreEstimate;
+  if (timeDecayMultiplier >= 0.99) {
+    return {
+      component: "timeDecayMultiplier",
+      band: "neutral",
+      summary: "Score is not time-decayed for this preview (the PR is within the fresh-PR grace period, or upstream time-decay is disabled — env SCORING_TIME_DECAY_ENABLED).",
+      lever: "No action needed; aged-PR projections automatically apply the upstream sigmoid decay when time-decay is enabled.",
+      leverageScore: 0,
+    };
+  }
+  const band = bandForMultiplier(timeDecayMultiplier, false);
+  return {
+    component: "timeDecayMultiplier",
+    band,
+    summary: `Score is time-decayed for this aged PR preview (multiplier ${timeDecayMultiplier.toFixed(2)} — upstream sigmoid curve; grace 12h, 50% loss at 10 days, 5% floor through the lookback window).`,
+    lever: "Land the work while it is fresh, or extend the upstream time-decay curve in the repo's master_repositories.json override for this repo to slow the decay.",
+    leverageScore: 20,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -272,6 +297,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     openPrBreakdown(preview),
     openIssueBreakdown(preview),
     mergedHistoryBreakdown(preview),
+    timeDecayBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -84,6 +84,7 @@ describe("explainScoreBreakdown", () => {
         "openPrMultiplier",
         "openIssueMultiplier",
         "mergedHistoryMultiplier",
+        "timeDecayMultiplier",
       ]),
     );
     for (const component of breakdown.components) {
@@ -162,6 +163,29 @@ describe("explainScoreBreakdown", () => {
     expect(breakdown.components.find((entry) => entry.component === "openPrMultiplier")).toMatchObject({ band: "blocked" });
     expect(breakdown.highestLeverageLever.component).toBe("openPrMultiplier");
     expect(breakdown.highestLeverageLever.lever).toMatch(/Land, merge, or close/i);
+  });
+
+  it("explains the time-decay multiplier as neutral (fresh / disabled) and reduced (aged with decay on)", () => {
+    // Default preview: applyTimeDecay is off / PR is fresh => multiplier is 1 => breakdown neutral, surface
+    // the decay-disable context so a contributor understands why there is no age penalty here.
+    const fresh = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none" } }),
+    );
+    expect(fresh.components.find((entry) => entry.component === "timeDecayMultiplier")).toMatchObject({ band: "neutral" });
+
+    // Opt-in + aged PR => upstream sigmoid reduces the multiplier => breakdown reduced with the aged-PR lever.
+    const aged = buildScorePreview({
+      repo,
+      snapshot,
+      input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none", applyTimeDecay: true, prAgeHours: 480 },
+    });
+    const agedBreakdown = explainScoreBreakdown(aged);
+    const decayed = agedBreakdown.components.find((entry) => entry.component === "timeDecayMultiplier")!;
+    expect(decayed.band).not.toBe("neutral");
+    expect(decayed.band).not.toBe("full");
+    expect(decayed.summary).toMatch(/time-decayed|decay/i);
+    expect(decayed.lever).toMatch(/fresh|time-decay curve|sigmoid/i);
+    expect(JSON.stringify(agedBreakdown)).not.toMatch(FORBIDDEN);
   });
 
   it("includes gate highlights without leaking forbidden language", () => {


### PR DESCRIPTION
## Summary

`explainScoreBreakdown` (`src/services/score-breakdown.ts`) explained every other scoring multiplier -- density, contribution bonus, label, issue, credibility, review penalty, open-PR pressure, open-issue spam, the merged-PR history floor (added by #1801), and now the issue-discovery validity floor (added by #1874) -- but silently omitted the **`timeDecayMultiplier`**, even though it multiplies into the final score (`preview.ts:432`) and is the only remaining multiplier on `scoreEstimate` without a breakdown component.

## What this adds

A `timeDecayBreakdown` component mirroring the sibling `mergedHistoryBreakdown` (#1801) and `issueDiscoveryHistoryBreakdown` (#1874):

- **neutral** when the multiplier is `>= 0.99` (the PR is fresh, or upstream time-decay -- env `SCORING_TIME_DECAY_ENABLED`, default OFF -- is disabled for the preview). The summary explicitly surfaces the env flag so a contributor understands why there is no age penalty on their preview.
- **reduced** (or further) with an aged-PR lever ("land the work while it is fresh, or extend the upstream time-decay curve in the repo's `master_repositories.json` override for this repo to slow the decay") when the multiplier has decayed -- purely upstream-sigmoid curve at `preview.ts:1265`.

Purely additive explanation; **no scoring behavior change**.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue -- this is a small, self-evident additive feat that completes the time-decay surface next to #1801 and #1874. The contributor fork PAT used here does not have upstream issue-create scope, and an unlinked PR is an explicitly allowed submission pattern per the contributing guide.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- `test/unit/score-breakdown.test.ts` 12/12 pass; `src/services/score-breakdown.ts` is 100% statements / 100% functions / 100% lines (the new component's two branches -- fresh / disabled and aged-with-decay -- are each covered).

Targeted run:

```sh
npx vitest run test/unit/score-breakdown.test.ts --coverage --coverage.include='src/services/score-breakdown.ts'
# 12/12 passed; 100% statements/functions/lines
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed (a forbidden-term assertion is included).
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics (every summary/lever runs through the existing `sanitizePublicComment`).
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes -- a purely additive explanation projection over an already-computed multiplier; no scoring logic change.
- [x] No UI changes.
- [x] No docs/changelog changes.

## UI Evidence

Not applicable -- backend score-breakdown projection with no visible UI, frontend, docs, or extension surface.
