### PR TITLE
fix(signals): match hyphenated docs-only no-issue rationale

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4953,7 +4953,11 @@ export function buildPrTextLint(input: PrTextLintInput): PrTextLintReport {
 // Exported so the deterministic no-linked-issue slop signal (#562) and the public PR-panel traceability check
 // share ONE definition of a "clear no-issue rationale" (maintenance / docs-only / "no issue: …" in the PR text).
 export function hasClearNoIssueRationale(pr: Pick<PullRequestRecord, "title" | "body">): boolean {
-  return /\b(?:no issue\s*(?:because\b|:)|no linked issue\s*(?:because\b|:)|no ticket\s*(?:because\b|:)|(?:maintenance|docs? only|typo|chore|cleanup)\b)/i.test([pr.title, pr.body ?? ""].join(" "));
+  // `docs?[\s-]+only` matches the space form ("docs only") AND the hyphenated "docs-only" / "doc-only"
+  // spelling this function's own docstring uses — the dominant GitHub/Conventional-Commits form. A bare
+  // `docs? only` missed the hyphen, so a docs-only PR with no linked issue was wrongly denied a clear
+  // no-issue rationale and hard-blocked under `linkedIssueGateMode === "block"`.
+  return /\b(?:no issue\s*(?:because\b|:)|no linked issue\s*(?:because\b|:)|no ticket\s*(?:because\b|:)|(?:maintenance|docs?[\s-]+only|typo|chore|cleanup)\b)/i.test([pr.title, pr.body ?? ""].join(" "));
 }
 
 function hasValidationNote(value: string): boolean {

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -26,6 +26,7 @@ import {
   buildRegistryChangeReport,
   buildRepoFitRecommendation,
   buildRoleContext,
+  hasClearNoIssueRationale,
   type ContributorFit,
   type ContributorOutcomeHistory,
   type ContributorScoringProfile,
@@ -1707,6 +1708,23 @@ describe("v2 signal builders", () => {
     expect(comment).toContain("Author: `unknown`");
     expect(comment).toContain("Public profile only");
     expect(comment).not.toMatch(/wallet|raw trust score|ranking/i);
+  });
+});
+
+describe("hasClearNoIssueRationale docs-only spelling", () => {
+  it("recognizes the hyphenated docs-only rationale, not only the space form", () => {
+    // The space form already worked; these hyphenated forms (the dominant GitHub / Conventional-Commits
+    // spelling, and the one this function's own docstring uses) were wrongly missed, hard-blocking a
+    // docs-only PR with no linked issue under linkedIssueGateMode === "block".
+    expect(hasClearNoIssueRationale({ title: "docs only: clarify README", body: "" })).toBe(true);
+    expect(hasClearNoIssueRationale({ title: "docs-only: clarify README", body: "" })).toBe(true);
+    expect(hasClearNoIssueRationale({ title: "doc-only update", body: "" })).toBe(true);
+    expect(hasClearNoIssueRationale({ title: "Improve install steps", body: "This is a docs-only change." })).toBe(true);
+  });
+
+  it("still rejects PR text with no clear no-issue rationale", () => {
+    expect(hasClearNoIssueRationale({ title: "Improve install steps", body: "Adds a new option." })).toBe(false);
+    expect(hasClearNoIssueRationale({ title: "Add documentation site", body: "" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`hasClearNoIssueRationale` in `src/signals/engine.ts` is the single shared definition of a "clear no-issue rationale" used by the deterministic no-linked-issue slop signal (`slop.ts`), the public PR-panel traceability check, and the **hard** linked-issue gate. Its regex matched the documentation rationale only as `docs? only` — a literal space — so the hyphenated `docs-only` / `doc-only` spelling (the dominant GitHub / Conventional-Commits form, and the exact spelling this function's **own docstring** and `slop.ts`'s comment use) was missed.

Consequence: a docs-only PR with **no linked issue**, titled e.g. `docs-only: …`, on a repo with `linkedIssueGateMode === "block"`, hits `hardLinkedIssueBlock` (engine.ts:4246, 4486) and is driven to a `failure` gate conclusion — which the engine auto-**closes** — despite carrying a valid no-issue rationale. It also misfires the slop signal, shows "Missing" on the traceability panel, and docks the readiness score.

Fix: widen the alternative to `docs?[\s-]+only`, which matches `docs only`, `docs-only`, and `doc-only` while leaving every other case unchanged.

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-evident one-token regex correctness fix in a single shared helper.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the changed line is covered by a new regression test (`hasClearNoIssueRationale docs-only spelling`) asserting the space, hyphenated, embedded, and negative cases. The test was confirmed to FAIL against the unpatched regex (`expected false to be true`) and pass after the fix. Downstream consumers stay green: `slop`, `linked-issue-hard-rules`, `predicted-gate`, `gate-check-policy` suites all pass.
- [x] New or changed behavior has unit tests for the new and negative paths

If any required check was skipped, explain why:

- The change is one regex character class in a pure exported helper in `src/signals`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Gate/slop/traceability now read a valid docs-only rationale correctly; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `hasClearNoIssueRationale({ title: "docs-only: clarify README", body: "" })` returned `false` (should be `true`); `"docs only: …"` returned `true`. The fix makes both — plus `"doc-only update"` and a body containing "…a docs-only change." — return `true`, while unrelated text like "Add documentation site" still returns `false`.
