### PR TITLE
feat(metrics): expose Redis token cache counters

### DIFF
--- a/src/selfhost/redis-token-cache.ts
+++ b/src/selfhost/redis-token-cache.ts
@@ -6,25 +6,42 @@
 // Also makes the cache shared across instances if the stack is ever scaled horizontally.
 import type { Redis } from "ioredis";
 import type { InstallationTokenStore } from "../github/app";
+import { incr } from "./metrics";
+
+const REDIS_TOKEN_CACHE_METRIC = "gittensory_redis_token_cache_total";
 
 const keyFor = (installationId: number): string =>
   `gh:insttoken:${installationId}`;
+
+function recordTokenCacheMetric(result: "hit" | "miss"): void {
+  incr(REDIS_TOKEN_CACHE_METRIC, { result });
+}
 
 export function createRedisTokenCache(redis: Redis): InstallationTokenStore {
   return {
     async get(installationId: number) {
       const raw = await redis.get(keyFor(installationId));
-      if (!raw) return null;
+      if (!raw) {
+        recordTokenCacheMetric("miss");
+        return null;
+      }
       try {
         const value = JSON.parse(raw) as {
           token?: unknown;
           expiresAtMs?: unknown;
         };
-        return typeof value.token === "string" &&
-          typeof value.expiresAtMs === "number"
-          ? { token: value.token, expiresAtMs: value.expiresAtMs }
-          : null;
+        if (typeof value.token !== "string") {
+          recordTokenCacheMetric("miss");
+          return null;
+        }
+        if (typeof value.expiresAtMs !== "number") {
+          recordTokenCacheMetric("miss");
+          return null;
+        }
+        recordTokenCacheMetric("hit");
+        return { token: value.token, expiresAtMs: value.expiresAtMs };
       } catch {
+        recordTokenCacheMetric("miss");
         return null;
       }
     },

--- a/test/unit/selfhost-redis-token-cache.test.ts
+++ b/test/unit/selfhost-redis-token-cache.test.ts
@@ -1,5 +1,6 @@
 import type { Redis } from "ioredis";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createRedisTokenCache } from "../../src/selfhost/redis-token-cache";
 
 /** Minimal ioredis stand-in that records the TTL passed to set(). */
@@ -23,20 +24,32 @@ function fakeRedis(): {
   return { redis, store, ttl: () => lastTtl };
 }
 
+afterEach(() => resetMetrics());
+
 describe("createRedisTokenCache (#perf installation-token persistence)", () => {
   it("get returns null for a missing installation", async () => {
     const { redis } = fakeRedis();
     expect(await createRedisTokenCache(redis).get(42)).toBeNull();
+
+    expect(await renderMetrics()).toContain(
+      'gittensory_redis_token_cache_total{result="miss"} 1',
+    );
   });
 
   it("set then get round-trips the token + expiry, with TTL ~ the token lifetime", async () => {
     const f = fakeRedis();
     const cache = createRedisTokenCache(f.redis);
     const expiresAtMs = Date.now() + 3_600_000;
-    await cache.set(7, { token: "tok", expiresAtMs });
+    await cache.set(7, { token: "sensitive-value", expiresAtMs });
     expect(f.ttl()).toBeGreaterThan(3500); // ~3600s
     expect(f.ttl()).toBeLessThanOrEqual(3600);
-    expect(await cache.get(7)).toEqual({ token: "tok", expiresAtMs });
+    expect(await cache.get(7)).toEqual({ token: "sensitive-value", expiresAtMs });
+
+    const metrics = await renderMetrics();
+    expect(metrics).toContain(
+      'gittensory_redis_token_cache_total{result="hit"} 1',
+    );
+    expect(metrics).not.toContain("sensitive-value");
   });
 
   it("floors the TTL at 1s for an already-near-expiry token", async () => {
@@ -52,14 +65,35 @@ describe("createRedisTokenCache (#perf installation-token persistence)", () => {
     const f = fakeRedis();
     f.store.set("gh:insttoken:9", "{not json");
     expect(await createRedisTokenCache(f.redis).get(9)).toBeNull();
+
+    expect(await renderMetrics()).toContain(
+      'gittensory_redis_token_cache_total{result="miss"} 1',
+    );
   });
 
-  it("get returns null when the stored shape is wrong", async () => {
+  it("get returns null when the cached token is not a string", async () => {
     const f = fakeRedis();
     f.store.set(
       "gh:insttoken:9",
-      JSON.stringify({ token: 123, expiresAtMs: "soon" }),
+      JSON.stringify({ token: 123, expiresAtMs: Date.now() + 60_000 }),
     );
     expect(await createRedisTokenCache(f.redis).get(9)).toBeNull();
+
+    expect(await renderMetrics()).toContain(
+      'gittensory_redis_token_cache_total{result="miss"} 1',
+    );
+  });
+
+  it("get returns null when the cached expiry is not a number", async () => {
+    const f = fakeRedis();
+    f.store.set(
+      "gh:insttoken:9",
+      JSON.stringify({ token: "sensitive-value", expiresAtMs: "soon" }),
+    );
+    expect(await createRedisTokenCache(f.redis).get(9)).toBeNull();
+
+    expect(await renderMetrics()).toContain(
+      'gittensory_redis_token_cache_total{result="miss"} 1',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add Prometheus hit/miss counters for the Redis-backed GitHub installation-token cache so self-host operators can see whether warm tokens are being reused or falling back to cold minting. Closes #2074.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. Also ran `npx vitest run test/unit/selfhost-redis-token-cache.test.ts --coverage.enabled true --coverage.include src/selfhost/redis-token-cache.ts` with 100% statements, branches, functions, and lines for the touched source file. `npm run test:ci` passed end to end, including REES tests and UI checks.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI, frontend, docs, or extension changes.

## Notes

- The metric uses only the fixed `result` label (`hit` or `miss`); token values and installation identifiers are not emitted as metric labels.
