### PR TITLE
test(utils): cover empty JSON input and blank error messages

### DIFF
--- a/test/unit/json-utils.test.ts
+++ b/test/unit/json-utils.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { errorMessage, jsonString, normalizeRepoFullName, parseJson, repoParts, strippedErrorMessage } from "../../src/utils/json";
+import { errorMessage, jsonString, normalizeRepoFullName, nowIso, parseJson, repoParts, strippedErrorMessage } from "../../src/utils/json";
 
 describe("JSON and string utility helpers", () => {
   it("keeps JSON parsing and stringification fallbacks explicit", () => {
     expect(parseJson<{ ok: boolean }>('{"ok":true}', { ok: false })).toEqual({ ok: true });
     expect(parseJson("{bad-json", { ok: false })).toEqual({ ok: false });
     expect(parseJson(null, { ok: false })).toEqual({ ok: false });
+    expect(parseJson("", { ok: false })).toEqual({ ok: false });
+    expect(parseJson(undefined, { ok: false })).toEqual({ ok: false });
     expect(jsonString(undefined)).toBe("null");
     expect(jsonString({ ok: true })).toBe('{"ok":true}');
+  });
+
+  it("emits ISO timestamps and empty error fallbacks", () => {
+    expect(nowIso()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(errorMessage(new Error(""))).toBe("unknown error");
   });
 
   it("normalizes repo names and error messages without leaking arbitrary thrown values", () => {


### PR DESCRIPTION
## Summary
- Extend `json-utils` tests for empty/undefined `parseJson` input, `nowIso`, and blank `Error` messages.

## Test plan
- [x] `npx vitest run test/unit/json-utils.test.ts`