### PR TITLE
fix(enrichment): accept full Go module path punctuation in dependency scan

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -45,7 +45,13 @@ const NPM_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;
 const NPM_ALIAS_RE = /^npm:(@[^/]+\/[^@]+|[^@]+)@(.+)$/;
 const NPM_VERSION_PREFIX_RE = /^[\^~>=<\s]+/;
 const PYPI_RE = /^([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s;]*)/;
-const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;
+// Go module paths are case-sensitive and the element grammar admits A-Z plus the full
+// punctuation set Go allows (`. _ ~ -`, per golang.org/x/mod/module modPathOK), not just `.`/`-`.
+// A narrower class silently drops uppercase or `_`/`~` paths (github.com/BurntSushi/toml,
+// github.com/foo_bar/baz, golang.org/x/~exp) from every dependency-fed scanner (CVE, license,
+// provenance, native-build). The class stays strictly more permissive, so lowercase paths are
+// unaffected, and the case-sensitive name is preserved verbatim for the OSV lookup.
+const GO_RE = /^([A-Za-z0-9._~\/-]+)\s+v([0-9][^\s]*)/;
 
 function parseLine(
   manifest: string,

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -130,6 +130,20 @@ test("extractDependencyChanges: PyPI + Go ecosystems", () => {
   assert.equal(eco.Go.to, "1.2.3");
 });
 
+test("extractDependencyChanges: Go paths with uppercase and `_`/`~` punctuation are parsed", () => {
+  // Go module paths are case-sensitive and admit the full `. _ ~ -` punctuation set; a narrower
+  // path class would silently drop these deps from the OSV scan. Names are preserved verbatim.
+  const changes = extractDependencyChanges([
+    { path: "go.mod", patch: "+\tgithub.com/BurntSushi/toml v1.4.0" },
+    { path: "go.mod", patch: "+\tgithub.com/foo_bar/baz v0.9.1" },
+    { path: "go.mod", patch: "+\texample.com/x/~exp v1.0.0" },
+  ]);
+  const byPkg = Object.fromEntries(changes.map((c) => [c.package, c]));
+  assert.equal(byPkg["github.com/BurntSushi/toml"].to, "1.4.0");
+  assert.equal(byPkg["github.com/foo_bar/baz"].to, "0.9.1");
+  assert.equal(byPkg["example.com/x/~exp"].to, "1.0.0");
+});
+
 test("queryOsv: maps vulns; severity from database_specific; fixedIn from affected; [] on non-ok", async () => {
   const cves = await queryOsv(
     "npm",


### PR DESCRIPTION
## Summary

The `go.mod` line parser in the REES dependency scanner used a lowercase-only path character class:

    const GO_RE = /^([a-z0-9.\/-]+)\s+v([0-9][^\s]*)/;

This was narrower than Go's actual module-path grammar in two ways. Go's `golang.org/x/mod/module.modPathOK` permits ASCII letters (case-sensitive), digits, and the punctuation set `- . _ ~` (plus `/` as separator) — but the class accepted only `.` and `-`, rejecting **uppercase** segments and the **`_`/`~`** punctuation.

Go module paths legitimately contain all of these — `github.com/BurntSushi/toml`, `github.com/Masterminds/semver`, `github.com/foo_bar/baz`, `golang.org/x/~exp`, or any capitalized GitHub owner. A non-matching line is silently dropped from `extractDependencyChanges`, so the dependency never reaches any dependency-fed analyzer — the OSV.dev CVE scan, license, provenance, and native-build checks. The result is a real review blind spot: a vulnerable dependency with such a path added in a PR would never be flagged.

This widens the class to `[A-Za-z0-9._~\/-]`, matching `modPathOK` exactly:

    const GO_RE = /^([A-Za-z0-9._~\/-]+)\s+v([0-9][^\s]*)/;

The change is strictly more permissive, so existing lowercase paths are unaffected, and the case-sensitive name is preserved verbatim for the OSV lookup. This supersedes #1911 (which fixed only the uppercase half) and closes the adjacent-punctuation parser gap noted in that review.

A regression test asserts uppercase, underscore, and tilde Go module paths are now parsed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — a small, self-evident parser fix; the rationale is in the Summary.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment test` (build → validate sourcemaps → analyzer-metadata check → full REES suite) — green; the new uppercase/`_`/`~` regression test passes.

If any required check was skipped, explain why:

- The change is entirely within `review-enrichment/src/analyzers/dependency-scan.ts` and its test; the relevant local gate is the REES suite (`rees:test`), which is green. The root `src/**` coverage jobs do not cover this package.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI changes.
- [x] No docs/changelog changes.

## Notes

- This is the follow-up the maintainer requested on #1911: it lands both the uppercase fix and the remaining `_`/`~` adjacent-punctuation gap so the Go path class matches Go module syntax exactly.
