### PR TITLE
feat(observability): label self-host rate-limit stalls

### DIFF
--- a/grafana/dashboards/gittensory.json
+++ b/grafana/dashboards/gittensory.json
@@ -525,7 +525,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "gittensory_orb_events_recorded_total",
+          "expr": "gittensory_orb_events_recorded_total or vector(0)",
           "legendFormat": "recorded"
         }
       ]
@@ -561,7 +561,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "gittensory_orb_events_exported_total",
+          "expr": "gittensory_orb_events_exported_total or vector(0)",
           "legendFormat": "exported"
         }
       ]
@@ -636,7 +636,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "gittensory_orb_installs_total",
+          "expr": "gittensory_orb_installs_total or vector(0)",
           "legendFormat": "installs"
         }
       ]
@@ -665,18 +665,18 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "rate(gittensory_orb_events_recorded_total[5m])",
+          "expr": "rate(gittensory_orb_events_recorded_total[5m]) or vector(0)",
           "legendFormat": "recorded/s"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "rate(gittensory_orb_events_exported_total[5m])",
+          "expr": "rate(gittensory_orb_events_exported_total[5m]) or vector(0)",
           "legendFormat": "exported/s"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "rate(gittensory_orb_webhook_total[5m])",
-          "legendFormat": "webhooks/s"
+          "expr": "sum by (result) (rate(gittensory_orb_webhook_total[5m])) or vector(0)",
+          "legendFormat": "{{result}} webhooks/s"
         }
       ]
     },
@@ -704,12 +704,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "gittensory_orb_events_recorded_total - gittensory_orb_events_exported_total",
+          "expr": "(gittensory_orb_events_recorded_total or vector(0)) - (gittensory_orb_events_exported_total or vector(0))",
           "legendFormat": "pending"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "gittensory_orb_events_exported_total",
+          "expr": "gittensory_orb_events_exported_total or vector(0)",
           "legendFormat": "exported (cumulative)"
         }
       ]
@@ -1386,7 +1386,7 @@
         "y": 90
       },
       "id": 113,
-      "title": "GitHub API Cache",
+      "title": "GitHub API Cache & Rate Limits",
       "type": "row"
     },
     {
@@ -1493,6 +1493,135 @@
         }
       ],
       "title": "GitHub Cache Totals",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 116,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (remaining_bucket, key_scope) (rate(gittensory_github_rest_rate_limit_observations_total[5m])) or vector(0)",
+          "legendFormat": "{{key_scope}} {{remaining_bucket}} remaining",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (status, retry, key_scope) (rate(gittensory_github_rest_rate_limit_responses_total[5m])) or vector(0)",
+          "legendFormat": "{{key_scope}} {{status}} {{retry}}",
+          "refId": "B"
+        }
+      ],
+      "title": "GitHub REST Rate Limits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 117,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_admission_deferred_total[5m])) or vector(0)",
+          "legendFormat": "admission {{kind}} {{key_scope}} {{job_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_budget_deferred_total[5m])) or vector(0)",
+          "legendFormat": "budget {{kind}} {{key_scope}} {{job_type}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limited_by_type_total[5m])) or vector(0)",
+          "legendFormat": "limited {{kind}} {{key_scope}} {{job_type}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Queue Rate-Limit Deferrals",
       "type": "timeseries"
     }
   ],

--- a/prometheus/rules/alerts.yml
+++ b/prometheus/rules/alerts.yml
@@ -99,6 +99,37 @@ groups:
           description: "{{ $value | printf \"%.0f\" }} jobs pending for over 10m — the worker is falling behind the enqueue rate."
           runbook: "Compare rate(gittensory_jobs_enqueued_total) vs rate(gittensory_jobs_processed_total). If enqueue > processed persistently, the worker is the bottleneck (slow AI/DB, or it's stuck). Check worker logs."
 
+  # ── GitHub API budget / queue admission pressure ──────────────────────────
+  - name: gittensory-github-rate-limits
+    rules:
+      - alert: GittensoryGitHubRateLimitResponses
+        # Live 403/429 GitHub rate-limit responses mean admission/caching did not avoid
+        # a depleted bucket. This should be rare; sustained values explain hard queue stalls.
+        expr: sum by (status, retry, key_scope) (rate(gittensory_github_rest_rate_limit_responses_total[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "gittensory is receiving GitHub REST rate-limit responses"
+          description: "GitHub REST rate-limit responses are occurring for over 2m. Check labels status/retry/key_scope on gittensory_github_rest_rate_limit_responses_total."
+          runbook: "Open the GitHub REST Rate Limits panel and compare with Queue Rate-Limit Deferrals. If responses are installation-scoped, lower concurrent GitHub work for that installation; if key_scope=none/other, identify the unaffiliated caller and route it through an admission key."
+
+      - alert: GittensoryQueueRateLimitDeferralsHigh
+        # Jobs are being intentionally parked to preserve GitHub budget. That is better
+        # than burning through the bucket, but a sustained storm means throughput is bound
+        # by GitHub admission rather than worker capacity.
+        expr: |
+          sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_admission_deferred_total[5m])) > 0.05
+          or
+          sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_budget_deferred_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "gittensory queue is rate-limit deferring jobs"
+          description: "GitHub rate-limit deferrals exceeded 0.05/s for 10m. The queue is protecting the bucket but throughput is GitHub-budget bound."
+          runbook: "Use gittensory_jobs_rate_limit_* labels (kind/key_scope/job_type) to identify the stuck class. Prefer reducing duplicate webhook/regate work or adding cache coverage before raising worker concurrency."
+
   # ── Qdrant vector backend ──────────────────────────────────────────────────
   - name: gittensory-qdrant
     rules:
@@ -150,6 +181,19 @@ groups:
           summary: "gittensory Orb export error rate above 5%"
           description: "{{ $value | humanizePercentage }} of Orb usage-event exports failed over the last 15m (sustained 15m). Billable events may not be reaching Orb."
           runbook: "Verify Orb API credentials/connectivity and check level=error logs around orb export. Recorded-but-unexported events (gittensory_orb_events_recorded_total vs _exported_total diverging) confirm a stuck exporter."
+
+      - alert: GittensoryWebhookEnqueueFailures
+        # A webhook accepted by the receiver but not durably queued becomes GitHub
+        # redelivery pressure and can look like queue jitter. Any sustained enqueue
+        # failures deserve attention.
+        expr: sum(rate(gittensory_webhook_enqueue_total{result="enqueue_failed"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "gittensory webhook enqueue failures detected"
+          description: "Webhook enqueue failures are occurring for over 2m. Labels event/action show which GitHub event class is failing."
+          runbook: "Check WEBHOOKS queue availability and the durable queue backend. If this coincides with Orb relay drains, inspect gittensory_orb_webhook_total{result=\"enqueue_failed\"}."
 
   # ── HTTP serving health (uses the PLANNED status label + duration histogram) ─
   # NOTE: gittensory_http_requests_total is gaining a status="2xx|3xx|4xx|5xx" label,

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -19,6 +19,8 @@ import type { RepositorySettings } from "../types";
 const GITHUB_FETCH_TIMEOUT_MS = 12_000;
 const GITHUB_API_PREFIX = "https://api.github.com";
 const GITHUB_RESPONSE_CACHE_METRIC = "gittensory_github_response_cache_total";
+const GITHUB_REST_RATE_LIMIT_OBSERVATION_METRIC = "gittensory_github_rest_rate_limit_observations_total";
+const GITHUB_REST_RATE_LIMIT_RESPONSE_METRIC = "gittensory_github_rest_rate_limit_responses_total";
 const DEFAULT_BRANCH_PROTECTION_TTL_SECONDS = 20 * 60;
 const DEFAULT_METADATA_TTL_SECONDS = 10 * 60;
 export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-gittensory-cache";
@@ -126,6 +128,37 @@ function recordGitHubCacheMetric(result: "hit" | "miss" | "set" | "coalesced" | 
   incr(GITHUB_RESPONSE_CACHE_METRIC, { result, class: cls });
 }
 
+function githubAdmissionKeyScope(admissionKey: GitHubRateLimitAdmissionKey | null | undefined): "installation" | "global" | "other" {
+  if (!admissionKey) return "global";
+  return admissionKey.startsWith("installation:") ? "installation" : "other";
+}
+
+function restRemainingBucket(remaining: number): "0" | "1-75" | "76-150" | "151+" {
+  if (remaining <= 0) return "0";
+  if (remaining <= 75) return "1-75";
+  if (remaining <= 150) return "76-150";
+  return "151+";
+}
+
+function recordGitHubRestRateLimitObservationMetric(admissionKey: GitHubRateLimitAdmissionKey, remaining: number): void {
+  incr(GITHUB_REST_RATE_LIMIT_OBSERVATION_METRIC, {
+    key_scope: githubAdmissionKeyScope(admissionKey),
+    remaining_bucket: restRemainingBucket(remaining),
+  });
+}
+
+function recordGitHubRateLimitResponseMetric(
+  status: number,
+  admissionKey: GitHubRateLimitAdmissionKey | null,
+  retry: "scheduled" | "exhausted",
+): void {
+  incr(GITHUB_REST_RATE_LIMIT_RESPONSE_METRIC, {
+    key_scope: githubAdmissionKeyScope(admissionKey),
+    retry,
+    status: String(status),
+  });
+}
+
 function parseRateLimitInt(value: string | null): number | null {
   if (value === null) return null;
   const parsed = Number(value);
@@ -144,6 +177,7 @@ function observeGitHubRestRateLimit(url: string, response: Response, admissionKe
     resetAt: new Date(reset * 1000).toISOString(),
     observedAtMs: Date.now(),
   });
+  recordGitHubRestRateLimitObservationMetric(admissionKey, remaining);
 }
 
 export function latestGitHubRestRateLimitObservation(admissionKey: GitHubRateLimitAdmissionKey): LocalGitHubRestRateLimitObservation | null {
@@ -286,7 +320,14 @@ async function fetchWithGitHubRetry(input: RequestInfo | URL, init?: GitHubTimeo
         });
     if (admissionKey) observeGitHubRestRateLimit(requestUrl(input), response, admissionKey);
     // Retry a transient rate-limit (with backoff) instead of surfacing it; stop once exhausted or it's not a limit.
-    if (attempt >= GITHUB_RATE_LIMIT_MAX_RETRIES || !(await isRateLimitedResponse(response))) break;
+    const rateLimited = await isRateLimitedResponse(response);
+    if (!rateLimited) break;
+    recordGitHubRateLimitResponseMetric(
+      response.status,
+      admissionKey,
+      attempt >= GITHUB_RATE_LIMIT_MAX_RETRIES ? "exhausted" : "scheduled",
+    );
+    if (attempt >= GITHUB_RATE_LIMIT_MAX_RETRIES) break;
     await sleep(rateLimitRetryMs(response, attempt));
   }
   return response;

--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -5,10 +5,80 @@ import { sha256Hex, verifyGitHubSignature } from "../utils/crypto";
 import { parsePositiveInt } from "../utils/json";
 import { relayVerify } from "../orb/relay";
 import { isSelfHostedReviewRuntime } from "../selfhost/review-runtime";
+import { incr } from "../selfhost/metrics";
 import { getSelfHostRequestTraceParent } from "../selfhost/trace-context";
 import { isNonActionableWebhookNoise } from "./self-authored";
 
 const DEFAULT_MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
+const WEBHOOK_METRIC_EVENTS = new Set([
+  "check_run",
+  "check_suite",
+  "installation",
+  "issue_comment",
+  "issues",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "push",
+]);
+const WEBHOOK_METRIC_ACTIONS = new Set([
+  "assigned",
+  "auto_merge_disabled",
+  "auto_merge_enabled",
+  "closed",
+  "completed",
+  "converted_to_draft",
+  "created",
+  "deleted",
+  "demilestoned",
+  "dequeued",
+  "dismissed",
+  "edited",
+  "enqueued",
+  "labeled",
+  "locked",
+  "milestoned",
+  "new_permissions_accepted",
+  "opened",
+  "pinned",
+  "ready_for_review",
+  "reopened",
+  "requested",
+  "requested_action",
+  "rerequested",
+  "review_request_removed",
+  "review_requested",
+  "submitted",
+  "suspend",
+  "synchronize",
+  "transferred",
+  "unassigned",
+  "unlabeled",
+  "unlocked",
+  "unpinned",
+  "unsuspend",
+]);
+
+function webhookMetricEvent(eventName: string): string {
+  return WEBHOOK_METRIC_EVENTS.has(eventName) ? eventName : "other";
+}
+
+function webhookMetricAction(action: unknown): string {
+  if (typeof action !== "string") return "none";
+  return WEBHOOK_METRIC_ACTIONS.has(action) ? action : "other";
+}
+
+function recordWebhookEnqueueMetric(
+  eventName: string,
+  action: unknown,
+  result: EnqueueWebhookResult,
+): void {
+  incr("gittensory_webhook_enqueue_total", {
+    action: webhookMetricAction(action),
+    event: webhookMetricEvent(eventName),
+    result,
+  });
+}
 
 export async function handleGitHubWebhook(c: Context<{ Bindings: Env }>): Promise<Response> {
   const deliveryId = c.req.header("x-github-delivery") ?? null;
@@ -67,12 +137,16 @@ export type EnqueueWebhookResult = "queued" | "duplicate" | "ignored" | "invalid
  *  now requires the self-host runtime cache so stale Cloudflare review-webhook traffic fails loudly instead of being
  *  accepted into a Worker path that no longer performs reviews. */
 export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventName: string, rawBody: string, traceParent?: string): Promise<EnqueueWebhookResult> {
-  if (!isSelfHostedReviewRuntime(env)) return "review_unavailable";
+  if (!isSelfHostedReviewRuntime(env)) {
+    recordWebhookEnqueueMetric(eventName, undefined, "review_unavailable");
+    return "review_unavailable";
+  }
 
   let payload: GitHubWebhookPayload;
   try {
     payload = JSON.parse(rawBody) as GitHubWebhookPayload;
   } catch {
+    recordWebhookEnqueueMetric(eventName, undefined, "invalid_json");
     return "invalid_json";
   }
 
@@ -83,6 +157,7 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
   // still in flight with the same payload. "error" rows are never suppressed so a failed enqueue/processing
   // can still be retried (#789).
   if (existingEvent && existingEvent.status !== "error" && (existingEvent.status === "processed" || existingEvent.payloadHash === payloadHash)) {
+    recordWebhookEnqueueMetric(eventName, payload.action, "duplicate");
     return "duplicate";
   }
 
@@ -96,10 +171,12 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
   };
   if (isNonActionableWebhookNoise(env, eventName, payload)) {
     await recordWebhookEvent(env, { ...eventRow, status: "processed" });
+    recordWebhookEnqueueMetric(eventName, payload.action, "ignored");
     return "ignored";
   }
   if (!env.WEBHOOKS) {
     await recordWebhookEvent(env, { ...eventRow, status: "error" });
+    recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
     return "enqueue_failed";
   }
 
@@ -115,9 +192,11 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     // re-deliver, instead of treating the webhook as handled (#786). Also covers the deploy-ordering case where
     // the WEBHOOKS queue is not yet provisioned — no event is lost.
     await recordWebhookEvent(env, { ...eventRow, status: "error" });
+    recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
     return "enqueue_failed";
   }
 
+  recordWebhookEnqueueMetric(eventName, payload.action, "queued");
   return "queued";
 }
 

--- a/src/selfhost/monitored-work.ts
+++ b/src/selfhost/monitored-work.ts
@@ -1,4 +1,5 @@
 import type { EnqueueWebhookResult } from "../github/webhook";
+import { incr } from "./metrics";
 import { withSentryMonitor } from "./sentry";
 
 export type OrbRelayEvent = {
@@ -15,6 +16,19 @@ type OrbRelayEnv = {
   ORB_ENROLLMENT_SECRET?: string | undefined;
   ORB_BROKER_URL?: string | undefined;
 };
+
+const ORB_RELAY_METRIC_EVENTS = new Set([
+  "check_suite",
+  "issue_comment",
+  "issues",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+]);
+
+function orbRelayMetricEvent(eventName: string): string {
+  return ORB_RELAY_METRIC_EVENTS.has(eventName) ? eventName : "other";
+}
 
 export async function runScheduledLoopWithMonitor<T>(
   cron: string,
@@ -57,6 +71,9 @@ export async function drainOrbRelayWithMonitor(args: {
     async () => {
       const events = await args.drain(args.relayEnv, args.state.pendingAck);
       args.state.pendingAck = [];
+      incr("gittensory_orb_relay_drains_total", {
+        result: events.length > 0 ? "events" : "empty",
+      });
       for (const ev of events) {
         const result = await args.enqueue(
           args.env,
@@ -64,6 +81,10 @@ export async function drainOrbRelayWithMonitor(args: {
           ev.eventName,
           ev.rawBody,
         );
+        incr("gittensory_orb_webhook_total", {
+          event: orbRelayMetricEvent(ev.eventName),
+          result,
+        });
         if (result !== "enqueue_failed") args.state.pendingAck.push(ev.deliveryId);
       }
       if (events.length > 0)

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -13,6 +13,7 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionTargetForJob,
+  githubRateLimitMetricContext,
   githubRateLimitRetryDelayMs,
   jobCoalesceKey,
   jobPriority,
@@ -337,27 +338,40 @@ export function createPgQueue(
       const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
       const rateLimitAdmission = await rateLimitAdmissionDelayMs(message);
       if (rateLimitAdmission !== null) {
-        const now = Date.now();
-        const retryAfter = now + rateLimitRetryDelayWithJitter(
-          rateLimitAdmission.delayMs,
-          `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+        const rateLimitMetric = githubRateLimitMetricContext(message, rateLimitAdmission);
+        await withOtelSpan(
+          "selfhost.queue.admission_deferred",
+          {
+            "job.type": message.type,
+            "queue.backend": "postgres",
+            ...rateLimitMetric.spanAttributes,
+          },
+          async () => {
+            const now = Date.now();
+            const retryAfter = now + rateLimitRetryDelayWithJitter(
+              rateLimitAdmission.delayMs,
+              `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+            );
+            const lastError = `github rate-limit ${rateLimitAdmission.kind} admission`;
+            const update = await pool.query(
+              `UPDATE ${TABLE} SET status='pending', run_after=GREATEST(run_after, $1), last_error=COALESCE(last_error, $2) WHERE id=$3`,
+              [retryAfter, lastError, job.id],
+            );
+            if (update.rowCount) {
+              await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total");
+              incr("gittensory_jobs_rate_limit_admission_deferred_total", rateLimitMetric.labels);
+              console.warn(
+                JSON.stringify({
+                  level: "warn",
+                  event: `selfhost_queue_${rateLimitAdmission.kind}_admission_deferred`,
+                  ...rateLimitMetric.logFields,
+                  retry_after_ms: Math.max(0, retryAfter - now),
+                }),
+              );
+            }
+          },
+          { parentTraceParent: jobTraceParent },
         );
-        const lastError = `github rate-limit ${rateLimitAdmission.kind} admission`;
-        const update = await pool.query(
-          `UPDATE ${TABLE} SET status='pending', run_after=GREATEST(run_after, $1), last_error=COALESCE(last_error, $2) WHERE id=$3`,
-          [retryAfter, lastError, job.id],
-        );
-        if (update.rowCount) {
-          await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total");
-          console.warn(
-            JSON.stringify({
-              level: "warn",
-              event: `selfhost_queue_${rateLimitAdmission.kind}_admission_deferred`,
-              jobType: message.type,
-              retry_after_ms: Math.max(0, retryAfter - now),
-            }),
-          );
-        }
         return true;
       }
       try {
@@ -386,13 +400,15 @@ export function createPgQueue(
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
           const target = githubRateLimitAdmissionTargetForJob(message);
           const deferred = target ? await deferPendingJobsForRateLimit(rateLimitDelayMs, now, target) : 0;
+          const rateLimitMetric = githubRateLimitMetricContext(message, target);
           if (target !== null && deferred > 0) {
             await recordQueueMetric("gittensory_jobs_rate_limit_deferred_total", deferred);
+            incr("gittensory_jobs_rate_limit_budget_deferred_total", rateLimitMetric.labels, deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
                 event: "selfhost_queue_rate_limit_budget_deferred",
-                admission_key: target.admissionKey,
+                ...rateLimitMetric.logFields,
                 deferred,
               }),
             );
@@ -406,6 +422,7 @@ export function createPgQueue(
             );
           }
           await recordQueueMetric("gittensory_jobs_rate_limited_total");
+          incr("gittensory_jobs_rate_limited_by_type_total", rateLimitMetric.labels);
           logAudit({
             event: "job_rate_limited",
             ts: Date.now(),

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -222,6 +222,62 @@ export type GitHubRateLimitAdmissionTarget = {
   admissionKey: GitHubRateLimitAdmissionKey | null;
 };
 
+export type GitHubRateLimitKeyScope = "installation" | "global" | "other";
+export type GitHubRateLimitMetricLabels = {
+  job_type: string;
+  key_scope: GitHubRateLimitKeyScope;
+  kind: GitHubRateLimitAdmissionKind | "unknown";
+};
+export type GitHubRateLimitMetricContext = {
+  labels: GitHubRateLimitMetricLabels;
+  spanAttributes: {
+    "github.rate_limit.kind": GitHubRateLimitAdmissionKind | "unknown";
+    "github.rate_limit.key_scope": GitHubRateLimitKeyScope;
+  };
+  logFields: {
+    jobType: string;
+    key_scope: GitHubRateLimitKeyScope;
+    kind: GitHubRateLimitAdmissionKind | "unknown";
+  };
+};
+
+export function githubRateLimitAdmissionKeyScope(
+  admissionKey: GitHubRateLimitAdmissionKey | null | undefined,
+): GitHubRateLimitKeyScope {
+  if (!admissionKey) return "global";
+  return admissionKey.startsWith("installation:") ? "installation" : "other";
+}
+
+export function githubRateLimitMetricLabels(
+  message: JobMessage,
+  target: GitHubRateLimitAdmissionTarget | null | undefined,
+): GitHubRateLimitMetricLabels {
+  return {
+    job_type: message.type,
+    key_scope: githubRateLimitAdmissionKeyScope(target?.admissionKey),
+    kind: target?.kind ?? "unknown",
+  };
+}
+
+export function githubRateLimitMetricContext(
+  message: JobMessage,
+  target: GitHubRateLimitAdmissionTarget | null | undefined,
+): GitHubRateLimitMetricContext {
+  const labels = githubRateLimitMetricLabels(message, target);
+  return {
+    labels,
+    spanAttributes: {
+      "github.rate_limit.kind": labels.kind,
+      "github.rate_limit.key_scope": labels.key_scope,
+    },
+    logFields: {
+      jobType: labels.job_type,
+      key_scope: labels.key_scope,
+      kind: labels.kind,
+    },
+  };
+}
+
 export function githubRateLimitAdmissionTargetForJob(
   message: JobMessage,
 ): GitHubRateLimitAdmissionTarget | null {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -14,6 +14,7 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionTargetForJob,
+  githubRateLimitMetricContext,
   githubRateLimitRetryDelayMs,
   jobCoalesceKey,
   jobPriority,
@@ -280,27 +281,40 @@ export function createSqliteQueue(
       const jobTraceParent = message.type === "github-webhook" ? message.traceParent : undefined;
       const rateLimitAdmission = rateLimitAdmissionDelayMs(driver, message);
       if (rateLimitAdmission !== null) {
-        const now = Date.now();
-        const retryAfter = now + rateLimitRetryDelayWithJitter(
-          rateLimitAdmission.delayMs,
-          `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+        const rateLimitMetric = githubRateLimitMetricContext(message, rateLimitAdmission);
+        await withOtelSpan(
+          "selfhost.queue.admission_deferred",
+          {
+            "job.type": message.type,
+            "queue.backend": "sqlite",
+            ...rateLimitMetric.spanAttributes,
+          },
+          async () => {
+            const now = Date.now();
+            const retryAfter = now + rateLimitRetryDelayWithJitter(
+              rateLimitAdmission.delayMs,
+              `${job.job_key ?? ""}:${job.id}:${job.payload}`,
+            );
+            const lastError = `github rate-limit ${rateLimitAdmission.kind} admission`;
+            const { changes } = driver.query(
+              `UPDATE ${TABLE} SET status='pending', run_after=max(run_after, ?), last_error=coalesce(last_error, ?) WHERE id=?`,
+              [retryAfter, lastError, job.id],
+            );
+            if (changes) {
+              recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total");
+              incr("gittensory_jobs_rate_limit_admission_deferred_total", rateLimitMetric.labels);
+              console.warn(
+                JSON.stringify({
+                  level: "warn",
+                  event: `selfhost_queue_${rateLimitAdmission.kind}_admission_deferred`,
+                  ...rateLimitMetric.logFields,
+                  retry_after_ms: Math.max(0, retryAfter - now),
+                }),
+              );
+            }
+          },
+          { parentTraceParent: jobTraceParent },
         );
-        const lastError = `github rate-limit ${rateLimitAdmission.kind} admission`;
-        const { changes } = driver.query(
-          `UPDATE ${TABLE} SET status='pending', run_after=max(run_after, ?), last_error=coalesce(last_error, ?) WHERE id=?`,
-          [retryAfter, lastError, job.id],
-        );
-        if (changes) {
-          recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total");
-          console.warn(
-            JSON.stringify({
-              level: "warn",
-              event: `selfhost_queue_${rateLimitAdmission.kind}_admission_deferred`,
-              jobType: message.type,
-              retry_after_ms: Math.max(0, retryAfter - now),
-            }),
-          );
-        }
         return true;
       }
       try {
@@ -329,13 +343,15 @@ export function createSqliteQueue(
           const retryAfter = now + rateLimitRetryDelayWithJitter(rateLimitDelayMs, `${job.job_key ?? ""}:${job.id}:${job.payload}`);
           const target = githubRateLimitAdmissionTargetForJob(message);
           const deferred = target ? deferPendingJobsForRateLimit(driver, rateLimitDelayMs, now, target) : 0;
+          const rateLimitMetric = githubRateLimitMetricContext(message, target);
           if (target !== null && deferred > 0) {
             recordQueueMetric(driver, "gittensory_jobs_rate_limit_deferred_total", deferred);
+            incr("gittensory_jobs_rate_limit_budget_deferred_total", rateLimitMetric.labels, deferred);
             console.warn(
               JSON.stringify({
                 level: "warn",
                 event: "selfhost_queue_rate_limit_budget_deferred",
-                admission_key: target.admissionKey,
+                ...rateLimitMetric.logFields,
                 deferred,
               }),
             );
@@ -349,6 +365,7 @@ export function createSqliteQueue(
             );
           }
           recordQueueMetric(driver, "gittensory_jobs_rate_limited_total");
+          incr("gittensory_jobs_rate_limited_by_type_total", rateLimitMetric.labels);
           logAudit({
             event: "job_rate_limited",
             ts: Date.now(),

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -194,6 +194,7 @@ describe("timeoutFetch", () => {
       resetAt: "2026-06-24T12:10:00.000Z",
       observedAtMs: now,
     });
+    expect(await renderMetrics()).toContain('gittensory_github_rest_rate_limit_observations_total{key_scope="installation",remaining_bucket="1-75"} 1');
     expect(latestGitHubRestRateLimitObservation(otherKey)).toBeNull();
 
     headers = new Headers({
@@ -229,6 +230,44 @@ describe("timeoutFetch", () => {
       resetAt: "2026-06-24T12:10:00.000Z",
       observedAtMs: now,
     });
+  });
+
+  it("buckets GitHub REST rate-limit observations by remaining budget and admission-key scope", async () => {
+    const reset = String(Math.floor(Date.parse("2026-06-24T12:10:00.000Z") / 1000));
+    const remainingByCall = ["0", "75", "150", "151"];
+    vi.stubGlobal("fetch", async () => {
+      const remaining = remainingByCall.shift() ?? "151";
+      return new Response("ok", {
+        headers: {
+          "x-ratelimit-resource": "core",
+          "x-ratelimit-remaining": remaining,
+          "x-ratelimit-reset": reset,
+        },
+      });
+    });
+
+    await timeoutFetch("https://api.github.com/repos/o/r/issues?bucket=zero", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(1),
+    });
+    await timeoutFetch("https://api.github.com/repos/o/r/issues?bucket=low", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(2),
+    });
+    await timeoutFetch("https://api.github.com/repos/o/r/issues?bucket=reserved", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: "pat:shared",
+    });
+    await timeoutFetch("https://api.github.com/repos/o/r/issues?bucket=healthy", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: "pat:shared",
+    });
+
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_observations_total{key_scope="installation",remaining_bucket="0"} 1');
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_observations_total{key_scope="installation",remaining_bucket="1-75"} 1');
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_observations_total{key_scope="other",remaining_bucket="76-150"} 1');
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_observations_total{key_scope="other",remaining_bucket="151+"} 1');
   });
 
   it("records keyed REST admission telemetry from installation Octokit reads", async () => {
@@ -459,6 +498,9 @@ describe("timeoutFetch", () => {
     expect(await response.json()).toEqual({ message: "API rate limit exceeded" });
     expect(getFetches).toBe(4);
     expect(set).not.toHaveBeenCalled();
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_responses_total{key_scope="global",retry="scheduled",status="403"} 3');
+    expect(metrics).toContain('gittensory_github_rest_rate_limit_responses_total{key_scope="global",retry="exhausted",status="403"} 1');
   });
 
   it("does not negative-cache stable metadata denials outside branch protection", async () => {
@@ -939,15 +981,23 @@ describe("timeoutFetch", () => {
     });
 
     const url = "https://api.github.com/repos/o/r/branches/main/protection/required_status_checks";
-    const firstRequest = timeoutFetch(url);
-    void firstRequest.catch(() => undefined);
-    const first = firstRequest.catch((error: Error) => error.message);
-    const second = timeoutFetch(url);
+    const first = timeoutFetch(url).then(
+      (response) => ({ type: "response" as const, response }),
+      (error: Error) => ({ type: "error" as const, message: error.message }),
+    );
+    const second = timeoutFetch(url).then(
+      (response) => ({ type: "response" as const, response }),
+      (error: Error) => ({ type: "error" as const, message: error.message }),
+    );
     await bothCacheReads;
     releaseFetch();
 
-    await expect(first).resolves.toContain("network down");
-    await expect(second.then((response) => response.json())).resolves.toEqual({ contexts: ["after-throw"] });
+    const results = await Promise.all([first, second]);
+    const failed = results.find((result) => result.type === "error");
+    const succeeded = results.find((result) => result.type === "response");
+    expect(failed).toMatchObject({ type: "error", message: "network down" });
+    if (!succeeded || succeeded.type !== "response") throw new Error("missing successful fallback response");
+    await expect(succeeded.response.json()).resolves.toEqual({ contexts: ["after-throw"] });
     expect(getFetches).toBe(2);
   });
 

--- a/test/unit/selfhost-grafana-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-dashboard.test.ts
@@ -23,6 +23,7 @@ type Dashboard = {
 const tmpRoots: string[] = [];
 const dashboardPath = join(process.cwd(), "grafana/dashboards/maintainer-reviews.json");
 const selfhostDashboardPath = join(process.cwd(), "grafana/dashboards/gittensory.json");
+const selfhostAlertsPath = join(process.cwd(), "prometheus/rules/alerts.yml");
 const timeFrom = "${__from:date:seconds}";
 const timeTo = "${__to:date:seconds}";
 
@@ -80,6 +81,30 @@ describe("Gittensory Self-Host Grafana dashboard", () => {
     expect(targets.some((target) => target.expr === "sum by (result) (rate(gittensory_github_response_cache_total[5m]))")).toBe(true);
     expect(targets.some((target) => target.expr === "sum by (class, result) (gittensory_github_response_cache_total)")).toBe(true);
     expect(targets.some((target) => target.legendFormat === "{{class}} {{result}}")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (remaining_bucket, key_scope) (rate(gittensory_github_rest_rate_limit_observations_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (status, retry, key_scope) (rate(gittensory_github_rest_rate_limit_responses_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_admission_deferred_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_budget_deferred_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limited_by_type_total[5m])) or vector(0)")).toBe(true);
+  });
+
+  it("keeps Orb dashboard panels zero-safe when telemetry counters are absent", () => {
+    const dashboard = readDashboard(selfhostDashboardPath);
+    const targets = dashboard.panels.flatMap((panel) => panel.targets ?? []);
+
+    expect(targets.some((target) => target.expr === "gittensory_orb_events_recorded_total or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "gittensory_orb_events_exported_total or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "gittensory_orb_installs_total or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (result) (rate(gittensory_orb_webhook_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "(gittensory_orb_events_recorded_total or vector(0)) - (gittensory_orb_events_exported_total or vector(0))")).toBe(true);
+  });
+
+  it("keeps rate-limit alerts grouped by the dashboard label dimensions", () => {
+    const alerts = readFileSync(selfhostAlertsPath, "utf8");
+
+    expect(alerts).toContain("sum by (status, retry, key_scope) (rate(gittensory_github_rest_rate_limit_responses_total[5m])) > 0");
+    expect(alerts).toContain("sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_admission_deferred_total[5m])) > 0.05");
+    expect(alerts).toContain("sum by (kind, key_scope, job_type) (rate(gittensory_jobs_rate_limit_budget_deferred_total[5m])) > 0.05");
   });
 });
 

--- a/test/unit/selfhost-monitored-work.test.ts
+++ b/test/unit/selfhost-monitored-work.test.ts
@@ -17,9 +17,11 @@ import {
   runScheduledLoopWithMonitor,
   type OrbRelayDrainState,
 } from "../../src/selfhost/monitored-work";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetMetrics();
 });
 
 describe("self-host monitored recurring work", () => {
@@ -135,6 +137,11 @@ describe("self-host monitored recurring work", () => {
     expect(log).toHaveBeenCalledWith(
       JSON.stringify({ event: "orb_relay_drained", count: 3 }),
     );
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('gittensory_orb_relay_drains_total{result="events"} 1');
+    expect(metrics).toContain('gittensory_orb_webhook_total{event="pull_request",result="queued"} 1');
+    expect(metrics).toContain('gittensory_orb_webhook_total{event="other",result="enqueue_failed"} 1');
+    expect(metrics).toContain('gittensory_orb_webhook_total{event="check_suite",result="duplicate"} 1');
   });
 
   it("clears previous Orb relay acks and stays quiet when the broker has no events", async () => {
@@ -155,6 +162,7 @@ describe("self-host monitored recurring work", () => {
     expect(state.pendingAck).toEqual([]);
     expect(enqueue).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
+    expect(await renderMetrics()).toContain('gittensory_orb_relay_drains_total{result="empty"} 1');
   });
 
   it("preserves pending Orb relay acks when the broker drain throws before delivery state is known", async () => {

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Pool, QueryResult } from "pg";
 import { createPgQueue } from "../../src/selfhost/pg-queue";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { RetryableJobError } from "../../src/queue/retryable";
 import type { JobMessage } from "../../src/types";
 
@@ -114,6 +115,7 @@ describe("createPgQueue (durable #977)", () => {
   beforeEach(() => { vi.spyOn(process.stdout, "write").mockImplementation(() => true); });
   afterEach(() => {
     vi.useRealTimers();
+    resetMetrics();
     vi.restoreAllMocks();
   });
 
@@ -549,6 +551,7 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("INSERT INTO _selfhost_job_stats"),
         ["gittensory_jobs_rate_limit_deferred_total", 1],
       );
+      expect(await renderMetrics()).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="agent-regate-pr",key_scope="installation",kind="background"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -635,6 +638,7 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("INSERT INTO _selfhost_job_stats"),
         ["gittensory_jobs_rate_limit_deferred_total", 1],
       );
+      expect(await renderMetrics()).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -929,6 +933,7 @@ describe("createPgQueue (durable #977)", () => {
       expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
       ["2"],
     );
+    expect(await renderMetrics()).toContain('gittensory_jobs_rate_limited_by_type_total{job_type="refresh-registry",key_scope="global",kind="unknown"} 1');
   });
 
   it("defers matching GitHub-budget jobs and coalesces a keyed rate-limit retry into the pending duplicate", async () => {
@@ -1028,6 +1033,9 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("INSERT INTO _selfhost_jobs (payload"),
         expect.arrayContaining([expect.stringContaining('"deliveryId":"after-rate-limit"'), expect.any(Number)]),
       );
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_jobs_rate_limit_budget_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
+      expect(metrics).toContain('gittensory_jobs_rate_limited_by_type_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_STARTUP_JITTER_MS;
       else process.env.QUEUE_STARTUP_JITTER_MS = oldJitter;

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -3,7 +3,10 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   consumingRetryDelayMs,
   githubRateLimitAdmissionDelayMs,
+  githubRateLimitAdmissionKeyScope,
   githubRateLimitAdmissionKeyForJob,
+  githubRateLimitMetricContext,
+  githubRateLimitMetricLabels,
   githubBackgroundRateLimitDelayMs,
   githubRateLimitRetryDelayMs,
   githubWebhookRateLimitDelayMs,
@@ -68,6 +71,51 @@ describe("self-host queue common helpers", () => {
     expect(isGitHubBudgetBackgroundJob({ type: "backfill-repo-segment", requestedBy: "schedule", repoFullName: "owner/repo", segment: "open_pull_requests" })).toBe(true);
     expect(isGitHubBudgetBackgroundJob({ type: "rag-index-repo", requestedBy: "schedule" })).toBe(true);
     expect(isGitHubBudgetBackgroundJob({ type: "refresh-installation-health", requestedBy: "schedule" })).toBe(false);
+  });
+
+  it("normalizes GitHub rate-limit metric labels without leaking raw admission keys", () => {
+    const webhookJob = {
+      type: "github-webhook",
+      deliveryId: "d1",
+      eventName: "pull_request",
+      payload: {},
+    } as JobMessage;
+
+    expect(githubRateLimitAdmissionKeyScope("installation:123")).toBe("installation");
+    expect(githubRateLimitAdmissionKeyScope(null)).toBe("global");
+    expect(githubRateLimitAdmissionKeyScope("pat:shared")).toBe("other");
+    expect(githubRateLimitMetricLabels(webhookJob, {
+      kind: "webhook",
+      admissionKey: "installation:123",
+    })).toEqual({
+      job_type: "github-webhook",
+      key_scope: "installation",
+      kind: "webhook",
+    });
+    expect(githubRateLimitMetricLabels({ type: "rag-index-repo", requestedBy: "schedule" } as JobMessage, null)).toEqual({
+      job_type: "rag-index-repo",
+      key_scope: "global",
+      kind: "unknown",
+    });
+    expect(githubRateLimitMetricContext(webhookJob, {
+      kind: "webhook",
+      admissionKey: "installation:456",
+    })).toEqual({
+      labels: {
+        job_type: "github-webhook",
+        key_scope: "installation",
+        kind: "webhook",
+      },
+      spanAttributes: {
+        "github.rate_limit.kind": "webhook",
+        "github.rate_limit.key_scope": "installation",
+      },
+      logFields: {
+        jobType: "github-webhook",
+        key_scope: "installation",
+        kind: "webhook",
+      },
+    });
   });
 
   it("derives admission keys from both installation-backed jobs and webhook payloads", () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import { createSqliteQueue } from "../../src/selfhost/sqlite-queue";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { RetryableJobError } from "../../src/queue/retryable";
 import type { JobMessage } from "../../src/types";
 
@@ -65,6 +66,7 @@ describe("createSqliteQueue (durable #980)", () => {
   beforeEach(() => { vi.spyOn(process.stdout, "write").mockImplementation(() => true); });
   afterEach(() => {
     vi.useRealTimers();
+    resetMetrics();
     vi.restoreAllMocks();
   });
 
@@ -186,6 +188,9 @@ describe("createSqliteQueue (durable #980)", () => {
       ).rows[0] as { c: number };
       expect(pendingBackground.c).toBe(2);
       expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limit_deferred_total: 2 });
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="agent-regate-pr",key_scope="installation",kind="background"} 1');
+      expect(metrics).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="rag-index-repo",key_scope="global",kind="background"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -340,6 +345,59 @@ describe("createSqliteQueue (durable #980)", () => {
         last_error: "github rate-limit webhook admission",
       });
       expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limit_deferred_total: 1 });
+      expect(await renderMetrics()).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
+    } finally {
+      if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+      else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips admission-deferral metrics when a claimed SQLite job is no longer updated", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
+    process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
+    try {
+      const base = makeDriver();
+      const driver = {
+        exec: base.exec.bind(base),
+        query: vi.fn((sql: string, params: unknown[]) => {
+          if (sql.includes("SET status='pending', run_after=max(run_after, ?)")) {
+            return { rows: [], changes: 0 };
+          }
+          return base.query(sql, params);
+        }),
+      } as ReturnType<typeof nodeSqliteDriver>;
+      driver.query(
+        `CREATE TABLE github_rate_limit_observations (
+          id TEXT PRIMARY KEY,
+          repo_full_name TEXT NOT NULL,
+          admission_key TEXT,
+          resource TEXT NOT NULL,
+          path TEXT NOT NULL,
+          status_code INTEGER NOT NULL,
+          limit_value INTEGER,
+          remaining INTEGER,
+          reset_at TEXT,
+          observed_at TEXT NOT NULL
+        )`,
+        [],
+      );
+      driver.query(
+        `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
+         VALUES (?, ?, ?, 'rest', ?, 403, 5000, 50, ?, ?)`,
+        ["rl-webhook", "owner/repo", "installation:123", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T12:00:00.000Z"],
+      );
+      const q = createSqliteQueue(driver, async () => {
+        throw new Error("should not consume admitted work");
+      });
+
+      await q.binding.send(installedWebhook("fresh", 123));
+      await q.drain();
+
+      expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+      expect(await renderMetrics()).not.toContain("gittensory_jobs_rate_limit_admission_deferred_total");
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -1122,6 +1180,7 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(pending[0]!.last_error).toBe("API rate limit exceeded for installation ID 123");
     expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limited_total: 1 });
     expect(q.stats()).not.toHaveProperty("gittensory_jobs_rate_limit_deferred_total");
+    expect(await renderMetrics()).toContain('gittensory_jobs_rate_limited_by_type_total{job_type="refresh-registry",key_scope="global",kind="unknown"} 1');
   });
 
   it("defers only the depleted keyed GitHub budget while unrelated work keeps draining", async () => {
@@ -1202,6 +1261,9 @@ describe("createSqliteQueue (durable #980)", () => {
       gittensory_jobs_rate_limited_total: 1,
       gittensory_jobs_rate_limit_deferred_total: 2,
     });
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('gittensory_jobs_rate_limit_budget_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 2');
+    expect(metrics).toContain('gittensory_jobs_rate_limited_by_type_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
   });
 
   it("coalesces a rate-limited active job into an existing pending duplicate without consuming attempts", async () => {

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { Context } from "hono";
-import { handleGitHubWebhook, handleOrbRelay } from "../../src/github/webhook";
+import { enqueueWebhookByEnv, handleGitHubWebhook, handleOrbRelay } from "../../src/github/webhook";
 import { getWebhookEvent, recordWebhookEvent } from "../../src/db/repositories";
 import { relaySignature } from "../../src/orb/relay";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import {
   clearSelfHostRequestTraceParent,
   setSelfHostRequestTraceParent,
 } from "../../src/selfhost/trace-context";
 import { createTestEnv } from "../helpers/d1";
+
+beforeEach(() => {
+  resetMetrics();
+});
 
 describe("github webhook body reader edge cases", () => {
   it("skips undefined stream chunks and still rejects invalid signatures", async () => {
@@ -73,6 +78,7 @@ describe("github webhook enqueue failure (#786)", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "enqueue_failed" });
     const event = await getWebhookEvent(env, "enqueue-missing-binding-1");
     expect(event?.status).toBe("error");
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="enqueue_failed"} 1');
   });
 
   it("flags the event 'error' and returns 500 when the queue send fails", async () => {
@@ -109,6 +115,7 @@ describe("github webhook enqueue failure (#786)", () => {
     // Flagged "error" so the dedup guard lets GitHub redeliver instead of suppressing it.
     const event = await getWebhookEvent(env, "enqueue-fail-1");
     expect(event?.status).toBe("error");
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="enqueue_failed"} 1');
   });
 });
 
@@ -149,10 +156,34 @@ describe("github webhook dedup (#789)", () => {
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toMatchObject({ status: "duplicate" });
     expect(sendCount).toBe(0); // not re-enqueued
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="duplicate"} 1');
   });
 });
 
 describe("github webhook queue isolation (#audit-webhook-queue)", () => {
+  it("records bounded enqueue metrics for invalid JSON and unknown event/action values", async () => {
+    const env = createTestEnv();
+    env.WEBHOOKS = { send: async () => undefined } as unknown as Queue;
+
+    await expect(enqueueWebhookByEnv(env, "invalid-json-metric", "pull_request", "{")).resolves.toBe("invalid_json");
+    await expect(
+      enqueueWebhookByEnv(
+        env,
+        "unknown-event-metric",
+        "workflow_job",
+        JSON.stringify({
+          action: "synchronize_again",
+          repository: { full_name: "JSONbored/gittensory" },
+          installation: { id: 1 },
+        }),
+      ),
+    ).resolves.toBe("queued");
+
+    const metrics = await renderMetrics();
+    expect(metrics).toContain('gittensory_webhook_enqueue_total{action="none",event="pull_request",result="invalid_json"} 1');
+    expect(metrics).toContain('gittensory_webhook_enqueue_total{action="other",event="other",result="queued"} 1');
+  });
+
   it("rejects retired direct review-app webhooks when the self-host review runtime is absent", async () => {
     const env = createTestEnv();
     delete env.SELFHOST_TRANSIENT_CACHE;
@@ -184,6 +215,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     expect(response.status).toBe(410);
     await expect(response.json()).resolves.toMatchObject({ error: "selfhost_review_runtime_required" });
     expect(webhookSends).toBe(0);
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="none",event="pull_request",result="review_unavailable"} 1');
   });
 
   it("INVARIANT: a valid webhook is enqueued onto the dedicated WEBHOOKS lane, never the shared JOBS queue", async () => {
@@ -218,6 +250,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     await expect(response.json()).resolves.toMatchObject({ status: "queued" });
     expect(webhookSends).toBe(1); // routed to the dedicated webhook lane
     expect(jobsSends).toBe(0); // never the shared maintenance queue
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="queued"} 1');
   });
 
   it("copies the internal self-host traceparent onto queued webhook jobs", async () => {
@@ -293,6 +326,7 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     expect(webhookSends).toBe(0);
     const event = await getWebhookEvent(env, "self-comment-ignore-1");
     expect(event?.status).toBe("processed");
+    expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="edited",event="issue_comment",result="ignored"} 1');
   });
 
   it("drops self-authored app CI completion webhooks before they add queue pressure", async () => {


### PR DESCRIPTION
## Summary
- Adds bounded Prometheus labels for GitHub REST budget observations, actual rate-limit responses, webhook enqueue outcomes, queue admission deferrals, rate-limit budget deferrals, and Orb relay drain results.
- Adds OpenTelemetry spans around queue admission deferrals so stalled work has trace context before it touches GitHub.
- Updates the self-host Grafana dashboard and Prometheus alerts to expose GitHub budget pressure, queue deferral storms, webhook enqueue failures, and zero-safe Orb panels.

## What changed
- GitHub REST calls now emit budget buckets and scheduled/exhausted retry response metrics.
- Webhook enqueue decisions now emit event/action/result labels for duplicate, ignored, invalid, unavailable, failed, and queued outcomes.
- SQLite and Postgres queue backends now emit matching labeled diagnostics for admission deferral and budget deferral paths.
- Orb pull-relay drains now report empty vs event batches and per-event enqueue results.
- Dashboard/tests assert the new observability contract and zero-safe PromQL.

## Why
- No issue because this is operational instrumentation for diagnosing self-host queue stalls and GitHub API budget pressure.
- The labels are intentionally bounded so operators can identify the stalled class without leaking repo identifiers or creating high-cardinality series.

## Validation
- `npx vitest run test/unit/github-client.test.ts test/unit/selfhost-queue-common.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts test/unit/selfhost-monitored-work.test.ts test/unit/webhook.test.ts test/unit/selfhost-grafana-dashboard.test.ts`
- `npm run typecheck`
- `npm run test:coverage`
- Diff coverage audit: all changed `src/**` lines and changed-line branches covered.
- `npm run test:ci`
- `npm audit --audit-level=moderate`
