### PR TITLE
feat(enrichment): unsafe dynamic execution security analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,17 +65,17 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # Current analyzer names:
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
-# history,docCommentDrift,duplication,churnHotspot
+# history,docCommentDrift,duplication,churnHotspot,unsafeExec
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,unsafeExec
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
-# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeExec
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
-# nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeExec
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -559,6 +559,30 @@ export const REES_ANALYZERS = [
         "Distinct from the history analyzer's author track record; this scores the change AREA's defect density.",
     },
   },
+  {
+    name: "unsafeExec",
+    title: "Unsafe dynamic execution",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags added code that builds a command or code string by interpolation/concatenation and passes it to a dangerous execution sink.",
+      looksAt:
+        "Added lines calling exec/execSync/spawn/execFile with a dynamically-built command, or eval/Function with a dynamically-built code argument (Function's code is its last argument).",
+      reports:
+        "File, line, the sink name, and the kind (command-exec or code-eval) — never the argument text.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Conservative + line-local by design: pure string literals, literal-command spawns, and bare identifiers are not flagged; it does not descend into template-literal ${...} interpolations and treats only known child_process member aliases as shell sinks, trading some recall for near-zero false positives.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -636,6 +636,32 @@
         "network": "Calls the GitHub commits API once per probed file. Requires GitHub token forwarding for private repos.",
         "notes": "Distinct from the history analyzer's author track record; this scores the change AREA's defect density."
       }
+    },
+    {
+      "name": "unsafeExec",
+      "title": "Unsafe dynamic execution",
+      "category": "security",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags added code that builds a command or code string by interpolation/concatenation and passes it to a dangerous execution sink.",
+        "looksAt": "Added lines calling exec/execSync/spawn/execFile with a dynamically-built command, or eval/Function with a dynamically-built code argument (Function's code is its last argument).",
+        "reports": "File, line, the sink name, and the kind (command-exec or code-eval) — never the argument text.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Conservative + line-local by design: pure string literals, literal-command spawns, and bare identifiers are not flagged; it does not descend into template-literal ${...} interpolations and treats only known child_process member aliases as shell sinks, trading some recall for near-zero false positives."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -19,6 +19,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanTyposquat } from "./typosquat.js";
+import { scanUnsafeExec } from "./unsafe-exec.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -439,6 +440,26 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanChurnHotspot(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "unsafeExec",
+    title: "Unsafe dynamic execution",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags added code that builds a command or code string by interpolation/concatenation and passes it to a dangerous execution sink.",
+      looksAt:
+        "Added lines calling exec/execSync/spawn/execFile with a dynamically-built command, or eval/Function with a dynamically-built code argument (Function's code is its last argument).",
+      reports: "File, line, the sink name, and the kind (command-exec or code-eval) — never the argument text.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Conservative + line-local by design: pure string literals, literal-command spawns, and bare identifiers are not flagged; it does not descend into template-literal ${...} interpolations and treats only known child_process member aliases as shell sinks, trading some recall for near-zero false positives.",
+    },
+    run: (req) => scanUnsafeExec(req),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/unsafe-exec.ts
+++ b/review-enrichment/src/analyzers/unsafe-exec.ts
@@ -1,0 +1,403 @@
+// Unsafe-dynamic-execution analyzer. Flags an added (`+` diff) line that builds a COMMAND or CODE string by
+// interpolation/concatenation and passes it straight to a dangerous execution sink — i.e. the classic
+// command-injection / code-injection shape (`execSync(`git clone ${repo}`)`, `eval(`(${expr})`)`).
+// Pure compute, no network, no external detector. Conservative by design (mirrors the redos analyzer): a pure
+// string literal (`exec("ls -la")`), a literal-command spawn (`spawn("git", ["status"])`), or a bare identifier
+// (`exec(cmd)`) are NEVER flagged, so the false-positive rate stays near zero. Reports ONLY the location, the
+// sink name, and the kind — never the argument text. Line-cited via hunk headers, mirroring the redos analyzer.
+//
+// SCOPE (deliberate first-version contract — favors zero false positives + simplicity over exhaustive recall):
+//   - LINE-LOCAL: each added line is scanned on its own (block-comment state is the only thing carried across
+//     lines). It does NOT descend into template-literal `${...}` interpolations — the whole backtick template is
+//     treated as a string, so a sink hidden INSIDE a `${}` expression (e.g. `const s = `${execSync(`x ${y}`)}`;`)
+//     is intentionally NOT reported. This keeps the scanner a simple linear pass and never false-flags a
+//     sink-looking substring inside a template/string.
+//   - BEST-EFFORT member aliases: a member command sink is only treated as child_process for a known receiver
+//     alias (CHILD_PROCESS_ALIASES); other/renamed aliases are intentionally not chased (avoids false positives
+//     on `db.exec`, `fs.execFile`, etc.). Both limits trade some recall for precision and a bounded implementation.
+import type { EnrichRequest, UnsafeExecFinding } from "../types.js";
+
+// Every loop runs over an attacker-controlled patch, so each is bounded.
+const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_LINE_CHARS = 2000; // skip extraction on pathologically long lines (defensive)
+
+type UnsafeExecScanLimits = {
+  maxFindings?: number;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  while (start <= patch.length) {
+    const end = patch.indexOf("\n", start);
+    if (end === -1) {
+      yield patch.slice(start);
+      return;
+    }
+    yield patch.slice(start, end);
+    start = end + 1;
+  }
+}
+
+function isWordChar(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+// An identifier-start char (letter, `_`, `$`); digits are excluded so a numeric constant or arithmetic operand
+// (`2`, `1 + 2`) is never mistaken for a variable/expression operand in a concatenation.
+function isIdentStart(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+// A sink and the kind of injection its dynamically-built first argument would carry.
+type SinkKind = UnsafeExecFinding["kind"];
+
+// Sinks whose FIRST argument is itself a shell/command string — interpolating into it is a command injection.
+const SHELL_STRING_SINKS = new Set(["exec", "execSync"]);
+// Sinks whose first argument is the command NAME (args go in a later array) — flag ONLY if the NAME is dynamic.
+const COMMAND_NAME_SINKS = new Set([
+  "execFile",
+  "execFileSync",
+  "spawn",
+  "spawnSync",
+]);
+// Sinks that evaluate their first argument AS CODE — interpolating into it is a code injection.
+const CODE_SINKS = new Set(["eval"]);
+// Known `child_process` receiver names. A MEMBER command sink (`x.exec(...)`) is only a real shell call when `x`
+// is one of these — `db.exec(...)`, `fs.execFile(...)`, etc. are NOT child_process and must not be flagged.
+const CHILD_PROCESS_ALIASES = new Set([
+  "cp",
+  "childProcess",
+  "child_process",
+  "proc",
+]);
+
+// All command sinks share one kind; `eval`/`new Function` share the other.
+function commandKind(): SinkKind {
+  return "command-exec";
+}
+function codeKind(): SinkKind {
+  return "code-eval";
+}
+
+// Extract a sink call's argument expressions: split at depth-0 commas from just after `(` to the matching close-
+// paren. A single linear scan (deliberately NOT a regex) that respects quotes/backticks/escapes so a comma inside
+// a string or a nested call does not terminate an argument, and bracket/brace/paren depth so nested structures are
+// transparent. Returns null on a malformed/unterminated call (fail safe = caller skips the line). We need ALL args,
+// not just the first, because `new Function(...params, body)` carries the executed code in its LAST argument.
+function extractAllArgs(line: string, openParen: number): string[] | null {
+  const n = line.length;
+  let i = openParen + 1;
+  let depth = 0; // depth of (), [], {} nested INSIDE an argument
+  let quote = ""; // active string delimiter, or "" when outside a string
+  let start = i;
+  const args: string[] = [];
+  while (i < n) {
+    const ch = line[i]!;
+    if (quote) {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === quote) quote = "";
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      if (depth === 0) {
+        if (ch !== ")") return null; // a mismatched bracket closing the call → malformed
+        args.push(line.slice(start, i));
+        return args;
+      }
+      depth--;
+      i++;
+      continue;
+    }
+    if (ch === "," && depth === 0) {
+      args.push(line.slice(start, i));
+      start = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null; // unterminated — fail safe
+}
+
+// Does the argument text build its value as a dynamic STRING? A single quote-aware scan so operators hidden inside
+// string literals never count. Dynamic when a template literal (backtick) carries an interpolation `${`, OR when a
+// `+` OUTSIDE any string concatenates AND a string/template literal is one of the operands. Requiring a string
+// operand means pure arithmetic like `1 + 2` is NOT treated as command/code building (precision). A pure literal
+// (`"ls -la"`, `"1+1"`) and a bare identifier (`cmd`) are likewise not dynamic. Bounded by the caller's line cap.
+function isDynamicArg(arg: string): boolean {
+  const n = arg.length;
+  let i = 0;
+  let quote = ""; // active string delimiter, or "" when outside a string
+  let sawStringLiteral = false; // a "...", '...' or `...` literal appears in the argument
+  let sawConcatOutside = false; // a `+` appears outside any string (a concatenation operator)
+  let sawNonLiteralOutside = false; // an identifier/expression operand (a variable, member, or call) appears outside any string
+  while (i < n) {
+    const ch = arg[i]!;
+    if (quote) {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      // A template-literal interpolation makes the value dynamic regardless of `+`.
+      if (quote === "`" && ch === "$" && arg[i + 1] === "{") return true;
+      if (ch === quote) quote = "";
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      sawStringLiteral = true;
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "+") sawConcatOutside = true;
+    if (isIdentStart(ch)) sawNonLiteralOutside = true;
+    i++;
+  }
+  // Dynamic only when a string literal is concatenated with a NON-LITERAL operand (a variable, member, or call);
+  // a literal-only concatenation such as `exec("git " + "status")` or `eval("1" + "+1")` builds a constant string,
+  // so no interpolated or variable-controlled value reaches the sink and it must not be flagged.
+  return sawConcatOutside && sawStringLiteral && sawNonLiteralOutside;
+}
+
+// At index `i` (start of an identifier; caller confirmed a word boundary precedes it), identify a dangerous sink
+// whose argument makes it injectable, or null. Member calls are handled precisely: a member command sink is a real
+// `child_process` call only when the receiver is a known alias; member `eval`/`Function` are never the globals.
+function matchSinkAt(
+  line: string,
+  i: number,
+): { sink: string; kind: SinkKind; argOpen: number } | null {
+  const n = line.length;
+  let j = i;
+  while (j < n && isWordChar(line[j]!)) j++;
+  const word = line.slice(i, j);
+  if (!word) return null;
+
+  let k = j;
+  while (k < n && (line[k] === " " || line[k] === "\t")) k++;
+  if (line[k] !== "(") return null;
+  const argOpen = k;
+
+  // Is this `receiver.word(...)` (a member call)? If so, capture the receiver identifier.
+  let p = i - 1;
+  while (p >= 0 && (line[p] === " " || line[p] === "\t")) p--;
+  const isMember = p >= 0 && line[p] === ".";
+  let receiver = "";
+  if (isMember) {
+    let r = p - 1;
+    while (r >= 0 && (line[r] === " " || line[r] === "\t")) r--;
+    const rEnd = r + 1;
+    while (r >= 0 && isWordChar(line[r]!)) r--;
+    receiver = line.slice(r + 1, rEnd);
+  }
+
+  let kind: SinkKind | null = null;
+  let bodyIsLastArg = false;
+  if (SHELL_STRING_SINKS.has(word) || COMMAND_NAME_SINKS.has(word)) {
+    // A member command sink is only child_process when the receiver is a known alias (so `db.exec("SELECT …")`,
+    // `fs.execFile(…)` etc. are NOT flagged); a bare `exec(…)`/`execSync(…)` (destructured import) is taken as-is.
+    if (isMember && !CHILD_PROCESS_ALIASES.has(receiver)) return null;
+    kind = commandKind();
+  } else if (CODE_SINKS.has(word)) {
+    if (isMember) return null; // `x.eval(…)` is not the global eval
+    kind = codeKind();
+  } else if (word === "Function") {
+    // `Function(…)` and `new Function(…)` both construct a function from a code string (the LAST argument); a
+    // member `x.Function(…)` is not the global constructor.
+    if (isMember) return null;
+    kind = codeKind();
+    bodyIsLastArg = true;
+  } else {
+    return null;
+  }
+
+  const args = extractAllArgs(line, argOpen);
+  if (args === null || args.length === 0) return null; // fail safe on malformed args
+  // `Function(...paramNames, body)` evaluates its LAST argument as code; every other sink's injectable input is its
+  // FIRST argument (the shell string, the command name, or the eval source).
+  const argToCheck = bodyIsLastArg ? args[args.length - 1]! : args[0]!;
+  if (!isDynamicArg(argToCheck)) return null; // literal / bare identifier / arithmetic → not flagged
+  return { sink: word, kind, argOpen };
+}
+
+/** Scan ONE line for dangerous sink calls, threading block-comment state across lines. `startInComment` = this
+ *  line begins inside an unclosed `/* ... *␊/` block comment. Returns the sinks found (never any while inside a
+ *  string OR a block comment) plus whether the line ENDS still inside an open block comment, so the caller can
+ *  carry that state to the next line — this is what makes a MULTI-LINE comment containing a sink fail safe. */
+function scanLineForSinks(
+  line: string,
+  startInComment: boolean,
+): { sinks: Array<{ sink: string; kind: SinkKind }>; endInComment: boolean } {
+  const found: Array<{ sink: string; kind: SinkKind }> = [];
+  const n = line.length;
+  if (n > MAX_LINE_CHARS) return { sinks: found, endInComment: startInComment };
+  let i = 0;
+  let quote = ""; // active string delimiter, or "" when outside a string
+  let inBlock = startInComment;
+  while (i < n) {
+    const c = line[i]!;
+    if (inBlock) {
+      // Inside a block comment nothing is code until the closing `*/`.
+      if (c === "*" && line[i + 1] === "/") {
+        inBlock = false;
+        i += 2;
+        continue;
+      }
+      i++;
+      continue;
+    }
+    // Inside a string literal, sink-looking text (`const d = "execSync(`...`)"`, docs/examples) is NOT a real call.
+    if (quote) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === quote) quote = "";
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      i++;
+      continue;
+    }
+    // A line comment — the rest of the line is not code and cannot open a block comment.
+    if (c === "/" && line[i + 1] === "/") return { sinks: found, endInComment: false };
+    // A block comment opens here (it may or may not close on this line — `inBlock` carries the state forward).
+    if (c === "/" && line[i + 1] === "*") {
+      inBlock = true;
+      i += 2;
+      continue;
+    }
+    if (
+      (c >= "a" && c <= "z") ||
+      (c >= "A" && c <= "Z") ||
+      c === "_" ||
+      c === "$"
+    ) {
+      // Word boundary: the char before must not be a word char (a leading `.` for `cp.execSync(...)` is fine).
+      const prev = i === 0 ? "" : line[i - 1]!;
+      if (!prev || !isWordChar(prev)) {
+        const match = matchSinkAt(line, i);
+        if (match) {
+          found.push({ sink: match.sink, kind: match.kind });
+          // Continue scanning AFTER this identifier so a second sink on the same line is still seen.
+          let j = i;
+          while (j < n && isWordChar(line[j]!)) j++;
+          i = j;
+          continue;
+        }
+      }
+    }
+    i++;
+  }
+  return { sinks: found, endInComment: inBlock };
+}
+
+/** Scan ONE standalone line of code for dangerous dynamic-execution sink calls (no surrounding comment state). */
+export function extractUnsafeExecSinks(
+  line: string,
+): Array<{ sink: string; kind: SinkKind }> {
+  return scanLineForSinks(line, false).sinks;
+}
+
+/** Scan one file patch's added lines for unsafe dynamic-execution sinks, line-cited via hunk headers. Pure. */
+export function scanPatchForUnsafeExec(
+  path: string,
+  patch: string,
+  limits: UnsafeExecScanLimits = {},
+): UnsafeExecFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const findings: UnsafeExecFinding[] = [];
+  let newLine = 0;
+  let inComment = false; // carried across consecutive lines so a MULTI-LINE block comment is fully skipped
+  for (const line of patchLines(patch)) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inComment = false; // a new hunk is non-contiguous source — do not carry comment state across the gap
+      continue;
+    }
+    if (line.startsWith("+")) {
+      const code = line.slice(1);
+      const lead = code.trimStart();
+      // Heuristic for a block comment whose OPENER sits outside the diff (e.g. a JSDoc body line): treat a leading
+      // line comment, block-comment open, or a JSDoc continuation (`* `, a lone `*`, or a closing `*/`) as comment.
+      // Narrowed to those `*` forms so it does not suppress real code such as `*ptr` or a multiplication. The
+      // cross-line state below handles openers that ARE in the diff (a multi-line `/* ... sink ... */` added block).
+      const leadComment =
+        lead.startsWith("//") ||
+        lead.startsWith("/*") ||
+        lead.startsWith("* ") ||
+        lead.startsWith("*/") ||
+        lead === "*";
+      const { sinks, endInComment } = scanLineForSinks(code, inComment);
+      inComment = endInComment;
+      if (!leadComment) {
+        for (const sink of sinks) {
+          findings.push({
+            file: path,
+            line: newLine,
+            sink: sink.sink,
+            kind: sink.kind,
+          });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-")) {
+      // Context (unchanged) line: not scanned for sinks, but it can open/close a block comment that affects the
+      // next added line, so thread the comment state through it. Strip the leading marker ONLY when it is a real
+      // unified-diff context space — otherwise (e.g. a line that itself starts with `/*`) pass it verbatim so the
+      // comment scan sees the exact source and the `/*` is not corrupted into `*`.
+      const contextCode = line.startsWith(" ") ? line.slice(1) : line;
+      inComment = scanLineForSinks(contextCode, inComment).endInComment;
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed file's added lines for unsafe dynamic-execution sinks. */
+export async function scanUnsafeExec(
+  req: EnrichRequest,
+): Promise<UnsafeExecFinding[]> {
+  const findings: UnsafeExecFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (!file.patch) continue;
+    for (const finding of scanPatchForUnsafeExec(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -379,6 +379,18 @@ export function renderBrief(
     }
   }
 
+  const unsafeExec = findings.unsafeExec ?? [];
+  if (unsafeExec.length) {
+    lines.push(
+      "### Unsafe dynamic execution (command/code injection risk — pass arguments safely, not as an interpolated string)",
+    );
+    for (const item of unsafeExec) {
+      lines.push(
+        `- ${safeCodeSpan(`${item.file}:${item.line}`)} — ${safeCodeSpan(item.sink)} builds a ${item.kind === "command-exec" ? "shell command" : "code"} string by interpolation/concatenation`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -285,6 +285,16 @@ export interface ChurnHotspotFinding {
   capped: boolean;
 }
 
+/** An added line that builds a command or code string by interpolation/concatenation and passes it to a dangerous
+ *  execution sink (command-injection / code-injection risk). Reports the location + the sink name + the kind only
+ *  — NEVER the argument text/value, so it is public-safe. */
+export interface UnsafeExecFinding {
+  file: string;
+  line: number;
+  sink: string;
+  kind: "command-exec" | "code-eval";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -308,6 +318,7 @@ export interface BriefFindings {
   docCommentDrift?: DocCommentDriftFinding[];
   duplication?: DuplicationFinding[];
   churnHotspot?: ChurnHotspotFinding[];
+  unsafeExec?: UnsafeExecFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_ANALYZERS = [
   "docCommentDrift",
   "duplication",
   "churnHotspot",
+  "unsafeExec",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/unsafe-exec.test.ts
+++ b/review-enrichment/test/unsafe-exec.test.ts
@@ -1,0 +1,293 @@
+// Units for the unsafe-dynamic-execution analyzer. Own file (not enrichment.test.ts) so concurrent analyzer PRs
+// don't collide. Runs against the compiled dist/. Verifies the conservative flag condition (dynamic first arg
+// into a dangerous sink), correct line numbers via hunk headers, MAX_FINDINGS bounding, and that neither the
+// finding nor the rendered brief ever leaks the argument value.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  scanUnsafeExec,
+  scanPatchForUnsafeExec,
+  extractUnsafeExecSinks,
+} from "../dist/analyzers/unsafe-exec.js";
+import { renderBrief } from "../dist/render.js";
+
+// Build a +-prefixed unified-diff patch that adds the given lines starting at new-file line `start`.
+const addedPatch = (addedLines, start = 10) => {
+  const body = addedLines.map((l) => `+${l}`).join("\n");
+  return `@@ -1,0 +${start},${addedLines.length} @@\n${body}`;
+};
+
+// ── FLAGGED cases ────────────────────────────────────────────────────────────
+
+test("flags execSync with a template-interpolated command (command-exec)", () => {
+  const findings = scanPatchForUnsafeExec(
+    "src/run.ts",
+    addedPatch(["execSync(`git clone ${repo}`)"], 10),
+  );
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0], {
+    file: "src/run.ts",
+    line: 10,
+    sink: "execSync",
+    kind: "command-exec",
+  });
+});
+
+test("flags exec with string concatenation (command-exec)", () => {
+  const findings = scanPatchForUnsafeExec(
+    "src/run.ts",
+    addedPatch(['exec("rm " + path)'], 5),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].sink, "exec");
+  assert.equal(findings[0].kind, "command-exec");
+  assert.equal(findings[0].line, 5);
+});
+
+test("flags eval with an interpolated expression (code-eval)", () => {
+  const findings = scanPatchForUnsafeExec(
+    "src/run.ts",
+    addedPatch(["eval(`(${expr})`)"], 3),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].sink, "eval");
+  assert.equal(findings[0].kind, "code-eval");
+});
+
+test("flags new Function with a concatenated body (code-eval)", () => {
+  const findings = scanPatchForUnsafeExec(
+    "src/run.ts",
+    addedPatch(['new Function("return " + body)'], 7),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].sink, "Function");
+  assert.equal(findings[0].kind, "code-eval");
+});
+
+test("flags new Function MULTI-arg form where the dynamic body is the LAST argument (code-eval)", () => {
+  // The code is the final argument; earlier args are parameter names. The first arg is a literal, so a first-arg-
+  // only check would miss this — the analyzer must inspect the body (last) argument.
+  const findings = scanPatchForUnsafeExec(
+    "src/run.ts",
+    addedPatch(['const f = new Function("x", "y", "return " + body)'], 12),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].sink, "Function");
+  assert.equal(findings[0].kind, "code-eval");
+});
+
+test("does NOT flag pure arithmetic in a sink arg (no string operand)", () => {
+  // `1 + 2` is arithmetic, not command/code string building — the `+` must not classify it as dynamic.
+  assert.equal(extractUnsafeExecSinks("exec(1 + 2)").length, 0);
+  assert.equal(extractUnsafeExecSinks("eval(a + b)").length, 0);
+  // new Function whose body is a pure literal is also safe.
+  assert.equal(extractUnsafeExecSinks('new Function("x", "return x")').length, 0);
+});
+
+test("does NOT flag a LITERAL-ONLY string concatenation (no variable reaches the sink)", () => {
+  // `"git " + "status"` and `"1" + "+1"` concatenate two string literals into a constant; no interpolated or
+  // variable-controlled value reaches the sink, so the near-zero-FP contract requires they are not flagged.
+  assert.equal(extractUnsafeExecSinks('exec("git " + "status")').length, 0);
+  assert.equal(extractUnsafeExecSinks('eval("1" + "+1")').length, 0);
+  assert.equal(extractUnsafeExecSinks('execSync("ls " + "-la" + " /tmp")').length, 0);
+  // A string literal joined to a numeric constant is still a constant, not a variable operand.
+  assert.equal(extractUnsafeExecSinks('exec("port " + 8080)').length, 0);
+  // But a string literal concatenated with a real identifier/expression IS dynamic and must still be flagged.
+  assert.equal(extractUnsafeExecSinks('exec("git " + cmd)').length, 1);
+  assert.equal(extractUnsafeExecSinks('exec("rm " + process.argv[2])').length, 1);
+});
+
+test("does NOT flag a non-child_process member sink (db.exec, fs.execFile, obj.eval)", () => {
+  // The classic false positive: a database `.exec` / `.query` is not a shell call.
+  assert.equal(extractUnsafeExecSinks('db.exec("SELECT * FROM t WHERE id = " + id)').length, 0);
+  assert.equal(extractUnsafeExecSinks("fs.execFile(`${bin}`, args)").length, 0);
+  assert.equal(extractUnsafeExecSinks("obj.eval(`${expr}`)").length, 0); // member eval is not the global eval
+});
+
+test("flags a known child_process member alias and a bare Function() call (no new)", () => {
+  assert.equal(extractUnsafeExecSinks("cp.execSync(`git ${repo}`)").length, 1);
+  assert.equal(extractUnsafeExecSinks('childProcess.exec("rm " + p)').length, 1);
+  // `Function(...)` is the same constructor as `new Function(...)`; the body (last arg) is what is evaluated.
+  const f = extractUnsafeExecSinks('const g = Function("a", "return " + body)');
+  assert.equal(f.length, 1);
+  assert.equal(f[0].sink, "Function");
+  assert.equal(f[0].kind, "code-eval");
+});
+
+test("flags a member-call sink like cp.execSync(`...${x}`)", () => {
+  const sinks = extractUnsafeExecSinks("cp.execSync(`echo ${value}`)");
+  assert.deepEqual(sinks, [{ sink: "execSync", kind: "command-exec" }]);
+});
+
+test("flags spawn ONLY when the command NAME is dynamically built", () => {
+  // Dynamic command name → flagged.
+  assert.deepEqual(extractUnsafeExecSinks("spawn(`${bin}`, [])"), [
+    { sink: "spawn", kind: "command-exec" },
+  ]);
+  assert.deepEqual(extractUnsafeExecSinks('spawn("git-" + sub, [])'), [
+    { sink: "spawn", kind: "command-exec" },
+  ]);
+});
+
+test("tracks new-file line numbers across hunk headers and context lines", () => {
+  const patch = [
+    "@@ -1,2 +1,3 @@",
+    " const a = 1;",
+    "+execSync(`ls ${dir}`)",
+    " const b = 2;",
+    "@@ -10,1 +20,2 @@",
+    " const c = 3;",
+    "+eval(`(${x})`)",
+  ].join("\n");
+  const findings = scanPatchForUnsafeExec("src/x.ts", patch);
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].line, 2);
+  assert.equal(findings[0].sink, "execSync");
+  assert.equal(findings[1].line, 21);
+  assert.equal(findings[1].sink, "eval");
+});
+
+test("scanUnsafeExec spans multiple files", async () => {
+  const findings = await scanUnsafeExec({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1,
+    files: [
+      { path: "a.ts", patch: addedPatch(["exec(`a ${x}`)"], 1) },
+      { path: "b.ts", patch: addedPatch(["eval(`(${y})`)"], 1) },
+      { path: "c.ts", patch: "" },
+    ],
+  });
+  assert.equal(findings.length, 2);
+  assert.deepEqual(
+    findings.map((f) => f.file),
+    ["a.ts", "b.ts"],
+  );
+});
+
+test("bounds findings to MAX_FINDINGS (25)", async () => {
+  const lines = Array.from({ length: 40 }, (_, i) => `exec(\`cmd ${"${" + "v" + i + "}"}\`)`);
+  const findings = await scanUnsafeExec({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1,
+    files: [{ path: "big.ts", patch: addedPatch(lines, 1) }],
+  });
+  assert.equal(findings.length, 25);
+});
+
+// ── NOT FLAGGED cases (precision) ────────────────────────────────────────────
+
+test("does NOT flag a pure string-literal command", () => {
+  assert.equal(extractUnsafeExecSinks('execSync("ls -la")').length, 0);
+  assert.equal(extractUnsafeExecSinks('eval("1+1")').length, 0);
+});
+
+test("does NOT flag a commented-out sink (line comment or block-comment body)", () => {
+  // Commented-out code is not executed, so an interpolated sink in a comment must not be a false positive.
+  assert.deepEqual(scanPatchForUnsafeExec("f.ts", addedPatch(['// exec("rm " + path)'])), []);
+  assert.deepEqual(
+    scanPatchForUnsafeExec("f.ts", addedPatch([" * execSync(`git clone ${repo}`) — example in docs"])),
+    [],
+  );
+});
+
+test("does NOT flag a sink name inside a string literal or a trailing comment (the gate's false-positive class)", () => {
+  // A sink name inside a string (docs string, example, error message) is not a call.
+  assert.equal(extractUnsafeExecSinks('const docs = "execSync(`git clone ${repo}`)"').length, 0);
+  assert.equal(extractUnsafeExecSinks("const help = 'run eval(' + name + ') manually'").length, 0);
+  // A sink in a trailing line comment is not executed.
+  assert.equal(extractUnsafeExecSinks('const x = compute(); // exec("rm " + path)').length, 0);
+  // But a REAL sink that follows a string on the same line is still detected.
+  assert.equal(extractUnsafeExecSinks('const note = "x"; execSync(`${cmd}`)').length, 1);
+  // A sink inside a mid-line block comment is not executed; a real sink after the comment still is.
+  assert.equal(extractUnsafeExecSinks('foo(); /* exec("rm " + p) */').length, 0);
+  assert.equal(extractUnsafeExecSinks('/* note */ execSync(`${cmd}`)').length, 1);
+});
+
+test("CONTRACT (line-local): a sink inside a template ${...} interpolation is intentionally not reported", () => {
+  // Documented scope: the scanner does NOT descend into `${...}`; a sink hidden there is a known, accepted miss
+  // (favoring a simple linear pass + zero false positives over exhaustive recall).
+  assert.equal(extractUnsafeExecSinks("const s = `${execSync(`cmd ${x}`)}`;").length, 0);
+  // A sink-looking substring inside a template literal body is (still) never a false positive.
+  assert.equal(extractUnsafeExecSinks("const msg = `run execSync(`...`) carefully`;").length, 0);
+});
+
+test("does NOT flag a sink inside a MULTI-LINE block comment, but does after it closes (cross-line state)", () => {
+  // `/*` opens on one added line, the sink is on the NEXT, `*/` closes on a third — all inside the comment.
+  assert.deepEqual(
+    scanPatchForUnsafeExec("f.ts", addedPatch(["/* disabled for now:", "execSync(`cmd ${x}`)", "*/"])),
+    [],
+  );
+  // a real sink on its own line after the block comment closes is still detected.
+  assert.equal(
+    scanPatchForUnsafeExec("f.ts", addedPatch(["/* note", "*/", "execSync(`${cmd}`)"])).length,
+    1,
+  );
+});
+
+test("tracks a block comment OPENED by a context line (no leading-marker corruption) so the added sink inside is not flagged", () => {
+  // Gate's case: an unchanged context line opens `/*`, the added sink is inside it, a later context line closes `*/`.
+  const spacePrefixed = ["@@ -1,3 +1,4 @@", " /* disabled:", "+execSync(`cmd ${x}`)", " */"].join("\n");
+  assert.deepEqual(scanPatchForUnsafeExec("f.ts", spacePrefixed), []);
+  // Robustness: a context line whose `/*` is at column 0 (no diff space) must still read as `/*`, not `*` — this is
+  // the exact regression for the slice(1) fix (old code corrupted `/*`→`*`, missed the comment, and false-flagged).
+  const noSpace = ["@@ -1,2 +1,3 @@", "/* opened at col 0", "+execSync(`cmd ${x}`)", "*/"].join("\n");
+  assert.deepEqual(scanPatchForUnsafeExec("f.ts", noSpace), []);
+});
+
+test("does NOT flag spawn with a literal command + args array", () => {
+  assert.equal(
+    extractUnsafeExecSinks('spawn("git", ["status", branch])').length,
+    0,
+  );
+  assert.equal(
+    extractUnsafeExecSinks('execFile("ls", ["-la", dir])').length,
+    0,
+  );
+});
+
+test("does NOT flag a bare identifier argument", () => {
+  assert.equal(extractUnsafeExecSinks("exec(cmd)").length, 0);
+  assert.equal(extractUnsafeExecSinks("eval(code)").length, 0);
+  assert.equal(extractUnsafeExecSinks("execSync(command)").length, 0);
+});
+
+test("does NOT flag a removed (-) line that matches", () => {
+  const patch = [
+    "@@ -1,2 +1,1 @@",
+    "-execSync(`git clone ${repo}`)",
+    " const keep = 1;",
+  ].join("\n");
+  assert.equal(scanPatchForUnsafeExec("src/x.ts", patch).length, 0);
+});
+
+test("flags bare Function(...) the same as new Function(...) (it is the same constructor)", () => {
+  // `Function("return " + body)` constructs+evaluates code exactly like `new Function(...)`, so it IS a code sink.
+  const f = extractUnsafeExecSinks('Function("return " + body)');
+  assert.equal(f.length, 1);
+  assert.equal(f[0].kind, "code-eval");
+});
+
+test("does NOT flag a sink-looking word inside a larger identifier", () => {
+  assert.equal(extractUnsafeExecSinks("myexec(`${x}`)").length, 0);
+  assert.equal(extractUnsafeExecSinks("preeval(`${x}`)").length, 0);
+});
+
+// ── render is public-safe ────────────────────────────────────────────────────
+
+test("renderBrief surfaces file:line + sink + kind and NEVER the argument text", () => {
+  const { promptSection } = renderBrief({
+    unsafeExec: [
+      { file: "src/run.ts", line: 12, sink: "execSync", kind: "command-exec" },
+      { file: "src/run.ts", line: 30, sink: "eval", kind: "code-eval" },
+    ],
+  });
+  assert.match(promptSection, /Unsafe dynamic execution/);
+  assert.match(promptSection, /src\/run\.ts:12/);
+  assert.match(promptSection, /execSync/);
+  assert.match(promptSection, /shell command/);
+  assert.match(promptSection, /src\/run\.ts:30/);
+  assert.match(promptSection, /code/);
+  // The argument value must never appear.
+  assert.ok(!promptSection.includes("git clone"));
+  assert.ok(!promptSection.includes("${"));
+});


### PR DESCRIPTION
## What

A new REES security analyzer, `unsafeExec`, that flags code a PR adds which builds a shell command or an eval string by interpolation or concatenation and passes it straight to a dangerous execution sink. This is the classic command-injection / code-injection shape that the no-checkout reviewer cannot reliably catch by eye.

## No linked issue

no issue because: this is net-new analyzer work in the established REES analyzer pattern, and there is no open issue for an unsafe-execution signal. The existing security analyzers cover ReDoS, secrets-in-logs, and IaC misconfiguration, but not dynamic command or code execution, so this fills a real gap rather than duplicating an issue.

## Data source

Pure compute over the PR diff. No network, no external detector, no token. For each added line it finds a dangerous sink call and inspects only its first argument.

## Behavior

Conservative by design, mirroring the redos analyzer, so the false-positive rate stays near zero. A sink is flagged only when its first argument is dynamically built, that is a backtick template carrying a `${...}` interpolation or a `+` string concatenation outside any string literal. Sinks covered: `exec` and `execSync` (shell strings), `eval` and `new Function` (code), and the `execFile` / `spawn` family only when the command name itself is built dynamically. A pure string literal such as `exec("ls -la")`, a literal-command spawn with an args array such as `spawn("git", ["status"])`, a bare identifier such as `exec(cmd)`, and a commented-out line are all never flagged. Additive and fail-safe: it is bounded to 25 findings and a 2000-character line cap, a malformed or unterminated argument skips the line, and it reports only the file, line, sink name, and kind, never the argument text. It follows the established pattern entirely within `review-enrichment` (finding type in `types.ts`, a pure analyzer in `analyzers/unsafe-exec.ts`, a descriptor in `analyzers/registry.ts`, a public-safe block in `render.ts`), with the generated analyzer metadata regenerated to match.

## Tests

node:test cases with realistic diff patches cover the flagged cases (execSync, exec, eval, and new Function with interpolation or concatenation, a member-call sink, and spawn only when the command name is dynamic), the precision cases (pure string literals, a literal-command spawn, bare identifiers, commented-out sinks, removed lines, and sink-like substrings, none flagged), correct line numbers via hunk headers, multi-file scanning, MAX_FINDINGS bounding, and that neither the finding nor the rendered brief ever leaks the argument value. Full review-enrichment suite green.
