### PR TITLE
fix(enrichment): match uppercase Go module paths in dependency scan

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -45,7 +45,10 @@ const NPM_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;
 const NPM_ALIAS_RE = /^npm:(@[^/]+\/[^@]+|[^@]+)@(.+)$/;
 const NPM_VERSION_PREFIX_RE = /^[\^~>=<\s]+/;
 const PYPI_RE = /^([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s;]*)/;
-const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;
+// Go module paths are case-sensitive and legitimately contain uppercase segments (github.com/BurntSushi/toml,
+// github.com/Masterminds/semver, any capitalized GitHub owner). The path class must accept A-Z or those deps
+// silently escape every dependency-fed scanner (CVE, license, provenance, native-build).
+const GO_RE = /^([A-Za-z0-9.\/-]+)\s+v([0-9][^\s]*)/;
 
 function parseLine(
   manifest: string,

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createAnalysisContext } from "../dist/analysis-context.js";
 import {
+  extractDependencyChanges,
   queryOsvBatch,
   scanDependencyChanges,
 } from "../dist/analyzers/dependency-scan.js";
@@ -94,6 +95,22 @@ test("createAnalysisContext parses common PR state once", () => {
     cappedWorkByCategory: {},
     analysisElapsedMs: 75,
   });
+});
+
+test("extractDependencyChanges parses Go module paths with uppercase segments", () => {
+  // Go module paths are case-sensitive and commonly carry uppercase (github.com/BurntSushi/toml, capitalized
+  // owners); the lowercase-only path class used to drop them, hiding those deps from the CVE/license/etc. scanners.
+  const changes = extractDependencyChanges([
+    {
+      path: "go.mod",
+      patch:
+        "@@ -1,2 +1,2 @@\n-\tgithub.com/BurntSushi/toml v1.3.2\n+\tgithub.com/BurntSushi/toml v1.4.0\n+\tgithub.com/spf13/cobra v1.8.0",
+    },
+  ]);
+  assert.deepEqual(changes, [
+    { ecosystem: "Go", package: "github.com/BurntSushi/toml", from: "1.3.2", to: "1.4.0" },
+    { ecosystem: "Go", package: "github.com/spf13/cobra", from: null, to: "1.8.0" },
+  ]);
 });
 
 test("request cache de-dupes in-flight external lookups and records safe metrics", async () => {


### PR DESCRIPTION
## Summary

The `go.mod` line parser in the REES dependency scanner used a lowercase-only path character class:

    const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;

Go module paths are case-sensitive and legitimately contain uppercase segments — e.g.
`github.com/BurntSushi/toml`, `github.com/Masterminds/semver`, `github.com/PuerkitoBio/goquery`, or
any capitalized GitHub owner. Those lines failed to match, so the dependency was silently dropped
from `extractDependencyChanges` and never reached any dependency-fed analyzer — the OSV.dev CVE scan,
license, provenance, and native-build checks. The result is a real review blind spot: a vulnerable,
uppercase-path Go dependency added in a PR would never be flagged.

The fix allows `A-Z` in the path character class. Go module paths stay case-sensitive, so the
extracted name is preserved verbatim for the OSV lookup. The change is strictly more permissive, so
existing lowercase paths are unaffected.

Before:

    const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;

After:

    // Go module paths are case-sensitive and legitimately contain uppercase segments
    // (github.com/BurntSushi/toml, github.com/Masterminds/semver, any capitalized GitHub owner).
    // The path class must accept A-Z or those deps silently escape every dependency-fed scanner
    // (CVE, license, provenance, native-build).
    const GO_RE = /^([A-Za-z0-9.\/-]+)\s+v([0-9][^\s]*)/;

A regression test asserts an uppercase-path Go module (`github.com/BurntSushi/toml`) is now parsed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — a small, self-evident parser fix; the rationale is in the Summary.

## Validation

All run from the repo root, green:

- [x] `git diff --check`
- [x] `npm run test:ci` — actionlint, db:migrations:check, typecheck, test:coverage, test:workers, build:mcp, test:mcp-pack, ui:openapi:check, ui:version-audit, ui:lint, ui:typecheck, ui:test, ui:build (5376 passed, 0 failed)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New regression test in `review-enrichment/test/analysis-context.test.ts` proves an uppercase-path Go module is parsed; full REES suite green.

## Safety

- [x] No secrets, wallet details, hotkeys, trust scores, private rankings, or maintainer evidence added.
- [x] No public GitHub comment text or sanitizer behavior changed.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session surface touched.
- [x] No API/OpenAPI/MCP contract change.
- [x] No visible UI/frontend/docs change → no UI Evidence required.
