### PR TITLE
fix(signals): drop unterminated HTML comment text from template scan

### DIFF
--- a/src/signals/slop.ts
+++ b/src/signals/slop.ts
@@ -479,7 +479,10 @@ function stripHtmlComments(input: string): string {
     output += input.slice(cursor, commentStart);
     const commentEnd = input.indexOf("-->", commentStart + 4);
     if (commentEnd === -1) {
-      output += input.slice(commentStart);
+      // An unterminated "<!--" is rendered by GitHub/CommonMark as a comment running to end-of-body — the
+      // text is hidden — so it must NOT survive as substantive content. Dropping it (rather than appending
+      // it) closes an evasion where a placeholder-only body dodges the unfilled-template signal just by
+      // omitting the closing "-->". Real prose BEFORE the comment was already appended above and is kept.
       break;
     }
 

--- a/test/unit/slop.test.ts
+++ b/test/unit/slop.test.ts
@@ -493,6 +493,20 @@ describe("buildIssueSlopAssessment (#533 issue-side triage)", () => {
     expect(buildUnfilledIssueTemplateFinding({ body: maliciousBody })).toMatchObject({ code: "unfilled_issue_template" });
   }, 1_000);
 
+  it("an unterminated HTML comment hides its placeholder text, so the body is still flagged as unfilled", () => {
+    // GitHub/CommonMark renders an unterminated "<!--" as a comment running to end-of-body, so the
+    // placeholder text is invisible. Keeping it would let a placeholder-only body dodge the signal just by
+    // dropping the closing "-->".
+    expect(buildUnfilledIssueTemplateFinding({ body: "<!-- describe the problem here" })).toMatchObject({
+      code: "unfilled_issue_template",
+    });
+    expect(buildUnfilledIssueTemplateFinding({ body: "### Bug\n<!-- describe the bug, steps to reproduce, expected vs actual" })).toMatchObject({
+      code: "unfilled_issue_template",
+    });
+    // Real prose BEFORE an unterminated comment is genuine content and still clears the signal (no over-flag).
+    expect(buildUnfilledIssueTemplateFinding({ body: "The save button throws on click.\n<!-- internal triage note" })).toBeNull();
+  });
+
   it("a single padding character does NOT defeat the unfilled-template check (#audit-§4)", () => {
     // Template scaffolding + one stray char that survives the punctuation strip — must still be flagged.
     expect(buildUnfilledIssueTemplateFinding({ body: "### Description\n<!-- describe -->\n.\n" })).toMatchObject({ code: "unfilled_issue_template" });


### PR DESCRIPTION
## Summary

`buildUnfilledIssueTemplateFinding` in `src/signals/slop.ts` flags an issue body that reduces to nothing substantive after stripping template scaffolding. It first runs the body through `stripHtmlComments` to remove HTML-comment placeholders (the `<!-- describe the problem here -->` scaffolding GitHub issue templates use), then fires only if no real 3+ letter word survives.

`stripHtmlComments` mishandled an **unterminated** `<!--` (no closing `-->`): it appended the rest of the input as if it were real content. But GitHub/CommonMark renders an unterminated `<!--` as a comment block running to **end-of-body** — the text is hidden. So a contributor could keep the placeholder text by simply **dropping the closing `-->`**, and the surviving words would suppress the `unfilled_issue_template` slop signal even though the rendered issue is empty.

Fix: in the unterminated-comment branch, drop the comment text (don't append it), matching how GitHub renders it. Prose that appears **before** the comment is already appended and is still preserved, so genuine content never over-flags.

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-evident parser-correctness fix in one helper that closes a signal-evasion.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the changed branch is covered by a new regression test asserting the hidden-placeholder body is flagged, a heading + unterminated-comment body is flagged, and real prose before an unterminated comment still clears the signal. The test was confirmed to FAIL against the unpatched helper (`expected null to match { code: 'unfilled_issue_template' }`). The full `slop` (63) and `ai-slop` (34) suites pass.
- [x] New or changed behavior has unit tests for the new branch and the no-over-flag path

If any required check was skipped, explain why:

- The change is one branch in a pure helper in `src/signals`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Slop classification only; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `buildUnfilledIssueTemplateFinding({ body: "<!-- describe the problem here" })` returned `null` (not flagged) before the fix and now returns `{ code: "unfilled_issue_template" }`. `buildUnfilledIssueTemplateFinding({ body: "The save button throws on click.\n<!-- internal triage note" })` returns `null` both before and after (real content before the comment is preserved).
