### PR TITLE
fix(github): hold per_page constant so backfill fetches every page

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3093,22 +3093,33 @@ async function githubPaged<T>(
 
   try {
     for (let page = startPage; items.length < limit; page += 1) {
-      const pageLimit = Math.min(100, limit - items.length);
+      // Hold `per_page` at 100 across the whole crawl: GitHub's `page` offset is `(page-1)*per_page`, so
+      // SHRINKING per_page as the budget depletes (e.g. per_page=50 on page 2 after 100 fetched) re-requests
+      // an already-seen slice instead of the next one — silently dropping items past the first page whenever
+      // `limit` is not a multiple of 100. Cap by trimming the accumulated items to `limit` instead. This also
+      // matches every other paginator in this file, which all request a constant `per_page=100`.
       const separator = path.includes("?") ? "&" : "?";
-      const pagePath = `${path}${separator}per_page=${pageLimit}&page=${page}`;
+      const pagePath = `${path}${separator}per_page=100&page=${page}`;
       const result = await githubJsonWithHeaders<T[]>(env, repo.fullName, pagePath, token, githubRateLimitOptions(admissionKey));
       etag = result.etag ?? etag;
       lastModified = result.lastModified ?? lastModified;
       lastCursor = String(page);
       pageCount += 1;
-      items.push(...result.data);
+      const remaining = limit - items.length;
+      const truncatedPage = result.data.length > remaining;
+      items.push(...result.data.slice(0, remaining));
       const hasNext = hasNextPage(result.link);
-      if (result.data.length < pageLimit || !hasNext) break;
-      nextCursor = String(page + 1);
-      if (items.length >= limit) {
+      // Reached the local cap with more still upstream (a next page is advertised, or this page held more
+      // than the cap left room for): stop and record a live resume cursor. Resume re-fetches the partially
+      // consumed page (its already-stored rows dedupe on number).
+      if (items.length >= limit && (hasNext || truncatedPage)) {
+        nextCursor = String(truncatedPage ? page : page + 1);
         status = "capped";
         warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path}; next page cursor is ${nextCursor}.`);
+        break;
       }
+      if (result.data.length < 100 || !hasNext) break;
+      nextCursor = String(page + 1);
     }
   } catch (error) {
     status = error instanceof GitHubApiError && error.rateLimited ? "rate_limited" : items.length > 0 ? "partial" : "error";

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1239,6 +1239,48 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("fetches every page when the limit is not a multiple of 100 (stable per_page offsets)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    const TOTAL = 150;
+    // Model GitHub's real pagination: `page` is an offset of `(page-1)*per_page`. If the crawl shrinks
+    // per_page mid-way (per_page=50 on page 2 after 100 fetched), it re-reads items 51-100 instead of
+    // 101-150, so those are never stored. A constant per_page=100 reads 1-100 then 101-150.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/repos/JSONbored/gittensory")) {
+        return Response.json({ name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", language: "TypeScript", owner: { login: "JSONbored" } });
+      }
+      if (url.includes("/labels?")) return Response.json([]);
+      if (url.includes("/pulls?")) return Response.json([]);
+      if (url.includes("/issues?")) {
+        const params = new URL(url).searchParams;
+        const perPage = Number(params.get("per_page"));
+        const page = Number(params.get("page"));
+        const start = (page - 1) * perPage; // 0-based offset, as GitHub computes it
+        const slice = Array.from({ length: Math.max(0, Math.min(start + perPage, TOTAL) - start) }, (_, i) => ({
+          number: start + i + 1,
+          title: `Issue ${start + i + 1}`,
+          state: "open",
+          user: { login: "reporter" },
+          labels: [],
+          body: "",
+        }));
+        const hasNext = start + perPage < TOTAL;
+        return Response.json(slice, hasNext ? { headers: { link: `<https://api.github.com/repositories/1/issues?page=${page + 1}>; rel="next"` } } : undefined);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: TOTAL, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    // All 150 unique issues must be stored — not 100 (which is what a shrinking-per_page crawl yields).
+    expect(result.repos[0]).toMatchObject({ status: "success", openIssues: TOTAL });
+  });
+
   it("runs a targeted labels segment refresh", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
## Summary

`githubPaged` in `src/github/backfill.ts` is the REST paginator backing the `open_issues`, `open_pull_requests`, and `recent_merged_pull_requests` backfill segments. Each iteration it recomputed `per_page` from the *remaining* budget:

```ts
const pageLimit = Math.min(100, limit - items.length);
const pagePath = `${path}...per_page=${pageLimit}&page=${page}`;
```

GitHub's `page` is an offset of `(page - 1) * per_page`. Shrinking `per_page` mid-crawl therefore re-requests an **already-fetched slice** instead of the next one: after page 1 fetches 100 items, page 2 uses `per_page=50` and returns items **51–100** (offset `1*50`), not 101–150. So whenever `limit` is **not a multiple of 100**, every item past the first page is silently dropped (page 2's rows are duplicates, deduped away on `number`). This is reachable through the public `backfillRegisteredRepositories(env, { limits })` override — the repo's own tests already pass `issues: 150` — so a repo with 150+ open issues stores only 100.

Fix: hold `per_page` at **100** for the whole crawl (matching every other paginator in this file, which all request a constant `per_page=100`) and cap by trimming the accumulated `items` to `limit`. The `capped` status and live resume cursor semantics are preserved (capped when the local cap is hit and GitHub still advertises more, or the page held more than the cap left room for).

No linked issue — this repo's `linkedIssuePolicy` is `preferred`, and this is a small, self-contained pagination-correctness fix in one helper.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `backfill` suite (141 tests) passes, including the existing multi-page, exactly-at-limit, and capped/partial tests whose semantics are preserved. A new regression test drives a non-multiple-of-100 crawl (`issues: 150`) through a fetch mock that models GitHub's real `(page-1)*per_page` offset and asserts all 150 issues are stored (not 100). It was confirmed to FAIL against the unpatched paginator (stored 100).
- [x] New or changed behavior has a regression test that models real pagination

If any required check was skipped, explain why:

- The change is one paginator loop in `src/github`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Backfill fidelity only; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: with `limits: { issues: 150 }` against a repo with 150 open issues, the crawl previously requested `per_page=100&page=1` (items 1–100) then `per_page=50&page=2` (offset 50 → items 51–100, duplicates), storing only 100 unique issues. It now requests `per_page=100&page=2` (items 101–150) and stores all 150.
- Segments whose limits are multiples of 100 (the defaults: 100 / 200 / 1000) are unaffected — the requests and results are byte-identical to before.
