### PR TITLE
fix(selfhost): import withOtelSpan in the durable queues (main typecheck broken)

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -6,6 +6,7 @@ import type { Pool } from "pg";
 import { logAudit, extractPayloadType } from "./audit";
 import { incr } from "./metrics";
 import { withReviewSpan } from "./tracing";
+import { withOtelSpan } from "./otel";
 import { captureError } from "./sentry";
 import {
   consumingRetryDelayMs,

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -7,6 +7,7 @@ import type { SqliteDriver } from "./d1-adapter";
 import { logAudit, extractPayloadType } from "./audit";
 import { incr } from "./metrics";
 import { withReviewSpan } from "./tracing";
+import { withOtelSpan } from "./otel";
 import { captureError } from "./sentry";
 import {
   consumingRetryDelayMs,


### PR DESCRIPTION
## Summary

`main` currently fails `npm run typecheck`: `src/selfhost/pg-queue.ts:345` and `src/selfhost/sqlite-queue.ts:288` call `withOtelSpan(...)` for the `*.queue.admission_deferred` span (exactly as `src/server.ts:689` does) but import only `withReviewSpan` from `./tracing` — `withOtelSpan` is never imported.

`#1922` (sampled Sentry spans) added those calls and `#1986` (Postgres tooling) merged right behind it; each was green on its own branch, but together on main the import is missing → `error TS2304: Cannot find name 'withOtelSpan'`. This blocks CI on **every** open PR.

Fix: add `import { withOtelSpan } from "./otel";` to both durable-queue files. Behavior-preserving — the span was already intended (it mirrors the existing `withReviewSpan` call a few lines down and `server.ts`'s usage).

## Validation
- [x] `npm run typecheck` (fails on main without this; passes with it)
- [x] `git diff --check`
- [x] `npx vitest run test/unit/selfhost-pg-queue.test.ts test/unit/selfhost-sqlite-queue.test.ts` — 95 pass
- No new tests: this is a missing-import compile fix; the span call sites are already covered by the queue tests.