### PR TITLE
fix(github): hold per_page constant per crawl so backfill paginates safely

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3092,23 +3092,37 @@ async function githubPaged<T>(
   let status: RepoSyncSegmentRecord["status"] = "complete";
 
   try {
+    // Hold `per_page` CONSTANT for the whole crawl. GitHub's `page` offset is `(page-1)*per_page`, so it is
+    // only valid if `per_page` never changes mid-crawl. The previous code recomputed it from the shrinking
+    // budget (`min(100, limit - items.length)`), which broke offsets past page 1 whenever `limit` was not a
+    // multiple of 100 (per_page=50 on page 2 re-read items 51-100 instead of 101-150). Using
+    // `min(100, limit)` keeps the request/cursor grid stable: a small `limit` fetches exactly `limit` per
+    // page (so a page-precision resume cursor advances by one page), and a large `limit` fetches full 100s.
+    const perPage = Math.min(100, limit);
     for (let page = startPage; items.length < limit; page += 1) {
-      const pageLimit = Math.min(100, limit - items.length);
       const separator = path.includes("?") ? "&" : "?";
-      const pagePath = `${path}${separator}per_page=${pageLimit}&page=${page}`;
+      const pagePath = `${path}${separator}per_page=${perPage}&page=${page}`;
       const result = await githubJsonWithHeaders<T[]>(env, repo.fullName, pagePath, token, githubRateLimitOptions(admissionKey));
       etag = result.etag ?? etag;
       lastModified = result.lastModified ?? lastModified;
       lastCursor = String(page);
       pageCount += 1;
-      items.push(...result.data);
+      const remaining = limit - items.length;
+      // A page can only overrun `remaining` once we have already consumed at least one full page (so `page`
+      // has advanced past the crawl's start): resume from THIS page to pick up its unconsumed tail. On the
+      // first page `remaining >= perPage >= result.data.length`, so this is false and the cursor advances,
+      // which is why a small-`limit` (per_page = limit) crawl can never stall on its own start page.
+      const truncatedPage = result.data.length > remaining;
+      items.push(...result.data.slice(0, remaining));
       const hasNext = hasNextPage(result.link);
-      if (result.data.length < pageLimit || !hasNext) break;
-      nextCursor = String(page + 1);
-      if (items.length >= limit) {
+      if (items.length >= limit && (hasNext || truncatedPage)) {
+        nextCursor = String(truncatedPage ? page : page + 1);
         status = "capped";
         warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path}; next page cursor is ${nextCursor}.`);
+        break;
       }
+      if (result.data.length < perPage || !hasNext) break;
+      nextCursor = String(page + 1);
     }
   } catch (error) {
     status = error instanceof GitHubApiError && error.rateLimited ? "rate_limited" : items.length > 0 ? "partial" : "error";

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1239,6 +1239,70 @@ describe("GitHub backfill", () => {
     );
   });
 
+  // A fetch mock that models GitHub's real pagination: `page` is an offset of `(page-1)*per_page`, and each
+  // page returns at most `per_page` items. If a crawl shrinks per_page mid-way, `page` points at an
+  // already-consumed slice; a stable per_page reads the next slice.
+  function issuesOffsetFetch(total: number) {
+    return async (input: RequestInfo | URL): Promise<Response> => {
+      const url = input.toString();
+      if (url.endsWith("/repos/JSONbored/gittensory")) {
+        return Response.json({ name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", language: "TypeScript", owner: { login: "JSONbored" } });
+      }
+      if (url.includes("/labels?")) return Response.json([]);
+      if (url.includes("/pulls?")) return Response.json([]);
+      if (url.includes("/issues?")) {
+        const params = new URL(url).searchParams;
+        const perPage = Number(params.get("per_page"));
+        const page = Number(params.get("page"));
+        const start = (page - 1) * perPage;
+        const slice = Array.from({ length: Math.max(0, Math.min(start + perPage, total) - start) }, (_, i) => ({
+          number: start + i + 1,
+          title: `Issue ${start + i + 1}`,
+          state: "open",
+          user: { login: "reporter" },
+          labels: [],
+          body: "",
+        }));
+        const hasNext = start + perPage < total;
+        return Response.json(slice, hasNext ? { headers: { link: `<https://api.github.com/repositories/1/issues?page=${page + 1}>; rel="next"` } } : undefined);
+      }
+      return new Response("not found", { status: 404 });
+    };
+  }
+
+  it("fetches every page when the limit is not a multiple of 100 (stable per_page offsets)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", issuesOffsetFetch(150));
+
+    const result = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: 150, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    // All 150 unique issues must be stored — a shrinking-per_page crawl re-reads page 1's tail and stores 100.
+    expect(result.repos[0]).toMatchObject({ status: "success", openIssues: 150 });
+  });
+
+  it("advances the resume cursor for a sub-100 cap instead of replaying the first page", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", issuesOffsetFetch(5));
+
+    // Cap at 2 (< 100) against a repo with 5 issues. The segment must resume from the NEXT page (cursor "2"),
+    // not the page it just consumed (cursor "1") — a same-page cursor would replay issues 1-2 forever and
+    // never reach 3-5. With per_page held at min(100, limit)=2, page 2 is offset 2 → the unread rows.
+    const result = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: 2, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    expect(result.repos[0]).toMatchObject({ openIssues: 2 });
+    expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "capped", nextCursor: "2" })]),
+    );
+  });
+
   it("runs a targeted labels segment refresh", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1303,6 +1303,26 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("resumes from the same page when a cap truncates it mid-page", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", issuesOffsetFetch(200));
+
+    // Cap at 150 against a repo with 200 issues: page 1 (per_page=100) yields 1-100, page 2 yields 101-200
+    // but the cap leaves room for only 50, so page 2 is consumed partway. The resume cursor must point at
+    // page 2 (the partially consumed page), not page 3, so a later run picks up 151-200 rather than skipping
+    // them. All 150 within the cap are stored (a shrinking-per_page crawl would store only 100).
+    const result = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: 150, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    expect(result.repos[0]).toMatchObject({ openIssues: 150 });
+    expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "capped", nextCursor: "2" })]),
+    );
+  });
+
   it("runs a targeted labels segment refresh", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
## Summary

`githubPaged` in `src/github/backfill.ts` is the REST paginator behind the `open_issues`, `open_pull_requests`, and `recent_merged_pull_requests` backfill segments. It recomputed `per_page` from the *shrinking* remaining budget each iteration (`Math.min(100, limit - items.length)`) while advancing `page`. Since GitHub's `page` is an offset of `(page - 1) * per_page`, changing `per_page` mid-crawl points `page` at an already-consumed slice: with `limit = 150`, page 2 used `per_page=50` and returned items **51–100** (offset `1*50`) instead of 101–150, so everything past the first page was silently dropped whenever `limit` was not a multiple of 100. This is reachable via the public `backfillRegisteredRepositories(env, { limits })` override (the repo's tests already use `issues: 150`).

**Fix:** compute `perPage = Math.min(100, limit)` **once** and hold it constant for the whole crawl. That keeps the request/cursor grid stable in both regimes:

- Large `limit`: `per_page=100`, so `page` offsets line up and every page reads the next 100 rows.
- Small `limit` (`< 100`): `per_page = limit`, so each page returns exactly `limit` rows and the **page-precision resume cursor advances one whole page** (`page + 1`) instead of re-requesting the page it just consumed.

That second point is the subtle part: a naive "always `per_page=100`, resume from the same page" would, for a sub-100 cap, keep replaying the first `limit` rows on every resume and never progress — so this fix deliberately preserves the sub-100 resume-advance and adds a test for it.

**No linked issue:** this is a small, self-contained pagination-correctness fix in one helper; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `backfill` suite (142 tests) passes, including the existing multi-page, exactly-at-limit, and capped/partial cursor tests (semantics preserved; multiple-of-100 limits are byte-identical to before). Two new regression tests, both driven through fetch mocks that model GitHub's real `(page-1)*per_page` offset:
  - `issues: 150` stores all 150 (not 100) — **fails against the original shrinking-per_page code**.
  - a sub-100 cap (`issues: 2`, 5 upstream) records resume cursor `"2"` (advance), not `"1"` (replay) — **fails against a naive constant-`per_page=100` fix**.
- [x] New/changed behavior has regression tests for both the offset and the sub-100 resume-cursor branch

If any required check was skipped, explain why:

- The change is one paginator loop in `src/github`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Backfill fidelity only; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Supersedes #2124, which correctly fixed the offset bug but introduced a sub-100 resume regression (a truncated first page recorded its own page as the resume cursor, so a `limit < 100` crawl replayed the first `limit` rows forever). This version holds `per_page = min(100, limit)` so the sub-100 case never truncates its start page, and adds the resume-advance regression test that pins it.
- Reproduction: with `limits: { issues: 150 }` against a 150-issue repo, the old crawl requested `per_page=100&page=1` then `per_page=50&page=2` (offset 50 → duplicates), storing 100 unique issues; it now requests `per_page=100&page=2` (items 101–150) and stores all 150. Limits that are multiples of 100 (defaults 100/200/1000) are unaffected.
