### PR TITLE
fix(enrichment): memoize generic angle probes

### DIFF
--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -138,7 +138,10 @@ export function parseDocParams(jsdoc: string): string[] {
  *  types (`Map<K, (v: V) => void>`). Generic vs comparison is decided by the char after the matching `>`: a
  *  comparison's `>` is followed by an operand (digit/identifier/string — `removed>0`); a generic close is followed
  *  by a type terminator (`,` `)` `(` `[` `>` `|` `&` whitespace or end). */
-function matchAngle(src: string, open: number): number {
+function matchAngle(src: string, open: number, cache: Map<number, number>): number {
+  const cached = cache.get(open);
+  if (cached !== undefined) return cached;
+  const opens: number[] = [];
   let angle = 0;
   let quote: string | null = null;
   for (let i = open; i < src.length; i++) {
@@ -150,19 +153,31 @@ function matchAngle(src: string, open: number): number {
     if (ch === '"' || ch === "'" || ch === "`") quote = ch;
     else if (ch === "<") {
       if (src[i + 1] === "=") i += 1; // `<=` is a comparison operator, not a generic open
-      else angle += 1;
+      else {
+        angle += 1;
+        opens.push(i);
+      }
     } else if (ch === ">" && src[i - 1] !== "=") {
       // (a `=>` arrow inside a function type — e.g. `Map<K, (v: V) => void>` — is not an angle close.)
-      if (src[i + 1] === "=") return -1; // `>=` is a comparison operator, never a generic close
+      if (src[i + 1] === "=") {
+        cache.set(open, -1);
+        return -1; // `>=` is a comparison operator, never a generic close
+      }
       angle -= 1;
+      opens.pop();
       if (angle === 0) {
         let j = i + 1;
         while (j < src.length && /\s/.test(src[j]!)) j += 1; // the next NON-whitespace token decides
         const next = src[j];
-        return next !== undefined && /[\w$"'`]/.test(next) ? -1 : i;
+        const close = next !== undefined && /[\w$"'`]/.test(next) ? -1 : i;
+        cache.set(open, close);
+        return close;
       }
     }
   }
+  // An unmatched generic-like opener cannot close when probed again from the same point. Remember every still-open
+  // candidate from this scan so repeated attacker-controlled `x<` tokens do not rescan the same suffixes.
+  for (const pending of opens) cache.set(pending, -1);
   return -1;
 }
 
@@ -176,6 +191,7 @@ function splitParams(src: string): string[] | null {
   let depth = 0;
   let start = 0;
   let quote: string | null = null;
+  const angleCache = new Map<number, number>();
   for (let i = 0; i < src.length; i++) {
     const ch = src[i]!;
     if (quote) {
@@ -188,7 +204,7 @@ function splitParams(src: string): string[] | null {
       depth -= 1;
       if (depth < 0) return null;
     } else if (ch === "<" && i > 0 && /[A-Za-z0-9_$]/.test(src[i - 1]!)) {
-      const close = matchAngle(src, i);
+      const close = matchAngle(src, i, angleCache);
       if (close !== -1) i = close; // skip the whole generic argument list, including its commas
     } else if (ch === "," && depth === 0) {
       parts.push(src.slice(start, i));

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -126,6 +126,13 @@ test("parseFunctionParams: comparison operators are not mistaken for generics (c
   assert.equal(parseFunctionParams("a = x<y, removed>0, b"), null);
 });
 
+test("parseFunctionParams: repeated unmatched generic probes stay linear", () => {
+  const params = Array.from({ length: 12_000 }, (_, i) => `p${i} = x<`).join(", ");
+  const start = performance.now();
+  assert.deepEqual(parseFunctionParams(params), Array.from({ length: 12_000 }, (_, i) => `p${i}`));
+  assert.ok(performance.now() - start < 500);
+});
+
 test("parseFunctionParams: fails closed (null) on destructuring or unbalanced brackets", () => {
   assert.equal(parseFunctionParams("{ a, b }"), null);
   assert.equal(parseFunctionParams("[a, b]"), null);


### PR DESCRIPTION
### Motivation
- Prevent quadratic/CPU-DoS behavior in `doc-comment-drift` when many unmatched identifier-adjacent `<` probes repeatedly scan the same suffixes during parameter parsing. This preserves the generic-aware parsing improvements while making adversarial inputs linear-time.

### Description
- Add a per-parse `angleCache: Map<number, number>` and thread it into `splitParams`, so all `matchAngle` probes for a single parameter list share memoized results. (`splitParams`, `matchAngle`, `parseFunctionParams` in `review-enrichment/src/analyzers/doc-comment-drift.ts`).
- Update `matchAngle` to consult and populate the cache, record definitive closes, and mark still-open unmatched `<` candidates as `-1` so repeated probes do not re-scan the same suffix.
- Add a regression/performance test `parseFunctionParams: repeated unmatched generic probes stay linear` that constructs a long parameter list of repeated `x<` probes and asserts parsing correctness and bounded elapsed time (`review-enrichment/test/doc-comment-drift.test.ts`).

### Testing
- Ran the review-enrichment unit suite with `npm --prefix review-enrichment test` and all tests passed (347 tests, 0 failures), including the new regression test which exercised the linear-time behavior.
- Built the review-enrichment package (`npm --prefix review-enrichment run build`) successfully (TypeScript compile succeeded).
- Attempted full repo gate `npm run test:ci`, but it could not complete in this environment due to external/network setup issues: `actionlint` setup failed to reach GitHub (DNS/EAI_AGAIN) and the WASM fallback raised workflow label errors, and `npm audit --audit-level=moderate` returned `403 Forbidden`; these failures are environmental and not related to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44495a6924832c8da7cf9f496749f2)