### PR TITLE
fix(mcp): avoid regex slash trimming in remote parsing

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -5,8 +5,14 @@ import { fileURLToPath } from "node:url";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+function stripTrailingSlashes(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 export function parseGitRemote(remoteUrl) {
-  const trimmed = String(remoteUrl ?? "").trim().replace(/\/+$/, "");
+  const trimmed = stripTrailingSlashes(String(remoteUrl ?? "").trim());
   const patterns = [
     /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
     /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1743,6 +1743,8 @@ describe("local MCP git metadata collection", () => {
     expect(parseGitRemote("git@github.com:entrius/allways-ui.git")).toBe("entrius/allways-ui");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory/")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("https://github.com/JSONbored/gittensory////")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote(`x${"/".repeat(32_000)}x`)).toBeUndefined();
 
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));
     git(tempDir, "init");


### PR DESCRIPTION
### Motivation

- The previous trailing-slash normalization used `replace(/\/+$/, "")`, which can trigger quadratic backtracking on attacker-controlled long runs of slashes and hang local MCP/CLI runs. 
- The change hardens local MCP availability by removing the backtracking-prone regex while preserving existing remote parsing semantics.

### Description

- Replaced the regex-based trailing-slash removal in `parseGitRemote` with a linear `stripTrailingSlashes` scanner to avoid regex backtracking (file: `packages/gittensory-mcp/lib/local-branch.js`).
- Kept the original GitHub remote matching patterns and return shape (`owner/repo`) intact so behavior is preserved for valid remotes.
- Added regression assertions to `test/unit/local-branch.test.ts` that cover multiple trailing slashes and a crafted long slash-run followed by a non-slash to exercise the previously-vulnerable path.

### Testing

- Ran the focused unit test `npx vitest run test/unit/local-branch.test.ts -t "parses remotes"` and it passed. 
- `npm run build:mcp`, `npm run test:mcp-pack`, and `npm run typecheck` completed successfully. 
- Full `npm run test:coverage` / `npm run test:ci` could not complete in this environment because `actionlint` setup failed due to network/DNS issues and the audit endpoint returned `403 Forbidden`, and a scoped coverage run showed the focused test passed but global coverage thresholds were not met when only the single-file coverage was measured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444bc87790832c8c30202b1b0251af)