### PR TITLE
feat(scoring): surface the review-collateral multiplier in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -190,6 +190,26 @@ function reviewPenaltyBreakdown(preview: ScorePreviewResult): ScoreMultiplierBre
   };
 }
 
+// Sibling of reviewPenaltyBreakdown: upstream models review churn twice — reviewPenaltyMultiplier shrinks the
+// current preview while reviewCollateralMultiplier raises the open-PR collateral fraction
+// (OPEN_PR_COLLATERAL_PERCENT × multiplier) reserved on concurrent PRs after CHANGES_REQUESTED reviews.
+function reviewCollateralBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { reviewCollateralMultiplier, collateralFraction } = preview.gates;
+  const elevated = reviewCollateralMultiplier > 1.01;
+  const band: ScoreMultiplierBand = elevated ? "reduced" : "neutral";
+  return {
+    component: "reviewCollateralMultiplier",
+    band,
+    summary: elevated
+      ? `Open-PR review collateral is elevated (effective fraction ${roundBand(collateralFraction)}) because prior CHANGES_REQUESTED reviews on open PRs raised the collateral multiplier above baseline.`
+      : `Open-PR review collateral is at the baseline fraction (${roundBand(collateralFraction)}); no CHANGES_REQUESTED review churn is inflating concurrent-PR collateral.`,
+    lever: elevated
+      ? "Resolve outstanding change requests on open PRs before opening more concurrent work, or expect tighter collateral on the open-PR allowance."
+      : "Keep open PRs review-clean to avoid collateral inflation on concurrent work.",
+    leverageScore: elevated ? Math.min(55, Math.round((reviewCollateralMultiplier - 1) * 40 + 20)) : 6,
+  };
+}
+
 function labelMultiplierBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { labelMultiplier } = preview.scoreEstimate;
   const band: ScoreMultiplierBand = labelMultiplier > 1 ? "full" : labelMultiplier < 1 ? "reduced" : "neutral";
@@ -269,6 +289,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     issueMultiplierBreakdown(preview),
     credibilityBreakdown(preview),
     reviewPenaltyBreakdown(preview),
+    reviewCollateralBreakdown(preview),
     openPrBreakdown(preview),
     openIssueBreakdown(preview),
     mergedHistoryBreakdown(preview),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -81,6 +81,7 @@ describe("explainScoreBreakdown", () => {
         "issueMultiplier",
         "credibilityMultiplier",
         "reviewPenaltyMultiplier",
+        "reviewCollateralMultiplier",
         "openPrMultiplier",
         "openIssueMultiplier",
         "mergedHistoryMultiplier",
@@ -212,6 +213,101 @@ describe("explainScoreBreakdown", () => {
     expect(breakdown.components.find((entry) => entry.component === "openPrMultiplier")).toMatchObject({ band: "full" });
     expect(breakdown.components.find((entry) => entry.component === "credibilityMultiplier")).toMatchObject({ band: "full" });
     expect(breakdown.components.find((entry) => entry.component === "reviewPenaltyMultiplier")).toMatchObject({ band: "full" });
+    expect(breakdown.components.find((entry) => entry.component === "reviewCollateralMultiplier")).toMatchObject({ band: "neutral" });
+  });
+
+  it("explains elevated open-PR review collateral as reduced strength and baseline as neutral", () => {
+    const baseline = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          sourceTokenScore: 80,
+          totalTokenScore: 100,
+          sourceLines: 50,
+          openPrCount: 1,
+          credibility: 1,
+          changesRequestedCount: 0,
+        },
+      }),
+    );
+    expect(baseline.components.find((entry) => entry.component === "reviewCollateralMultiplier")).toMatchObject({
+      band: "neutral",
+      summary: expect.stringMatching(/baseline fraction/i),
+    });
+
+    const elevated = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot: {
+          ...snapshot,
+          constants: { ...snapshot.constants, MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER: 2.0 },
+        },
+        input: {
+          repoFullName: repo.fullName,
+          sourceTokenScore: 80,
+          totalTokenScore: 100,
+          sourceLines: 50,
+          openPrCount: 1,
+          credibility: 1,
+          changesRequestedCount: 4,
+        },
+      }),
+    );
+    const collateral = elevated.components.find((entry) => entry.component === "reviewCollateralMultiplier");
+    expect(collateral).toMatchObject({ band: "reduced" });
+    expect(collateral?.summary).toMatch(/elevated|CHANGES_REQUESTED/i);
+    expect(collateral?.summary).toMatch(/0\.32/);
+    expect(collateral?.lever).toMatch(/change requests/i);
+    expect(JSON.stringify(elevated)).not.toMatch(FORBIDDEN);
+
+    const capped = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot: {
+          ...snapshot,
+          constants: { ...snapshot.constants, MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER: 2.0 },
+        },
+        input: {
+          repoFullName: repo.fullName,
+          sourceTokenScore: 80,
+          totalTokenScore: 100,
+          sourceLines: 50,
+          openPrCount: 1,
+          credibility: 1,
+          changesRequestedCount: 10,
+        },
+      }),
+    );
+    expect(capped.components.find((entry) => entry.component === "reviewCollateralMultiplier")).toMatchObject({
+      band: "reduced",
+      summary: expect.stringMatching(/0\.4/),
+    });
+  });
+
+  it("prioritizes open PR blocking above elevated review collateral", () => {
+    const preview = buildScorePreview({
+      repo,
+      snapshot: {
+        ...snapshot,
+        constants: { ...snapshot.constants, MAX_OPEN_PR_REVIEW_COLLATERAL_MULTIPLIER: 2.0 },
+      },
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 80,
+        totalTokenScore: 100,
+        sourceLines: 50,
+        openPrCount: 8,
+        existingContributorTokenScore: 50,
+        credibility: 1,
+        changesRequestedCount: 4,
+      },
+    });
+
+    const breakdown = explainScoreBreakdown(preview);
+    expect(breakdown.components.find((entry) => entry.component === "reviewCollateralMultiplier")).toMatchObject({ band: "reduced" });
+    expect(breakdown.highestLeverageLever.component).toBe("openPrMultiplier");
   });
 
   it("marks penalty label multipliers as reduced strength (#994)", () => {


### PR DESCRIPTION
## Summary

`explainScoreBreakdown` (`src/services/score-breakdown.ts`) explains the **review penalty multiplier** (`reviewPenaltyMultiplier`) but silently omits the sibling **review-collateral multiplier** (`gates.reviewCollateralMultiplier` / `gates.collateralFraction`), even though upstream models it separately in `src/scoring/preview.ts` (#916) and it directly affects how much token score is reserved as open-PR collateral when a contributor has `CHANGES_REQUESTED` reviews on other open PRs.

Miners juggling concurrent work see open-PR pressure explained via `openPrMultiplier`, yet get no plain-English lever for why their collateral fraction is elevated above the base `OPEN_PR_COLLATERAL_PERCENT`.

## What this adds

A `reviewCollateralBreakdown` component mirroring the existing `reviewPenaltyBreakdown` and sibling gate explainers (#1453, #1801):

- **neutral / full** when `reviewCollateralMultiplier` is at the baseline (no elevated collateral from review churn on open PRs).
- **reduced** when the multiplier is above 1 — summary names the effective collateral fraction (`collateralFraction`) and ties it to prior `CHANGES_REQUESTED` review churn on open PRs.
- Actionable lever: resolve outstanding change requests on open PRs before opening more concurrent work, or expect tighter collateral on the allowance.

Purely additive explanation over already-computed gate fields; **no scoring behavior change**.

## Files touched (estimated)

| File | Change |
| --- | --- |
| `src/services/score-breakdown.ts` | Add `reviewCollateralBreakdown`, wire into `explainScoreBreakdown` |
| `test/unit/score-breakdown.test.ts` | Baseline, elevated-collateral, and forbidden-term regression cases |

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — aim for **100%** statements/branches on changed lines in `src/services/score-breakdown.ts`
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`

Targeted test run:

```sh
npx vitest run test/unit/score-breakdown.test.ts --coverage --coverage.include='src/services/score-breakdown.ts'
```

## Notes

Analogues to imitate end-to-end: `reviewPenaltyBreakdown` and `openPrBreakdown` in `src/services/score-breakdown.ts`, plus the merged-history floor tests in `test/unit/score-breakdown.test.ts`.
