### PR TITLE
feat(enrichment): add dependency maintenance-health analyzer (#1511)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,17 +65,17 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # Current analyzer names:
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
-# history,docCommentDrift,duplication,churnHotspot
+# depHealth,history,docCommentDrift,duplication,churnHotspot
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,depHealth
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
-# iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# iacMisconfig,nativeBuild,depHealth,history,docCommentDrift,duplication,churnHotspot
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
-# nativeBuild,history,docCommentDrift,duplication,churnHotspot
+# nativeBuild,depHealth,history,docCommentDrift,duplication,churnHotspot
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -455,6 +455,28 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "depHealth",
+    title: "Dependency maintenance health",
+    category: "supply-chain",
+    cost: "registry",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files", "public-network"],
+    limits: {
+      maxQueries: 25,
+    },
+    docs: {
+      summary:
+        "Flags newly-added or upgraded dependencies that are deprecated, yanked, or long unmaintained.",
+      looksAt: "New or upgraded npm and PyPI direct dependency versions.",
+      reports:
+        "Package, version, ecosystem, and the maintenance kind: deprecated, yanked, or stale (with last release date).",
+      network: "Calls the npm registry and PyPI JSON API. No GitHub token required.",
+      notes:
+        "Registry prose is never returned; a package is called stale only after several years with no release, and any network failure fails safe.",
+    },
+  },
+  {
     name: "history",
     title: "Author and change-area history",
     category: "history",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -525,6 +525,32 @@
       }
     },
     {
+      "name": "depHealth",
+      "title": "Dependency maintenance health",
+      "category": "supply-chain",
+      "cost": "registry",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files",
+        "public-network"
+      ],
+      "limits": {
+        "maxQueries": 25
+      },
+      "docs": {
+        "summary": "Flags newly-added or upgraded dependencies that are deprecated, yanked, or long unmaintained.",
+        "looksAt": "New or upgraded npm and PyPI direct dependency versions.",
+        "reports": "Package, version, ecosystem, and the maintenance kind: deprecated, yanked, or stale (with last release date).",
+        "network": "Calls the npm registry and PyPI JSON API. No GitHub token required.",
+        "notes": "Registry prose is never returned; a package is called stale only after several years with no release, and any network failure fails safe."
+      }
+    },
+    {
       "name": "history",
       "title": "Author and change-area history",
       "category": "history",

--- a/review-enrichment/src/analyzers/dep-health.ts
+++ b/review-enrichment/src/analyzers/dep-health.ts
@@ -1,0 +1,203 @@
+// Dependency maintenance-health analyzer (#1511). For each dependency a PR newly adds or upgrades, flags an
+// adoption / future-supply-chain risk the no-checkout reviewer cannot see: a version marked DEPRECATED on npm, a
+// YANKED PyPI release, or a package that is STALE (no release in over STALE_YEARS). One version-scoped registry
+// read per dep; pure classification after that. Additive + fail-safe: a network failure skips that dep, never a
+// finding. Public-safe output: package@version + the factual maintenance property (never registry prose).
+import type {
+  AnalyzerDiagnostics,
+  DepHealthFinding,
+  EnrichRequest,
+} from "../types.js";
+import type { AnalysisContext } from "../analysis-context.js";
+import { extractDependencyChanges } from "./dependency-scan.js";
+import { boundedFetchJson } from "../external-fetch.js";
+
+const MAX_QUERIES = 25;
+const MAX_NPM_JSON_BYTES = 1024 * 1024;
+const MAX_PYPI_JSON_BYTES = 2 * 1024 * 1024;
+// Precision-first: a mature library can go a while between releases, so require a long gap before calling a
+// package stale — the finding is advisory ("verify still maintained"), not a hard block.
+const STALE_YEARS = 3;
+const STALE_MS = STALE_YEARS * 365 * 24 * 60 * 60 * 1000;
+
+const NPM_PACKAGE_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
+const PYPI_PACKAGE_RE = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+const VERSION_SAFE_RE = /^[A-Za-z0-9][A-Za-z0-9._+!-]{0,63}$/;
+
+interface ScanLimits {
+  maxQueries?: number;
+}
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  limits?: ScanLimits;
+  analysis?: Pick<AnalysisContext, "fetchJson">;
+  diagnostics?: AnalyzerDiagnostics;
+}
+
+/** Is this dependency change one we can query a registry for (supported ecosystem + safe name/version)? */
+function isQueryable(change: { ecosystem: string; package: string; to: string }): boolean {
+  if (change.ecosystem === "npm") return NPM_PACKAGE_RE.test(change.package) && VERSION_SAFE_RE.test(change.to);
+  if (change.ecosystem === "PyPI") return PYPI_PACKAGE_RE.test(change.package) && VERSION_SAFE_RE.test(change.to);
+  return false;
+}
+
+type HealthClass = Pick<DepHealthFinding, "kind" | "reason" | "lastRelease">;
+
+function staleReason(ecosystem: string): string {
+  return `no ${ecosystem} release in over ${STALE_YEARS} years — verify the package is still maintained`;
+}
+
+function isoDay(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// ── npm ─────────────────────────────────────────────────────────────────────
+
+/** The subset of an npm packument this analyzer reads. */
+export interface NpmPackument {
+  "dist-tags"?: { latest?: string };
+  versions?: Record<string, { deprecated?: unknown }>;
+  time?: Record<string, string>;
+}
+
+/** Pure: the packument's most-recent publish time in ms, or null. Prefers `time.modified`, then the latest
+ *  dist-tag's timestamp, then the max of all per-version timestamps. */
+export function npmLastPublishMs(pkg: NpmPackument): number | null {
+  const times = pkg.time ?? {};
+  const latestTag = pkg["dist-tags"]?.latest;
+  const preferred = times.modified ?? (latestTag ? times[latestTag] : undefined);
+  const preferredMs = preferred ? Date.parse(preferred) : NaN;
+  if (Number.isFinite(preferredMs)) return preferredMs;
+  let max = NaN;
+  for (const [key, value] of Object.entries(times)) {
+    if (key === "created" || key === "modified") continue;
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms) && (!Number.isFinite(max) || ms > max)) max = ms;
+  }
+  return Number.isFinite(max) ? max : null;
+}
+
+/** Pure: classify an npm version's maintenance health (deprecated wins over stale), or null. */
+export function classifyNpm(pkg: NpmPackument, version: string, now: number): HealthClass | null {
+  const deprecated = pkg.versions?.[version]?.deprecated;
+  if (typeof deprecated === "string" && deprecated.trim().length > 0) {
+    return { kind: "deprecated", reason: "marked deprecated on the npm registry" };
+  }
+  const last = npmLastPublishMs(pkg);
+  if (last !== null && now - last > STALE_MS) {
+    return { kind: "stale", reason: staleReason("npm"), lastRelease: isoDay(last) };
+  }
+  return null;
+}
+
+// ── PyPI ────────────────────────────────────────────────────────────────────
+
+/** The subset of a PyPI package JSON this analyzer reads. */
+export interface PypiPackage {
+  releases?: Record<string, Array<{ yanked?: boolean; upload_time_iso_8601?: string }>>;
+}
+
+/** Pure: is this exact PyPI version yanked? True only when the version has files and every file is yanked. */
+export function pypiVersionYanked(pkg: PypiPackage, version: string): boolean {
+  const files = pkg.releases?.[version];
+  return Array.isArray(files) && files.length > 0 && files.every((file) => file.yanked === true);
+}
+
+/** Pure: the newest upload time in ms across every release file, or null. */
+export function pypiLastUploadMs(pkg: PypiPackage): number | null {
+  let max = NaN;
+  for (const files of Object.values(pkg.releases ?? {})) {
+    for (const file of files ?? []) {
+      const ms = file.upload_time_iso_8601 ? Date.parse(file.upload_time_iso_8601) : NaN;
+      if (Number.isFinite(ms) && (!Number.isFinite(max) || ms > max)) max = ms;
+    }
+  }
+  return Number.isFinite(max) ? max : null;
+}
+
+/** Pure: classify a PyPI version's maintenance health (yanked wins over stale), or null. */
+export function classifyPypi(pkg: PypiPackage, version: string, now: number): HealthClass | null {
+  if (pypiVersionYanked(pkg, version)) {
+    return { kind: "yanked", reason: "this release is yanked on PyPI and should not be installed" };
+  }
+  const last = pypiLastUploadMs(pkg);
+  if (last !== null && now - last > STALE_MS) {
+    return { kind: "stale", reason: staleReason("PyPI"), lastRelease: isoDay(last) };
+  }
+  return null;
+}
+
+// ── Fetch + entrypoint ────────────────────────────────────────────────────────
+
+async function fetchJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  options: ScanOptions,
+  endpointCategory: "npm-packument" | "pypi-json",
+  maxBytes: number,
+): Promise<T | null> {
+  if (options.signal?.aborted) return null;
+  const fetchOptions = {
+    endpointCategory,
+    signal: options.signal,
+    fetchImpl,
+    diagnostics: options.diagnostics,
+    phase: "dep-health",
+    subcall: endpointCategory,
+    maxBytes,
+    maxCallsPerCategory: options.limits?.maxQueries ?? MAX_QUERIES,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<T>(url, fetchOptions)
+    : await boundedFetchJson<T>(url, fetchOptions);
+  return response.ok ? response.data : null;
+}
+
+/** Analyzer entrypoint: added/changed deps → version-scoped registry metadata → only the deps with a maintenance
+ *  risk (deprecated / yanked / stale). `now` is injectable for deterministic staleness tests. */
+export async function scanDepHealth(
+  req: EnrichRequest,
+  fetchImpl: typeof fetch = fetch,
+  now: number = Date.now(),
+  options: ScanOptions = {},
+): Promise<DepHealthFinding[]> {
+  // Filter to queryable changes BEFORE the cap so unsupported/invalid entries can't starve a later real dep.
+  const changes = extractDependencyChanges(req.files ?? [])
+    .filter(isQueryable)
+    .slice(0, options.limits?.maxQueries ?? MAX_QUERIES);
+  const findings: DepHealthFinding[] = [];
+  for (const change of changes) {
+    if (options.signal?.aborted) break;
+    let health: HealthClass | null = null;
+    if (change.ecosystem === "npm") {
+      const data = await fetchJson<NpmPackument>(
+        fetchImpl,
+        `https://registry.npmjs.org/${encodeURIComponent(change.package)}`,
+        options,
+        "npm-packument",
+        MAX_NPM_JSON_BYTES,
+      );
+      health = data && classifyNpm(data, change.to, now);
+    } else {
+      // PyPI — the only other ecosystem isQueryable admits.
+      const data = await fetchJson<PypiPackage>(
+        fetchImpl,
+        `https://pypi.org/pypi/${encodeURIComponent(change.package)}/json`,
+        options,
+        "pypi-json",
+        MAX_PYPI_JSON_BYTES,
+      );
+      health = data && classifyPypi(data, change.to, now);
+    }
+    if (health) {
+      findings.push({
+        ecosystem: change.ecosystem,
+        package: change.package,
+        version: change.to,
+        ...health,
+      });
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -3,6 +3,7 @@ import { scanAssetWeight } from "./asset-weight.js";
 import { scanChurnHotspot } from "./churn-hotspot.js";
 import { scanCodeowners } from "./codeowners.js";
 import { scanCommitSignature } from "./commit-signature.js";
+import { scanDepHealth } from "./dep-health.js";
 import { dependencyAnalyzer } from "./dependency/descriptor.js";
 import { scanDocCommentDrift } from "./doc-comment-drift.js";
 import { scanDuplication } from "./duplication-scan.js";
@@ -336,6 +337,27 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanNativeBuild(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "depHealth",
+    title: "Dependency maintenance health",
+    category: "supply-chain",
+    cost: "registry",
+    defaultEnabled: true,
+    requires: ["files", "public-network"],
+    limits: { maxQueries: 25 },
+    docs: {
+      summary:
+        "Flags newly-added or upgraded dependencies that are deprecated, yanked, or long unmaintained.",
+      looksAt: "New or upgraded npm and PyPI direct dependency versions.",
+      reports:
+        "Package, version, ecosystem, and the maintenance kind: deprecated, yanked, or stale (with last release date).",
+      network: "Calls the npm registry and PyPI JSON API. No GitHub token required.",
+      notes:
+        "Registry prose is never returned; a package is called stale only after several years with no release, and any network failure fails safe.",
+    },
+    run: (req, { signal, analysis, diagnostics }) =>
+      scanDepHealth(req, fetch, Date.now(), { signal, analysis, diagnostics }),
   }),
   descriptor({
     name: "history",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -295,6 +295,21 @@ export function renderBrief(
     }
   }
 
+  const depHealth = findings.depHealth ?? [];
+  if (depHealth.length) {
+    lines.push(
+      "### Dependency maintenance health (deprecated / yanked / unmaintained)",
+    );
+    for (const item of depHealth) {
+      const label =
+        item.kind === "deprecated" ? "DEPRECATED" : item.kind === "yanked" ? "YANKED" : "STALE";
+      const suffix = item.lastRelease ? ` (last release ${item.lastRelease})` : "";
+      lines.push(
+        `- ${safeCodeSpan(`${item.package}@${item.version}`)} (${item.ecosystem}): **${label}** — ${item.reason}${suffix}`,
+      );
+    }
+  }
+
   const history = findings.history ?? [];
   for (const item of history) {
     const entries: string[] = [];

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -239,6 +239,21 @@ export interface NativeBuildFinding {
   reason: string;
 }
 
+/** A newly-added/upgraded direct dependency whose registry metadata signals a maintenance risk the no-checkout
+ *  reviewer is blind to: a version marked DEPRECATED (npm), a YANKED release (PyPI), or a package with no release
+ *  in years (STALE). Adoption risk + future supply-chain liability. Reports package@version + the factual
+ *  maintenance property only — never the registry's deprecation/yank prose. (#1511) */
+export interface DepHealthFinding {
+  ecosystem: string;
+  package: string;
+  version: string;
+  kind: "deprecated" | "yanked" | "stale";
+  /** Short, public-safe explanation of the maintenance risk. */
+  reason: string;
+  /** `stale` only: the ISO date (YYYY-MM-DD) of the package's most recent release. */
+  lastRelease?: string;
+}
+
 /** Public-safe historical context the no-checkout reviewer is blind to and the engine deliberately does NOT compute:
  *  the author's track record IN THIS repo, past PRs that already changed the same files (with their outcome), and
  *  whether the diff covers the linked issue's stated requirement. Surfaced as a single block (0-or-1 element array).
@@ -304,6 +319,7 @@ export interface BriefFindings {
   commitSignature?: CommitSignatureFinding[];
   iacMisconfig?: IacMisconfigFinding[];
   nativeBuild?: NativeBuildFinding[];
+  depHealth?: DepHealthFinding[];
   history?: HistoryFinding[];
   docCommentDrift?: DocCommentDriftFinding[];
   duplication?: DuplicationFinding[];

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_ANALYZERS = [
   "commitSignature",
   "iacMisconfig",
   "nativeBuild",
+  "depHealth",
   "history",
   "docCommentDrift",
   "duplication",

--- a/review-enrichment/test/enrichment.test.ts
+++ b/review-enrichment/test/enrichment.test.ts
@@ -27,6 +27,14 @@ import {
 } from "../dist/analyzers/actions-pin.js";
 import { scanEol, extractVersionPins } from "../dist/analyzers/eol-check.js";
 import {
+  classifyNpm,
+  classifyPypi,
+  npmLastPublishMs,
+  pypiLastUploadMs,
+  pypiVersionYanked,
+  scanDepHealth,
+} from "../dist/analyzers/dep-health.js";
+import {
   extractRegexSources,
   hasCatastrophicBacktracking,
   scanPatchForRedos,
@@ -141,6 +149,94 @@ test("extractDependencyChanges: PyPI exact pins with PEP 508 extras are parsed u
   assert.equal(byPkg.requests.to, "2.31.0");
   assert.equal(byPkg.requests.from, "2.30.0");
   assert.equal(byPkg.celery.to, "5.4.0");
+});
+
+const DEP_HEALTH_NOW = Date.parse("2026-06-30T00:00:00Z");
+
+test("scanDepHealth: flags a deprecated npm dependency version", async () => {
+  const findings = await scanDepHealth(
+    { files: [{ path: "package.json", patch: '+    "oldpkg": "1.0.0",' }] },
+    async () => ({
+      ok: true,
+      json: async () => ({
+        "dist-tags": { latest: "1.0.0" },
+        time: { modified: "2026-05-01T00:00:00Z", "1.0.0": "2026-05-01T00:00:00Z" },
+        versions: { "1.0.0": { deprecated: "use @scope/newpkg instead" } },
+      }),
+    }),
+    DEP_HEALTH_NOW,
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "deprecated");
+  assert.equal(findings[0].package, "oldpkg");
+  assert.equal(findings[0].version, "1.0.0");
+});
+
+test("scanDepHealth: flags a yanked PyPI release", async () => {
+  const findings = await scanDepHealth(
+    { files: [{ path: "requirements.txt", patch: "+badpkg==2.0.0" }] },
+    async () => ({
+      ok: true,
+      json: async () => ({
+        releases: {
+          "2.0.0": [{ yanked: true, upload_time_iso_8601: "2026-01-01T00:00:00Z" }],
+          "1.0.0": [{ yanked: false, upload_time_iso_8601: "2025-01-01T00:00:00Z" }],
+        },
+      }),
+    }),
+    DEP_HEALTH_NOW,
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "yanked");
+  assert.equal(findings[0].package, "badpkg");
+});
+
+test("scanDepHealth: flags a stale package and skips a recently-released one", async () => {
+  const findings = await scanDepHealth(
+    { files: [{ path: "requirements.txt", patch: "+abandoned==1.0.0\n+fresh==2.0.0" }] },
+    async (url) => ({
+      ok: true,
+      json: async () =>
+        String(url).includes("abandoned")
+          ? { releases: { "1.0.0": [{ upload_time_iso_8601: "2020-01-01T00:00:00Z" }] } }
+          : { releases: { "2.0.0": [{ upload_time_iso_8601: "2026-01-01T00:00:00Z" }] } },
+    }),
+    DEP_HEALTH_NOW,
+  );
+  const byPkg = Object.fromEntries(findings.map((f) => [f.package, f]));
+  assert.equal(byPkg.abandoned.kind, "stale");
+  assert.equal(byPkg.abandoned.lastRelease, "2020-01-01");
+  assert.equal(byPkg.fresh, undefined); // released within the window → not flagged
+});
+
+test("scanDepHealth: fails safe (no finding) on a non-ok registry response", async () => {
+  const findings = await scanDepHealth(
+    { files: [{ path: "package.json", patch: '+    "somepkg": "1.0.0",' }] },
+    async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    DEP_HEALTH_NOW,
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("dep-health pure classifiers: publish-time selection, yanked, and null-health", () => {
+  // npmLastPublishMs: prefer time.modified, else the latest dist-tag's time, else max version time, else null.
+  assert.equal(npmLastPublishMs({ time: { modified: "2024-01-01T00:00:00Z" } }), Date.parse("2024-01-01T00:00:00Z"));
+  assert.equal(
+    npmLastPublishMs({ "dist-tags": { latest: "2.0.0" }, time: { "1.0.0": "2020-01-01T00:00:00Z", "2.0.0": "2023-01-01T00:00:00Z" } }),
+    Date.parse("2023-01-01T00:00:00Z"),
+  );
+  assert.equal(npmLastPublishMs({ time: {} }), null);
+  // pypiLastUploadMs = newest across all files; yanked only when the version has files and every one is yanked.
+  assert.equal(
+    pypiLastUploadMs({ releases: { "1.0.0": [{ upload_time_iso_8601: "2021-01-01T00:00:00Z" }], "2.0.0": [{ upload_time_iso_8601: "2022-06-01T00:00:00Z" }] } }),
+    Date.parse("2022-06-01T00:00:00Z"),
+  );
+  assert.equal(pypiVersionYanked({ releases: { "1.0.0": [{ yanked: true }, { yanked: false }] } }, "1.0.0"), false);
+  assert.equal(pypiVersionYanked({ releases: { "1.0.0": [{ yanked: true }] } }, "1.0.0"), true);
+  assert.equal(pypiVersionYanked({ releases: {} }, "9.9.9"), false);
+  // classify* returns null for a healthy, recent, non-deprecated version (exercises the fall-through).
+  assert.equal(classifyNpm({ time: { modified: "2026-05-01T00:00:00Z" }, versions: { "1.0.0": {} } }, "1.0.0", DEP_HEALTH_NOW), null);
+  assert.equal(classifyPypi({ releases: { "1.0.0": [{ upload_time_iso_8601: "2026-05-01T00:00:00Z" }] } }, "1.0.0", DEP_HEALTH_NOW), null);
 });
 
 test("queryOsv: maps vulns; severity from database_specific; fixedIn from affected; [] on non-ok", async () => {


### PR DESCRIPTION
## Summary

Adds a REES analyzer (**#1511**, tier: solid) that flags a newly-added or upgraded direct dependency carrying a maintenance risk the no-checkout `claude --print` reviewer cannot see:

- **deprecated** — the npm version is marked `deprecated` on the registry
- **yanked** — the exact PyPI release is yanked and should not be installed
- **stale** — no release in over 3 years (advisory: "verify the package is still maintained")

It does one version-scoped registry read per dependency (npm packument / PyPI JSON — both free, no key), then pure classification. **Additive and fail-safe**: any network failure skips that dep rather than emitting a finding, and registry prose is never returned — only `package@version` + the factual maintenance property. Findings render as a public-safe brief block the engine splices into the review.

Scoped to the **lean V1** (npm + PyPI, the two ecosystems the dependency parser already extracts); the archived-repo and sole-maintainer signals the issue also mentions (deps.dev / ecosyste.ms) are a natural follow-up.

## Implementation (the established REES analyzer pattern)

1. `DepHealthFinding` type + `depHealth` key in `src/types.ts`
2. `src/analyzers/dep-health.ts` — pure classifiers (`classifyNpm`, `classifyPypi`, `npmLastPublishMs`, `pypiLastUploadMs`, `pypiVersionYanked`) + `scanDepHealth`, injectable `fetch` and `now`
3. Descriptor registered in `src/analyzers/registry.ts`
4. Public-safe block in `src/render.ts`
5. Regenerated analyzer metadata (+ the generated UI mirror)
6. `node:test` units in `test/enrichment.test.ts`

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused: one new analyzer, wired through the documented pattern; no engine changes.
- [x] Follows `CONTRIBUTING.md`; does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: **Closes #1511** (a maintainer-authored feature request).

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment test` (build → validate sourcemaps → analyzer-metadata check → full REES suite) — green; new units cover deprecated / yanked / stale (both sides of the 3-year boundary), the fail-safe path, and every pure classifier.
- [x] Rebased on `main` — no conflict.
- [ ] Root `npm run test:ci` — the change is confined to `review-enrichment/**` (plus the generated UI mirror `apps/gittensory-ui/src/lib/rees-analyzers.ts`), outside the root `src/**` Codecov patch scope. Verified by CI.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public output is sanitized and low-noise: `package@version` + the factual maintenance kind only; registry deprecation/yank prose is never surfaced.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] UI change is limited to the generated analyzer-registry mirror (regenerated, not hand-edited).
- [x] No docs/changelog changes.

