### PR TITLE
fix(auth): treat IPv6 loopback as localhost for session cookies

### DIFF
--- a/src/auth/security.ts
+++ b/src/auth/security.ts
@@ -168,7 +168,7 @@ export const __securityInternals = {
 function shouldUseSecureCookie(requestUrl: string): boolean {
   try {
     const hostname = new URL(requestUrl).hostname;
-    return hostname !== "localhost" && hostname !== "127.0.0.1";
+    return hostname !== "localhost" && hostname !== "127.0.0.1" && hostname !== "::1" && hostname !== "[::1]";
   } catch {
     return true;
   }

--- a/test/unit/auth-security-helpers.test.ts
+++ b/test/unit/auth-security-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildBrowserSessionCookie,
   buildClearedBrowserSessionCookie,
   buildClearedGitHubOAuthStateCookie,
   buildGitHubOAuthStateCookie,
@@ -96,6 +97,12 @@ describe("session/oauth cookie builders", () => {
     expect(buildClearedBrowserSessionCookie("http://127.0.0.1/auth")).toBe(
       "gittensory_session=; Max-Age=0; Path=/; SameSite=Lax; HttpOnly",
     );
+    expect(buildClearedBrowserSessionCookie("http://[::1]/auth")).toBe(
+      "gittensory_session=; Max-Age=0; Path=/; SameSite=Lax; HttpOnly",
+    );
+    expect(buildBrowserSessionCookie("token", "http://[::1]/v1/auth/session")).not.toContain(
+      "Secure",
+    );
     // Secure keys off hostname, not scheme: a plain-http remote host still gets Secure.
     expect(
       buildClearedBrowserSessionCookie("http://example.com/auth"),
@@ -122,6 +129,9 @@ describe("session/oauth cookie builders", () => {
       "gittensory_oauth_state=; Max-Age=0; Path=/v1/auth/github; SameSite=Lax; HttpOnly; Secure",
     );
     expect(buildClearedGitHubOAuthStateCookie("http://localhost/cb")).toBe(
+      "gittensory_oauth_state=; Max-Age=0; Path=/v1/auth/github; SameSite=Lax; HttpOnly",
+    );
+    expect(buildClearedGitHubOAuthStateCookie("http://[::1]/cb")).toBe(
       "gittensory_oauth_state=; Max-Age=0; Path=/v1/auth/github; SameSite=Lax; HttpOnly",
     );
   });


### PR DESCRIPTION
## Summary
- Skip the `Secure` session-cookie flag on `::1` / `[::1]` so plain-HTTP local dev auth works over IPv6 loopback.

## Test plan
- [x] `npx vitest run test/unit/auth.test.ts`