### PR TITLE
fix(selfhost): reject compose interpolation in image

### DIFF
--- a/scripts/deploy-selfhost-image.sh
+++ b/scripts/deploy-selfhost-image.sh
@@ -129,8 +129,8 @@ validate_inputs() {
     exit 1
   fi
   case "$image" in
-    *[[:space:]\"\'\\]*)
-      echo "error: image contains unsupported whitespace, quote, or backslash characters" >&2
+    *[[:space:]\"\'\\\$\{\}]*)
+      echo "error: image contains unsupported whitespace, quote, backslash, or compose interpolation characters" >&2
       exit 1
       ;;
   esac

--- a/test/unit/selfhost-image-deploy.test.ts
+++ b/test/unit/selfhost-image-deploy.test.ts
@@ -192,4 +192,23 @@ describe("self-host image deploy script", () => {
       harness.cleanup();
     }
   });
+
+  it.each([
+    "registry.example/gittensory:${GITHUB_OAUTH_CLIENT_SECRET}",
+    "registry.example/gittensory:$GITHUB_OAUTH_CLIENT_SECRET",
+    "registry.example/gittensory:{GITHUB_OAUTH_CLIENT_SECRET}",
+  ])("rejects compose interpolation characters in image %s", (image) => {
+    const { harness, result } = runHarness({ args: [image], envFile: "EXISTING=1\n" });
+    try {
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "image contains unsupported whitespace, quote, backslash, or compose interpolation characters",
+      );
+      expect(readFileSync(harness.envPath, "utf8")).toBe("EXISTING=1\n");
+      expect(harness.readImages()).toBe("");
+      expect(harness.readCalls()).not.toContain(" pull ");
+    } finally {
+      harness.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
### Motivation
- The self-host deploy script wrote an unescaped image string into a generated Docker Compose override, allowing Compose `${...}`/`$VAR` interpolation to expand secrets from the project `.env` during `docker compose pull` and leak them to an attacker-controlled registry.
- Existing validation rejected whitespace/quotes/backslashes but still permitted `$`, `{`, and `}`, so crafted image values could trigger interpolation before the container ever ran.

### Description
- Strengthen `validate_inputs()` in `scripts/deploy-selfhost-image.sh` to reject compose interpolation characters by adding `$`, `{`, and `}` to the disallowed pattern and update the error message accordingly.
- Add regression tests in `test/unit/selfhost-image-deploy.test.ts` that pass crafted image strings containing `${SECRET}`, `$SECRET`, and brace syntax to assert the script fails early, does not persist the image to the env file, does not write a generated override image, and does not call `docker compose pull`.
- Files changed: `scripts/deploy-selfhost-image.sh`, `test/unit/selfhost-image-deploy.test.ts`.

### Testing
- Ran `bash -n scripts/deploy-selfhost-image.sh` with no syntax errors (passed).
- Ran the unit suite for the modified tests with `npx vitest run test/unit/selfhost-image-deploy.test.ts` and all tests passed (`9 tests` passed).
- Ran `npm run typecheck` and it completed successfully.
- Attempted full gate `npm run test:ci` but it was blocked locally by `actionlint` setup/network fallbacks reporting pre-existing workflow runner label config, so the full CI was not executed here.
- Attempted `npm audit --audit-level=moderate` but it failed locally due to the registry audit endpoint returning `403`, so dependency-audit was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439d62cad4832cb7ab2340d6d7a23e)