### PR TITLE
fix(db): normalize digest subscriptions without a D1-forbidden temp table

### DIFF
--- a/migrations/0083_normalize_digest_subscription_logins.sql
+++ b/migrations/0083_normalize_digest_subscription_logins.sql
@@ -1,26 +1,29 @@
-CREATE TEMP TABLE digest_subscriptions_canonical AS
-SELECT id, lower(login) AS login, lower(email) AS email, status, source, created_at, updated_at
-FROM (
-  SELECT
-    id,
-    login,
-    email,
-    status,
-    source,
-    created_at,
-    updated_at,
-    row_number() OVER (
-      PARTITION BY lower(login), lower(email)
-      ORDER BY updated_at DESC, created_at DESC, id DESC
-    ) AS rn
-  FROM digest_subscriptions
-)
-WHERE rn = 1;
+-- Normalize digest_subscriptions login/email to lowercase, deduplicating rows that would collide under the
+-- unique (login, email) index once normalized. Written WITHOUT a temp table: Cloudflare D1's SQL authorizer
+-- rejects CREATE TEMP TABLE with "not authorized: SQLITE_AUTH [code: 7500]" (temp objects are unsupported on
+-- the remote), so the original temp-table form applied fine on self-hosted SQLite but failed the remote
+-- `wrangler d1 migrations apply`.
 
-DELETE FROM digest_subscriptions;
+-- 1. Drop the losers: within each case-insensitive (login, email) group keep only the newest row and delete
+--    the rest. The row_number() tie-break (updated_at, then created_at, then id — all DESC) matches the
+--    original, so the surviving id per group is unchanged.
+DELETE FROM digest_subscriptions
+WHERE id IN (
+  SELECT id
+  FROM (
+    SELECT
+      id,
+      row_number() OVER (
+        PARTITION BY lower(login), lower(email)
+        ORDER BY updated_at DESC, created_at DESC, id DESC
+      ) AS rn
+    FROM digest_subscriptions
+  )
+  WHERE rn > 1
+);
 
-INSERT INTO digest_subscriptions (id, login, email, status, source, created_at, updated_at)
-SELECT id, login, email, status, source, created_at, updated_at
-FROM digest_subscriptions_canonical;
-
-DROP TABLE digest_subscriptions_canonical;
+-- 2. Canonicalize the survivors. Post-dedup every surviving row already has a distinct
+--    (lower(login), lower(email)), so lowering login/email in place cannot violate the unique index.
+UPDATE digest_subscriptions
+SET login = lower(login),
+    email = lower(email);

--- a/migrations/0083_normalize_digest_subscription_logins.sql
+++ b/migrations/0083_normalize_digest_subscription_logins.sql
@@ -1,12 +1,8 @@
--- Normalize digest_subscriptions login/email to lowercase, deduplicating rows that would collide under the
--- unique (login, email) index once normalized. Written WITHOUT a temp table: Cloudflare D1's SQL authorizer
--- rejects CREATE TEMP TABLE with "not authorized: SQLITE_AUTH [code: 7500]" (temp objects are unsupported on
--- the remote), so the original temp-table form applied fine on self-hosted SQLite but failed the remote
--- `wrangler d1 migrations apply`.
+-- Normalize digest_subscriptions login/email to lowercase, deduplicating rows that collide under the unique
+-- (login, email) index. No CREATE TEMP TABLE: Cloudflare D1's remote authorizer rejects temp objects with
+-- "not authorized: SQLITE_AUTH". Delete losers BEFORE lowercasing survivors, or canonicalization trips the index.
 
--- 1. Drop the losers: within each case-insensitive (login, email) group keep only the newest row and delete
---    the rest. The row_number() tie-break (updated_at, then created_at, then id — all DESC) matches the
---    original, so the surviving id per group is unchanged.
+-- Drop every row but the newest per case-insensitive (login, email) group (tie-break: updated_at, created_at, id).
 DELETE FROM digest_subscriptions
 WHERE id IN (
   SELECT id
@@ -22,8 +18,7 @@ WHERE id IN (
   WHERE rn > 1
 );
 
--- 2. Canonicalize the survivors. Post-dedup every surviving row already has a distinct
---    (lower(login), lower(email)), so lowering login/email in place cannot violate the unique index.
+-- Lowercase the survivors; post-dedup each has a distinct lowercased (login, email), so the unique index holds.
 UPDATE digest_subscriptions
 SET login = lower(login),
     email = lower(email);

--- a/test/unit/digest-subscription-normalization.test.ts
+++ b/test/unit/digest-subscription-normalization.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+// Regression coverage for migrations/0083, which normalizes digest_subscriptions login/email to lowercase and
+// deduplicates rows that collide under the unique (login, email) index. The migration was rewritten off a
+// CREATE TEMP TABLE (rejected by D1's remote authorizer with SQLITE_AUTH) onto a DELETE-then-UPDATE form; these
+// tests pin the semantics — winner selection, case-normalization, and no unique-index violation — against the
+// REAL migration file so a future edit that reorders the steps or changes the tie-break fails here.
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "migrations");
+const migrationSql = (name: string) => readFileSync(join(migrationsDir, name), "utf8");
+
+type Row = { id: string; login: string; email: string; status: string };
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(migrationSql("0014_digest_subscriptions.sql"));
+  return db;
+}
+
+function insert(db: DatabaseSync, row: Omit<Row, "status"> & { status?: string; created_at: string; updated_at: string }): void {
+  db.prepare(
+    "INSERT INTO digest_subscriptions (id, login, email, status, source, created_at, updated_at) VALUES (?, ?, ?, ?, 'app', ?, ?)",
+  ).run(row.id, row.login, row.email, row.status ?? "active", row.created_at, row.updated_at);
+}
+
+function allRows(db: DatabaseSync): Row[] {
+  return db.prepare("SELECT id, login, email, status FROM digest_subscriptions ORDER BY login, email").all() as Row[];
+}
+
+describe("0083 digest-subscription normalization migration", () => {
+  it("keeps the newest row per case-insensitive (login, email) group and lowercases every survivor", () => {
+    const db = freshDb();
+    // One case-collision group (same lower(login)/lower(email), differing case + timestamps)...
+    insert(db, { id: "a1", login: "Alice", email: "A@X.com", created_at: "2024-01-01", updated_at: "2024-01-01" }); // oldest loser
+    insert(db, { id: "a2", login: "alice", email: "a@x.com", status: "paused", created_at: "2024-01-02", updated_at: "2024-01-05" }); // newest → survives
+    insert(db, { id: "a3", login: "ALICE", email: "a@X.COM", created_at: "2024-01-03", updated_at: "2024-01-03" }); // middle loser
+    // ...plus a mixed-case unique row and an already-lowercase unique row, both of which must survive.
+    insert(db, { id: "b1", login: "Bob", email: "bob@y.com", created_at: "2024-01-01", updated_at: "2024-01-01" });
+    insert(db, { id: "c1", login: "carol", email: "carol@z.com", created_at: "2024-01-01", updated_at: "2024-01-01" });
+
+    db.exec(migrationSql("0083_normalize_digest_subscription_logins.sql"));
+
+    const rows = allRows(db);
+    // Collision group collapses to its newest member (a2); the two unique rows remain — 3 total.
+    expect(rows.map((r) => r.id)).toEqual(["a2", "b1", "c1"]);
+    // The survivor is row a2 verbatim (its own status), not a merge of the group's fields.
+    expect(rows.find((r) => r.id === "a2")).toMatchObject({ login: "alice", email: "a@x.com", status: "paused" });
+    // Every survivor is lowercased.
+    expect(rows.every((r) => r.login === r.login.toLowerCase() && r.email === r.email.toLowerCase())).toBe(true);
+    expect(rows.find((r) => r.id === "b1")).toMatchObject({ login: "bob", email: "bob@y.com" });
+  });
+
+  it("does not violate the unique index when a mixed-case row lowercases onto an existing lowercase sibling", () => {
+    const db = freshDb();
+    // Reversing the migration's delete/update order would make canonicalizing 'Dave' collide with the existing
+    // 'dave' row mid-UPDATE. Delete-before-update keeps only the newest, so the UPDATE is collision-free.
+    insert(db, { id: "d1", login: "dave", email: "d@e.com", created_at: "2024-01-01", updated_at: "2024-01-01" }); // older loser
+    insert(db, { id: "d2", login: "Dave", email: "D@E.com", status: "paused", created_at: "2024-01-02", updated_at: "2024-01-02" }); // newer → survives
+
+    expect(() => db.exec(migrationSql("0083_normalize_digest_subscription_logins.sql"))).not.toThrow();
+
+    expect(allRows(db)).toEqual([{ id: "d2", login: "dave", email: "d@e.com", status: "paused" }]);
+  });
+
+  it("is a no-op on data that is already lowercase and collision-free", () => {
+    const db = freshDb();
+    insert(db, { id: "e1", login: "erin", email: "erin@f.com", created_at: "2024-01-01", updated_at: "2024-01-01" });
+    insert(db, { id: "f1", login: "frank", email: "frank@g.com", created_at: "2024-01-01", updated_at: "2024-01-01" });
+
+    db.exec(migrationSql("0083_normalize_digest_subscription_logins.sql"));
+
+    expect(allRows(db)).toEqual([
+      { id: "e1", login: "erin", email: "erin@f.com", status: "active" },
+      { id: "f1", login: "frank", email: "frank@g.com", status: "active" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`migrations/0083_normalize_digest_subscription_logins.sql` used `CREATE TEMP TABLE`, which Cloudflare D1's remote SQL authorizer rejects with `not authorized: SQLITE_AUTH [code: 7500]`. It's the first of the pending migrations (0083–0087), so it blocked the rest **and** the `wrangler deploy` that follows in `deploy:api`, stalling the gittensory-api Worker build (deploy log 2026-07-01T07:30:18Z).

Local SQLite — used by the migration tests — has no authorizer, so temp tables run fine there and the migration passed CI; the failure only surfaces at the `--remote` apply during deploy.

## What changed

- Rewrote 0083 to drop the temp table. Equivalent, D1-safe form:
  - `DELETE` the non-newest row per case-insensitive `(login, email)` group, using the same `row_number()` tie-break (`updated_at`, `created_at`, `id`, all DESC) — the surviving id per group is unchanged.
  - `UPDATE` the survivors to lowercase `login`/`email`. Post-dedup every survivor has a distinct lowercased `(login, email)`, so it can't violate the unique index. Ordering matters: delete-before-update, or canonicalization would trip the index mid-`UPDATE`.
- Trimmed the migration's header comment to the durable invariant.
- Added `test/unit/digest-subscription-normalization.test.ts` — regression coverage.

Edited in place (not a new migration) intentionally: 0083 never applied to remote D1 (the ledger only records successes), so the next apply re-runs the corrected version; on self-host it's already recorded as applied by filename, so the edit is inert and the data is already correct there.

## Why

Unblock the gittensory-api deploy; 0083–0087 and the worker deploy are all stuck behind this one statement.

## Validation

- `test/unit/digest-subscription-normalization.test.ts` (new, 3 cases) applies the **real** 0014 schema + 0083 migration to in-memory SQLite and asserts: winner selection (newest row per case-insensitive group survives, verbatim), lowercase canonicalization, the delete-before-update ordering invariant (a mixed-case row lowercasing onto an existing lowercase sibling does not violate the unique index), and the no-op case on already-normalized data.
- `test/unit/check-migrations-script.test.ts` and `test/unit/selfhost-migrate.test.ts` (applies every migration incl. 0083) — pass.
- `npx tsc --noEmit` — clean.

## Notes

No linked issue — this is a no-issue PR: an urgent production hotfix for a broken gittensory-api deploy (remote D1 rejects the temp table in migration 0083), not tracked feature work.

Root cause is a whole class of bug: pre-merge CI applies migrations to permissive local SQLite, but only the remote D1 authorizer (which runs post-merge in the deploy) rejects temp tables / `ATTACH` / `PRAGMA` / etc. A follow-up PR will add a static denylist guard to `scripts/check-migrations.mjs` so these are caught pre-merge.