### PR TITLE
fix(enrichment): bound doc drift file reads

### DIFF
--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -10,6 +10,7 @@ import type { EnrichRequest, DocCommentDriftFinding } from "../types.js";
 const MAX_FILES = 20;
 const MAX_FINDINGS = 50;
 const MAX_SIGNATURE_LINES = 40;
+const MAX_FETCH_BYTES = 1_000_000;
 const SOURCE_RE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests?\/)/;
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -20,6 +21,34 @@ const FUNC_DECL_RE = /^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s*\
 
 interface ScanOptions {
   signal?: AbortSignal;
+}
+
+async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
+  const length = Number(resp.headers.get("content-length"));
+  if (Number.isFinite(length) && length > MAX_FETCH_BYTES) return null;
+  if (!resp.body) return null;
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  try {
+    while (true) {
+      if (signal?.aborted) return null;
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_FETCH_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 /** Reconstruct the pre-PR content of a file by reverse-applying its unified `patch` to the post-PR `newContent`:
@@ -292,7 +321,7 @@ export async function scanDocCommentDrift(
         `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}?ref=${encodeURIComponent(headSha)}`,
         { headers, signal: options.signal },
       );
-      if (resp.ok) content = await resp.text();
+      if (resp.ok) content = await readBoundedText(resp, options.signal);
     } catch {
       content = null;
     }

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -19,8 +19,8 @@ const baseReq = (files) => ({
   githubToken: "ght",
   files,
 });
-const fileWith = (content) => async () => ({ ok: true, text: async () => content });
-const status = (code) => async () => ({ ok: code >= 200 && code < 300, status: code, text: async () => "" });
+const fileWith = (content, init) => async () => new Response(content, init);
+const status = (code) => async () => new Response("", { status: code });
 const oldParams = (entries) => new Map(entries.map(([name, ids]) => [name, new Set(ids)]));
 
 const DRIFTED = `/**\n * @param oldName the old one\n */\nexport function doThing(newName) {\n  return newName;\n}\n`;
@@ -174,6 +174,43 @@ test("scanDocCommentDrift: fetches the file at headSha and reports drift", async
   assert.equal(findings.length, 1);
   assert.equal(findings[0].file, "src/a.ts");
   assert.deepEqual(findings[0].staleParams, ["oldName"]);
+});
+
+test("scanDocCommentDrift: skips oversized file responses before reading the body", async () => {
+  let bodyAccessed = false;
+  const out = await scanDocCommentDrift(
+    baseReq([{ path: "src/a.ts", patch: DRIFT_PATCH }]),
+    async () => ({
+      ok: true,
+      headers: new Headers({ "content-length": "1000001" }),
+      get body() {
+        bodyAccessed = true;
+        return new Response(DRIFTED).body;
+      },
+    }),
+  );
+  assert.deepEqual(out, []);
+  assert.equal(bodyAccessed, false);
+});
+
+test("scanDocCommentDrift: cancels streamed file responses that exceed the byte cap", async () => {
+  let canceled = false;
+  const chunk = new Uint8Array(500_001);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(chunk);
+      controller.enqueue(chunk);
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  const out = await scanDocCommentDrift(
+    baseReq([{ path: "src/a.ts", patch: DRIFT_PATCH }]),
+    async () => new Response(stream),
+  );
+  assert.deepEqual(out, []);
+  assert.equal(canceled, true);
 });
 
 test("scanDocCommentDrift: requires a github token and a head sha", async () => {


### PR DESCRIPTION
### Motivation
- Prevent unbounded GitHub Contents API downloads when the doc-comment drift analyzer fetches full source files, which could allow attacker-controlled large responses to exhaust memory or block the event loop.

### Description
- Add a `MAX_FETCH_BYTES` cap and implement `readBoundedText(resp, signal)` to reject oversized responses based on `Content-Length` and to stream-read while cancelling if the byte cap is exceeded.
- Replace the previous `resp.text()` call with `readBoundedText(...)` so file fetches fail-closed on missing bodies, oversized `Content-Length`, aborted signals, or streams that exceed the cap (file: `review-enrichment/src/analyzers/doc-comment-drift.ts`).
- Update tests to use real `Response` objects and add regression tests that assert skipping responses with excessive `Content-Length` and cancelling streamed responses that exceed the cap (file: `review-enrichment/test/doc-comment-drift.test.ts`).

### Testing
- Ran `git diff --check` which produced no errors.
- Ran the analyzer unit suite via `npm --prefix review-enrichment test` which executed the updated `doc-comment-drift` tests (including the new regression cases) and passed locally (all tests green).
- Attempted the full local gate via `npm run test:ci` but it was blocked by `actionlint` setup using a WASM fallback that reported an unknown self-hosted runner label due to transient DNS/setup issues, so the repo-wide CI command did not fully complete in this environment.
- `npm audit --audit-level=moderate` could not complete here due to the registry audit endpoint returning `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439d638940832c8151b554d6081be9)