### PR TITLE
feat(signals): treat __fixtures__ and __mocks__ paths as test evidence

### DIFF
--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -6,7 +6,8 @@ export function isTestPath(file: string): boolean {
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|js|jsx)$/i.test(file) ||
-    /(^|\/)__snapshots__\//i.test(file)
+    /(^|\/)__snapshots__\//i.test(file) ||
+    /(^|\/)(__fixtures__|__mocks__)\//i.test(file)
   );
 }
 

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -13,6 +13,8 @@ describe("test evidence helpers", () => {
     expect(isTestPath("playwright/smoke.spec.ts")).toBe(true);
     expect(isTestPath("cypress/e2e/checkout.cy.js")).toBe(true);
     expect(isTestPath("components/__snapshots__/Card.tsx.snap")).toBe(true);
+    expect(isTestPath("src/__fixtures__/user.json")).toBe(true);
+    expect(isTestPath("lib/__mocks__/fetch.ts")).toBe(true);
     expect(isTestPath("src/state.snap")).toBe(false);
     expect(isTestPath("src/widget.rs")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Count Jest/Vitest `__fixtures__` and `__mocks__` directories as test paths in `isTestPath`.
- Improves missing-test-evidence classification when fixture/mock files accompany source changes.

## No-issue rationale
Small slop/test-evidence hardening with no linked issue.

## Test plan
- [x] `npx vitest run test/unit/test-evidence.test.ts`

Made with [Cursor](https://cursor.com)