### PR TITLE
fix(rees): fall back to direct OSV queries when lockfile batch fails

### DIFF
--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -363,7 +363,49 @@ export function extractLockfileChanges(
   return changes;
 }
 
-/** Batch-query OSV.dev for lockfile resolutions. Best-effort: returns empty CVE arrays on any failure. */
+/**
+ * Direct single-package OSV query — the per-package fallback for a failed batch. Without it a transient
+ * /v1/querybatch outage silently yields zero transitive CVEs (#1502): a fail-closed blind spot where a
+ * vulnerable lockfile-only pin escapes the scan entirely. Mirrors the graceful batch→direct degradation the
+ * manifest dependency-scan analyzer already performs.
+ */
+async function queryOsvSingle(
+  change: LockfileChange,
+  fetchImpl: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<Cve[]> {
+  if (signal?.aborted) return [];
+  const fetchOptions = {
+    endpointCategory: "osv-query",
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      package: { name: change.package, ecosystem: change.ecosystem },
+      version: change.to,
+    }),
+    signal,
+    fetchImpl,
+    diagnostics: options.diagnostics,
+    phase: "lockfile-drift",
+    subcall: "osv-query",
+    maxBytes: 1024 * 1024,
+    maxCallsPerCategory: MAX_OSV_QUERIES,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<{ vulns?: OsvVuln[] }>(
+        "https://api.osv.dev/v1/query",
+        fetchOptions,
+      )
+    : await boundedFetchJson<{ vulns?: OsvVuln[] }>(
+        "https://api.osv.dev/v1/query",
+        fetchOptions,
+      );
+  if (!response.ok) return [];
+  return toCves(response.data.vulns);
+}
+
+/** Batch-query OSV.dev for lockfile resolutions. Best-effort: on batch failure, falls back to per-package direct queries. */
 export async function queryOsvBatch(
   changes: LockfileChange[],
   fetchImpl: typeof fetch = fetch,
@@ -397,7 +439,19 @@ export async function queryOsvBatch(
     : await boundedFetchJson<{
       results?: Array<{ vulns?: OsvVuln[] }>;
     }>("https://api.osv.dev/v1/querybatch", fetchOptions);
-  if (!response.ok) return results;
+  if (!response.ok) {
+    // The batch endpoint failed as a whole. Fall back to per-package direct queries so a transient
+    // /v1/querybatch outage does not silently report zero transitive CVEs — the empty-map path here was a
+    // fail-closed blind spot. Mirrors the dependency-scan analyzer's batch→direct fallback.
+    for (const change of changes) {
+      if (signal?.aborted) break;
+      results.set(
+        `${change.ecosystem}::${change.package}@${change.to}`,
+        await queryOsvSingle(change, fetchImpl, signal, options),
+      );
+    }
+    return results;
+  }
   changes.forEach((change, index) => {
     results.set(
       `${change.ecosystem}::${change.package}@${change.to}`,

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -419,6 +419,53 @@ test("queryOsvBatch: sends lockfile resolutions to OSV batch and maps indexed re
   assert.equal(cves.get("npm::minimist@0.0.8")[0].fixedIn, "1.2.6");
 });
 
+test("queryOsvBatch: falls back to per-package direct queries when the batch endpoint fails", async () => {
+  // Regression (#1502): a failed /v1/querybatch used to return an empty map, silently reporting zero
+  // transitive CVEs for every package. The direct fallback must still surface the vulnerable pin.
+  const cves = await queryOsvBatch(
+    [
+      { file: "package-lock.json", line: 3, ecosystem: "npm", package: "minimist", from: "1.2.8", to: "0.0.8" },
+      { file: "package-lock.json", line: 9, ecosystem: "npm", package: "lodash", from: "4.17.21", to: "4.17.11" },
+    ],
+    async (url, init) => {
+      if (String(url).endsWith("/querybatch")) return { ok: false, status: 503, json: async () => ({}) };
+      const name = JSON.parse(String(init?.body)).package.name;
+      const vulns =
+        name === "minimist"
+          ? [{ id: "GHSA-x", database_specific: { severity: "HIGH" }, affected: [{ ranges: [{ events: [{ fixed: "1.2.6" }] }] }] }]
+          : [];
+      return { ok: true, json: async () => ({ vulns }) };
+    },
+  );
+  assert.equal(cves.get("npm::minimist@0.0.8")[0].severity, "high");
+  assert.equal(cves.get("npm::minimist@0.0.8")[0].fixedIn, "1.2.6");
+  assert.deepEqual(cves.get("npm::lodash@4.17.11"), []); // queried, not silently dropped
+});
+
+test("queryOsvBatch: batch and direct both failing yields empty CVEs (no crash)", async () => {
+  const cves = await queryOsvBatch(
+    [{ file: "package-lock.json", line: 3, ecosystem: "npm", package: "minimist", from: "1.2.8", to: "0.0.8" }],
+    async () => ({ ok: false, status: 500, json: async () => ({}) }),
+  );
+  assert.deepEqual(cves.get("npm::minimist@0.0.8"), []);
+});
+
+test("queryOsvBatch: an aborted signal stops the direct fallback", async () => {
+  const controller = new AbortController();
+  const cves = await queryOsvBatch(
+    [{ file: "package-lock.json", line: 3, ecosystem: "npm", package: "minimist", from: "1.2.8", to: "0.0.8" }],
+    async (url) => {
+      if (String(url).endsWith("/querybatch")) {
+        controller.abort();
+        return { ok: false, status: 503, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({ vulns: [] }) };
+    },
+    controller.signal,
+  );
+  assert.equal(cves.size, 0); // aborted before the fallback loop queried anything
+});
+
 test("scanLockfileDrift: reports only vulnerable lockfile-only resolutions", async () => {
   const findings = await scanLockfileDrift(
     {


### PR DESCRIPTION
## Summary

The lockfile-drift analyzer's `queryOsvBatch` returned an empty result map on **any** `/v1/querybatch` failure:

    if (!response.ok) return results;

So a transient OSV batch-endpoint outage (503/500/timeout) silently reported **zero transitive CVEs for every changed package**. A vulnerable lockfile-only pin — precisely the transitive downgrade this analyzer exists to catch (it sees resolutions the manifest diff never names) — would escape the scan entirely. That's a fail-closed blind spot in a security check: an outage is indistinguishable from "clean."

The manifest `dependency-scan` analyzer already handles this correctly — on a batch failure it falls back to per-package direct queries. This aligns lockfile-drift with that proven pattern: when the batch request fails, fall back to per-package direct `/v1/query` calls and merge the partial results. The fallback honors the abort signal and the per-category call cap, and the happy path (batch succeeds) is unchanged.

Regression tests cover:
- batch fails → direct fallback succeeds → the vulnerable pin is still surfaced (and a clean package is queried, not silently dropped);
- batch and direct both fail → empty CVEs, no crash;
- an aborted signal stops the fallback loop.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — a small, self-evident robustness fix in one analyzer; the rationale is in the Summary.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment test` (build → validate sourcemaps → analyzer-metadata check → full REES suite) — green; the three new `queryOsvBatch` fallback regression tests pass.
- [x] Rebased on `main` — no conflict.
- [ ] Root `npm run test:ci` jobs — not exercised by this change; it is confined to `review-enrichment/**`, which is outside the root `src/**` Codecov patch scope. Verified by CI.

If any required check was skipped, explain why:

- The change is entirely within `review-enrichment/src/analyzers/lockfile-drift.ts` and its test; the relevant local gate is the REES suite (`rees:test`), which is green. The root `src/**` coverage jobs do not cover this package.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI changes.
- [x] No docs/changelog changes.
