### PR TITLE
fix(signals): count focused validation runs as passing evidence

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -45,6 +45,17 @@ export type LocalBranchValidation = {
   exitCode?: number | undefined;
 };
 
+/**
+ * A local validation command counts as passing test evidence when it ran green — either a full run
+ * (`"passed"`) or a focused subset (`"focused"`, e.g. `vitest run path/to/file.test.ts`). Single-sourced
+ * so every evidence surface (the PR-packet validation summary, the freshness evidence list, the
+ * `validation_as_test_evidence` finding, and the v2 workspace-intelligence count) agrees on what passing
+ * means instead of drifting apart.
+ */
+export function isPassingValidation(entry: LocalBranchValidation): boolean {
+  return entry.status === "passed" || entry.status === "focused";
+}
+
 export type LocalBranchScorer = {
   mode: "metadata_only" | "external_command" | "gittensor_root";
   activeModel?: string | undefined;
@@ -841,7 +852,7 @@ function buildLocalFindings(
           },
         ]
       : []),
-    ...((input.validation ?? []).some((entry) => entry.status === "passed") && !changedFiles.some((file) => isTestFile(file.path))
+    ...((input.validation ?? []).some(isPassingValidation) && !changedFiles.some((file) => isTestFile(file.path))
       ? [
           {
             code: "validation_as_test_evidence",
@@ -1209,7 +1220,7 @@ function renderPrPacketMarkdown(title: string, sections: Array<{ heading: string
 
 function summarizeValidation(validation: LocalBranchValidation[]): LocalBranchAnalysis["prPacket"]["validationSummary"] {
   return {
-    passed: validation.filter((entry) => entry.status === "passed" || entry.status === "focused").length,
+    passed: validation.filter(isPassingValidation).length,
     failed: validation.filter((entry) => entry.status === "failed").length,
     notRun: validation.filter((entry) => entry.status === "not_run" || entry.status === "skipped" || entry.status === "unknown").length,
     commands: validation,
@@ -1218,7 +1229,7 @@ function summarizeValidation(validation: LocalBranchValidation[]): LocalBranchAn
 
 function validationEvidence(validation: LocalBranchValidation[] | undefined): string[] {
   return (validation ?? [])
-    .filter((entry) => entry.status === "passed" || entry.status === "focused")
+    .filter(isPassingValidation)
     .map((entry) => entry.command);
 }
 

--- a/src/signals/local-workspace-intelligence.ts
+++ b/src/signals/local-workspace-intelligence.ts
@@ -1,3 +1,4 @@
+import { isPassingValidation } from "./local-branch";
 import type { LocalBranchAnalysis, LocalBranchAnalysisInput, LocalBranchChangedFile, LocalBranchValidation } from "./local-branch";
 import { isTestPath } from "./test-evidence";
 import { sanitizeLocalScorerWarnings } from "./local-scorer-diagnostics";
@@ -55,7 +56,7 @@ export function buildLocalWorkspaceIntelligence(args: {
 }): LocalWorkspaceIntelligence {
   const validation = args.input.validation ?? [];
   const testFileCount = args.changedFiles.filter((file) => isTestPath(file.path)).length;
-  const passedValidationCount = validation.filter((entry) => entry.status === "passed").length;
+  const passedValidationCount = validation.filter(isPassingValidation).length;
   const hasTestFiles = testFileCount > 0;
   const hasValidation = passedValidationCount > 0;
   const testEvidenceLevel = hasTestFiles && hasValidation ? "both" : hasTestFiles ? "test_files" : hasValidation ? "validation_commands" : "none";

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { SCENARIO_MAX_BRANCH_REF_CHARS, SCENARIO_MAX_LINKED_ISSUE_NUMBERS } from "../../src/scenarios/input-model";
-import { buildLocalBranchAnalysis, findCurrentBranchPullRequest } from "../../src/signals/local-branch";
+import { buildLocalBranchAnalysis, findCurrentBranchPullRequest, isPassingValidation } from "../../src/signals/local-branch";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../../src/signals/local-scorer-diagnostics";
 import type { ContributorOutcomeHistory, ContributorProfile, ContributorScoringProfile, IssueQualityReport } from "../../src/signals/engine";
 import type { RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
@@ -1115,6 +1115,46 @@ describe("local branch analysis", () => {
     expect(analysis.localFindings).toEqual(expect.arrayContaining([expect.objectContaining({ code: "validation_as_test_evidence" })]));
     expect(analysis.workspaceIntelligence.testEvidence.level).toBe("validation_commands");
     expect(analysis.recommendedRerunCondition).toMatch(/git fetch origin/i);
+  });
+
+  it("treats a focused validation run as passing test evidence across every surface (regression)", () => {
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        baseRef: "origin/main",
+        baseSha: "base",
+        headSha: "head",
+        remoteTrackingSha: "base",
+        body: "Fixes #7",
+        changedFiles: [{ path: "internal/entity/model.go", additions: 10, deletions: 2, status: "modified" }],
+        // A focused subset run (`vitest run path`) is green evidence; summarizeValidation/validationEvidence
+        // already count it, so the finding and the v2 workspace count must agree instead of dropping it.
+        validation: [{ command: "vitest run internal/entity/model.test.ts", status: "focused", summary: "focused subset passed" }],
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Entity model edge case", state: "open", labels: ["bug"], linkedPrs: [] }],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.prPacket.validationSummary.passed).toBe(1);
+    expect(analysis.baseFreshness.passedValidationCount).toBe(1);
+    expect(analysis.localFindings).toEqual(expect.arrayContaining([expect.objectContaining({ code: "validation_as_test_evidence" })]));
+    expect(analysis.workspaceIntelligence.testEvidence.passedValidationCount).toBe(1);
+    expect(analysis.workspaceIntelligence.testEvidence.level).toBe("validation_commands");
+    expect(analysis.preflight.findings.map((finding) => finding.code)).not.toContain("local_diff_missing_tests");
+  });
+
+  it("counts only green validation statuses (passed or focused) as passing evidence", () => {
+    expect(isPassingValidation({ command: "npm test", status: "passed" })).toBe(true);
+    expect(isPassingValidation({ command: "vitest run x", status: "focused" })).toBe(true);
+    for (const status of ["failed", "not_run", "skipped", "unknown"] as const) {
+      expect(isPassingValidation({ command: "npm test", status })).toBe(false);
+    }
   });
 
   it("treats focused validation as evidence and failed validation as actionable", () => {

--- a/test/unit/local-workspace-intelligence.test.ts
+++ b/test/unit/local-workspace-intelligence.test.ts
@@ -136,6 +136,40 @@ describe("local workspace intelligence v2", () => {
     expect(preflight.findings.map((finding) => finding.code)).not.toContain("local_diff_missing_tests");
   });
 
+  it("treats a focused validation run as test evidence, matching the PR-packet summary", () => {
+    const intelligence = buildLocalWorkspaceIntelligence({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        changedFiles: [{ path: "internal/entity/model.go", status: "modified" }],
+        validation: [{ command: "vitest run internal/entity/model.test.ts", status: "focused", summary: "focused subset passed" }],
+      },
+      analysis: {
+        baseFreshness: { status: "fresh", changedFileCount: 1, testFileCount: 0, passedValidationCount: 1, warnings: [] },
+        branchQualityBlockers: [],
+        accountStateBlockers: [],
+        recommendedRerunCondition: "Rerun after any branch, base, or PR state changes before opening/submitting.",
+        prPacket: {
+          titleSuggestion: "Entity model fix",
+          markdown: "# Entity model fix\n",
+          bodySections: [],
+          reviewerNotes: [],
+          validationSummary: {
+            passed: 1,
+            failed: 0,
+            notRun: 0,
+            commands: [{ command: "vitest run internal/entity/model.test.ts", status: "focused", summary: "focused subset passed" }],
+          },
+          publicSafeWarnings: [],
+        },
+      },
+      changedFiles: [{ path: "internal/entity/model.go", status: "modified" }],
+    });
+
+    expect(intelligence.testEvidence.passedValidationCount).toBe(1);
+    expect(intelligence.testEvidence.level).toBe("validation_commands");
+  });
+
   it("records metadata-only scorer diagnostics when no external scorer is configured", () => {
     const intelligence = buildLocalWorkspaceIntelligence({
       input: {


### PR DESCRIPTION
## Summary

A local validation command with `status: "focused"` is a green run of a *subset* of tests (e.g. `vitest run path/to/file.test.ts`). The PR-packet validation summary (`summarizeValidation`), the freshness evidence list (`validationEvidence`), and `services/pr-body-draft.ts` already count a focused run as passing evidence — but two surfaces still matched only `"passed"`, so the same focused run was credited or dropped depending on where you looked:

- `src/signals/local-workspace-intelligence.ts` `passedValidationCount` counted only `"passed"`, so a focused-only run collapsed `testEvidence.level` to `"none"` instead of `"validation_commands"`.
- `src/signals/local-branch.ts` — the `validation_as_test_evidence` local finding fired on `.some(status === "passed")` only, so it never surfaced for a focused run.

This single-sources the rule as an exported `isPassingValidation(entry)` predicate (`"passed" || "focused"`) and routes all four sites through it, so the evidence surfaces agree by construction and cannot drift apart again. Pure deterministic signal logic — no schema, OpenAPI, or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident consistency fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only change confined to `src/signals/**`, so the UI / MCP-package / OpenAPI / workers-pool steps are not exercised by the diff and were not run locally (the local Windows working tree has pre-existing, unrelated failures from CRLF line endings and missing optional CLI binaries that do not occur in CI's Linux environment). CI runs the full `validate` matrix on a clean checkout. The changed lines and both branches of the new predicate are fully covered by the added tests.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI/MCP surface changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Added a direct unit test for `isPassingValidation` (covering `passed`, `focused`, and the non-passing statuses) plus regression tests through `buildLocalBranchAnalysis` and `buildLocalWorkspaceIntelligence` that assert a focused run yields `passedValidationCount === 1`, `testEvidence.level === "validation_commands"`, and the `validation_as_test_evidence` finding.
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
