### PR TITLE
fix(ci): use a colon-prefixed branch for fork tokenless Codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,20 @@ jobs:
       # actual commit, not a synthetic merge), so HEAD has one parent and that recovery can't fire. Pass
       # the same explicit overrides as the trusted upload above so the report attaches to the real PR head,
       # not a merge sha GitHub's PR checks list has no reason to display.
+      #
+      # override_branch is prefixed with the fork owner (owner:branch) -- per Codecov's own docs, only a
+      # branch string containing a colon is recognized as "unprotected" and eligible for a tokenless
+      # upload; a bare branch name looks like it could be a real (possibly protected) branch on the base
+      # repo and gets rejected with "Token required because branch is protected" even with no token
+      # configured at all. codecov-cli's own auto-detection never adds this prefix either (verified in its
+      # source), so this must be supplied explicitly.
       - name: Upload coverage to Codecov (fork PR tokenless)
         if: ${{ success() && needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.fork == true }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info
           disable_search: true
-          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: true
@@ -191,7 +198,7 @@ jobs:
           files: ./reports/junit/vitest.xml
           report_type: test_results
           disable_search: true
-          override_branch: ${{ github.event.pull_request.head.ref }}
+          override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
           override_commit: ${{ github.event.pull_request.head.sha }}
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: false

--- a/test/unit/codecov-policy.test.ts
+++ b/test/unit/codecov-policy.test.ts
@@ -100,9 +100,16 @@ describe("Codecov policy", () => {
     // recover the real head sha assumes a 2-parent merge commit at HEAD -- which our checkout step (it
     // fetches github.event.pull_request.head.sha directly) never produces. Without an explicit override,
     // the report would attach to a sha GitHub's PR checks list has no reason to ever display.
-    expect(forkCoverageWith.override_branch).toBe("${{ github.event.pull_request.head.ref }}");
     expect(forkCoverageWith.override_commit).toBe("${{ github.event.pull_request.head.sha }}");
     expect(forkCoverageWith.override_pr).toBe("${{ github.event.pull_request.number }}");
+    // Codecov only treats a branch as "unprotected" (eligible for tokenless upload) when its name has a
+    // colon-separated prefix; a bare branch name gets rejected with "Token required because branch is
+    // protected" even with no token configured anywhere. codecov-cli's own auto-detection never adds
+    // this prefix, so it must be supplied explicitly -- omitting it is exactly the regression this guards.
+    expect(String(forkCoverageWith.override_branch)).toContain(":");
+    expect(forkCoverageWith.override_branch).toBe(
+      "${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}",
+    );
 
     const forkTestResultsUpload = steps.find(
       (step) => step.name === "Upload Vitest results to Codecov (fork PR tokenless)",
@@ -113,6 +120,7 @@ describe("Codecov policy", () => {
     expect(forkTestResultsWith.report_type).toBe("test_results");
     expect(forkTestResultsWith.fail_ci_if_error).toBe(false);
     expect(forkTestResultsWith.override_commit).toBe("${{ github.event.pull_request.head.sha }}");
+    expect(String(forkTestResultsWith.override_branch)).toContain(":");
 
     // The trusted (token) path must still explicitly exclude forks -- it must never see the token env
     // used, and the two paths must be mutually exclusive so a fork PR never double-uploads.


### PR DESCRIPTION
## Summary
- Fixes a live CI failure hit on a real fork PR rebase: the fork-tokenless Codecov upload steps (added in #2273) started failing with `Upload queued for processing failed: {"message":"Token required because branch is protected"}`.
- Root cause: `override_branch` was set to the bare fork branch name (e.g. `feat/mcp-block-explorer-feed-filters`). Per Codecov's own docs, only a branch string with a colon-separated prefix (e.g. `forkname:branch`) is recognized as "unprotected" and eligible for a tokenless upload — a bare name looks like it could be a real (possibly protected) branch on the base repo and gets rejected, even with zero token configuration anywhere. Confirmed directly in `codecov-cli`'s source (`services/commit/__init__.py`): `if branch and ":" in branch: ... elif token is None: # protected, warns/rejects`. `codecov-cli`'s own auto-detection never adds this prefix either (checked `helpers/ci_adapters/github_actions.py` — `_get_branch()` returns the bare `GITHUB_HEAD_REF`), so it has to be supplied explicitly by the caller.
- Fix: prefix `override_branch` with the fork owner (`${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}`) on both fork-tokenless upload steps. `override_commit`/`override_pr` are untouched — the protected-branch check only inspects the branch string.

## Why
Follow-up to #2273. The prior fix correctly attributed fork-tokenless uploads to the real PR head sha (closing a misattribution gap flagged by the gate's own AI review), but didn't account for Codecov's separate "is this branch protected" check, which is evaluated purely on the branch string format. This is a live, user-reported failure on an actual contributor PR rebase, not a theoretical concern.

## Scope
- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (CI workflow only).
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue linked — direct follow-up fix for a live CI failure discovered and diagnosed in this session.

## Validation
- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run test:coverage` locally (no `src/**` lines changed; `test/unit/codecov-policy.test.ts` updated with assertions for the colon-prefixed branch format)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] `test/unit/codecov-policy.test.ts` extended to assert the fork-tokenless steps' `override_branch` contains a colon and matches the `owner:branch` format

## Safety
- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise.
- [ ] Auth/CORS/session negative-path tests — N/A, no such change.
- [ ] API/OpenAPI/MCP behavior — N/A.
- [ ] UI changes — N/A, CI-only change.
- [ ] Public docs/changelogs — N/A.