### PR TITLE
fix(selfhost): defer queue admission when rate-limit resetAt is unparseable

### DIFF
--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -97,7 +97,14 @@ export function isGitHubBudgetBackgroundJob(message: JobMessage): boolean {
 
 function githubObservedRateLimitDelayMs(
   observation:
-    | { remaining?: unknown; reset_at?: unknown; resetAt?: unknown }
+    | {
+        remaining?: unknown;
+        reset_at?: unknown;
+        resetAt?: unknown;
+        observed_at?: unknown;
+        observedAt?: unknown;
+        observedAtMs?: unknown;
+      }
     | null
     | undefined,
   floor: number,
@@ -119,7 +126,13 @@ function githubObservedRateLimitDelayMs(
   if (remaining === null || !resetAt) return null;
   if (remaining > floor) return null;
   const ms = Date.parse(resetAt) - nowMs;
-  if (!Number.isFinite(ms) || ms <= 0) return null;
+  if (!Number.isFinite(ms)) {
+    const observedMs = observationMs(observation);
+    const deferUntilMs = observedMs !== null ? observedMs + 60_000 : nowMs + 60_000;
+    if (nowMs >= deferUntilMs) return null;
+    return Math.max(30_000, deferUntilMs - nowMs);
+  }
+  if (ms <= 0) return null;
   return Math.max(30_000, Math.min(900_000, (Math.ceil(ms / 1000) + 15) * 1000));
 }
 

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -98,6 +98,15 @@ describe("self-host queue common helpers", () => {
     expect(githubWebhookRateLimitDelayMs({ remaining: 50, reset_at: "2026-06-24T11:59:00.000Z" }, now)).toBeNull();
   });
 
+  it("defers webhook and background admission when resetAt is unparseable but REST budget is exhausted", () => {
+    const now = Date.parse("2026-06-24T12:00:00.000Z");
+    const observation = { remaining: 50, reset_at: "not-a-date", observed_at: "2026-06-24T12:00:00.000Z" };
+    expect(githubWebhookRateLimitDelayMs(observation, now)).toBe(60_000);
+    expect(githubBackgroundRateLimitDelayMs({ remaining: 120, reset_at: "not-a-date", observed_at: "2026-06-24T12:00:00.000Z" }, now)).toBe(60_000);
+    expect(githubWebhookRateLimitDelayMs({ remaining: 200, reset_at: "not-a-date", observed_at: "2026-06-24T12:00:00.000Z" }, now)).toBeNull();
+    expect(githubWebhookRateLimitDelayMs(observation, now + 60_000)).toBeNull();
+  });
+
   it("computes admission delays from the newest unkeyed persisted candidate", () => {
     const now = Date.parse("2026-06-24T12:00:00.000Z");
     expect(


### PR DESCRIPTION
## Summary

- `githubObservedRateLimitDelayMs` now returns a conservative 60s admission delay when REST budget is at/below the floor but `resetAt` is malformed, matching `delayUntil`'s fail-closed behavior.
- Adds regression tests for webhook and background admission paths.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No upstream issue was opened: neither contributor token has `CreateIssue` permission on `JSONbored/gittensory`. This is a narrow fail-closed guard for self-host queue admission.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- N/A

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only change.

## Notes

Pairs with the Cloudflare-worker `shouldWaitForGitHubRateLimit` guard; both defer conservatively when `resetAt` cannot be parsed.

Made with [Cursor](https://cursor.com)