### PR TITLE
fix(signals): pin lifecycle classification for explicit validate/pre-start targets

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -738,6 +738,7 @@ const STOPWORDS = new Set([
 const MAX_COLLISION_PAIRWISE_ISSUES = 80;
 const MAX_COLLISION_PAIRWISE_PULL_REQUESTS = 120;
 const MAX_COLLISION_PAIRWISE_RECENT_MERGES = 40;
+const ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP = 300;
 const REPO_OUTCOME_STALE_OPEN_DAYS = 30;
 const REPO_OUTCOME_MIN_DECIDED_SAMPLE = 3;
 const REPO_OUTCOME_MERGE_WELL_RATE = 0.7;
@@ -3001,6 +3002,7 @@ export function buildIssueDiscoveryLifecycleReport(
   pullRequests: PullRequestRecord[],
   fullName: string,
   recentMergedPullRequests: RecentMergedPullRequestRecord[] = [],
+  pinIssueNumbers: number[] = [],
 ): IssueDiscoveryLifecycleReport {
   const lane = buildLaneAdvice(repo, fullName);
   // One-time PR-by-issue index so each per-issue classification is an O(1) lookup, not a full PR rescan.
@@ -3008,8 +3010,16 @@ export function buildIssueDiscoveryLifecycleReport(
     open: indexPullRequestsByLinkedIssue(pullRequests),
     merged: indexPullRequestsByLinkedIssue(recentMergedPullRequests),
   };
-  const states = issues
-    .slice(0, 300)
+  const cappedIssues = issues.slice(0, ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP);
+  const cappedNumbers = new Set(cappedIssues.map((issue) => issue.number));
+  const pinnedIssues = pinIssueNumbers
+    .filter((number) => !cappedNumbers.has(number))
+    .map((number) => issues.find((issue) => issue.number === number))
+    .filter((issue): issue is IssueRecord => issue != null);
+  // Pin explicitly requested targets (validate-linked-issue / check-before-start) even when they sit outside
+  // the bulk cap — callers pass issues in updatedAt-desc order, so stale targets beyond 300 were silently skipped.
+  const issuesToClassify = pinnedIssues.length > 0 ? [...cappedIssues, ...pinnedIssues] : cappedIssues;
+  const states = issuesToClassify
     .map((issue) => classifyIssueDiscoveryLifecycle(issue, pullRequests, recentMergedPullRequests, lane, linkedIndex))
     .sort((left, right) => lifecycleRank(left.state) - lifecycleRank(right.state) || left.number - right.number);
   return {
@@ -3060,7 +3070,7 @@ export function buildLinkedIssueValidation(
   issueNumber: number,
   plannedChange: LinkedIssuePlannedChange = {},
 ): LinkedIssueValidationReport {
-  const lifecycle = buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests);
+  const lifecycle = buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests, [issueNumber]);
   const issue = issues.find((candidate) => candidate.number === issueNumber);
   const lifecycleEntry = lifecycle.states.find((entry) => entry.number === issueNumber);
   const open = issue?.state === "open";
@@ -3180,9 +3190,6 @@ export function buildPreStartCheck(
   target: PreStartCheckTarget,
 ): PreStartCheckReport {
   const lane = buildLaneAdvice(repo, fullName);
-  const collisions = buildCollisionReport(fullName, issues, pullRequests, recentMergedPullRequests);
-  const quality = buildIssueQualityReport(repo, issues, pullRequests, fullName, [], collisions, recentMergedPullRequests);
-  const lifecycle = buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests);
   const openIssues = issues.filter((issue) => issue.state === "open");
 
   let resolvedIssue: IssueRecord | undefined;
@@ -3210,11 +3217,18 @@ export function buildPreStartCheck(
   }
 
   const resolvedNumber = resolvedIssue?.number;
-  const qualityEntry = resolvedNumber == null ? undefined : quality.issues.find((entry) => entry.number === resolvedNumber);
-  const lifecycleEntry = resolvedNumber == null ? undefined : lifecycle.states.find((entry) => entry.number === resolvedNumber);
+  const pinIssueNumbers =
+    resolvedNumber != null ? [resolvedNumber] : typeof target.issueNumber === "number" ? [target.issueNumber] : [];
+
+  const collisions = buildCollisionReport(fullName, issues, pullRequests, recentMergedPullRequests);
+  const quality = buildIssueQualityReport(repo, issues, pullRequests, fullName, [], collisions, recentMergedPullRequests);
+  const lifecycle = buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests, pinIssueNumbers);
 
   const plannedPaths = (target.plannedPaths ?? []).map((path) => path.toLowerCase());
   if (matchedBy === "none" && plannedPaths.length > 0) matchedBy = "planned_paths";
+
+  const qualityEntry = resolvedNumber == null ? undefined : quality.issues.find((entry) => entry.number === resolvedNumber);
+  const lifecycleEntry = resolvedNumber == null ? undefined : lifecycle.states.find((entry) => entry.number === resolvedNumber);
 
   const issueClusters =
     resolvedNumber == null ? [] : collisions.clusters.filter((cluster) => cluster.items.some((item) => item.type === "issue" && item.number === resolvedNumber));

--- a/test/unit/linked-issue-validation.test.ts
+++ b/test/unit/linked-issue-validation.test.ts
@@ -142,4 +142,22 @@ describe("buildLinkedIssueValidation", () => {
     expect(report.blockingReason).toMatch(/#999 was not found/i);
     assertPublicSafe(report);
   });
+
+  it("classifies duplicate targets beyond the 300-issue lifecycle cap (regression for pinned lifecycle lookup)", () => {
+    const manyIssues = Array.from({ length: 301 }, (_, index) =>
+      issue(index + 1, `Cached issue ${index + 1}`, {
+        updatedAt: new Date(Date.now() - index * 60_000).toISOString(),
+      }),
+    );
+    manyIssues[300] = issue(301, "Duplicate beyond lifecycle cap", {
+      labels: ["duplicate"],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    });
+    const report = buildLinkedIssueValidation(repo("owner/repo"), manyIssues, [], [], "owner/repo", 301);
+    expect(report.lifecycle).toBe("duplicate");
+    expect(report.multiplierWouldApply).toBe(false);
+    expect(report.multiplierStatus).toBe("invalid");
+    expect(report.blockingReason).toMatch(/duplicate/i);
+    assertPublicSafe(report);
+  });
 });

--- a/test/unit/pre-start-check.test.ts
+++ b/test/unit/pre-start-check.test.ts
@@ -146,6 +146,23 @@ describe("buildPreStartCheck", () => {
     assertPublicSafe(invalid);
   });
 
+  it("avoids duplicate targets beyond the 300-issue lifecycle cap (regression for pinned lifecycle lookup)", () => {
+    const manyIssues = Array.from({ length: 301 }, (_, index) =>
+      issue(index + 1, `Cached issue ${index + 1}`, {
+        updatedAt: new Date(Date.now() - index * 60_000).toISOString(),
+      }),
+    );
+    manyIssues[300] = issue(301, "Duplicate beyond lifecycle cap", {
+      labels: ["duplicate"],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    });
+    const report = buildPreStartCheck(repo("owner/repo"), manyIssues, [], [], "owner/repo", { issueNumber: 301 });
+    expect(report.lifecycle).toBe("duplicate");
+    expect(report.recommendation).toBe("avoid");
+    expect(report.blockers.some((blocker) => /duplicate in cached metadata/i.test(blocker))).toBe(true);
+    assertPublicSafe(report);
+  });
+
   it("raises for a thin issue that needs more proof", () => {
     const r = repo("owner/repo");
     const issues = [issue(6, "Something is broken somewhere", { body: "broken" })];


### PR DESCRIPTION
## Summary

- `buildIssueDiscoveryLifecycleReport` classified only the first 300 cached issues; targets beyond that cap were omitted from lifecycle lookup.
- `validate-linked-issue` and `check-before-start` now pin the explicitly requested issue number so duplicate/invalid/solved guards always run, even on large queues.
- Reordered pre-start target resolution before lifecycle/quality assembly so title- and number-based targets both benefit from pinning.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Issue filing on upstream currently requires maintainer write access from this account; the bug and regression tests are self-contained in the PR.

## Validation

- [x] `npx vitest run test/unit/linked-issue-validation.test.ts test/unit/pre-start-check.test.ts -t "lifecycle cap"`
- [ ] Full `npm run test:ci` — Windows environment lacks Linux-only MCP/CLI binaries; Linux CI is authoritative.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] New regression tests cover 301-issue queues where issue #301 carries a duplicate label.

## Notes

Regression tests: `classifies duplicate targets beyond the 300-issue lifecycle cap` in linked-issue-validation and pre-start-check.