### PR TITLE
fix(github): align maintainer digest failing-check detection with readiness classifier

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -17,6 +17,7 @@ import {
   type QueueHealth,
   type RepoOutcomePatterns,
 } from "../signals/engine";
+import { isFailingCheckSummary } from "../signals/local-branch";
 import { buildMaintainerNoiseReport, type MaintainerNoiseReport } from "../signals/reward-risk";
 
 const PUBLIC_MENTION_COMMAND_CATALOG = [
@@ -1290,7 +1291,10 @@ function summarizeQueuePullRequest(
 ): MaintainerQueuePullRequestSummary {
   const ageDays = daysSince(pr.updatedAt ?? pr.createdAt);
   const confirmedMiner = Boolean(pr.authorLogin && confirmedMinerLogins.has(normalizeLogin(pr.authorLogin)));
-  const failedChecks = checks.filter((check) => ["failure", "timed_out", "cancelled"].includes(check.conclusion ?? "")).length;
+  // Share the readiness path's canonical classifier so the digest counts the SAME failing checks the gate sees:
+  // a failure carried on `status` (commit-status rows / runs that errored before concluding), startup_failure /
+  // failed / action_required, and any case variant — not just three lowercase `conclusion` values.
+  const failedChecks = checks.filter(isFailingCheckSummary).length;
   const signals: MaintainerQueuePullRequestSummary["signals"] = [
     ...(confirmedMiner ? ["confirmed_miner" as const] : []),
     ...(pr.linkedIssues.length === 0 ? ["missing_linked_issue" as const] : []),

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -737,8 +737,22 @@ function matchingCheckSummaries(pr: PullRequestRecord, checkSummaries: CheckSumm
   );
 }
 
+/** Conclusion/status values that mark a single cached check as failing or attention-needing. */
+const FAILING_CHECK_STATES = ["failure", "failed", "timed_out", "cancelled", "action_required", "startup_failure"];
+
+/**
+ * Canonical "is this ONE cached check failing?" predicate, shared so every surface (readiness, the maintainer
+ * queue digest) classifies a check identically. A cached check may carry its outcome on `conclusion` (check
+ * runs) OR only on `status` (commit-status rows and runs that errored before concluding), so fall back to
+ * `status` when `conclusion` is absent, and case-fold both — GitHub conclusions are lowercase, but cached/commit
+ * statuses are not guaranteed to be.
+ */
+export function isFailingCheckSummary(check: CheckSummaryRecord): boolean {
+  return FAILING_CHECK_STATES.includes((check.conclusion ?? check.status).toLowerCase());
+}
+
 function hasFailingCheck(checks: CheckSummaryRecord[]): boolean {
-  return checks.some((check) => ["failure", "failed", "timed_out", "cancelled", "action_required", "startup_failure"].includes((check.conclusion ?? check.status).toLowerCase()));
+  return checks.some(isFailingCheckSummary);
 }
 
 function hasPendingCheck(checks: CheckSummaryRecord[]): boolean {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -1517,6 +1517,39 @@ describe("GitHub mention commands", () => {
     expect(emptyNoise).not.toContain("Suggested triage:");
   });
 
+  it("counts failing cached checks with the canonical readiness classifier (status-carried, startup_failure, case-fold)", () => {
+    const prWithChecks = (number: number, checks: Array<{ status: string; conclusion?: string | null }>) =>
+      buildMaintainerQueueDigest({
+        repo: { fullName: "owner/repo", isRegistered: true, registryConfig: { emissionShare: 0.1, issueDiscoveryShare: 0, labelMultipliers: {}, maintainerCut: 0, raw: {}, repo: "owner/repo" } } as any,
+        issues: [issue(1, "Linked fix")],
+        pullRequests: [pr(number, "Check signal coverage", "alice", { linkedIssues: [1], updatedAt: "2099-01-01T00:00:00.000Z" })],
+        checkSummariesByPullNumber: {
+          [number]: checks.map((check, index) => ({
+            id: `check-${number}-${index}`,
+            repoFullName: "owner/repo",
+            pullNumber: number,
+            name: `check-${index}`,
+            status: check.status,
+            conclusion: check.conclusion ?? null,
+            payload: {},
+          })),
+        },
+      });
+
+    const statusCarried = prWithChecks(20, [{ status: "failure", conclusion: null }]).needsAuthorPullRequests[0];
+    expect(statusCarried?.signals).toContain("checks_need_attention");
+    expect(statusCarried?.reasons).toContain("1 cached check(s) need attention.");
+
+    const startupFailure = prWithChecks(21, [{ status: "completed", conclusion: "startup_failure" }]).needsAuthorPullRequests[0];
+    expect(startupFailure?.signals).toContain("checks_need_attention");
+
+    const mixedCase = prWithChecks(22, [{ status: "completed", conclusion: "FAILURE" }]).needsAuthorPullRequests[0];
+    expect(mixedCase?.signals).toContain("checks_need_attention");
+
+    const clean = prWithChecks(23, [{ status: "completed", conclusion: "success" }]).needsAuthorPullRequests[0];
+    expect(clean?.signals ?? []).not.toContain("checks_need_attention");
+  });
+
   it("builds maintainer-only queue digests with safe routing, sorting, and private-detail pointers", () => {
     const digest = sampleMaintainerDigest();
     expect(digest.totals.confirmedMinerPullRequests).toBe(2);


### PR DESCRIPTION
## Summary

- Export `isFailingCheckSummary` from `src/signals/local-branch.ts` as the canonical cached-check failure predicate (conclusion or status, full failing set, case-folded).
- Reuse it in `summarizeQueuePullRequest` so the maintainer queue digest surfaces `checks_need_attention` for the same failing checks the readiness path already sees.
- Add regression coverage for status-carried failures, `startup_failure`, mixed-case conclusions, and clean checks.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Issue creation is currently blocked for contributor accounts on the upstream repo; this is a focused correctness fix with regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` runs in GitHub Actions; targeted vitest covered the new regression.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend signal/digest logic only.

## Notes

-


Made with [Cursor](https://cursor.com)