### PR TITLE
test(utils): cover json helper edge cases

### DIFF
--- a/test/unit/json-utils.test.ts
+++ b/test/unit/json-utils.test.ts
@@ -1,24 +1,42 @@
 import { describe, expect, it } from "vitest";
-import { errorMessage, jsonString, normalizeRepoFullName, parseJson, repoParts, strippedErrorMessage } from "../../src/utils/json";
+import {
+  errorMessage,
+  jsonString,
+  normalizeRepoFullName,
+  parseJson,
+  repoParts,
+  strippedErrorMessage,
+} from "../../src/utils/json";
 
-describe("JSON and string utility helpers", () => {
-  it("keeps JSON parsing and stringification fallbacks explicit", () => {
-    expect(parseJson<{ ok: boolean }>('{"ok":true}', { ok: false })).toEqual({ ok: true });
-    expect(parseJson("{bad-json", { ok: false })).toEqual({ ok: false });
-    expect(parseJson(null, { ok: false })).toEqual({ ok: false });
-    expect(jsonString(undefined)).toBe("null");
-    expect(jsonString({ ok: true })).toBe('{"ok":true}');
+describe("json utils", () => {
+  it("parseJson returns fallback on empty or invalid JSON", () => {
+    expect(parseJson(null, { ok: true })).toEqual({ ok: true });
+    expect(parseJson("", { ok: true })).toEqual({ ok: true });
+    expect(parseJson("{bad", { ok: true })).toEqual({ ok: true });
+    expect(parseJson('{"n":1}', { ok: false })).toEqual({ n: 1 });
   });
 
-  it("normalizes repo names and error messages without leaking arbitrary thrown values", () => {
-    expect(normalizeRepoFullName(" JSONbored/gittensory ")).toBe("JSONbored/gittensory");
-    expect(repoParts("JSONbored/gittensory")).toEqual({ owner: "JSONbored", name: "gittensory" });
-    expect(repoParts("")).toEqual({ owner: "", name: "" });
-    expect(repoParts("owner/nested/name")).toEqual({ owner: "owner", name: "nested/name" });
+  it("jsonString stringifies values and maps undefined to null", () => {
+    expect(jsonString({ a: 1 })).toBe('{"a":1}');
+    expect(jsonString(undefined)).toBe("null");
+  });
 
-    expect(errorMessage(new Error("specific failure"))).toBe("specific failure");
-    expect(errorMessage("string failure", "fallback failure")).toBe("fallback failure");
-    expect(strippedErrorMessage(new Error("Error: wrapped failure"), "fallback failure")).toBe("wrapped failure");
-    expect(strippedErrorMessage("string failure", "fallback failure")).toBe("fallback failure");
+  it("errorMessage and strippedErrorMessage normalize unknown errors", () => {
+    expect(errorMessage(new Error("boom"), "fallback")).toBe("boom");
+    expect(errorMessage("plain", "fallback")).toBe("fallback");
+    expect(strippedErrorMessage(new Error("Error: nested"), "fallback")).toBe(
+      "nested",
+    );
+    expect(strippedErrorMessage("plain", "fallback")).toBe("fallback");
+  });
+
+  it("normalizeRepoFullName trims whitespace", () => {
+    expect(normalizeRepoFullName("  org/app  ")).toBe("org/app");
+  });
+
+  it("repoParts splits owner and nested repo names", () => {
+    expect(repoParts("")).toEqual({ owner: "", name: "" });
+    expect(repoParts("org/app")).toEqual({ owner: "org", name: "app" });
+    expect(repoParts("org/sub/repo")).toEqual({ owner: "org", name: "sub/repo" });
   });
 });


### PR DESCRIPTION
## Summary
- Add focused unit tests for `parseJson`, `repoParts`, `errorMessage`, and related helpers in `src/utils/json.ts`

## Test plan
- [x] `npx vitest run test/unit/json-utils.test.ts`

