### PR TITLE
fix(queue): make the three @gittensory mention commands respect pause/dry-run/freeze

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6345,6 +6345,15 @@ async function maybeProcessGateOverrideCommand(
     return true;
   }
 
+  // Respect pause/dry-run/global-freeze like every other agent-driven write in this file (#2256). Without this,
+  // an operator's pause or the DB kill-switch does not stop a maintainer's @gittensory gate-override from
+  // flipping the live Gate check-run to neutral and posting a real confirmation comment.
+  const mode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: settings.agentPaused,
+    agentDryRun: settings.agentDryRun,
+  });
+
   // #16 (audit): the cached pr.headSha can be stale if a commit landed between the comment and this processing.
   // The override is a per-commit neutral check-run, so posting it on the cached SHA is a silent no-op on the LIVE
   // head (whose Gate check stays blocking). Re-fetch the live head and override THAT commit (fail-open to the
@@ -6372,6 +6381,7 @@ async function maybeProcessGateOverrideCommand(
     repoFullName,
     advisory,
     { actor, reason: safeReason },
+    mode,
   );
   await recordAuditEvent(env, {
     eventType: "github_app.gate_overridden",
@@ -6406,6 +6416,7 @@ async function maybeProcessGateOverrideCommand(
     repoFullName,
     issue.number,
     confirmation,
+    mode,
   );
   await recordGithubProductUsage(env, "gate_overridden", {
     actor,
@@ -6529,6 +6540,26 @@ async function maybeProcessPlanCommand(
       targetKey,
       req.actor,
       "cooldown_active",
+    );
+    return true;
+  }
+  // Respect pause/dry-run/global-freeze like every other agent-driven write in this file (#2257). Checked right
+  // before the only effectful work (a real Workers AI call + a public comment) so a paused/dry-run repo never
+  // incurs the AI cost speculatively — mirroring how the reopen-reclose handler skips its write uniformly for
+  // both dry_run and paused, not just paused.
+  const planMode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: settings.agentPaused,
+    agentDryRun: settings.agentDryRun,
+  });
+  if (planMode !== "live") {
+    await recordPlanSkip(
+      env,
+      deliveryId,
+      req.repoFullName,
+      targetKey,
+      req.actor,
+      planMode === "dry_run" ? "dry_run" : "agent_paused",
     );
     return true;
   }
@@ -7210,6 +7241,13 @@ async function maybeProcessGittensoryMentionCommand(
         commenter,
       ),
     ]);
+  // Respect pause/dry-run/global-freeze like every other agent-driven write in this file (#2258) — the answer
+  // card is a live public comment post, same as gate-override's confirmation comment.
+  const mentionMode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: settings.agentPaused,
+    agentDryRun: settings.agentDryRun,
+  });
   const pullRequestAuthor =
     cachedPullRequest?.authorLogin ?? issue.user?.login ?? null;
   const needsMinerDetection = commandAuthorizationNeedsMinerDetection({
@@ -7315,6 +7353,7 @@ async function maybeProcessGittensoryMentionCommand(
     repoFullName,
     issue.number,
     body,
+    mentionMode,
   );
   await upsertAgentCommandAnswer(env, {
     id: answerId,

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6383,19 +6383,6 @@ async function maybeProcessGateOverrideCommand(
     { actor, reason: safeReason },
     mode,
   );
-  await recordAuditEvent(env, {
-    eventType: "github_app.gate_overridden",
-    actor,
-    targetKey: `${repoFullName}#${pr.number}`,
-    outcome: "completed",
-    detail: safeReason,
-    metadata: {
-      deliveryId,
-      repoFullName,
-      headSha: advisory.headSha ?? null,
-      cachedHeadSha: pr.headSha ?? null,
-    },
-  });
   const confirmation = sanitizePublicComment(
     [
       AGENT_COMMAND_COMMENT_MARKER,
@@ -6418,22 +6405,69 @@ async function maybeProcessGateOverrideCommand(
     confirmation,
     mode,
   );
-  await recordGithubProductUsage(env, "gate_overridden", {
-    actor,
-    repoFullName,
-    targetKey: `${repoFullName}#${pr.number}`,
-    outcome: "completed",
-    metadata: {
-      actorKind: authorization.actorKind,
-      headSha: advisory.headSha ?? null,
-    },
-  });
-  // #554 gate false-positive telemetry: flag the gate-block row as maintainer-overridden — the strongest
-  // false-positive signal (a human explicitly judged the block wrong). Best-effort + no-op if no block was
-  // recorded; never affects the override outcome above.
-  await markGateOutcomeOverridden(env, repoFullName, pr.number).catch(
-    () => undefined,
-  );
+  // createOrUpdateOverriddenGateCheckRun/createOrUpdateAgentCommandComment already suppress the actual GitHub
+  // writes for a non-live mode -- calling them unconditionally is fine (and lets a dry-run still exercise the
+  // code path). What must NOT happen unconditionally is recording this as a completed override: a paused or
+  // dry-run command never flipped the check-run or posted the confirmation, so audit/usage must reflect that
+  // instead of reporting a real override that did not occur (mirrors recordPlanSkip's *_skipped convention).
+  if (mode === "live") {
+    await recordAuditEvent(env, {
+      eventType: "github_app.gate_overridden",
+      actor,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail: safeReason,
+      metadata: {
+        deliveryId,
+        repoFullName,
+        headSha: advisory.headSha ?? null,
+        cachedHeadSha: pr.headSha ?? null,
+      },
+    });
+    await recordGithubProductUsage(env, "gate_overridden", {
+      actor,
+      repoFullName,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      metadata: {
+        actorKind: authorization.actorKind,
+        headSha: advisory.headSha ?? null,
+      },
+    });
+    // #554 gate false-positive telemetry: flag the gate-block row as maintainer-overridden — the strongest
+    // false-positive signal (a human explicitly judged the block wrong). Best-effort + no-op if no block was
+    // recorded; never affects the override outcome above. Only meaningful once the check-run was actually
+    // flipped (mode === "live") -- a paused/dry-run "override" never changed the live gate result.
+    await markGateOutcomeOverridden(env, repoFullName, pr.number).catch(
+      () => undefined,
+    );
+  } else {
+    await recordAuditEvent(env, {
+      eventType: "github_app.gate_override_skipped",
+      actor,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail: mode === "dry_run" ? "dry_run" : "agent_paused",
+      metadata: {
+        deliveryId,
+        repoFullName,
+        headSha: advisory.headSha ?? null,
+        cachedHeadSha: pr.headSha ?? null,
+        mode,
+      },
+    });
+    await recordGithubProductUsage(env, "gate_override_skipped", {
+      actor,
+      repoFullName,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "skipped",
+      metadata: {
+        actorKind: authorization.actorKind,
+        headSha: advisory.headSha ?? null,
+        mode,
+      },
+    });
+  }
   return true;
 }
 
@@ -7370,52 +7404,98 @@ async function maybeProcessGittensoryMentionCommand(
       responseCommentStored: Boolean(responseComment?.id),
     },
   });
-  await recordAuditEvent(env, {
-    eventType: "github_app.agent_command_replied",
-    actor: commenter,
-    targetKey: `${repoFullName}#${issue.number}`,
-    outcome: "completed",
-    metadata: {
+  // createOrUpdateAgentCommandComment already suppresses the answer-card post for a non-live mode. As with
+  // gate-override above, what must NOT happen unconditionally is recording this as a completed reply: a
+  // paused/dry-run mention command never posted the card, so telemetry (and the feedback prompt, which
+  // presumes a real reply exists to react to) must reflect that instead of a reply that never happened.
+  if (mentionMode === "live") {
+    await recordAuditEvent(env, {
+      eventType: "github_app.agent_command_replied",
+      actor: commenter,
+      targetKey: `${repoFullName}#${issue.number}`,
+      outcome: "completed",
+      metadata: {
+        deliveryId,
+        command: command.name,
+        actorKind: authorization.actorKind,
+        runId: bundle?.run.id ?? null,
+        answerId,
+      },
+    });
+    await recordAgentCommandUsage(env, {
+      repoFullName,
+      targetKey,
+      actor: commenter,
+      command: command.name,
+      actorKind: authorization.actorKind,
+      outcome: "replied",
+      detail:
+        bundle?.run.status ?? (maintainerDigest ? "maintainer_digest" : "no_run"),
+      family: maintainerDigest ? "maintainer_digest" : "agent_command",
+      runId: bundle?.run.id ?? null,
+    });
+    await recordGithubProductUsage(env, "agent_command_replied", {
+      actor: commenter,
+      repoFullName,
+      targetKey: `${repoFullName}#${issue.number}`,
+      outcome: "completed",
+      metadata: {
+        command: command.name,
+        actorKind: authorization.actorKind,
+        hasAgentRun: Boolean(bundle),
+        family: maintainerDigest ? "queue_digest" : "agent_command",
+      },
+    });
+    await recordAgentCommandFeedbackPrompt(env, {
       deliveryId,
       command: command.name,
-      actorKind: authorization.actorKind,
-      runId: bundle?.run.id ?? null,
-      answerId,
-    },
-  });
-  await recordAgentCommandUsage(env, {
-    repoFullName,
-    targetKey,
-    actor: commenter,
-    command: command.name,
-    actorKind: authorization.actorKind,
-    outcome: "replied",
-    detail:
-      bundle?.run.status ?? (maintainerDigest ? "maintainer_digest" : "no_run"),
-    family: maintainerDigest ? "maintainer_digest" : "agent_command",
-    runId: bundle?.run.id ?? null,
-  });
-  await recordGithubProductUsage(env, "agent_command_replied", {
-    actor: commenter,
-    repoFullName,
-    targetKey: `${repoFullName}#${issue.number}`,
-    outcome: "completed",
-    metadata: {
+      actor: commenter,
+      targetKey: `${repoFullName}#${issue.number}`,
+      actorKind:
+        authorization.actorKind === "maintainer" ? "maintainer" : "author",
+      family: maintainerDigest ? "maintainer_digest" : "agent_command",
+    });
+  } else {
+    const reason = mentionMode === "dry_run" ? "dry_run" : "agent_paused";
+    await recordAuditEvent(env, {
+      eventType: "github_app.agent_command_reply_skipped",
+      actor: commenter,
+      targetKey: `${repoFullName}#${issue.number}`,
+      outcome: "completed",
+      detail: reason,
+      metadata: {
+        deliveryId,
+        command: command.name,
+        actorKind: authorization.actorKind,
+        answerId,
+        mode: mentionMode,
+      },
+    });
+    await recordAgentCommandUsage(env, {
+      repoFullName,
+      targetKey,
+      actor: commenter,
       command: command.name,
       actorKind: authorization.actorKind,
-      hasAgentRun: Boolean(bundle),
-      family: maintainerDigest ? "queue_digest" : "agent_command",
-    },
-  });
-  await recordAgentCommandFeedbackPrompt(env, {
-    deliveryId,
-    command: command.name,
-    actor: commenter,
-    targetKey: `${repoFullName}#${issue.number}`,
-    actorKind:
-      authorization.actorKind === "maintainer" ? "maintainer" : "author",
-    family: maintainerDigest ? "maintainer_digest" : "agent_command",
-  });
+      outcome: "skipped",
+      detail: reason,
+      family: maintainerDigest ? "maintainer_digest" : "agent_command",
+      runId: bundle?.run.id ?? null,
+    });
+    await recordGithubProductUsage(env, "agent_command_reply_skipped", {
+      actor: commenter,
+      repoFullName,
+      targetKey: `${repoFullName}#${issue.number}`,
+      outcome: "skipped",
+      metadata: {
+        command: command.name,
+        actorKind: authorization.actorKind,
+        hasAgentRun: Boolean(bundle),
+        family: maintainerDigest ? "queue_digest" : "agent_command",
+        mode: mentionMode,
+      },
+    });
+  }
   return true;
 }
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3620,6 +3620,54 @@ describe("queue processors", () => {
     expect(skip?.detail).toBe("no_plan_generated");
   });
 
+  it("planner: respects agentPaused — never spends Workers AI on a paused repo (#2257)", async () => {
+    const run = vi.fn(async () => ({ response: "should not run" }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
+    await setupPlannerRepo(env);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentPaused: true });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" });
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory plan", "maintainer1"));
+    expect(run).not.toHaveBeenCalled(); // no speculative AI spend on a paused repo
+    const skip = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.issue_plan_skipped").first<{ detail: string }>();
+    expect(skip?.detail).toBe("agent_paused");
+  });
+
+  it("planner: respects a global freeze — never spends Workers AI while the DB kill-switch is engaged (#2257)", async () => {
+    const run = vi.fn(async () => ({ response: "should not run" }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AGENT_ACTIONS_PAUSED: "true", AI: { run } as unknown as Ai });
+    await setupPlannerRepo(env);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" });
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory plan", "maintainer1"));
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("planner: respects agentDryRun — never spends Workers AI on a dry-run repo (#2257)", async () => {
+    const run = vi.fn(async () => ({ response: "should not run" }));
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
+    await setupPlannerRepo(env);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" });
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory plan", "maintainer1"));
+    expect(run).not.toHaveBeenCalled();
+    const skip = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.issue_plan_skipped").first<{ detail: string }>();
+    expect(skip?.detail).toBe("dry_run");
+  });
+
   it("planner: enforces a per-actor per-repo cooldown before spending AI", async () => {
     const run = vi.fn(async () => ({ response: "## Summary\nPlan." }));
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_PLANNER: "true", AI: { run } as unknown as Ai });
@@ -7342,6 +7390,48 @@ describe("queue processors", () => {
     expect(JSON.stringify(usageEvents)).not.toMatch(/wallet|hotkey|raw trust|deliveryId|installation-token/i);
   });
 
+  it("a @gittensory Q&A mention command respects agentPaused — never posts the answer card live (#2258)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentPaused: true });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 77,
+      title: "Paused Q&A context",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      author_association: "NONE",
+      labels: [],
+      body: "Fixes #1",
+    });
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "maintain" });
+      if (url.includes("/issues/") && url.includes("/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/") && url.includes("/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 1001 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "agent-command-help-paused",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 77, title: "Paused Q&A context", state: "open", pull_request: {}, user: { login: "oktofeesh1" }, author_association: "NONE" },
+        comment: { id: 1, body: "@gittensory help", user: { login: "maintainer", type: "User" }, author_association: "OWNER" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0); // the answer card must never post live on a paused repo
+  });
+
   it("posts maintainer-only queue digest commands from cached public-safe metadata", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     delete (env as Partial<Env>).PUBLIC_SITE_ORIGIN;
@@ -8636,6 +8726,69 @@ describe("queue processors", () => {
     expect(settingsAfter?.gate_check_mode).toBe("enabled");
     const overrideAdvisory = await env.DB.prepare("select id from advisories where target_key = ?").bind("JSONbored/gittensory#90").first<{ id: string }>();
     expect(overrideAdvisory ?? null).toBeNull();
+  });
+
+  it("gate-override respects agentPaused — never flips the live check-run or posts a confirmation comment (#2256)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      agentPaused: true,
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 91,
+      title: "Override me while paused",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "paused-override-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { checkPatches: 0, commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/commits/paused-override-sha/check-runs") && method === "GET") {
+        return Response.json({ total_count: 1, check_runs: [{ id: 556, name: "Gittensory Orb Review Agent" }] });
+      }
+      if (url.includes("/check-runs/556") && method === "PATCH") {
+        calls.checkPatches += 1;
+        return Response.json({ id: 556 });
+      }
+      if (url.includes("/issues/91/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/91/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9101 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-override-paused",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 91, title: "Override me while paused", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 810, body: "@gittensory gate-override please", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    // Neither write reached GitHub — a pause must stop this exactly like every other agent-driven write.
+    expect(calls.checkPatches).toBe(0);
+    expect(calls.commentPosts).toBe(0);
   });
 
   it("overrides the LIVE head, not the stale cached SHA, when a commit landed after the command (#16)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7440,6 +7440,56 @@ describe("queue processors", () => {
     expect(usageEvents.some((event) => event.eventName === "agent_command_replied")).toBe(false);
   });
 
+  it("a @gittensory maintainer-digest command respects agentDryRun — records dry_run, not agent_paused (#2258)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 78,
+      title: "Dry-run digest context",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      author_association: "NONE",
+      labels: [],
+      body: "Fixes #1",
+    });
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "maintain" });
+      if (url.includes("/issues/") && url.includes("/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/") && url.includes("/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 1002 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "agent-command-queue-summary-dry-run",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 78, title: "Dry-run digest context", state: "open", pull_request: {}, user: { login: "oktofeesh1" }, author_association: "NONE" },
+        comment: { id: 2, body: "@gittensory queue-summary", user: { login: "maintainer", type: "User" }, author_association: "OWNER" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0); // the digest must never post live on a dry-run repo
+    const skipped = await env.DB.prepare("select outcome, detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.agent_command_reply_skipped")
+      .first<{ outcome: string; detail: string; metadata_json: string }>();
+    expect(skipped).toMatchObject({ outcome: "completed", detail: "dry_run" });
+    const usageEvents = await listProductUsageEvents(env, { limit: 10 });
+    expect(usageEvents).toEqual(
+      expect.arrayContaining([expect.objectContaining({ eventName: "agent_command_reply_skipped", outcome: "skipped", metadata: expect.objectContaining({ family: "queue_digest" }) })]),
+    );
+  });
+
   it("posts maintainer-only queue digest commands from cached public-safe metadata", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     delete (env as Partial<Env>).PUBLIC_SITE_ORIGIN;
@@ -8734,6 +8784,66 @@ describe("queue processors", () => {
     expect(settingsAfter?.gate_check_mode).toBe("enabled");
     const overrideAdvisory = await env.DB.prepare("select id from advisories where target_key = ?").bind("JSONbored/gittensory#90").first<{ id: string }>();
     expect(overrideAdvisory ?? null).toBeNull();
+  });
+
+  it("a real gate-override still completes even when the false-positive telemetry write fails (best-effort)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 94,
+      title: "Override me (telemetry write fails)",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "override-sha-telemetry" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const telemetrySpy = vi.spyOn(repositoriesModule, "markGateOutcomeOverridden").mockRejectedValueOnce(new Error("D1 write failed"));
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/commits/override-sha-telemetry/check-runs") && method === "GET") {
+        return Response.json({ total_count: 1, check_runs: [{ id: 559, name: "Gittensory Orb Review Agent" }] });
+      }
+      if (url.includes("/check-runs/559") && method === "PATCH") return Response.json({ id: 559 });
+      if (url.includes("/issues/94/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/94/comments") && method === "POST") return Response.json({ id: 9104 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-override-telemetry-fail",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 94, title: "Override me (telemetry write fails)", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 812, body: "@gittensory gate-override known flaky", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(telemetrySpy).toHaveBeenCalled();
+    // The override itself (audit + usage) still completed — the false-positive flag is best-effort and never
+    // affects the primary override outcome.
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ? and target_key = ?")
+      .bind("github_app.gate_overridden", "JSONbored/gittensory#94")
+      .first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("completed");
   });
 
   it("gate-override respects agentPaused — never flips the live check-run or posts a confirmation comment (#2256)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7430,6 +7430,14 @@ describe("queue processors", () => {
     });
 
     expect(calls.commentPosts).toBe(0); // the answer card must never post live on a paused repo
+    // REGRESSION: a paused command must not be audited/usage-tracked as a real, completed reply.
+    const replied = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.agent_command_replied").first<{ id: string }>();
+    expect(replied).toBeUndefined();
+    const skipped = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.agent_command_reply_skipped").first<{ outcome: string; detail: string }>();
+    expect(skipped).toMatchObject({ outcome: "completed", detail: "agent_paused" });
+    const usageEvents = await listProductUsageEvents(env, { limit: 10 });
+    expect(usageEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventName: "agent_command_reply_skipped", outcome: "skipped" })]));
+    expect(usageEvents.some((event) => event.eventName === "agent_command_replied")).toBe(false);
   });
 
   it("posts maintainer-only queue digest commands from cached public-safe metadata", async () => {
@@ -8789,6 +8797,85 @@ describe("queue processors", () => {
     // Neither write reached GitHub — a pause must stop this exactly like every other agent-driven write.
     expect(calls.checkPatches).toBe(0);
     expect(calls.commentPosts).toBe(0);
+    // REGRESSION: a paused command must not be audited/usage-tracked as a real, completed override.
+    const overridden = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.gate_overridden").first<{ id: string }>();
+    expect(overridden).toBeUndefined();
+    const skipped = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.gate_override_skipped").first<{ outcome: string; detail: string }>();
+    expect(skipped).toMatchObject({ outcome: "completed", detail: "agent_paused" });
+    const usageEvents = await listProductUsageEvents(env, { limit: 10 });
+    expect(usageEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventName: "gate_override_skipped", outcome: "skipped" })]));
+    expect(usageEvents.some((event) => event.eventName === "gate_overridden")).toBe(false);
+  });
+
+  it("gate-override respects agentDryRun on a PR with no head sha — records dry_run, not agent_paused (#2256)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      agentDryRun: true,
+    });
+    // No head sha — also exercises the metadata's `?? null` fallback on the skip-path audit/usage records.
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 93,
+      title: "Override me (dry-run, no head)",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: {},
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { checkPatches: 0, commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/pulls/93") && method === "GET") return Response.json({ number: 93, state: "open", head: {} });
+      if (url.includes("/issues/93/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/93/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9103 });
+      }
+      if (url.includes("/check-runs") && method === "PATCH") {
+        calls.checkPatches += 1;
+        return Response.json({ id: 557 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-override-dry-run-no-head",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 93, title: "Override me (dry-run, no head)", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 811, body: "@gittensory gate-override please", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.checkPatches).toBe(0);
+    expect(calls.commentPosts).toBe(0);
+    const skipped = await env.DB.prepare("select outcome, detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.gate_override_skipped")
+      .first<{ outcome: string; detail: string; metadata_json: string }>();
+    expect(skipped).toMatchObject({ outcome: "completed", detail: "dry_run" });
+    const metadata = JSON.parse(skipped?.metadata_json ?? "{}") as { headSha?: string | null; cachedHeadSha?: string | null; mode?: string };
+    expect(metadata.headSha).toBeNull();
+    expect(metadata.cachedHeadSha).toBeNull();
+    expect(metadata.mode).toBe("dry_run");
+    const usageEvents = await listProductUsageEvents(env, { limit: 10 });
+    expect(usageEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventName: "gate_override_skipped", outcome: "skipped" })]));
   });
 
   it("overrides the LIVE head, not the stale cached SHA, when a commit landed after the command (#16)", async () => {


### PR DESCRIPTION
## What

`gate-override`, `plan`, and the Q&A mention-command handler each perform a live GitHub write (a check-run flip, an AI-generated comment, an answer card) but none of them computed `resolveAgentActionMode` before writing — unlike every other agent-driven write in this file. An operator's pause, an `agentDryRun` setting, or the DB kill-switch stopped every other action but not these three:

- **gate-override** still flipped the live Gate check-run to neutral and posted a real confirmation comment.
- **plan** still spent a real Workers AI call and posted a real comment — the costliest of the three, since AI generation has a real budget cost.
- The **Q&A handler** still posted a real answer card.

## Fix

Compute `mode` for each and thread it through `createOrUpdateOverriddenGateCheckRun` / `createOrUpdateAgentCommandComment`, which already accept a `mode` parameter that suppresses the write internally (unlike `createIssueComment`, which has none — so the plan command instead short-circuits before `generateIssuePlan`/`createIssueComment` entirely on a non-live mode, avoiding the AI spend rather than incurring it and merely suppressing the resulting comment).

## Tests

- gate-override: paused repo → the check-run PATCH and the confirmation comment POST never fire.
- plan: paused, globally-frozen, and dry-run repos → Workers AI is never called (each records the correct skip reason: `agent_paused` or `dry_run`).
- Q&A mention command: paused repo → the answer card never posts.
- Full existing suite for all three handlers unaffected (206/206, 253/253 in scoped runs).

Full unsharded `test:coverage` green; `typecheck` green.

Advances #1936. Closes #2256, #2257, #2258.