### PR TITLE
feat(scoring): surface tied-leverage disclosure in score breakdown

### DIFF
--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -20,8 +20,9 @@ export type ScoreBreakdownExplanation = {
   highestLeverageLever: {
     component: string;
     lever: string;
-    /** Components that tie with the top one at the same leverageScore; surfaced so a contributor
-     *  can see the alphabetical tie-breaker isn't a strictly-dominant choice. Empty when no tie. */
+    /** Other components that tie with the selected top component at the same leverageScore
+     *  (excludes the selected top component itself). Surfaced so a contributor can see the
+     *  alphabetical tie-breaker isn't a strictly-dominant choice. Empty when no tie exists. */
     tiedLeverageComponents: string[];
     reason: string;
   };

--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -21,8 +21,9 @@ export type ScoreBreakdownExplanation = {
     component: string;
     lever: string;
     /** Other components that tie with the selected top component at the same leverageScore
-     *  (excludes the selected top component itself). Surfaced so a contributor can see the
-     *  alphabetical tie-breaker isn't a strictly-dominant choice. Empty when no tie exists. */
+     *  (excludes the selected top component itself). Ordered alphabetically (same tie-breaker
+     *  used to pick the top component). Surfaced so a contributor can see the alphabetical
+     *  tie-breaker isn't a strictly-dominant choice. Empty when no tie exists. */
     tiedLeverageComponents: string[];
     reason: string;
   };

--- a/src/services/score-breakdown.ts
+++ b/src/services/score-breakdown.ts
@@ -20,6 +20,9 @@ export type ScoreBreakdownExplanation = {
   highestLeverageLever: {
     component: string;
     lever: string;
+    /** Components that tie with the top one at the same leverageScore; surfaced so a contributor
+     *  can see the alphabetical tie-breaker isn't a strictly-dominant choice. Empty when no tie. */
+    tiedLeverageComponents: string[];
     reason: string;
   };
 };
@@ -361,15 +364,23 @@ function gateHighlightsFor(preview: ScorePreviewResult): ScoreBreakdownExplanati
 function pickHighestLeverage(components: ScoreMultiplierBreakdown[]): ScoreBreakdownExplanation["highestLeverageLever"] {
   const ranked = [...components].sort((left, right) => right.leverageScore - left.leverageScore || left.component.localeCompare(right.component));
   const top = ranked[0]!;
+  // Surface any components tied at the top leverageScore so the alphabetical tie-breaker
+  // (localeCompare above) is not silently dominant — a contributor fixing only the named top
+  // component would miss equally-impactful tied components. Empty when no tie exists.
+  const tied = ranked.filter((entry, idx) => idx > 0 && entry.leverageScore === top.leverageScore).map((entry) => entry.component);
+  const tiedClause = tied.length > 0
+    ? ` (${top.component} ties with ${tied.join(", ")} at the same leverage score; any of these is the highest-leverage lever.)`
+    : "";
   const reason =
     top.band === "blocked"
-      ? `${top.component} is fully blocking or zeroing part of the preview right now.`
+      ? `${top.component} is fully blocking or zeroing part of the preview right now.${tiedClause}`
       : top.band === "reduced"
-        ? `${top.component} is the largest remaining reducer in the multiplier stack.`
-        : `${top.component} is the best next optimization lever among non-blocking multipliers.`;
+        ? `${top.component} is the largest remaining reducer in the multiplier stack.${tiedClause}`
+        : `${top.component} is the best next optimization lever among non-blocking multipliers.${tiedClause}`;
   return {
     component: top.component,
     lever: top.lever,
+    tiedLeverageComponents: tied,
     reason: sanitizePublicComment(reason),
   };
 }

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -477,8 +477,8 @@ describe("explainScoreBreakdown", () => {
     expect(breakdown.components.find((entry) => entry.component === "credibilityMultiplier")).toMatchObject({ band: "blocked" });
     expect(breakdown.components.find((entry) => entry.component === "openPrMultiplier")).toMatchObject({ band: "blocked" });
   });
-  it("blocks base-score projection when the source-token gate has not passed", () => {
 
+  it("blocks base-score projection when the source-token gate has not passed", () => {
     const preview = buildScorePreview({
       repo,
       snapshot,

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -679,22 +679,53 @@ describe("explainScoreBreakdown", () => {
   });
 
   it("surfaces tied-leverage components when multiple levers share the top leverageScore", () => {
+    // Both openPrMultiplier and openIssueMultiplier blocked at leverageScore 100.
+    // With existingContributorTokenScore = 0, openPrThreshold = 2 and openIssueThreshold = 2.
+    // openPrCount = 3 > 2 → blocked (leverageScore 100).
+    // openIssueCount = 3 > 2 → blocked (leverageScore 100).
+    // Alphabetical winner: "openIssueMultiplier" (I < P), tied component: "openPrMultiplier".
     const preview = buildScorePreview({
       repo,
       snapshot,
       input: {
         repoFullName: repo.fullName,
-        sourceTokenScore: 80,
-        totalTokenScore: 90,
-        sourceLines: 50,
-        openPrCount: 20,
-        existingContributorTokenScore: 50,
-        credibility: 0.005,
+        sourceTokenScore: 100,
+        totalTokenScore: 200,
+        sourceLines: 100,
+        openPrCount: 3,
+        openIssueCount: 3,
+        existingContributorTokenScore: 0,
+        credibility: 1,
       },
     });
     const breakdown = explainScoreBreakdown(preview);
     const top = breakdown.highestLeverageLever;
-    expect(top.tiedLeverageComponents).toBeDefined();
-    expect(Array.isArray(top.tiedLeverageComponents)).toBe(true);
+    expect(top.component).toBe("openIssueMultiplier");
+    expect(top.tiedLeverageComponents).toEqual(["openPrMultiplier"]);
+    expect(top.reason).toMatch(/openIssueMultiplier ties with openPrMultiplier at the same leverage score/);
+    expect(breakdown.components.find((c) => c.component === "openIssueMultiplier")?.leverageScore).toBe(100);
+    expect(breakdown.components.find((c) => c.component === "openPrMultiplier")?.leverageScore).toBe(100);
+  });
+
+  it("returns empty tiedLeverageComponents when no tie exists at the top leverageScore", () => {
+    // Single top lever (credibilityMultiplier at 85) — no tie.
+    const preview = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 100,
+        totalTokenScore: 200,
+        sourceLines: 100,
+        openPrCount: 0,
+        openIssueCount: 0,
+        existingContributorTokenScore: 0,
+        credibility: 0.01,
+      },
+    });
+    const breakdown = explainScoreBreakdown(preview);
+    const top = breakdown.highestLeverageLever;
+    expect(top.tiedLeverageComponents).toEqual([]);
+    expect(top.reason).not.toMatch(/ties with/);
   });
 });

--- a/test/unit/score-breakdown.test.ts
+++ b/test/unit/score-breakdown.test.ts
@@ -477,8 +477,8 @@ describe("explainScoreBreakdown", () => {
     expect(breakdown.components.find((entry) => entry.component === "credibilityMultiplier")).toMatchObject({ band: "blocked" });
     expect(breakdown.components.find((entry) => entry.component === "openPrMultiplier")).toMatchObject({ band: "blocked" });
   });
-
   it("blocks base-score projection when the source-token gate has not passed", () => {
+
     const preview = buildScorePreview({
       repo,
       snapshot,
@@ -676,5 +676,25 @@ describe("explainScoreBreakdown", () => {
     expect(isSaturated).toMatchObject({ band: "full" });
     expect(isSaturated.summary).toMatch(/saturated near the score cap/);
     expect(JSON.stringify(explainScoreBreakdown(saturated))).not.toMatch(FORBIDDEN);
+  });
+
+  it("surfaces tied-leverage components when multiple levers share the top leverageScore", () => {
+    const preview = buildScorePreview({
+      repo,
+      snapshot,
+      input: {
+        repoFullName: repo.fullName,
+        sourceTokenScore: 80,
+        totalTokenScore: 90,
+        sourceLines: 50,
+        openPrCount: 20,
+        existingContributorTokenScore: 50,
+        credibility: 0.005,
+      },
+    });
+    const breakdown = explainScoreBreakdown(preview);
+    const top = breakdown.highestLeverageLever;
+    expect(top.tiedLeverageComponents).toBeDefined();
+    expect(Array.isArray(top.tiedLeverageComponents)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Replaces #1982 (cannot reopen after force-push per GitHub policy).

**What changed:**
- ScoreBreakdownExplanation.highestLeverageLever gains a tiedLeverageComponents: string[] field
- pickHighestLeverage surfaces all components sharing the top leverageScore
- Tests cover no-tie (singleton) and blocked tie paths

**Rationale:** When two scoring levers tie for highest leverageScore, the breakdown silently showed only one. This disclosure lets contributors see all tied levers so they can prioritize which to fix first.

**Files changed:**
- src/services/score-breakdown.ts — pickHighestLeverage collects ties; ScoreBreakdownExplanation.highestLeverageLever adds tiedLeverageComponents
- test/unit/score-breakdown.test.ts — 2 new test cases (blocked tie scenario + no-tie scenario)

**Validation:**
- npx vitest run test/unit/score-breakdown.test.ts — 24/24 pass
- npm run typecheck clean
- git diff --check clean

**Linked issue:** Closes #2142 (spawned from the tied-leverage gap identified in that issue).