### PR TITLE
fix(signals): reuse canonical failing-check classifier across signal surfaces

### DIFF
--- a/src/signals/contributor-open-pr-monitor.ts
+++ b/src/signals/contributor-open-pr-monitor.ts
@@ -11,6 +11,7 @@ import {
 import type { CheckSummaryRecord, PullRequestFileRecord, PullRequestRecord, PullRequestReviewRecord } from "../types";
 import { nowIso } from "../utils/json";
 import { buildRoleContext } from "./engine";
+import { isFailingCheckSummary } from "./local-branch";
 import { isTestPath } from "./test-evidence";
 
 export type OpenPrWorkClassification =
@@ -149,7 +150,7 @@ function buildNextStepPacket(
   missingTests: boolean,
 ): ContributorOpenPrNextStepPacket {
   const changeRequestCount = reviews.filter((review) => review.state.toUpperCase() === "CHANGES_REQUESTED").length;
-  const checkFailureCount = checks.filter((check) => check.conclusion === "failure" || check.conclusion === "timed_out" || check.conclusion === "cancelled").length;
+  const checkFailureCount = checks.filter(isFailingCheckSummary).length;
   const classification = mapPendingClassToWorkClassification(classified, { changeRequestCount, checkFailureCount, duplicateProne, missingTests });
   const nextSteps = nextStepsForClassification(classification, classified.repoFullName, classified.number);
   const summary = `${classified.repoFullName}#${classified.number}: ${classification.replace(/_/g, " ")} — ${classified.title}`;

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -27,6 +27,7 @@ import { nowIso } from "../utils/json";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { labelMatchesPattern, projectLinkedIssueMultiplierForPlannedSolve, type LinkedIssueMultiplierStatus } from "../scoring/preview";
 import { hasLocalTestEvidence } from "./test-evidence";
+import { isFailingCheckSummary } from "./local-branch";
 import { isDuplicateClusterWinnerByClaim } from "./duplicate-winner";
 import { PREFLIGHT_LIMITS } from "./preflight-limits";
 import type { UnifiedCollapsible } from "../review/unified-comment";
@@ -2719,7 +2720,7 @@ export function buildPullRequestMaintainerPacket(args: {
   const deletions = args.files.reduce((sum, file) => sum + file.deletions, 0);
   const approvalCount = args.reviews.filter((review) => review.state.toUpperCase() === "APPROVED").length;
   const changeRequestCount = args.reviews.filter((review) => review.state.toUpperCase() === "CHANGES_REQUESTED").length;
-  const checkFailureCount = args.checks.filter((check) => check.conclusion === "failure" || check.conclusion === "timed_out" || check.conclusion === "cancelled").length;
+  const checkFailureCount = args.checks.filter(isFailingCheckSummary).length;
   const findings: SignalFinding[] = [];
   if (!pr) {
     findings.push({

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -29,6 +29,7 @@ import {
   type RepoFitRecommendation,
   type RoleContext,
 } from "./engine";
+import { isFailingCheckSummary } from "./local-branch";
 
 export type RewardRiskActionKind =
   | "cleanup_existing_prs"
@@ -469,7 +470,7 @@ export function buildPullRequestReviewability(args: {
 }): PullRequestReviewability {
   const intelligence = buildPullRequestReviewIntelligence(args);
   const pr = args.pullRequest;
-  const failingChecks = args.checks.filter((check) => ["failure", "timed_out", "cancelled"].includes(check.conclusion ?? "")).length;
+  const failingChecks = args.checks.filter(isFailingCheckSummary).length;
   const broadDiff = intelligence.changeSummary.fileCount >= 12 || intelligence.changeSummary.additions + intelligence.changeSummary.deletions >= 800;
   const noiseSources = [
     ...(pr?.state && pr.state !== "open" ? [`PR is ${pr.state}.`] : []),

--- a/test/unit/contributor-open-pr-monitor.test.ts
+++ b/test/unit/contributor-open-pr-monitor.test.ts
@@ -246,6 +246,28 @@ describe("contributor open PR monitor", () => {
     expect(packet.nextSteps.join(" ")).not.toMatch(/\/Users\/|\/home\/|upload source/i);
   });
 
+  it("classifies status-carried and startup_failure checks as failing_checks (canonical classifier)", () => {
+    const classified = classifyOpenPullRequest({ pr: pr({ number: 55 }), roleContext: outsideContributorRole, reviews: [], checks: [] });
+    const statusCarried = __contributorOpenPrMonitorInternals.buildNextStepPacket(
+      classified,
+      [],
+      [{ id: "1", repoFullName: "entrius/allways-ui", pullNumber: 55, name: "ci", status: "failure", conclusion: null, payload: {} }],
+      false,
+      false,
+    );
+    expect(statusCarried.classification).toBe("failing_checks");
+    expect(statusCarried.nextSteps.join(" ")).toContain("Fix failing checks");
+
+    const startupFailure = __contributorOpenPrMonitorInternals.buildNextStepPacket(
+      classified,
+      [],
+      [{ id: "2", repoFullName: "entrius/allways-ui", pullNumber: 55, name: "ci", status: "completed", conclusion: "startup_failure", payload: {} }],
+      false,
+      false,
+    );
+    expect(startupFailure.classification).toBe("failing_checks");
+  });
+
   it("flags duplicate-prone titles across open PRs in the same repo", () => {
     const open = [pr({ number: 40, title: "fix parser bug" }), pr({ number: 41, title: "fix parser bug" })];
     const flagged = __contributorOpenPrMonitorInternals.duplicatePronePullNumbers(open);

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -294,6 +294,38 @@ describe("v2 signal builders", () => {
     expect(packet.reviewSignals.checkFailureCount).toBe(1);
   });
 
+  it("counts status-carried and startup_failure checks in maintainer packet and reviewability", () => {
+    const baseArgs = {
+      repo,
+      pullRequest: pullRequests[0]!,
+      issues,
+      pullRequests,
+      files: [],
+      reviews: [],
+      recentMergedPullRequests,
+      repoFullName: repo.fullName,
+      pullNumber: 10,
+    };
+    const statusCarried = buildPullRequestMaintainerPacket({
+      ...baseArgs,
+      checks: [{ id: "check-status", repoFullName: repo.fullName, pullNumber: 10, name: "validate", status: "failure", conclusion: null, payload: {} }],
+    });
+    expect(statusCarried.reviewSignals.checkFailureCount).toBe(1);
+    expect(statusCarried.findings.map((finding) => finding.code)).toContain("checks_need_attention");
+
+    const startupFailure = buildPullRequestMaintainerPacket({
+      ...baseArgs,
+      checks: [{ id: "check-startup", repoFullName: repo.fullName, pullNumber: 10, name: "validate", status: "completed", conclusion: "startup_failure", payload: {} }],
+    });
+    expect(startupFailure.reviewSignals.checkFailureCount).toBe(1);
+
+    const reviewability = buildPullRequestReviewability({
+      ...baseArgs,
+      checks: [{ id: "check-status", repoFullName: repo.fullName, pullNumber: 10, name: "validate", status: "failure", conclusion: null, payload: {} }],
+    });
+    expect(reviewability.noiseSources).toContain("1 failing or cancelled check(s).");
+  });
+
   it("reports registry changes between snapshots", () => {
     const current = snapshot("new", [
       { repo: "JSONbored/gittensory", emissionShare: 0.02, issueDiscoveryShare: 0, labelMultipliers: { bug: 1.1 } },


### PR DESCRIPTION
## Summary

- Reuse `isFailingCheckSummary` from `src/signals/local-branch.ts` in the contributor open-PR monitor, maintainer PR packet, and PR reviewability scorer.
- Align those surfaces with the maintainer digest/readiness path (#1902): status-carried failures, `startup_failure` / `failed` / `action_required`, and case variants now surface `failing_checks`, `checks_need_attention`, and reviewability noise consistently.
- Add regression coverage for status-carried and `startup_failure` check shapes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Issue creation is currently blocked for contributor accounts on the upstream repo; this is a focused follow-up to #1902 with regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` runs in GitHub Actions; targeted vitest covered the new regressions.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend signal logic only.

## Notes

-


Made with [Cursor](https://cursor.com)