### PR TITLE
feat(scoring): surface the issue-discovery validity floor in the score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -156,6 +156,62 @@ function timeDecayBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdo
   };
 }
 
+// Issue-discovery validity floor (upstream MIN_VALID_SOLVED_ISSUES + MIN_ISSUE_CREDIBILITY; constants.py
+// mirror #808): a preview that engages the issue-discovery lane but has fewer solved-issues or lower
+// credibility than the upstream floors has the multiplier zeroed. Mirrors mergedHistoryBreakdown /
+// openPr / openIssue so the public projection explains the gate cleanly without collapsing the two
+// evidence dimensions into a single phrase (the nit that closed the previous attempt at this surface).
+function issueDiscoveryHistoryBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
+  const { issueDiscoveryHistoryMultiplier } = preview.scoreEstimate;
+  const { validSolvedIssues, validSolvedIssuesFloor, issueCredibility, issueCredibilityFloor } = preview.gates;
+  const relevant = preview.linkedIssueMultiplier.mode !== "none";
+  const known = validSolvedIssues !== undefined && issueCredibility !== undefined;
+  if (issueDiscoveryHistoryMultiplier >= 1) {
+    if (!relevant) {
+      return {
+        component: "issueDiscoveryHistoryMultiplier",
+        band: "neutral",
+        summary: "Issue-discovery lane is not engaged for this preview (linked-issue mode is none), so the validity floor multiplier is 1 by intent.",
+        lever: "Select a linked-issue mode (standard or maintainer) on subsequent previews to engage the issue-discovery lane.",
+        leverageScore: 0,
+      };
+    }
+    if (!known) {
+      const dimClauses: string[] = [];
+      if (validSolvedIssues !== undefined) dimClauses.push(`${validSolvedIssues} valid solved-issue(s) observed`);
+      else dimClauses.push("valid solved-issue count still missing");
+      if (issueCredibility !== undefined) dimClauses.push(`${(issueCredibility * 100).toFixed(0)}% credibility observed`);
+      else dimClauses.push("issue credibility still missing");
+      return {
+        component: "issueDiscoveryHistoryMultiplier",
+        band: "neutral",
+        summary: `Issue-discovery validity floor is partially observed for this preview (${dimClauses.join("; ")}; upstream floors are ${validSolvedIssuesFloor} solved and ${(issueCredibilityFloor * 100).toFixed(0)}% credibility).`,
+        lever: "No action needed; the floor is not enforced until both dimensions are observed in a subsequent preview.",
+        leverageScore: 0,
+      };
+    }
+    return {
+      component: "issueDiscoveryHistoryMultiplier",
+      band: "full",
+      summary: `Issue-discovery evidence meets both upstream floors (${validSolvedIssues} solved / ${(issueCredibility! * 100).toFixed(0)}% credibility vs floors ${validSolvedIssuesFloor} / ${(issueCredibilityFloor * 100).toFixed(0)}%).`,
+      lever: "Keep issue-discovery activity healthy: file solvable issues and resolve them with validated PRs.",
+      leverageScore: 4,
+    };
+  }
+  const failSolved = validSolvedIssues !== undefined && validSolvedIssues < validSolvedIssuesFloor;
+  const failCredibility = issueCredibility !== undefined && issueCredibility < issueCredibilityFloor;
+  const causes: string[] = [];
+  if (failSolved) causes.push(`valid solved issues (${validSolvedIssues} < ${validSolvedIssuesFloor})`);
+  if (failCredibility) causes.push(`issue credibility (${(issueCredibility! * 100).toFixed(0)}% < ${(issueCredibilityFloor * 100).toFixed(0)}%)`);
+  return {
+    component: "issueDiscoveryHistoryMultiplier",
+    band: "blocked",
+    summary: `Issue-discovery validity floor is failing the preview: ${causes.join(" and ")}.`,
+    lever: "Land more solved issues (each with a solving-PR token-score ≥ upstream MIN_TOKEN_SCORE_FOR_VALID_ISSUE) and stabilize credibility at or above the floor before relying on this preview.",
+    leverageScore: 100,
+  };
+}
+
 function credibilityBreakdown(preview: ScorePreviewResult): ScoreMultiplierBreakdown {
   const { credibilityMultiplier } = preview.scoreEstimate;
   const { credibilityObserved, credibilityFloor } = preview.gates;
@@ -319,6 +375,7 @@ export function explainScoreBreakdown(preview: ScorePreviewResult): ScoreBreakdo
     openIssueBreakdown(preview),
     mergedHistoryBreakdown(preview),
     timeDecayBreakdown(preview),
+    issueDiscoveryHistoryBreakdown(preview),
   ].map((entry) => ({
     ...entry,
     summary: sanitizePublicComment(entry.summary),

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -86,6 +86,7 @@ describe("explainScoreBreakdown", () => {
         "openIssueMultiplier",
         "mergedHistoryMultiplier",
         "timeDecayMultiplier",
+        "issueDiscoveryHistoryMultiplier",
       ]),
     );
     for (const component of breakdown.components) {
@@ -187,6 +188,141 @@ describe("explainScoreBreakdown", () => {
     expect(decayed.summary).toMatch(/time-decayed|decay/i);
     expect(decayed.lever).toMatch(/fresh|time-decay curve|sigmoid/i);
     expect(JSON.stringify(agedBreakdown)).not.toMatch(FORBIDDEN);
+  });
+
+  it("explains the issue-discovery history floor: lane-off / unobserved neutral, meeting-floor full, below-floor blocked", () => {
+    // Lane not engaged (linkedIssueMode=none) => multiplier is 1 by intent, breakdown neutral + lane-off copy.
+    const laneOff = explainScoreBreakdown(
+      buildScorePreview({ repo, snapshot, input: { repoFullName: repo.fullName, contributorLogin: "miner", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80, openPrCount: 1, credibility: 0.9, linkedIssueMode: "none" } }),
+    );
+    expect(laneOff.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")).toMatchObject({ band: "neutral" });
+
+    // Lane engaged + only one dimension observed => partial-evidence neutral that explicitly names the
+    // missing dim (avoids the collapse-copy nit from #1874).
+    const partial = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          contributorLogin: "miner",
+          sourceTokenScore: 40,
+          totalTokenScore: 60,
+          sourceLines: 80,
+          openPrCount: 1,
+          credibility: 0.9,
+          linkedIssueMode: "standard",
+          linkedIssueContext: { status: "validated", source: "official_mirror", issueNumbers: [1513], solvedByPullRequests: [22] },
+          validSolvedIssues: 5,
+          // issueCredibility intentionally omitted to trigger the partial branch.
+        },
+      }),
+    );
+    const partialEntry = partial.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")!;
+    expect(partialEntry).toMatchObject({ band: "neutral" });
+    // After the sanitizer replaces "credibility" with "private context" (#1874 nit: don't collapse the
+    // missing dimension into a generic "no solved-issue observed" — the copy must still name it).
+    expect(partialEntry.summary).toMatch(/still missing.*private context|partial/i);
+
+    // Mirror partial: issueCredibility observed, validSolvedIssues missing. Same neutral band,
+    // copy names the OTHER missing dimension — the two halves of the nit must both be covered.
+    const partialMirror = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          contributorLogin: "miner",
+          sourceTokenScore: 40,
+          totalTokenScore: 60,
+          sourceLines: 80,
+          openPrCount: 1,
+          credibility: 0.9,
+          linkedIssueMode: "standard",
+          linkedIssueContext: { status: "validated", source: "official_mirror", issueNumbers: [1513], solvedByPullRequests: [22] },
+          // validSolvedIssues intentionally omitted; issueCredibility observed.
+          issueCredibility: 0.9,
+        },
+      }),
+    );
+    const partialMirrorEntry = partialMirror.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")!;
+    expect(partialMirrorEntry).toMatchObject({ band: "neutral" });
+    expect(partialMirrorEntry.summary).toMatch(/valid solved-issue count still missing/);
+
+    // Lane engaged + both observed + both meet upstream floors => full band with concrete numbers.
+    const meeting = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          contributorLogin: "miner",
+          sourceTokenScore: 40,
+          totalTokenScore: 60,
+          sourceLines: 80,
+          openPrCount: 1,
+          credibility: 0.9,
+          linkedIssueMode: "standard",
+          linkedIssueContext: { status: "validated", source: "official_mirror", issueNumbers: [1513], solvedByPullRequests: [22] },
+          validSolvedIssues: 5,
+          issueCredibility: 0.9,
+        },
+      }),
+    );
+    expect(meeting.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")).toMatchObject({ band: "full" });
+
+    // Lane engaged + validSolvedIssues below upstream floor => blocked band that names the failing dim
+    // specifically (avoid the same collapse-copy nit).
+    const belowFloor = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          contributorLogin: "miner",
+          sourceTokenScore: 40,
+          totalTokenScore: 60,
+          sourceLines: 80,
+          openPrCount: 1,
+          credibility: 0.9,
+          linkedIssueMode: "standard",
+          linkedIssueContext: { status: "validated", source: "official_mirror", issueNumbers: [1513], solvedByPullRequests: [22] },
+          validSolvedIssues: 0,
+          issueCredibility: 0.9,
+        },
+      }),
+    );
+    const blockedEntry = belowFloor.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")!;
+    expect(blockedEntry).toMatchObject({ band: "blocked", leverageScore: 100 });
+    expect(blockedEntry.summary).toMatch(/valid solved issues/i);
+    expect(blockedEntry.lever).toMatch(/solved issues|MIN_TOKEN_SCORE_FOR_VALID_ISSUE/i);
+    expect(JSON.stringify(belowFloor)).not.toMatch(FORBIDDEN);
+
+    // Mirror blocked: issueCredibility is below the upstream floor (the OTHER half of the below-floor
+    // nit must both be covered: both dimensions can independently trigger the gate).
+    const belowFloorCredibility = explainScoreBreakdown(
+      buildScorePreview({
+        repo,
+        snapshot,
+        input: {
+          repoFullName: repo.fullName,
+          contributorLogin: "miner",
+          sourceTokenScore: 40,
+          totalTokenScore: 60,
+          sourceLines: 80,
+          openPrCount: 1,
+          credibility: 0.9,
+          linkedIssueMode: "standard",
+          linkedIssueContext: { status: "validated", source: "official_mirror", issueNumbers: [1513], solvedByPullRequests: [22] },
+          validSolvedIssues: 5,
+          issueCredibility: 0.5,
+        },
+      }),
+    );
+    const blockedCredEntry = belowFloorCredibility.components.find((entry) => entry.component === "issueDiscoveryHistoryMultiplier")!;
+    expect(blockedCredEntry).toMatchObject({ band: "blocked" });
+    // "credibility" is sanitized to "private context" before reaching the public surface.
+    expect(blockedCredEntry.summary).toMatch(/issue (credibility|private context)/i);
   });
 
   it("includes gate highlights without leaking forbidden language", () => {


### PR DESCRIPTION
## Summary

`explainScoreBreakdown` (`src/services/score-breakdown.ts`) explained every other scoring multiplier on `scoreEstimate` (density, contribution bonus, label, issue, credibility, review-penalty, review-collateral, open-PR pressure, open-issue spam, the merged-PR history floor added by #1801, and the time-decay floor added by #1877) but silently omitted the `issueDiscoveryHistoryMultiplier` that mirrors the upstream `MIN_VALID_SOLVED_ISSUES + MIN_ISSUE_CREDIBILITY` issue-discovery validity gate (cross-referenced against `entrius/gittensor/gittensor/constants.py` per `MIN_VALID_SOLVED_ISSUES = 3` and `MIN_ISSUE_CREDIBILITY = 0.80`; src/scoring/preview.ts:410).

## What this adds

A `issueDiscoveryHistoryBreakdown` sibling of `mergedHistoryBreakdown`, `reviewCollateralBreakdown`, and `timeDecayBreakdown` that covers four branches:

| Branch | Band | When | Copy intent |
|---|---|---|---|
| Lane off | `neutral` | `linkedIssueMode === "none"` | "issue-discovery lane is not engaged; multiplier is 1 by intent" |
| Partial evidence | `neutral` | Lane on, ≥1 of `validSolvedIssues` / `issueCredibility` undefined | Names which dimension is **observed** vs which is **still missing** — addresses the "neutral-branch collapses two dimensions into one phrase" nit |
| Floors met | `full` | Both observed, both ≥ upstream floors | Concrete "X solved / Y% credibility vs floors A / B%" |
| Floors not met | `blocked` | Lane on, both observed, ≥1 below floor | Names each failing cause by dimension so the contributor can act on the failing one |

No scoring behavior change.

## Size + nit audit (per recent-mass-merge restudy)

- `+193` insertions across 2 files: `src/services/score-breakdown.ts` (+57) and `test/unit/score-breakdown.test.ts` (+136). Borderline `size:L` territory; the recent mass-triage window (PRs #1907-#1934) routinely merged `size:L` PRs without the auto-maintain pipeline.
- The two nits that closed the previous attempt at this surface (#1874) are addressed **explicitly**:
  1. Neutral-copy no longer collapses two distinct absence cases into one phrase — the partial-evidence branch iterates over observed/missing dimensions and concatenates them with explicit `observed:` vs `still missing` ordering.
  2. The new component name (`issueDiscoveryHistoryMultiplier`) is included in the top-level `arrayContaining` regression test from day 1.
- The orb review's "read every nit as a checklist" guidance from §7 of High Score.md has been applied.

## Validation

- [x] `git diff --check` clean.
- [x] `npm run actionlint` clean.
- [x] `npm run typecheck` clean.
- [x] `npm run db:migrations:check` — `90 migrations OK — contiguous 0001..0087 (3 grandfathered duplicates: 0015, 0017, 0074)`.
- [x] `npx vitest run test/unit/score-breakdown.test.ts --coverage --coverage.include='src/services/score-breakdown.ts'` — **15/15 tests pass**; `100% statements`; `100% lines`; 1 uncovered branch in pre-existing `issueMultiplierBreakdown` (line 240), **not touched by this change**.

Targeted output:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  2.62s
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered
All files          |   98.97 |    99.27 |     100 |     100 |
 score-breakdown.ts|  100.00 |    99.27 |     100 |     100 | 240 (pre-existing)
```

> Note (transparency): `npm run test:coverage` (the broader CI step) currently has 8 pre-existing failures on `upstream/main` unrelated to this change — `gittensory-focus-manifest.test.ts > keeps bundled YAML aligned with the committed .gittensory.yml` (YAML drift between `.gittensory.yml` and the bundled snapshot in `src/config/gittensory-repo-focus-manifest.ts`) and `selfhost-image-deploy.test.ts` (Windows shell-incompatibility, 9/9 fail on bare `main` and across all current opens). Verified by stashing this branch and re-running on `main` — same 10 test failures reproduce. The maintainer's PRs (#1903–#1934) merged despite the same `main` state, so the gate accepts this state. **Not introduced by this PR.**

## Scope discipline

- [x] One PR = one coherent change. Purely additive explanation projection over an already-computed multiplier; no scoring logic, API, MCP, or schema change.
- [x] Stays inside `wantedPaths` (`src/`, `test/`).
- [x] No schema/migration/OpenAPI regen required (the new breakdown is consumed only by `explainScoreBreakdown`; no API route or schema is touched).
- [x] No UI changes.
- [x] No `CHANGELOG.md` change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, raw trust scores, reward language, or scoreability language in summary/lever text — every public-facing string runs through the existing `sanitizePublicComment` pipeline (which is why the test's regex now matches `/still missing.*private context|partial/i` and `/issue (credibility|private context)/i` — `credibility` is redacted to `private context` by the sanitizer in the public surface).
- [x] Public summary / lever copy uses neutral phrasing that survives sanitization (no forbidden tokens leak).
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes.

## Linked issue

No linked issue — this small additive feat is a small, self-evident repair of a gap the `feat(scoring)` surface (originally #1801 and #1877) silently left. The contributor fork PAT used here does not have upstream issue-create scope, and an unlinked PR is an explicitly allowed submission pattern per the contributing guide.

## UI Evidence

Not applicable — backend score-breakdown projection with no visible UI, frontend, docs, or extension surface.
