### PR TITLE
fix(signals): rank issue-quality report before capping to 100

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -740,6 +740,7 @@ const MAX_COLLISION_PAIRWISE_ISSUES = 80;
 const MAX_COLLISION_PAIRWISE_PULL_REQUESTS = 120;
 const MAX_COLLISION_PAIRWISE_RECENT_MERGES = 40;
 const ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP = 300;
+const ISSUE_QUALITY_REPORT_CAP = 100;
 const REPO_OUTCOME_STALE_OPEN_DAYS = 30;
 const REPO_OUTCOME_MIN_DECIDED_SAMPLE = 3;
 const REPO_OUTCOME_MERGE_WELL_RATE = 0.7;
@@ -2925,7 +2926,7 @@ export function buildIssueQualityReport(
   const lane = buildLaneAdvice(repo, fullName);
   const collisions = prebuiltCollisions ?? buildCollisionReport(fullName, issues, pullRequests, recentMergedPullRequests);
   const bountyByIssue = indexBountiesByIssue(bounties);
-  // Build per-issue indexes ONCE: the loop below runs over up to 100 open issues, and each previously re-scanned
+  // Build per-issue indexes ONCE: the loop below runs over every open issue, and each previously re-scanned
   // the full PR list (up to 10k) twice plus every collision cluster. O(issues·PRs) → O(issues + PRs).
   const prsByLinkedIssue = indexPullRequestsByLinkedIssue(pullRequests);
   const prByNumber = new Map(pullRequests.map((pr) => [pr.number, pr] as const));
@@ -2935,7 +2936,6 @@ export function buildIssueQualityReport(
   const lifecycleByIssue = new Map(buildIssueDiscoveryLifecycleReport(repo, issues, pullRequests, fullName, recentMergedPullRequests).states.map((entry) => [entry.number, entry]));
   const reports = issues
     .filter((issue) => issue.state === "open")
-    .slice(0, 100)
     .map((issue) => {
       const linkedPrs = resolveLinkedPullRequests(issue, pullRequests, prsByLinkedIssue, prByNumber);
       const linkedMergedPrs = resolveLinkedPullRequests(issue, recentMergedPullRequests, mergedPrsByLinkedIssue, mergedPrByNumber);
@@ -2991,7 +2991,8 @@ export function buildIssueQualityReport(
               : "ready";
       return { number: issue.number, title: issue.title, lifecycle, linkage, bounty: bountyContext, status, score, reasons, warnings };
     })
-    .sort((left, right) => right.score - left.score || left.number - right.number);
+    .sort((left, right) => right.score - left.score || left.number - right.number)
+    .slice(0, ISSUE_QUALITY_REPORT_CAP);
   return {
     repoFullName: fullName,
     generatedAt: nowIso(),

--- a/test/unit/issue-quality.test.ts
+++ b/test/unit/issue-quality.test.ts
@@ -293,6 +293,23 @@ describe("issue quality reports", () => {
     const report = buildIssueQualityReport(repo, issues, [], repo.fullName);
     expect(report.issues.length).toBeLessThanOrEqual(100);
   });
+
+  it("ranks by score before capping to 100, so a strong issue beyond the first 100 in DB order is not dropped (regression)", () => {
+    const repo = issueDiscoveryRepo("owner/rank-before-cap");
+    // 110 thin, stale filler issues (low score) followed by one detailed, fresh, labelled issue (highest score) —
+    // capping by DB-order position before scoring would drop the strong issue entirely.
+    const filler = Array.from({ length: 110 }, (_, index) =>
+      issue(repo.fullName, index + 1, `bulk ${index}`, { body: "Short.", updatedAt: "2025-01-01T00:00:00.000Z" }),
+    );
+    const strongIssue = issue(repo.fullName, 111, "Detailed, well-labelled issue", {
+      body: "x".repeat(220),
+      labels: ["bug"],
+      updatedAt: now(),
+    });
+    const report = buildIssueQualityReport(repo, [...filler, strongIssue], [], repo.fullName);
+    expect(report.issues).toHaveLength(100);
+    expect(report.issues[0]).toMatchObject({ number: 111, score: 100 });
+  });
 });
 
 describe("buildContributorOpportunities x issue quality", () => {


### PR DESCRIPTION
## Summary

- `buildIssueQualityReport` in `src/signals/engine.ts` capped the open-issue list to the first 100
  (`issues.filter((issue) => issue.state === "open").slice(0, 100)`) **before** scoring and sorting by
  score. Once a repo has more than 100 open issues, whichever 100 happen to be first in the caller's
  input array (not necessarily the highest-quality ones) are the only issues ever scored — a genuinely
  stronger issue sitting past position 100 is dropped from the report entirely, even though it would
  outrank most of the retained 100.
- This moves the cap to run after scoring and sorting (adds a named `ISSUE_QUALITY_REPORT_CAP = 100`
  constant, matching the existing `MAX_COLLISION_PAIRWISE_ISSUES` / `ISSUE_DISCOVERY_LIFECYCLE_REPORT_CAP`
  style), and updates the stale perf comment above it ("runs over up to 100 open issues" -> "runs over
  every open issue") since the per-issue indexes built just above already make the loop
  O(issues + PRs), so scoring every open issue instead of a pre-capped 100 is unaffected performance-wise.
- No issue is linked: this repo's own `.gittensory.yml` sets `issueDiscoveryPolicy: discouraged` and
  `linkedIssuePolicy: preferred` (not required). This is a small, self-contained, self-evident fix
  confined to one file plus its regression test.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` chain on this Windows dev machine stops at `test:coverage` because of a fixed set of pre-existing, environment-only failures unrelated to this diff: a CRLF-vs-LF mismatch from a Windows `core.autocrlf` checkout (`gittensory-focus-manifest.test.ts`), missing `claude`/`codex` CLI binaries on PATH (`selfhost-ai.test.ts`), a libuv/Windows subprocess assertion in the `gittensory-mcp` CLI test harness (`mcp-cli-doctor.test.ts`, `mcp-cli-profiles.test.ts`), and a couple of tests that are flaky under full-suite parallel load but pass individually (`mcp-output-schemas.test.ts`, one `mcp-cli-doctor.test.ts` case). None touch `src/signals/**` or the changed test file. The targeted suites for this change (`issue-quality.test.ts`, `signals.test.ts`, `signals-coverage.test.ts`) pass cleanly and `tsc --noEmit` is clean. I did not reach `test:workers`/`build:mcp`/`ui:*` locally because the `&&`-chained `test:ci` script stops at the first failing step; this PR does not touch workers, MCP packaging, or `apps/gittensory-ui/**`, so those steps are unaffected by the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

If any required check was skipped, explain why: this PR has no auth/CORS/session surface and no UI change, so those boxes are not applicable.

## Notes

- Added a regression test (`test/unit/issue-quality.test.ts`) with 110 low-scoring filler issues
  followed by one high-scoring issue placed past the old cap boundary, asserting the strong issue is
  ranked first in the returned 100. I confirmed this by reverting the source change locally and
  observing the new test fail with the strong issue dropped and a low-scoring filler issue returned
  first instead.