### PR TITLE
fix(selfhost): normalize SQLite text for Postgres migration

### DIFF
--- a/scripts/migrate-selfhost-sqlite-to-postgres.ts
+++ b/scripts/migrate-selfhost-sqlite-to-postgres.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import pg, { type PoolClient } from "pg";
 import { createPgAdapter } from "../src/selfhost/pg-adapter";
 import { createPgQueue } from "../src/selfhost/pg-queue";
@@ -32,6 +33,7 @@ interface SkipResult {
 
 const INTERNAL_SQLITE_TABLES = new Set(["d1_migrations", "_cf_KV", "__drizzle_migrations", "_selfhost_migrations"]);
 const TABLES_ALLOWED_AFTER_SCHEMA_INIT = new Set(["global_agent_controls", "global_contributor_blacklist"]);
+const POSTGRES_TEXT_NUL_REPLACEMENT = "\uFFFD";
 
 function usage(): string {
   return `Usage: npm run selfhost:postgres:migrate -- --sqlite <path> --postgres-url <url> [--execute]
@@ -242,6 +244,16 @@ function valuePlaceholder(index: number, table: string, column: string): string 
   return base;
 }
 
+export function normalizePostgresValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  // SQLite text can contain NUL bytes from arbitrary repo files; Postgres text/json inputs cannot.
+  return value.includes("\0") ? value.replaceAll("\0", POSTGRES_TEXT_NUL_REPLACEMENT) : value;
+}
+
+function sqliteCellForPostgres(row: Record<string, unknown>, column: string): unknown {
+  return normalizePostgresValue(row[column] ?? null);
+}
+
 function insertSql(table: string, columns: string[], primaryKey: string[], rowCount: number): string {
   const columnSql = columns.map(quoteIdent).join(", ");
   const valuesSql = Array.from({ length: rowCount }, (_, rowIndex) => {
@@ -260,7 +272,7 @@ async function copyTable(db: DatabaseSync, client: PoolClient, table: string, co
   for (let offset = 0; offset < total; offset += batchSize) {
     const rows = sqliteRows(db, table, columns, batchSize, offset);
     if (rows.length === 0) continue;
-    const values = rows.flatMap((row) => columns.map((column) => row[column] ?? null));
+    const values = rows.flatMap((row) => columns.map((column) => sqliteCellForPostgres(row, column)));
     await client.query(insertSql(table, columns, primaryKey, rows.length), values);
   }
   return total;
@@ -280,7 +292,7 @@ async function countTargetRowsMatchingSourceRows(
     if (rows.length === 0) continue;
     const values: unknown[] = [];
     for (const row of rows) {
-      for (const column of columns) values.push(row[column] ?? null);
+      for (const column of columns) values.push(sqliteCellForPostgres(row, column));
     }
     const condition = rows
       .map((_, rowIndex) => {
@@ -313,7 +325,7 @@ async function countConflictingTargetRowsForSourceKeys(
       .map((row) => {
         const parameterByColumn = new Map<string, number>();
         for (const column of compareColumns) {
-          values.push(row[column] ?? null);
+          values.push(sqliteCellForPostgres(row, column));
           parameterByColumn.set(column, values.length);
         }
         const keyPredicates = keyColumns.map((column) => `${quoteIdent(column)} IS NOT DISTINCT FROM $${parameterByColumn.get(column)}`);
@@ -460,7 +472,9 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/test/unit/selfhost-migrate.test.ts
+++ b/test/unit/selfhost-migrate.test.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import { runSelfHostMigrations } from "../../src/selfhost/migrate";
+import { normalizePostgresValue } from "../../scripts/migrate-selfhost-sqlite-to-postgres";
 
 describe("runSelfHostMigrations (#980)", () => {
   it("applies un-applied migrations in order, idempotently", async () => {
@@ -99,4 +100,13 @@ INSERT INTO notes (body) VALUES ('triggered');`,
     });
   });
 
+});
+
+describe("SQLite-to-Postgres migrator helpers", () => {
+  it("normalizes embedded NUL bytes in SQLite text before Postgres copy", () => {
+    expect(normalizePostgresValue("repo\0chunk")).toBe("repo\uFFFDchunk");
+    expect(normalizePostgresValue("plain text")).toBe("plain text");
+    expect(normalizePostgresValue(null)).toBeNull();
+    expect(normalizePostgresValue(42)).toBe(42);
+  });
 });


### PR DESCRIPTION
## Summary

- Normalize embedded NUL bytes in SQLite text values before the self-host Postgres migrator writes them to Postgres.
- Apply the same normalization to migration validation comparisons so dry-runs and non-empty target checks use the exact values Postgres can store.
- Add focused regression coverage for NUL normalization and non-string passthrough.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No issue because this is a narrow operational follow-up to the Postgres cutover tooling added in #1986. A migration dry-run found cached repo chunk text containing embedded NUL bytes, which SQLite allows but Postgres rejects for text/json inputs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Additional focused checks:

- `npx vitest run test/unit/selfhost-migrate.test.ts test/unit/selfhost-grafana-reporting.test.ts test/unit/selfhost-pg-dialect.test.ts`
- Temporary Postgres smoke: migrated a SQLite `repo_chunks` row containing an embedded NUL byte with `--execute`, then verified Postgres stored the replacement-character-normalized text.

If any required check was skipped, explain why:

- None.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable; this is a self-host migration script/test change only.

## Notes

- `scripts/**` is outside Codecov's measured `src/**` patch surface, but the behavior is covered by a focused unit regression and an actual SQLite-to-Postgres smoke.
- The migrator replaces only the unrepresentable NUL byte so cached text rows remain migratable without dropping the row.