### PR TITLE
fix(bounties): degrade null import payload to empty instead of throwing

### DIFF
--- a/src/bounties/ingest.ts
+++ b/src/bounties/ingest.ts
@@ -16,7 +16,10 @@ type GittIssueListPayload = {
 };
 
 export function normalizeGittBountySnapshot(payload: unknown): BountyRecord[] {
-  const data = payload as GittIssueListPayload;
+  // Guard the root before dereferencing `.issues`: the caller feeds `c.req.json().catch(() => null)`,
+  // so an empty or non-JSON import body arrives as `null`. `?? []` only guards a MISSING `.issues` on an
+  // already-non-null object, so a bare `null`/non-object payload would throw instead of degrading to [].
+  const data = (payload && typeof payload === "object" ? payload : {}) as GittIssueListPayload;
   return (data.issues ?? []).flatMap((issue) => {
     if (issue.id === undefined || !issue.repository_full_name || !issue.issue_number || !issue.status) return [];
     const amountText = issue.bounty_alpha ?? (issue.bounty_amount === undefined ? undefined : String(issue.bounty_amount));

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -22,6 +22,12 @@ describe("small adapters and normalizers", () => {
 
   it("normalizes gitt bounty snapshots and drops incomplete rows", () => {
     expect(normalizeGittBountySnapshot({})).toEqual([]);
+    // A null / non-JSON body (the import route feeds `c.req.json().catch(() => null)`) or any non-object
+    // payload must degrade to [] instead of throwing.
+    expect(normalizeGittBountySnapshot(null)).toEqual([]);
+    expect(normalizeGittBountySnapshot(undefined)).toEqual([]);
+    expect(normalizeGittBountySnapshot("not json")).toEqual([]);
+    expect(normalizeGittBountySnapshot(42)).toEqual([]);
     const records = normalizeGittBountySnapshot({
       success: true,
       issues: [


### PR DESCRIPTION
## Summary

`normalizeGittBountySnapshot(payload: unknown)` in `src/bounties/ingest.ts` casts `payload as GittIssueListPayload` and reads `data.issues` **before** the `?? []` guard runs. That `?? []` only guards a *missing* `.issues` on an already-non-null object, so a bare `null` / `undefined` (or non-object) payload throws `TypeError: Cannot read properties of null (reading 'issues')`.

The import route feeds exactly that shape:

```ts
// src/api/routes.ts (POST /v1/internal/bounties/import)
const body = await c.req.json().catch(() => null);
const bounties = normalizeGittBountySnapshot(body);
```

So an empty or non-JSON request body sets `body = null`, and the route throws an unhandled 500 instead of importing zero bounties.

Fix: guard the root before dereferencing — `const data = (payload && typeof payload === "object" ? payload : {}) as GittIssueListPayload;` — so any non-object payload degrades to `[]`, matching the tolerant `{}` → `[]` contract the sibling test already documents ("drops incomplete rows"). Pure normalizer — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident robustness fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped: `src/bounties/ingest.ts` at 100% line + branch coverage via the added `test/unit/adapters.test.ts` cases; see note)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change confined to `src/bounties/ingest.ts`. I ran `test/unit/adapters.test.ts` (8 passed) and a scoped coverage run showing `src/bounties/ingest.ts` at 100% line + branch coverage (the added `null` / `undefined` / non-object cases exercise both sides of the new guard). I did not run the full `test:coverage` / workers / MCP / UI steps because they are unrelated to this diff, and the local Windows working tree has pre-existing, unrelated failures (CRLF line endings, missing optional CLI binaries, Node-24-vs-pinned-Node-22). CI runs the full `validate` matrix on a clean, pinned-Node checkout.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes (this hardens an input normalizer; the null/non-object negative paths are covered by the added tests).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Behavior fix for the import route's normalizer; no request/response schema changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Regression test in `test/unit/adapters.test.ts` adds `normalizeGittBountySnapshot(null)`, `(undefined)`, `("not json")`, and `(42)` → all `[]`, alongside the existing `{}` and populated-object cases, covering both branches of the new root guard.
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
