### PR TITLE
fix(queue): ignore stale low rate-limit observations

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -610,22 +610,22 @@ export function createPgQueue(
     if (target === null) return null;
     const res = await pool.query(
       `WITH exact_observation AS (
-        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+        SELECT admission_key, remaining, reset_at, observed_at FROM github_rate_limit_observations
           WHERE resource='rest' AND remaining IS NOT NULL AND $1::text IS NOT NULL AND admission_key=$1
           ORDER BY observed_at DESC
           LIMIT 1
       ), fallback_observation AS (
-        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+        SELECT admission_key, remaining, reset_at, observed_at FROM github_rate_limit_observations
           WHERE resource='rest' AND remaining IS NOT NULL AND admission_key IS NULL
           ORDER BY observed_at DESC
           LIMIT 1
       )
-      SELECT remaining, reset_at, observed_at FROM exact_observation
+      SELECT admission_key, remaining, reset_at, observed_at FROM exact_observation
       UNION ALL
-      SELECT remaining, reset_at, observed_at FROM fallback_observation`,
+      SELECT admission_key, remaining, reset_at, observed_at FROM fallback_observation`,
       [target.admissionKey],
     );
-    const rows = res.rows as Array<{ remaining?: number | string | null; reset_at?: string | null; observed_at?: string | null }>;
+    const rows = res.rows as Array<{ admission_key?: string | null; remaining?: number | string | null; reset_at?: string | null; observed_at?: string | null }>;
     const delayMs = githubRateLimitAdmissionDelayMs(target.kind, target.admissionKey, rows);
     return delayMs === null ? null : { ...target, delayMs };
   }

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -386,13 +386,13 @@ export function createPgQueue(
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
           const target = githubRateLimitAdmissionTargetForJob(message);
           const deferred = target ? await deferPendingJobsForRateLimit(rateLimitDelayMs, now, target) : 0;
-          if (deferred) {
+          if (target !== null && deferred > 0) {
             await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total", deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
                 event: "selfhost_queue_rate_limit_budget_deferred",
-                admission_key: target?.admissionKey ?? null,
+                admission_key: target.admissionKey,
                 deferred,
               }),
             );

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -13,7 +13,6 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionKeyForJob,
-  githubRateLimitAdmissionRemainingFloor,
   githubRateLimitRetryDelayMs,
   isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
@@ -615,16 +614,22 @@ export function createPgQueue(
           : null;
     if (kind === null) return null;
     const admissionKey = githubRateLimitAdmissionKeyForJob(message);
-    const remainingFloor = githubRateLimitAdmissionRemainingFloor(kind);
     const res = await pool.query(
-      `SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
-        WHERE resource='rest' AND remaining IS NOT NULL AND (
-          ($1::text IS NOT NULL AND admission_key=$1)
-          OR admission_key IS NULL
-        )
-        ORDER BY CASE WHEN remaining <= $2 THEN 1 ELSE 0 END DESC, observed_at DESC
-        LIMIT 16`,
-      [admissionKey, remainingFloor],
+      `WITH exact_observation AS (
+        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+          WHERE resource='rest' AND remaining IS NOT NULL AND $1::text IS NOT NULL AND admission_key=$1
+          ORDER BY observed_at DESC
+          LIMIT 1
+      ), fallback_observation AS (
+        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+          WHERE resource='rest' AND remaining IS NOT NULL AND admission_key IS NULL
+          ORDER BY observed_at DESC
+          LIMIT 1
+      )
+      SELECT remaining, reset_at, observed_at FROM exact_observation
+      UNION ALL
+      SELECT remaining, reset_at, observed_at FROM fallback_observation`,
+      [admissionKey],
     );
     const rows = res.rows as Array<{ remaining?: number | string | null; reset_at?: string | null; observed_at?: string | null }>;
     const delayMs = githubRateLimitAdmissionDelayMs(kind, admissionKey, rows);

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -12,9 +12,8 @@ import {
   deterministicJitterMs,
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
-  githubRateLimitAdmissionKeyForJob,
+  githubRateLimitAdmissionTargetForJob,
   githubRateLimitRetryDelayMs,
-  isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
@@ -23,6 +22,8 @@ import {
   queueStartupJitterMinJobs,
   queueStartupJitterMs,
   rateLimitRetryDelayWithJitter,
+  matchesGitHubRateLimitAdmissionTarget,
+  type GitHubRateLimitAdmissionTarget,
 } from "./queue-common";
 import type { JobMessage } from "../types";
 
@@ -105,7 +106,6 @@ export function createPgQueue(
   let activeBackground = 0;
   const activeJobIds = new Set<string>();
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let githubRateLimitCooldownUntil = 0;
 
   async function init(): Promise<void> {
     await pool.query(DDL);
@@ -223,7 +223,7 @@ export function createPgQueue(
     const payload = JSON.stringify(message);
     const priority = jobPriority(payload);
     const key = jobCoalesceKey(payload);
-    const runAfter = nextRunAfter(now, delaySeconds * 1000, `${key ?? ""}:${payload}`);
+    const runAfter = now + delaySeconds * 1000;
     if (key) {
       const existing = (
         await pool.query(
@@ -252,7 +252,6 @@ export function createPgQueue(
   }
 
   async function claimNext(): Promise<JobRow | null> {
-    if (Date.now() < githubRateLimitCooldownUntil) return null;
     const now = Date.now();
     const foreground = await claimNextWhere(now, "priority >= $2");
     if (foreground) return foreground;
@@ -285,13 +284,6 @@ export function createPgQueue(
       [now, FOREGROUND_QUEUE_PRIORITY_FLOOR],
     );
     return (res.rows[0] as JobRow | undefined) ?? null;
-  }
-
-  function nextRunAfter(now: number, delayMs: number, seed: string): number {
-    const requested = now + delayMs;
-    if (now >= githubRateLimitCooldownUntil) return requested;
-    const cooldownDelay = githubRateLimitCooldownUntil - now;
-    return Math.max(requested, now + rateLimitRetryDelayWithJitter(cooldownDelay, seed));
   }
 
   async function processOne(): Promise<boolean> {
@@ -392,16 +384,16 @@ export function createPgQueue(
         if (rateLimitDelayMs !== null) {
           const now = Date.now();
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
-          githubRateLimitCooldownUntil = Math.max(githubRateLimitCooldownUntil, now + rateLimitDelayMs);
-          const deferred = await deferPendingJobsForRateLimit(rateLimitDelayMs, now);
+          const target = githubRateLimitAdmissionTargetForJob(message);
+          const deferred = target ? await deferPendingJobsForRateLimit(rateLimitDelayMs, now, target) : 0;
           if (deferred) {
             await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total", deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
-                event: "selfhost_queue_rate_limit_cooldown",
+                event: "selfhost_queue_rate_limit_budget_deferred",
+                admission_key: target?.admissionKey ?? null,
                 deferred,
-                cooldown_until: githubRateLimitCooldownUntil,
               }),
             );
           }
@@ -588,6 +580,7 @@ export function createPgQueue(
   async function deferPendingJobsForRateLimit(
     delayMs: number,
     now: number,
+    blocked: GitHubRateLimitAdmissionTarget,
   ): Promise<number> {
     const res = await pool.query(
       `SELECT id, payload, job_key FROM ${TABLE} WHERE status='pending' AND run_after<=$1`,
@@ -595,25 +588,26 @@ export function createPgQueue(
     );
     let changed = 0;
     for (const row of res.rows as Array<{ id: string; payload: string; job_key?: string | null }>) {
+      let candidate: GitHubRateLimitAdmissionTarget | null = null;
+      try {
+        candidate = githubRateLimitAdmissionTargetForJob(JSON.parse(row.payload) as JobMessage);
+      } catch {
+        candidate = null;
+      }
+      if (!matchesGitHubRateLimitAdmissionTarget(candidate, blocked)) continue;
       const runAfter = now + rateLimitRetryDelayWithJitter(delayMs, `${row.job_key ?? ""}:${row.id}:${row.payload}`);
       const update = await pool.query(
         `UPDATE ${TABLE} SET run_after=GREATEST(run_after, $1), last_error=COALESCE(last_error, $2) WHERE id=$3 AND status='pending'`,
-        [runAfter, "github rate-limit cooldown", row.id],
+        [runAfter, "github rate-limit budget deferred", row.id],
       );
       changed += update.rowCount ?? 0;
     }
     return changed;
   }
 
-  async function rateLimitAdmissionDelayMs(message: JobMessage): Promise<{ kind: "background" | "webhook"; delayMs: number } | null> {
-    const kind =
-      message.type === "github-webhook"
-        ? "webhook"
-        : isGitHubBudgetBackgroundJob(message)
-          ? "background"
-          : null;
-    if (kind === null) return null;
-    const admissionKey = githubRateLimitAdmissionKeyForJob(message);
+  async function rateLimitAdmissionDelayMs(message: JobMessage): Promise<(GitHubRateLimitAdmissionTarget & { delayMs: number }) | null> {
+    const target = githubRateLimitAdmissionTargetForJob(message);
+    if (target === null) return null;
     const res = await pool.query(
       `WITH exact_observation AS (
         SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
@@ -629,11 +623,11 @@ export function createPgQueue(
       SELECT remaining, reset_at, observed_at FROM exact_observation
       UNION ALL
       SELECT remaining, reset_at, observed_at FROM fallback_observation`,
-      [admissionKey],
+      [target.admissionKey],
     );
     const rows = res.rows as Array<{ remaining?: number | string | null; reset_at?: string | null; observed_at?: string | null }>;
-    const delayMs = githubRateLimitAdmissionDelayMs(kind, admissionKey, rows);
-    return delayMs === null ? null : { kind, delayMs };
+    const delayMs = githubRateLimitAdmissionDelayMs(target.kind, target.admissionKey, rows);
+    return delayMs === null ? null : { ...target, delayMs };
   }
 
   async function mergeRescheduledJobIntoPending(

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -144,6 +144,8 @@ function observationMs(
 }
 
 type AdmissionObservation = {
+  admission_key?: unknown;
+  admissionKey?: unknown;
   remaining?: unknown;
   reset_at?: unknown;
   resetAt?: unknown;
@@ -152,18 +154,53 @@ type AdmissionObservation = {
   observedAtMs?: unknown;
 };
 
-function newestRateLimitObservation(
-  admissionKey: GitHubRateLimitAdmissionKey | null | undefined,
-  persisted: AdmissionObservation | null | undefined,
-):
-  | AdmissionObservation
-  | null
-  | undefined {
-  const local = admissionKey ? latestGitHubRestRateLimitObservation(admissionKey) : null;
-  if (!local) return persisted;
-  if (!persisted) return local;
-  const persistedMs = observationMs(persisted);
-  return persistedMs !== null && persistedMs > local.observedAtMs ? persisted : local;
+function observationAdmissionKey(
+  observation: AdmissionObservation | null | undefined,
+): GitHubRateLimitAdmissionKey | null | undefined {
+  if (typeof observation?.admission_key === "string") {
+    return observation.admission_key as GitHubRateLimitAdmissionKey;
+  }
+  if (typeof observation?.admissionKey === "string") {
+    return observation.admissionKey as GitHubRateLimitAdmissionKey;
+  }
+  if (observation?.admission_key === null || observation?.admissionKey === null) {
+    return null;
+  }
+  return undefined;
+}
+
+function newerRateLimitObservation(
+  current: AdmissionObservation | null | undefined,
+  candidate: AdmissionObservation | null | undefined,
+): AdmissionObservation | null {
+  if (!candidate) return current ?? null;
+  if (!current) return candidate;
+  const currentMs = observationMs(current);
+  const candidateMs = observationMs(candidate);
+  if (candidateMs === null) return currentMs === null ? candidate : current;
+  if (currentMs === null) return candidate;
+  return candidateMs > currentMs ? candidate : current;
+}
+
+function rateLimitAdmissionDelayForObservation(
+  kind: GitHubRateLimitAdmissionKind,
+  observation: AdmissionObservation | null | undefined,
+  nowMs: number,
+): number | null {
+  return kind === "webhook"
+    ? githubWebhookRateLimitDelayMs(observation, nowMs)
+    : githubBackgroundRateLimitDelayMs(observation, nowMs);
+}
+
+function fallbackObservationCanOverrideExact(
+  fallback: AdmissionObservation | null,
+  exact: AdmissionObservation | null,
+): boolean {
+  if (!fallback) return false;
+  if (!exact) return true;
+  const fallbackMs = observationMs(fallback);
+  const exactMs = observationMs(exact);
+  return fallbackMs === null || exactMs === null || fallbackMs > exactMs;
 }
 
 export function githubRateLimitAdmissionKeyForJob(message: JobMessage): GitHubRateLimitAdmissionKey | null {
@@ -218,17 +255,26 @@ export function githubRateLimitAdmissionDelayMs(
   persisted: AdmissionObservation | readonly AdmissionObservation[] | null | undefined,
   nowMs = Date.now(),
 ): number | null {
+  const local = admissionKey ? latestGitHubRestRateLimitObservation(admissionKey) : null;
   const candidates = Array.isArray(persisted) ? persisted : [persisted];
-  let maxDelay: number | null = null;
-  for (const candidate of candidates.length > 0 ? candidates : [undefined]) {
-    const observation = newestRateLimitObservation(admissionKey, candidate);
-    const delay =
-      kind === "webhook"
-        ? githubWebhookRateLimitDelayMs(observation, nowMs)
-        : githubBackgroundRateLimitDelayMs(observation, nowMs);
-    if (delay !== null) maxDelay = Math.max(maxDelay ?? 0, delay);
+  const keyedCandidateMayOmitKey = Boolean(admissionKey) && !Array.isArray(persisted);
+  let exact: AdmissionObservation | null = local;
+  let fallback: AdmissionObservation | null = null;
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const candidateKey = observationAdmissionKey(candidate);
+    if (admissionKey && (candidateKey === admissionKey || (candidateKey === undefined && keyedCandidateMayOmitKey))) {
+      exact = newerRateLimitObservation(exact, candidate);
+    } else if (candidateKey === null || candidateKey === undefined) {
+      fallback = newerRateLimitObservation(fallback, candidate);
+    }
   }
-  return maxDelay;
+  const exactDelay = rateLimitAdmissionDelayForObservation(kind, exact, nowMs);
+  if (exactDelay !== null) return exactDelay;
+  const fallbackDelay = rateLimitAdmissionDelayForObservation(kind, fallback, nowMs);
+  return fallbackDelay !== null && fallbackObservationCanOverrideExact(fallback, exact)
+    ? fallbackDelay
+    : null;
 }
 
 export function githubBackgroundRateLimitDelayMs(

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -178,8 +178,42 @@ export function githubRateLimitAdmissionKeyForJob(message: JobMessage): GitHubRa
     : null;
 }
 
+export type GitHubRateLimitAdmissionKind = "background" | "webhook";
+
+export type GitHubRateLimitAdmissionTarget = {
+  kind: GitHubRateLimitAdmissionKind;
+  admissionKey: GitHubRateLimitAdmissionKey | null;
+};
+
+export function githubRateLimitAdmissionTargetForJob(
+  message: JobMessage,
+): GitHubRateLimitAdmissionTarget | null {
+  if (message.type === "github-webhook") {
+    return {
+      kind: "webhook",
+      admissionKey: githubRateLimitAdmissionKeyForJob(message),
+    };
+  }
+  if (!isGitHubBudgetBackgroundJob(message)) return null;
+  return {
+    kind: "background",
+    admissionKey: githubRateLimitAdmissionKeyForJob(message),
+  };
+}
+
+export function matchesGitHubRateLimitAdmissionTarget(
+  candidate: GitHubRateLimitAdmissionTarget | null,
+  blocked: GitHubRateLimitAdmissionTarget,
+): boolean {
+  if (candidate === null) return false;
+  // Null-key GitHub jobs are legacy/unknown actor work; park them with a depleted known bucket,
+  // and park all GitHub-budget work when the depleted bucket itself is unknown.
+  if (blocked.admissionKey === null) return true;
+  return candidate.admissionKey === blocked.admissionKey || candidate.admissionKey === null;
+}
+
 export function githubRateLimitAdmissionDelayMs(
-  kind: "background" | "webhook",
+  kind: GitHubRateLimitAdmissionKind,
   admissionKey: GitHubRateLimitAdmissionKey | null | undefined,
   persisted: AdmissionObservation | readonly AdmissionObservation[] | null | undefined,
   nowMs = Date.now(),

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -171,9 +171,8 @@ function observationAdmissionKey(
 
 function newerRateLimitObservation(
   current: AdmissionObservation | null | undefined,
-  candidate: AdmissionObservation | null | undefined,
+  candidate: AdmissionObservation,
 ): AdmissionObservation | null {
-  if (!candidate) return current ?? null;
   if (!current) return candidate;
   const currentMs = observationMs(current);
   const candidateMs = observationMs(candidate);

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -200,7 +200,8 @@ function fallbackObservationCanOverrideExact(
   if (!exact) return true;
   const fallbackMs = observationMs(fallback);
   const exactMs = observationMs(exact);
-  return fallbackMs === null || exactMs === null || fallbackMs > exactMs;
+  if (fallbackMs === null) return false;
+  return exactMs === null || fallbackMs > exactMs;
 }
 
 export function githubRateLimitAdmissionKeyForJob(message: JobMessage): GitHubRateLimitAdmissionKey | null {
@@ -269,12 +270,10 @@ export function githubRateLimitAdmissionDelayMs(
       fallback = newerRateLimitObservation(fallback, candidate);
     }
   }
-  const exactDelay = rateLimitAdmissionDelayForObservation(kind, exact, nowMs);
-  if (exactDelay !== null) return exactDelay;
-  const fallbackDelay = rateLimitAdmissionDelayForObservation(kind, fallback, nowMs);
-  return fallbackDelay !== null && fallbackObservationCanOverrideExact(fallback, exact)
-    ? fallbackDelay
-    : null;
+  const observation = fallbackObservationCanOverrideExact(fallback, exact)
+    ? fallback
+    : exact;
+  return rateLimitAdmissionDelayForObservation(kind, observation, nowMs);
 }
 
 export function githubBackgroundRateLimitDelayMs(

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -611,21 +611,21 @@ function rateLimitAdmissionDelayMs(
   try {
     const rows = driver.query(
       `WITH exact_observation AS (
-        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+        SELECT admission_key, remaining, reset_at, observed_at FROM github_rate_limit_observations
           WHERE resource='rest' AND remaining IS NOT NULL AND ? IS NOT NULL AND admission_key=?
           ORDER BY observed_at DESC
           LIMIT 1
       ), fallback_observation AS (
-        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+        SELECT admission_key, remaining, reset_at, observed_at FROM github_rate_limit_observations
           WHERE resource='rest' AND remaining IS NOT NULL AND admission_key IS NULL
           ORDER BY observed_at DESC
           LIMIT 1
       )
-      SELECT remaining, reset_at, observed_at FROM exact_observation
+      SELECT admission_key, remaining, reset_at, observed_at FROM exact_observation
       UNION ALL
-      SELECT remaining, reset_at, observed_at FROM fallback_observation`,
+      SELECT admission_key, remaining, reset_at, observed_at FROM fallback_observation`,
       [target.admissionKey, target.admissionKey],
-    ).rows as Array<{ remaining?: number | null; reset_at?: string | null; observed_at?: string | null }>;
+    ).rows as Array<{ admission_key?: string | null; remaining?: number | null; reset_at?: string | null; observed_at?: string | null }>;
     const delayMs = githubRateLimitAdmissionDelayMs(target.kind, target.admissionKey, rows);
     return delayMs === null ? null : { ...target, delayMs };
   } catch {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -13,9 +13,8 @@ import {
   deterministicJitterMs,
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
-  githubRateLimitAdmissionKeyForJob,
+  githubRateLimitAdmissionTargetForJob,
   githubRateLimitRetryDelayMs,
-  isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
   jobPriority,
   queueBackgroundConcurrency,
@@ -24,6 +23,8 @@ import {
   queueStartupJitterMinJobs,
   queueStartupJitterMs,
   rateLimitRetryDelayWithJitter,
+  matchesGitHubRateLimitAdmissionTarget,
+  type GitHubRateLimitAdmissionTarget,
 } from "./queue-common";
 import type { JobMessage } from "../types";
 
@@ -159,14 +160,13 @@ export function createSqliteQueue(
   let activeBackground = 0;
   const activeJobIds = new Set<number>();
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let githubRateLimitCooldownUntil = 0;
 
   function enqueue(message: JobMessage, delaySeconds: number): void {
     const now = Date.now();
     const payload = JSON.stringify(message);
     const priority = jobPriority(payload);
     const key = jobCoalesceKey(payload);
-    const runAfter = nextRunAfter(now, delaySeconds * 1000, `${key ?? ""}:${payload}`);
+    const runAfter = now + delaySeconds * 1000;
     if (key) {
       const existing = driver.query(
         `SELECT id FROM ${TABLE} WHERE status='pending' AND job_key=? ORDER BY priority DESC, run_after DESC, id LIMIT 1`,
@@ -193,7 +193,6 @@ export function createSqliteQueue(
   }
 
   function claimNext(): JobRow | null {
-    if (Date.now() < githubRateLimitCooldownUntil) return null;
     const now = Date.now();
     const foreground = claimNextWhere(now, "priority>=?");
     if (foreground) return foreground;
@@ -224,13 +223,6 @@ export function createSqliteQueue(
     );
     /* v8 ignore next */ // the no-rows branch is a multi-writer guard; unreachable in the single-process model
     return changes ? row : null;
-  }
-
-  function nextRunAfter(now: number, delayMs: number, seed: string): number {
-    const requested = now + delayMs;
-    if (now >= githubRateLimitCooldownUntil) return requested;
-    const cooldownDelay = githubRateLimitCooldownUntil - now;
-    return Math.max(requested, now + rateLimitRetryDelayWithJitter(cooldownDelay, seed));
   }
 
   async function processOne(): Promise<boolean> {
@@ -335,16 +327,16 @@ export function createSqliteQueue(
         if (rateLimitDelayMs !== null) {
           const now = Date.now();
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
-          githubRateLimitCooldownUntil = Math.max(githubRateLimitCooldownUntil, now + rateLimitDelayMs);
-          const deferred = deferPendingJobsForRateLimit(driver, rateLimitDelayMs, now);
+          const target = githubRateLimitAdmissionTargetForJob(message);
+          const deferred = target ? deferPendingJobsForRateLimit(driver, rateLimitDelayMs, now, target) : 0;
           if (deferred) {
             recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total", deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
-                event: "selfhost_queue_rate_limit_cooldown",
+                event: "selfhost_queue_rate_limit_budget_deferred",
+                admission_key: target?.admissionKey ?? null,
                 deferred,
-                cooldown_until: githubRateLimitCooldownUntil,
               }),
             );
           }
@@ -585,6 +577,7 @@ function deferPendingJobsForRateLimit(
   driver: SqliteDriver,
   delayMs: number,
   now: number,
+  blocked: GitHubRateLimitAdmissionTarget,
 ): number {
   const { rows } = driver.query(
     `SELECT id, payload, job_key FROM ${TABLE} WHERE status='pending' AND run_after<=?`,
@@ -592,10 +585,17 @@ function deferPendingJobsForRateLimit(
   );
   let changed = 0;
   for (const row of rows as Array<{ id: number; payload: string; job_key?: string | null }>) {
+    let candidate: GitHubRateLimitAdmissionTarget | null = null;
+    try {
+      candidate = githubRateLimitAdmissionTargetForJob(JSON.parse(row.payload) as JobMessage);
+    } catch {
+      candidate = null;
+    }
+    if (!matchesGitHubRateLimitAdmissionTarget(candidate, blocked)) continue;
     const runAfter = now + rateLimitRetryDelayWithJitter(delayMs, `${row.job_key ?? ""}:${row.id}:${row.payload}`);
     const { changes } = driver.query(
       `UPDATE ${TABLE} SET run_after=max(run_after, ?), last_error=coalesce(last_error, ?) WHERE id=? AND status='pending'`,
-      [runAfter, "github rate-limit cooldown", row.id],
+      [runAfter, "github rate-limit budget deferred", row.id],
     );
     changed += changes;
   }
@@ -605,16 +605,10 @@ function deferPendingJobsForRateLimit(
 function rateLimitAdmissionDelayMs(
   driver: SqliteDriver,
   message: JobMessage,
-): { kind: "background" | "webhook"; delayMs: number } | null {
-  const kind =
-    message.type === "github-webhook"
-      ? "webhook"
-      : isGitHubBudgetBackgroundJob(message)
-        ? "background"
-        : null;
-  if (kind === null) return null;
+): (GitHubRateLimitAdmissionTarget & { delayMs: number }) | null {
+  const target = githubRateLimitAdmissionTargetForJob(message);
+  if (target === null) return null;
   try {
-    const admissionKey = githubRateLimitAdmissionKeyForJob(message);
     const rows = driver.query(
       `WITH exact_observation AS (
         SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
@@ -630,10 +624,10 @@ function rateLimitAdmissionDelayMs(
       SELECT remaining, reset_at, observed_at FROM exact_observation
       UNION ALL
       SELECT remaining, reset_at, observed_at FROM fallback_observation`,
-      [admissionKey, admissionKey],
+      [target.admissionKey, target.admissionKey],
     ).rows as Array<{ remaining?: number | null; reset_at?: string | null; observed_at?: string | null }>;
-    const delayMs = githubRateLimitAdmissionDelayMs(kind, admissionKey, rows);
-    return delayMs === null ? null : { kind, delayMs };
+    const delayMs = githubRateLimitAdmissionDelayMs(target.kind, target.admissionKey, rows);
+    return delayMs === null ? null : { ...target, delayMs };
   } catch {
     return null;
   }

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -329,13 +329,13 @@ export function createSqliteQueue(
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
           const target = githubRateLimitAdmissionTargetForJob(message);
           const deferred = target ? deferPendingJobsForRateLimit(driver, rateLimitDelayMs, now, target) : 0;
-          if (deferred) {
+          if (target !== null && deferred > 0) {
             recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total", deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
                 event: "selfhost_queue_rate_limit_budget_deferred",
-                admission_key: target?.admissionKey ?? null,
+                admission_key: target.admissionKey,
                 deferred,
               }),
             );

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -14,7 +14,6 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionKeyForJob,
-  githubRateLimitAdmissionRemainingFloor,
   githubRateLimitRetryDelayMs,
   isGitHubBudgetBackgroundJob,
   jobCoalesceKey,
@@ -616,16 +615,22 @@ function rateLimitAdmissionDelayMs(
   if (kind === null) return null;
   try {
     const admissionKey = githubRateLimitAdmissionKeyForJob(message);
-    const remainingFloor = githubRateLimitAdmissionRemainingFloor(kind);
     const rows = driver.query(
-      `SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
-        WHERE resource='rest' AND remaining IS NOT NULL AND (
-          (? IS NOT NULL AND admission_key=?)
-          OR admission_key IS NULL
-        )
-        ORDER BY CASE WHEN remaining <= ? THEN 1 ELSE 0 END DESC, observed_at DESC
-        LIMIT 16`,
-      [admissionKey, admissionKey, remainingFloor],
+      `WITH exact_observation AS (
+        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+          WHERE resource='rest' AND remaining IS NOT NULL AND ? IS NOT NULL AND admission_key=?
+          ORDER BY observed_at DESC
+          LIMIT 1
+      ), fallback_observation AS (
+        SELECT remaining, reset_at, observed_at FROM github_rate_limit_observations
+          WHERE resource='rest' AND remaining IS NOT NULL AND admission_key IS NULL
+          ORDER BY observed_at DESC
+          LIMIT 1
+      )
+      SELECT remaining, reset_at, observed_at FROM exact_observation
+      UNION ALL
+      SELECT remaining, reset_at, observed_at FROM fallback_observation`,
+      [admissionKey, admissionKey],
     ).rows as Array<{ remaining?: number | null; reset_at?: string | null; observed_at?: string | null }>;
     const delayMs = githubRateLimitAdmissionDelayMs(kind, admissionKey, rows);
     return delayMs === null ? null : { kind, delayMs };

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -646,6 +646,27 @@ describe("createPgQueue (durable #977)", () => {
     );
   });
 
+  it("does not keep webhook admission closed from stale legacy rows after a newer healthy exact observation", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const m = makePool();
+    m.setRateLimitRows([
+      { admission_key: null, repo_full_name: "owner/repo", remaining: "0", reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+      { admission_key: "installation:123", repo_full_name: "owner/repo", remaining: "4000", reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+    ]);
+    m.enqueueJob("webhook", { type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: { installation: { id: 123 }, repository: { full_name: "owner/repo" } } });
+    const seen: string[] = [];
+    const q = createPgQueue(m.pool, async (j) => void seen.push(typeOf(j)));
+
+    await q.drain();
+
+    expect(seen).toEqual(["github-webhook"]);
+    expect(m.pool.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("SET status='pending', run_after=GREATEST"),
+      expect.anything(),
+    );
+  });
+
   it("does not pre-yield webhook jobs for another installation's persisted REST exhaustion", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -47,23 +47,16 @@ function makePool(): MockPool {
     const q = String(sql);
     if (q.includes("FROM github_rate_limit_observations")) {
       const admissionKey = typeof params?.[0] === "string" ? params[0] : null;
-      const remainingFloor = typeof params?.[1] === "number" ? params[1] : Number.POSITIVE_INFINITY;
-      const rows = rateLimitRows
-        .filter(
-          (row) =>
-            (admissionKey !== null && row.admission_key === admissionKey) ||
-            row.admission_key === undefined ||
-            row.admission_key === null,
-        )
-        .sort((a, b) => {
-          const unsafe =
-            (Number(b.remaining) <= remainingFloor ? 1 : 0) - (Number(a.remaining) <= remainingFloor ? 1 : 0);
-          if (unsafe !== 0) return unsafe;
+      const newest = (rows: typeof rateLimitRows) =>
+        [...rows].sort((a, b) => {
           const observed = Date.parse(b.observed_at ?? "") - Date.parse(a.observed_at ?? "");
           if (Number.isFinite(observed) && observed !== 0) return observed;
           return 0;
-        })
-        .slice(0, 16);
+        })[0];
+      const rows = [
+        ...(admissionKey !== null ? [newest(rateLimitRows.filter((row) => row.admission_key === admissionKey))].filter(Boolean) : []),
+        newest(rateLimitRows.filter((row) => row.admission_key === undefined || row.admission_key === null)),
+      ].filter(Boolean);
       return { rows, rowCount: rows.length };
     }
     if (q.includes("SET status='pending', run_after=GREATEST")) {
@@ -610,6 +603,27 @@ describe("createPgQueue (durable #977)", () => {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
     }
+  });
+
+  it("does not keep webhook admission closed from stale legacy low rows after a newer healthy legacy observation", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const m = makePool();
+    m.setRateLimitRows([
+      { admission_key: null, repo_full_name: "owner/repo", remaining: "0", reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+      { admission_key: null, repo_full_name: "owner/repo", remaining: "4000", reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+    ]);
+    m.enqueueJob("webhook", { type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: { installation: { id: 123 }, repository: { full_name: "owner/repo" } } });
+    const seen: string[] = [];
+    const q = createPgQueue(m.pool, async (j) => void seen.push(typeOf(j)));
+
+    await q.drain();
+
+    expect(seen).toEqual(["github-webhook"]);
+    expect(m.pool.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("SET status='pending', run_after=GREATEST"),
+      expect.anything(),
+    );
   });
 
   it("does not pre-yield webhook jobs for another installation's persisted REST exhaustion", async () => {

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -25,6 +25,26 @@ const ciWebhook = (deliveryId: string, eventName: "check_suite" | "check_run" = 
       [eventName]: { head_sha: sha, pull_requests: [{ number: 1629 }] },
     },
   }) as unknown as JobMessage;
+const installedWebhook = (deliveryId: string, installationId: number): JobMessage =>
+  ({
+    type: "github-webhook",
+    deliveryId,
+    eventName: "pull_request",
+    payload: {
+      action: "synchronize",
+      installation: { id: installationId },
+      repository: { full_name: "JSONbored/gittensory" },
+      pull_request: { number: 1629, head: { sha: "c".repeat(40) } },
+    },
+  }) as unknown as JobMessage;
+const regateJob = (installationId: number | null, prNumber = 1629): JobMessage =>
+  ({
+    type: "agent-regate-pr",
+    deliveryId: `sweep:jsonbored/gittensory#${prNumber}`,
+    repoFullName: "jsonbored/gittensory",
+    prNumber,
+    ...(installationId === null ? {} : { installationId }),
+  }) as unknown as JobMessage;
 const typeOf = (m: JobMessage): string => (m as unknown as { type: string }).type;
 
 type MockFn = { mockResolvedValueOnce(v: unknown): void };
@@ -145,7 +165,7 @@ describe("createPgQueue (durable #977)", () => {
   it("init() skips already-normalized priority and job-key rows", async () => {
     const priorityUpdateSql = "UPDATE _selfhost_jobs SET priority=$1";
     const jobKeyUpdateSql = "UPDATE _selfhost_jobs SET job_key=$1";
-    const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+    const fn = vi.fn().mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
       if (q.includes("SELECT id, payload, priority")) {
         return {
@@ -761,7 +781,39 @@ describe("createPgQueue (durable #977)", () => {
     );
   });
 
-  it("defers due jobs and coalesces a keyed rate-limit retry into the pending duplicate", async () => {
+  it("does not defer GitHub work when a non-GitHub job throws a GitHub-looking rate limit", async () => {
+    const m = makePool();
+    m.enqueueJob("1", msg("refresh-registry"), 0);
+    m.enqueueJob("2", installedWebhook("github-still-runs", 123), 0);
+    const seen: string[] = [];
+    const rateLimit = new Error("API rate limit exceeded for installation ID 123");
+    Object.assign(rateLimit, {
+      status: 403,
+      response: { headers: { "retry-after": "120" } },
+    });
+    const q = createPgQueue(
+      m.pool,
+      async (message) => {
+        seen.push(message.type === "github-webhook" ? message.deliveryId ?? "" : message.type);
+        if (message.type === "refresh-registry") throw rateLimit;
+      },
+      { maxRetries: 1, backoffMs: () => 0 },
+    );
+    await q.init();
+    await q.drain();
+
+    expect(seen).toEqual(["refresh-registry", "github-still-runs"]);
+    expect(m.pool.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
+      expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", expect.any(String)]),
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
+      ["2"],
+    );
+  });
+
+  it("defers matching GitHub-budget jobs and coalesces a keyed rate-limit retry into the pending duplicate", async () => {
     const oldJitter = process.env.QUEUE_STARTUP_JITTER_MS;
     process.env.QUEUE_STARTUP_JITTER_MS = "0";
     const rateLimit = new Error("API rate limit exceeded for installation ID 123");
@@ -769,16 +821,19 @@ describe("createPgQueue (durable #977)", () => {
       status: 403,
       response: { headers: { "retry-after": "120" } },
     });
-    const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+    let claimed = false;
+    const fn = vi.fn().mockImplementation(async (sql: unknown, params?: unknown[]) => {
       const q = String(sql);
       if (q.includes("SELECT id, payload, priority")) return { rows: [], rowCount: 0 };
       if (q.includes("SELECT id, payload, job_key") && q.includes("status IN")) return { rows: [], rowCount: 0 };
       if (q.includes("WHERE status='processing'")) return { rows: [], rowCount: 0 };
       if (q.includes("UPDATE _selfhost_jobs SET status='processing'")) {
+        if (claimed) return { rows: [], rowCount: 0 };
+        claimed = true;
         return {
           rows: [{
             id: "active",
-            payload: JSON.stringify({ type: "github-webhook" }),
+            payload: JSON.stringify(installedWebhook("ci-active", 123)),
             attempts: 0,
             job_key: "github-webhook:ci-completed:jsonbored/gittensory@abc1234#7",
           }],
@@ -787,7 +842,13 @@ describe("createPgQueue (durable #977)", () => {
       }
       if (q.includes("SELECT id, payload, job_key FROM _selfhost_jobs WHERE status='pending' AND run_after<=$1")) {
         return {
-          rows: [{ id: "pending-due", payload: JSON.stringify(msg("agent-regate-pr")), job_key: "agent-regate-pr:jsonbored/gittensory#9" }],
+          rows: [
+            { id: "pending-same", payload: JSON.stringify(regateJob(123, 9)), job_key: "agent-regate-pr:jsonbored/gittensory#9" },
+            { id: "pending-legacy", payload: JSON.stringify(regateJob(null, 10)), job_key: "agent-regate-pr:jsonbored/gittensory#10" },
+            { id: "pending-other", payload: JSON.stringify(regateJob(456, 11)), job_key: "agent-regate-pr:jsonbored/gittensory#11" },
+            { id: "pending-local", payload: JSON.stringify(msg("local-cleanup")), job_key: null },
+            { id: "pending-malformed", payload: "{not json", job_key: null },
+          ],
           rowCount: 1,
         };
       }
@@ -796,6 +857,12 @@ describe("createPgQueue (durable #977)", () => {
       }
       if (q.includes("SELECT id FROM _selfhost_jobs WHERE status='pending' AND job_key=$1 ORDER BY")) {
         return { rows: [], rowCount: 0 };
+      }
+      if (
+        q.includes("SET run_after=GREATEST(run_after, $1), last_error=COALESCE") &&
+        params?.[2] === "pending-legacy"
+      ) {
+        return { rows: [], rowCount: null };
       }
       return { rows: [], rowCount: 1 };
     });
@@ -809,11 +876,27 @@ describe("createPgQueue (durable #977)", () => {
       );
       await q.init();
       await q.drain();
-      await q.binding.send(ciWebhook("after-cooldown"), { delaySeconds: 0 });
+      await q.binding.send(ciWebhook("after-rate-limit"), { delaySeconds: 0 });
 
       expect(fn).toHaveBeenCalledWith(
         expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
-        expect.arrayContaining([expect.any(Number), "github rate-limit cooldown", "pending-due"]),
+        expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-same"]),
+      );
+      expect(fn).toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
+        expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-legacy"]),
+      );
+      expect(fn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
+        expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-other"]),
+      );
+      expect(fn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
+        expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-local"]),
+      );
+      expect(fn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
+        expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-malformed"]),
       );
       expect(fn).toHaveBeenCalledWith(
         expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=$2"),
@@ -825,7 +908,7 @@ describe("createPgQueue (durable #977)", () => {
       );
       expect(fn).toHaveBeenCalledWith(
         expect.stringContaining("INSERT INTO _selfhost_jobs (payload"),
-        expect.arrayContaining([expect.stringContaining('"deliveryId":"after-cooldown"'), expect.any(Number)]),
+        expect.arrayContaining([expect.stringContaining('"deliveryId":"after-rate-limit"'), expect.any(Number)]),
       );
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_STARTUP_JITTER_MS;
@@ -833,11 +916,12 @@ describe("createPgQueue (durable #977)", () => {
     }
   });
 
-  it("opens a shared cooldown after GitHub rate limits so the pump does not claim the next due job", async () => {
+  it("keeps claiming unrelated work after a keyed GitHub rate limit", async () => {
     const m = makePool();
-    m.enqueueJob("1", { type: "github-webhook" }, 0);
-    m.enqueueJob("2", { type: "agent-regate-pr" }, 0);
-    let calls = 0;
+    m.enqueueJob("1", installedWebhook("blocked-installation", 123), 0);
+    m.enqueueJob("2", installedWebhook("other-installation", 456), 0);
+    m.enqueueJob("3", msg("local-cleanup"), 0);
+    const seen: string[] = [];
     const rateLimit = new Error("API rate limit exceeded for installation ID 123");
     Object.assign(rateLimit, {
       status: 403,
@@ -845,18 +929,28 @@ describe("createPgQueue (durable #977)", () => {
     });
     const q = createPgQueue(
       m.pool,
-      async () => {
-        calls += 1;
-        throw rateLimit;
+      async (message) => {
+        seen.push(message.type === "github-webhook" ? message.deliveryId ?? "" : message.type);
+        if (message.type === "github-webhook" && message.deliveryId === "blocked-installation") {
+          throw rateLimit;
+        }
       },
       { maxRetries: 1, backoffMs: () => 0 },
     );
     await q.init();
     await q.drain();
-    expect(calls).toBe(1);
+    expect(seen).toEqual(["blocked-installation", "other-installation", "local-cleanup"]);
     expect(m.pool.query).toHaveBeenCalledWith(
       expect.stringContaining("SELECT id, payload, job_key FROM _selfhost_jobs WHERE status='pending' AND run_after<=$1"),
       expect.arrayContaining([expect.any(Number)]),
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
+      ["2"],
+    );
+    expect(m.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
+      ["3"],
     );
   });
 

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -597,7 +597,7 @@ describe("createPgQueue (durable #977)", () => {
     }
   });
 
-  it("pre-yields from exact admission exhaustion before newer legacy repo observations", async () => {
+  it("does not keep webhook admission closed from stale exact rows after a newer healthy legacy observation", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
     const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
@@ -614,10 +614,10 @@ describe("createPgQueue (durable #977)", () => {
 
       await q.drain();
 
-      expect(seen).toEqual([]);
-      expect(m.pool.query).toHaveBeenCalledWith(
+      expect(seen).toEqual(["github-webhook"]);
+      expect(m.pool.query).not.toHaveBeenCalledWith(
         expect.stringContaining("SET status='pending', run_after=GREATEST"),
-        [Date.parse("2026-06-24T12:10:15.000Z"), "github rate-limit webhook admission", "webhook"],
+        expect.anything(),
       );
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -128,6 +128,7 @@ describe("self-host queue common helpers", () => {
   it("uses the newest comparable exact or legacy admission observation", () => {
     const now = Date.parse("2026-06-24T12:00:00.000Z");
     const key = githubRateLimitAdmissionKeyForInstallation(123);
+    const unrelatedKey = githubRateLimitAdmissionKeyForInstallation(456);
     expect(
       githubRateLimitAdmissionDelayMs(
         "webhook",
@@ -161,6 +162,49 @@ describe("self-host queue common helpers", () => {
         now,
       ),
     ).toBeNull();
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        key,
+        [
+          { admission_key: key, remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+          { admission_key: null, remaining: 0, reset_at: "2026-06-24T12:10:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBeNull();
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        key,
+        [
+          { admission_key: unrelatedKey, remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBeNull();
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        null,
+        [
+          { remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z" },
+          { remaining: 0, reset_at: "2026-06-24T12:10:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBe(615_000);
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        null,
+        [
+          { remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z" },
+          { remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBe(615_000);
   });
 
   it("uses the newest local REST rate-limit observation for admission control", async () => {

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -98,7 +98,7 @@ describe("self-host queue common helpers", () => {
     expect(githubWebhookRateLimitDelayMs({ remaining: 50, reset_at: "2026-06-24T11:59:00.000Z" }, now)).toBeNull();
   });
 
-  it("computes admission delays from any unsafe persisted candidate", () => {
+  it("computes admission delays from the newest unkeyed persisted candidate", () => {
     const now = Date.parse("2026-06-24T12:00:00.000Z");
     expect(
       githubRateLimitAdmissionDelayMs(
@@ -110,8 +110,57 @@ describe("self-host queue common helpers", () => {
         ],
         now,
       ),
-    ).toBe(615_000);
+    ).toBeNull();
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        null,
+        [
+          { remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+          { remaining: 75, reset_at: "2026-06-24T12:15:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBe(900_000);
     expect(githubRateLimitAdmissionDelayMs("background", null, [], now)).toBeNull();
+  });
+
+  it("prefers exact admission observations over stale legacy fallback rows", () => {
+    const now = Date.parse("2026-06-24T12:00:00.000Z");
+    const key = githubRateLimitAdmissionKeyForInstallation(123);
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        key,
+        [
+          { admission_key: null, remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+          { admission_key: key, remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBeNull();
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        key,
+        [
+          { admissionKey: key, remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+          { admission_key: null, remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBe(615_000);
+    expect(
+      githubRateLimitAdmissionDelayMs(
+        "webhook",
+        key,
+        [
+          { admission_key: key, remaining: 0, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T11:59:00.000Z" },
+          { admission_key: null, remaining: 4000, reset_at: "2026-06-24T12:20:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" },
+        ],
+        now,
+      ),
+    ).toBe(615_000);
   });
 
   it("uses the newest local REST rate-limit observation for admission control", async () => {
@@ -150,7 +199,7 @@ describe("self-host queue common helpers", () => {
       githubRateLimitAdmissionDelayMs(
         "webhook",
         key,
-        { remaining: 500, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:01:00.000Z" },
+        { admission_key: key, remaining: 500, reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:01:00.000Z" },
         now,
       ),
     ).toBeNull();

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -125,7 +125,7 @@ describe("self-host queue common helpers", () => {
     expect(githubRateLimitAdmissionDelayMs("background", null, [], now)).toBeNull();
   });
 
-  it("prefers exact admission observations over stale legacy fallback rows", () => {
+  it("uses the newest comparable exact or legacy admission observation", () => {
     const now = Date.parse("2026-06-24T12:00:00.000Z");
     const key = githubRateLimitAdmissionKeyForInstallation(123);
     expect(
@@ -160,7 +160,7 @@ describe("self-host queue common helpers", () => {
         ],
         now,
       ),
-    ).toBe(615_000);
+    ).toBeNull();
   });
 
   it("uses the newest local REST rate-limit observation for admission control", async () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -549,6 +549,45 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
   });
 
+  it("does not keep webhook admission closed from stale legacy rows after a newer healthy exact observation", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const driver = makeDriver();
+    driver.query(
+      `CREATE TABLE github_rate_limit_observations (
+        id TEXT PRIMARY KEY,
+        repo_full_name TEXT NOT NULL,
+        admission_key TEXT,
+        resource TEXT NOT NULL,
+        path TEXT NOT NULL,
+        status_code INTEGER NOT NULL,
+        limit_value INTEGER,
+        remaining INTEGER,
+        reset_at TEXT,
+        observed_at TEXT NOT NULL
+      )`,
+      [],
+    );
+    driver.query(
+      `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+       VALUES (?, ?, NULL, 'rest', ?, 403, 5000, 0, ?, ?)`,
+      ["rl-webhook-legacy-old-low", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T11:59:00.000Z"],
+    );
+    driver.query(
+      `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+       VALUES (?, ?, ?, 'rest', ?, 200, 5000, 4000, ?, ?)`,
+      ["rl-webhook-exact-new-healthy", "owner/repo", "installation:123", "/x", "2026-06-24T12:20:00.000Z", "2026-06-24T12:00:00.000Z"],
+    );
+    const seen: string[] = [];
+    const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
+
+    await q.binding.send({ type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: { installation: { id: 123 }, repository: { full_name: "owner/repo" } } });
+    await q.drain();
+
+    expect(seen).toEqual(["github-webhook"]);
+    expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+  });
+
   it("does not pre-yield webhook jobs for another installation's persisted REST exhaustion", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -38,6 +38,26 @@ const ciWebhook = (deliveryId: string, eventName: "check_suite" | "check_run" = 
       [eventName]: { head_sha: sha, pull_requests: [{ number: 1629 }] },
     },
   }) as unknown as JobMessage;
+const installedWebhook = (deliveryId: string, installationId: number): JobMessage =>
+  ({
+    type: "github-webhook",
+    deliveryId,
+    eventName: "pull_request",
+    payload: {
+      action: "synchronize",
+      installation: { id: installationId },
+      repository: { full_name: "JSONbored/gittensory" },
+      pull_request: { number: 1629, head: { sha: "c".repeat(40) } },
+    },
+  }) as unknown as JobMessage;
+const regateJob = (installationId: number | null, prNumber = 1629): JobMessage =>
+  ({
+    type: "agent-regate-pr",
+    deliveryId: `sweep:jsonbored/gittensory#${prNumber}`,
+    repoFullName: "jsonbored/gittensory",
+    prNumber,
+    ...(installationId === null ? {} : { installationId }),
+  }) as unknown as JobMessage;
 const typeOf = (m: JobMessage): string => (m as unknown as { type: string }).type;
 
 describe("createSqliteQueue (durable #980)", () => {
@@ -945,9 +965,9 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limited_total");
   });
 
-  it("defers the due backlog and stops claiming when GitHub is rate-limited", async () => {
+  it("does not defer GitHub work when a non-GitHub job throws a GitHub-looking rate limit", async () => {
     const driver = makeDriver();
-    let calls = 0;
+    const seen: string[] = [];
     const rateLimit = new Error("API rate limit exceeded for installation ID 123");
     Object.assign(rateLimit, {
       status: 403,
@@ -955,49 +975,113 @@ describe("createSqliteQueue (durable #980)", () => {
     });
     const q = createSqliteQueue(
       driver,
-      async () => {
-        calls += 1;
-        throw rateLimit;
+      async (message) => {
+        seen.push(message.type === "github-webhook" ? message.deliveryId ?? "" : message.type);
+        if (message.type === "refresh-registry") throw rateLimit;
+      },
+      { maxRetries: 1, backoffMs: () => 0 },
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
+      [JSON.stringify(msg("refresh-registry"))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 9)",
+      [JSON.stringify(installedWebhook("github-still-runs", 123))],
+    );
+
+    await q.drain();
+
+    const pending = driver.query(
+      "SELECT payload, last_error FROM _selfhost_jobs WHERE status='pending'",
+      [],
+    ).rows as Array<{ payload: string; last_error: string }>;
+    expect(seen).toEqual(["refresh-registry", "github-still-runs"]);
+    expect(pending).toHaveLength(1);
+    expect(JSON.parse(pending[0]!.payload)).toMatchObject({ type: "refresh-registry" });
+    expect(pending[0]!.last_error).toBe("API rate limit exceeded for installation ID 123");
+    expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limited_total: 1 });
+    expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+  });
+
+  it("defers only the depleted keyed GitHub budget while unrelated work keeps draining", async () => {
+    const driver = makeDriver();
+    const seen: string[] = [];
+    const rateLimit = new Error("API rate limit exceeded for installation ID 123");
+    Object.assign(rateLimit, {
+      status: 403,
+      response: { headers: { "retry-after": "120" } },
+    });
+    const q = createSqliteQueue(
+      driver,
+      async (message) => {
+        seen.push(
+          message.type === "github-webhook" ? message.deliveryId ?? "" : message.type,
+        );
+        if (message.type === "github-webhook" && message.deliveryId === "blocked-installation") {
+          throw rateLimit;
+        }
       },
       { maxRetries: 1, backoffMs: () => 0 },
     );
     const before = Date.now();
     driver.query(
-      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 0, 0)",
-      [JSON.stringify(msg("github-webhook"))],
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
+      [JSON.stringify(installedWebhook("blocked-installation", 123))],
     );
     driver.query(
-      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 0, 0)",
-      [JSON.stringify(msg("agent-regate-pr"))],
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 9)",
+      [JSON.stringify(regateJob(123, 9))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 9)",
+      [JSON.stringify(regateJob(null, 10))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
+      [JSON.stringify(installedWebhook("other-installation", 456))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 0)",
+      [JSON.stringify(msg("local-cleanup"))],
+    );
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 8)",
+      ["{not json"],
     );
 
     await q.drain();
 
     const rows = driver.query(
-      "SELECT status, attempts, run_after, last_error FROM _selfhost_jobs ORDER BY id",
+      "SELECT payload, status, attempts, run_after, last_error FROM _selfhost_jobs WHERE status='pending' ORDER BY id",
       [],
-    ).rows as Array<{ status: string; attempts: number; run_after: number; last_error: string }>;
-    expect(calls).toBe(1);
-    expect(rows).toHaveLength(2);
+    ).rows as Array<{ payload: string; status: string; attempts: number; run_after: number; last_error: string | null }>;
+    const deadMalformed = driver.query(
+      "SELECT status, last_error FROM _selfhost_jobs WHERE payload=?",
+      ["{not json"],
+    ).rows[0] as { status: string; last_error: string };
+    expect(seen).toEqual(["blocked-installation", "other-installation", "local-cleanup"]);
+    expect(rows).toHaveLength(3);
+    expect(deadMalformed).toEqual({ status: "dead", last_error: "unparseable payload" });
     expect(rows.every((row) => row.status === "pending")).toBe(true);
     expect(rows.every((row) => row.attempts === 0)).toBe(true);
     expect(rows.every((row) => row.run_after > before)).toBe(true);
-    expect(rows.map((row) => row.last_error)).toEqual([
-      "API rate limit exceeded for installation ID 123",
-      "github rate-limit cooldown",
-    ]);
+    const byType = new Map(rows.map((row) => {
+      const payload = JSON.parse(row.payload) as { type: string; deliveryId?: string; prNumber?: number };
+      const key =
+        payload.type === "agent-regate-pr"
+          ? `${payload.type}:${payload.prNumber}`
+          : payload.deliveryId ?? payload.type;
+      return [key, row];
+    }));
+    expect(byType.get("blocked-installation")?.last_error).toBe("API rate limit exceeded for installation ID 123");
+    expect(byType.get("agent-regate-pr:9")?.last_error).toBe("github rate-limit budget deferred");
+    expect(byType.get("agent-regate-pr:10")?.last_error).toBe("github rate-limit budget deferred");
     expect(q.stats()).toMatchObject({
+      gittensory_jobs_processed_total: 2,
       gittensory_jobs_rate_limited_total: 1,
-      gittensory_jobs_rate_limit_deferred_total: 1,
+      gittensory_jobs_rate_limit_deferred_total: 2,
     });
-
-    await q.binding.send(msg("github-webhook"));
-    const afterEnqueue = driver.query(
-      "SELECT run_after FROM _selfhost_jobs ORDER BY id DESC LIMIT 1",
-      [],
-    ).rows[0] as { run_after: number };
-    expect(calls).toBe(1);
-    expect(afterEnqueue.run_after).toBeGreaterThan(before + 100_000);
   });
 
   it("coalesces a rate-limited active job into an existing pending duplicate without consuming attempts", async () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -490,6 +490,45 @@ describe("createSqliteQueue (durable #980)", () => {
     }
   });
 
+  it("does not keep webhook admission closed from stale legacy low rows after a newer healthy legacy observation", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const driver = makeDriver();
+    driver.query(
+      `CREATE TABLE github_rate_limit_observations (
+        id TEXT PRIMARY KEY,
+        repo_full_name TEXT NOT NULL,
+        admission_key TEXT,
+        resource TEXT NOT NULL,
+        path TEXT NOT NULL,
+        status_code INTEGER NOT NULL,
+        limit_value INTEGER,
+        remaining INTEGER,
+        reset_at TEXT,
+        observed_at TEXT NOT NULL
+      )`,
+      [],
+    );
+    driver.query(
+      `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+       VALUES (?, ?, NULL, 'rest', ?, 403, 5000, 0, ?, ?)`,
+      ["rl-webhook-legacy-old-low", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T11:59:00.000Z"],
+    );
+    driver.query(
+      `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+       VALUES (?, ?, NULL, 'rest', ?, 200, 5000, 4000, ?, ?)`,
+      ["rl-webhook-legacy-new-healthy", "owner/repo", "/x", "2026-06-24T12:20:00.000Z", "2026-06-24T12:00:00.000Z"],
+    );
+    const seen: string[] = [];
+    const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
+
+    await q.binding.send({ type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: { installation: { id: 123 }, repository: { full_name: "owner/repo" } } });
+    await q.drain();
+
+    expect(seen).toEqual(["github-webhook"]);
+    expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+  });
+
   it("does not pre-yield webhook jobs for another installation's persisted REST exhaustion", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -454,7 +454,7 @@ describe("createSqliteQueue (durable #980)", () => {
     }
   });
 
-  it("pre-yields from exact admission exhaustion before newer legacy repo observations", async () => {
+  it("does not keep webhook admission closed from stale exact rows after a newer healthy legacy observation", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
     const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
@@ -492,17 +492,8 @@ describe("createSqliteQueue (durable #980)", () => {
       await q.binding.send({ type: "github-webhook", deliveryId: "fresh", eventName: "pull_request", payload: { installation: { id: 123 }, repository: { full_name: "owner/repo" } } });
       await q.drain();
 
-      expect(seen).toEqual([]);
-      const row = driver.query(
-        "SELECT status, attempts, run_after, last_error FROM _selfhost_jobs",
-        [],
-      ).rows[0] as { status: string; attempts: number; run_after: number; last_error: string };
-      expect(row).toMatchObject({
-        status: "pending",
-        attempts: 0,
-        run_after: Date.parse("2026-06-24T12:10:15.000Z"),
-        last_error: "github rate-limit webhook admission",
-      });
+      expect(seen).toEqual(["github-webhook"]);
+      expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;


### PR DESCRIPTION
## Summary
- Fix self-host queue admission so stale low GitHub REST observations do not keep the queue paused after newer healthy observations exist.

## What changed
- Read only the latest exact admission-key observation and the latest unkeyed fallback observation for SQLite and Postgres queues.
- Keep legacy/global fallback behavior for pre-migration rows.
- Add SQLite and Postgres regressions for stale low unkeyed rows followed by newer healthy rows.

## Why
- The previous query ranked low-remaining rows first, so old low observations could pin webhook/background jobs until an old reset even after newer rows showed the bucket had recovered.

## Validation
- `npx vitest run test/unit/selfhost-queue-common.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts`