### PR TITLE
feat(enrichment): flag unsafe DOM / code-execution sinks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,17 +65,17 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # Current analyzer names:
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
-# history,docCommentDrift,duplication,churnHotspot
+# history,docCommentDrift,duplication,churnHotspot,unsafeDom
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,unsafeDom
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
-# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeDom
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
-# nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeDom
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -559,6 +559,29 @@ export const REES_ANALYZERS = [
         "Distinct from the history analyzer's author track record; this scores the change AREA's defect density.",
     },
   },
+  {
+    name: "unsafeDom",
+    title: "Unsafe DOM / code-execution sinks",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+      looksAt:
+        "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+      reports: "File, line, the sink, and the unsafe-sink kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal and comment text is stripped before matching, so a sink named in a string or comment is not flagged.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -636,6 +636,32 @@
         "network": "Calls the GitHub commits API once per probed file. Requires GitHub token forwarding for private repos.",
         "notes": "Distinct from the history analyzer's author track record; this scores the change AREA's defect density."
       }
+    },
+    {
+      "name": "unsafeDom",
+      "title": "Unsafe DOM / code-execution sinks",
+      "category": "security",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+        "looksAt": "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+        "reports": "File, line, the sink, and the unsafe-sink kind.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "String-literal and comment text is stripped before matching, so a sink named in a string or comment is not flagged."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -19,6 +19,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanTyposquat } from "./typosquat.js";
+import { scanUnsafeDom } from "./unsafe-dom.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -439,6 +440,26 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanChurnHotspot(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "unsafeDom",
+    title: "Unsafe DOM / code-execution sinks",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+      looksAt:
+        "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+      reports: "File, line, the sink, and the unsafe-sink kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal and comment text is stripped before matching, so a sink named in a string or comment is not flagged.",
+    },
+    run: (req, { signal }) => scanUnsafeDom(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/unsafe-dom.ts
+++ b/review-enrichment/src/analyzers/unsafe-dom.ts
@@ -1,0 +1,222 @@
+// Unsafe DOM / code-execution sink analyzer. Flags added JS/TS lines that pass data into a DOM-HTML or a
+// dynamic-code-execution sink — `el.innerHTML = x`, `dangerouslySetInnerHTML={…}`, `document.write(…)`,
+// `eval(…)`, `new Function(…)`, `setTimeout("code", …)` — a client-side XSS / arbitrary-code-execution surface
+// distinct from the secret-into-a-LOG-sink scan (secret-log inspects logging sinks) and the regex-backtracking
+// SHAPE scan (redos). Pure compute, no network. Precision-first: string-literal, regex-literal, AND `//` line-comment
+// content is stripped before matching (own linear-pass `codeOnly`, no regex, so it can never backtrack), so an
+// `innerHTML` named inside a string, a `/.../ ` regex, or a comment is not flagged. Line-cited via hunk headers.
+import type { EnrichRequest, UnsafeDomFinding } from "../types.js";
+
+const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_LINE_CHARS = 2000; // skip pathologically long lines (defensive)
+
+// Only scan source files: these sinks are meaningful in JS/TS/JSX/TSX and single-file component sources, not in
+// config, data, or docs. Keeps the signal high and avoids matching prose in YAML/JSON/Markdown.
+const CODE_PATH_RE = /\.(?:jsx?|tsx?|mjs|cjs|mts|cts|vue|svelte)$/i;
+
+// All matchers below are FLAT alternations (no group is itself quantified), so each is linear-time — this analyzer
+// can never be the ReDoS class it sits beside. Each kind is a separate flat regex run on the code-only line.
+//
+// DOM-HTML write sinks: assignment to innerHTML/outerHTML (not the `==`/`===` comparison), or insertAdjacentHTML().
+const INNER_HTML_RE = /\.(?:innerHTML|outerHTML)\s*=(?!=)|\.insertAdjacentHTML\s*\(/;
+// React/JSX raw-HTML escape hatch.
+const DANGEROUS_JSX_RE = /\bdangerouslySetInnerHTML\b/;
+// Legacy document.write / document.writeln HTML injection.
+const DOCUMENT_WRITE_RE = /\bdocument\s*\.\s*write(?:ln)?\s*\(/;
+// Global eval(...) — boundary-gated so member calls (`obj.eval(`) and identifier substrings (`retrieval(`) are excluded.
+const EVAL_CALL_RE = /(?:^|[^.\w$])eval\s*\(/;
+// The Function constructor compiles a string into code.
+const FUNCTION_CTOR_RE = /\bnew\s+Function\s*\(/;
+// setTimeout/setInterval with a STRING (or template) first argument is an implicit eval; a function first arg is safe.
+// SET_TIMER_CALL_RE confirms a real call survives codeOnly (so a setTimeout named in a comment/string is excluded);
+// SET_TIMER_STRING_RE confirms the first argument is a string/template — tested on the ORIGINAL line because
+// codeOnly blanks string/template bodies, which would otherwise erase the very signal this kind depends on.
+const SET_TIMER_CALL_RE = /\bset(?:Timeout|Interval)\s*\(/;
+const SET_TIMER_STRING_RE = /\bset(?:Timeout|Interval)\s*\(\s*['"`]/;
+
+/** Blank out string-literal content, regex-literal bodies, and `//` line-comment tails in a single linear pass — no
+ *  regex, so it can never backtrack. `${…}` template-interpolation bodies are kept (they are real code). Lets the
+ *  matchers above run against code, not string/regex/comment prose, so an `innerHTML` mentioned in a string, a
+ *  `/.../ ` regex literal, or a comment is not a hit. */
+export function codeOnly(s: string): string {
+  let out = "";
+  let i = 0;
+  const n = s.length;
+  while (i < n) {
+    const c = s[i]!;
+    if (c === "/" && s[i + 1] === "/") {
+      break; // line comment — drop the rest of the line
+    }
+    if (c === "/") {
+      // Distinguish a regex literal from a division operator: a regex can begin only where an expression is
+      // expected (line start, or right after an operator / open bracket), never after a value (identifier,
+      // number, `)`, or `]`). Skip a regex body so a sink-looking token inside `/.../` (e.g. /document\.write\(/)
+      // is not matched as real code — this is the false-positive class regex-unaware sink scanners suffer from.
+      let k = out.length - 1;
+      while (k >= 0 && (out[k] === " " || out[k] === "\t")) k--;
+      const prev = k >= 0 ? out[k]! : "";
+      if (prev === "" || "(,=:[!&|?{;+-*%<>~^".includes(prev)) {
+        i++; // past the opening slash
+        let inClass = false; // inside a [...] character class a `/` is literal, not the terminator
+        while (i < n) {
+          const ch = s[i];
+          if (ch === "\\") {
+            i += 2;
+            continue;
+          }
+          if (ch === "[") inClass = true;
+          else if (ch === "]") inClass = false;
+          else if (ch === "/" && !inClass) {
+            i++; // closing slash
+            break;
+          }
+          i++;
+        }
+        out += " ";
+        continue;
+      }
+      out += c; // division operator — keep it as code
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i++;
+      while (i < n && s[i] !== c) {
+        if (s[i] === "\\") i++;
+        i++;
+      }
+      i++; // closing quote
+      out += " ";
+      continue;
+    }
+    if (c === "`") {
+      i++;
+      while (i < n && s[i] !== "`") {
+        if (s[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (s[i] === "$" && s[i + 1] === "{") {
+          i += 2;
+          let depth = 1;
+          while (i < n && depth > 0) {
+            if (s[i] === "{") depth++;
+            else if (s[i] === "}") depth--;
+            if (depth > 0) out += s[i];
+            i++;
+          }
+          continue;
+        }
+        i++; // ordinary template-literal char — drop it
+      }
+      i++; // closing backtick
+      out += " ";
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function sinkLabel(match: string): string {
+  return match.replace(/\s+/g, "").replace(/\($/, "");
+}
+
+/** Classify one line: does it write to a DOM-HTML sink or execute a dynamic-code sink? Returns the kind + a
+ *  public-safe sink label, or null. String/comment content is stripped first so only real code matches. */
+export function detectUnsafeDom(
+  line: string,
+): { kind: UnsafeDomFinding["kind"]; sink: string } | null {
+  const code = codeOnly(line);
+  let m: RegExpExecArray | null;
+  if ((m = INNER_HTML_RE.exec(code)))
+    return { kind: "inner-html", sink: sinkLabel(m[0]) };
+  if (DANGEROUS_JSX_RE.test(code))
+    return { kind: "dangerous-jsx", sink: "dangerouslySetInnerHTML" };
+  if ((m = DOCUMENT_WRITE_RE.exec(code)))
+    return { kind: "document-write", sink: sinkLabel(m[0]) };
+  if (EVAL_CALL_RE.test(code)) return { kind: "eval-call", sink: "eval" };
+  if (FUNCTION_CTOR_RE.test(code))
+    return { kind: "function-ctor", sink: "new Function" };
+  if (SET_TIMER_CALL_RE.test(code) && (m = SET_TIMER_STRING_RE.exec(line)))
+    return { kind: "set-timeout-string", sink: sinkLabel(m[0]) };
+  return null;
+}
+
+type UnsafeDomScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  // Stream by patch line so large diffs do not require an intermediate split array; abort is sampled per line below.
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+/** Scan one file patch's added lines for unsafe DOM / code-execution sinks, line-cited via hunk headers. Pure. */
+export function scanPatchForUnsafeDom(
+  path: string,
+  patch: string,
+  limits: UnsafeDomScanLimits = {},
+): UnsafeDomFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const findings: UnsafeDomFinding[] = [];
+  let newLine = 0;
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        const hit = detectUnsafeDom(body);
+        if (hit) {
+          findings.push({
+            file: path,
+            line: newLine,
+            kind: hit.kind,
+            sink: hit.sink,
+          });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-")) {
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed source file's added lines for unsafe DOM / code-execution sinks. */
+export async function scanUnsafeDom(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<UnsafeDomFinding[]> {
+  const findings: UnsafeDomFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch || !CODE_PATH_RE.test(file.path)) continue;
+    for (const finding of scanPatchForUnsafeDom(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      // The per-file scan is capped to the remaining budget; keep this as a final invariant if that scanner changes.
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -379,6 +379,18 @@ export function renderBrief(
     }
   }
 
+  const unsafeDom = findings.unsafeDom ?? [];
+  if (unsafeDom.length) {
+    lines.push(
+      "### Unsafe DOM / code-execution sinks (XSS / arbitrary-code-execution risk — sanitize or avoid)",
+    );
+    for (const item of unsafeDom) {
+      lines.push(
+        `- ${safeCodeSpan(`${item.file}:${item.line}`)} — ${safeCodeSpan(item.sink)} (${item.kind}); avoid this sink or sanitize/escape the input`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -350,6 +350,7 @@ function inputSkipReason(
     case "redos":
     case "secret":
     case "secretLog":
+    case "unsafeDom":
       return analysis.hasAddedLines ? null : "no_added_lines";
     case "provenance":
       return analysis.dependencyManifestPaths.length ||

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -308,6 +308,7 @@ export interface BriefFindings {
   docCommentDrift?: DocCommentDriftFinding[];
   duplication?: DuplicationFinding[];
   churnHotspot?: ChurnHotspotFinding[];
+  unsafeDom?: UnsafeDomFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a
@@ -336,6 +337,23 @@ export interface DuplicationFinding {
   sourceLine: number;
   /** Number of contiguous significant lines that matched verbatim (after whitespace normalization). */
   lines: number;
+}
+
+/** An added source line that passes data into a DOM-HTML write sink (`innerHTML`, `dangerouslySetInnerHTML`,
+ *  `document.write`) or a dynamic-code-execution sink (`eval`, `new Function`, a string-bodied `setTimeout`/
+ *  `setInterval`) — a client-side XSS / arbitrary-code-execution surface. Reports the location + sink + kind
+ *  only; string-literal and comment text is stripped before matching so a sink named in prose is not flagged. */
+export interface UnsafeDomFinding {
+  file: string;
+  line: number;
+  kind:
+    | "inner-html"
+    | "dangerous-jsx"
+    | "document-write"
+    | "eval-call"
+    | "function-ctor"
+    | "set-timeout-string";
+  sink: string;
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped" | "capped" | "timeout";

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_ANALYZERS = [
   "docCommentDrift",
   "duplication",
   "churnHotspot",
+  "unsafeDom",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/unsafe-dom.test.ts
+++ b/review-enrichment/test/unsafe-dom.test.ts
@@ -1,0 +1,214 @@
+// Units for the unsafe-DOM / code-execution-sink analyzer. Kept separate so analyzer PRs do not collide in one
+// shared test file. Covers every branch of detectUnsafeDom/codeOnly/scanPatchForUnsafeDom/scanUnsafeDom plus the
+// render arms, using hand-built unified-diff fixtures (no network, no GitHub).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  codeOnly,
+  detectUnsafeDom,
+  scanPatchForUnsafeDom,
+  scanUnsafeDom,
+} from "../dist/analyzers/unsafe-dom.js";
+import { renderBrief } from "../dist/render.js";
+
+/** Build a single-hunk patch whose body is the given added lines (each prefixed with `+`). */
+const addedPatch = (...lines) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+const req = (files) => ({ repoFullName: "o/r", prNumber: 1, files });
+
+test("detectUnsafeDom flags each unsafe sink kind", () => {
+  assert.equal(detectUnsafeDom("el.innerHTML = userInput;")?.kind, "inner-html");
+  assert.equal(detectUnsafeDom("node.outerHTML = markup;")?.kind, "inner-html");
+  assert.equal(
+    detectUnsafeDom("el.insertAdjacentHTML('beforeend', html);")?.kind,
+    "inner-html",
+  );
+  assert.equal(
+    detectUnsafeDom("return <div dangerouslySetInnerHTML={{ __html: html }} />;")
+      ?.kind,
+    "dangerous-jsx",
+  );
+  assert.equal(detectUnsafeDom("document.write(payload);")?.kind, "document-write");
+  assert.equal(detectUnsafeDom("document.writeln(payload);")?.kind, "document-write");
+  assert.equal(detectUnsafeDom("const r = eval(expr);")?.kind, "eval-call");
+  assert.equal(
+    detectUnsafeDom("const f = new Function('a', 'return a');")?.kind,
+    "function-ctor",
+  );
+  assert.equal(
+    detectUnsafeDom("setTimeout('doStuff()', 100);")?.kind,
+    "set-timeout-string",
+  );
+  assert.equal(
+    detectUnsafeDom("setInterval(`tick()`, 100);")?.kind,
+    "set-timeout-string",
+  );
+});
+
+test("detectUnsafeDom returns a public-safe sink label", () => {
+  assert.equal(detectUnsafeDom("el.innerHTML = x;")?.sink, ".innerHTML=");
+  assert.equal(detectUnsafeDom("document.write(x);")?.sink, "document.write");
+  assert.equal(detectUnsafeDom("eval(x);")?.sink, "eval");
+  assert.equal(detectUnsafeDom("new Function(b);")?.sink, "new Function");
+  assert.equal(
+    detectUnsafeDom("return <b dangerouslySetInnerHTML={h} />;")?.sink,
+    "dangerouslySetInnerHTML",
+  );
+});
+
+test("detectUnsafeDom ignores sinks named only in strings or comments", () => {
+  assert.equal(detectUnsafeDom('const s = "el.innerHTML = x";'), null);
+  assert.equal(detectUnsafeDom("// el.innerHTML = x"), null);
+  assert.equal(detectUnsafeDom("foo(); // document.write(x)"), null);
+  assert.equal(detectUnsafeDom("obj.eval(payload);"), null); // member call, not global eval
+  assert.equal(detectUnsafeDom("const x = retrieval(y);"), null); // identifier substring
+  assert.equal(detectUnsafeDom("setTimeout(fn, 100);"), null); // function arg, not a string
+  assert.equal(detectUnsafeDom("if (el.innerHTML === expected) {}"), null); // comparison, not assignment
+  assert.equal(detectUnsafeDom("const plain = compute(value);"), null); // no sink
+});
+
+test("detectUnsafeDom ignores sinks inside a regex literal (regex-token false-positive class)", () => {
+  // Analyzers spell sink patterns AS regex literals; scanning the regex body as code would falsely flag them.
+  assert.equal(detectUnsafeDom("const re = /document\\.write\\(/;"), null);
+  assert.equal(detectUnsafeDom("if (/\\.innerHTML\\s*=/.test(src)) report();"), null);
+  assert.equal(detectUnsafeDom("line = line.replace(/eval\\(/g, '');"), null);
+  assert.equal(detectUnsafeDom("const r = /new Function\\(/;"), null);
+  // a `/` used as division is NOT a regex: a real sink later on the line is still detected
+  assert.equal(
+    detectUnsafeDom("const ratio = a / b; el.innerHTML = c;")?.kind,
+    "inner-html",
+  );
+  // a `/` inside a [...] character class does not prematurely terminate the regex literal
+  assert.equal(detectUnsafeDom("const re = /[a-z/]eval\\(/;"), null);
+});
+
+test("codeOnly blanks string/comment content but keeps interpolation code", () => {
+  assert.equal(codeOnly('a "secret" b').includes("secret"), false);
+  assert.equal(codeOnly("a // tail comment").includes("tail"), false);
+  assert.ok(codeOnly("`x${ realCode }y`").includes("realCode"));
+  // escaped quote inside a string, then a real sink outside it
+  assert.equal(
+    detectUnsafeDom('const s = "he said \\"hi\\""; document.write(x);')?.kind,
+    "document-write",
+  );
+  // escaped backtick inside a template, then a sink in the interpolation
+  assert.equal(
+    detectUnsafeDom("render(`a\\`b ${ node.innerHTML = v }`);")?.kind,
+    "inner-html",
+  );
+});
+
+test("scanPatchForUnsafeDom cites the new-file line and skips header/removed/context lines", () => {
+  const patch = [
+    "--- a/app.ts",
+    "+++ b/app.ts",
+    "@@ -1,2 +1,3 @@",
+    " context();", // context line: newLine advances
+    "-old.innerHTML = a;", // removed line: ignored, does not advance newLine
+    "+el.innerHTML = b;", // added at new-file line 2
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("app.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0], {
+    file: "app.ts",
+    line: 2,
+    kind: "inner-html",
+    sink: ".innerHTML=",
+  });
+});
+
+test("scanPatchForUnsafeDom tracks line numbers across multiple hunks", () => {
+  const patch = [
+    "@@ -1,1 +1,1 @@",
+    "+document.write(a);", // line 1
+    "@@ -10,1 +20,2 @@",
+    " keep();", // line 20
+    "+eval(b);", // line 21
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("a.ts", patch);
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].line, 1);
+  assert.equal(findings[1].line, 21);
+});
+
+test("scanPatchForUnsafeDom skips pathologically long lines", () => {
+  const long = `el.innerHTML = ${"x".repeat(2001)};`;
+  const findings = scanPatchForUnsafeDom("a.ts", `@@ -1,0 +1,1 @@\n+${long}`);
+  assert.equal(findings.length, 0);
+});
+
+test("scanPatchForUnsafeDom honors the finding budget", () => {
+  assert.deepEqual(
+    scanPatchForUnsafeDom("a.ts", addedPatch("eval(x);"), { maxFindings: 0 }),
+    [],
+  );
+  const capped = scanPatchForUnsafeDom(
+    "a.ts",
+    addedPatch("eval(a);", "eval(b);", "eval(c);"),
+    { maxFindings: 2 },
+  );
+  assert.equal(capped.length, 2);
+});
+
+test("scanPatchForUnsafeDom throws when the signal is already aborted", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () =>
+      scanPatchForUnsafeDom("a.ts", addedPatch("eval(x);"), {
+        signal: controller.signal,
+      }),
+    /analyzer_aborted/,
+  );
+});
+
+test("scanUnsafeDom scans code files and skips non-code or patch-less files", async () => {
+  const findings = await scanUnsafeDom(
+    req([
+      { path: "src/app.tsx", patch: addedPatch("el.innerHTML = a;") }, // scanned
+      { path: "README.md", patch: addedPatch("document.write(x);") }, // skipped: not a code path
+      { path: "src/no-patch.ts" }, // skipped: no patch
+    ]),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "src/app.tsx");
+});
+
+test("scanUnsafeDom returns [] when the request carries no files", async () => {
+  assert.deepEqual(await scanUnsafeDom({ repoFullName: "o/r", prNumber: 1 }), []);
+});
+
+test("scanUnsafeDom caps total findings at the global budget", async () => {
+  const many = Array.from({ length: 30 }, (_, i) => `eval(x${i});`);
+  const findings = await scanUnsafeDom(
+    req([{ path: "a.ts", patch: addedPatch(...many) }]),
+  );
+  assert.equal(findings.length, 25);
+});
+
+test("scanUnsafeDom throws when the signal is already aborted", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    scanUnsafeDom(
+      req([{ path: "a.ts", patch: addedPatch("eval(x);") }]),
+      controller.signal,
+    ),
+    /analyzer_aborted/,
+  );
+});
+
+test("renderBrief includes the unsafe-DOM section when findings exist", () => {
+  const { promptSection } = renderBrief({
+    unsafeDom: [{ file: "src/a.ts", line: 3, kind: "eval-call", sink: "eval" }],
+  });
+  assert.match(promptSection, /Unsafe DOM \/ code-execution sinks/);
+  assert.match(promptSection, /src\/a\.ts:3/);
+  assert.match(promptSection, /eval-call/);
+});
+
+test("renderBrief omits the unsafe-DOM section when there are no findings", () => {
+  const { promptSection } = renderBrief({ unsafeDom: [] });
+  assert.equal(promptSection, "");
+});


### PR DESCRIPTION
## What

A new local REES analyzer, `unsafeDom`, that flags added JS/TS lines which pass data into a **DOM-HTML write sink** (`innerHTML`/`outerHTML` assignment, `insertAdjacentHTML`, `dangerouslySetInnerHTML`, `document.write`/`writeln`) or a **dynamic code-execution sink** (`eval`, `new Function`, a string-bodied `setTimeout`/`setInterval`) — the client-side XSS / arbitrary-code-execution surface a no-checkout reviewer cannot reliably catch by eye.

## Why it is a distinct dimension

Orthogonal to every existing analyzer: `redos` inspects regex backtracking *shapes*, `secretLog` inspects *logging* sinks, `secret`/`secretScan` inspect literal *values*, and `iacMisconfig` inspects *config-file paths* (it excludes `.ts`/`.js`). None model HTML-write or dynamic-eval sinks in source. The analyzer mirrors the proven `iac-misconfig`/`secret-log` skeleton (per-line patch scan, hunk-header line citation, `MAX_FINDINGS`/`MAX_LINE_CHARS` caps, `AbortSignal`).

## Precision — regex-literal aware

`codeOnly` strips string-literal, **regex-literal**, and `//` line-comment content in a single linear pass (no regex, so it can never backtrack) before matching. A sink named inside a string, a `/.../ ` regex, or a comment is therefore never flagged — e.g. `const re = /document\.write\(/;` is **not** a hit, and `setTimeout(fn, 1)` (function arg) and `el.innerHTML === x` (comparison, not assignment) are excluded. Regex-vs-division is disambiguated structurally, and `[...]` character classes are handled so an inner `/` does not end the literal. Every matcher is a flat, linear-time alternation, so the analyzer can never be the ReDoS class it sits beside.

## Output

Public-safe: location + sink + kind only, never code or values. Bounded at 25 findings/line-2000-chars, fail-safe on abort, `cost: "local"` (no network).

## No linked issue

Net-new analyzer, so there is no tracking issue to link.

## Tests

`review-enrichment/test/unsafe-dom.test.ts` (node:test) covers every branch: each sink kind, string/comment/regex-literal negatives, division-not-regex, character-class handling, multi-hunk line citation, removed/context-line skipping, long-line and budget caps, abort, the non-code-path skip, and both render arms. `npm test` is green and analyzer metadata is regenerated and committed.
