### PR TITLE
fix(orb): preserve actionable relay PR events

### DIFF
--- a/src/github/webhook-coalesce.ts
+++ b/src/github/webhook-coalesce.ts
@@ -5,8 +5,6 @@ const COALESCABLE_PULL_REQUEST_ACTIONS = new Set([
   "synchronize",
   "edited",
   "ready_for_review",
-  "labeled",
-  "unlabeled",
 ]);
 
 export function githubWebhookCoalesceKey(

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -551,6 +551,44 @@ describe("enqueueRelayPending", () => {
     expect(JSON.parse(rows.results[0]?.raw_body ?? "{}")).toMatchObject({ marker: "new" });
   });
 
+  it("does not let label-only PR events coalesce away pending gate-triggering PR events", async () => {
+    const e = brokeredEnv();
+    const prBody = (action: string, marker: string) =>
+      JSON.stringify({
+        action,
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 1629, head: { sha: "a".repeat(40) } },
+        marker,
+      });
+
+    await enqueueRelayPending(e, {
+      deliveryId: "pr-opened-actionable",
+      installationId: 9608,
+      eventName: "pull_request",
+      rawBody: prBody("opened", "actionable"),
+    });
+    await enqueueRelayPending(e, {
+      deliveryId: "pr-labeled-not-actionable",
+      installationId: 9608,
+      eventName: "pull_request",
+      rawBody: prBody("labeled", "label-only"),
+    });
+
+    const events = await pullRelayPending(e, 9608);
+    expect(events.map((event) => event.deliveryId).sort()).toEqual([
+      "pr-labeled-not-actionable",
+      "pr-opened-actionable",
+    ]);
+    expect(
+      Object.fromEntries(
+        events.map((event) => [event.deliveryId, JSON.parse(event.rawBody).action]),
+      ),
+    ).toEqual({
+      "pr-labeled-not-actionable": "labeled",
+      "pr-opened-actionable": "opened",
+    });
+  });
+
   it("keeps exact duplicate coalescible delivery IDs idempotent", async () => {
     const e = brokeredEnv();
     const body = (marker: string) =>

--- a/test/unit/github-webhook-coalesce.test.ts
+++ b/test/unit/github-webhook-coalesce.test.ts
@@ -24,7 +24,7 @@ describe("githubWebhookCoalesceKey", () => {
     ).toBe("github-webhook:ci-completed:jsonbored/gittensory@def5678");
   });
 
-  it("coalesces refresh-like pull request events and ignores terminal actions", () => {
+  it("coalesces gate-triggering pull request events and ignores non-actionable or terminal actions", () => {
     expect(
       githubWebhookCoalesceKey("pull_request", {
         action: "synchronize",
@@ -40,13 +40,15 @@ describe("githubWebhookCoalesceKey", () => {
         pull_request: { number: 100, head: { sha: "BEEF123" } },
       } as GitHubWebhookPayload),
     ).toBe("github-webhook:pr-refresh:jsonbored/gittensory#100@beef123");
-    expect(
-      githubWebhookCoalesceKey("pull_request", {
-        action: "closed",
-        repository: { full_name: "JSONbored/Gittensory" },
-        pull_request: { number: 100, head: { sha: "BEEF123" } },
-      } as GitHubWebhookPayload),
-    ).toBeNull();
+    for (const action of ["labeled", "unlabeled", "closed"]) {
+      expect(
+        githubWebhookCoalesceKey("pull_request", {
+          action,
+          repository: { full_name: "JSONbored/Gittensory" },
+          pull_request: { number: 100, head: { sha: "BEEF123" } },
+        } as GitHubWebhookPayload),
+      ).toBeNull();
+    }
   });
 
   it("returns null for malformed or non-coalescible webhook shapes", () => {


### PR DESCRIPTION
### Motivation

- The relay coalescing key treated `labeled`/`unlabeled` as pr-refresh events and could delete an earlier actionable PR webhook (e.g. `opened`/`synchronize`) when a label-only event arrived, allowing a pull-mode self-host relay to drop the only gate-triggering event.  

### Description

- Remove `labeled` and `unlabeled` from the pull-request coalescible action set in `src/github/webhook-coalesce.ts` so label-only PR events no longer share the PR refresh coalesce key.  
- Update the unit test in `test/unit/github-webhook-coalesce.test.ts` to assert that `labeled`, `unlabeled`, and `closed` do not produce a PR-refresh coalesce key while actionable events still do.  
- Add an integration regression in `test/integration/orb-relay.test.ts` that enqueues an actionable `opened` PR event followed by a `labeled` event and asserts both pending rows remain (the actionable event is not coalesced away).  

### Testing

- Ran `git diff --check` and `npm run typecheck` and both succeeded.  
- Ran the targeted tests with `npx vitest run test/unit/github-webhook-coalesce.test.ts test/integration/orb-relay.test.ts` and the modified unit and integration tests passed.  
- Attempted `npm run test:ci` but the run could not complete in this environment because `actionlint` setup fell back due to network DNS issues and the fallback flagged the repository's custom self-hosted runner label, so the full CI sweep was not completed here.  
- `npm audit --audit-level=moderate` could not complete locally because the npm audit bulk advisory endpoint returned `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439d630b70832cb4f5232cc975a90d)