### PR TITLE
fix(selfhost): replay cached branch protection denials

### DIFF
--- a/src/selfhost/redis-response-cache.ts
+++ b/src/selfhost/redis-response-cache.ts
@@ -9,6 +9,10 @@ import type { CachedGitHubResponse, GitHubResponseCache } from "../github/client
 
 const keyFor = (key: string): string => `gh:resp:${key}`;
 
+function isReplayableCachedStatus(status: unknown): status is number {
+  return status === 200 || status === 403 || status === 404;
+}
+
 export function createRedisResponseCache(
   redis: Redis,
   ttlSeconds: number,
@@ -19,12 +23,12 @@ export function createRedisResponseCache(
       if (!raw) return null;
       try {
         const value = JSON.parse(raw) as Partial<CachedGitHubResponse>;
-        return typeof value.status === "number" &&
-          value.status === 200 &&
+        const status = value.status;
+        return isReplayableCachedStatus(status) &&
           typeof value.body === "string" &&
           typeof value.contentType === "string"
           ? {
-              status: value.status,
+              status,
               body: value.body,
               contentType: value.contentType,
               ...(typeof value.link === "string" ? { link: value.link } : {}),

--- a/test/unit/selfhost-redis-response-cache.test.ts
+++ b/test/unit/selfhost-redis-response-cache.test.ts
@@ -53,6 +53,30 @@ describe("createRedisResponseCache (#perf GitHub GET cache)", () => {
     });
   });
 
+  it("replays cached branch-protection permission denials and missing resources", async () => {
+    const f = fakeRedis();
+    const cache = createRedisResponseCache(f.redis, 30);
+    const forbidden = {
+      status: 403,
+      body: '{"message":"Resource not accessible by integration"}',
+      contentType: "application/json",
+    };
+    const missing = {
+      status: 404,
+      body: '{"message":"Branch not found"}',
+      contentType: "application/json",
+      link: '<https://api.github.com/repos/o/r/branches/dev/protection/required_status_checks?page=2>; rel="next"',
+      etag: '"abc123"',
+      lastModified: "Tue, 30 Jun 2026 20:00:00 GMT",
+    };
+
+    await cache.set("branch-protection-denied", forbidden, 3600);
+    await cache.set("branch-protection-missing", missing, 3600);
+
+    expect(await cache.get("branch-protection-denied")).toEqual(forbidden);
+    expect(await cache.get("branch-protection-missing")).toEqual(missing);
+  });
+
   it("honors a per-entry TTL override from the shared GitHub client", async () => {
     const f = fakeRedis();
     await createRedisResponseCache(f.redis, 30).set(
@@ -89,7 +113,7 @@ describe("createRedisResponseCache (#perf GitHub GET cache)", () => {
     expect(await createRedisResponseCache(f.redis, 20).get(URL_A)).toBeNull();
   });
 
-  it("get returns null for non-200 cached responses", async () => {
+  it("get returns null for non-replayable cached responses", async () => {
     const f = fakeRedis();
     f.store.set(
       "gh:resp:" + URL_A,
@@ -100,6 +124,40 @@ describe("createRedisResponseCache (#perf GitHub GET cache)", () => {
       }),
     );
     expect(await createRedisResponseCache(f.redis, 20).get(URL_A)).toBeNull();
+  });
+
+  it("get returns null for malformed replayable status values", async () => {
+    const f = fakeRedis();
+    const cache = createRedisResponseCache(f.redis, 20);
+
+    f.store.set(
+      "gh:resp:string-status",
+      JSON.stringify({
+        status: "403",
+        body: "{}",
+        contentType: "application/json",
+      }),
+    );
+    f.store.set(
+      "gh:resp:too-low-status",
+      JSON.stringify({
+        status: 99,
+        body: "{}",
+        contentType: "application/json",
+      }),
+    );
+    f.store.set(
+      "gh:resp:too-high-status",
+      JSON.stringify({
+        status: 600,
+        body: "{}",
+        contentType: "application/json",
+      }),
+    );
+
+    expect(await cache.get("string-status")).toBeNull();
+    expect(await cache.get("too-low-status")).toBeNull();
+    expect(await cache.get("too-high-status")).toBeNull();
   });
 
   it("ignores malformed optional replay headers while keeping the valid cached response", async () => {


### PR DESCRIPTION
## Summary
No issue because this is an operational regression fix for production cache behavior. The Redis-backed GitHub response cache now replays the branch-protection 403/404 responses that the shared GitHub client intentionally stores.

## What changed
- Allow Redis cache hits for replayable GitHub statuses: 200, branch-protection 403, and branch-protection 404.
- Keep malformed cached payloads and non-replayable statuses, including 500s, fail-closed.
- Add regression coverage for cached branch-protection denials and missing resources, plus malformed status invariants.

## Why
The GitHub client was already writing stable branch-protection negative-cache entries, but the production Redis adapter discarded all non-200 cached records on read. That caused repeated live `required_status_checks` calls instead of Redis hits.

## Validation
- `npx vitest run test/unit/selfhost-redis-response-cache.test.ts test/unit/github-client.test.ts`
- `npx vitest run test/unit/selfhost-redis-response-cache.test.ts --coverage --coverage.reporter=text --coverage.include=src/selfhost/redis-response-cache.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run test:ci`
- `npm audit --audit-level=moderate`

## Notes
Focused self-host runtime fix only; no schema, generated API, or UI changes.
