### PR TITLE
fix(github): keep digest title truncation from splitting surrogate pairs

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1380,7 +1380,14 @@ function shortText(value: string, maxLength: number): string {
     .replace(/\s+/g, " ")
     .trim();
   const safeText = neutralizePublicMarkdownText(sanitized);
-  return safeText.length > maxLength ? `${safeText.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...` : safeText;
+  if (safeText.length <= maxLength) return safeText;
+  // `slice` counts UTF-16 code units, so the cut can fall between the surrogate halves of an astral
+  // character (an emoji) and leave a lone high surrogate — invalid UTF-16 that becomes a U+FFFD mojibake
+  // glyph when the digest comment is UTF-8 encoded for the public GitHub comment. Drop a dangling high
+  // surrogate before the ellipsis so truncation never splits a pair.
+  let truncated = safeText.slice(0, Math.max(0, maxLength - 3));
+  if (/[\uD800-\uDBFF]$/.test(truncated)) truncated = truncated.slice(0, -1);
+  return `${truncated.trimEnd()}...`;
 }
 
 function neutralizePublicMarkdownText(value: string): string {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -1738,6 +1738,62 @@ describe("GitHub mention commands", () => {
     }
   });
 
+  it("does not split a surrogate pair when truncating an over-long emoji digest title", () => {
+    // A string has a lone surrogate (and turns into a U+FFFD mojibake glyph once UTF-8 encoded for the
+    // GitHub comment) iff a high surrogate is not followed by a low one, or vice versa.
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    // 60 × 🎉 (U+1F389) = 120 UTF-16 code units, well over the 90/100-unit digest title caps. Each emoji
+    // is a surrogate pair on an even index, so an odd `maxLength - 3` cut would split the final kept pair.
+    const emojiTitle = "🎉".repeat(60);
+    const digest = {
+      ...sampleMaintainerDigest(),
+      reviewNowPullRequests: [
+        {
+          number: 88,
+          title: emojiTitle,
+          authorLogin: "miner",
+          linkedIssues: [8],
+          labels: [],
+          confirmedMiner: false,
+          ageDays: 0,
+          reasons: ["Linked issue is present."],
+          signals: [],
+        },
+      ],
+      duplicateClusters: [
+        {
+          id: "emoji-title",
+          risk: "high",
+          reason: "Likely_duplicate title cluster",
+          items: [{ type: "pull_request", number: 88, title: emojiTitle }],
+        },
+      ],
+    } satisfies ReturnType<typeof sampleMaintainerDigest>;
+
+    const reviewNow = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory review-now")!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 99, title: "Digest", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+      maintainerDigest: digest,
+    });
+    const duplicateClusters = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory duplicate-clusters")!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 99, title: "Digest", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+      maintainerDigest: digest,
+    });
+
+    for (const body of [reviewNow, duplicateClusters]) {
+      expect(body).toContain("..."); // the title was truncated
+      expect(loneSurrogate.test(body)).toBe(false); // no split surrogate pair
+      expect(body).not.toContain("�"); // no replacement-character mojibake
+    }
+  });
+
   it("falls back to repository placeholder when queue digest has no source records", () => {
     const digest = buildMaintainerQueueDigest({
       repo: null,


### PR DESCRIPTION
## Summary

`shortText` in `src/github/commands.ts` truncates maintainer-queue digest titles with `safeText.slice(0, maxLength - 3)`. `String.prototype.slice` counts UTF-16 **code units**, so when the cut lands between the high and low halves of an astral character (any emoji, e.g. `🎉` = `U+D83C U+DF89`) it keeps the high surrogate and drops the low one, leaving a **lone high surrogate**. That is invalid UTF-16 and becomes a `U+FFFD` (`�`) mojibake glyph the moment the comment body is UTF-8 encoded for GitHub — and these titles render directly into **public** `@gittensory` digest comments (PR digest items via `formatPrDigestItem`, and duplicate-cluster refs via `duplicateClusterSection`).

This fix drops a dangling high surrogate after the cap and before the ellipsis, so truncation never splits a pair (the UTF-16-unit length budget is preserved; non-astral text is byte-identical).

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-evident UTF-16 correctness fix scoped to a single render helper.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the new `shortText` branch (the dangling-high-surrogate drop) is covered by a regression test that renders both the review-now PR-digest and duplicate-cluster paths and asserts no lone surrogate / no `U+FFFD`. The not-split branch is covered by the existing over-long ASCII-title digest tests. The regression test was confirmed to FAIL against the unpatched helper.
- [x] New or changed behavior has unit tests for the new branch and render paths

If any required check was skipped, explain why:

- The change is a single pure-helper branch in `src/github`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This fix strictly improves public-output correctness.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Public digest output is now always well-formed UTF-16; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: a digest title of `"🎉".repeat(60)` rendered through `shortText(title, 90)` previously yielded a string ending (before `...`) in a lone high surrogate `0xD83C`, which UTF-8-encodes to `�`. It now ends on a complete character.
