### PR TITLE
fix(github): anchor own-bot review-thread author match to login start

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2687,8 +2687,12 @@ function isTrustedScannerReviewThreadAuthor(login: string | null | undefined): b
   return typeof login === "string" && TRUSTED_SCANNER_REVIEW_THREAD_AUTHORS.has(login.toLowerCase());
 }
 
-function isOwnReviewThreadAuthor(login: string | null | undefined): boolean {
-  return /\bgittensory[-\w]*\[bot\]$/i.test(login ?? "") || /^(gittensory|gittensory-orb)$/i.test(login ?? "");
+// Match only OUR OWN app bot login (a `gittensory` / `gittensory-orb[bot]` PREFIX), never a third-party slug
+// that merely ENDS in `-gittensory[bot]`. Anchored to `^`: a `\b` boundary also fires after a hyphen, so the
+// prior `\bgittensory…` misclassified e.g. `evil-gittensory[bot]` as our own author and dropped its
+// review-thread comment as a self-authored non-blocker (fail-open) instead of evaluating it as external.
+export function isOwnReviewThreadAuthor(login: string | null | undefined): boolean {
+  return /^gittensory[-\w]*\[bot\]$/i.test(login ?? "") || /^(gittensory|gittensory-orb)$/i.test(login ?? "");
 }
 
 /** The deterministic linked-issue facts the hard-rule evaluator needs (labels / assignees / open-state). */

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -37,6 +37,7 @@ import {
   fetchLiveCiAggregate,
   fetchLiveReviewThreadBlockers,
   fetchRequiredStatusContexts,
+  isOwnReviewThreadAuthor,
   isRateLimitedGitHubFailure,
   refreshContributorActivity,
   refreshInstallationHealth,
@@ -4796,3 +4797,25 @@ function githubTotalsResponse(counts: { openIssues: number; openPullRequests: nu
     },
   });
 }
+
+describe("isOwnReviewThreadAuthor", () => {
+  it("matches our own gittensory app bot logins by prefix", () => {
+    for (const login of ["gittensory[bot]", "gittensory-orb[bot]", "gittensory-review[bot]", "GITTENSORY[bot]", "gittensory", "gittensory-orb"]) {
+      expect(isOwnReviewThreadAuthor(login)).toBe(true);
+    }
+  });
+
+  it("does not match a third-party bot whose slug only ends in -gittensory[bot] (regression)", () => {
+    // A `\b` boundary also fires after a hyphen, so the unanchored regex misclassified these external bots as
+    // our own author and dropped their review-thread comments as self-authored non-blockers (fail-open).
+    for (const login of ["evil-gittensory[bot]", "x-gittensory[bot]", "not-gittensory", "gittensory-fork"]) {
+      expect(isOwnReviewThreadAuthor(login)).toBe(false);
+    }
+  });
+
+  it("treats an absent login as not our own author", () => {
+    expect(isOwnReviewThreadAuthor(null)).toBe(false);
+    expect(isOwnReviewThreadAuthor(undefined)).toBe(false);
+    expect(isOwnReviewThreadAuthor("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`isOwnReviewThreadAuthor` in `src/github/backfill.ts` identifies Gittensory's own app bot so its own review-thread comments are never counted as external blockers. The first regex alternative was anchored with `\b` instead of `^`:

```ts
/\bgittensory[-\w]*\[bot\]$/i.test(login ?? "") || /^(gittensory|gittensory-orb)$/i.test(login ?? "")
```

A `\b` word boundary also fires **after a hyphen**, so any login that merely *ends* in `-gittensory[bot]` matched. Through the caller `isAuthorizedReviewThreadAuthor` (where an "own author" returns `false` = not an external blocker), a third-party GitHub App slugged like `evil-gittensory[bot]` would have its unresolved review-thread comment **silently dropped as self-authored** instead of being evaluated as an external blocker — a fail-open. The intended contract is a *prefix* match on our own slug, as the sibling anchored alternative `/^(gittensory|gittensory-orb)$/i` shows.

Fix: anchor the first alternative to `^gittensory[-\w]*\[bot\]$`, so it still matches `gittensory[bot]` / `gittensory-orb[bot]` / `gittensory-*[bot]` but rejects `evil-gittensory[bot]` / `x-gittensory[bot]`. The predicate is exported and a regression test is added. Pure predicate — no schema, OpenAPI, or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident correctness fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (see note below)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change confined to `src/github/backfill.ts`, so the UI / MCP-package / OpenAPI / workers-pool steps are not exercised by the diff. I ran `test/unit/backfill.test.ts` (136 passed) plus a scoped coverage run confirming the changed predicate lines and both branches are fully covered; I did not run the full `test:coverage` locally because this Windows working tree has pre-existing, unrelated failures (CRLF line endings, missing optional CLI binaries) that do not occur in CI's Linux environment. CI runs the full `validate` matrix on a clean checkout.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes (this is a bot-login classification predicate; its non-matching path is covered by the added regression test).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI/MCP surface changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Regression test in `test/unit/backfill.test.ts` covers: our own bot logins matched by prefix (`gittensory[bot]`, `gittensory-orb[bot]`, `gittensory-review[bot]`, case-insensitive, and the bare `gittensory` / `gittensory-orb`); third-party slugs that only end in `-gittensory[bot]` now correctly returning `false`; and absent/empty logins.
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
