### PR TITLE
fix(selfhost): paginate Orb export by event_at and target_id tie-break

### DIFF
--- a/migrations/0088_orb_export_cursor_target_id.sql
+++ b/migrations/0088_orb_export_cursor_target_id.sql
@@ -1,0 +1,4 @@
+-- Orb fleet export watermark tie-break: when multiple resolved PRs share the same event_at, a
+-- timestamp-only cursor skips the remainder after a partial batch. Persist the last exported
+-- target_id alongside last_exported_at so pagination can resume within a tied timestamp group.
+ALTER TABLE orb_export_cursor ADD COLUMN last_exported_target_id TEXT NOT NULL DEFAULT '';

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -141,8 +141,8 @@ const FLEET_QUERY = `
     LEFT JOIN rev ON gd.target_id = rev.target_id
     WHERE gd.rn = 1 AND po.rn = 1
   ) AS resolved
-  WHERE event_at > ?
-  ORDER BY event_at
+  WHERE (event_at > ?) OR (event_at = ? AND target_id > ?)
+  ORDER BY event_at ASC, target_id ASC
   LIMIT ?`;
 
 /** ms between the gate decision and the resolution; null if implausible (NaN or negative). */
@@ -176,12 +176,13 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
 
   // Read this instance's export watermark (resumes where the last run left off).
   const cursorRow = await db
-    .prepare(`SELECT last_exported_at FROM orb_export_cursor WHERE instance_hash = ?`)
+    .prepare(`SELECT last_exported_at, last_exported_target_id FROM orb_export_cursor WHERE instance_hash = ?`)
     .bind(instance)
-    .first<{ last_exported_at: string }>();
-  const cursor = cursorRow?.last_exported_at ?? "2000-01-01T00:00:00Z";
+    .first<{ last_exported_at: string; last_exported_target_id?: string }>();
+  const cursorAt = cursorRow?.last_exported_at ?? "2000-01-01T00:00:00Z";
+  const cursorTargetId = cursorRow?.last_exported_target_id ?? "";
 
-  const { results } = await db.prepare(FLEET_QUERY).bind(cursor, batchSize).all<FleetRow>();
+  const { results } = await db.prepare(FLEET_QUERY).bind(cursorAt, cursorAt, cursorTargetId, batchSize).all<FleetRow>();
   if (!results || results.length === 0) return 0;
 
   const payload: OrbExportPayload = {
@@ -223,11 +224,13 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
     return 0;
   }
 
-  // Advance the watermark to the newest event in this batch (rows are ordered by event_at ascending).
-  const newWatermark = results[results.length - 1]!.event_at;
+  // Advance the watermark to the newest event in this batch (rows are ordered by event_at, target_id).
+  const lastRow = results[results.length - 1]!;
   await db
-    .prepare(`INSERT OR REPLACE INTO orb_export_cursor (instance_hash, last_exported_at, updated_at) VALUES (?, ?, ?)`)
-    .bind(instance, newWatermark, new Date().toISOString())
+    .prepare(
+      `INSERT OR REPLACE INTO orb_export_cursor (instance_hash, last_exported_at, last_exported_target_id, updated_at) VALUES (?, ?, ?, ?)`,
+    )
+    .bind(instance, lastRow.event_at, lastRow.target_id, new Date().toISOString())
     .run();
 
   incr("gittensory_orb_events_exported_total", {}, results.length);

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -16,6 +16,7 @@ function makeDb(): D1Database {
     );
     CREATE TABLE orb_export_cursor (
       instance_hash TEXT PRIMARY KEY, last_exported_at TEXT NOT NULL DEFAULT '2000-01-01T00:00:00Z',
+      last_exported_target_id TEXT NOT NULL DEFAULT '',
       updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
     );
     CREATE TABLE system_flags (
@@ -208,6 +209,20 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     expect(n).toBe(3); // batch cap
     expect(headers?.["x-orb-signature"]).toMatch(/^sha256=[a-f0-9]{64}$/);
     expect(headers?.authorization).toBe("Bearer collector-secret");
+  });
+
+  it("exports every PR sharing the same event_at across batched runs (composite cursor tie-break)", async () => {
+    const db = makeDb();
+    const at = "2026-06-01T02:00:00Z";
+    for (let pr = 1; pr <= 5; pr++) {
+      await audit(db, "o/r", pr, "gate_decision", "merge", "2026-06-01T00:00:00Z");
+      await audit(db, "o/r", pr, "pr_outcome", "merged", at);
+    }
+    const fetchOk = async () => new Response(null, { status: 200 });
+    expect(await exportOrbBatch(db, 2, fetchOk)).toBe(2);
+    expect(await exportOrbBatch(db, 2, fetchOk)).toBe(2);
+    expect(await exportOrbBatch(db, 2, fetchOk)).toBe(1);
+    expect(await exportOrbBatch(db, 2, fetchOk)).toBe(0);
   });
 
   it("falls back to GITHUB_APP_ID for the instance id and applies the anonymize default when ORB_* are unset", async () => {


### PR DESCRIPTION
## Summary

- Add `last_exported_target_id` to `orb_export_cursor` (migration `0088_orb_export_cursor_target_id.sql`) so the Orb fleet exporter can resume within a tied `event_at` group.
- Paginate resolved PR rows with `(event_at > cursor) OR (event_at = cursor AND target_id > cursorTargetId)` and `ORDER BY event_at ASC, target_id ASC`.
- Advance both watermark fields from the last exported row; add regression coverage for five PRs sharing one `event_at` exported in batches of two.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Issue creation is currently blocked for contributor accounts on the upstream repo; this is a focused data-loss fix with regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` runs in GitHub Actions; `test/unit/selfhost-orb-collector.test.ts` covers the new composite-cursor path.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — self-host Orb export logic only.

## Notes

-


Made with [Cursor](https://cursor.com)