### PR TITLE
fix(selfhost): attribute forwarded-log Sentry issues to the event, not the forwarder

### DIFF
--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -456,6 +456,12 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
       .join(" ") || "(no message — see the log context)");
   const errorEvent = new Error(value);
   errorEvent.name = event ?? "GittensoryLog";
+  // This exception is SYNTHETIC — minted here from a console line, never thrown at the code that failed. Its captured
+  // JS stack therefore points at this forwarder and the console sink that called it (installStructuredLogForwarding),
+  // not at the origin. Left attached, Sentry computes EVERY forwarded issue's culprit as forwardStructuredLogToSentry,
+  // burying the real signal. Reduce the stack to its header line (the parser yields zero frames from it) so no frame
+  // is misattributed; the event slug supplies the culprit below and the `log` context keeps the full payload.
+  errorEvent.stack = `${errorEvent.name}: ${value}`;
   Sentry.withScope((scope) => {
     scope.setLevel(severity);
     setOtelTraceScope(scope);
@@ -469,6 +475,15 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
     }
     // Group recurrences of ONE failure into a single issue (by event, not the variable detail in the value).
     if (event) scope.setFingerprint(["gittensory-log", event]);
+    // Give the issue a legible culprit (the location Sentry shows under the title). It derives from event.transaction
+    // when set, else from the now-stripped stack — so point it at the operational event slug (e.g.
+    // "orb_broker_unavailable") rather than the forwarder. setTransactionName on the scope does NOT populate
+    // event.transaction in this SDK version, so set it on the event via a scoped processor.
+    if (event)
+      scope.addEventProcessor((sentryEvent) => {
+        sentryEvent.transaction = event;
+        return sentryEvent;
+      });
     Sentry!.captureException(errorEvent);
   });
 }

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock @sentry/node so the dynamic import inside initSentry() resolves to spies. Hoisted so vi.mock can see it.
 const mocks = vi.hoisted(() => {
-  const scope = { setContext: vi.fn(), setLevel: vi.fn(), setTag: vi.fn(), setFingerprint: vi.fn() };
+  const scope = { setContext: vi.fn(), setLevel: vi.fn(), setTag: vi.fn(), setFingerprint: vi.fn(), addEventProcessor: vi.fn() };
   return {
     scope,
     init: vi.fn(),
@@ -633,6 +633,35 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.scope.setTag).toHaveBeenCalledWith("installationId", "143010787");
     // Recurrences of one failure group into a single issue by event.
     expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["gittensory-log", "orb_broker_unavailable"]);
+  });
+
+  it("strips the synthetic wrapper stack so the issue culprit is not forwardStructuredLogToSentry", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "orb_broker_unavailable", error: "timeout" }),
+    );
+    // The captured Error's stack is reduced to its header line — no "at …" frames — so Sentry cannot attribute the
+    // issue to this forwarder (or the console sink) the way it did when the real (synthetic) stack was attached.
+    const stack = lastCapturedError().stack ?? "";
+    expect(stack).not.toMatch(/\n\s+at /);
+    expect(stack).toBe("orb_broker_unavailable: timeout");
+  });
+
+  it("sets the issue culprit (event.transaction) to the event slug, and skips it when there is no event", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "orb_broker_unavailable", error: "timeout" }),
+    );
+    // The scoped event processor stamps the operational event slug as the transaction (Sentry's culprit input).
+    const processor = mocks.scope.addEventProcessor.mock.calls.at(-1)?.[0] as (
+      e: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    expect(processor({})).toEqual({ transaction: "orb_broker_unavailable" });
+
+    // A no-event error log has no slug to use as a culprit, so no transaction processor is registered.
+    mocks.scope.addEventProcessor.mockClear();
+    forwardStructuredLogToSentry(JSON.stringify({ level: "error", code: 500 }));
+    expect(mocks.scope.addEventProcessor).not.toHaveBeenCalled();
   });
 
   it("indexes self-host AI provider dimensions as Sentry tags", async () => {


### PR DESCRIPTION
## Summary

Every self-host Sentry issue's **culprit** (the location shown under the title, and the thing operators scan the issue list by) resolves to `forwardStructuredLogToSentry` — the log forwarder itself — hiding what actually failed.

Cause: the forwarder mints a **synthetic** `new Error(value)` from a console line. That error's captured JS stack points at the forwarder and the console sink that called it (`installStructuredLogForwarding`), never at the code that logged the failure. Sentry derives the culprit from that stack, so every forwarded issue is attributed to the forwarder.

This fixes it two ways, so issues read by their real operational identity:

1. **Strip the synthetic wrapper stack** — reduce the error's `stack` to its header line so the parser yields zero frames and nothing is misattributed to the forwarder/sink.
2. **Set the culprit to the event slug** — Sentry derives the culprit from `event.transaction` when present, so a scoped event processor stamps it with the operational event slug (e.g. `orb_broker_unavailable`). (`Scope.setTransactionName` does **not** populate `event.transaction` in `@sentry/node` 10.x, so it's set on the event directly.)

Grouping is unchanged — recurrences still fingerprint by `event` — and the full payload stays in the `log` context.

No linked issue: small observability fix surfaced while investigating live self-host Sentry events.

## Scope

- [x] Conventional Commit title.
- [x] Backend-only, one module (`src/selfhost/sentry.ts` + its test).
- [x] Behavior-preserving except the intended culprit/stack change; no config, schema, or API surface change.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — added a test that the captured error's stack has no `at …` frames, and one that the scoped processor stamps `event.transaction` with the slug (and is skipped when there's no event, covering both branches). Verified the changed region is 100% statement + branch covered.
- [x] `npm run test:ci`
- [x] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- No `cf-typegen` / migration / openapi: pure runtime change to the self-host log→Sentry forwarder.

## Safety

- [x] No secrets/wallets/hotkeys/etc. The event slug used as the culprit is already emitted as a tag today, and `scrubEvent` still scrubs `transaction` before send.
- [x] No public GitHub text / auth / API / UI change.
