### PR TITLE
fix(services): keep card truncation from splitting surrogate pairs

### DIFF
--- a/src/services/agent-action-explanation-card.ts
+++ b/src/services/agent-action-explanation-card.ts
@@ -130,5 +130,10 @@ function sanitizePublicCardText(value: string): string {
 }
 
 function compactText(value: string): string {
-  return value.replace(/\s+/g, " ").trim().slice(0, 300);
+  const compact = value.replace(/\s+/g, " ").trim().slice(0, 300);
+  // `slice(0, 300)` counts UTF-16 code units, so the 300-unit cap can fall between the high and low
+  // halves of an astral character (an emoji) and leave a lone, unpaired high surrogate — invalid UTF-16
+  // that renders as the replacement character and can break strict JSON/UTF-8 consumers of the API and
+  // public-safe card text. Drop a dangling high surrogate so truncation never splits a pair.
+  return /[\uD800-\uDBFF]$/.test(compact) ? compact.slice(0, -1) : compact;
 }

--- a/test/unit/agent-orchestrator.test.ts
+++ b/test/unit/agent-orchestrator.test.ts
@@ -791,6 +791,55 @@ describe("agent orchestrator", () => {
     expect(card.publicSafe.summary).not.toMatch(/\/root\/work|\/var\/log|C:\/Users\/alice/);
   });
 
+  it("does not split a surrogate pair when truncating a card field at the 300-character cap", () => {
+    // A string is well-formed UTF-16 iff it has no lone surrogate (a high surrogate not followed by a
+    // low one, or a low surrogate not preceded by a high one). Equivalent to String#isWellFormed without
+    // requiring the es2024 lib.
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    // The 😀 (U+1F600) astral char straddles the 300th UTF-16 code unit: indices 0..298 are 'a',
+    // index 299 is the emoji's HIGH surrogate, and its LOW surrogate falls at index 300 (cut off).
+    // A naive slice(0, 300) would leave the lone high surrogate, producing invalid UTF-16.
+    const split = buildAgentActionExplanationCard({
+      actionType: "choose_next_work",
+      status: "recommended",
+      why: [],
+      riskImpact: "a".repeat(299) + "😀" + "tail",
+      blockedBy: [],
+      publicSafeSummary: "",
+      safetyClass: "public_safe",
+    });
+    expect(split.risk).toHaveLength(299);
+    expect(split.risk.endsWith("a")).toBe(true);
+    expect(/[\uD800-\uDBFF]$/.test(split.risk)).toBe(false); // no dangling high surrogate
+    expect(loneSurrogate.test(split.risk)).toBe(false);
+
+    // A complete emoji whose LOW surrogate lands exactly on the 300th unit is a full pair and is kept.
+    const exactPair = buildAgentActionExplanationCard({
+      actionType: "choose_next_work",
+      status: "recommended",
+      why: [],
+      riskImpact: "a".repeat(298) + "😀" + "more",
+      blockedBy: [],
+      publicSafeSummary: "",
+      safetyClass: "public_safe",
+    });
+    expect(exactPair.risk).toHaveLength(300);
+    expect(exactPair.risk.endsWith("😀")).toBe(true);
+    expect(loneSurrogate.test(exactPair.risk)).toBe(false);
+
+    // A short field containing emoji is preserved untouched (well under the cap, no over-trimming).
+    const shortEmoji = buildAgentActionExplanationCard({
+      actionType: "choose_next_work",
+      status: "recommended",
+      why: [],
+      riskImpact: "ship 😀 now",
+      blockedBy: [],
+      publicSafeSummary: "",
+      safetyClass: "public_safe",
+    });
+    expect(shortEmoji.risk).toBe("ship 😀 now");
+  });
+
   it("covers local action ready and blocker-free branches from prepared metadata", () => {
     const run = __agentOrchestratorInternals.buildRunRecord({
       objective: "local ready branch",


### PR DESCRIPTION
## Summary

`compactText` in `src/services/agent-action-explanation-card.ts` caps every explanation-card field at 300 characters with `slice(0, 300)`. `String.prototype.slice` counts UTF-16 **code units**, so when the 300-unit boundary lands between the high and low halves of an astral character (any emoji, e.g. `😀` = `U+D83D U+DE00`) the low surrogate is dropped and the result ends in a **lone high surrogate** — invalid UTF-16 that renders as `�` and can break strict JSON/UTF-8 consumers of the `AgentActionExplanationCard` API/MCP payload and its `publicSafe.*` GitHub-bound text.

This fix makes the truncation surrogate-aware: after the 300-unit cap it drops a dangling high surrogate, so the output is always well-formed UTF-16 (a complete pair that ends exactly on the boundary is preserved). The change is purely defensive and leaves all non-astral text byte-identical.

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-evident UTF-16 correctness fix scoped to a single helper.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the changed `compactText` branch (the dangling-high-surrogate drop) is covered by a new regression test, including the kept-complete-pair and short-emoji branches.
- [ ] Full `npm run test:ci` suite (run the relevant unit + typecheck locally; see notes)
- [x] New or changed behavior has unit tests for the new branch and boundary paths

If any required check was skipped, explain why:

- The change is a single pure-helper branch in `src/services`; it touches no API schema, wrangler binding, migration, or UI, so the OpenAPI/cf-typegen/migration regeneration steps are not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Output is now always well-formed UTF-16; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `compactText("a".repeat(299) + "😀" + "tail")` previously returned a 300-unit string ending in `0xD83D` (a lone high surrogate, `isWellFormed() === false`); it now returns a 299-unit string ending on a complete character.
