### PR TITLE
fix(upstream): look up unmodeled scoring drift by fingerprint, not capped list

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1279,6 +1279,13 @@ export async function getOpenUpstreamDriftReportByFingerprint(env: Env, fingerpr
   return row ? toUpstreamDriftReportRecord(row) : null;
 }
 
+/** Lookup a drift report by its stable fingerprint regardless of status (resolved reports included). */
+export async function getUpstreamDriftReportByFingerprint(env: Env, fingerprint: string): Promise<UpstreamDriftReportRecord | null> {
+  const db = getDb(env.DB);
+  const [row] = await db.select().from(upstreamDriftReports).where(eq(upstreamDriftReports.fingerprint, fingerprint)).limit(1);
+  return row ? toUpstreamDriftReportRecord(row) : null;
+}
+
 export async function persistScorePreview(env: Env, preview: ScorePreviewRecord): Promise<void> {
   const db = getDb(env.DB);
   await db.insert(scorePreviews).values({

--- a/src/upstream/unmodeled-scoring-drift.ts
+++ b/src/upstream/unmodeled-scoring-drift.ts
@@ -1,6 +1,6 @@
 import {
   getLatestUpstreamRulesetSnapshot,
-  listUpstreamDriftReports,
+  getUpstreamDriftReportByFingerprint,
   upsertUpstreamDriftReport,
 } from "../db/repositories";
 import type { UpstreamDriftArea, UpstreamDriftReportRecord, UpstreamDriftSeverity } from "../types";
@@ -23,7 +23,10 @@ export async function syncUnmodeledScoringConstantDrift(
   },
 ): Promise<UpstreamDriftReportRecord | null> {
   const fingerprint = await unmodeledScoringConstantsFingerprint();
-  const existing = (await listUpstreamDriftReports(env, 50)).find((report) => report.fingerprint === fingerprint) ?? null;
+  // Key by fingerprint directly — `listUpstreamDriftReports` is capped and ordered by `updatedAt`, so an older
+  // unmodeled-constants report can fall off the newest-50 window and be treated as missing (duplicate open reports,
+  // lost issue metadata, resolve no-ops).
+  const existing = (await getUpstreamDriftReportByFingerprint(env, fingerprint)) ?? null;
   const now = nowIso();
 
   if (args.unmodeledConstants.length === 0) {

--- a/test/unit/unmodeled-scoring-drift.test.ts
+++ b/test/unit/unmodeled-scoring-drift.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { listUpstreamDriftReports, updateUpstreamDriftReportIssue } from "../../src/db/repositories";
+import { listUpstreamDriftReports, updateUpstreamDriftReportIssue, upsertUpstreamDriftReport } from "../../src/db/repositories";
 import { syncUnmodeledScoringConstantDrift, unmodeledScoringConstantsFingerprint } from "../../src/upstream/unmodeled-scoring-drift";
 import { createTestEnv } from "../helpers/d1";
 
@@ -101,5 +101,50 @@ describe("unmodeled scoring constant drift", () => {
     const report = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: names });
     expect(report?.summary).toMatch(/, …$/);
     expect(report?.severity).toBe("high");
+  });
+
+  it("looks up the stable unmodeled-constants fingerprint even when it falls off the newest-50 drift list", async () => {
+    const env = createTestEnv();
+    const fingerprint = await unmodeledScoringConstantsFingerprint();
+    const opened = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: ["ALPHA"] });
+    expect(opened?.fingerprint).toBe(fingerprint);
+
+    // Push the unmodeled report out of `listUpstreamDriftReports(env, 50)`'s recency window.
+    await upsertUpstreamDriftReport(env, { ...opened!, updatedAt: "2020-01-01T00:00:00.000Z" });
+    for (let index = 0; index < 51; index++) {
+      await upsertUpstreamDriftReport(env, {
+        id: `newer-${index}`,
+        fingerprint: `newer-drift-${index}`,
+        severity: "low",
+        status: "open",
+        summary: `newer drift ${index}`,
+        affectedAreas: ["registry"],
+        previousRulesetId: null,
+        currentRulesetId: null,
+        issueNumber: null,
+        issueUrl: null,
+        payload: { changes: ["noop"] },
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        updatedAt: `2026-06-30T${String(index).padStart(2, "0")}:00:00.000Z`,
+      });
+    }
+    expect((await listUpstreamDriftReports(env, 50)).some((report) => report.fingerprint === fingerprint)).toBe(false);
+
+    await updateUpstreamDriftReportIssue(env, fingerprint, {
+      number: 811,
+      url: "https://github.com/JSONbored/gittensory/issues/811",
+    });
+    const updated = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: ["ALPHA", "BETA"] });
+    expect(updated).toMatchObject({
+      id: opened!.id,
+      fingerprint,
+      status: "open",
+      issueNumber: 811,
+      issueUrl: "https://github.com/JSONbored/gittensory/issues/811",
+      payload: expect.objectContaining({ unmodeledUpstreamConstants: ["ALPHA", "BETA"] }),
+    });
+
+    const resolved = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: [] });
+    expect(resolved).toMatchObject({ id: opened!.id, fingerprint, status: "resolved" });
   });
 });

--- a/test/unit/unmodeled-scoring-drift.test.ts
+++ b/test/unit/unmodeled-scoring-drift.test.ts
@@ -109,8 +109,15 @@ describe("unmodeled scoring constant drift", () => {
     const opened = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: ["ALPHA"] });
     expect(opened?.fingerprint).toBe(fingerprint);
 
-    // Push the unmodeled report out of `listUpstreamDriftReports(env, 50)`'s recency window.
-    await upsertUpstreamDriftReport(env, { ...opened!, updatedAt: "2020-01-01T00:00:00.000Z" });
+    // Push the unmodeled report out of `listUpstreamDriftReports(env, 50)`'s recency window and seed linked-issue
+    // metadata directly on the row — do NOT call `updateUpstreamDriftReportIssue` here; that helper rewrites
+    // `updatedAt` to now and would put the row back inside the capped list, defeating the regression.
+    await upsertUpstreamDriftReport(env, {
+      ...opened!,
+      updatedAt: "2020-01-01T00:00:00.000Z",
+      issueNumber: 811,
+      issueUrl: "https://github.com/JSONbored/gittensory/issues/811",
+    });
     for (let index = 0; index < 51; index++) {
       await upsertUpstreamDriftReport(env, {
         id: `newer-${index}`,
@@ -130,10 +137,6 @@ describe("unmodeled scoring constant drift", () => {
     }
     expect((await listUpstreamDriftReports(env, 50)).some((report) => report.fingerprint === fingerprint)).toBe(false);
 
-    await updateUpstreamDriftReportIssue(env, fingerprint, {
-      number: 811,
-      url: "https://github.com/JSONbored/gittensory/issues/811",
-    });
     const updated = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: ["ALPHA", "BETA"] });
     expect(updated).toMatchObject({
       id: opened!.id,
@@ -144,6 +147,7 @@ describe("unmodeled scoring constant drift", () => {
       payload: expect.objectContaining({ unmodeledUpstreamConstants: ["ALPHA", "BETA"] }),
     });
 
+    await upsertUpstreamDriftReport(env, { ...updated!, updatedAt: "2020-01-01T00:00:00.000Z" });
     const resolved = await syncUnmodeledScoringConstantDrift(env, { unmodeledConstants: [] });
     expect(resolved).toMatchObject({ id: opened!.id, fingerprint, status: "resolved" });
   });


### PR DESCRIPTION
## Summary

- Add `getUpstreamDriftReportByFingerprint` so drift sync can load a report by its stable fingerprint regardless of status.
- Switch `syncUnmodeledScoringConstantDrift` from scanning `listUpstreamDriftReports(env, 50)` to the fingerprint-keyed lookup, preventing duplicate open reports, lost issue metadata, and resolve no-ops when the row ages out of the recency window.
- Add regression coverage that ages the unmodeled-constants report past the newest-50 list and verifies update + resolve still hit the same row.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Issue creation is currently blocked for contributor accounts on the upstream repo; this is a focused correctness fix with regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` runs in GitHub Actions; targeted vitest covered the new regression suite.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend drift-sync logic only.

## Notes

-


Made with [Cursor](https://cursor.com)