### PR TITLE
fix(review): wait for active ci before orb gate

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2039,10 +2039,33 @@ const BOT_OWNED_CHECK_NAMES = new Set<string>([
   GITTENSORY_CONTEXT_CHECK_NAME,
 ]);
 
+const GITHUB_ACTIONS_VALIDATE_AGGREGATE_CONTEXT = "validate";
+const GITHUB_ACTIONS_VALIDATE_AGGREGATE_PREREQUISITES = new Set([
+  "changes",
+  "security",
+  "validate-code",
+]);
+
 function isOwnGitHubAppCheckRun(env: Env, run: GitHubCheckRunPayload): boolean {
   const appSlug = typeof run.app?.slug === "string" ? run.app.slug.trim().toLowerCase() : "";
   const ownSlug = env.GITHUB_APP_SLUG.trim().toLowerCase();
   return ownSlug.length > 0 && appSlug === ownSlug && BOT_OWNED_CHECK_NAMES.has(run.name);
+}
+
+function normalizeCiContextName(name: string): string {
+  const trimmed = name.trim();
+  const slashIndex = trimmed.lastIndexOf("/");
+  return slashIndex >= 0 ? trimmed.slice(slashIndex + 1).trim() : trimmed;
+}
+
+function missingConventionalValidateAggregate(contextNames: ReadonlySet<string>): boolean {
+  const normalized = new Set<string>();
+  for (const name of contextNames) normalized.add(normalizeCiContextName(name));
+  if (normalized.has(GITHUB_ACTIONS_VALIDATE_AGGREGATE_CONTEXT)) return false;
+  for (const prerequisite of GITHUB_ACTIONS_VALIDATE_AGGREGATE_PREREQUISITES) {
+    if (!normalized.has(prerequisite)) return false;
+  }
+  return true;
 }
 
 export type LiveCiAggregate = {
@@ -2051,6 +2074,9 @@ export type LiveCiAggregate = {
   // than ciState: a non-required pending check must not fail the gate, but review execution should still wait
   // until every visible CI signal has settled.
   hasPending: boolean;
+  // A currently visible check-run/status/suite is still queued, waiting, or in_progress. Unlike inferred missing
+  // contexts or unreadable pages, this is active CI and must not be overridden by the stale-CI surfacing cap.
+  hasVisiblePending: boolean;
   // Checks that FAIL the gate. Any completed red check/status is adverse, required or not; required contexts are
   // still used for absent/pending detection so missing required CI cannot silently pass.
   failingDetails: Array<{ name: string; summary?: string; detailsUrl?: string }>;
@@ -2103,7 +2129,7 @@ export async function fetchLiveCiAggregate(
   // Completed red checks/statuses still fail the aggregate even when they are not branch-protection-required.
   requiredContexts?: ReadonlySet<string> | null,
 ): Promise<LiveCiAggregate> {
-  if (!headSha) return { ciState: "unverified", hasPending: false, failingDetails: [], nonRequiredFailingDetails: [] };
+  if (!headSha) return { ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] };
   const enforceRequiredOnly = requiredContexts != null && requiredContexts.size > 0;
   const isRequired = (name: string): boolean => !enforceRequiredOnly || requiredContexts.has(name);
   const failingDetails: LiveCiAggregate["failingDetails"] = [];
@@ -2121,10 +2147,10 @@ export async function fetchLiveCiAggregate(
   // if the suites read is unreadable AND we never saw a first-party run, we cannot confirm the workflow ran, so
   // we must fail CLOSED rather than certify "passed" off only always-on third-party checks (#review-audit, #1799).
   let sawFirstPartyCheckRun = false;
-  // Track which required context names actually appear in any API result. An absent required context
-  // (never queued, in-progress, or complete) has no entry to push anyPending — without this guard it
-  // would be silently ignored and ciState could become "passed" while it never ran.
-  const seenContextNames = enforceRequiredOnly ? new Set<string>() : null;
+  // Track which context names actually appear in any API result. Required contexts use this to catch an absent
+  // required check, and fold-all mode uses it to catch this repo family's late-materializing aggregate `validate`
+  // check when branch-protection/ruleset contexts are not readable.
+  const seenContextNames = new Set<string>();
 
   // 1) Check-runs (GitHub Actions jobs, CodeQL, app checks).
   for (let page = 1; page <= PR_DETAIL_MAX_PAGES; page += 1) {
@@ -2140,7 +2166,7 @@ export async function fetchLiveCiAggregate(
       break;
     }
     for (const run of result.data.check_runs ?? []) {
-      seenContextNames?.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
+      seenContextNames.add(run.name); // mark BEFORE bot-check skip: a bot-owned required context is "seen"
       if ((run.app?.slug ?? "").toLowerCase() === "github-actions") sawFirstPartyCheckRun = true;
       if (isOwnGitHubAppCheckRun(env, run)) continue; // never wait on the bot's own Gate/Context check-runs (see above)
       total += 1;
@@ -2182,7 +2208,7 @@ export async function fetchLiveCiAggregate(
   for (const ctx of commitStatuses) {
     const name = ctx.context ?? "status";
     total += 1;
-    seenContextNames?.add(name);
+    seenContextNames.add(name);
     const state = (ctx.state ?? "").toLowerCase();
     if (state === "failure" || state === "error") {
       const summary = typeof ctx.description === "string" ? ctx.description.trim().slice(0, 200) : "";
@@ -2198,13 +2224,19 @@ export async function fetchLiveCiAggregate(
   // A required context that never appeared in any result is not safe to treat as passed — count it as pending
   // so the gate waits rather than approving a PR whose required CI never ran (e.g. a workflow that doesn't
   // trigger on forks, or a check that was skipped).
-  if (seenContextNames) {
+  if (enforceRequiredOnly) {
     for (const ctx of requiredContexts!) {
       if (!seenContextNames.has(ctx)) {
         anyPending = true;
-        anyVisiblePending = true;
       }
     }
+  }
+
+  // Branch-protection reads can be unavailable for installation tokens/rulesets. In fold-all mode, a dependent
+  // aggregate check can briefly be absent after its prerequisites have settled; treat that as pending so the Orb
+  // check does not publish before the actual required `validate` context exists.
+  if (!enforceRequiredOnly && missingConventionalValidateAggregate(seenContextNames)) {
+    anyPending = true;
   }
 
   // Check-suite hardening (#ci-foldall-checksuites / #dependent-ci-materialization): the check-run/status scan can
@@ -2249,7 +2281,7 @@ export async function fetchLiveCiAggregate(
     checkRunsIncomplete ||
     statusIncomplete ||
     ciState === "pending";
-  return { ciState, hasPending, failingDetails, nonRequiredFailingDetails };
+  return { ciState, hasPending, hasVisiblePending: anyVisiblePending, failingDetails, nonRequiredFailingDetails };
 }
 
 /**

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1877,14 +1877,13 @@ async function prReadyForReview(
   // block/close, but hasPending tracks any visible non-bot CI that is not settled yet.
   const ci = await cachedLiveCiAggregate(env, repoFullName, liveFacts, pr.headSha, pr.baseRef, token).catch(() => undefined);
   if (ci?.hasPending) {
-    // Staleness cap: genuinely-running CI settles in minutes. A required check that stays pending far longer
-    // (an orphaned / never-completing check — e.g. a fork check that never reports back) would otherwise make us
-    // defer FOREVER → the PR is silently stuck and never surfaces (the dominant metagraphed stall). Past
-    // STUCK_CI_DEFER_MS we stop deferring and let the gate FINALIZE, so the PR is surfaced (held / needs-human),
-    // or disposed if a verdict is reachable — never silently deferred. first-seen is tracked in the self-host
-    // Redis transient cache per PR+headSha (a new push = new SHA = fresh window); a cache miss degrades to the
-    // old defer (safe — never acts early). (#ci-stuck-finalize)
+    // Staleness cap: inferred or unreadable pending CI can otherwise defer FOREVER (orphaned required context,
+    // transiently unreadable pages, fork check that never reports). Past STUCK_CI_DEFER_MS we stop deferring and
+    // let the gate FINALIZE so the PR surfaces. A visibly queued/in_progress GitHub check/status is active CI,
+    // though, so never cut in front of it. first-seen is tracked in the self-host Redis transient cache per
+    // PR+headSha (a new push = a fresh window); a cache miss degrades to the old defer. (#ci-stuck-finalize)
     if (
+      ci.hasVisiblePending ||
       !(await ciPendingDeferStuck(env, repoFullName, pr.number, pr.headSha))
     ) {
       await recordAuditEvent(env, {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -3405,7 +3405,7 @@ describe("GitHub backfill", () => {
 
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", null, "public-token", null);
 
-      expect(aggregate).toEqual({ ciState: "unverified", hasPending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+      expect(aggregate).toEqual({ ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
@@ -3438,6 +3438,7 @@ describe("GitHub backfill", () => {
 
       expect(aggregate.ciState).toBe("failed");
       expect(aggregate.hasPending).toBe(true);
+      expect(aggregate.hasVisiblePending).toBe(true);
       expect(aggregate.failingDetails.map((detail) => detail.name).sort()).toEqual(["attacker/non-required-check", "attacker/non-required-status"]);
       expect(aggregate.nonRequiredFailingDetails).toEqual([]);
     });
@@ -3474,6 +3475,7 @@ describe("GitHub backfill", () => {
 
       expect(aggregate.ciState).toBe("pending");
       expect(aggregate.hasPending).toBe(true);
+      expect(aggregate.hasVisiblePending).toBe(true);
       expect(aggregate.failingDetails).toEqual([]);
     });
 
@@ -3692,6 +3694,56 @@ describe("GitHub backfill", () => {
       });
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
       expect(aggregate.ciState).toBe("passed");
+    });
+
+    it("fold-all: waits for the required validate aggregate after its prerequisites settle", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?"))
+          return Response.json({
+            check_runs: [
+              { name: "CI / changes", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "CI / validate-code", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "CI / security", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+            ],
+          });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+
+      expect(aggregate.ciState).toBe("pending");
+      expect(aggregate.hasPending).toBe(true);
+      expect(aggregate.hasVisiblePending).toBe(false);
+      expect(aggregate.failingDetails).toEqual([]);
+    });
+
+    it("fold-all: passes once the validate aggregate check exists", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?"))
+          return Response.json({
+            check_runs: [
+              { name: "changes", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "validate-code", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "security", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+              { name: "validate", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+            ],
+          });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+
+      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.hasPending).toBe(false);
+      expect(aggregate.hasVisiblePending).toBe(false);
     });
 
     it("fold-all: an UNREADABLE check-suites read with NO first-party check-run reads PENDING, not passed (#review-audit / #1799)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -980,6 +980,145 @@ describe("queue processors", () => {
     }
   });
 
+  it("keeps deferring when CI is visibly running even after the stale-CI cap", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Still running CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await env.SELFHOST_TRANSIENT_CACHE?.set(
+      "ci-pending-first-seen:owner/agent-repo#7:a7",
+      String(Date.now() - 31 * 60 * 1000),
+      7 * 24 * 3600,
+    );
+    const requiredContextsSpy = vi
+      .spyOn(backfillModule, "fetchRequiredStatusContexts")
+      .mockResolvedValue(null);
+    let gateChecks = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Still running CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ check_runs: [{ name: "CI / validate-code", status: "in_progress", conclusion: null, app: { slug: "github-actions" } }] });
+      if (url.includes("/commits/a7/status")) return Response.json({ statuses: [] });
+      if (url.includes("/check-runs") && method === "POST") {
+        gateChecks += 1;
+        return Response.json({ id: 901 }, { status: 201 });
+      }
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "visible-ci-still-running", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      expect(gateChecks).toBe(0);
+      const deferred = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_deferred_ci_pending")
+        .first<{ n: number }>();
+      const finalized = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_finalized_ci_stuck")
+        .first<{ n: number }>();
+      expect(deferred?.n).toBe(1);
+      expect(finalized?.n).toBe(0);
+    } finally {
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
+  it("keeps deferring inferred pending CI before the stale-CI cap", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregate").mockResolvedValue({
+      ciState: "pending",
+      hasPending: true,
+      hasVisiblePending: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+    });
+    let gateChecks = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/check-runs") && method === "POST") {
+        gateChecks += 1;
+        return Response.json({ id: 901 }, { status: 201 });
+      }
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "fresh-inferred-ci", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      expect(gateChecks).toBe(0);
+      const deferred = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_deferred_ci_pending")
+        .first<{ n: number }>();
+      expect(deferred?.n).toBe(1);
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
+  it("surfaces inferred pending CI after the stale-CI cap", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await env.SELFHOST_TRANSIENT_CACHE?.set(
+      "ci-pending-first-seen:owner/agent-repo#7:a7",
+      String(Date.now() - 31 * 60 * 1000),
+      7 * 24 * 3600,
+    );
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregate").mockResolvedValue({
+      ciState: "pending",
+      hasPending: true,
+      hasVisiblePending: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+    });
+    let gateChecks = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Stale missing aggregate CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/check-runs") && (method === "POST" || method === "PATCH")) {
+        gateChecks += 1;
+        return Response.json({ id: 901 }, { status: method === "POST" ? 201 : 200 });
+      }
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stale-inferred-ci", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      expect(gateChecks).toBeGreaterThan(0);
+      const finalized = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?")
+        .bind("github_app.review_finalized_ci_stuck")
+        .first<{ n: number }>();
+      expect(finalized?.n).toBe(1);
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
   it("#sweep-resync: a failing resync upsert is swallowed (fail-open) — the sweep never throws", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
@@ -4991,6 +5130,7 @@ describe("queue processors", () => {
       .mockResolvedValue({
         ciState: "passed",
         hasPending: false,
+        hasVisiblePending: false,
         failingDetails: [],
         nonRequiredFailingDetails: [],
       });


### PR DESCRIPTION
## Summary
- prevent the Orb gate from publishing while GitHub still has a visible queued or in-progress CI check/status/suite
- keep the stale-CI surfacing cap for inferred or unreadable pending states so orphaned CI does not hide PRs forever
- treat the `changes`/`validate-code`/`security` prerequisite pattern as pending until the aggregate `validate` context exists when required contexts are unavailable

## Why
The review gate could briefly publish before the required aggregate `validate` check had materialized, or after the stale-CI cap even while a live check was still running. That made the Orb check appear to restart before CI had actually settled.

## Validation
- `npm run test:ci`
- `npm audit --audit-level=moderate`
