### PR TITLE
fix(review): guard stale PR output and actions

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -464,6 +464,7 @@ export async function createOrUpdateSkippedGateCheckRun(
   advisory: Advisory,
   reason = "PR closed before full evaluation.",
   mode: AgentActionMode = "live",
+  options: { checkRunId?: number | undefined } = {},
 ): Promise<CheckRunOutcome | null> {
   return createOrUpdateNamedCheckRun(
     env,
@@ -474,6 +475,7 @@ export async function createOrUpdateSkippedGateCheckRun(
       name: GITTENSORY_GATE_CHECK_NAME,
       status: "completed",
       conclusion: "skipped",
+      checkRunId: options.checkRunId,
       output: {
         title: "Gittensory Orb Review Agent skipped",
         summary: reason,

--- a/src/github/pr-freshness.ts
+++ b/src/github/pr-freshness.ts
@@ -1,0 +1,79 @@
+import { createInstallationToken } from "./app";
+import { fetchLivePullRequest } from "./backfill";
+import type { GitHubPullRequestPayload } from "../types";
+
+export type PullRequestFreshness =
+  | {
+      status: "current";
+      liveHeadSha: string | null;
+      liveState: string | null;
+    }
+  | {
+      status: "stale";
+      reason: "unavailable" | "closed" | "head_unresolved" | "head_changed";
+      expectedHeadSha: string | null;
+      liveHeadSha: string | null;
+      liveState: string | null;
+    };
+
+function normalizedHead(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function reviewedPullRequestHeadSha(
+  pullRequestHeadSha: string | null | undefined,
+  advisoryHeadSha: string | null | undefined,
+): string | null {
+  return normalizedHead(pullRequestHeadSha) ?? normalizedHead(advisoryHeadSha);
+}
+
+export function classifyPullRequestFreshness(
+  live: Pick<GitHubPullRequestPayload, "state" | "head"> | null | undefined,
+  expectedHeadSha: string | null | undefined,
+): PullRequestFreshness {
+  const expected = normalizedHead(expectedHeadSha);
+  if (!live) {
+    return { status: "stale", reason: "unavailable", expectedHeadSha: expected, liveHeadSha: null, liveState: null };
+  }
+  const liveState = typeof live.state === "string" ? live.state : null;
+  const liveHeadSha = normalizedHead(live.head?.sha);
+  if (!liveState) {
+    return { status: "stale", reason: "unavailable", expectedHeadSha: expected, liveHeadSha, liveState: null };
+  }
+  if (liveState !== "open") {
+    return { status: "stale", reason: "closed", expectedHeadSha: expected, liveHeadSha, liveState };
+  }
+  if (expected && !liveHeadSha) {
+    return { status: "stale", reason: "head_unresolved", expectedHeadSha: expected, liveHeadSha: null, liveState };
+  }
+  if (expected && liveHeadSha !== expected) {
+    return { status: "stale", reason: "head_changed", expectedHeadSha: expected, liveHeadSha, liveState };
+  }
+  return { status: "current", liveHeadSha, liveState };
+}
+
+export async function fetchPullRequestFreshness(
+  env: Env,
+  args: {
+    installationId: number;
+    repoFullName: string;
+    pullNumber: number;
+    expectedHeadSha?: string | null | undefined;
+  },
+): Promise<PullRequestFreshness> {
+  const token =
+    (await createInstallationToken(env, args.installationId).catch(() => undefined)) ??
+    env.GITHUB_PUBLIC_TOKEN;
+  if (!token) return classifyPullRequestFreshness(undefined, args.expectedHeadSha);
+  const live = await fetchLivePullRequest(env, args.repoFullName, args.pullNumber, token);
+  return classifyPullRequestFreshness(live, args.expectedHeadSha);
+}
+
+export function pullRequestFreshnessDetail(result: PullRequestFreshness): string {
+  if (result.status === "current") return "PR is current";
+  if (result.reason === "unavailable") return "live PR state could not be verified";
+  if (result.reason === "closed") return `PR is no longer open (live state: ${result.liveState ?? "unknown"})`;
+  if (result.reason === "head_unresolved") return "live PR head SHA could not be verified";
+  return `PR head changed from ${result.expectedHeadSha ?? "unknown"} to ${result.liveHeadSha ?? "unknown"}`;
+}

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1412,12 +1412,12 @@ export function agentMaintenanceHeadMatchesGate(reviewedHeadSha: string | null |
 type BlockingPullRequestFreshness = Extract<
   PullRequestFreshness,
   { status: "stale" }
-> & { reason: "closed" | "head_changed" };
+>;
 
 function freshnessBlocksReviewOutput(
   freshness: PullRequestFreshness,
 ): freshness is BlockingPullRequestFreshness {
-  return freshness.status === "stale" && (freshness.reason === "closed" || freshness.reason === "head_changed");
+  return freshness.status === "stale";
 }
 
 async function reviewTargetFreshness(

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4722,23 +4722,16 @@ async function maybePublishPrPublicSurface(
   let aiReviewExpected = false;
   let gateFinalized = false;
   const reviewedHeadSha = reviewedPullRequestHeadSha(pr.headSha, advisory.headSha);
-  const currentFreshness: PullRequestFreshness = {
-    status: "current",
-    liveHeadSha: null,
-    liveState: null,
-  };
   const freshnessForReviewOutput = (phase: string): Promise<PullRequestFreshness> =>
-    reviewedHeadSha && (gateEnabled || prelimHasPublicOutput)
-      ? reviewTargetFreshness(env, {
-          installationId,
-          repoFullName,
-          pullNumber: pr.number,
-          expectedHeadSha: reviewedHeadSha,
-          deliveryId: webhook.deliveryId,
-          phase,
-          actor: author,
-        })
-      : Promise.resolve(currentFreshness);
+    reviewTargetFreshness(env, {
+      installationId,
+      repoFullName,
+      pullNumber: pr.number,
+      expectedHeadSha: reviewedHeadSha,
+      deliveryId: webhook.deliveryId,
+      phase,
+      actor: author,
+    });
   const skipStaleReviewOutput = async (freshness: PullRequestFreshness): Promise<boolean> => {
     if (!freshnessBlocksReviewOutput(freshness)) return false;
     if (gateEnabled && pendingGateCheckRunId !== undefined && !gateFinalized) {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -136,6 +136,12 @@ import {
   removePullRequestLabel,
 } from "../github/labels";
 import { githubRateLimitAdmissionKeyForInstallation, resolveRepoActionMode } from "../github/client";
+import {
+  fetchPullRequestFreshness,
+  pullRequestFreshnessDetail,
+  reviewedPullRequestHeadSha,
+  type PullRequestFreshness,
+} from "../github/pr-freshness";
 import { ALL_TYPE_LABELS, resolvePrTypeLabel } from "../settings/pr-type-label";
 import { fetchPublicContributorProfile } from "../github/public";
 import { refreshRegistry } from "../registry/sync";
@@ -1401,6 +1407,55 @@ export function hasVerifiedRequiredContexts(
 
 export function agentMaintenanceHeadMatchesGate(reviewedHeadSha: string | null | undefined, currentHeadSha: string | null | undefined): boolean {
   return reviewedHeadSha == null || currentHeadSha == null || currentHeadSha === reviewedHeadSha;
+}
+
+type BlockingPullRequestFreshness = Extract<
+  PullRequestFreshness,
+  { status: "stale" }
+> & { reason: "closed" | "head_changed" };
+
+function freshnessBlocksReviewOutput(
+  freshness: PullRequestFreshness,
+): freshness is BlockingPullRequestFreshness {
+  return freshness.status === "stale" && (freshness.reason === "closed" || freshness.reason === "head_changed");
+}
+
+async function reviewTargetFreshness(
+  env: Env,
+  args: {
+    installationId: number;
+    repoFullName: string;
+    pullNumber: number;
+    expectedHeadSha?: string | null | undefined;
+    deliveryId: string;
+    phase: string;
+    actor: string | null;
+  },
+): Promise<PullRequestFreshness> {
+  const freshness = await fetchPullRequestFreshness(env, {
+    installationId: args.installationId,
+    repoFullName: args.repoFullName,
+    pullNumber: args.pullNumber,
+    expectedHeadSha: args.expectedHeadSha,
+  });
+  if (!freshnessBlocksReviewOutput(freshness)) return freshness;
+  await recordAuditEvent(env, {
+    eventType: "github_app.pr_review_stale",
+    actor: args.actor,
+    targetKey: `${args.repoFullName}#${args.pullNumber}`,
+    outcome: "denied",
+    detail: `${pullRequestFreshnessDetail(freshness)} — stale review output suppressed`,
+    metadata: {
+      deliveryId: args.deliveryId,
+      repoFullName: args.repoFullName,
+      phase: args.phase,
+      reason: freshness.reason,
+      expectedHeadSha: freshness.expectedHeadSha,
+      liveHeadSha: freshness.liveHeadSha,
+      liveState: freshness.liveState,
+    },
+  }).catch(() => undefined);
+  return freshness;
 }
 
 /**
@@ -4666,6 +4721,39 @@ async function maybePublishPrPublicSurface(
   let inlineCommentsEnabledForReview = false;
   let aiReviewExpected = false;
   let gateFinalized = false;
+  const reviewedHeadSha = reviewedPullRequestHeadSha(pr.headSha, advisory.headSha);
+  const currentFreshness: PullRequestFreshness = {
+    status: "current",
+    liveHeadSha: null,
+    liveState: null,
+  };
+  const freshnessForReviewOutput = (phase: string): Promise<PullRequestFreshness> =>
+    reviewedHeadSha && (gateEnabled || prelimHasPublicOutput)
+      ? reviewTargetFreshness(env, {
+          installationId,
+          repoFullName,
+          pullNumber: pr.number,
+          expectedHeadSha: reviewedHeadSha,
+          deliveryId: webhook.deliveryId,
+          phase,
+          actor: author,
+        })
+      : Promise.resolve(currentFreshness);
+  const skipStaleReviewOutput = async (freshness: PullRequestFreshness): Promise<boolean> => {
+    if (!freshnessBlocksReviewOutput(freshness)) return false;
+    if (gateEnabled && pendingGateCheckRunId !== undefined && !gateFinalized) {
+      await createOrUpdateSkippedGateCheckRun(
+        env,
+        installationId,
+        repoFullName,
+        advisory,
+        pullRequestFreshnessDetail(freshness),
+        mode,
+        { checkRunId: pendingGateCheckRunId },
+      ).catch(() => undefined);
+    }
+    return true;
+  };
   // The PR's changed files are needed by the slop/manifest gates, the AI review + grounding + RAG, the secret
   // scan, the check-run, and the unified comment. Resolve them AT MOST ONCE per review and share across the
   // gate phase (inside the try) AND the publish phase (check-run + comment, after the try): memoize the first
@@ -4896,13 +4984,18 @@ async function maybePublishPrPublicSurface(
     // stale green/yellow/red verdict while the current head is being recomputed. In-place upsert: once the final
     // verdict is ready it overwrites this comment. GitHub rate-limits still abort so the queue can retry instead
     // of leaving a stale public surface visible.
-    if (
-      shouldPostReviewingPlaceholder({
-        reviewWillRun: true,
-        mode,
-        willComment: decision.willComment,
-      })
-    ) {
+    const shouldPostPlaceholder = shouldPostReviewingPlaceholder({
+      reviewWillRun: true,
+      mode,
+      willComment: decision.willComment,
+    });
+    if (shouldPostPlaceholder) {
+      if (
+        await skipStaleReviewOutput(
+          await freshnessForReviewOutput("pre_public_output"),
+        )
+      )
+        return undefined;
       const placeholderBody = `${PR_PANEL_COMMENT_MARKER}\n\n${renderReviewingPlaceholder()}`;
       try {
         await createOrUpdatePrIntelligenceComment(
@@ -5148,6 +5241,10 @@ async function maybePublishPrPublicSurface(
         conclusion: gateEvaluation.conclusion,
         reasonCode,
       });
+    }
+    const finalFreshness = await freshnessForReviewOutput("final_publish");
+    if (await skipStaleReviewOutput(finalFreshness)) {
+      return undefined;
     }
     if (gateEnabled) {
       try {

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -20,7 +20,6 @@ const AGENT_ACTOR = "gittensory";
 // agent-execution test can enforce the invariant that every member is also counted by agentRequiresPrWrite
 // (PR_WRITE_ACTION_CLASSES is a superset), so this runtime guard never disagrees with the readiness gate.
 export const PR_WRITE_CLASSES = new Set<AgentActionClass>(["request_changes", "approve", "merge", "close", "update_branch"]);
-const PR_MUTATION_CLASSES = new Set<AgentActionClass>(["label", "request_changes", "approve", "merge", "close"]);
 
 export type AgentActionExecutionContext = {
   installationId: number;
@@ -110,19 +109,18 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("queued", `awaiting maintainer approval — ${action.reason}`);
       continue;
     }
-    // 5) Freshness guard: any PR mutation must still target the reviewed, open head. This protects approval-queue
-    //    replays and slow webhook jobs from force-pushes or manual closes that happen after the review was planned.
-    if (PR_MUTATION_CLASSES.has(action.actionClass)) {
-      const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
-      if (!expectedHeadSha) {
-        await audit("denied", "live PR head guard unavailable — action not executed");
-        continue;
-      }
-      const freshness = await freshnessFor(expectedHeadSha);
-      if (freshness.status !== "current") {
-        await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
-        continue;
-      }
+    // 5) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
+    //    target the reviewed, open head. This protects approval-queue replays and slow webhook jobs from
+    //    force-pushes or manual closes that happen after the review was planned.
+    const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
+    if (!expectedHeadSha) {
+      await audit("denied", "live PR head guard unavailable — action not executed");
+      continue;
+    }
+    const freshness = await freshnessFor(expectedHeadSha);
+    if (freshness.status !== "current") {
+      await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
+      continue;
     }
     // 6) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -3,7 +3,7 @@ import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
-import { fetchPullRequestFreshness, pullRequestFreshnessDetail, type PullRequestFreshness } from "../github/pr-freshness";
+import { fetchPullRequestFreshness, pullRequestFreshnessDetail } from "../github/pr-freshness";
 import { isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
 import type { PlannedAgentAction } from "../settings/agent-actions";
@@ -61,19 +61,6 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
   // globalPaused folds the env-var brake AND the DB-backed kill-switch (#audit-§5.2) so an operator can halt the
   // fleet instantly via one DB row, without a redeploy.
   const mode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: ctx.agentPaused, agentDryRun: ctx.agentDryRun });
-  const freshnessByHead = new Map<string, Promise<PullRequestFreshness>>();
-  const freshnessFor = (expectedHeadSha: string): Promise<PullRequestFreshness> => {
-    const existing = freshnessByHead.get(expectedHeadSha);
-    if (existing) return existing;
-    const freshness = fetchPullRequestFreshness(env, {
-      installationId: ctx.installationId,
-      repoFullName: ctx.repoFullName,
-      pullNumber: ctx.pullNumber,
-      expectedHeadSha,
-    });
-    freshnessByHead.set(expectedHeadSha, freshness);
-    return freshness;
-  };
 
   for (const action of planned) {
     const autonomyLevel = resolveAutonomy(ctx.autonomy, action.actionClass);
@@ -117,7 +104,12 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", "live PR head guard unavailable — action not executed");
       continue;
     }
-    const freshness = await freshnessFor(expectedHeadSha);
+    const freshness = await fetchPullRequestFreshness(env, {
+      installationId: ctx.installationId,
+      repoFullName: ctx.repoFullName,
+      pullNumber: ctx.pullNumber,
+      expectedHeadSha,
+    });
     if (freshness.status !== "current") {
       await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
       continue;

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -3,6 +3,7 @@ import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
+import { fetchPullRequestFreshness, pullRequestFreshnessDetail, type PullRequestFreshness } from "../github/pr-freshness";
 import { isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
 import type { PlannedAgentAction } from "../settings/agent-actions";
@@ -19,6 +20,7 @@ const AGENT_ACTOR = "gittensory";
 // agent-execution test can enforce the invariant that every member is also counted by agentRequiresPrWrite
 // (PR_WRITE_ACTION_CLASSES is a superset), so this runtime guard never disagrees with the readiness gate.
 export const PR_WRITE_CLASSES = new Set<AgentActionClass>(["request_changes", "approve", "merge", "close", "update_branch"]);
+const PR_MUTATION_CLASSES = new Set<AgentActionClass>(["label", "request_changes", "approve", "merge", "close"]);
 
 export type AgentActionExecutionContext = {
   installationId: number;
@@ -60,6 +62,19 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
   // globalPaused folds the env-var brake AND the DB-backed kill-switch (#audit-§5.2) so an operator can halt the
   // fleet instantly via one DB row, without a redeploy.
   const mode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)), agentPaused: ctx.agentPaused, agentDryRun: ctx.agentDryRun });
+  const freshnessByHead = new Map<string, Promise<PullRequestFreshness>>();
+  const freshnessFor = (expectedHeadSha: string): Promise<PullRequestFreshness> => {
+    const existing = freshnessByHead.get(expectedHeadSha);
+    if (existing) return existing;
+    const freshness = fetchPullRequestFreshness(env, {
+      installationId: ctx.installationId,
+      repoFullName: ctx.repoFullName,
+      pullNumber: ctx.pullNumber,
+      expectedHeadSha,
+    });
+    freshnessByHead.set(expectedHeadSha, freshness);
+    return freshness;
+  };
 
   for (const action of planned) {
     const autonomyLevel = resolveAutonomy(ctx.autonomy, action.actionClass);
@@ -83,24 +98,38 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", `autonomy for ${action.actionClass} is ${autonomyLevel} — action not currently enabled`);
       continue;
     }
-    // 3) auto_with_approval stages the action in the approval queue (#779) for a one-tap maintainer decision
-    //    instead of executing it now.
+    // 3) dry-run records the intent without touching GitHub, so it does not need a live freshness read.
+    if (mode === "dry_run") {
+      await audit("dry_run", `dry-run: would ${action.actionClass} — ${action.reason}`);
+      continue;
+    }
+    // 4) auto_with_approval stages the action in the approval queue (#779) for a one-tap maintainer decision
+    //    instead of executing it now. Staging is not a GitHub mutation; execution/replay runs this guard later.
     if (action.requiresApproval) {
       await stageForApproval(env, ctx, action, autonomyLevel);
       await audit("queued", `awaiting maintainer approval — ${action.reason}`);
       continue;
     }
-    // 4) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
+    // 5) Freshness guard: any PR mutation must still target the reviewed, open head. This protects approval-queue
+    //    replays and slow webhook jobs from force-pushes or manual closes that happen after the review was planned.
+    if (PR_MUTATION_CLASSES.has(action.actionClass)) {
+      const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
+      if (!expectedHeadSha) {
+        await audit("denied", "live PR head guard unavailable — action not executed");
+        continue;
+      }
+      const freshness = await freshnessFor(expectedHeadSha);
+      if (freshness.status !== "current") {
+        await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
+        continue;
+      }
+    }
+    // 6) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
       await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
       continue;
     }
-    // 5) dry-run records the intent without touching GitHub.
-    if (mode === "dry_run") {
-      await audit("dry_run", `dry-run: would ${action.actionClass} — ${action.reason}`);
-      continue;
-    }
-    // 6) live — perform the real mutation, recording success or the error.
+    // 7) live — perform the real mutation, recording success or the error.
     try {
       await performAction(env, ctx, action);
       await audit("completed", action.reason);

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -84,7 +84,7 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(createIssueComment).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "closing");
     expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
     expect(updatePullRequestBranch).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "sha7");
-    expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(1);
+    expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(6);
     expect((await auditFor(env, "merge"))?.outcome).toBe("completed");
   });
 
@@ -243,6 +243,33 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(outcomes.find((outcome) => outcome.actionClass === "update_branch")?.detail).toContain("PR head changed from sha7 to newsha");
     const audit = await auditFor(env, "merge");
     expect(audit?.outcome).toBe("denied");
+  });
+
+  it("LIVE: rechecks freshness after update_branch before later PR-visible actions", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchPullRequestFreshness)
+      .mockResolvedValueOnce({
+        status: "current",
+        liveHeadSha: "sha7",
+        liveState: "open",
+      })
+      .mockResolvedValueOnce({
+        status: "stale",
+        reason: "head_changed",
+        expectedHeadSha: "sha7",
+        liveHeadSha: "sha8",
+        liveState: "open",
+      });
+
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [updateBranch, approve]);
+
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["completed", "denied"]);
+    expect(updatePullRequestBranch).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "sha7");
+    expect(createPullRequestReview).not.toHaveBeenCalled();
+    expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(2);
+    expect(fetchPullRequestFreshness).toHaveBeenNthCalledWith(1, env, expect.objectContaining({ expectedHeadSha: "sha7" }));
+    expect(fetchPullRequestFreshness).toHaveBeenNthCalledWith(2, env, expect.objectContaining({ expectedHeadSha: "sha7" }));
+    expect(outcomes[1]?.detail).toContain("PR head changed from sha7 to sha8");
   });
 
   it("LIVE: denies mutations when the PR is already closed", async () => {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -209,12 +209,13 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
   it("LIVE with minimal action payloads: denies PR mutations when no reviewed head can be pinned", async () => {
     const env = createTestEnv({});
     const bare = (actionClass: PlannedAgentAction["actionClass"]): PlannedAgentAction => ({ actionClass, requiresApproval: false, reason: "x" });
-    const outcomes = await executeAgentMaintenanceActions(env, ctx({ headSha: undefined }), [bare("label"), bare("request_changes"), bare("approve"), bare("merge"), bare("close")]);
-    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied", "denied"]);
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ headSha: undefined }), [bare("label"), bare("request_changes"), bare("approve"), bare("merge"), bare("close"), bare("update_branch")]);
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied", "denied", "denied"]);
     expect(ensurePullRequestLabel).not.toHaveBeenCalled();
     expect(createPullRequestReview).not.toHaveBeenCalled();
     expect(mergePullRequest).not.toHaveBeenCalled();
     expect(closePullRequest).not.toHaveBeenCalled();
+    expect(updatePullRequestBranch).not.toHaveBeenCalled();
     expect(createIssueComment).not.toHaveBeenCalled();
     expect(fetchPullRequestFreshness).not.toHaveBeenCalled();
     expect(outcomes[0]?.detail).toContain("head guard unavailable");
@@ -230,14 +231,16 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
       liveState: "open",
     });
 
-    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [label, approve, merge, close]);
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [label, approve, merge, close, updateBranch]);
 
-    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied"]);
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied", "denied"]);
     expect(ensurePullRequestLabel).not.toHaveBeenCalled();
     expect(createPullRequestReview).not.toHaveBeenCalled();
     expect(mergePullRequest).not.toHaveBeenCalled();
     expect(closePullRequest).not.toHaveBeenCalled();
+    expect(updatePullRequestBranch).not.toHaveBeenCalled();
     expect(outcomes[0]?.detail).toContain("PR head changed from sha7 to newsha");
+    expect(outcomes.find((outcome) => outcome.actionClass === "update_branch")?.detail).toContain("PR head changed from sha7 to newsha");
     const audit = await auditFor(env, "merge");
     expect(audit?.outcome).toBe("denied");
   });

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -11,9 +11,21 @@ vi.mock("../../src/github/labels", () => ({
   ensurePullRequestLabel: vi.fn(async () => ({ applied: true, created: false })),
   removePullRequestLabel: vi.fn(async () => undefined),
 }));
+vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/github/pr-freshness")>();
+  return {
+    ...actual,
+    fetchPullRequestFreshness: vi.fn(async (_env: Env, args: { expectedHeadSha?: string | null }) => ({
+      status: "current" as const,
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    })),
+  };
+});
 
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
+import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
 import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
@@ -48,6 +60,11 @@ async function auditFor(env: Env, actionClass: string): Promise<{ outcome: strin
 describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchPullRequestFreshness).mockImplementation(async (_env, args) => ({
+      status: "current",
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    }));
   });
 
   it("actionParams threads expectedHeadSha for an update_branch action (and omits absent fields)", () => {
@@ -67,6 +84,7 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(createIssueComment).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "closing");
     expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
     expect(updatePullRequestBranch).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "sha7");
+    expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(1);
     expect((await auditFor(env, "merge"))?.outcome).toBe("completed");
   });
 
@@ -77,6 +95,7 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     const pinnedMerge: PlannedAgentAction = { actionClass: "merge", requiresApproval: false, reason: "clean", mergeMethod: "squash", expectedHeadSha: "reviewed-sha" };
     await executeAgentMaintenanceActions(env, ctx({ headSha: "live-sha" }), [pinnedMerge]);
     expect(mergePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7, { mergeMethod: "squash", sha: "reviewed-sha" });
+    expect(fetchPullRequestFreshness).toHaveBeenCalledWith(env, expect.objectContaining({ expectedHeadSha: "reviewed-sha" }));
   });
 
   it("LIVE label with labelOp=add + comment: adds the label AND posts the comment", async () => {
@@ -187,16 +206,63 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });
   });
 
-  it("LIVE with minimal action payloads: applies defensive defaults and omits the sha guard when headSha is absent", async () => {
+  it("LIVE with minimal action payloads: denies PR mutations when no reviewed head can be pinned", async () => {
     const env = createTestEnv({});
     const bare = (actionClass: PlannedAgentAction["actionClass"]): PlannedAgentAction => ({ actionClass, requiresApproval: false, reason: "x" });
-    await executeAgentMaintenanceActions(env, ctx({ headSha: undefined }), [bare("label"), bare("request_changes"), bare("approve"), bare("merge"), bare("close")]);
-    expect(ensurePullRequestLabel).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "", { createMissingLabel: true });
-    expect(createPullRequestReview).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "REQUEST_CHANGES", "");
-    expect(createPullRequestReview).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "APPROVE", "");
-    expect(mergePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7, { mergeMethod: "squash" }); // no sha guard
-    expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
-    expect(createIssueComment).not.toHaveBeenCalled(); // no closeComment → no comment posted
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ headSha: undefined }), [bare("label"), bare("request_changes"), bare("approve"), bare("merge"), bare("close")]);
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied", "denied"]);
+    expect(ensurePullRequestLabel).not.toHaveBeenCalled();
+    expect(createPullRequestReview).not.toHaveBeenCalled();
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    expect(closePullRequest).not.toHaveBeenCalled();
+    expect(createIssueComment).not.toHaveBeenCalled();
+    expect(fetchPullRequestFreshness).not.toHaveBeenCalled();
+    expect(outcomes[0]?.detail).toContain("head guard unavailable");
+  });
+
+  it("LIVE: denies mutations when the PR was force-pushed after the action was planned", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "sha7",
+      liveHeadSha: "newsha",
+      liveState: "open",
+    });
+
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [label, approve, merge, close]);
+
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual(["denied", "denied", "denied", "denied"]);
+    expect(ensurePullRequestLabel).not.toHaveBeenCalled();
+    expect(createPullRequestReview).not.toHaveBeenCalled();
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    expect(closePullRequest).not.toHaveBeenCalled();
+    expect(outcomes[0]?.detail).toContain("PR head changed from sha7 to newsha");
+    const audit = await auditFor(env, "merge");
+    expect(audit?.outcome).toBe("denied");
+  });
+
+  it("LIVE: denies mutations when the PR is already closed", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "closed",
+      expectedHeadSha: "sha7",
+      liveHeadSha: "sha7",
+      liveState: "closed",
+    });
+
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [close]);
+
+    expect(outcomes).toEqual([
+      expect.objectContaining({
+        actionClass: "close",
+        outcome: "denied",
+        detail: expect.stringContaining("no longer open"),
+      }),
+    ]);
+    expect(createIssueComment).not.toHaveBeenCalled();
+    expect(closePullRequest).not.toHaveBeenCalled();
   });
 
   it("records a failed mutation as error rather than swallowing it", async () => {

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -9,6 +9,17 @@ vi.mock("../../src/github/pr-actions", () => ({
 vi.mock("../../src/github/labels", () => ({
   ensurePullRequestLabel: vi.fn(async () => ({ applied: true, created: false })),
 }));
+vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/github/pr-freshness")>();
+  return {
+    ...actual,
+    fetchPullRequestFreshness: vi.fn(async (_env: Env, args: { expectedHeadSha?: string | null }) => ({
+      status: "current" as const,
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    })),
+  };
+});
 
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel } from "../../src/github/labels";

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyPullRequestFreshness,
+  fetchPullRequestFreshness,
+  pullRequestFreshnessDetail,
+  reviewedPullRequestHeadSha,
+} from "../../src/github/pr-freshness";
+import { createTestEnv } from "../helpers/d1";
+
+describe("PR freshness guards", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("classifies a matching open head as current", () => {
+    const result = classifyPullRequestFreshness({ state: "open", head: { sha: "sha1" } }, "sha1");
+    expect(result).toEqual({ status: "current", liveHeadSha: "sha1", liveState: "open" });
+    expect(pullRequestFreshnessDetail(result)).toBe("PR is current");
+  });
+
+  it("allows an open PR when no exact head was requested", () => {
+    expect(classifyPullRequestFreshness({ state: "open", head: {} }, null)).toEqual({
+      status: "current",
+      liveHeadSha: null,
+      liveState: "open",
+    });
+  });
+
+  it("treats unavailable live state as stale for callers that require proof", () => {
+    const result = classifyPullRequestFreshness(undefined, "sha1");
+    expect(result).toMatchObject({ status: "stale", reason: "unavailable", expectedHeadSha: "sha1" });
+    expect(pullRequestFreshnessDetail(result)).toBe("live PR state could not be verified");
+  });
+
+  it("treats malformed live PR responses without state as unverifiable", () => {
+    const result = classifyPullRequestFreshness({ state: undefined as unknown as string, head: { sha: "sha1" } }, "sha1");
+    expect(result).toMatchObject({ status: "stale", reason: "unavailable", liveHeadSha: "sha1", liveState: null });
+  });
+
+  it("treats closed PRs as stale even when the head still matches", () => {
+    const result = classifyPullRequestFreshness({ state: "closed", head: { sha: "sha1" } }, "sha1");
+    expect(result).toMatchObject({ status: "stale", reason: "closed", liveState: "closed", liveHeadSha: "sha1" });
+    expect(pullRequestFreshnessDetail(result)).toBe("PR is no longer open (live state: closed)");
+  });
+
+  it("treats missing live head as stale when an exact reviewed head is required", () => {
+    const result = classifyPullRequestFreshness({ state: "open", head: {} }, "sha1");
+    expect(result).toMatchObject({ status: "stale", reason: "head_unresolved", expectedHeadSha: "sha1" });
+    expect(pullRequestFreshnessDetail(result)).toBe("live PR head SHA could not be verified");
+  });
+
+  it("treats a force-pushed head as stale", () => {
+    const result = classifyPullRequestFreshness({ state: "open", head: { sha: "newsha" } }, "oldsha");
+    expect(result).toMatchObject({ status: "stale", reason: "head_changed", expectedHeadSha: "oldsha", liveHeadSha: "newsha" });
+    expect(pullRequestFreshnessDetail(result)).toBe("PR head changed from oldsha to newsha");
+  });
+
+  it("uses public-safe unknown fallbacks when stale detail metadata is absent", () => {
+    expect(
+      pullRequestFreshnessDetail({
+        status: "stale",
+        reason: "closed",
+        expectedHeadSha: "sha1",
+        liveHeadSha: "sha1",
+        liveState: null,
+      }),
+    ).toBe("PR is no longer open (live state: unknown)");
+    expect(
+      pullRequestFreshnessDetail({
+        status: "stale",
+        reason: "head_changed",
+        expectedHeadSha: null,
+        liveHeadSha: null,
+        liveState: "open",
+      }),
+    ).toBe("PR head changed from unknown to unknown");
+  });
+
+  it("uses the stored PR head before falling back to advisory metadata", () => {
+    expect(reviewedPullRequestHeadSha(" pr-sha ", "advisory-sha")).toBe("pr-sha");
+    expect(reviewedPullRequestHeadSha(null, " advisory-sha ")).toBe("advisory-sha");
+    expect(reviewedPullRequestHeadSha(" ", undefined)).toBeNull();
+  });
+
+  it("fetches live PR state using the existing GitHub GET path", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("/repos/owner/repo/pulls/7");
+      return Response.json({ state: "open", head: { sha: "sha7" } });
+    });
+    await expect(
+      fetchPullRequestFreshness(env, {
+        installationId: 123,
+        repoFullName: "owner/repo",
+        pullNumber: 7,
+        expectedHeadSha: "sha7",
+      }),
+    ).resolves.toMatchObject({ status: "current", liveHeadSha: "sha7" });
+  });
+
+  it("fails closed when no token can verify live PR state", async () => {
+    const env = createTestEnv();
+    const result = await fetchPullRequestFreshness(env, {
+      installationId: 123,
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      expectedHeadSha: "sha7",
+    });
+    expect(result).toMatchObject({ status: "stale", reason: "unavailable" });
+  });
+});

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2520,6 +2520,73 @@ describe("queue processors", () => {
     }
   });
 
+  it("suppresses public review output for no-head reviews when the live PR is closed", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "off",
+      aiReviewMode: "off",
+    });
+    let commentPosts = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/61/files")) return Response.json([{ filename: "src/no-head.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const noHead = true;" }]);
+      if (url.includes("/issues/61/comments") && method === "POST") {
+        commentPosts += 1;
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/issues/61/comments") && method === "GET") return Response.json([]);
+      return new Response("not found", { status: 404 });
+    });
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue(classifyPullRequestFreshness({ state: "closed", head: {} }, null));
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "no-head-closed-before-public-output",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 61, title: "No head before publish", state: "open", user: { login: "contributor" }, head: {}, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    expect(fetchPullRequestFreshness).toHaveBeenCalledWith(env, expect.objectContaining({ expectedHeadSha: null }));
+    expect(commentPosts).toBe(0);
+    const stale = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_review_stale")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(stale?.detail).toContain("PR is no longer open");
+    expect(JSON.parse(stale?.metadata_json ?? "{}")).toMatchObject({
+      phase: "pre_public_output",
+      reason: "closed",
+      expectedHeadSha: null,
+      liveHeadSha: null,
+      liveState: "closed",
+    });
+    const published = await env.DB.prepare("select event_type from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_published")
+      .all();
+    expect(published.results).toEqual([]);
+  });
+
   it("still suppresses stale public output when the stale audit write fails", async () => {
     const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
     let staleAuditWrites = 0;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -48,7 +48,23 @@ import { agentMaintenanceHeadMatchesGate, changedPathsForGuardrail, processJob }
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import {
+  classifyPullRequestFreshness,
+  fetchPullRequestFreshness,
+} from "../../src/github/pr-freshness";
 import { createTestEnv } from "../helpers/d1";
+
+vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/github/pr-freshness")>();
+  return {
+    ...actual,
+    fetchPullRequestFreshness: vi.fn(async (_env: Env, args: { expectedHeadSha?: string | null }) => ({
+      status: "current" as const,
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    })),
+  };
+});
 
 // The re-gate sweep now FANS OUT the heavy re-review + marker stamp into per-PR `agent-regate-pr` jobs
 // (#audit-sweep-fanout). A test asserting the re-review/stamp side effects must run the sweep AND drain the
@@ -71,6 +87,12 @@ describe("queue processors", () => {
   // stay deterministic regardless of when CI runs.
   beforeEach(() => {
     clearInstallationTokenCacheForTest();
+    vi.mocked(fetchPullRequestFreshness).mockReset();
+    vi.mocked(fetchPullRequestFreshness).mockImplementation(async (_env, args) => ({
+      status: "current",
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    }));
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
   });
@@ -873,8 +895,9 @@ describe("queue processors", () => {
 
     await processJob(env, { type: "agent-regate-pr", deliveryId: "dedup-pulls-get", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
 
-    // Readiness reuses the resync payload; the freshness guard adds one live PR read before auto-maintain refreshes merge-state and CI.
-    expect(barePullGets).toBe(3);
+    // Readiness reuses the resync payload; the freshness guard runs before auto-maintain refreshes merge-state and CI.
+    expect(barePullGets).toBe(2);
+    expect(fetchPullRequestFreshness).toHaveBeenCalledWith(env, expect.objectContaining({ expectedHeadSha: "a7" }));
     expect(branchProtectionGets).toBe(1);
     expect(liveCheckRunsGets).toBe(2);
     expect(statusGets).toBe(2);
@@ -1053,7 +1076,6 @@ describe("queue processors", () => {
       if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
       return Response.json({});
     });
-
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "ci-bypass-current",
@@ -2361,6 +2383,13 @@ describe("queue processors", () => {
       if (url.includes("/issues/55/comments") && method === "GET") return Response.json([]);
       return new Response("not found", { status: 404 });
     });
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "oldsha",
+      liveHeadSha: "newsha",
+      liveState: "open",
+    });
 
     await processJob(env, {
       type: "github-webhook",
@@ -2389,6 +2418,106 @@ describe("queue processors", () => {
       .bind("github_app.pr_public_surface_published")
       .all();
     expect(published.results).toEqual([]);
+  });
+
+  it("suppresses public review output when live PR freshness cannot verify the reviewed head", async () => {
+    const cases = [
+      {
+        pullNumber: 59,
+        deliveryId: "unavailable-before-public-output",
+        title: "Unavailable before publish",
+        freshness: classifyPullRequestFreshness(undefined, "oldsha"),
+        expectedDetail: "live PR state could not be verified",
+        expectedMetadata: {
+          reason: "unavailable",
+          expectedHeadSha: "oldsha",
+          liveHeadSha: null,
+          liveState: null,
+        },
+      },
+      {
+        pullNumber: 60,
+        deliveryId: "head-unresolved-before-public-output",
+        title: "Unresolved head before publish",
+        freshness: classifyPullRequestFreshness(
+          {
+            state: "open",
+            head: {},
+          },
+          "oldsha",
+        ),
+        expectedDetail: "live PR head SHA could not be verified",
+        expectedMetadata: {
+          reason: "head_unresolved",
+          expectedHeadSha: "oldsha",
+          liveHeadSha: null,
+          liveState: "open",
+        },
+      },
+    ] as const;
+
+    for (const scenario of cases) {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await persistRegistrySnapshot(
+        env,
+        normalizeRegistryPayload(
+          { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+          { kind: "raw-github", url: "https://example.test" },
+          "2026-05-23T00:00:00.000Z",
+        ),
+      );
+      await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+      await upsertRepositorySettings(env, {
+        repoFullName: "JSONbored/gittensory",
+        commentMode: "all_prs",
+        publicSurface: "comment_only",
+        autoLabelEnabled: false,
+        checkRunMode: "off",
+        gateCheckMode: "off",
+        aiReviewMode: "off",
+      });
+      let commentPosts = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url === "https://api.gittensor.io/miners") return Response.json([]);
+        if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+        if (url.includes(`/pulls/${scenario.pullNumber}/files`)) return Response.json([{ filename: "src/stale.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const stale = true;" }]);
+        if (url.includes(`/issues/${scenario.pullNumber}/comments`) && method === "POST") {
+          commentPosts += 1;
+          return Response.json({ id: 1 }, { status: 201 });
+        }
+        if (url.includes(`/issues/${scenario.pullNumber}/comments`) && method === "GET") return Response.json([]);
+        return new Response("not found", { status: 404 });
+      });
+      vi.mocked(fetchPullRequestFreshness).mockResolvedValue(scenario.freshness);
+
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: scenario.deliveryId,
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: scenario.pullNumber, title: scenario.title, state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "Fixes #1" },
+        },
+      });
+
+      expect(commentPosts).toBe(0);
+      const stale = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+        .bind("github_app.pr_review_stale")
+        .first<{ detail: string; metadata_json: string }>();
+      expect(stale?.detail).toContain(scenario.expectedDetail);
+      expect(JSON.parse(stale?.metadata_json ?? "{}")).toMatchObject({
+        phase: "pre_public_output",
+        ...scenario.expectedMetadata,
+      });
+      const published = await env.DB.prepare("select event_type from audit_events where event_type = ?")
+        .bind("github_app.pr_public_surface_published")
+        .all();
+      expect(published.results).toEqual([]);
+    }
   });
 
   it("still suppresses stale public output when the stale audit write fails", async () => {
@@ -2434,6 +2563,13 @@ describe("queue processors", () => {
       }
       if (url.includes("/issues/57/comments") && method === "GET") return Response.json([]);
       return new Response("not found", { status: 404 });
+    });
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "oldsha",
+      liveHeadSha: "newsha",
+      liveState: "open",
     });
 
     try {
@@ -2517,6 +2653,13 @@ describe("queue processors", () => {
       }
       return new Response("not found", { status: 404 });
     });
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "oldsha",
+      liveHeadSha: "newsha",
+      liveState: "open",
+    });
 
     await processJob(env, {
       type: "github-webhook",
@@ -2530,7 +2673,8 @@ describe("queue processors", () => {
       },
     });
 
-    expect(livePullReads).toBe(1);
+    expect(livePullReads).toBe(0);
+    expect(fetchPullRequestFreshness).toHaveBeenCalledWith(env, expect.objectContaining({ expectedHeadSha: "oldsha" }));
     expect(checkBodies).toHaveLength(2);
     expect(checkBodies[0]).toMatchObject({ status: "in_progress", output: { title: "Gittensory Orb Review Agent is evaluating" } });
     expect(checkBodies[1]).toMatchObject({
@@ -2588,6 +2732,13 @@ describe("queue processors", () => {
         throw new Error("check-run update failed");
       }
       return new Response("not found", { status: 404 });
+    });
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValue({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "oldsha",
+      liveHeadSha: "newsha",
+      liveState: "open",
     });
 
     await processJob(env, {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2391,6 +2391,75 @@ describe("queue processors", () => {
     expect(published.results).toEqual([]);
   });
 
+  it("still suppresses stale public output when the stale audit write fails", async () => {
+    const originalRecordAuditEvent = repositoriesModule.recordAuditEvent;
+    let staleAuditWrites = 0;
+    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockImplementation(async (auditEnv, event) => {
+      if (event.eventType === "github_app.pr_review_stale") {
+        staleAuditWrites += 1;
+        throw new Error("D1 audit failed");
+      }
+      await originalRecordAuditEvent(auditEnv, event);
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "off",
+      aiReviewMode: "off",
+    });
+    let commentPosts = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/57/files")) return Response.json([{ filename: "src/stale.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const stale = true;" }]);
+      if (/\/pulls\/57(?:\?|$)/.test(url)) return Response.json({ number: 57, title: "Stale audit failure", state: "open", user: { login: "contributor" }, head: { sha: "newsha" }, labels: [], body: "Fixes #1" });
+      if (url.includes("/issues/57/comments") && method === "POST") {
+        commentPosts += 1;
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/issues/57/comments") && method === "GET") return Response.json([]);
+      return new Response("not found", { status: 404 });
+    });
+
+    try {
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "stale-audit-failure",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 57, title: "Stale audit failure", state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "Fixes #1" },
+        },
+      });
+    } finally {
+      auditSpy.mockRestore();
+    }
+
+    expect(staleAuditWrites).toBe(1);
+    expect(commentPosts).toBe(0);
+    const published = await env.DB.prepare("select event_type from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_published")
+      .all();
+    expect(published.results).toEqual([]);
+  });
+
   it("finalizes the pending gate as skipped when the PR head changes after review work", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await persistRegistrySnapshot(
@@ -2472,6 +2541,68 @@ describe("queue processors", () => {
         summary: "PR head changed from oldsha to newsha",
       },
     });
+    const stale = await env.DB.prepare("select metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_review_stale")
+      .first<{ metadata_json: string }>();
+    expect(JSON.parse(stale?.metadata_json ?? "{}")).toMatchObject({ phase: "final_publish", reason: "head_changed" });
+  });
+
+  it("still suppresses stale final output when the skipped gate check update fails", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      aiReviewMode: "off",
+    });
+    let patchAttempts = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url === "https://api.github.com/graphql") {
+        return Response.json({ data: { repository: { pullRequest: { reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } } } });
+      }
+      if (url.includes("/pulls/58/files")) return Response.json([{ filename: "src/final.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const final = true;" }]);
+      if (/\/pulls\/58(?:\?|$)/.test(url)) return Response.json({ number: 58, title: "Stale skip failure", state: "open", user: { login: "contributor" }, head: { sha: "newsha" }, labels: [], body: "No issue link." });
+      if (url.includes("/commits/oldsha/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/oldsha/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 907 }, { status: 201 });
+      if (url.includes("/check-runs/907") && method === "PATCH") {
+        patchAttempts += 1;
+        throw new Error("check-run update failed");
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "stale-skip-failure",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 58, title: "Stale skip failure", state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    expect(patchAttempts).toBe(1);
     const stale = await env.DB.prepare("select metadata_json from audit_events where event_type = ?")
       .bind("github_app.pr_review_stale")
       .first<{ metadata_json: string }>();
@@ -3183,7 +3314,7 @@ describe("queue processors", () => {
         updateBranchCalls += 1;
         return Response.json({ message: "Updating pull request branch." }, { status: 202 });
       }
-      if (/\/pulls\/48(?:\?|$)/.test(url)) return Response.json({ number: 48, mergeable_state: "behind" });
+      if (/\/pulls\/48(?:\?|$)/.test(url)) return Response.json({ number: 48, state: "open", head: { sha: "behindsha" }, mergeable_state: "behind" });
       return new Response("not found", { status: 404 });
     });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -873,8 +873,8 @@ describe("queue processors", () => {
 
     await processJob(env, { type: "agent-regate-pr", deliveryId: "dedup-pulls-get", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
 
-    // Readiness reuses the resync payload, but auto-maintain refreshes merge-state and CI after gate publication.
-    expect(barePullGets).toBe(2);
+    // Readiness reuses the resync payload; the freshness guard adds one live PR read before auto-maintain refreshes merge-state and CI.
+    expect(barePullGets).toBe(3);
     expect(branchProtectionGets).toBe(1);
     expect(liveCheckRunsGets).toBe(2);
     expect(statusGets).toBe(2);
@@ -2324,6 +2324,158 @@ describe("queue processors", () => {
     });
 
     expect(calls).toEqual({ minerList: 1, gateChecks: 2 });
+  });
+
+  it("suppresses public review output when the live PR head changed before publish", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "off",
+      aiReviewMode: "off",
+    });
+    let commentPosts = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/stale.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const stale = true;" }]);
+      if (/\/pulls\/55(?:\?|$)/.test(url)) return Response.json({ number: 55, title: "Stale before publish", state: "open", user: { login: "contributor" }, head: { sha: "newsha" }, labels: [], body: "Fixes #1" });
+      if (url.includes("/issues/55/comments") && method === "POST") {
+        commentPosts += 1;
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/issues/55/comments") && method === "GET") return Response.json([]);
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "stale-before-public-output",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 55, title: "Stale before publish", state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "Fixes #1" },
+      },
+    });
+
+    expect(commentPosts).toBe(0);
+    const stale = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_review_stale")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(stale?.detail).toContain("PR head changed from oldsha to newsha");
+    expect(JSON.parse(stale?.metadata_json ?? "{}")).toMatchObject({
+      phase: "pre_public_output",
+      reason: "head_changed",
+      expectedHeadSha: "oldsha",
+      liveHeadSha: "newsha",
+    });
+    const published = await env.DB.prepare("select event_type from audit_events where event_type = ?")
+      .bind("github_app.pr_public_surface_published")
+      .all();
+    expect(published.results).toEqual([]);
+  });
+
+  it("finalizes the pending gate as skipped when the PR head changes after review work", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      aiReviewMode: "off",
+    });
+    let livePullReads = 0;
+    const checkBodies: Array<{ status?: string; conclusion?: string; output?: { title?: string; summary?: string } }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url === "https://api.github.com/graphql") {
+        return Response.json({ data: { repository: { pullRequest: { reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } } } });
+      }
+      if (url.includes("/pulls/56/files")) return Response.json([{ filename: "src/final.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const final = true;" }]);
+      if (/\/pulls\/56(?:\?|$)/.test(url)) {
+        livePullReads += 1;
+        return Response.json({
+          number: 56,
+          title: "Stale after review",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "newsha" },
+          labels: [],
+          body: "No issue link.",
+        });
+      }
+      if (url.includes("/commits/oldsha/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/oldsha/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      if (url.includes("/check-runs") && method === "POST") {
+        checkBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        return Response.json({ id: 906 }, { status: 201 });
+      }
+      if (url.includes("/check-runs/906") && method === "PATCH") {
+        checkBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        return Response.json({ id: 906 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "stale-after-review",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 56, title: "Stale after review", state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "No issue link." },
+      },
+    });
+
+    expect(livePullReads).toBe(1);
+    expect(checkBodies).toHaveLength(2);
+    expect(checkBodies[0]).toMatchObject({ status: "in_progress", output: { title: "Gittensory Orb Review Agent is evaluating" } });
+    expect(checkBodies[1]).toMatchObject({
+      status: "completed",
+      conclusion: "skipped",
+      output: {
+        title: "Gittensory Orb Review Agent skipped",
+        summary: "PR head changed from oldsha to newsha",
+      },
+    });
+    const stale = await env.DB.prepare("select metadata_json from audit_events where event_type = ?")
+      .bind("github_app.pr_review_stale")
+      .first<{ metadata_json: string }>();
+    expect(JSON.parse(stale?.metadata_json ?? "{}")).toMatchObject({ phase: "final_publish", reason: "head_changed" });
   });
 
   it("auto-maintain (#778): a blocking gate on an agent-configured repo records the changes-requested label, never a formal request_changes (dry-run)", async () => {

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -9,6 +9,17 @@ vi.mock("../../src/github/pr-actions", () => ({
 vi.mock("../../src/github/labels", () => ({
   ensurePullRequestLabel: vi.fn(async () => ({ applied: true, created: false })),
 }));
+vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/github/pr-freshness")>();
+  return {
+    ...actual,
+    fetchPullRequestFreshness: vi.fn(async (_env: Env, args: { expectedHeadSha?: string | null }) => ({
+      status: "current" as const,
+      liveHeadSha: args.expectedHeadSha ?? null,
+      liveState: "open",
+    })),
+  };
+});
 
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { createSessionForGitHubUser } from "../../src/auth/security";

--- a/test/unit/safety.test.ts
+++ b/test/unit/safety.test.ts
@@ -90,6 +90,7 @@ function stubFinalizeFetch(seen: { conclusion?: string | undefined }): void {
     const method = init?.method ?? "GET";
     if (url === "https://api.gittensor.io/miners") return Response.json([{ uid: 7, githubUsername: "contributor", githubId: "123", totalPrs: 4, totalMergedPrs: 3, totalOpenPrs: 1, totalClosedPrs: 0, totalOpenIssues: 0, totalClosedIssues: 0, totalSolvedIssues: 0, totalValidSolvedIssues: 0, isEligible: true, credibility: 1, eligibleRepoCount: 1 }]);
     if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+    if (/\/pulls\/42(?:\?|$)/.test(url)) return Response.json({ number: 42, state: "open", head: { sha: "gate123" } });
     if (url.includes("/check-runs") && method === "GET") return Response.json({ total_count: 0, check_runs: [] });
     if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 900 }, { status: 201 });
     if (url.includes("/check-runs/900") && method === "PATCH") {


### PR DESCRIPTION
## Summary
Prevents stale review output and automated PR mutations from landing after a PR is closed or force-pushed.

No linked issue because this is a focused operational race fix found while hardening the review pipeline before enabling fully automated dispositions.

## What changed
- Added a live PR freshness helper for reviewed head/state checks.
- Suppressed reviewing placeholders, final gate output, public comments, labels, and check completion when the reviewed head is stale.
- Reuses the pending gate check when marking stale output as skipped, avoiding duplicate skipped checks.
- Requires reviewed-head freshness before PR-mutating automated actions while leaving approval staging non-mutating.
- Added regression coverage for force-push, closed PR, no-head, approval replay, and stale public-output paths.

## Why
A review that finishes after a force-push or close can otherwise update visible PR state with a verdict for code that is no longer current.

## Validation
- `npx vitest run test/unit/pr-freshness.test.ts test/unit/agent-action-executor.test.ts test/unit/agent-approval-queue.test.ts test/unit/routes-agent-approval.test.ts test/unit/queue.test.ts`
- `npm run test:ci`
- `npm audit --audit-level=moderate`
