### PR TITLE
fix(agent-actions): retract a stale bot approval when a newer commit no longer qualifies

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -5,6 +5,11 @@ import type { AutoMergeMethod } from "../types";
 
 const ISSUE_EVENTS_PAGE_SIZE = 100;
 const ISSUE_EVENTS_RECENT_PAGE_LIMIT = 10;
+// Reviews are returned oldest-first with no sort override, so finding the LATEST bot approval means walking
+// every page rather than stopping at the first — a single per_page:100 fetch would only see the bot's
+// earliest reviews on a PR with a long review history and could dismiss (or miss) the wrong one.
+const REVIEW_PAGE_SIZE = 100;
+const REVIEW_PAGE_LIMIT = 10;
 
 // The GitHub write primitives the maintainer auto-maintain layer (#778) uses to act on a PR's STATE — never
 // its source. Thin wrappers over the installation-scoped REST API, mirroring labels.ts / comments.ts. Each
@@ -104,12 +109,16 @@ export async function dismissLatestBotApproval(env: Env, installationId: number,
     const token = await createInstallationToken(env, installationId);
     const octokit = makeInstallationOctokit(env, token, "live", githubRateLimitAdmissionKeyForInstallation(installationId));
     const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
-    const response = await octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", { owner, repo, pull_number: pullNumber, per_page: 100 });
-    const reviews = response.data as Array<{ id: number; state?: string; user?: { login?: string | null } | null }>;
-    // Reviews are returned oldest-first; the LAST matching entry is the bot's most recent APPROVE.
+    // Reviews are returned oldest-first; the LAST matching entry across ALL pages is the bot's most recent
+    // APPROVE. Stopping at page 1 would find (or miss) the wrong review on a PR with >100 total reviews.
     let latestApprovalId: number | undefined;
-    for (const review of reviews) {
-      if (review.user?.login === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
+    for (let page = 1; page <= REVIEW_PAGE_LIMIT; page += 1) {
+      const response = await octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", { owner, repo, pull_number: pullNumber, per_page: REVIEW_PAGE_SIZE, page });
+      const batch = response.data as Array<{ id: number; state?: string; user?: { login?: string | null } | null }>;
+      for (const review of batch) {
+        if (review.user?.login === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
+      }
+      if (batch.length < REVIEW_PAGE_SIZE) break;
     }
     if (latestApprovalId === undefined) return { dismissed: false };
     await octokit.request("PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals", {

--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -92,6 +92,40 @@ export async function mergePullRequest(
   return { merged: data.merged ?? true, sha: data.sha ?? null };
 }
 
+/** Dismiss the bot's own most recent APPROVE review (#2254). GitHub's `reviewDecision` is derived from the
+ *  LATEST review per reviewer, so a stale bot approval left in place after a later commit no longer qualifies
+ *  can still satisfy a "require approving reviews" branch-protection rule and let a human merge un-reviewed
+ *  code directly on GitHub, bypassing this gate entirely. Best-effort: any failure (no bot review found, the
+ *  review already dismissed, a transient API error) returns `dismissed: false` rather than throwing — this is
+ *  a cleanup action, not the primary mutation, and must never crash the maintenance pass it runs alongside. */
+export async function dismissLatestBotApproval(env: Env, installationId: number, repoFullName: string, pullNumber: number, message: string): Promise<{ dismissed: boolean }> {
+  try {
+    const { owner, repo } = splitRepo(repoFullName);
+    const token = await createInstallationToken(env, installationId);
+    const octokit = makeInstallationOctokit(env, token, "live", githubRateLimitAdmissionKeyForInstallation(installationId));
+    const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
+    const response = await octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", { owner, repo, pull_number: pullNumber, per_page: 100 });
+    const reviews = response.data as Array<{ id: number; state?: string; user?: { login?: string | null } | null }>;
+    // Reviews are returned oldest-first; the LAST matching entry is the bot's most recent APPROVE.
+    let latestApprovalId: number | undefined;
+    for (const review of reviews) {
+      if (review.user?.login === botLogin && review.state === "APPROVED") latestApprovalId = review.id;
+    }
+    if (latestApprovalId === undefined) return { dismissed: false };
+    await octokit.request("PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals", {
+      owner,
+      repo,
+      pull_number: pullNumber,
+      review_id: latestApprovalId,
+      message,
+      event: "DISMISS",
+    });
+    return { dismissed: true };
+  } catch {
+    return { dismissed: false };
+  }
+}
+
 /** Rebase a PR onto its base via GitHub's update-branch (merges the current base into the PR head). Keeps a
  *  BEHIND PR current before reviewing/merging so the review + required CI run against the merged result —
  *  reviewbot parity. `expectedHeadSha` guards against racing a head that moved since we read it. The PUT

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -127,7 +127,7 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       // exact commit on the next sweep (a GitHub App's own approval does not reliably flip reviewDecision to
       // APPROVED, so reviewDecision alone can't dedup). A new commit clears the match → the bot approves it.
       // Best-effort: a failed persist only risks one redundant re-approval, never a wrong disposition.
-      if (action.actionClass === "approve" && ctx.headSha) {
+      if (action.actionClass === "approve" && !action.dismissStaleApproval && ctx.headSha) {
         await markPullRequestApproved(env, ctx.repoFullName, ctx.pullNumber, ctx.headSha).catch(() => undefined);
       }
       // Per-repo Discord notification on a terminal/visible action (reviewbot parity): merge→merged,

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -2,7 +2,7 @@ import { bumpPullRequestMergeAttempt, createPendingAgentActionIfAbsent, insertNo
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
-import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
+import { closePullRequest, createIssueComment, createPullRequestReview, dismissLatestBotApproval, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
 import { fetchPullRequestFreshness, pullRequestFreshnessDetail } from "../github/pr-freshness";
 import { isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { buildAgentActionAudit, isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
@@ -203,7 +203,11 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
       await createPullRequestReview(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, "REQUEST_CHANGES", action.reviewBody ?? "");
       return;
     case "approve":
-      await createPullRequestReview(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, "APPROVE", action.reviewBody ?? "");
+      if (action.dismissStaleApproval) {
+        await dismissLatestBotApproval(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, "Gittensory retracted this approval — a newer commit no longer qualifies.");
+      } else {
+        await createPullRequestReview(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, "APPROVE", action.reviewBody ?? "");
+      }
       return;
     case "merge": {
       // Pin the merge to the REVIEWED head (action.expectedHeadSha) when present — for an approval-queue replay
@@ -234,6 +238,7 @@ export function actionParams(action: PlannedAgentAction): AgentPendingActionPara
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),
     ...(action.expectedHeadSha !== undefined ? { expectedHeadSha: action.expectedHeadSha } : {}),
+    ...(action.dismissStaleApproval !== undefined ? { dismissStaleApproval: action.dismissStaleApproval } : {}),
   };
 }
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -463,6 +463,10 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       requiresApproval: approval("approve"),
       reason: "stale approval retracted — a newer commit no longer qualifies for approval",
       dismissStaleApproval: true,
+      // Pin to the head that was actually evaluated as stale (mirrors the merge action's head pinning above) so
+      // a queued (auto_with_approval) dismissal replayed later can't retract a DIFFERENT, newer bot approval if
+      // the head moved again while this row waited for a maintainer (#2361).
+      ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
     });
   }
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -465,8 +465,9 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       dismissStaleApproval: true,
       // Pin to the head that was actually evaluated as stale (mirrors the merge action's head pinning above) so
       // a queued (auto_with_approval) dismissal replayed later can't retract a DIFFERENT, newer bot approval if
-      // the head moved again while this row waited for a maintainer (#2361).
-      ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
+      // the head moved again while this row waited for a maintainer (#2361). input.pr.headSha is already
+      // narrowed non-null by the `else if` condition above (line ~454), so no fallback branch is needed here.
+      expectedHeadSha: input.pr.headSha,
     });
   }
 

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -63,6 +63,11 @@ export type PlannedAgentAction = {
   // actions; treated as a heuristic close only when explicitly tagged "heuristic".
   closeKind?: "linked-issue-hard-rule" | "blacklist" | "heuristic";
   expectedHeadSha?: string;
+  // For an `approve` action: retract the bot's own prior approval instead of posting a new one — a later commit
+  // no longer qualifies for approval, but the PR isn't merging or closing this pass, so the stale APPROVE
+  // (which still counts toward a "require approving reviews" branch-protection rule) must not be left in place.
+  // (#2254)
+  dismissStaleApproval?: boolean;
 };
 
 export type AgentActionPlanInput = {
@@ -436,6 +441,28 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       requiresApproval: approval("approve"),
       reason: "gate passed, CI green",
       reviewBody: "Gittensory approves — the gate is satisfied and CI is green.",
+    });
+  } else if (
+    // A prior bot approval is now STALE: a later commit landed (approvedHeadSha !== the current head) and this
+    // pass isn't posting a fresh approve (the branch above didn't fire). GitHub's reviewDecision is derived from
+    // the LATEST review per reviewer, so leaving the old APPROVE in place can still satisfy a "require approving
+    // reviews" rule and let a human merge the new, un-reviewed commit directly on GitHub. Only matters when the
+    // PR stays open under review this pass — canMerge/willClose/willCloseForLinkedIssue each make it moot (a
+    // merge doesn't care about the stale review, and a close removes the PR from mergeable consideration
+    // entirely). (#2254)
+    input.pr.approvedHeadSha != null &&
+    input.pr.headSha != null &&
+    input.pr.approvedHeadSha !== input.pr.headSha &&
+    acting("approve") &&
+    !canMerge &&
+    !willClose &&
+    !willCloseForLinkedIssue
+  ) {
+    actions.push({
+      actionClass: "approve",
+      requiresApproval: approval("approve"),
+      reason: "stale approval retracted — a newer commit no longer qualifies for approval",
+      dismissStaleApproval: true,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -683,6 +683,10 @@ export type AgentPendingActionParams = {
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;
   expectedHeadSha?: string;
+  // For an `approve` action: retract the bot's own stale approval instead of posting a new one (see
+  // PlannedAgentAction.dismissStaleApproval). Must round-trip through staging like every other action-specific
+  // field. (#2254)
+  dismissStaleApproval?: boolean;
 };
 
 export type AgentPendingActionStatus = "pending" | "accepted" | "rejected";

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -120,6 +120,24 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(row?.approvedHeadSha).not.toBe("sha7");
   });
 
+  it("REGRESSION (#2361): a queued stale-approval dismissal pinned to an evaluated head is denied when the live head has since moved again", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({
+      status: "stale",
+      reason: "head_changed",
+      expectedHeadSha: "evaluated-sha",
+      liveHeadSha: "sha7",
+      liveState: "open",
+    });
+    // ctx().headSha ("sha7") is the CURRENT live head at accept/replay time; expectedHeadSha ("evaluated-sha")
+    // is the head this dismissal was actually staged against. Without the pin, the freshness guard would fall
+    // back to ctx.headSha and treat this as fresh, retracting whatever bot approval currently sits on "sha7".
+    const dismiss: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "stale approval retracted", dismissStaleApproval: true, expectedHeadSha: "evaluated-sha" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [dismiss]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(dismissLatestBotApproval).not.toHaveBeenCalled();
+  });
+
   it("LIVE request_changes/approve without a reviewBody falls back to an empty string", async () => {
     const env = createTestEnv({});
     const bareRequestChanges: PlannedAgentAction = { actionClass: "request_changes", requiresApproval: false, reason: "blocked" };

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -30,7 +30,7 @@ import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
 import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
-import { isGlobalAgentFrozen, setGlobalAgentFrozen } from "../../src/db/repositories";
+import { isGlobalAgentFrozen, setGlobalAgentFrozen, upsertPullRequestFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 function ctx(over: Partial<AgentActionExecutionContext> = {}): AgentActionExecutionContext {
@@ -101,6 +101,23 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
   it("actionParams threads dismissStaleApproval for a stale-approval retraction action", () => {
     const dismiss: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "stale", dismissStaleApproval: true };
     expect(actionParams(dismiss)).toEqual({ dismissStaleApproval: true });
+  });
+
+  it("REGRESSION (#2361): retracting a stale approval does NOT stamp the current (unqualified) head as approved", async () => {
+    const env = createTestEnv({});
+    // approvedHeadSha starts at the OLD (actually-reviewed) commit; ctx().headSha ("sha7") is the NEWER,
+    // no-longer-qualifying commit this dismissal is reacting to.
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "c" }, head: { sha: "sha7" }, labels: [], body: "" });
+    const dismiss: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "stale approval retracted", dismissStaleApproval: true };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [dismiss]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(dismissLatestBotApproval).toHaveBeenCalled();
+    const row = await env.DB.prepare("select approved_head_sha as approvedHeadSha from pull_requests where repo_full_name = ? and number = ?")
+      .bind("owner/repo", 7)
+      .first<{ approvedHeadSha: string | null }>();
+    // A real approve would have set this to "sha7" (see the "LIVE: executes each action class" test above for
+    // that positive case) -- a dismissal must never mark the un-reviewed head as approved.
+    expect(row?.approvedHeadSha).not.toBe("sha7");
   });
 
   it("LIVE request_changes/approve without a reviewBody falls back to an empty string", async () => {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../src/github/pr-actions", () => ({
   closePullRequest: vi.fn(async () => ({ state: "closed" })),
   createIssueComment: vi.fn(async () => ({ id: 2 })),
   updatePullRequestBranch: vi.fn(async () => undefined),
+  dismissLatestBotApproval: vi.fn(async () => ({ dismissed: true })),
 }));
 vi.mock("../../src/github/labels", () => ({
   ensurePullRequestLabel: vi.fn(async () => ({ applied: true, created: false })),
@@ -23,7 +24,7 @@ vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
   };
 });
 
-import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
+import { closePullRequest, createIssueComment, createPullRequestReview, dismissLatestBotApproval, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
 import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
 import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
@@ -86,6 +87,29 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(updatePullRequestBranch).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "sha7");
     expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(6);
     expect((await auditFor(env, "merge"))?.outcome).toBe("completed");
+  });
+
+  it("LIVE approve with dismissStaleApproval retracts the stale review instead of posting a new one (#2254)", async () => {
+    const env = createTestEnv({});
+    const dismiss: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "stale approval retracted", dismissStaleApproval: true };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [dismiss]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(dismissLatestBotApproval).toHaveBeenCalledWith(env, 123, "owner/repo", 7, expect.any(String));
+    expect(createPullRequestReview).not.toHaveBeenCalled();
+  });
+
+  it("actionParams threads dismissStaleApproval for a stale-approval retraction action", () => {
+    const dismiss: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "stale", dismissStaleApproval: true };
+    expect(actionParams(dismiss)).toEqual({ dismissStaleApproval: true });
+  });
+
+  it("LIVE request_changes/approve without a reviewBody falls back to an empty string", async () => {
+    const env = createTestEnv({});
+    const bareRequestChanges: PlannedAgentAction = { actionClass: "request_changes", requiresApproval: false, reason: "blocked" };
+    const bareApprove: PlannedAgentAction = { actionClass: "approve", requiresApproval: false, reason: "passed" };
+    await executeAgentMaintenanceActions(env, ctx(), [bareRequestChanges, bareApprove]);
+    expect(createPullRequestReview).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "REQUEST_CHANGES", "");
+    expect(createPullRequestReview).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "APPROVE", "");
   });
 
   it("LIVE merge pins the GitHub merge to the action's reviewed head (expectedHeadSha) over the context head", async () => {

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -125,6 +125,17 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(approveAction).toMatchObject({ dismissStaleApproval: true });
     });
 
+    it("pins the retraction to the head that was actually evaluated as stale (#2361)", () => {
+      // Without expectedHeadSha, a queued (auto_with_approval) dismissal replays against whatever head is
+      // current at accept time — not the head that made the dismissal valid — so a delayed accept could retract
+      // a DIFFERENT, newer bot approval than the one this plan pass actually judged stale.
+      const plan = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: { approve: "auto_with_approval" }, authorIsOwner: true, pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } }),
+      );
+      const approveAction = plan.find((a) => a.actionClass === "approve");
+      expect(approveAction).toMatchObject({ dismissStaleApproval: true, expectedHeadSha: "newsha" });
+    });
+
     it("does NOT retract when the PR is closing instead — a close makes the stale approval moot", () => {
       const plan = classes(
         planAgentMaintenanceActions(

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -114,6 +114,57 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
+  describe("stale-approval retraction (#2254)", () => {
+    it("retracts a stale approval when a newer commit is no longer review-good and the PR stays open (held, not closed)", () => {
+      // Owner-authored + closeOwnerAuthors unset ⇒ closeEligible is false ⇒ this bad-verdict PR is HELD, not
+      // closed — exactly the case where a stale APPROVE from an earlier good commit would otherwise linger.
+      const plan = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: { approve: "auto" }, authorIsOwner: true, pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } }),
+      );
+      const approveAction = plan.find((a) => a.actionClass === "approve");
+      expect(approveAction).toMatchObject({ dismissStaleApproval: true });
+    });
+
+    it("does NOT retract when the PR is closing instead — a close makes the stale approval moot", () => {
+      const plan = classes(
+        planAgentMaintenanceActions(
+          input({ conclusion: "failure", autonomy: { approve: "auto", close: "auto" }, blockerTitles: ["x"], pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } }),
+        ),
+      );
+      expect(plan).toContain("close");
+      const approveAction = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: { approve: "auto", close: "auto" }, blockerTitles: ["x"], pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } }),
+      ).find((a) => a.actionClass === "approve");
+      expect(approveAction).toBeUndefined();
+    });
+
+    it("does NOT retract when the newer commit IS review-good — a fresh approve fires instead", () => {
+      const good = { conclusion: "success" as const, autonomy: { approve: "auto" as const }, ciState: "passed" as const };
+      const approveAction = planAgentMaintenanceActions(input({ ...good, pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } })).find((a) => a.actionClass === "approve");
+      expect(approveAction).toBeDefined();
+      expect(approveAction?.dismissStaleApproval).toBeUndefined(); // a normal fresh approve, not a retraction
+    });
+
+    it("does NOT retract when there is nothing stale to retract (never approved, or already approved this exact head)", () => {
+      const neverApproved = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: { approve: "auto" }, authorIsOwner: true, pr: { labels: [], headSha: "newsha" } }),
+      ).find((a) => a.actionClass === "approve");
+      expect(neverApproved).toBeUndefined();
+
+      const sameHead = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: { approve: "auto" }, authorIsOwner: true, pr: { labels: [], headSha: "abc123", approvedHeadSha: "abc123" } }),
+      ).find((a) => a.actionClass === "approve");
+      expect(sameHead).toBeUndefined();
+    });
+
+    it("respects the approve autonomy dial — no retraction when approve is not acting", () => {
+      const plan = planAgentMaintenanceActions(
+        input({ conclusion: "failure", autonomy: {}, authorIsOwner: true, pr: { labels: [], headSha: "newsha", approvedHeadSha: "oldsha" } }),
+      );
+      expect(plan.find((a) => a.actionClass === "approve")).toBeUndefined();
+    });
+  });
+
   it("merges only a clean, approved, passing PR (reviewDecision drives the approval gate)", () => {
     const ok = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
     expect(ok.find((a) => a.actionClass === "merge")).toMatchObject({ mergeMethod: "squash" });

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -309,6 +309,36 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 8, "retract")).resolves.toEqual({ dismissed: false });
   });
 
+  it("finds the bot's LATEST approve on a second page, not an earlier one from page 1 (#2361)", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    // Page 1 is a full 100-row page (forces pagination to continue) whose only bot review is an EARLIER
+    // approve; the actual latest bot approve is review id 999 on page 2 — a single-page fetch would wrongly
+    // dismiss the page-1 review (or miss the real latest one) instead.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, state: "COMMENTED", user: { login: "human-reviewer" } }));
+    page1[0] = { id: 1, state: "APPROVED", user: { login: "gittensory[bot]" } };
+    const page2 = [
+      { id: 998, state: "CHANGES_REQUESTED", user: { login: "gittensory[bot]" } },
+      { id: 999, state: "APPROVED", user: { login: "gittensory[bot]" } },
+    ];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/10/reviews") && !url.includes("/dismissals") && method === "GET") {
+        const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        return Response.json(page === 1 ? page1 : page === 2 ? page2 : []);
+      }
+      if (url.includes("/pulls/10/reviews/999/dismissals") && method === "PUT") {
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+        return Response.json({ id: 999, state: "DISMISSED" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const result = await dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 10, "stale approval retracted");
+    expect(result).toEqual({ dismissed: true });
+    expect(calls).toHaveLength(1); // page 1's review 1 was never dismissed
+  });
+
   it("is best-effort — an API error returns dismissed:false instead of throwing", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       if (input.toString().includes("/access_tokens")) return Response.json({ token: "t" });

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { closePullRequest, createIssueComment, createPullRequestReview, createPullRequestReviewComments, getLastCloserLogin, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
+import { closePullRequest, createIssueComment, createPullRequestReview, createPullRequestReviewComments, dismissLatestBotApproval, getLastCloserLogin, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { createTestEnv } from "../helpers/d1";
 
 function envWithKey() {
@@ -271,6 +271,50 @@ describe("GitHub PR action primitives (#778)", () => {
       return new Response("unexpected", { status: 500 });
     });
     await expect(getLastCloserLogin(envWithKey(), 123, "owner/repo", 24)).resolves.toEqual({ login: null, coveredAllPages: true });
+  });
+
+  it("dismisses the bot's own LATEST approve review, ignoring other reviewers and earlier bot reviews (#2254)", async () => {
+    const calls: Array<{ method: string; url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/7/reviews") && !url.includes("/dismissals") && method === "GET") {
+        return Response.json([
+          { id: 1, state: "COMMENTED", user: { login: "human-reviewer" } },
+          { id: 2, state: "APPROVED", user: { login: "gittensory[bot]" } }, // an EARLIER bot approve
+          { id: 3, state: "CHANGES_REQUESTED", user: { login: "gittensory[bot]" } },
+          { id: 4, state: "APPROVED", user: { login: "gittensory[bot]" } }, // the LATEST bot approve — this one
+        ]);
+      }
+      if (url.includes("/pulls/7/reviews/4/dismissals") && method === "PUT") {
+        calls.push({ method, url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+        return Response.json({ id: 4, state: "DISMISSED" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    const result = await dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 7, "stale approval retracted");
+    expect(result).toEqual({ dismissed: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body).toMatchObject({ message: "stale approval retracted", event: "DISMISS" });
+  });
+
+  it("is a no-op when the bot never approved this PR", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/8/reviews")) return Response.json([{ id: 1, state: "APPROVED", user: { login: "human-reviewer" } }]);
+      return new Response("unexpected", { status: 500 });
+    });
+    await expect(dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 8, "retract")).resolves.toEqual({ dismissed: false });
+  });
+
+  it("is best-effort — an API error returns dismissed:false instead of throwing", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes("/access_tokens")) return Response.json({ token: "t" });
+      throw new Error("network failure");
+    });
+    await expect(dismissLatestBotApproval(envWithKey(), 123, "owner/repo", 9, "retract")).resolves.toEqual({ dismissed: false });
   });
 
   it("updates branch without an expected head sha (omits expected_head_sha — FALSE branch of the spread ternary)", async () => {


### PR DESCRIPTION
## What

GitHub's `reviewDecision` (which "require approving reviews" branch protection reads) is derived from each reviewer's LATEST review. When gittensory approves a PR and a later commit lands that no longer qualifies for approval — CI regresses, the PR becomes unmergeable, etc. — the planner correctly stops issuing new approvals, but the bot's existing approval review stays in place and keeps satisfying the branch-protection rule. A human can then merge un-reviewed/no-longer-qualifying code directly on GitHub, bypassing the gate entirely.

Auto-approve also had no precision circuit-breaker at all — `downgradeMergeToHold`/`downgradeCloseToHold` exist for merge/close, but nothing constrained fresh approvals the same way.

## Fix

- `dismissLatestBotApproval` (new, `src/github/pr-actions.ts`): finds the bot's own most recent APPROVE review and dismisses it via `PUT .../reviews/{review_id}/dismissals`. Best-effort — any failure (no bot review found, already dismissed, transient API error) returns `{dismissed: false}` instead of throwing, since this is a cleanup action riding alongside the primary maintenance pass, not the primary mutation.
- Planner (`src/settings/agent-actions.ts`): a new branch fires when `approvedHeadSha !== headSha` (a newer commit landed since the bot's last approval) and the PR can no longer merge and isn't already being closed — stages an `approve` action with `dismissStaleApproval: true` instead of a fresh review. Reuses the existing `approve` action class + autonomy dial rather than a new action class or `request_changes` (which the bot deliberately never posts — a stale request-changes review would keep a PR un-mergeable forever).
- Executor (`src/services/agent-action-executor.ts`): the `approve` case branches on `dismissStaleApproval` to call the new dismiss primitive instead of posting a new review.
- Threaded `dismissStaleApproval` through `actionParams()`/`AgentPendingActionParams` (`src/types.ts`) so it round-trips through approval-queue staging like every other action-specific field.

## Tests

- `dismissLatestBotApproval`: dismisses only the bot's LATEST approve (ignoring other reviewers and earlier bot reviews), no-ops when the bot never approved, best-effort on API error.
- Planner: retracts when held-not-closed; does NOT retract when closing instead, when a fresh approve fires instead, when nothing is stale, or when the approve autonomy dial isn't acting.
- Executor: LIVE approve with `dismissStaleApproval` calls the dismiss primitive and does not post a new review; `actionParams` round-trips `dismissStaleApproval`.

Full unsharded `test:coverage` green (5607 passed, 4 skipped); `typecheck` green; `npm audit` clean.

Advances #1936. Closes #2254.