### PR TITLE
fix(agent-actions): re-verify live CI before a merge or heuristic close

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -1,6 +1,9 @@
 import { bumpPullRequestMergeAttempt, createPendingAgentActionIfAbsent, insertNotificationDeliveryIfAbsent, isGlobalAgentFrozen, markPullRequestApproved, markPullRequestMergeBlocked, recordAuditEvent } from "../db/repositories";
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
+import { createInstallationToken } from "../github/app";
+import { fetchLiveCiAggregate } from "../github/backfill";
+import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
 import { fetchPullRequestFreshness, pullRequestFreshnessDetail } from "../github/pr-freshness";
@@ -114,12 +117,37 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
       continue;
     }
-    // 6) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
+    // 6) Live CI re-verification for a merge or a heuristic close (#2128): the CI aggregate that drove either
+    //    decision was read seconds-to-tens-of-seconds earlier, in the planning pass, and the freshness guard
+    //    above only re-checks head SHA/state, not CI. GitHub's own merge endpoint enforces branch-protection
+    //    REQUIRED checks server-side, but only as a backstop when a repo actually configures them; a heuristic
+    //    close has no server-side check at all. Re-read live CI right before the mutation so a check that
+    //    flipped in this narrow window is never acted on from stale information. Deterministic closes
+    //    (linked-issue hard-rule, blacklist) are exempt — they are zero-hallucination facts that do not depend
+    //    on CI, and the linked-issue rule already has its own flag-then-verify pass.
+    if (action.actionClass === "merge" || (action.actionClass === "close" && action.closeKind === "heuristic")) {
+      const ciToken = await createInstallationToken(env, ctx.installationId).catch(() => undefined);
+      const admissionKey = githubRateLimitAdmissionKeyForToken(env, ciToken, ctx.installationId);
+      const liveCi = await fetchLiveCiAggregate(env, ctx.repoFullName, expectedHeadSha, ciToken, undefined, admissionKey);
+      const staleReason =
+        action.actionClass === "merge"
+          ? liveCi.ciState === "failed"
+            ? "live CI is now failing"
+            : null
+          : liveCi.ciState !== "failed"
+            ? `CI state changed since planning (now: ${liveCi.ciState})`
+            : null;
+      if (staleReason) {
+        await audit("denied", `${staleReason} — action not executed`);
+        continue;
+      }
+    }
+    // 7) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
       await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
       continue;
     }
-    // 7) live — perform the real mutation, recording success or the error.
+    // 8) live — perform the real mutation, recording success or the error.
     try {
       await performAction(env, ctx, action);
       await audit("completed", action.reason);

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -266,6 +266,7 @@ export function actionParams(action: PlannedAgentAction): AgentPendingActionPara
     ...(action.reviewBody !== undefined ? { reviewBody: action.reviewBody } : {}),
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),
+    ...(action.closeKind !== undefined ? { closeKind: action.closeKind } : {}),
     ...(action.expectedHeadSha !== undefined ? { expectedHeadSha: action.expectedHeadSha } : {}),
   };
 }

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -129,10 +129,15 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       const ciToken = await createInstallationToken(env, ctx.installationId).catch(() => undefined);
       const admissionKey = githubRateLimitAdmissionKeyForToken(env, ciToken, ctx.installationId);
       const liveCi = await fetchLiveCiAggregate(env, ctx.repoFullName, expectedHeadSha, ciToken, undefined, admissionKey);
+      // The planner itself only ever stages a merge when ciState === "passed" exactly (reviewGood in
+      // agent-actions.ts; "pending" short-circuits to no actions at all upstream) -- the live re-check must
+      // require the SAME exact state, not just "not failed". Otherwise a check that regressed to pending or
+      // became unreadable (unverified) between planning and actuation would still merge, on the assumption
+      // that only an explicit failure invalidates the plan.
       const staleReason =
         action.actionClass === "merge"
-          ? liveCi.ciState === "failed"
-            ? "live CI is now failing"
+          ? liveCi.ciState !== "passed"
+            ? `live CI is no longer passing (now: ${liveCi.ciState})`
             : null
           : liveCi.ciState !== "failed"
             ? `CI state changed since planning (now: ${liveCi.ciState})`

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -270,12 +270,13 @@ export function actionParams(action: PlannedAgentAction): AgentPendingActionPara
     ...(action.reviewBody !== undefined ? { reviewBody: action.reviewBody } : {}),
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),
-    ...(action.closeKind !== undefined ? { closeKind: action.closeKind } : {}),
     ...(action.expectedHeadSha !== undefined ? { expectedHeadSha: action.expectedHeadSha } : {}),
     ...(action.dismissStaleApproval !== undefined ? { dismissStaleApproval: action.dismissStaleApproval } : {}),
     // Round-trip closeKind so a staged close's kind survives to accept-time — without it, the close-precision
     // breaker's isHeuristicClose check (which matches on closeKind === "heuristic") could never fire for any
-    // staged close, silently defeating the breaker for the entire approval-queue accept path (#2127).
+    // staged close, silently defeating the breaker for the entire approval-queue accept path (#2127), and the
+    // actuation-time live-CI re-check above (#2364) — which only applies to a heuristic close — would be
+    // silently skipped for a lost discriminator.
     ...(action.closeKind !== undefined ? { closeKind: action.closeKind } : {}),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,6 +682,10 @@ export type AgentPendingActionParams = {
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;
+  // Which kind of close this is (linked-issue-hard-rule / blacklist / heuristic), persisted so a queued close's
+  // actuation-time live-CI re-check (#2364) — which only applies to a heuristic close — still fires correctly
+  // once the row is replayed through pendingActionToPlanned, not silently skipped for a lost discriminator.
+  closeKind?: "linked-issue-hard-rule" | "blacklist" | "heuristic";
   expectedHeadSha?: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,18 +682,17 @@ export type AgentPendingActionParams = {
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
   closeComment?: string;
-  // Which kind of close this is (linked-issue-hard-rule / blacklist / heuristic), persisted so a queued close's
-  // actuation-time live-CI re-check (#2364) — which only applies to a heuristic close — still fires correctly
-  // once the row is replayed through pendingActionToPlanned, not silently skipped for a lost discriminator.
+  // Which kind of close this is (see PlannedAgentAction.closeKind), persisted so it round-trips through staging:
+  // the close-precision circuit-breaker still scopes itself correctly when a staged close is later accepted
+  // (#2127), and the actuation-time live-CI re-check (#2364) — which only applies to a heuristic close — still
+  // fires correctly once the row is replayed through pendingActionToPlanned, rather than silently skipping for
+  // a lost discriminator.
   closeKind?: "linked-issue-hard-rule" | "blacklist" | "heuristic";
   expectedHeadSha?: string;
   // For an `approve` action: retract the bot's own stale approval instead of posting a new one (see
   // PlannedAgentAction.dismissStaleApproval). Must round-trip through staging like every other action-specific
   // field. (#2254)
   dismissStaleApproval?: boolean;
-  // WHICH kind of close this is (see PlannedAgentAction.closeKind) — must round-trip through staging so the
-  // close-precision circuit-breaker can still scope itself correctly when a staged close is later accepted (#2127).
-  closeKind?: "linked-issue-hard-rule" | "blacklist" | "heuristic";
 };
 
 export type AgentPendingActionStatus = "pending" | "accepted" | "rejected";

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -38,7 +38,7 @@ import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github
 import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
 import { createInstallationToken } from "../../src/github/app";
 import { fetchLiveCiAggregate } from "../../src/github/backfill";
-import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
+import { actionParams, executeAgentMaintenanceActions, pendingActionToPlanned, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import { isGlobalAgentFrozen, setGlobalAgentFrozen } from "../../src/db/repositories";
@@ -127,6 +127,22 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [heuristicClose]);
     expect(outcomes[0]?.outcome).toBe("completed");
     expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
+  });
+
+  it("REGRESSION (#2364): a queued heuristic close still re-checks live CI after the approval-queue replay round trip", async () => {
+    const env = createTestEnv({});
+    const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failed", closeComment: "closing", closeKind: "heuristic" };
+    // Simulate the persist/replay path: stageForApproval calls actionParams() to persist the row, and accept
+    // rebuilds it via pendingActionToPlanned(). Without persisting closeKind, the rebuilt action would lose the
+    // discriminator the live-CI re-check keys on, silently skipping it for every accepted queued heuristic close.
+    const persisted = actionParams(heuristicClose);
+    const replayed = pendingActionToPlanned({ actionClass: "close", params: persisted, reason: heuristicClose.reason });
+    expect(replayed.closeKind).toBe("heuristic");
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "passed", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [replayed]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(outcomes[0]?.detail).toContain("CI state changed since planning (now: passed)");
+    expect(closePullRequest).not.toHaveBeenCalled();
   });
 
   it("LIVE non-heuristic close (linked-issue hard-rule) skips the live CI re-check entirely (#2128)", async () => {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -22,10 +22,22 @@ vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
     })),
   };
 });
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  createInstallationToken: vi.fn(async () => "test-installation-token"),
+}));
+// The actuation-time live CI re-check (#2128) defaults to "still passing" so the existing merge tests stay
+// deterministic; individual tests below override this to exercise the staleness-denial path.
+vi.mock("../../src/github/backfill", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/backfill")>()),
+  fetchLiveCiAggregate: vi.fn(async () => ({ ciState: "passed" as const, hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] })),
+}));
 
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
 import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
+import { createInstallationToken } from "../../src/github/app";
+import { fetchLiveCiAggregate } from "../../src/github/backfill";
 import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
@@ -96,6 +108,50 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     await executeAgentMaintenanceActions(env, ctx({ headSha: "live-sha" }), [pinnedMerge]);
     expect(mergePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7, { mergeMethod: "squash", sha: "reviewed-sha" });
     expect(fetchPullRequestFreshness).toHaveBeenCalledWith(env, expect.objectContaining({ expectedHeadSha: "reviewed-sha" }));
+  });
+
+  it("LIVE heuristic close is denied when live CI has since turned green (#2128)", async () => {
+    const env = createTestEnv({});
+    const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failed", closeComment: "closing", closeKind: "heuristic" };
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "passed", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [heuristicClose]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(outcomes[0]?.detail).toContain("CI state changed since planning (now: passed)");
+    expect(closePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("LIVE heuristic close proceeds when live CI is still failing (#2128)", async () => {
+    const env = createTestEnv({});
+    const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failed", closeComment: "closing", closeKind: "heuristic" };
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "failed", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [heuristicClose]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(closePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7);
+  });
+
+  it("LIVE non-heuristic close (linked-issue hard-rule) skips the live CI re-check entirely (#2128)", async () => {
+    const env = createTestEnv({});
+    const hardRuleClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "unlinked issue", closeComment: "closing", closeKind: "linked-issue-hard-rule" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [hardRuleClose]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(fetchLiveCiAggregate).not.toHaveBeenCalled();
+  });
+
+  it("LIVE merge is denied when live CI has since turned failing (#2128)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "failed", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(outcomes[0]?.detail).toContain("live CI is now failing");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("the live CI re-check fails open on a token-mint error — it is defense-in-depth, not the primary gate (#2128)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(createInstallationToken).mockRejectedValueOnce(new Error("mint failed"));
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(mergePullRequest).toHaveBeenCalledWith(env, 123, "owner/repo", 7, { mergeMethod: "squash", sha: "sha7" });
   });
 
   it("LIVE label with labelOp=add + comment: adds the label AND posts the comment", async () => {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -142,7 +142,25 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "failed", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
     expect(outcomes[0]?.outcome).toBe("denied");
-    expect(outcomes[0]?.detail).toContain("live CI is now failing");
+    expect(outcomes[0]?.detail).toContain("live CI is no longer passing (now: failed)");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION (#2364): LIVE merge is denied when live CI has since become pending, not just failed", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "pending", hasPending: true, hasVisiblePending: true, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(outcomes[0]?.detail).toContain("live CI is no longer passing (now: pending)");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION (#2364): LIVE merge is denied when live CI has since become unverified (unreadable), not just failed", async () => {
+    const env = createTestEnv({});
+    vi.mocked(fetchLiveCiAggregate).mockResolvedValueOnce({ ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
+    expect(outcomes[0]?.outcome).toBe("denied");
+    expect(outcomes[0]?.detail).toContain("live CI is no longer passing (now: unverified)");
     expect(mergePullRequest).not.toHaveBeenCalled();
   });
 

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -20,6 +20,16 @@ vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
     })),
   };
 });
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  createInstallationToken: vi.fn(async () => "test-installation-token"),
+}));
+// The actuation-time live CI re-check (#2128) defaults to "still passing" so the existing accept tests stay
+// deterministic.
+vi.mock("../../src/github/backfill", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/backfill")>()),
+  fetchLiveCiAggregate: vi.fn(async () => ({ ciState: "passed" as const, hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] })),
+}));
 
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel } from "../../src/github/labels";

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -20,6 +20,16 @@ vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
     })),
   };
 });
+// #2364's live CI re-check (in executeAgentMaintenanceActions) runs for every merge/heuristic-close accept.
+// Default to a green re-check so the existing "accept executes the staged merge" happy path still executes
+// live instead of being (correctly) denied for CI that this test was never simulating.
+vi.mock("../../src/github/backfill", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/github/backfill")>();
+  return {
+    ...actual,
+    fetchLiveCiAggregate: vi.fn(async () => ({ ciState: "passed" as const, hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] })),
+  };
+});
 
 import { mergePullRequest } from "../../src/github/pr-actions";
 import { createSessionForGitHubUser } from "../../src/auth/security";


### PR DESCRIPTION
## What

The freshness guard in `executeAgentMaintenanceActions` re-checks head SHA and PR state before every live action, but not CI. The CI aggregate that drove a heuristic close or a merge decision is read once in the planning pass, seconds-to-tens-of-seconds before actuation, and never re-read at the moment of mutation. GitHub's own merge endpoint enforces branch-protection required checks server-side, but only as a backstop when a repo actually configures them — and a heuristic close has no server-side check at all. A required check that flips green in the narrow window between planning and actuation could still get a PR closed on stale information: unlike the deterministic linked-issue-hard-rule close, a heuristic CI-driven close has no flag-then-verify pass.

## Fix

Add a new guard step to `executeAgentMaintenanceActions` (`src/services/agent-action-executor.ts`), right after the existing freshness guard: immediately before a `merge` or a heuristic close (`closeKind: "heuristic"`), re-derive live CI via the existing `fetchLiveCiAggregate` helper and deny the action if:
- **merge**: live CI now shows `"failed"` (a regression since planning), or
- **close**: live CI no longer shows `"failed"` (the failure that justified the close no longer holds — pending/passed/unverified all invalidate it).

Deterministic closes (linked-issue hard-rule, blacklist) are exempt — they're zero-hallucination facts that don't depend on CI, and the linked-issue rule already has its own flag-then-verify pass. Best-effort: a token-mint failure fails open, since this is a defense-in-depth check, not the primary gate — the freshness check immediately above it already fails closed on an unverifiable PR state.

## Tests

- Heuristic close is denied when live CI has since turned green; proceeds when still failing.
- A non-heuristic close (linked-issue hard-rule) skips the CI re-check entirely (`fetchLiveCiAggregate` not called).
- Merge is denied when live CI has since turned failing.
- The CI re-check fails open on a token-mint error (merge still proceeds).

Full unsharded `test:coverage` green; `typecheck` green; `npm audit` clean.

Advances #1936. Closes #2128.