### PR TITLE
fix(rees): scan complete patches for secrets

### DIFF
--- a/review-enrichment/src/analyzers/secret/descriptor.ts
+++ b/review-enrichment/src/analyzers/secret/descriptor.ts
@@ -1,5 +1,5 @@
 import type { AnalyzerDescriptor } from "../types.js";
-import { scanAddedLinesForSecrets } from "../secret-scan.js";
+import { scanSecrets } from "../secret-scan.js";
 
 export const secretAnalyzer: AnalyzerDescriptor<"secret"> = {
   name: "secret",
@@ -17,8 +17,7 @@ export const secretAnalyzer: AnalyzerDescriptor<"secret"> = {
     notes:
       "High-confidence patterns are treated as rotate-and-remove candidates; generic assignments stay verify-first.",
   },
-  run: (_req, { analysis }) =>
-    Promise.resolve(scanAddedLinesForSecrets(analysis.addedLines)),
+  run: (req) => scanSecrets(req),
   render: (secrets, { safeCodeSpan }) => {
     const lines: string[] = [];
     if (!secrets.length) return lines;

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -70,6 +70,39 @@ test("buildBrief uses the descriptor-derived default registry", async () => {
   assert.equal(brief.analyzerStatus.dependency, "skipped");
 });
 
+test("secret analyzer scans added lines beyond shared context cap", async () => {
+  const syntheticGithubToken = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");
+  const paddedPatch = [
+    "@@ -1,0 +1,5001 @@",
+    ...Array.from({ length: 5000 }, (_, index) => `+const harmless${index} = ${index};`),
+    `+const token = "${syntheticGithubToken}";`,
+  ].join("\n");
+
+  const brief = await buildBrief({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1809,
+    analyzers: ["secret"],
+    files: [
+      {
+        path: "src/padded-secret.ts",
+        patch: paddedPatch,
+      },
+    ],
+  });
+
+  assert.equal(brief.partial, false);
+  assert.equal(brief.analyzerStatus.secret, "ok");
+  assert.deepEqual(brief.findings.secret, [
+    {
+      file: "src/padded-secret.ts",
+      line: 5001,
+      kind: "github_token",
+      confidence: "high",
+    },
+  ]);
+  assert.match(brief.promptSection, /src\/padded-secret\.ts:5001/);
+});
+
 test("migrated analyzers own their prompt rendering through descriptors", () => {
   assert.equal(typeof getAnalyzerDescriptor("dependency")?.render, "function");
   assert.equal(typeof getAnalyzerDescriptor("secret")?.render, "function");


### PR DESCRIPTION
### Motivation

- A recently introduced shared added-line context is capped and can silently omit later added lines, letting an attacker pad a diff before a secret and cause the hardcoded-secret analyzer to miss it. The change ensures the secret analyzer examines the full per-file patch so secrets cannot be hidden by padding. 

### Description

- Route the hardcoded-secret analyzer to the full-patch scanner by replacing the descriptor run implementation to call `scanSecrets(req)` instead of `scanAddedLinesForSecrets(analysis.addedLines)` in `review-enrichment/src/analyzers/secret/descriptor.ts`.
- Add a regression test `secret analyzer scans added lines beyond shared context cap` to `review-enrichment/test/analyzer-registry.test.ts` that constructs a patch with 5,000 harmless added lines followed by a token-shaped added line and asserts the secret is reported at the expected file:line.

### Testing

- Ran the targeted REES unit tests with `npm --prefix review-enrichment test -- --test-name-pattern "secret analyzer scans added lines beyond shared context cap|buildBrief uses the descriptor-derived default registry"` and the tests passed. 
- Ran the full REES test suite via `npm run rees:test` (which builds and runs all REES tests) and all tests passed (all REES tests reported passing). 
- Attempting the repository-wide gate with `npm run test:ci` and `npm audit --audit-level=moderate` could not be completed in this environment due to external network / registry access issues (actionlint setup network lookup and `npm audit` returned remote errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444c92fb4c832c84d07812c4756d09)