### PR TITLE
ci(migrations): reject D1-incompatible SQL in check-migrations before merge

### DIFF
--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -17,9 +17,9 @@
 //   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
 //     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
 //     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
-const DIR = "migrations";
+const DIR = process.env.CHECK_MIGRATIONS_DIR || "migrations";
 const NAME = /^(\d{4})_[a-z0-9]+(?:_[a-z0-9]+)*\.sql$/;
 const KNOWN_DUPLICATES = new Map([
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
@@ -31,6 +31,90 @@ const fail = (message) => {
   process.stderr.write(`check-migrations: ${message}\n`);
   process.exit(1);
 };
+
+// D1 remote-authorizer compatibility. These statements run fine on the LOCAL SQLite that CI/tests apply
+// migrations to, but the REMOTE D1 authorizer rejects them at `wrangler d1 migrations apply --remote` with
+// `not authorized: SQLITE_AUTH [code: 7500]` — which breaks the deploy AFTER merge, where pre-merge CI can't
+// see it (a `CREATE TEMP TABLE` in 0083 did exactly this). This scan is the only pre-merge gate for that class.
+// `CREATE TEMP` matches anywhere (it always starts a statement); the rest anchor to a statement boundary
+// (start-of-file or after a `;`) so a trigger body's own `BEGIN`/`END` and mid-statement words don't trip.
+// The anchored patterns use a variable-length lookbehind (`(?<=(?:^|;)\s*)`, supported by V8/Node) so the
+// match starts on the keyword itself — reported line numbers point at the statement, not the preceding `;`.
+const D1_FORBIDDEN = [
+  [/create\s+temp(?:orary)?\b/gi, "temporary object (CREATE TEMP/TEMPORARY) — D1 rejects temp tables/triggers/views/indexes; rewrite without one (e.g. DELETE the losers, then UPDATE the survivors)"],
+  [/(?<=(?:^|;)\s*)attach\b/gi, "ATTACH is not supported on D1"],
+  [/(?<=(?:^|;)\s*)detach\b/gi, "DETACH is not supported on D1"],
+  [/(?<=(?:^|;)\s*)vacuum\b/gi, "VACUUM is not supported on D1"],
+  [/(?<=(?:^|;)\s*)pragma\b/gi, "PRAGMA is not supported on D1"],
+  [/(?<=(?:^|;)\s*)(?:begin|commit|rollback|savepoint|release)\b/gi, "explicit transaction control — wrangler wraps each migration in its own transaction"],
+];
+
+// Blank out comments and string/identifier literals (preserving newlines for accurate line numbers) so a
+// forbidden keyword inside a comment or a quoted value can never trip a false positive.
+function cleanSql(sql) {
+  let out = "";
+  for (let i = 0; i < sql.length; ) {
+    const c = sql[i];
+    const c2 = sql[i + 1];
+    if (c === "-" && c2 === "-") {
+      out += "  ";
+      i += 2;
+      while (i < sql.length && sql[i] !== "\n") {
+        out += " ";
+        i += 1;
+      }
+      continue;
+    }
+    if (c === "/" && c2 === "*") {
+      out += "  ";
+      i += 2;
+      while (i < sql.length && !(sql[i] === "*" && sql[i + 1] === "/")) {
+        out += sql[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      if (i < sql.length) {
+        out += "  ";
+        i += 2;
+      }
+      continue;
+    }
+    if (c === "'" || c === '"' || c === "`") {
+      out += " ";
+      i += 1;
+      while (i < sql.length) {
+        if (sql[i] === c) {
+          if (sql[i + 1] === c) {
+            out += "  ";
+            i += 2;
+            continue;
+          }
+          out += " ";
+          i += 1;
+          break;
+        }
+        out += sql[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      continue;
+    }
+    if (c === "[") {
+      out += " ";
+      i += 1;
+      while (i < sql.length && sql[i] !== "]") {
+        out += sql[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      if (i < sql.length) {
+        out += " ";
+        i += 1;
+      }
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
 
 const files = readdirSync(DIR)
   .filter((f) => f.endsWith(".sql"))
@@ -72,6 +156,25 @@ for (let i = 1; i < numbers.length; i += 1) {
     const curr = String(numbers[i]).padStart(4, "0");
     fail(`migration number gap: ${prev} -> ${curr}. Migrations must be a contiguous sequence (no skipped numbers).`);
   }
+}
+
+const sqlViolations = [];
+for (const file of files) {
+  const cleaned = cleanSql(readFileSync(`${DIR}/${file}`, "utf8"));
+  for (const [re, why] of D1_FORBIDDEN) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(cleaned)) !== null) {
+      const line = cleaned.slice(0, match.index).split("\n").length;
+      sqlViolations.push(`${file}:${line} — ${why}`);
+      if (re.lastIndex === match.index) re.lastIndex += 1;
+    }
+  }
+}
+if (sqlViolations.length > 0) {
+  fail(
+    `D1-incompatible SQL — the remote D1 authorizer rejects these at deploy (SQLITE_AUTH [code: 7500]), even though the local SQLite used by CI accepts them:\n  ${sqlViolations.join("\n  ")}`,
+  );
 }
 
 const first = String(numbers[0]).padStart(4, "0");

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -1,10 +1,75 @@
 import { execFileSync } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// Run scripts/check-migrations.mjs over a throwaway fixture dir (via CHECK_MIGRATIONS_DIR) and normalize the
+// pass/fail into { status, out }. On a non-zero exit execFileSync throws; the violation text is on stderr.
+function runCheck(files: Record<string, string>): { status: number; out: string } {
+  const dir = mkdtempSync(join(tmpdir(), "gtmig-check-"));
+  tmpDirs.push(dir);
+  for (const [name, body] of Object.entries(files)) writeFileSync(join(dir, name), body);
+  try {
+    const stdout = execFileSync(process.execPath, ["scripts/check-migrations.mjs"], {
+      encoding: "utf8",
+      env: { ...process.env, CHECK_MIGRATIONS_DIR: dir },
+    });
+    return { status: 0, out: stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
 
 describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(process.execPath, ["scripts/check-migrations.mjs"], { encoding: "utf8" });
 
     expect(output).toContain("(3 grandfathered duplicates: 0015, 0017, 0074)");
+  });
+
+  it("rejects a migration that creates a temporary object (the D1 remote authorizer blocks it)", () => {
+    const r = runCheck({ "0001_temp.sql": "CREATE TEMP TABLE scratch AS SELECT 1;\n" });
+
+    expect(r.status).toBe(1);
+    expect(r.out).toContain("0001_temp.sql:1");
+    expect(r.out).toMatch(/SQLITE_AUTH/);
+    expect(r.out).toMatch(/temporary object/i);
+  });
+
+  it("rejects explicit transaction control and points at each offending statement line", () => {
+    const r = runCheck({ "0001_txn.sql": "BEGIN;\nUPDATE t SET x = 1;\nCOMMIT;\n" });
+
+    expect(r.status).toBe(1);
+    expect(r.out).toContain("0001_txn.sql:1"); // BEGIN
+    expect(r.out).toContain("0001_txn.sql:3"); // COMMIT — line points at the keyword, not the preceding `;`
+  });
+
+  it.each(["ATTACH DATABASE 'x' AS x;", "DETACH DATABASE x;", "VACUUM;", "PRAGMA foreign_keys = ON;"])(
+    "rejects the D1-unsupported statement: %s",
+    (stmt) => {
+      const r = runCheck({ "0001_stmt.sql": `${stmt}\n` });
+
+      expect(r.status).toBe(1);
+      expect(r.out).toContain("0001_stmt.sql:1");
+    },
+  );
+
+  it("does not flag forbidden keywords that appear only in a comment, a string, or a trigger body", () => {
+    const r = runCheck({
+      "0001_ok.sql":
+        "-- this migration does not VACUUM or PRAGMA anything\n" +
+        "CREATE TABLE t (note TEXT DEFAULT 'please COMMIT and ATTACH nothing');\n" +
+        "CREATE TRIGGER tr AFTER INSERT ON t BEGIN UPDATE t SET note = 'x'; END;\n",
+    });
+
+    expect(r.status).toBe(0);
+    expect(r.out).toContain("1 migrations OK");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening to [#2004](https://github.com/JSONbored/gittensory/pull/2004). That PR fixed a `CREATE TEMP TABLE` in migration 0083 that passed CI but broke the deploy — the remote D1 authorizer rejects temp objects with `not authorized: SQLITE_AUTH [code: 7500]`. Pre-merge CI can't see this class of bug because it applies migrations to a permissive **local** SQLite (node:sqlite / Miniflare) with no authorizer; the remote authorizer only runs post-merge at `wrangler d1 migrations apply --remote`. This adds the deterministic pre-merge guard.

## What changed

- `scripts/check-migrations.mjs` (already CI-wired via the `migrations/**` path filter) now scans every migration's SQL for the constructs D1's remote authorizer blocks and fails with `file:line`:
  - temporary objects (`CREATE TEMP` / `CREATE TEMPORARY` table/trigger/view/index)
  - `ATTACH` / `DETACH`, `VACUUM`, `PRAGMA`
  - explicit transaction control (`BEGIN` / `COMMIT` / `ROLLBACK` / `SAVEPOINT` / `RELEASE`) — wrangler wraps each migration in its own transaction
- A `cleanSql` pass blanks comments and string/identifier literals (preserving newlines) so a forbidden keyword inside a comment or quoted value can't false-positive; the anchored patterns use a variable-length lookbehind so reported line numbers point at the statement, not the preceding `;`.
- `CHECK_MIGRATIONS_DIR` env override lets the tests run the real script over throwaway fixtures.

This complements the private review-agent rubric (which flags the same class in AI review) with a deterministic CI check.

## Why

Catch remote-D1-only rejections before merge instead of at deploy, so a green PR can't stall the Worker deploy.

## Validation

- `npm run db:migrations:check` — passes on all 90 current migrations (no false positives).
- `test/unit/check-migrations-script.test.ts` (extended): asserts the guard flags a temp table, transaction control (with accurate per-statement line numbers), and `ATTACH`/`DETACH`/`VACUUM`/`PRAGMA`, while forbidden keywords appearing only in a comment, a string literal, or a trigger `BEGIN…END` body stay clean.
- `npx tsc --noEmit` — clean.

## Notes

No linked issue — a small, self-evident CI-guard hardening following directly from the #2004 incident (not tracked feature work). Scope is `scripts/` + `test/` only; no `src/`, migrations, or UI touched.