### PR TITLE
feat(enrichment): flag unsafe DOM / code-execution sinks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,17 +65,17 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # Current analyzer names:
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
-# history,docCommentDrift,duplication,churnHotspot
+# history,docCommentDrift,duplication,churnHotspot,unsafeDom
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,unsafeDom
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
-# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeDom
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
-# nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# nativeBuild,history,docCommentDrift,duplication,churnHotspot,unsafeDom
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -559,6 +559,29 @@ export const REES_ANALYZERS = [
         "Distinct from the history analyzer's author track record; this scores the change AREA's defect density.",
     },
   },
+  {
+    name: "unsafeDom",
+    title: "Unsafe DOM / code-execution sinks",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+      looksAt:
+        "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+      reports: "File, line, the sink, and the unsafe-sink kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal, regex-literal, and comment text is stripped before matching, so a sink named in a string, regex, or comment is not flagged.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -636,6 +636,32 @@
         "network": "Calls the GitHub commits API once per probed file. Requires GitHub token forwarding for private repos.",
         "notes": "Distinct from the history analyzer's author track record; this scores the change AREA's defect density."
       }
+    },
+    {
+      "name": "unsafeDom",
+      "title": "Unsafe DOM / code-execution sinks",
+      "category": "security",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+        "looksAt": "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+        "reports": "File, line, the sink, and the unsafe-sink kind.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "String-literal, regex-literal, and comment text is stripped before matching, so a sink named in a string, regex, or comment is not flagged."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -19,6 +19,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanTyposquat } from "./typosquat.js";
+import { scanUnsafeDom } from "./unsafe-dom.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -439,6 +440,26 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanChurnHotspot(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "unsafeDom",
+    title: "Unsafe DOM / code-execution sinks",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags added code that passes data into a DOM-HTML write sink or a dynamic code-execution sink.",
+      looksAt:
+        "Added JS/TS/JSX lines using innerHTML, dangerouslySetInnerHTML, document.write, eval, new Function, or a string-bodied setTimeout/setInterval.",
+      reports: "File, line, the sink, and the unsafe-sink kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal, regex-literal, and comment text is stripped before matching, so a sink named in a string, regex, or comment is not flagged.",
+    },
+    run: (req, { signal }) => scanUnsafeDom(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/unsafe-dom.ts
+++ b/review-enrichment/src/analyzers/unsafe-dom.ts
@@ -1,0 +1,391 @@
+// Unsafe DOM / code-execution sink analyzer. Flags added JS/TS lines that pass data into a DOM-HTML write sink
+// (`el.innerHTML = x`, `dangerouslySetInnerHTML={…}`, `document.write(…)`, `insertAdjacentHTML(…)`) or a dynamic
+// code-execution sink (`eval(…)`, `new Function(…)`, a string-bodied `setTimeout`/`setInterval`) — a client-side
+// XSS / arbitrary-code-execution surface distinct from the secret-into-a-LOG-sink scan (secret-log) and the
+// regex-backtracking SHAPE scan (redos). Pure compute, no network. Precision-first: `codeOnly` reduces a line to
+// just its code — blanking string contents (keeping the quotes), recursively stripping `${…}` interpolation
+// bodies, dropping regex-literal bodies, and dropping `//` and `/* */` comments (block comments are tracked across
+// added lines) — in a single linear pass with no regex, so it can never backtrack. Every sink is then matched
+// against that code view, so a sink named inside a string, interpolation string, regex, or comment is never
+// flagged. Line-cited via hunk headers, mirroring the other local analyzers.
+import type { EnrichRequest, UnsafeDomFinding } from "../types.js";
+
+const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_LINE_CHARS = 2000; // skip pathologically long lines (defensive)
+
+// Only scan source files: these sinks are meaningful in JS/TS/JSX/TSX and single-file component sources, not in
+// config, data, or docs. This is an intentional precision tradeoff — extensionless entrypoints or unusual
+// framework filenames are skipped to keep the signal high and avoid matching prose in YAML/JSON/Markdown.
+const CODE_PATH_RE = /\.(?:jsx?|tsx?|mjs|cjs|mts|cts|vue|svelte)$/i;
+
+// All matchers below are FLAT alternations (no group is itself quantified), so each is linear-time — this analyzer
+// can never be the ReDoS class it sits beside. Each runs against the code-only view of the line.
+//
+// DOM-HTML write sinks: plain or compound assignment to innerHTML/outerHTML (`=` or `+=`, but not the `==`/`===`
+// comparison), or insertAdjacentHTML().
+const INNER_HTML_RE = /\.(?:innerHTML|outerHTML)\s*\+?=(?!=)|\.insertAdjacentHTML\s*\(/;
+// React/JSX raw-HTML escape hatch — narrowed to a prop/object assignment (`dangerouslySetInnerHTML={…}` or
+// `dangerouslySetInnerHTML: {…}`) so a bare identifier of the same name is not flagged.
+const DANGEROUS_JSX_RE = /\bdangerouslySetInnerHTML\s*[=:]\s*\{/;
+// Legacy document.write / document.writeln HTML injection.
+const DOCUMENT_WRITE_RE = /\bdocument\s*\.\s*write(?:ln)?\s*\(/;
+// Global eval(...) — boundary-gated so member calls (`obj.eval(`) and identifier substrings (`retrieval(`) are excluded.
+const EVAL_CALL_RE = /(?:^|[^.\w$])eval\s*\(/;
+// The Function constructor compiles a string into code.
+const FUNCTION_CTOR_RE = /\bnew\s+Function\s*\(/;
+// setTimeout/setInterval with a STRING (or template) first argument is an implicit eval; a function first arg is safe.
+// Matched against the code-only view, where string contents are blanked but the quotes are kept, so the
+// string-first-argument signal survives while a `setTimeout` named in a comment/string/interpolation does not.
+const SET_TIMER_STRING_RE = /\bset(?:Timeout|Interval)\s*\(\s*['"`]/;
+
+function isWordChar(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+// Keywords after which a `/` begins a regex literal, not a division — `return /re/`, `typeof /re/`, etc.
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  "return",
+  "typeof",
+  "instanceof",
+  "in",
+  "of",
+  "new",
+  "delete",
+  "void",
+  "do",
+  "else",
+  "yield",
+  "throw",
+  "await",
+  "case",
+]);
+
+/** Decide whether a `/` begins a regex literal (vs a division operator), from the code emitted so far. A regex can
+ *  begin at expression start: line start, after an operator/open-bracket, or after an expression-start keyword —
+ *  never after a value (identifier, number, `)`, or `]`). No regex used here. */
+function isRegexStart(out: string): boolean {
+  let k = out.length - 1;
+  while (k >= 0 && (out[k] === " " || out[k] === "\t")) k--;
+  if (k < 0) return true; // line start ⇒ expression position
+  const ch = out[k]!;
+  if (isWordChar(ch)) {
+    let j = k;
+    while (j >= 0 && isWordChar(out[j]!)) j--;
+    return REGEX_PRECEDING_KEYWORDS.has(out.slice(j + 1, k + 1));
+  }
+  if (ch === ")" || ch === "]") return false; // division after a value
+  return "(,=:[!&|?{;+-*%<>~^".includes(ch); // operator / open bracket ⇒ regex
+}
+
+/** Reduce a line to just its code, returning the stripped code plus whether the line ends inside an unterminated
+ *  `/* *​/` block comment (so the scanner can carry that state to the next added line). Blanks string contents
+ *  (keeping the quotes), recursively strips `${…}` interpolation bodies, drops regex-literal bodies, and drops
+ *  `//` line and `/* *​/` block comments. Single linear pass, no regex, so it can never backtrack. `startInBlock`
+ *  continues a block comment opened on a previous line. */
+export function codeOnly(
+  s: string,
+  startInBlock = false,
+): { code: string; inBlock: boolean } {
+  let out = "";
+  let i = 0;
+  const n = s.length;
+  if (startInBlock) {
+    while (i < n && !(s[i] === "*" && s[i + 1] === "/")) i++;
+    if (i >= n) return { code: " ", inBlock: true }; // comment still open at end of line
+    i += 2;
+    out += " ";
+  }
+  while (i < n) {
+    const c = s[i]!;
+    if (c === "/" && s[i + 1] === "/") {
+      break; // line comment — drop the rest of the line
+    }
+    if (c === "/" && s[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(s[i] === "*" && s[i + 1] === "/")) i++;
+      if (i >= n) {
+        out += " ";
+        return { code: out, inBlock: true }; // block comment runs past end of line
+      }
+      i += 2;
+      out += " ";
+      continue;
+    }
+    if (c === "/") {
+      if (isRegexStart(out)) {
+        i++; // past the opening slash
+        let inClass = false; // inside a [...] character class a `/` is literal, not the terminator
+        while (i < n) {
+          const ch = s[i];
+          if (ch === "\\") {
+            i += 2;
+            continue;
+          }
+          if (ch === "[") inClass = true;
+          else if (ch === "]") inClass = false;
+          else if (ch === "/" && !inClass) {
+            i++; // closing slash
+            break;
+          }
+          i++;
+        }
+        out += " ";
+        continue;
+      }
+      out += "/"; // division operator — keep it as code
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i++;
+      while (i < n && s[i] !== c) {
+        if (s[i] === "\\") i++;
+        i++;
+      }
+      i++; // closing quote
+      out += c + c; // keep an empty quoted literal (e.g. "" / '') so a string first-arg stays detectable
+      continue;
+    }
+    if (c === "`") {
+      out += "`";
+      i++;
+      while (i < n && s[i] !== "`") {
+        if (s[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (s[i] === "$" && s[i + 1] === "{") {
+          // Collect the interpolation body with brace matching that skips strings, nested templates, and regex
+          // literals — so a `}` inside any of them does not close the interpolation early and swallow a later
+          // real sink — then strip the body with the same machine (recursively) so a sink that is only string/
+          // regex/comment text inside the interpolation does not survive as code.
+          i += 2;
+          let depth = 1;
+          let inner = "";
+          while (i < n && depth > 0) {
+            const ic = s[i]!;
+            if (ic === '"' || ic === "'") {
+              inner += ic;
+              i++;
+              while (i < n && s[i] !== ic) {
+                if (s[i] === "\\") {
+                  inner += s[i];
+                  i++;
+                }
+                if (i < n) {
+                  inner += s[i];
+                  i++;
+                }
+              }
+              if (i < n) {
+                inner += s[i];
+                i++;
+              }
+              continue;
+            }
+            if (ic === "`") {
+              inner += ic;
+              i++;
+              let nest = 0; // track ${ } nesting inside this nested template so its braces are balanced
+              while (i < n) {
+                if (s[i] === "\\") {
+                  inner += s[i] + (s[i + 1] ?? "");
+                  i += 2;
+                  continue;
+                }
+                if (s[i] === "`" && nest === 0) {
+                  inner += s[i];
+                  i++;
+                  break;
+                }
+                if (s[i] === "$" && s[i + 1] === "{") {
+                  nest++;
+                  inner += "${";
+                  i += 2;
+                  continue;
+                }
+                if (s[i] === "}" && nest > 0) {
+                  nest--;
+                  inner += "}";
+                  i++;
+                  continue;
+                }
+                inner += s[i];
+                i++;
+              }
+              continue;
+            }
+            if (ic === "/" && isRegexStart(inner)) {
+              inner += "/";
+              i++;
+              let inClass = false;
+              while (i < n) {
+                if (s[i] === "\\") {
+                  inner += s[i] + (s[i + 1] ?? "");
+                  i += 2;
+                  continue;
+                }
+                if (s[i] === "[") inClass = true;
+                else if (s[i] === "]") inClass = false;
+                else if (s[i] === "/" && !inClass) {
+                  inner += s[i];
+                  i++;
+                  break;
+                }
+                inner += s[i];
+                i++;
+              }
+              continue;
+            }
+            if (ic === "{") {
+              depth++;
+              inner += ic;
+              i++;
+              continue;
+            }
+            if (ic === "}") {
+              depth--;
+              if (depth > 0) inner += ic;
+              i++;
+              continue;
+            }
+            inner += ic;
+            i++;
+          }
+          out += `\${${codeOnly(inner).code}}`;
+          continue;
+        }
+        i++; // ordinary template-literal char — drop it
+      }
+      out += "`"; // closing backtick (kept, so a template first-arg stays detectable)
+      i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return { code: out, inBlock: false };
+}
+
+function sinkLabel(match: string): string {
+  return match.replace(/\s+/g, "").replace(/\($/, "");
+}
+
+/** Classify one stripped code view: does it write to a DOM-HTML sink or execute a dynamic-code sink? Returns the
+ *  kind + a public-safe sink label, or null. Reports only the FIRST matching sink class on the line (brevity). */
+function detectUnsafeDomInCode(
+  code: string,
+): { kind: UnsafeDomFinding["kind"]; sink: string } | null {
+  let m: RegExpExecArray | null;
+  if ((m = INNER_HTML_RE.exec(code)))
+    return { kind: "inner-html", sink: sinkLabel(m[0]) };
+  if (DANGEROUS_JSX_RE.test(code))
+    return { kind: "dangerous-jsx", sink: "dangerouslySetInnerHTML" };
+  if ((m = DOCUMENT_WRITE_RE.exec(code)))
+    return { kind: "document-write", sink: sinkLabel(m[0]) };
+  if (EVAL_CALL_RE.test(code)) return { kind: "eval-call", sink: "eval" };
+  if (FUNCTION_CTOR_RE.test(code))
+    return { kind: "function-ctor", sink: "new Function" };
+  if ((m = SET_TIMER_STRING_RE.exec(code)))
+    return { kind: "set-timeout-string", sink: sinkLabel(m[0]) };
+  return null;
+}
+
+/** Classify one line (single-line context: not inside a carried block comment). */
+export function detectUnsafeDom(
+  line: string,
+): { kind: UnsafeDomFinding["kind"]; sink: string } | null {
+  return detectUnsafeDomInCode(codeOnly(line).code);
+}
+
+type UnsafeDomScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  // Stream by patch line so large diffs do not require an intermediate split array; abort is sampled per line below.
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+/** Scan one file patch's added lines for unsafe DOM / code-execution sinks, line-cited via hunk headers. Block-
+ *  comment state is carried across consecutive added lines (and reset at hunk/context/removed boundaries). Pure. */
+export function scanPatchForUnsafeDom(
+  path: string,
+  patch: string,
+  limits: UnsafeDomScanLimits = {},
+): UnsafeDomFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const findings: UnsafeDomFinding[] = [];
+  let newLine = 0;
+  let inBlock = false; // inside an added multi-line /* */ comment
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inBlock = false; // a new hunk is non-contiguous; do not carry comment state across it
+      continue;
+    }
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      const stripped = codeOnly(body, inBlock);
+      inBlock = stripped.inBlock;
+      if (body.length <= MAX_LINE_CHARS) {
+        const hit = detectUnsafeDomInCode(stripped.code);
+        if (hit) {
+          findings.push({
+            file: path,
+            line: newLine,
+            kind: hit.kind,
+            sink: hit.sink,
+          });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-")) {
+      // context line: it is part of the new file, so parse it for block-comment state (a `/* */` can open on a
+      // context line and continue onto an added line) but never report findings on it.
+      inBlock = codeOnly(line.slice(1), inBlock).inBlock;
+      newLine++;
+    }
+    // a removed line is not part of the new file: skip it without advancing newLine or changing comment state.
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed source file's added lines for unsafe DOM / code-execution sinks. */
+export async function scanUnsafeDom(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<UnsafeDomFinding[]> {
+  const findings: UnsafeDomFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch || !CODE_PATH_RE.test(file.path)) continue;
+    for (const finding of scanPatchForUnsafeDom(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      // The per-file scan is capped to the remaining budget; keep this as a final invariant if that scanner changes.
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -379,6 +379,18 @@ export function renderBrief(
     }
   }
 
+  const unsafeDom = findings.unsafeDom ?? [];
+  if (unsafeDom.length) {
+    lines.push(
+      "### Unsafe DOM / code-execution sinks (XSS / arbitrary-code-execution risk — sanitize or avoid)",
+    );
+    for (const item of unsafeDom) {
+      lines.push(
+        `- ${safeCodeSpan(`${item.file}:${item.line}`)} — ${safeCodeSpan(item.sink)} (${item.kind}); avoid this sink or sanitize/escape the input`,
+      );
+    }
+  }
+
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 
   const header =

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -350,6 +350,7 @@ function inputSkipReason(
     case "redos":
     case "secret":
     case "secretLog":
+    case "unsafeDom":
       return analysis.hasAddedLines ? null : "no_added_lines";
     case "provenance":
       return analysis.dependencyManifestPaths.length ||

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -308,6 +308,7 @@ export interface BriefFindings {
   docCommentDrift?: DocCommentDriftFinding[];
   duplication?: DuplicationFinding[];
   churnHotspot?: ChurnHotspotFinding[];
+  unsafeDom?: UnsafeDomFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a
@@ -336,6 +337,23 @@ export interface DuplicationFinding {
   sourceLine: number;
   /** Number of contiguous significant lines that matched verbatim (after whitespace normalization). */
   lines: number;
+}
+
+/** An added source line that passes data into a DOM-HTML write sink (`innerHTML`, `dangerouslySetInnerHTML`,
+ *  `document.write`) or a dynamic-code-execution sink (`eval`, `new Function`, a string-bodied `setTimeout`/
+ *  `setInterval`) — a client-side XSS / arbitrary-code-execution surface. Reports the location + sink + kind
+ *  only; string-literal and comment text is stripped before matching so a sink named in prose is not flagged. */
+export interface UnsafeDomFinding {
+  file: string;
+  line: number;
+  kind:
+    | "inner-html"
+    | "dangerous-jsx"
+    | "document-write"
+    | "eval-call"
+    | "function-ctor"
+    | "set-timeout-string";
+  sink: string;
 }
 
 export type AnalyzerStatus = "ok" | "degraded" | "skipped" | "capped" | "timeout";

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_ANALYZERS = [
   "docCommentDrift",
   "duplication",
   "churnHotspot",
+  "unsafeDom",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/unsafe-dom.test.ts
+++ b/review-enrichment/test/unsafe-dom.test.ts
@@ -1,0 +1,327 @@
+// Units for the unsafe-DOM / code-execution-sink analyzer. Kept separate so analyzer PRs do not collide in one
+// shared test file. Covers every branch of detectUnsafeDom/codeOnly/scanPatchForUnsafeDom/scanUnsafeDom plus the
+// render arms, using hand-built unified-diff fixtures (no network, no GitHub).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  codeOnly,
+  detectUnsafeDom,
+  scanPatchForUnsafeDom,
+  scanUnsafeDom,
+} from "../dist/analyzers/unsafe-dom.js";
+import { renderBrief } from "../dist/render.js";
+
+/** Build a single-hunk patch whose body is the given added lines (each prefixed with `+`). */
+const addedPatch = (...lines) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+const req = (files) => ({ repoFullName: "o/r", prNumber: 1, files });
+
+test("detectUnsafeDom flags each unsafe sink kind", () => {
+  assert.equal(detectUnsafeDom("el.innerHTML = userInput;")?.kind, "inner-html");
+  assert.equal(detectUnsafeDom("node.outerHTML = markup;")?.kind, "inner-html");
+  assert.equal(
+    detectUnsafeDom("el.insertAdjacentHTML('beforeend', html);")?.kind,
+    "inner-html",
+  );
+  assert.equal(
+    detectUnsafeDom("return <div dangerouslySetInnerHTML={{ __html: html }} />;")
+      ?.kind,
+    "dangerous-jsx",
+  );
+  assert.equal(detectUnsafeDom("document.write(payload);")?.kind, "document-write");
+  assert.equal(detectUnsafeDom("document.writeln(payload);")?.kind, "document-write");
+  assert.equal(detectUnsafeDom("const r = eval(expr);")?.kind, "eval-call");
+  assert.equal(
+    detectUnsafeDom("const f = new Function('a', 'return a');")?.kind,
+    "function-ctor",
+  );
+  assert.equal(
+    detectUnsafeDom("setTimeout('doStuff()', 100);")?.kind,
+    "set-timeout-string",
+  );
+  assert.equal(
+    detectUnsafeDom("setInterval(`tick()`, 100);")?.kind,
+    "set-timeout-string",
+  );
+});
+
+test("detectUnsafeDom returns a public-safe sink label", () => {
+  assert.equal(detectUnsafeDom("el.innerHTML = x;")?.sink, ".innerHTML=");
+  assert.equal(detectUnsafeDom("document.write(x);")?.sink, "document.write");
+  assert.equal(detectUnsafeDom("eval(x);")?.sink, "eval");
+  assert.equal(detectUnsafeDom("new Function(b);")?.sink, "new Function");
+  assert.equal(
+    detectUnsafeDom("return <b dangerouslySetInnerHTML={h} />;")?.sink,
+    "dangerouslySetInnerHTML",
+  );
+});
+
+test("detectUnsafeDom ignores sinks named only in strings or comments", () => {
+  assert.equal(detectUnsafeDom('const s = "el.innerHTML = x";'), null);
+  assert.equal(detectUnsafeDom("// el.innerHTML = x"), null);
+  assert.equal(detectUnsafeDom("foo(); // document.write(x)"), null);
+  assert.equal(detectUnsafeDom("obj.eval(payload);"), null); // member call, not global eval
+  assert.equal(detectUnsafeDom("const x = retrieval(y);"), null); // identifier substring
+  assert.equal(detectUnsafeDom("setTimeout(fn, 100);"), null); // function arg, not a string
+  assert.equal(detectUnsafeDom("if (el.innerHTML === expected) {}"), null); // comparison, not assignment
+  assert.equal(detectUnsafeDom("const plain = compute(value);"), null); // no sink
+});
+
+test("detectUnsafeDom ignores sinks inside a regex literal (regex-token false-positive class)", () => {
+  // Analyzers spell sink patterns AS regex literals; scanning the regex body as code would falsely flag them.
+  assert.equal(detectUnsafeDom("const re = /document\\.write\\(/;"), null);
+  assert.equal(detectUnsafeDom("if (/\\.innerHTML\\s*=/.test(src)) report();"), null);
+  assert.equal(detectUnsafeDom("line = line.replace(/eval\\(/g, '');"), null);
+  assert.equal(detectUnsafeDom("const r = /new Function\\(/;"), null);
+  // a `/` used as division is NOT a regex: a real sink later on the line is still detected
+  assert.equal(
+    detectUnsafeDom("const ratio = a / b; el.innerHTML = c;")?.kind,
+    "inner-html",
+  );
+  // a `/` inside a [...] character class does not prematurely terminate the regex literal
+  assert.equal(detectUnsafeDom("const re = /[a-z/]eval\\(/;"), null);
+});
+
+test("codeOnly blanks string/comment content but keeps interpolation code", () => {
+  assert.equal(codeOnly('a "secret" b').code.includes("secret"), false);
+  assert.equal(codeOnly("a // tail comment").code.includes("tail"), false);
+  assert.ok(codeOnly("`x${ realCode }y`").code.includes("realCode"));
+  // escaped quote inside a string, then a real sink outside it
+  assert.equal(
+    detectUnsafeDom('const s = "he said \\"hi\\""; document.write(x);')?.kind,
+    "document-write",
+  );
+  // escaped backtick inside a template, then a sink in the interpolation
+  assert.equal(
+    detectUnsafeDom("render(`a\\`b ${ node.innerHTML = v }`);")?.kind,
+    "inner-html",
+  );
+});
+
+test("scanPatchForUnsafeDom cites the new-file line and skips header/removed/context lines", () => {
+  const patch = [
+    "--- a/app.ts",
+    "+++ b/app.ts",
+    "@@ -1,2 +1,3 @@",
+    " context();", // context line: newLine advances
+    "-old.innerHTML = a;", // removed line: ignored, does not advance newLine
+    "+el.innerHTML = b;", // added at new-file line 2
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("app.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0], {
+    file: "app.ts",
+    line: 2,
+    kind: "inner-html",
+    sink: ".innerHTML=",
+  });
+});
+
+test("scanPatchForUnsafeDom tracks line numbers across multiple hunks", () => {
+  const patch = [
+    "@@ -1,1 +1,1 @@",
+    "+document.write(a);", // line 1
+    "@@ -10,1 +20,2 @@",
+    " keep();", // line 20
+    "+eval(b);", // line 21
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("a.ts", patch);
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].line, 1);
+  assert.equal(findings[1].line, 21);
+});
+
+test("scanPatchForUnsafeDom skips pathologically long lines", () => {
+  const long = `el.innerHTML = ${"x".repeat(2001)};`;
+  const findings = scanPatchForUnsafeDom("a.ts", `@@ -1,0 +1,1 @@\n+${long}`);
+  assert.equal(findings.length, 0);
+});
+
+test("scanPatchForUnsafeDom honors the finding budget", () => {
+  assert.deepEqual(
+    scanPatchForUnsafeDom("a.ts", addedPatch("eval(x);"), { maxFindings: 0 }),
+    [],
+  );
+  const capped = scanPatchForUnsafeDom(
+    "a.ts",
+    addedPatch("eval(a);", "eval(b);", "eval(c);"),
+    { maxFindings: 2 },
+  );
+  assert.equal(capped.length, 2);
+});
+
+test("scanPatchForUnsafeDom throws when the signal is already aborted", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () =>
+      scanPatchForUnsafeDom("a.ts", addedPatch("eval(x);"), {
+        signal: controller.signal,
+      }),
+    /analyzer_aborted/,
+  );
+});
+
+test("scanUnsafeDom scans code files and skips non-code or patch-less files", async () => {
+  const findings = await scanUnsafeDom(
+    req([
+      { path: "src/app.tsx", patch: addedPatch("el.innerHTML = a;") }, // scanned
+      { path: "README.md", patch: addedPatch("document.write(x);") }, // skipped: not a code path
+      { path: "src/no-patch.ts" }, // skipped: no patch
+    ]),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, "src/app.tsx");
+});
+
+test("scanUnsafeDom returns [] when the request carries no files", async () => {
+  assert.deepEqual(await scanUnsafeDom({ repoFullName: "o/r", prNumber: 1 }), []);
+});
+
+test("scanUnsafeDom caps total findings at the global budget", async () => {
+  const many = Array.from({ length: 30 }, (_, i) => `eval(x${i});`);
+  const findings = await scanUnsafeDom(
+    req([{ path: "a.ts", patch: addedPatch(...many) }]),
+  );
+  assert.equal(findings.length, 25);
+});
+
+test("scanUnsafeDom throws when the signal is already aborted", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    scanUnsafeDom(
+      req([{ path: "a.ts", patch: addedPatch("eval(x);") }]),
+      controller.signal,
+    ),
+    /analyzer_aborted/,
+  );
+});
+
+test("renderBrief includes the unsafe-DOM section when findings exist", () => {
+  const { promptSection } = renderBrief({
+    unsafeDom: [{ file: "src/a.ts", line: 3, kind: "eval-call", sink: "eval" }],
+  });
+  assert.match(promptSection, /Unsafe DOM \/ code-execution sinks/);
+  assert.match(promptSection, /src\/a\.ts:3/);
+  assert.match(promptSection, /eval-call/);
+});
+
+test("renderBrief omits the unsafe-DOM section when there are no findings", () => {
+  const { promptSection } = renderBrief({ unsafeDom: [] });
+  assert.equal(promptSection, "");
+});
+
+test("detectUnsafeDom does not flag a safe timer when a comment/string later names a timer", () => {
+  // a safe setTimeout(fn) must not be reported because a later comment or string mentions a string-bodied timer
+  assert.equal(detectUnsafeDom('setTimeout(fn, 1); // setTimeout("x")'), null);
+  assert.equal(
+    detectUnsafeDom("setTimeout(fn, 1); const s = \"setTimeout('x')\";"),
+    null,
+  );
+  assert.equal(detectUnsafeDom("setInterval(handler, 1000);"), null);
+  // a genuine string-bodied timer is still flagged
+  assert.equal(detectUnsafeDom("setTimeout('run()', 1);")?.kind, "set-timeout-string");
+  assert.equal(detectUnsafeDom("setInterval(`tick()`, 1);")?.kind, "set-timeout-string");
+});
+
+test("codeOnly treats `/` after an expression-start keyword as a regex literal", () => {
+  assert.equal(detectUnsafeDom("return /document\\.write\\(/.test(src);"), null);
+  assert.equal(detectUnsafeDom("throw /eval\\(/;"), null);
+  assert.equal(detectUnsafeDom("yield /new Function\\(/;"), null);
+  // a keyword-LIKE identifier (not the keyword itself) before `/` stays a division operator
+  assert.equal(
+    detectUnsafeDom("const returns = a / b; el.innerHTML = c;")?.kind,
+    "inner-html",
+  );
+});
+
+test("detectUnsafeDom flags dangerouslySetInnerHTML only as a prop/object assignment", () => {
+  assert.equal(
+    detectUnsafeDom("<div dangerouslySetInnerHTML={{ __html: x }} />")?.kind,
+    "dangerous-jsx",
+  );
+  assert.equal(
+    detectUnsafeDom("const props = { dangerouslySetInnerHTML: { __html: x } };")
+      ?.kind,
+    "dangerous-jsx",
+  );
+  // a bare identifier of the same name is not a sink
+  assert.equal(detectUnsafeDom("const dangerouslySetInnerHTML = computeFlag();"), null);
+});
+
+test("codeOnly strips block-comment text", () => {
+  assert.equal(detectUnsafeDom("foo(); /* el.innerHTML = x */ bar();"), null);
+  // a real sink before a block comment is still detected
+  assert.equal(detectUnsafeDom("el.innerHTML = y; /* note */")?.kind, "inner-html");
+});
+
+test("codeOnly recursively strips sinks inside template interpolation", () => {
+  assert.equal(detectUnsafeDom('const s = `${"document.write(x)"}`;'), null);
+  assert.equal(detectUnsafeDom("const s = `${ /eval\\(/ }`;"), null);
+  // a real sink that is actual code inside the interpolation is still detected
+  assert.equal(
+    detectUnsafeDom("const h = `${ (el.innerHTML = v) }`;")?.kind,
+    "inner-html",
+  );
+});
+
+test("scanPatchForUnsafeDom carries block-comment state across added lines", () => {
+  const patch = [
+    "@@ -1,0 +1,4 @@",
+    "+/* a comment that mentions",
+    "+ document.write(x) and more",
+    "+*/",
+    "+el.innerHTML = real;",
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("a.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "inner-html");
+  assert.equal(findings[0].line, 4);
+  // a new hunk is non-contiguous, so block-comment state does not carry across it
+  const patch2 = [
+    "@@ -1,0 +1,1 @@",
+    "+/* opened here",
+    "@@ -5,0 +9,1 @@",
+    "+document.write(x);",
+  ].join("\n");
+  const f2 = scanPatchForUnsafeDom("a.ts", patch2);
+  assert.equal(f2.length, 1);
+  assert.equal(f2[0].line, 9);
+});
+
+test("detectUnsafeDom flags compound assignment to innerHTML/outerHTML", () => {
+  assert.equal(detectUnsafeDom("el.innerHTML += html;")?.kind, "inner-html");
+  assert.equal(detectUnsafeDom("node.outerHTML += markup;")?.kind, "inner-html");
+  // an equality comparison is still excluded
+  assert.equal(detectUnsafeDom("if (el.innerHTML == x) {}"), null);
+});
+
+test("codeOnly brace-matches interpolation past strings/regex/nested-templates so later sinks survive", () => {
+  assert.equal(
+    detectUnsafeDom('const h = `${ foo("}") || (el.innerHTML = x) }`;')?.kind,
+    "inner-html",
+  );
+  assert.equal(
+    detectUnsafeDom("const h = `${ /}/.test(s) || (el.innerHTML = x) }`;")?.kind,
+    "inner-html",
+  );
+  assert.equal(
+    detectUnsafeDom("const h = `${ `}` + (document.write(x), 1) }`;")?.kind,
+    "document-write",
+  );
+});
+
+test("scanPatchForUnsafeDom honors a block comment opened on a context line", () => {
+  const patch = [
+    "@@ -1,3 +1,4 @@",
+    " /* an existing comment that opens here",
+    "+ document.write(x) still inside the comment",
+    " */",
+    "+el.innerHTML = real;",
+  ].join("\n");
+  const findings = scanPatchForUnsafeDom("a.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "inner-html");
+});


### PR DESCRIPTION
## What

A new local REES analyzer, `unsafeDom`, that flags added JS/TS lines which pass data into a **DOM-HTML write sink** (`innerHTML`/`outerHTML` assignment, `insertAdjacentHTML`, `dangerouslySetInnerHTML`, `document.write`/`writeln`) or a **dynamic code-execution sink** (`eval`, `new Function`, a string-bodied `setTimeout`/`setInterval`) — the client-side XSS / arbitrary-code-execution surface a no-checkout reviewer cannot reliably catch by eye.

## Why it is a distinct dimension

Orthogonal to every existing analyzer: `redos` inspects regex backtracking *shapes*, `secretLog` inspects *logging* sinks, `secret`/`secretScan` inspect literal *values*, and `iacMisconfig` inspects *config-file paths* (it excludes `.ts`/`.js`). None model HTML-write or dynamic-eval sinks in source. The analyzer mirrors the proven `iac-misconfig`/`secret-log` skeleton (per-line patch scan, hunk-header line citation, `MAX_FINDINGS`/`MAX_LINE_CHARS` caps, `AbortSignal`).

## Precision — single code-only view

Every sink is matched against one code-only view of the line produced by `codeOnly`, which in a single linear pass (no regex, so it can never backtrack):

- **blanks string contents but keeps the quotes**, so a real string-bodied `setTimeout('code', 1)` is detected, while a safe `setTimeout(fn, 1); // setTimeout("x")` and `setTimeout(fn, 1); const s = "setTimeout('x')";` are **not** — the timer's string-first-argument check runs on the same stripped view that proves the call is real, never on the raw line;
- **drops regex-literal bodies**, recognizing a regex start after operators *and* after expression-start keywords (`return`, `throw`, `yield`, `typeof`, …) with `[...]` character-class handling, so `return /document\.write\(/.test(src)` is **not** flagged;
- **drops `//` and `/* */` comment text.**

`dangerouslySetInnerHTML` is matched only as a prop/object assignment (`={…}` / `: {…}`), not as a bare identifier. `innerHTML` assignment is distinguished from an `===` comparison, and `eval` is boundary-gated so member calls (`obj.eval(`) and substrings (`retrieval(`) are excluded. Every matcher is a flat, linear-time alternation.

## Output

Public-safe: location + sink + kind only, never code or values. Bounded at 25 findings / 2000 chars per line, fail-safe on abort, `cost: "local"` (no network).

## No linked issue

Net-new analyzer, so there is no tracking issue to link.

## Tests

`review-enrichment/test/unsafe-dom.test.ts` (node:test) covers every branch: each sink kind; string / `//` comment / `/* */` block-comment / regex-literal negatives (including a regex after expression-start keywords); safe-timer-followed-by-comment-or-string negatives; division-not-regex; `dangerouslySetInnerHTML` bare-identifier negative; character-class handling; multi-hunk line citation; removed/context-line skipping; long-line and budget caps; abort; the non-code-path skip; and both render arms. `npm test` is green and analyzer metadata is regenerated and committed.
