### PR TITLE
fix(rees): bound shared diff context parsing

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -20,6 +20,10 @@ import {
 
 type ChangedFile = NonNullable<EnrichRequest["files"]>[number];
 
+const MAX_CONTEXT_PATCH_BYTES = 1_000_000;
+const MAX_CONTEXT_ADDED_LINES = 5_000;
+const MAX_CONTEXT_PATCH_HUNKS = 2_000;
+
 export interface AddedLine {
   file: string;
   line: number;
@@ -68,6 +72,7 @@ export interface AnalysisContext {
   changedFilePaths: readonly string[];
   addedLines: readonly AddedLine[];
   patchHunks: readonly PatchHunk[];
+  hasAddedLines: boolean;
   fileCategories: readonly FileCategory[];
   dependencyManifestPaths: readonly string[];
   cache: RequestScopedCache;
@@ -198,6 +203,10 @@ export function createAnalysisContext(
   const metrics = new AnalysisMetrics(startedAtMs, now);
   const cache = new RequestScopedCache(metrics);
   const dependencyChangeCache = new Map<string, readonly DepChange[]>();
+  let changedFilePathsCache: readonly string[] | undefined;
+  let addedLinesCache: readonly AddedLine[] | undefined;
+  let patchHunksCache: readonly PatchHunk[] | undefined;
+  let hasAddedLinesCache: boolean | undefined;
   const fileCategories = changedFiles.map((file) => categorizeFile(file.path));
   const dependencyManifestPaths = fileCategories
     .filter((file) => file.category === "dependency-manifest")
@@ -206,9 +215,22 @@ export function createAnalysisContext(
   const context: AnalysisContext = {
     repo: parseRepoIdentity(req),
     changedFiles,
-    changedFilePaths: changedFiles.map((file) => file.path),
-    addedLines: collectAddedLines(changedFiles),
-    patchHunks: collectPatchHunks(changedFiles),
+    get changedFilePaths() {
+      changedFilePathsCache ??= changedFiles.map((file) => file.path);
+      return changedFilePathsCache;
+    },
+    get addedLines() {
+      addedLinesCache ??= collectAddedLines(changedFiles, { metrics });
+      return addedLinesCache;
+    },
+    get patchHunks() {
+      patchHunksCache ??= collectPatchHunks(changedFiles, { metrics });
+      return patchHunksCache;
+    },
+    get hasAddedLines() {
+      hasAddedLinesCache ??= filesHaveAddedLines(changedFiles, { metrics });
+      return hasAddedLinesCache;
+    },
     fileCategories,
     dependencyManifestPaths,
     cache,
@@ -278,12 +300,15 @@ export function createAnalysisContext(
   return context;
 }
 
-export function collectAddedLines(files: readonly ChangedFile[]): AddedLine[] {
+export function collectAddedLines(
+  files: readonly ChangedFile[],
+  options: { metrics?: AnalysisMetrics } = {},
+): AddedLine[] {
   const addedLines: AddedLine[] = [];
   for (const file of files) {
     if (!file.patch) continue;
     let newLine = 0;
-    for (const line of file.patch.split("\n")) {
+    for (const line of boundedPatchLines(file.patch, options.metrics, "added_lines_patch_bytes")) {
       if (line.startsWith("+++") || line.startsWith("---")) continue;
       if (line.startsWith("diff ") || line.startsWith("index ")) continue;
       const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
@@ -292,6 +317,10 @@ export function collectAddedLines(files: readonly ChangedFile[]): AddedLine[] {
         continue;
       }
       if (line.startsWith("+")) {
+        if (addedLines.length >= MAX_CONTEXT_ADDED_LINES) {
+          options.metrics?.recordCappedWork("added_lines", 1);
+          return addedLines;
+        }
         addedLines.push({ file: file.path, line: newLine, text: line.slice(1) });
         newLine += 1;
       } else if (!line.startsWith("-")) {
@@ -302,14 +331,21 @@ export function collectAddedLines(files: readonly ChangedFile[]): AddedLine[] {
   return addedLines;
 }
 
-export function collectPatchHunks(files: readonly ChangedFile[]): PatchHunk[] {
+export function collectPatchHunks(
+  files: readonly ChangedFile[],
+  options: { metrics?: AnalysisMetrics } = {},
+): PatchHunk[] {
   const hunks: PatchHunk[] = [];
   for (const file of files) {
     if (!file.patch) continue;
-    for (const line of file.patch.split("\n")) {
+    for (const line of boundedPatchLines(file.patch, options.metrics, "patch_hunk_bytes")) {
       const hunk =
         /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
       if (!hunk) continue;
+      if (hunks.length >= MAX_CONTEXT_PATCH_HUNKS) {
+        options.metrics?.recordCappedWork("patch_hunks", 1);
+        return hunks;
+      }
       hunks.push({
         file: file.path,
         oldStart: Number(hunk[1]),
@@ -320,6 +356,43 @@ export function collectPatchHunks(files: readonly ChangedFile[]): PatchHunk[] {
     }
   }
   return hunks;
+}
+
+export function filesHaveAddedLines(
+  files: readonly ChangedFile[],
+  options: { metrics?: AnalysisMetrics } = {},
+): boolean {
+  for (const file of files) {
+    if (!file.patch) continue;
+    for (const line of boundedPatchLines(
+      file.patch,
+      options.metrics,
+      "has_added_lines_patch_bytes",
+    )) {
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (line.startsWith("+")) return true;
+    }
+  }
+  return false;
+}
+
+function* boundedPatchLines(
+  patch: string,
+  metrics: AnalysisMetrics | undefined,
+  cappedCategory: string,
+): Generator<string> {
+  const maxLength = Math.min(patch.length, MAX_CONTEXT_PATCH_BYTES);
+  let lineStart = 0;
+  while (lineStart <= maxLength) {
+    const newline = patch.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 || newline > maxLength ? maxLength : newline;
+    yield patch.slice(lineStart, lineEnd);
+    if (newline === -1 || newline >= maxLength) break;
+    lineStart = newline + 1;
+  }
+  if (patch.length > MAX_CONTEXT_PATCH_BYTES) {
+    metrics?.recordCappedWork(cappedCategory, patch.length - MAX_CONTEXT_PATCH_BYTES);
+  }
 }
 
 function parseRepoIdentity(req: EnrichRequest): RepoIdentity {

--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -372,6 +372,7 @@ export function filesHaveAddedLines(
       if (line.startsWith("+++") || line.startsWith("---")) continue;
       if (line.startsWith("+")) return true;
     }
+    if (file.patch.length > MAX_CONTEXT_PATCH_BYTES) return true;
   }
   return false;
 }

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -350,7 +350,7 @@ function inputSkipReason(
     case "redos":
     case "secret":
     case "secretLog":
-      return analysis.addedLines.length ? null : "no_added_lines";
+      return analysis.hasAddedLines ? null : "no_added_lines";
     case "provenance":
       return analysis.dependencyManifestPaths.length ||
         analysis.changedFiles.some((file) => file.status === "added" || file.status === "copied")

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -338,3 +338,69 @@ test("scanDependencyChanges falls back to direct OSV queries after an oversized 
   assert.equal(context.snapshotMetrics().cacheMisses, 4);
   assert.equal(context.snapshotMetrics().cacheHits, 0);
 });
+
+test("createAnalysisContext leaves expensive diff surfaces lazy for skipped analyzers", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1817,
+    files: [
+      {
+        path: "src/huge.ts",
+        patch: ["@@ -1,0 +1,2 @@", "+const first = true;"].join("\n"),
+      },
+    ],
+  });
+
+  assert.deepEqual(context.snapshotMetrics().cappedWorkByCategory, {});
+  assert.equal(context.changedFilePaths.length, 1);
+  assert.deepEqual(context.snapshotMetrics().cappedWorkByCategory, {});
+  assert.equal(context.hasAddedLines, true);
+  assert.deepEqual(context.snapshotMetrics().cappedWorkByCategory, {});
+});
+
+test("createAnalysisContext caps materialized diff surfaces", () => {
+  const oversizedPatch = [
+    "@@ -1,0 +1,6000 @@",
+    ...Array.from({ length: 6000 }, (_, index) => `+const value${index} = ${index};`),
+  ].join("\n");
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1817,
+    files: [
+      {
+        path: "src/huge.ts",
+        patch: oversizedPatch,
+      },
+    ],
+  });
+
+  assert.equal(context.addedLines.length, 5000);
+  assert.equal(context.addedLines.at(-1).line, 5000);
+  assert.deepEqual(context.snapshotMetrics().cappedWorkByCategory, {
+    added_lines: 1,
+  });
+});
+
+test("createAnalysisContext caps oversized patch scans without splitting the full patch", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1817,
+    files: [
+      {
+        path: "src/huge.ts",
+        patch: `${" context\n".repeat(130000)}+const beyondCap = true;`,
+      },
+    ],
+  });
+
+  assert.equal(context.hasAddedLines, false);
+  assert.equal(context.addedLines.length, 0);
+  assert.equal(
+    context.snapshotMetrics().cappedWorkByCategory.has_added_lines_patch_bytes > 0,
+    true,
+  );
+  assert.equal(
+    context.snapshotMetrics().cappedWorkByCategory.added_lines_patch_bytes > 0,
+    true,
+  );
+});

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -381,7 +381,23 @@ test("createAnalysisContext caps materialized diff surfaces", () => {
   });
 });
 
-test("createAnalysisContext caps oversized patch scans without splitting the full patch", () => {
+test("createAnalysisContext keeps uncapped context-only patches as no added lines", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1817,
+    files: [
+      {
+        path: "src/context-only.ts",
+        patch: "@@ -1,1 +1,1 @@\n const value = true;",
+      },
+    ],
+  });
+
+  assert.equal(context.hasAddedLines, false);
+  assert.deepEqual(context.snapshotMetrics().cappedWorkByCategory, {});
+});
+
+test("createAnalysisContext treats capped patch scans as added-line presence", () => {
   const context = createAnalysisContext({
     repoFullName: "JSONbored/gittensory",
     prNumber: 1817,
@@ -393,7 +409,7 @@ test("createAnalysisContext caps oversized patch scans without splitting the ful
     ],
   });
 
-  assert.equal(context.hasAddedLines, false);
+  assert.equal(context.hasAddedLines, true);
   assert.equal(context.addedLines.length, 0);
   assert.equal(
     context.snapshotMetrics().cappedWorkByCategory.has_added_lines_patch_bytes > 0,

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -178,3 +178,71 @@ test("registry analyzers skip when their relevant inputs are absent", async () =
   assert.equal(brief.telemetry.analyzers.secret.status, "ok");
   assert.ok(brief.telemetry.skippedWorkByCategory.analyzer_no_dependency_manifest >= 1);
 });
+
+test("added-line analyzers skip uncapped patches with no additions", async () => {
+  let secretRan = false;
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 1811,
+      analyzers: ["secret"],
+      files: [
+        {
+          path: "src/context-only.ts",
+          patch: "@@ -1,1 +1,1 @@\n const value = true;",
+        },
+      ],
+    },
+    {
+      secret: async () => {
+        secretRan = true;
+        return [];
+      },
+    },
+  );
+
+  assert.equal(secretRan, false);
+  assert.equal(brief.analyzerStatus.secret, "skipped");
+  assert.equal(brief.telemetry.analyzers.secret.skipReason, "no_added_lines");
+  assert.equal(brief.telemetry.skippedWorkByCategory.analyzer_no_added_lines, 1);
+});
+
+test("added-line analyzers run when patch scan is capped before additions", async () => {
+  const ran = new Set();
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 1811,
+      analyzers: ["redos", "secret", "secretLog"],
+      files: [
+        {
+          path: "src/late-addition.ts",
+          patch: `${" context\n".repeat(130000)}+console.log(process.env.TOKEN);`,
+        },
+      ],
+      budget: { timeoutMs: 2000 },
+    },
+    {
+      redos: async () => {
+        ran.add("redos");
+        return [];
+      },
+      secret: async () => {
+        ran.add("secret");
+        return [];
+      },
+      secretLog: async () => {
+        ran.add("secretLog");
+        return [];
+      },
+    },
+  );
+
+  assert.deepEqual([...ran].sort(), ["redos", "secret", "secretLog"]);
+  assert.equal(brief.analyzerStatus.redos, "ok");
+  assert.equal(brief.analyzerStatus.secret, "ok");
+  assert.equal(brief.analyzerStatus.secretLog, "ok");
+  assert.equal(brief.telemetry.analyzerCount.skipped, 0);
+  assert.equal(brief.telemetry.skippedWorkByCategory.analyzer_no_added_lines, undefined);
+  assert.ok(brief.telemetry.cappedWorkByCategory.has_added_lines_patch_bytes > 0);
+});


### PR DESCRIPTION
### Motivation

- The shared `AnalysisContext` eagerly parsed every file patch (calling `collectAddedLines` and `collectPatchHunks`) for every /v1/enrich request, which could consume unbounded CPU and memory before analyzer timeouts applied. 
- This made the engine vulnerable to large attacker-controlled diffs causing service degradation or process OOM even when no analyzers needed the parsed surfaces.

### Description

- Make `changedFilePaths`, `addedLines`, and `patchHunks` lazy, cached getters on `AnalysisContext` and add a cheap `hasAddedLines` getter to check presence without materializing full arrays. 
- Add bounded patch scanning via `boundedPatchLines` with limits `MAX_CONTEXT_PATCH_BYTES`, `MAX_CONTEXT_ADDED_LINES`, and `MAX_CONTEXT_PATCH_HUNKS`, and record capped-work metrics when limits are hit. 
- Update `collectAddedLines` and `collectPatchHunks` to accept optional `metrics` and to stop/return early when caps are reached, and modify scheduler logic to use `hasAddedLines` instead of forcing `addedLines`. 
- Add regression tests covering lazy behavior, capped materialization of added-lines, and oversized-patch short-circuiting in `review-enrichment/test/analysis-context.test.ts`.

### Testing

- Built the REES package with `npm --prefix review-enrichment run build` and ran the review-enrichment unit tests with `npm --prefix review-enrichment test`, and all tests passed (new tests included). 
- Exercised targeted suites with `node --test` for `review-enrichment/test/analysis-context.test.ts`, `scheduler.test.ts`, and `sentry-degradation.test.ts`, and they passed. 
- Attempted the full local gate `npm run test:ci`, but the environment could not fetch the official `actionlint` setup (network fallback reported a repo-specific runner label mismatch), and `npm audit --audit-level=moderate` failed due to the registry returning `403 Forbidden` in this environment, so those two checks did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439d634058832ca9552d0205d50a07)