### PR TITLE
fix(selfhost): name Sentry's server_name from SENTRY_SERVER_NAME, not the origin URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -268,6 +268,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # SENTRY_DSN=
 # SENTRY_DSN_FILE=                          # optional mounted secret file; existing *_FILE loader reads it
 # SENTRY_ENVIRONMENT=selfhost
+# SENTRY_SERVER_NAME=                       # clean name for THIS instance in Sentry (e.g. gittensory-us-east);
+#                                           #   unset defaults to the OS hostname — never the public-origin URL
 # SENTRY_RELEASE=
 # SENTRY_TRACES_SAMPLE_RATE=0
 

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -6,6 +6,7 @@ import {
   PUBLIC_LOCAL_PATH_SCRUB_PATTERN,
   PUBLIC_UNSAFE_TERMS,
 } from "../signals/redaction";
+import { hostname } from "node:os";
 import { currentOtelTraceIds } from "./otel";
 
 type SentryNs = typeof import("@sentry/node");
@@ -312,7 +313,10 @@ export async function initSentry(env: NodeJS.ProcessEnv): Promise<boolean> {
     environment: sentryEnvironment,
     ...(release ? { release } : {}),
     tracesSampleRate,
-    serverName: env.PUBLIC_API_ORIGIN,
+    // Identify this instance by a CLEAN, configurable name — not the public-origin URL. An operator sets
+    // SENTRY_SERVER_NAME (e.g. "gittensory-us-east"); unset falls back to the OS hostname, which is dynamic
+    // per instance with no hardcoded value and reads as a name rather than a URL.
+    serverName: nonBlank(env.SENTRY_SERVER_NAME) ?? hostname(),
     beforeSend: (e) => scrubEvent(e),
     beforeSendTransaction: (e) => scrubEvent(e),
   });

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hostname } from "node:os";
 
 // Mock @sentry/node so the dynamic import inside initSentry() resolves to spies. Hoisted so vi.mock can see it.
 const mocks = vi.hoisted(() => {
@@ -334,13 +335,18 @@ describe("enabled when SENTRY_DSN is set", () => {
       SENTRY_ENVIRONMENT: "staging",
       SENTRY_RELEASE: "v9",
       SENTRY_TRACES_SAMPLE_RATE: "0.5",
-      PUBLIC_API_ORIGIN: "https://self.host",
+      SENTRY_SERVER_NAME: "gittensory-us-east",
     } as unknown as NodeJS.ProcessEnv);
     const opts = mocks.init.mock.calls[0]![0];
     expect(opts.environment).toBe("staging");
     expect(opts.release).toBe("v9");
     expect(opts.tracesSampleRate).toBe(0.5);
-    expect(opts.serverName).toBe("https://self.host");
+    expect(opts.serverName).toBe("gittensory-us-east");
+  });
+
+  it("defaults serverName to the OS hostname (not the API-origin URL) when SENTRY_SERVER_NAME is unset/blank", async () => {
+    await initSentry({ SENTRY_DSN: "d", SENTRY_SERVER_NAME: "  ", PUBLIC_API_ORIGIN: "https://self.host" } as unknown as NodeJS.ProcessEnv);
+    expect(mocks.init.mock.calls[0]![0].serverName).toBe(hostname());
   });
 
   it("uses the image-baked version as the release fallback and ignores blank overrides", async () => {


### PR DESCRIPTION
## Summary

Sentry events showed `server_name` as the **public-origin URL** because `initSentry` set `serverName: env.PUBLIC_API_ORIGIN`. That reads as a URL rather than an instance name, and it isn't configurable as an identity.

This names the instance from a dedicated, operator-configurable `SENTRY_SERVER_NAME`, falling back to the **OS hostname** when it's unset — dynamic per instance, no hardcoded value, and a proper name instead of a URL. Documented in `.env.example`.

No linked issue: small, self-evident config fix surfaced while investigating live Sentry events.

## Scope

- [x] Conventional Commit title.
- [x] Focused, backend-only change (`src/selfhost/sentry.ts` + its test + `.env.example`).
- [x] Config-driven, not hardcoded: any self-hoster gets a clean default (hostname) and can override with `SENTRY_SERVER_NAME`.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — updated the existing init test to assert the `SENTRY_SERVER_NAME` override and added a test that a blank/unset value falls back to `os.hostname()` (both sides of the `?? ` are covered).
- [x] `npm run test:ci`
- [x] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No `cf-typegen` / migration: `SENTRY_SERVER_NAME` is read from `process.env` in the self-host `initSentry` (like the other `SENTRY_*` vars), so it needs no Cloudflare binding or DB change.

## Safety

- [x] No secrets/wallets/hotkeys/etc.; `SENTRY_SERVER_NAME` is a plain instance label.
- [x] No hardcoded operator-private values — the default is the dynamic OS hostname.
- [x] No public GitHub text / auth / API / UI change.

## Notes

- To get a clean name on an existing deployment: set `SENTRY_SERVER_NAME=<your-instance>` in the self-host `.env` (otherwise the container's hostname is used).
- Related (separate, not in this PR): every issue's **culprit** currently resolves to `forwardStructuredLogToSentry` (`sentry.ts:457`) because the structured-log→Sentry forwarder wraps errors in a `new Error()` there, so the real origin (e.g. `buildReviewEnrichment`) is hidden. Fixing the culprit/grouping attribution is a good follow-up.
