### PR TITLE
fix(orb): back off per-failure relay retries to avoid a fleet-wide storm (#1950)

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -141,6 +141,11 @@ export async function registerOrbRelay(env: Env, secret: string, relayUrl: strin
 const RELAY_RETRY_MAX_ATTEMPTS = 5;
 const RELAY_RETRY_BATCH_SIZE = 25;
 const RELAY_RETRY_CONCURRENCY = 5;
+// Per-failure backoff (#1950): a row that just failed is not retried again until this window elapses, so a
+// sustained outage does not re-attempt the whole failed-relay backlog on every ~2-min cron tick — which, fleet-wide,
+// is a synchronized POST storm against the central Orb exactly when it is already degraded. Never-attempted rows
+// (last_attempt_at IS NULL) stay immediately eligible, so a transient blip still recovers on the very next tick.
+const RELAY_RETRY_BACKOFF_MINUTES = 5;
 
 // Pull-mode relay (#16): a brokered self-host behind NAT/tailnet can't receive PUSHED forwards, so the Orb instead
 // ENQUEUES its events here and the engine drains them outbound. The batch caps how many rows a single pull returns
@@ -276,11 +281,14 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
   if (pruned.meta.changes > 0) {
     console.error(JSON.stringify({ level: "error", event: "orb_relay_events_dropped", message: `${pruned.meta.changes} relay event(s) dropped after ${RELAY_RETRY_MAX_ATTEMPTS} retries or 1h TTL`, count: pruned.meta.changes }));
   }
+  // Skip rows still inside their per-failure backoff window (#1950): a row whose last attempt was under
+  // RELAY_RETRY_BACKOFF_MINUTES ago waits for a later tick, so a down container is not re-POSTed every ~2 min.
+  // The bound modifier keeps this portable (the pg-dialect rewrites datetime('now', ?) → now() + (?)::interval).
   const { results } = await env.DB
     .prepare(
-      "SELECT delivery_id, event_name, installation_id, raw_body FROM orb_relay_failures WHERE expires_at >= datetime('now') AND attempts < ? ORDER BY created_at, delivery_id LIMIT ?",
+      "SELECT delivery_id, event_name, installation_id, raw_body FROM orb_relay_failures WHERE expires_at >= datetime('now') AND attempts < ? AND (last_attempt_at IS NULL OR last_attempt_at <= datetime('now', ?)) ORDER BY created_at, delivery_id LIMIT ?",
     )
-    .bind(RELAY_RETRY_MAX_ATTEMPTS, RELAY_RETRY_BATCH_SIZE)
+    .bind(RELAY_RETRY_MAX_ATTEMPTS, `-${RELAY_RETRY_BACKOFF_MINUTES} minutes`, RELAY_RETRY_BATCH_SIZE)
     .all<{ delivery_id: string; event_name: string; installation_id: number; raw_body: string }>();
   if (!results.length) return;
 

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -335,6 +335,41 @@ describe("retryFailedRelays", () => {
     expect(row?.attempts).toBe(1);
   });
 
+  it("SKIPS a row still inside its per-failure backoff window (#1950)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9600);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    // A row that last failed 1 minute ago (attempts=1) is inside the 5-minute backoff window.
+    await db(e)
+      .prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, attempts, last_attempt_at) VALUES (?, ?, ?, ?, ?, datetime('now', '-1 minutes'))")
+      .bind("backoff-recent", "pull_request", 9600, "{}", 1)
+      .run();
+    let calls = 0;
+    const fetchFail = (() => {
+      calls += 1;
+      return Promise.resolve(new Response("bad", { status: 503 }));
+    }) as typeof fetch;
+    await retryFailedRelays(e, { fetchImpl: fetchFail });
+    expect(calls).toBe(0); // backed off → not re-POSTed this tick, so no fleet-wide storm on a down container
+    const row = await db(e).prepare("SELECT attempts FROM orb_relay_failures WHERE delivery_id='backoff-recent'").first<{ attempts: number }>();
+    expect(row?.attempts).toBe(1); // untouched
+  });
+
+  it("RETRIES a row once its per-failure backoff window has elapsed (#1950)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 9601);
+    await registerOrbRelay(e, secret, "https://c.example/v1/orb/relay");
+    // A row that last failed 10 minutes ago (attempts=1) is past the 5-minute backoff → eligible again.
+    await db(e)
+      .prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, attempts, last_attempt_at) VALUES (?, ?, ?, ?, ?, datetime('now', '-10 minutes'))")
+      .bind("backoff-elapsed", "pull_request", 9601, "{}", 1)
+      .run();
+    const fetchFail = (() => Promise.resolve(new Response("bad", { status: 503 }))) as typeof fetch;
+    await retryFailedRelays(e, { fetchImpl: fetchFail });
+    const row = await db(e).prepare("SELECT attempts FROM orb_relay_failures WHERE delivery_id='backoff-elapsed'").first<{ attempts: number }>();
+    expect(row?.attempts).toBe(2); // eligible → retried, attempts incremented
+  });
+
   it("DELETES a row when forwardOrbEvent skips it (event no longer forwardable)", async () => {
     const e = brokeredEnv();
     // Store a failure for an event that was later removed from RELAY_FORWARD_EVENTS (e.g. check_run).


### PR DESCRIPTION
## Summary

`retryFailedRelays` (the `retry-orb-relay` cron, ~every 2 min) already bounds its per-tick work (`RELAY_RETRY_BATCH_SIZE`) and per-row attempts (5 / 1h TTL), but a row was eligible on **every** tick regardless of when it last failed. During a sustained outage of a brokered container, every self-host in the fleet re-POSTs its whole failed-relay backlog every 2 minutes — a synchronized outbound storm against the central Orb exactly when it is already degraded.

This adds a per-failure backoff: a row whose `last_attempt_at` is under `RELAY_RETRY_BACKOFF_MINUTES` (5) old is skipped until a later tick, so a down container is re-attempted at most ~every 5 min instead of every 2. **Never-attempted rows (`last_attempt_at IS NULL`) stay immediately eligible**, so a transient blip still recovers on the very next tick. No schema change — the store already has `attempts` + `last_attempt_at`.

Portability: the backoff bound is a modifier parameter (`datetime('now', ?)`), which the self-host PG dialect rewrites to `now() + (?)::interval` (line `src/selfhost/pg-dialect.ts:44`), so the placeholder count/order is unchanged across SQLite (D1) and Postgres.

Advances #1950 (rec #15 from the #1936 audit) and meets its acceptance criteria: per-instance POST rate decays during a sustained outage, and the backlog still drains within a bounded number of ticks after recovery.

## Scope

- [x] Conventional Commit title.
- [x] Focused, backend-only change (one file + tests).
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`.
- [x] Linked issue (advances #1950).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — the changed `retryFailedRelays` select is exercised by the existing `orb-relay` integration suite; added two regression tests covering **both** sides of the backoff (a row still inside the window is skipped and not re-POSTed; a row past the window is retried and its attempts increment). The `last_attempt_at IS NULL` immediate-eligibility path stays covered by the existing store→retry tests.
- [x] `npm run test:ci`
- [x] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No `ui:openapi` / `cf-typegen` / migration regen: reuses the existing `orb_relay_failures.last_attempt_at` column; no API/schema/binding/DB change.

## Safety

- [x] No secrets/wallets/hotkeys/trust-scores/etc.
- [x] No public GitHub text change.
- [x] No auth/CORS/session change.
- [x] No API/OpenAPI/MCP change. No UI change.

## Notes

- Chose a fixed 5-minute backoff over per-attempt exponential to keep the SQL portable (a per-row exponential interval would need `(1 << attempts)` inside the `datetime()` modifier, whose parentheses break the pg-dialect rewrite regex). Fixed backoff already satisfies the "rate decays" acceptance criterion; exponential can be a follow-up if the fleet needs a longer tail.
