### PR TITLE
perf(scoring): memoize the fnmatch→RegExp compile in labelMatchesPattern

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -912,6 +912,15 @@ export function labelMatchesPattern(label: string, pattern: string): boolean {
   return labelPatternToRegExp(pattern.toLowerCase()).test(label.toLowerCase());
 }
 
+// Compiled fnmatch→RegExp matchers are memoized by pattern. The same small,
+// config-derived set of label keys is matched on every scored PR/issue, so the
+// per-call recompile inside the nested label loops in engine.ts is pure waste.
+// Keys are configured label patterns (bounded, not attacker-supplied), so the
+// cache needs no eviction bound. The compiled RegExp carries only the "i" flag
+// (no global/sticky `lastIndex` state), so sharing one instance across calls is
+// safe and byte-identical to recompiling on every call.
+const labelPatternRegExpCache = new Map<string, RegExp>();
+
 // Upstream resolves label multipliers by matching each configured key as a Python `fnmatch` GLOB, not a
 // literal string: `fnmatch(label.lower(), pattern.lower())` in
 // gittensor/validator/oss_contributions/label_resolution.py, so a repo can configure `type:*`, `kind/*`, or
@@ -923,6 +932,8 @@ export function labelMatchesPattern(label: string, pattern: string): boolean {
 // run, `?` any single character, and `[seq]`/`[!seq]` a character class. Literal keys are unaffected — for a
 // pattern with no glob metacharacter the RegExp is an exact match, so existing configs score identically.
 function labelPatternToRegExp(pattern: string): RegExp {
+  const cached = labelPatternRegExpCache.get(pattern);
+  if (cached !== undefined) return cached;
   let regex = "";
   let i = 0;
   while (i < pattern.length) {
@@ -960,7 +971,9 @@ function labelPatternToRegExp(pattern: string): RegExp {
       regex += char;
     }
   }
-  return new RegExp(`^${regex}$`, "i");
+  const compiled = new RegExp(`^${regex}$`, "i");
+  labelPatternRegExpCache.set(pattern, compiled);
+  return compiled;
 }
 
 function escapeRegExpLiteral(value: string): string {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLatestScoringModelSnapshot, listUpstreamDriftReports, persistScoringModelSnapshot } from "../../src/db/repositories";
 import { DEFAULT_ISSUE_DISCOVERY_SHARE, DEFAULT_SCORING_CONSTANTS, detectActiveModel, findUnmodeledUpstreamConstants, getOrCreateScoringModelSnapshot, isTimeDecayEnabled, parsePythonNumberConstants, refreshScoringModelSnapshot, SCORING_SNAPSHOT_STALE_MS, scoringSnapshotStalenessWarning } from "../../src/scoring/model";
-import { buildScorePreview, calculateTimeDecay, makeScorePreviewRecord, resolveTimeDecay } from "../../src/scoring/preview";
+import { buildScorePreview, calculateTimeDecay, labelMatchesPattern, makeScorePreviewRecord, resolveTimeDecay } from "../../src/scoring/preview";
 import { unmodeledScoringConstantsFingerprint } from "../../src/upstream/unmodeled-scoring-drift";
 import type { ScorePreviewInput } from "../../src/scoring/preview";
 import type { JsonValue, RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
@@ -1888,5 +1888,29 @@ NOVELTY_BONUS_SCALAR = 3
       expect(saturationBase(1000)).toBe(saturationBase(500));
       expect(saturationBase(1000)).not.toBe(saturationBase(400));
     });
+  });
+});
+
+describe("label pattern matcher memoization (#2106)", () => {
+  it("returns identical fnmatch results on repeated calls for the same pattern (cache hit path)", () => {
+    // First call for `type:*` compiles + caches; subsequent calls must hit the cache
+    // and stay byte-identical. Repeating the pattern exercises the memoized branch.
+    expect(labelMatchesPattern("type:bug-fix", "type:*")).toBe(true);
+    expect(labelMatchesPattern("kind:chore", "type:*")).toBe(false);
+    expect(labelMatchesPattern("type:feature", "type:*")).toBe(true);
+    expect(labelMatchesPattern("type:bug-fix", "type:*")).toBe(true);
+  });
+
+  it("preserves case-insensitive fnmatch glob semantics through the cache", () => {
+    expect(labelMatchesPattern("Priority:1", "priority:?")).toBe(true);
+    expect(labelMatchesPattern("priority:10", "priority:?")).toBe(false);
+    expect(labelMatchesPattern("kind/bug", "kind/[bc]ug")).toBe(true);
+    expect(labelMatchesPattern("kind/dug", "kind/[!bc]ug")).toBe(true);
+    // Descending class is a never-match in Python fnmatch; an unclosed `[` stays literal.
+    expect(labelMatchesPattern("x", "[z-a]")).toBe(false);
+    expect(labelMatchesPattern("[bug", "[bug")).toBe(true);
+    // A literal key (no glob metacharacter) matches only its exact label.
+    expect(labelMatchesPattern("bug", "bug")).toBe(true);
+    expect(labelMatchesPattern("bugfix", "bug")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`labelPatternToRegExp` (`src/scoring/preview.ts`) recompiled a `RegExp` from the fnmatch pattern on every call. It is invoked inside nested `.some()` / `.filter()` label loops in `src/signals/engine.ts` (L1031/1121/1126) — i.e. O(labels × patterns) recompiles per PR. This memoizes the compiled matchers in a module-level `Map<string, RegExp>` keyed by pattern, so each pattern compiles once.

## Why it is safe (byte-identical)

The compiled `RegExp` carries only the `"i"` flag — no `g`/`y` — so `.test()` holds no `lastIndex` state, and a single shared instance behaves identically to a fresh compile. This is a pure optimization with no scoring/behavior change. Cache keys are configured label patterns (small, config-bounded, not attacker-supplied), so no eviction bound is needed.

## Tests

Added `label pattern matcher memoization (#2106)` in `test/unit/scoring.test.ts`:

- repeated-pattern calls exercise the memoized (cache-hit) path and stay identical;
- the fnmatch glob semantics matrix (`*`, `?`, `[seq]`, `[!seq]`, descending range, unclosed `[`, and literal keys) is preserved through the cache.

## Validation

Commands run from the repo root:

- `npm run typecheck` — pass
- `npx vitest run test/unit/scoring.test.ts` — 80/80 pass
- `npx vitest run test/unit` — 5346 pass (the 6 failures are the pre-existing, Docker-dependent `selfhost-image-deploy` suite, identical on the untouched baseline and unaffected by this change)
- Patch coverage on the changed lines: 100% (both arms of the new cache branch covered)

Closes #2106
