### PR TITLE
fix(mcp): parseGitRemote accepts trailing-slash GitHub URLs

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 export function parseGitRemote(remoteUrl) {
-  const trimmed = String(remoteUrl ?? "").trim();
+  const trimmed = String(remoteUrl ?? "").trim().replace(/\/+$/, "");
   const patterns = [
     /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
     /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1676,6 +1676,7 @@ describe("local MCP git metadata collection", () => {
     const { collectLocalBranchMetadata, parseGitRemote } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
     expect(parseGitRemote("git@github.com:entrius/allways-ui.git")).toBe("entrius/allways-ui");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("https://github.com/JSONbored/gittensory/")).toBe("JSONbored/gittensory");
 
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));
     git(tempDir, "init");


### PR DESCRIPTION
## Summary
- Strip trailing slashes from `origin` remotes before parsing so `https://github.com/owner/repo/` resolves correctly in MCP local-branch metadata

## Test plan
- [x] `npx vitest run test/unit/local-branch.test.ts -t "parses remotes"`

