### PR TITLE
fix(mcp): word-boundary linked-issue closing keywords

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -557,9 +557,13 @@ function assertSourceUploadDisabled() {
   }
 }
 
-function extractLinkedIssues(text) {
+// Word-boundary the closing keywords (as the server-side extractors in src/db/repositories.ts and
+// src/signals/engine.ts already do) so a keyword embedded in a longer word does not spuriously link an
+// issue: without \b, `hotfix 5` / `prefixes 12` matched the `fix`/`fixes` substring and captured the
+// trailing number. The bare `#` branch stays boundary-free so `#123` still matches anywhere.
+export function extractLinkedIssues(text) {
   const issues = [];
-  for (const match of String(text).matchAll(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|#)\s*#?(\d+)/gi)) issues.push(Number(match[1]));
+  for (const match of String(text).matchAll(/(?:\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)|#)\s*#?(\d+)/gi)) issues.push(Number(match[1]));
   return issues.filter((issue) => Number.isInteger(issue) && issue > 0);
 }
 

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1737,6 +1737,21 @@ describe("local MCP git metadata collection", () => {
     );
   });
 
+  it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {
+    // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
+    const { extractLinkedIssues } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
+    // Standalone closing keywords (hash optional, as this client-side extractor allows) and bare #refs link.
+    expect(extractLinkedIssues("fixes #5")).toEqual([5]);
+    expect(extractLinkedIssues("Closes 12 and resolves #34")).toEqual([12, 34]);
+    expect(extractLinkedIssues("see #7")).toEqual([7]);
+    expect(extractLinkedIssues("closes#3")).toEqual([3]);
+    // Regression: a closing keyword embedded in a longer word must NOT capture a trailing number.
+    expect(extractLinkedIssues("hotfix 5")).toEqual([]);
+    expect(extractLinkedIssues("prefixes 12")).toEqual([]);
+    expect(extractLinkedIssues("unclosed 9")).toEqual([]);
+    expect(extractLinkedIssues("no references here")).toEqual([]);
+  });
+
   it("parses remotes, changed-file stats, linked issues, and refuses source upload mode", async () => {
     // @ts-expect-error package helper is plain JS because the local wrapper ships as a Node bin package.
     const { collectLocalBranchMetadata, parseGitRemote } = await import("../../packages/gittensory-mcp/lib/local-branch.js");


### PR DESCRIPTION
## Summary

`extractLinkedIssues` in `packages/gittensory-mcp/lib/local-branch.js` extracts GitHub closing-keyword issue references from the branch name, title, body, and commit messages to populate `linkedIssues` — which the MCP sends to the API for eligibility, score preview, and gate prediction. Its regex matched the closing keywords with **no word boundary**:

```js
/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|#)\s*#?(\d+)/gi
```

so a keyword embedded in a longer word matched and captured the trailing number:

```js
extractLinkedIssues("hotfix 5")     // => [5]   (should be [])
extractLinkedIssues("prefixes 12")  // => [12]  (should be [])
extractLinkedIssues("unclosed 9")   // => [9]   (should be [])
```

A branch like `hotfix-cache 5` or a commit `postfix 3` would spuriously link an issue, feeding a false linked-issue signal into the local preflight.

Fix: anchor the keyword alternatives with `\b`, matching the two canonical **server-side** extractors that already do this — `src/db/repositories.ts:5718` and `src/signals/engine.ts:5241` both use `/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)…/`. The MCP client-side extractor was the outlier that dropped the `\b`. The bare `#` branch stays boundary-free so `#123` still matches anywhere. Pure helper — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident correctness fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (see note below)
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack` (see note below)
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The change is confined to the MCP package helper (`packages/gittensory-mcp/lib/local-branch.js`), which is plain JS outside Codecov's `src/**/*.ts` include, so it carries no patch-coverage obligation; a regression test was still added in `test/unit/local-branch.test.ts` (imported via the existing dynamic-import harness) and passes. `build:mcp` (the package's `node --check`) passes and `typecheck` is clean. I did not run the full `test:coverage` / UI / workers steps because they are unrelated to this MCP-only diff, and I could not run `test:mcp-pack` locally because this machine runs Node 24 while the repo pins Node 22 (`.nvmrc`); `scripts/check-mcp-package.mjs` throws `ERR_INVALID_ARG_TYPE` on Node 24 identically on unmodified `main`. CI runs the full `validate` matrix on the pinned Node.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Behavior fix in the MCP local helper; covered by the added regression test. No request/response schema changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change; MCP changelog is a release-prep artifact.)

## Notes

- Regression test in `test/unit/local-branch.test.ts` asserts standalone keywords still link (`fixes #5`, `Closes 12 and resolves #34`, `see #7`, `closes#3`) while embedded-keyword substrings no longer do (`hotfix 5`, `prefixes 12`, `unclosed 9`).
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
