### PR TITLE
fix(queue): preserve retries for throttled background jobs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ export default {
                 resetAt,
               }),
             );
-            message.retry({ delaySeconds: delayUntil(resetAt) });
+            await env.JOBS.send(message.body, { delaySeconds: delayUntil(resetAt) });
+            message.ack();
             continue;
           }
         }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -169,6 +169,12 @@ describe("worker entrypoint", () => {
     await recordGitHubRateLimitObservation(env, { repoFullName: "owner/repo", resource: "rest", path: "/x", statusCode: 200, limitValue: 5000, remaining: 120, resetAt: "2026-06-24T12:10:00.000Z", observedAt: "2026-06-24T12:00:00.000Z" });
     const acked: string[] = [];
     const retries: Array<{ delaySeconds?: number } | undefined> = [];
+    const requeued: Array<{ message: import("../../src/types").JobMessage; delaySeconds?: number }> = [];
+    env.JOBS = {
+      async send(message: import("../../src/types").JobMessage, options?: { delaySeconds?: number }) {
+        requeued.push({ message, ...(options?.delaySeconds === undefined ? {} : { delaySeconds: options.delaySeconds }) });
+      },
+    } as unknown as Queue;
     const batch = {
       messages: [
         {
@@ -182,8 +188,20 @@ describe("worker entrypoint", () => {
 
     await worker.queue(batch, env);
 
-    expect(acked).toEqual([]);
-    expect(retries).toEqual([{ delaySeconds: 615 }]);
+    expect(acked).toEqual(["background-regate"]);
+    expect(retries).toEqual([]);
+    expect(requeued).toEqual([
+      {
+        message: {
+          type: "agent-regate-pr",
+          deliveryId: "sweep:owner/repo#7",
+          repoFullName: "owner/repo",
+          prNumber: 7,
+          installationId: 123,
+        },
+        delaySeconds: 615,
+      },
+    ]);
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
### Motivation
- Prevent Cloudflare queue retry-budget exhaustion for throttled GitHub-budget background jobs by avoiding repeated `message.retry()` calls that can dead-letter work before the GitHub rate-limit resets.

### Description
- Replace the Cloudflare admission-path retry with a re-enqueue using `await env.JOBS.send(message.body, { delaySeconds: delayUntil(resetAt) })` and `message.ack()` so the original delivery's retry attempts are not consumed during admission throttling.
- Keep the existing error-path retry semantics unchanged so transient failures still use `message.retry()` when appropriate.
- Update the worker entrypoint unit test to stub `env.JOBS`, assert the original message is acked, and assert a replacement delayed message is enqueued with the expected `delaySeconds` and original payload.

### Testing
- Ran the unit tests for the worker entrypoint with `npx vitest run test/unit/index.test.ts --reporter=verbose` and all tests in that file passed.
- Ran type checking with `npm run typecheck` and it succeeded.
- Measured coverage for the modified test with `npm run test:coverage -- test/unit/index.test.ts` and the targeted file-level assertions passed.
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate` but both were blocked in the local environment (`actionlint` download/DNS fallback and an `npm audit` 403), so the full CI gate was not completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439b190294832cab2e5e3bd310f1b7)