### PR TITLE
perf(github): skip the files fetch for already-hydrated merged PRs (#1941)

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -30,6 +30,7 @@ import {
   upsertPullRequestDetailSyncState,
   upsertPullRequestFromGitHub,
   upsertPullRequestReview,
+  listRecentMergedPullRequests,
   upsertRecentMergedPullRequest,
   upsertRepoLabel,
   upsertRepoSyncSegment,
@@ -1238,14 +1239,37 @@ async function backfillRecentMergedSegment(
       // Hydrate each merged PR's changed files (like the monolithic backfill path) so
       // recent_merged_pull_requests.changedFiles is populated instead of always empty.
       const warnings: string[] = [];
-      await mapWithConcurrency(merged, 8, async (pr) => {
-        const changedFiles = await fetchPullRequestFiles(env, repo.fullName, pr.number, token, warnings).catch(() => []);
-        await upsertRecentMergedPullRequest(env, toRecentMergedPullRequest(repo.fullName, pr, changedFiles));
-      });
+      await hydrateMergedPullRequestFiles(env, repo.fullName, merged, token, warnings, 8);
       return merged.length;
     },
     { progressiveHistory: true, countPersisted: () => countRecentMergedPullRequests(env, repo.fullName) },
   );
+}
+
+// A merged PR is immutable, so its changed-file list never changes once stored. Skip the per-PR `/pulls/{n}/files`
+// fetch — the N+1 REST fan-out that dominated this segment's GitHub cost — for any merged PR ALREADY hydrated,
+// re-upserting only the cheap metadata (the upsert preserves the stored files when passed an empty list). One
+// `listRecentMergedPullRequests` read per batch replaces up to one `/files` fetch per merged PR. (#1941)
+async function hydrateMergedPullRequestFiles(
+  env: Env,
+  repoFullName: string,
+  merged: GitHubPullRequestPayload[],
+  token: string | undefined,
+  warnings: string[],
+  concurrency: number,
+): Promise<void> {
+  const alreadyHydrated = new Set(
+    (await listRecentMergedPullRequests(env, repoFullName))
+      .filter((record) => record.changedFiles.length > 0)
+      .map((record) => record.number),
+  );
+  await mapWithConcurrency(merged, concurrency, async (pr) => {
+    // fetchPullRequestFiles never throws — it returns [] (and records a warning) on any fetch failure.
+    const changedFiles = alreadyHydrated.has(pr.number)
+      ? []
+      : await fetchPullRequestFiles(env, repoFullName, pr.number, token, warnings);
+    await upsertRecentMergedPullRequest(env, toRecentMergedPullRequest(repoFullName, pr, changedFiles));
+  });
 }
 
 function isNotModifiedResponse<T>(result: GitHubJsonConditionalResponse<T>): result is GitHubJsonNotModifiedResponse {
@@ -1691,10 +1715,7 @@ async function backfillRepository(env: Env, repo: RepositoryRecord, limits: Back
     const normalizedPullRequests = await mapWithConcurrency(pullRequests, 16, async (pr) => upsertPullRequestFromGitHub(env, repo.fullName, pr, { seenOpenAt: startedAt }));
 
     const mergedFileWarningStart = warnings.length;
-    await mapWithConcurrency(recentMerged, limits.detailConcurrency, async (pr) => {
-      const changedFiles = await fetchPullRequestFiles(env, repo.fullName, pr.number, token, warnings).catch(() => []);
-      await upsertRecentMergedPullRequest(env, toRecentMergedPullRequest(repo.fullName, pr, changedFiles));
-    });
+    await hydrateMergedPullRequestFiles(env, repo.fullName, recentMerged, token, warnings, limits.detailConcurrency);
 
     const detailTargets = normalizedPullRequests.slice(0, limits.pullRequestDetails);
     const detailWarningStart = warnings.length;

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1023,6 +1023,45 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("skips the /files fetch for a merged PR whose changed files are already stored (#1941)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    // PR 9 was hydrated with files by a prior sync; a merged PR is immutable, so its files can never change.
+    await upsertRecentMergedPullRequest(env, {
+      repoFullName: "JSONbored/gittensory",
+      number: 9,
+      title: "Fix webhook",
+      authorLogin: "oktofeesh1",
+      mergedAt: "2026-05-22T00:00:00.000Z",
+      labels: ["bug"],
+      linkedIssues: [1],
+      changedFiles: ["src/github/webhook.ts"],
+      payload: {},
+    });
+    let fileFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "https://api.github.com/graphql") return githubTotalsResponse({ openIssues: 0, openPullRequests: 0, mergedPullRequests: 1, closedPullRequests: 1, labels: 0 });
+      if (url.includes("/pulls?state=closed")) {
+        return Response.json([{ number: 9, title: "Fix webhook processing (edited)", state: "closed", merged_at: "2026-05-22T00:00:00.000Z", user: { login: "oktofeesh1" }, labels: [{ name: "bug" }], body: "Fixes #1" }]);
+      }
+      if (url.includes("/pulls/9/files")) {
+        fileFetches += 1;
+        return Response.json([{ filename: "src/github/webhook.ts", status: "modified", additions: 12, deletions: 3, changes: 15 }]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await backfillRepositorySegment(env, { repoFullName: "JSONbored/gittensory", segment: "recent_merged_pull_requests", mode: "full" });
+
+    expect(result).toMatchObject({ status: "complete" });
+    expect(fileFetches).toBe(0); // already hydrated → the per-PR /files fetch (the N+1) is skipped
+    // The cheap metadata is still refreshed (title updated) and the stored files are preserved.
+    expect(await listRecentMergedPullRequests(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ number: 9, title: "Fix webhook processing (edited)", changedFiles: ["src/github/webhook.ts"] })]),
+    );
+  });
+
   it("preserves previously-hydrated merged PR files when a later upsert has none", async () => {
     const env = createTestEnv();
     await upsertRecentMergedPullRequest(env, {


### PR DESCRIPTION
## Summary

The recent-merged backfill segment (and the monolithic path) fetched `GET /pulls/{n}/files` for **every** merged PR on every sync — an N+1 REST fan-out. But a merged PR is **immutable**: its changed-file list never changes once stored, so re-fetching it every 6-hour full sync is pure waste.

This skips the per-PR `/files` fetch for any merged PR already hydrated: one `listRecentMergedPullRequests` read per batch builds the set of PRs that already have stored files, and those PRs get only a cheap metadata re-upsert (the upsert already preserves stored files when passed an empty list — `repositories.ts:3144`). Both identical N+1 sites now go through a shared `hydrateMergedPullRequestFiles` helper.

Advances #1941 (rec #9 from the #1936 audit).

## Scope

- [x] Conventional Commit title.
- [x] Focused, backend-only change (one file + a test), DRYs two duplicate loops into one helper.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`.
- [x] Linked issue (advances #1941).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — added a regression test that pre-stores a merged PR with files, runs the recent-merged segment, and asserts **zero** `/pulls/{n}/files` fetches while the metadata is still refreshed and the stored files preserved (it fails without the skip). The not-already-stored (fetch) branch stays covered by the existing "hydrates merged PR changed files" test; the changed region is 100% covered (statements + branches).
- [x] `npm run test:ci` · all 134 backfill tests pass (the refactor into the shared helper is behavior-preserving)
- [x] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No migration / OpenAPI / cf-typegen: single-file backend change, no schema/API/binding change.

## Safety

- [x] No secrets/wallets/hotkeys/trust-scores/etc.
- [x] No public GitHub text change.
- [x] No auth/CORS/session change.
- [x] No API/OpenAPI/MCP change. No UI change.

## Notes

- Correctness: only the expensive `/files` fetch is skipped; the merged PR's metadata (title/labels/merged_at) is still re-upserted each pass, and skipping only happens when files are already stored (a first-time or files-less record still fetches). Merged PRs are terminal, so their file list cannot change after storage.
- Also removed a provably-dead `.catch(() => [])` on `fetchPullRequestFiles` (it never throws — `githubPaginatedList` catches per-page and returns `[]`/`undefined`), which the original inline sites carried.
