### PR TITLE
test(crypto): cover uppercase hex in timingSafeEqualHex

### DIFF
--- a/test/unit/crypto.test.ts
+++ b/test/unit/crypto.test.ts
@@ -27,6 +27,7 @@ describe("webhook signature verification", () => {
     expect(timingSafeEqualHex("", "00")).toBe(false);
     expect(timingSafeEqualHex("00", "01")).toBe(false);
     expect(timingSafeEqualHex("00", "00")).toBe(true);
+    expect(timingSafeEqualHex("ABCD", "abcd")).toBe(true);
   });
 
   it("uses timing-safe token comparisons and one-way token hashes", async () => {


### PR DESCRIPTION
## Summary
- Add regression coverage that `timingSafeEqualHex` treats uppercase and lowercase hex as equal.

## No-issue rationale
Test-only coverage lock with no linked issue.

## Test plan
- [x] `npx vitest run test/unit/crypto.test.ts`

Made with [Cursor](https://cursor.com)