### PR TITLE
fix(enrichment): parse PyPI exact pins declared with PEP 508 extras

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -44,7 +44,11 @@ interface ScanOptions {
 const NPM_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;
 const NPM_ALIAS_RE = /^npm:(@[^/]+\/[^@]+|[^@]+)@(.+)$/;
 const NPM_VERSION_PREFIX_RE = /^[\^~>=<\s]+/;
-const PYPI_RE = /^([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s;]*)/;
+// The optional `[extras]` group (PEP 508 — requests[security], uvicorn[standard], celery[redis,auth])
+// must be consumed but not captured: OSV.dev keys PyPI by the base project name, and a class that
+// stopped at `[` silently dropped every pinned-with-extras dependency from the CVE scan.
+const PYPI_RE =
+  /^([A-Za-z0-9._-]+)(?:\[[A-Za-z0-9._,\s-]+\])?\s*==\s*([0-9][^\s;]*)/;
 const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;
 
 function parseLine(

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -130,6 +130,19 @@ test("extractDependencyChanges: PyPI + Go ecosystems", () => {
   assert.equal(eco.Go.to, "1.2.3");
 });
 
+test("extractDependencyChanges: PyPI exact pins with PEP 508 extras are parsed under the base name", () => {
+  // requests[security]==x is a valid exact pin; a path class that stopped at `[` dropped it from the
+  // OSV scan. The extras are consumed but not captured — OSV keys PyPI by the base project name.
+  const changes = extractDependencyChanges([
+    { path: "requirements.txt", patch: "+requests[security]==2.31.0\n-requests[security]==2.30.0" },
+    { path: "requirements.txt", patch: "+celery[redis,auth]==5.4.0" },
+  ]);
+  const byPkg = Object.fromEntries(changes.map((c) => [c.package, c]));
+  assert.equal(byPkg.requests.to, "2.31.0");
+  assert.equal(byPkg.requests.from, "2.30.0");
+  assert.equal(byPkg.celery.to, "5.4.0");
+});
+
 test("queryOsv: maps vulns; severity from database_specific; fixedIn from affected; [] on non-ok", async () => {
   const cves = await queryOsv(
     "npm",


### PR DESCRIPTION
## Summary

The `requirements.txt` parser in the REES dependency scanner used a package character class that stopped at `[`:

    const PYPI_RE = /^([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s;]*)/;

So any **exact pin declared with PEP 508 extras** — `requests[security]==2.31.0`, `uvicorn[standard]==0.30.0`, `celery[redis,auth]==5.4.0` — failed to match and was silently dropped from `extractDependencyChanges`. The dependency then never reached any dependency-fed analyzer — the OSV.dev CVE scan, license, provenance, and native-build checks. Extras on a pinned requirement are a common, idiomatic form, so this is a real review blind spot: a vulnerable, extras-declared dependency added in a PR would never be flagged.

This adds an optional, non-capturing PEP 508 `[extras]` group between the name and `==`:

    const PYPI_RE =
      /^([A-Za-z0-9._-]+)(?:\[[A-Za-z0-9._,\s-]+\])?\s*==\s*([0-9][^\s;]*)/;

OSV.dev keys PyPI by the base project name, so the extras are consumed but **not** captured — the queried name is unchanged. The change is strictly more permissive: plain pins and environment markers (`pkg==1.0 ; python_version >= '3.10'`) parse exactly as before, and non-`==` lines remain ignored by design.

A regression test asserts single- and multi-extra pins are parsed under their base name.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — a small, self-evident parser fix; the rationale is in the Summary.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment test` (build → validate sourcemaps → analyzer-metadata check → full REES suite) — green; the new PEP 508 extras regression test passes.

If any required check was skipped, explain why:

- The change is entirely within `review-enrichment/src/analyzers/dependency-scan.ts` and its test; the relevant local gate is the REES suite (`rees:test`), which is green. The root `src/**` coverage jobs do not cover this package.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI changes.
- [x] No docs/changelog changes.

