### PR TITLE
fix(selfhost): attribute structured-log Sentry culprit to event slug

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -138,6 +138,23 @@ export function resolveSentryRelease(
   return nonBlank(env.SENTRY_RELEASE) ?? nonBlank(env.GITTENSORY_VERSION);
 }
 
+/** Structured console.error logs are forwarded as synthetic exceptions whose stack always originates in
+ *  forwardStructuredLogToSentry. Re-attribute the Sentry culprit to the log's event slug so operators see
+ *  orb_broker_unavailable (etc.) instead of the forwarder frame. */
+function attributeStructuredLogCulprit(event: {
+  culprit?: string;
+  fingerprint?: unknown;
+  tags?: Record<string, unknown>;
+  exception?: Array<{ type?: string }>;
+}): void {
+  const fingerprint = event.fingerprint;
+  if (!Array.isArray(fingerprint) || fingerprint[0] !== "gittensory-log") return;
+  const eventSlug =
+    (typeof event.tags?.event === "string" ? event.tags.event : undefined) ??
+    event.exception?.[0]?.type;
+  if (eventSlug) event.culprit = eventSlug;
+}
+
 /** beforeSend scrubber — redact anything token/secret-like before an event leaves the box (privacy boundary). */
 export function scrubEvent<T>(event: T): T | null {
   try {
@@ -153,6 +170,8 @@ export function scrubEvent<T>(event: T): T | null {
       spans?: unknown;
       transaction?: unknown;
       user?: unknown;
+      culprit?: string;
+      fingerprint?: unknown;
     };
     scrubRequest(e.request);
     scrubAllowedContexts(e.contexts);
@@ -167,6 +186,7 @@ export function scrubEvent<T>(event: T): T | null {
     if (Array.isArray(e.breadcrumbs)) {
       for (const breadcrumb of e.breadcrumbs) scrubRecord(breadcrumb, 0);
     }
+    attributeStructuredLogCulprit(e);
   } catch {
     return null;
   }

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -138,6 +138,21 @@ export function resolveSentryRelease(
   return nonBlank(env.SENTRY_RELEASE) ?? nonBlank(env.GITTENSORY_VERSION);
 }
 
+function structuredLogExceptionType(exception: unknown): string | undefined {
+  if (!exception || typeof exception !== "object") return undefined;
+  const values = (exception as { values?: Array<{ type?: unknown }> }).values;
+  if (Array.isArray(values)) {
+    const type = values[0]?.type;
+    if (typeof type === "string") return type;
+  }
+  // Convenience/test shape only — production Sentry events use exception.values[0].type.
+  if (Array.isArray(exception)) {
+    const type = (exception[0] as { type?: unknown } | undefined)?.type;
+    if (typeof type === "string") return type;
+  }
+  return undefined;
+}
+
 /** Structured console.error logs are forwarded as synthetic exceptions whose stack always originates in
  *  forwardStructuredLogToSentry. Re-attribute the Sentry culprit to the log's event slug so operators see
  *  orb_broker_unavailable (etc.) instead of the forwarder frame. */
@@ -145,13 +160,13 @@ function attributeStructuredLogCulprit(event: {
   culprit?: string;
   fingerprint?: unknown;
   tags?: Record<string, unknown>;
-  exception?: Array<{ type?: string }>;
+  exception?: unknown;
 }): void {
   const fingerprint = event.fingerprint;
   if (!Array.isArray(fingerprint) || fingerprint[0] !== "gittensory-log") return;
   const eventSlug =
     (typeof event.tags?.event === "string" ? event.tags.event : undefined) ??
-    event.exception?.[0]?.type;
+    structuredLogExceptionType(event.exception);
   if (eventSlug) event.culprit = eventSlug;
 }
 

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -261,6 +261,34 @@ describe("scrubEvent — redact secrets before an event leaves the box", () => {
 
     expect(scrubEvent(event)).toBeNull();
   });
+
+  it("attributes structured-log issues to the log event slug, not the forwarder frame", () => {
+    const ev = scrubbedEvent({
+      culprit: "forwardStructuredLogToSentry",
+      fingerprint: ["gittensory-log", "orb_broker_unavailable"],
+      tags: { event: "orb_broker_unavailable" },
+      exception: [{ type: "orb_broker_unavailable", value: "timeout" }],
+    }) as { culprit?: string };
+    expect(ev.culprit).toBe("orb_broker_unavailable");
+  });
+
+  it("falls back to the synthetic exception type when a structured log omits the event tag", () => {
+    const ev = scrubbedEvent({
+      culprit: "forwardStructuredLogToSentry",
+      fingerprint: ["gittensory-log", "relay_drained_error"],
+      exception: [{ type: "relay_drained_error", value: "relay failed" }],
+    }) as { culprit?: string };
+    expect(ev.culprit).toBe("relay_drained_error");
+  });
+
+  it("leaves non-structured-log events unchanged", () => {
+    const ev = scrubbedEvent({
+      culprit: "buildReviewEnrichment",
+      fingerprint: ["other"],
+      tags: { event: "orb_broker_unavailable" },
+    }) as { culprit?: string };
+    expect(ev.culprit).toBe("buildReviewEnrichment");
+  });
 });
 
 describe("disabled when SENTRY_DSN is unset (modular opt-out → complete no-op)", () => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -267,16 +267,16 @@ describe("scrubEvent — redact secrets before an event leaves the box", () => {
       culprit: "forwardStructuredLogToSentry",
       fingerprint: ["gittensory-log", "orb_broker_unavailable"],
       tags: { event: "orb_broker_unavailable" },
-      exception: [{ type: "orb_broker_unavailable", value: "timeout" }],
+      exception: { values: [{ type: "orb_broker_unavailable", value: "timeout" }] },
     }) as { culprit?: string };
     expect(ev.culprit).toBe("orb_broker_unavailable");
   });
 
-  it("falls back to the synthetic exception type when a structured log omits the event tag", () => {
+  it("falls back to exception.values[0].type when a structured log omits the event tag", () => {
     const ev = scrubbedEvent({
       culprit: "forwardStructuredLogToSentry",
       fingerprint: ["gittensory-log", "relay_drained_error"],
-      exception: [{ type: "relay_drained_error", value: "relay failed" }],
+      exception: { values: [{ type: "relay_drained_error", value: "relay failed" }] },
     }) as { culprit?: string };
     expect(ev.culprit).toBe("relay_drained_error");
   });


### PR DESCRIPTION
## Summary

Structured console.error logs are forwarded to Sentry as synthetic exceptions in `forwardStructuredLogToSentry`. Because the error is constructed there, every issue's **culprit** resolved to `forwardStructuredLogToSentry` (`sentry.ts`) instead of the real failure origin (e.g. `orb_broker_unavailable`, `gate_check_permission_missing`).

This re-attributes the culprit during `scrubEvent` (the existing `beforeSend` hook) for events fingerprinted as `gittensory-log`, using the indexed `event` tag or the synthetic exception type. Operators can now triage by failure class in Sentry's issue list.

Follow-up called out in #1987. No linked issue — small, self-evident observability fix in a single helper.

## Scope

- [x] Conventional Commit title.
- [x] Focused backend-only change (`src/selfhost/sentry.ts` + regression tests).
- [x] Follows `CONTRIBUTING.md`; no UI/API/schema/migration changes.

## Validation

- [ ] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` — new regression tests cover the structured-log culprit path, the exception-type fallback, and the negative (non-structured-log) case.
- [ ] `npm run test:ci`

If any required check was skipped, explain why:

- Node/npm is not available in this environment; CI on the PR will run the full gate.

## Safety

- [x] No secrets/wallets/hotkeys; only Sentry event metadata is adjusted.
- [x] No public GitHub text / auth / API / UI change.