### PR TITLE
fix(mcp): parse git:// GitHub remotes in local branch metadata

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -11,6 +11,7 @@ export function parseGitRemote(remoteUrl) {
     /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
     /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
     /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^git:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
   ];
   for (const pattern of patterns) {
     const match = trimmed.match(pattern);

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1743,6 +1743,7 @@ describe("local MCP git metadata collection", () => {
     expect(parseGitRemote("git@github.com:entrius/allways-ui.git")).toBe("entrius/allways-ui");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory/")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("git://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
 
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));
     git(tempDir, "init");


### PR DESCRIPTION
## Summary
- Teach `parseGitRemote` to accept legacy `git://github.com/owner/repo(.git)` remotes.
- Lets local MCP preflight infer `repoFullName` without `--repo` for that URL shape.

## Test plan
- [x] `npx vitest run test/unit/local-branch.test.ts -t \"parses remotes\"`

