### PR TITLE
fix(github): compare PR head SHAs case-insensitively

### DIFF
--- a/src/github/pr-freshness.ts
+++ b/src/github/pr-freshness.ts
@@ -19,7 +19,7 @@ export type PullRequestFreshness =
 
 function normalizedHead(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
-  return trimmed ? trimmed : null;
+  return trimmed ? trimmed.toLowerCase() : null;
 }
 
 export function reviewedPullRequestHeadSha(

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -82,6 +82,19 @@ describe("PR freshness guards", () => {
     expect(reviewedPullRequestHeadSha(" ", undefined)).toBeNull();
   });
 
+  it("normalizes head SHAs case-insensitively before comparing or returning them", () => {
+    expect(reviewedPullRequestHeadSha(" AbC123 ", "fallback")).toBe("abc123");
+    expect(
+      classifyPullRequestFreshness({ state: "open", head: { sha: "AbC123" } }, "abc123"),
+    ).toEqual({ status: "current", liveHeadSha: "abc123", liveState: "open" });
+    expect(
+      classifyPullRequestFreshness({ state: "open", head: { sha: "abc123" } }, " ABC123 "),
+    ).toEqual({ status: "current", liveHeadSha: "abc123", liveState: "open" });
+    expect(
+      classifyPullRequestFreshness({ state: "open", head: { sha: "NewSha" } }, "oldsha"),
+    ).toMatchObject({ status: "stale", reason: "head_changed", expectedHeadSha: "oldsha", liveHeadSha: "newsha" });
+  });
+
   it("fetches live PR state using the existing GitHub GET path", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary
- Normalize PR head SHAs to lowercase before freshness comparison so mixed-case GitHub responses do not false-positive as `head_changed`.

## Test plan
- [x] `npx vitest run test/unit/pr-freshness.test.ts`
