### PR TITLE
fix(utils): trim repo full names in repoParts before splitting

### DIFF
--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -29,8 +29,9 @@ export function normalizeRepoFullName(value: string): string {
 }
 
 export function repoParts(fullName: string): { owner: string; name: string } {
-  if (fullName.length === 0) return { owner: "", name: "" };
-  const [owner, ...rest] = fullName.split("/") as [string, ...string[]];
+  const normalized = fullName.trim();
+  if (normalized.length === 0) return { owner: "", name: "" };
+  const [owner, ...rest] = normalized.split("/") as [string, ...string[]];
   return {
     owner,
     name: rest.join("/"),

--- a/test/unit/json-utils.test.ts
+++ b/test/unit/json-utils.test.ts
@@ -21,4 +21,11 @@ describe("JSON and string utility helpers", () => {
     expect(strippedErrorMessage(new Error("Error: wrapped failure"), "fallback failure")).toBe("wrapped failure");
     expect(strippedErrorMessage("string failure", "fallback failure")).toBe("fallback failure");
   });
+
+  it("repoParts trims outer whitespace before splitting, matching normalizeRepoFullName", () => {
+    expect(repoParts(" JSONbored/gittensory ")).toEqual({ owner: "JSONbored", name: "gittensory" });
+    expect(repoParts("  owner/nested/name  ")).toEqual({ owner: "owner", name: "nested/name" });
+    expect(repoParts("   ")).toEqual({ owner: "", name: "" });
+    expect(repoParts("\towner/repo\n")).toEqual({ owner: "owner", name: "repo" });
+  });
 });


### PR DESCRIPTION
## Summary
- Trim whitespace in `repoParts` before splitting so padded `owner/repo` strings do not corrupt owner or repo segments.

## Test plan
- [x] `npx vitest run test/unit/json-utils.test.ts test/unit/adapters.test.ts`