### PR TITLE
fix(enrichment): require exactly two repo segments in churn-hotspot

### DIFF
--- a/review-enrichment/src/analyzers/churn-hotspot.ts
+++ b/review-enrichment/src/analyzers/churn-hotspot.ts
@@ -100,7 +100,9 @@ export async function scanChurnHotspot(
 ): Promise<ChurnHotspotFinding[]> {
   const { repoFullName, githubToken, files = [] } = req;
   if (!githubToken) return [];
-  const [owner, repo] = repoFullName.split("/");
+  const parts = repoFullName.split("/");
+  if (parts.length !== 2) return [];
+  const [owner, repo] = parts;
   if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
 
   const headers = githubHeaders(githubToken);

--- a/review-enrichment/test/churn-hotspot.test.ts
+++ b/review-enrichment/test/churn-hotspot.test.ts
@@ -76,6 +76,19 @@ test("scanChurnHotspot: requires a github token and a valid repo slug", async ()
   assert.deepEqual(await scanChurnHotspot({ repoFullName: "bad slug/x!", prNumber: 1, githubToken: "t", files: [{ path: "src/a.ts" }] }, async () => jsonResponse(commits(20, 2))), []);
 });
 
+test("scanChurnHotspot: rejects multi-segment repo slugs without fetching", async () => {
+  let called = false;
+  const out = await scanChurnHotspot(
+    { repoFullName: "octo/repo/extra", prNumber: 1, githubToken: "ghp_test", files: [{ path: "src/a.ts" }] },
+    async () => {
+      called = true;
+      return jsonResponse(commits(20, 2));
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanChurnHotspot: fails safe on a non-ok or throwing fetch", async () => {
   assert.deepEqual(await scanChurnHotspot(req([{ path: "src/a.ts" }]), async () => jsonResponse({}, 500)), []);
   assert.deepEqual(


### PR DESCRIPTION
## Summary
- Reject multi-segment `repoFullName` values in the churn-hotspot analyzer before issuing GitHub API calls.

## Test plan
- [x] `npm run rees:test`