### PR TITLE
feat(signals): classify Elixir, Swift, and Gradle lockfiles

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -43,6 +43,9 @@ const LOCKFILE_NAMES: ReadonlySet<string> = new Set([
   "deno.lock",
   "pubspec.lock",
   "podfile.lock",
+  "mix.lock",
+  "package.resolved",
+  "gradle.lockfile",
 ]);
 
 const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -67,6 +67,9 @@ describe("isLockfile", () => {
       "deno.lock",
       "pubspec.lock",
       "Podfile.lock",
+      "mix.lock",
+      "Package.resolved",
+      "gradle.lockfile",
     ]) {
       expect(isLockfile(path)).toBe(true);
     }


### PR DESCRIPTION
## Summary
- Recognize `mix.lock`, `Package.resolved`, and `gradle.lockfile` as dependency lockfiles in slop path matchers

## Test plan
- [x] `npx vitest run test/unit/path-matchers.test.ts`

