### PR TITLE
fix(signals): compare repo names case-insensitively in contributor detection

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1321,7 +1321,11 @@ export function detectGittensorContributor(
   repoStats: ContributorRepoStatRecord[] = [],
 ): ContributorDetection {
   const priorPullRequests = pullRequests.filter(
-    (pr) => sameLogin(pr.authorLogin, login) && !(pr.repoFullName === currentPr.repoFullName && pr.number === currentPr.number),
+    // Exclude the current PR case-insensitively on repo name, matching `sameRepo` used everywhere else in
+    // this module (and the `sameLogin` in this same predicate). A raw `===` let a cached copy of the current
+    // PR stored under different repo-name casing (GitHub full-names are case-insensitive) slip through and be
+    // miscounted as the contributor's own "prior activity".
+    (pr) => sameLogin(pr.authorLogin, login) && !(sameRepo(pr.repoFullName, currentPr.repoFullName) && pr.number === currentPr.number),
   );
   const priorIssues = issues.filter((issue) => sameLogin(issue.authorLogin, login));
   const priorMergedPullRequests = priorPullRequests.filter((pr) => pr.mergedAt || pr.state === "merged");

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -1138,6 +1138,17 @@ describe("world-class backend signals", () => {
     expect(detection).toMatchObject({ detected: true, priorPullRequests: 1, priorMergedPullRequests: 0 });
   });
 
+  it("excludes the current PR from prior activity even when the cached copy has different repo-name casing", () => {
+    // GitHub repo full-names are case-insensitive, and this module compares them with `sameRepo`
+    // everywhere else. A cached copy of the current PR stored under different casing must still be
+    // recognized as the current PR (not counted as the contributor's own "prior activity").
+    const currentPr = pullRequests[0]!;
+    const cachedCurrentDifferentCasing: PullRequestRecord = { ...currentPr, repoFullName: currentPr.repoFullName.toUpperCase() };
+    const detection = detectGittensorContributor("oktofeesh1", currentPr, [cachedCurrentDifferentCasing], []);
+
+    expect(detection).toMatchObject({ detected: false, priorPullRequests: 0, priorMergedPullRequests: 0 });
+  });
+
   it("builds private contributor outcome and strategy reports across maintainer and cleanup lanes", () => {
     const ownerRepo: RepositoryRecord = {
       ...repo,


### PR DESCRIPTION
## Summary

`detectGittensorContributor` in `src/signals/engine.ts` builds a contributor's *prior* PR activity by filtering the cached PR list and excluding the current PR. The exclusion used a **case-sensitive** repo comparison:

```ts
!(pr.repoFullName === currentPr.repoFullName && pr.number === currentPr.number)
```

This is inconsistent on two counts: the **author** half of the very same predicate uses the case-insensitive `sameLogin`, and **every other** repo comparison in this ~5,000-line module (14 of them) uses the case-insensitive `sameRepo` helper — this was the only raw `repoFullName ===`. GitHub repo full-names are case-insensitive, and different ingestion paths (webhook payload, GraphQL backfill, registry) can cache the same repo under different casing. When the cached copy of the current PR has different casing than `currentPr`, the `===` fails, the current PR is **not** excluded, and the contributor's *own current PR* is miscounted as "prior activity" — inflating `priorPullRequests` / `priorMergedPullRequests` and flipping the standalone `detected` result to `true`.

Fix: use `sameRepo` for the exclusion, matching the rest of the module.

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-evident consistency/correctness fix in one predicate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the changed predicate is covered by a new regression test asserting the current PR is still excluded (`detected: false`, `priorPullRequests: 0`) when its cached copy has different repo-name casing. The test was confirmed to FAIL against the unpatched code (`expected { detected: true } to match { detected: false }`). The existing same-casing exclusion test and the full `signals` (37) and `signals-v2` (36) suites pass.
- [x] New or changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one predicate in a pure exported helper in `src/signals`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Contributor-detection counts only; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `detectGittensorContributor("oktofeesh1", currentPr, [{ ...currentPr, repoFullName: currentPr.repoFullName.toUpperCase() }], [])` returned `{ detected: true, priorPullRequests: 1 }` before the fix (miscounting the current PR) and now returns `{ detected: false, priorPullRequests: 0 }`.
