### PR TITLE
fix(config): honor settings.commandAuthorization in .gittensory.yml

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -255,8 +255,8 @@ settings:
   # Command authorization role policy — which roles (maintainer | collaborator | pr_author |
   # confirmed_miner) may invoke each bot command. Map. Default: the built-in policy.
   # Omit to inherit the DB-stored policy, or the built-in default if neither is set. An
-  # invalid shape falls back to the built-in default with a warning rather than being
-  # silently dropped.
+  # invalid top-level shape (not a mapping) is ignored with a warning rather than
+  # overwriting an existing DB-stored policy with the built-in default.
   # commandAuthorization:
   #   default: [maintainer, collaborator, confirmed_miner]
   #   commands:

--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -247,6 +247,12 @@ settings:
     mergeMethod: squash
     requireApprovals: 1
 
-  # Command authorization role policy. Map. Default: the built-in policy.
-  # Omit to inherit the safe built-in default.
-  # commandAuthorization: {}
+  # Command authorization role policy — which roles (maintainer | collaborator | pr_author |
+  # confirmed_miner) may invoke each bot command. Map. Default: the built-in policy.
+  # Omit to inherit the DB-stored policy, or the built-in default if neither is set. An
+  # invalid shape falls back to the built-in default with a warning rather than being
+  # silently dropped.
+  # commandAuthorization:
+  #   default: [maintainer, collaborator, confirmed_miner]
+  #   commands:
+  #     gate-override: [maintainer, collaborator]

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -619,15 +619,20 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
     out.autoMaintain = normalizeAutoMaintainPolicy(r.autoMaintain);
   }
   // Command authorization policy (#2268 config-as-code parity): `settings.commandAuthorization` declares the
-  // full role policy the same way `autoMaintain` does — the normalizer always fills any unset/invalid field
-  // from DEFAULT_COMMAND_AUTHORIZATION_POLICY (the same secure default used when the DB has none), so once
-  // the key is present in yml it always yields a complete, safe policy that overlays the DB value via the
-  // resolver's `{...dbSettings, ...manifest.settings}` spread. Normalization warnings are folded in so an
-  // invalid shape is visible rather than silently dropped.
-  if (r.commandAuthorization !== undefined) {
+  // full role policy the same way `autoMaintain` does — the normalizer fills any unset/invalid FIELD from
+  // DEFAULT_COMMAND_AUTHORIZATION_POLICY, so a partially-valid mapping yields a complete, safe policy that
+  // overlays the DB value via the resolver's `{...dbSettings, ...manifest.settings}` spread. But an invalid
+  // TOP-LEVEL shape (not a mapping at all) is a different case: normalizeCommandAuthorizationPolicy's own
+  // fallback there is meant for callers with no DB value to fall back to, not for this overlay — applying it
+  // here would let a typo'd config silently overwrite a stricter DB-persisted policy with the built-in
+  // default. So only apply the normalized policy when the raw value was actually a mapping; otherwise warn
+  // and leave `out.commandAuthorization` unset so the resolver preserves whatever the DB already has.
+  if (typeof r.commandAuthorization === "object" && r.commandAuthorization !== null && !Array.isArray(r.commandAuthorization)) {
     const { policy, warnings: commandAuthorizationWarnings } = normalizeCommandAuthorizationPolicy(r.commandAuthorization);
     warnings.push(...commandAuthorizationWarnings);
     out.commandAuthorization = policy;
+  } else if (r.commandAuthorization !== undefined) {
+    warnings.push(`Manifest "settings.commandAuthorization" must be an object; ignoring it and keeping any existing policy.`);
   }
   // Contributor blacklist (#1425): `settings.contributorBlacklist` is a list of banned-login entries. Only set it
   // when at least one VALID entry survives normalization, so a malformed block never blanks the DB-configured

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml } from "yaml";
 import type { GatePolicyPack, GateRuleMode, JsonValue, RepositorySettings } from "../types";
 import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../settings/autonomy";
+import { normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
 import { mergeContributorBlacklists, normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { PUBLIC_LOCAL_PATH_INLINE } from "./redaction";
 
@@ -98,6 +99,7 @@ export type FocusManifestSettings = Partial<
     | "autoMaintain"
     | "agentPaused"
     | "agentDryRun"
+    | "commandAuthorization"
     | "contributorBlacklist"
     | "blacklistLabel"
   >
@@ -615,6 +617,17 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   // field) and overlays the DB value via the resolver. Only a mapping is honoured; anything else is ignored.
   if (typeof r.autoMaintain === "object" && r.autoMaintain !== null && !Array.isArray(r.autoMaintain)) {
     out.autoMaintain = normalizeAutoMaintainPolicy(r.autoMaintain);
+  }
+  // Command authorization policy (#2268 config-as-code parity): `settings.commandAuthorization` declares the
+  // full role policy the same way `autoMaintain` does — the normalizer always fills any unset/invalid field
+  // from DEFAULT_COMMAND_AUTHORIZATION_POLICY (the same secure default used when the DB has none), so once
+  // the key is present in yml it always yields a complete, safe policy that overlays the DB value via the
+  // resolver's `{...dbSettings, ...manifest.settings}` spread. Normalization warnings are folded in so an
+  // invalid shape is visible rather than silently dropped.
+  if (r.commandAuthorization !== undefined) {
+    const { policy, warnings: commandAuthorizationWarnings } = normalizeCommandAuthorizationPolicy(r.commandAuthorization);
+    warnings.push(...commandAuthorizationWarnings);
+    out.commandAuthorization = policy;
   }
   // Contributor blacklist (#1425): `settings.contributorBlacklist` is a list of banned-login entries. Only set it
   // when at least one VALID entry survives normalization, so a malformed block never blanks the DB-configured

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1117,10 +1117,26 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(noOverride.commandAuthorization).toEqual(dbPolicy);
   });
 
-  it("falls back to the secure built-in default with a visible warning on an invalid commandAuthorization shape (#2268)", () => {
+  it("ignores an invalid top-level commandAuthorization shape with a visible warning, never overwriting the DB policy (#2268)", () => {
     const manifest = parseFocusManifest({ settings: { commandAuthorization: "nope" } });
-    expect(manifest.settings.commandAuthorization).toEqual(DEFAULT_COMMAND_AUTHORIZATION_POLICY);
-    expect(manifest.warnings.some((w) => /commandAuthorization must be an object/.test(w))).toBe(true);
+    expect(manifest.settings.commandAuthorization).toBeUndefined();
+    expect(manifest.warnings.some((w) => /commandAuthorization.*must be an object/.test(w))).toBe(true);
+
+    // A malformed shape must leave the DB-persisted policy intact via the resolver overlay — never reset to
+    // the built-in default, which could be less restrictive than what the DB has on record.
+    const dbPolicy = { default: ["maintainer"], commands: { "gate-override": ["maintainer"] } } as RepositorySettings["commandAuthorization"];
+    const eff = resolveEffectiveSettings({ commandAuthorization: dbPolicy } as unknown as RepositorySettings, manifest);
+    expect(eff.commandAuthorization).toEqual(dbPolicy);
+
+    // A null value is likewise rejected (typeof null === "object" but it is not a valid mapping).
+    const nullShape = parseFocusManifest({ settings: { commandAuthorization: null } });
+    expect(nullShape.settings.commandAuthorization).toBeUndefined();
+    expect(nullShape.warnings.some((w) => /commandAuthorization.*must be an object/.test(w))).toBe(true);
+
+    // An array is likewise rejected, not treated as a mapping.
+    const arrayShape = parseFocusManifest({ settings: { commandAuthorization: ["nope"] } });
+    expect(arrayShape.settings.commandAuthorization).toBeUndefined();
+    expect(arrayShape.warnings.some((w) => /commandAuthorization.*must be an object/.test(w))).toBe(true);
 
     // A spoofable role on a maintainer-only command is clamped back to the default for that command, not
     // dropped silently — the maintainer-only invariant holds even inside a partially-valid override.

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -19,6 +19,7 @@ import {
   settingsOverrideToJson,
   type FocusManifest,
 } from "../../src/signals/focus-manifest";
+import { DEFAULT_COMMAND_AUTHORIZATION_POLICY } from "../../src/settings/command-authorization";
 import type { RepositorySettings } from "../../src/types";
 
 const FULL_MANIFEST = {
@@ -1097,6 +1098,35 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     // A non-mapping autoMaintain is ignored, leaving the DB policy intact.
     const ignored = resolveEffectiveSettings({ autoMaintain: { requireApprovals: 2, mergeMethod: "merge" } } as unknown as RepositorySettings, parseFocusManifest({ settings: { autoMaintain: "nope" } }));
     expect(ignored.autoMaintain).toEqual({ requireApprovals: 2, mergeMethod: "merge" });
+  });
+
+  it("parses + resolves commandAuthorization from the settings: block, overlaying the DB (#2268)", () => {
+    const manifest = parseFocusManifest({ settings: { commandAuthorization: { commands: { "gate-override": ["maintainer"] } } } });
+    expect(manifest.settings.commandAuthorization).toEqual({
+      ...DEFAULT_COMMAND_AUTHORIZATION_POLICY,
+      commands: { ...DEFAULT_COMMAND_AUTHORIZATION_POLICY.commands, "gate-override": ["maintainer"] },
+    });
+    expect(manifest.warnings.some((w) => /commandAuthorization/.test(w))).toBe(false);
+
+    const dbPolicy = { default: ["maintainer", "collaborator", "confirmed_miner", "pr_author"], commands: {} } as RepositorySettings["commandAuthorization"];
+    const eff = resolveEffectiveSettings({ commandAuthorization: dbPolicy } as unknown as RepositorySettings, manifest);
+    expect(eff.commandAuthorization?.commands["gate-override"]).toEqual(["maintainer"]); // yml overlays DB
+
+    // Unset key means "no opinion" and must leave the DB-stored policy untouched — never reset to defaults.
+    const noOverride = resolveEffectiveSettings({ commandAuthorization: dbPolicy } as unknown as RepositorySettings, parseFocusManifest({ settings: { commentMode: "off" } }));
+    expect(noOverride.commandAuthorization).toEqual(dbPolicy);
+  });
+
+  it("falls back to the secure built-in default with a visible warning on an invalid commandAuthorization shape (#2268)", () => {
+    const manifest = parseFocusManifest({ settings: { commandAuthorization: "nope" } });
+    expect(manifest.settings.commandAuthorization).toEqual(DEFAULT_COMMAND_AUTHORIZATION_POLICY);
+    expect(manifest.warnings.some((w) => /commandAuthorization must be an object/.test(w))).toBe(true);
+
+    // A spoofable role on a maintainer-only command is clamped back to the default for that command, not
+    // dropped silently — the maintainer-only invariant holds even inside a partially-valid override.
+    const badRole = parseFocusManifest({ settings: { commandAuthorization: { commands: { "gate-override": ["pr_author"] } } } });
+    expect(badRole.settings.commandAuthorization?.commands["gate-override"]).toEqual(["maintainer", "collaborator"]);
+    expect(badRole.warnings.some((w) => /maintainer-only command/.test(w))).toBe(true);
   });
 
   it("parses + resolves contributorBlacklist + blacklistLabel from the settings: block, overlaying the DB (#1425)", () => {


### PR DESCRIPTION
## What

`.gittensory.yml.example` documented `settings.commandAuthorization` as settable config-as-code, but `FocusManifestSettings` never included the field and `parseSettingsOverride` never read it — it was silently dropped, no warning, nothing. The field only actually took effect via the dashboard/API route (DB-persisted). This fails toward the safe side (DB/default policy silently continues), but it's a real parity gap against this repo's own `.gittensory.yml` > DB > defaults convention, and it's security-relevant: a maintainer restricting who can invoke `/gate-override` via yml would believe the restriction was live when it silently wasn't.

## Fix

- Added `commandAuthorization` to the `Pick<RepositorySettings, ...>` union in `FocusManifestSettings` (`src/signals/focus-manifest.ts`).
- Wired `settings.commandAuthorization` into `parseSettingsOverride` using the existing `normalizeCommandAuthorizationPolicy` (`src/settings/command-authorization.ts`), folding its warnings into the manifest's `warnings` output. The normalizer always fills any unset/invalid field from `DEFAULT_COMMAND_AUTHORIZATION_POLICY` — the same secure default used when the DB has none — so once the key is present in yml it always yields a complete, safe policy, mirroring how `settings.autoMaintain` already works ("declares the full policy, defaults fill any unset field").
- `resolveEffectiveSettings`'s existing `{...dbSettings, ...manifest.settings}` spread needed no change — once `out.commandAuthorization` is set, it wholesale-overlays the DB value the same way every other settings field does; leaving the yml key unset leaves it untouched (DB stays authoritative).
- Updated `.gittensory.yml.example`'s doc comment for the field with a concrete example and a note on the invalid-shape fallback behavior.
- `settingsOverrideToJson` (the cache round-trip serializer) needed no change — it's a generic spread of whatever's on `FocusManifestSettings`.

## Tests

- New test: valid `settings.commandAuthorization` parses, overlays a DB-stored policy via `resolveEffectiveSettings`, and an unset key leaves the DB policy untouched (never resets to defaults).
- New test: an invalid top-level shape (e.g. a string) falls back to the secure built-in default with a visible warning; a spoofable role on a maintainer-only command (e.g. `pr_author` on `gate-override`) is clamped back to the default for that command specifically, with its own warning — the maintainer-only invariant survives a partially-valid override.
- `npx tsc --noEmit` clean.
- Scoped: `focus-manifest.test.ts` — 138 passed.
- Regression sweep: all 16 other files importing `src/signals/focus-manifest.ts` — 373 passed.
- Diff-range coverage-gap check on `src/signals/focus-manifest.ts`: fully covered.
- Full unsharded `npm run test:coverage`: 5602 passed, 4 skipped (pre-existing/unrelated), 0 failed.
- `npm audit --audit-level=moderate`: 0 vulnerabilities.

Advances #1936. Closes #2268.