### PR TITLE
fix(mcp): parse http and git protocol GitHub remotes

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -16,7 +16,9 @@ export function parseGitRemote(remoteUrl) {
   const patterns = [
     /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
     /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^http:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
     /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^git:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
   ];
   for (const pattern of patterns) {
     const match = trimmed.match(pattern);

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1759,6 +1759,8 @@ describe("local MCP git metadata collection", () => {
     expect(parseGitRemote("https://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory/")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory////")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("http://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("git://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
     expect(parseGitRemote(`x${"/".repeat(32_000)}x`)).toBeUndefined();
 
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-local-"));


### PR DESCRIPTION
## Summary
- Teach `parseGitRemote` to accept `git://github.com/owner/repo` and `http://github.com/owner/repo` remotes.
- Lets local MCP preflight infer `repoFullName` without `--repo` for legacy URL shapes.

## No-issue rationale
MCP remote parsing hardening with no linked issue.

## Test plan
- [x] `npx vitest run test/unit/local-branch.test.ts -t \"parses remotes\"`

Made with [Cursor](https://cursor.com)