### PR TITLE
fix(selfhost): repair Postgres sidecar operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   1024 = bge-m3/mxbai-embed-large). Must match AI_EMBED_MODEL;
 #                                            #   recreate the Qdrant collection when changing this after startup.
 # GITTENSORY_REPORTING_SOURCE_DATABASE_URL=  # optional Postgres reporting reader URL. Defaults to DATABASE_URL.
+# GITTENSORY_BACKUP_SOURCE_DATABASE_URL=     # optional Postgres backup reader URL. Defaults to DATABASE_URL.
 # MIGRATIONS_DIR=/app/migrations
 # CRON_INTERVAL_MS=120000                    # maintain/sweep + sync cadence (default ~2 min)
 

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -52,6 +52,14 @@ LITESTREAM_REGION=us-east-1`}
       />
       <CodeBlock lang="bash" code={`docker compose --profile litestream up -d`} />
 
+      <h2>Scheduled backups</h2>
+      <p>
+        The bundled <code>backup</code> profile writes the active app database to the{" "}
+        <code>gittensory-backups</code> volume. SQLite installs use an online backup; Postgres
+        installs use <code>pg_dump</code>. The same run also snapshots Qdrant when it is enabled.
+      </p>
+      <CodeBlock lang="bash" code={`docker compose --profile backup up -d`} />
+
       <h2>Multi-instance: Postgres and Redis</h2>
       <FeatureRow
         items={[

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -506,7 +506,7 @@ services:
       - runner-work:/tmp/runner
 
   # ── Backups (--profile backup) ────────────────────────────────────────────
-  # Online SQLite backup (WAL-safe, consistent even while the app writes) + a Qdrant snapshot, on a loop
+  # Active database backup (Postgres pg_dump or WAL-safe SQLite online backup) + a Qdrant snapshot, on a loop
   # (default daily), kept in the gittensory-backups volume with retention. Run on demand:
   #   docker compose --profile backup run --rm backup sh /backup.sh
   backup:
@@ -515,6 +515,8 @@ services:
     profiles: ["backup"]
     environment:
       DATABASE_PATH: /data/gittensory.sqlite
+      DATABASE_URL: "${DATABASE_URL:-}"
+      GITTENSORY_BACKUP_SOURCE_DATABASE_URL: "${GITTENSORY_BACKUP_SOURCE_DATABASE_URL:-}"
       QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
       BACKUP_RETAIN: ${BACKUP_RETAIN:-7}
     volumes:
@@ -524,7 +526,7 @@ services:
       - ./scripts/backup.sh:/backup.sh:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - "apk add --no-cache sqlite curl >/dev/null 2>&1 && while true; do sh /backup.sh || echo '[backup] run failed'; sleep ${BACKUP_INTERVAL_SECONDS:-86400}; done"
+      - "apk add --no-cache sqlite postgresql16-client curl >/dev/null 2>&1 && while true; do sh /backup.sh || echo '[backup] run failed'; sleep ${BACKUP_INTERVAL_SECONDS:-86400}; done"
 
 volumes:
   gittensory-data:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,27 +1,40 @@
 #!/bin/sh
-# Self-host backup: an online SQLite backup (safe while the app is writing) + a Qdrant snapshot, with retention.
+# Self-host backup: active DB backup (Postgres dump or online SQLite backup) + a Qdrant snapshot, with retention.
 # Run by the `backup` compose service (--profile backup) on a loop, or on demand:
-#   docker compose run --rm backup sh /backup.sh
-# Backups land in the `gittensory-backups` volume at /backups/{sqlite,qdrant}.
+#   docker compose --profile backup run --rm backup sh /backup.sh
+# Backups land in the `gittensory-backups` volume at /backups/{postgres,sqlite,qdrant}.
 set -eu
 
 TS=$(date -u +%Y%m%dT%H%M%SZ)
 RETAIN=${BACKUP_RETAIN:-7}
 DB=${DATABASE_PATH:-/data/gittensory.sqlite}
-OUT=/backups
-mkdir -p "$OUT/sqlite" "$OUT/qdrant"
+PG_DB="${GITTENSORY_BACKUP_SOURCE_DATABASE_URL:-${DATABASE_URL:-}}"
+OUT=${BACKUP_OUT_DIR:-/backups}
+mkdir -p "$OUT/postgres" "$OUT/sqlite" "$OUT/qdrant"
 
-# 1) SQLite — the Online Backup API yields a consistent copy even while the app writes (WAL-safe).
-if [ -f "$DB" ]; then
-  sqlite3 "$DB" ".backup '$OUT/sqlite/gittensory-$TS.sqlite'"
-  gzip -f "$OUT/sqlite/gittensory-$TS.sqlite"
-  echo "[backup] sqlite -> $OUT/sqlite/gittensory-$TS.sqlite.gz"
-else
-  echo "[backup] sqlite db not found at $DB (skipping)"
-fi
+# 1) Active app database. Prefer Postgres when DATABASE_URL is set; otherwise keep the SQLite online backup path.
+case "$PG_DB" in
+  postgres://*|postgresql://*)
+    if ! command -v pg_dump >/dev/null 2>&1; then
+      echo "[backup] pg_dump not found; cannot back up Postgres database" >&2
+      exit 1
+    fi
+    pg_dump -Fc -f "$OUT/postgres/gittensory-$TS.dump" "$PG_DB"
+    echo "[backup] postgres -> $OUT/postgres/gittensory-$TS.dump"
+    ;;
+  *)
+    if [ -f "$DB" ]; then
+      sqlite3 "$DB" ".backup '$OUT/sqlite/gittensory-$TS.sqlite'"
+      gzip -f "$OUT/sqlite/gittensory-$TS.sqlite"
+      echo "[backup] sqlite -> $OUT/sqlite/gittensory-$TS.sqlite.gz"
+    else
+      echo "[backup] sqlite db not found at $DB (skipping)"
+    fi
+    ;;
+esac
 
 # 2) Qdrant — trigger a full storage snapshot, download it, then delete it from Qdrant's own storage so snapshots
-#    don't accumulate inside the vector store. Best-effort: a Qdrant outage must not fail the SQLite backup.
+#    don't accumulate inside the vector store. Best-effort: a Qdrant outage must not fail the DB backup.
 if [ -n "${QDRANT_URL:-}" ]; then
   NAME=$(curl -sf -X POST "$QDRANT_URL/snapshots" 2>/dev/null | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
   if [ -n "$NAME" ]; then
@@ -35,7 +48,7 @@ if [ -n "${QDRANT_URL:-}" ]; then
 fi
 
 # 3) Retention — keep only the newest $RETAIN in each directory.
-for d in sqlite qdrant; do
+for d in postgres sqlite qdrant; do
   ls -1t "$OUT/$d" 2>/dev/null | tail -n +"$((RETAIN + 1))" | while IFS= read -r f; do
     rm -f "$OUT/$d/$f"
     echo "[backup] pruned old backup $d/$f"

--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -22,7 +22,7 @@ sqlite_dot_string() {
 }
 
 csv_temp_file() {
-  mktemp "$CSV_TMP_DIR/$1.XXXXXX.csv"
+  mktemp "$CSV_TMP_DIR/$1.XXXXXX"
 }
 
 source_column_exists() {

--- a/test/unit/selfhost-backup-script.test.ts
+++ b/test/unit/selfhost-backup-script.test.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tmpRoots: string[] = [];
+
+function tmpRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gittensory-backup-"));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+function fakePgDump(root: string): string {
+  const bin = join(root, "pg-bin");
+  mkdirSync(bin);
+  writeExecutable(
+    join(bin, "pg_dump"),
+    `#!/bin/sh
+out=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "$out" ]; then
+  echo 'missing -f output' >&2
+  exit 2
+fi
+printf 'postgres dump\\n' > "$out"
+`,
+  );
+  return bin;
+}
+
+function fakeSqlite(root: string): string {
+  const bin = join(root, "sqlite-bin");
+  mkdirSync(bin);
+  writeExecutable(
+    join(bin, "sqlite3"),
+    `#!/bin/sh
+cmd="$2"
+out="$(printf '%s\\n' "$cmd" | sed "s/^\\\\.backup '\\\\(.*\\\\)'$/\\\\1/")"
+if [ "$out" = "$cmd" ]; then
+  echo "unexpected sqlite command: $cmd" >&2
+  exit 2
+fi
+printf 'sqlite backup\\n' > "$out"
+`,
+  );
+  return bin;
+}
+
+function runBackup(root: string, env: Record<string, string>): string {
+  return execFileSync("sh", ["scripts/backup.sh"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      BACKUP_OUT_DIR: join(root, "backups"),
+      BACKUP_RETAIN: "7",
+      GITTENSORY_BACKUP_SOURCE_DATABASE_URL: "",
+      QDRANT_URL: "",
+      ...env,
+    },
+  });
+}
+
+describe("self-host backup script", () => {
+  it("backs up Postgres when DATABASE_URL is set instead of copying stale SQLite", () => {
+    const root = tmpRoot();
+    const pgBin = fakePgDump(root);
+    const staleSqlite = join(root, "stale.sqlite");
+    writeFileSync(staleSqlite, "stale sqlite");
+
+    const output = runBackup(root, {
+      DATABASE_URL: "postgres://gittensory:pw@postgres:5432/gittensory",
+      DATABASE_PATH: staleSqlite,
+      PATH: `${pgBin}:${process.env.PATH ?? ""}`,
+    });
+
+    const postgresBackups = readdirSync(join(root, "backups", "postgres"));
+    expect(output).toContain("[backup] postgres ->");
+    expect(postgresBackups).toHaveLength(1);
+    expect(postgresBackups[0]).toMatch(/^gittensory-\d{8}T\d{6}Z\.dump$/);
+    expect(readdirSync(join(root, "backups", "sqlite"))).toEqual([]);
+  });
+
+  it("keeps the SQLite online backup path when no Postgres URL is configured", () => {
+    const root = tmpRoot();
+    const sqliteBin = fakeSqlite(root);
+    const appDb = join(root, "gittensory.sqlite");
+    writeFileSync(appDb, "sqlite db");
+
+    const output = runBackup(root, {
+      DATABASE_PATH: appDb,
+      DATABASE_URL: "",
+      PATH: `${sqliteBin}:${process.env.PATH ?? ""}`,
+    });
+
+    const sqliteBackups = readdirSync(join(root, "backups", "sqlite"));
+    expect(output).toContain("[backup] sqlite ->");
+    expect(sqliteBackups).toHaveLength(1);
+    expect(sqliteBackups[0]).toMatch(/^gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
+    expect(existsSync(join(root, "backups", "postgres"))).toBe(true);
+    expect(readdirSync(join(root, "backups", "postgres"))).toEqual([]);
+  });
+});

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -78,6 +78,42 @@ esac
   return bin;
 }
 
+function busyboxLikeMktemp(root: string): string {
+  const bin = join(root, "busybox-bin");
+  mkdirSync(bin);
+  const mktemp = join(bin, "mktemp");
+  writeFileSync(
+    mktemp,
+    `#!/bin/sh
+if [ "$1" = "-d" ]; then
+  base="\${TMPDIR:-/tmp}/tmp.$$"
+  n=0
+  while [ -e "$base-$n" ]; do n=$((n + 1)); done
+  mkdir "$base-$n"
+  printf '%s\\n' "$base-$n"
+  exit 0
+fi
+
+case "$1" in
+  *XXXXXX)
+    base="\${1%XXXXXX}"
+    n=0
+    out="$base$n"
+    while [ -e "$out" ]; do n=$((n + 1)); out="$base$n"; done
+    : > "$out"
+    printf '%s\\n' "$out"
+    ;;
+  *)
+    echo 'mktemp: Invalid argument' >&2
+    exit 1
+    ;;
+esac
+`,
+  );
+  chmodSync(mktemp, 0o755);
+  return bin;
+}
+
 function failingPsql(root: string): string {
   const bin = join(root, "broken-bin");
   mkdirSync(bin);
@@ -283,6 +319,22 @@ esac
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.private') IS NULL FROM ai_usage_events;")).toBe("1");
     expect(readdirSync(csvTmp)).toEqual([]);
+  });
+
+  it("uses BusyBox-compatible mktemp templates for Postgres CSV exports", () => {
+    const root = tmpRoot();
+    const outDb = join(root, "reporting.sqlite");
+    const psqlBin = fakePsql(root);
+    const mktempBin = busyboxLikeMktemp(root);
+
+    runExporter(root, join(root, "unused.sqlite"), outDb, {
+      DATABASE_URL: "postgres://gittensory:pw@postgres:5432/gittensory",
+      PATH: `${mktempBin}:${psqlBin}:${process.env.PATH ?? ""}`,
+    });
+
+    expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
+    expect(sqlite(outDb, "SELECT count(*) FROM review_targets;")).toBe("3");
+    expect(sqlite(outDb, "SELECT sum(estimated_neurons) FROM ai_usage_events;")).toBe("42");
   });
 
   it("fails closed when Postgres metadata cannot be inspected", () => {


### PR DESCRIPTION
## Summary
Fixes the self-host sidecars needed by Postgres deployments: the Grafana reporting exporter and the scheduled backup profile.

## What changed
- Makes the Grafana reporting exporter work under Alpine/BusyBox while still writing the redacted SQLite reporting snapshot for Grafana.
- Teaches the backup profile to detect Postgres via `DATABASE_URL` and write `pg_dump` snapshots into the `gittensory-backups` volume.
- Keeps the SQLite online backup fallback and Qdrant snapshot retention path intact.
- Documents the scheduled backup profile and adds a backup source override env knob.
- Adds shell-level regression tests for Postgres and SQLite backup modes.

## Why
Postgres cutover left two sidecar gaps: the reporting exporter could fail before refreshing Grafana data, and the scheduled backup sidecar only protected the stale SQLite volume instead of the active Postgres database.

## Validation
- `npx vitest run test/unit/selfhost-backup-script.test.ts test/unit/selfhost-grafana-reporting.test.ts`
- `npm run test:ci`
- `npm audit --audit-level=moderate`

## Notes
- No issue because this is operational hardening found during the self-host Postgres cutover.
- `litestream` remains SQLite-only; Postgres deployments should use `--profile backup` for `pg_dump` snapshots.