### PR TITLE
fix(backup): fail loudly when the SQLite online backup does not verify

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -12,6 +12,10 @@ PG_DB="${GITTENSORY_BACKUP_SOURCE_DATABASE_URL:-${DATABASE_URL:-}}"
 OUT=${BACKUP_OUT_DIR:-/backups}
 mkdir -p "$OUT/postgres" "$OUT/sqlite" "$OUT/qdrant"
 
+# Set to 1 if the SQLite online backup fails verification, so we skip its retention prune
+# (never delete the last good backup) and still exit non-zero at the end (fail loudly).
+SQLITE_BACKUP_FAILED=0
+
 # 1) Active app database. Prefer Postgres when DATABASE_URL is set; otherwise keep the SQLite online backup path.
 case "$PG_DB" in
   postgres://*|postgresql://*)
@@ -24,9 +28,20 @@ case "$PG_DB" in
     ;;
   *)
     if [ -f "$DB" ]; then
-      sqlite3 "$DB" ".backup '$OUT/sqlite/gittensory-$TS.sqlite'"
-      gzip -f "$OUT/sqlite/gittensory-$TS.sqlite"
-      echo "[backup] sqlite -> $OUT/sqlite/gittensory-$TS.sqlite.gz"
+      SQLITE_OUT="$OUT/sqlite/gittensory-$TS.sqlite"
+      # `.backup` can exit 0 while writing a partial/corrupt file, so verify the result
+      # (non-empty AND `PRAGMA integrity_check` == ok) before we gzip it or let retention
+      # prune older, good backups. A failed backup must be loud, not silently "successful".
+      if sqlite3 "$DB" ".backup '$SQLITE_OUT'" \
+        && [ -s "$SQLITE_OUT" ] \
+        && [ "$(sqlite3 "$SQLITE_OUT" 'PRAGMA integrity_check;' 2>/dev/null)" = "ok" ]; then
+        gzip -f "$SQLITE_OUT"
+        echo "[backup] sqlite -> $SQLITE_OUT.gz"
+      else
+        rm -f "$SQLITE_OUT"
+        echo "[backup] ERROR: sqlite online backup failed verification; keeping previous backups" >&2
+        SQLITE_BACKUP_FAILED=1
+      fi
     else
       echo "[backup] sqlite db not found at $DB (skipping)"
     fi
@@ -49,10 +64,22 @@ fi
 
 # 3) Retention — keep only the newest $RETAIN in each directory.
 for d in postgres sqlite qdrant; do
+  # After a failed SQLite backup, skip its prune so the newest surviving (older) backups are kept.
+  if [ "$d" = sqlite ] && [ "$SQLITE_BACKUP_FAILED" = 1 ]; then
+    echo "[backup] skipping sqlite retention after a failed backup (preserving existing backups)"
+    continue
+  fi
+  # ls is safe here: backup filenames are controlled timestamps with no spaces or newlines.
+  # shellcheck disable=SC2012
   ls -1t "$OUT/$d" 2>/dev/null | tail -n +"$((RETAIN + 1))" | while IFS= read -r f; do
     rm -f "$OUT/$d/$f"
     echo "[backup] pruned old backup $d/$f"
   done
 done
+
+if [ "$SQLITE_BACKUP_FAILED" = 1 ]; then
+  echo "[backup] FAILED ($TS): sqlite online backup did not verify; see errors above" >&2
+  exit 1
+fi
 
 echo "[backup] complete ($TS); retaining newest $RETAIN per target"

--- a/test/unit/backup-script.test.ts
+++ b/test/unit/backup-script.test.ts
@@ -1,0 +1,116 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const scriptPath = resolve("scripts/backup.sh");
+
+// A stub `sqlite3` placed first on PATH so the test is hermetic (no real sqlite3 needed)
+// and can deterministically drive both the healthy and the corrupt-online-backup paths:
+//   STUB_SQLITE_MODE=ok      -> `.backup` writes non-empty bytes, integrity_check -> "ok"
+//   STUB_SQLITE_MODE=corrupt -> `.backup` still exits 0 (the silent failure #2084 is about)
+//                               but writes junk and integrity_check -> "malformed"
+const STUB_SQLITE = `#!/bin/sh
+cmd="$2"
+case "$cmd" in
+  .backup*)
+    out=$(printf '%s' "$cmd" | sed -e "s/^.backup //" -e "s/'//g")
+    if [ "\${STUB_SQLITE_MODE:-ok}" = corrupt ]; then
+      printf %s "not-a-sqlite-db" > "$out"
+    else
+      printf %s "stub-sqlite-backup-bytes" > "$out"
+    fi
+    ;;
+  *integrity_check*)
+    if [ "\${STUB_SQLITE_MODE:-ok}" = corrupt ]; then echo malformed; else echo ok; fi
+    ;;
+esac
+exit 0
+`;
+
+function createHarness() {
+  const dir = mkdtempSync(join(tmpdir(), "gittensory-backup-"));
+  const binDir = join(dir, "bin");
+  const outDir = join(dir, "backups");
+  const dbPath = join(dir, "gittensory.sqlite");
+  mkdirSync(binDir);
+  writeFileSync(dbPath, "dummy-db"); // must exist so `[ -f "$DB" ]` is true
+  const stub = join(binDir, "sqlite3");
+  writeFileSync(stub, STUB_SQLITE);
+  chmodSync(stub, 0o755);
+  return { dir, binDir, outDir, dbPath };
+}
+
+function runBackup(h: ReturnType<typeof createHarness>, mode: "ok" | "corrupt") {
+  // Absolute /bin/sh so the command itself never depends on PATH; the script's own
+  // sqlite3/gzip/date lookups use the PATH we inject (stub bin first, real tools after).
+  return spawnSync("/bin/sh", [scriptPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${h.binDir}:${process.env.PATH ?? ""}`,
+      BACKUP_OUT_DIR: h.outDir,
+      DATABASE_PATH: h.dbPath,
+      BACKUP_RETAIN: "1",
+      STUB_SQLITE_MODE: mode,
+      // Force the SQLite branch + skip Qdrant regardless of the ambient test env.
+      DATABASE_URL: "",
+      GITTENSORY_BACKUP_SOURCE_DATABASE_URL: "",
+      QDRANT_URL: "",
+    },
+  });
+}
+
+describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
+  let harness: ReturnType<typeof createHarness>;
+
+  beforeEach(() => {
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    rmSync(harness.dir, { recursive: true, force: true });
+  });
+
+  it("gzips the backup and exits 0 when the online backup verifies", () => {
+    const res = runBackup(harness, "ok");
+
+    expect(res.status).toBe(0);
+    const files = readdirSync(join(harness.outDir, "sqlite"));
+    expect(files.filter((f) => f.endsWith(".sqlite.gz")).length).toBe(1);
+    // no uncompressed leftover
+    expect(files.filter((f) => f.endsWith(".sqlite")).length).toBe(0);
+  });
+
+  it("fails loudly, removes the bad file, and skips retention when the backup is corrupt", () => {
+    // Seed more good backups than BACKUP_RETAIN (=1): if retention were NOT skipped on a
+    // failed backup it would prune these down to 1, so preserving BOTH proves the skip.
+    const sqliteDir = join(harness.outDir, "sqlite");
+    mkdirSync(sqliteDir, { recursive: true });
+    writeFileSync(join(sqliteDir, "gittensory-OLD1.sqlite.gz"), "old-good-1");
+    writeFileSync(join(sqliteDir, "gittensory-OLD2.sqlite.gz"), "old-good-2");
+
+    const res = runBackup(harness, "corrupt");
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain("failed verification");
+    const files = readdirSync(sqliteDir);
+    // both previously-good backups survive (retention skipped after the failure)
+    expect(files).toContain("gittensory-OLD1.sqlite.gz");
+    expect(files).toContain("gittensory-OLD2.sqlite.gz");
+    // the corrupt/partial uncompressed file was removed, and no new gz was produced
+    expect(files.filter((f) => f.endsWith(".sqlite")).length).toBe(0);
+    expect(files.filter((f) => f.endsWith(".sqlite.gz")).sort()).toEqual([
+      "gittensory-OLD1.sqlite.gz",
+      "gittensory-OLD2.sqlite.gz",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/backup.sh` ran `sqlite3 "$DB" ".backup ..."` then unconditionally gzipped the result and let retention prune. Because `sqlite3 .backup` can exit 0 while writing a partial/corrupt file, a failed online backup was gzipped, printed a success line, and could cause retention to evict the last *good* backup — the silent-durability gap this issue (part of #1821) describes.

## Fix (`scripts/backup.sh`)

- Verify the online backup before trusting it: non-empty **and** `sqlite3 <out> 'PRAGMA integrity_check'` returns `ok`, *before* gzip.
- On failure: remove the bad file, log an error to stderr, **skip the sqlite retention prune** so an older good backup survives, and **exit non-zero** (fail loudly).
- The Qdrant step's best-effort behavior is unchanged.

## Tests

Adds `test/unit/backup-script.test.ts` — a hermetic node harness that stubs `sqlite3` on `PATH` (no real sqlite3 needed) and drives both paths:

- healthy → gzips the backup, exits 0;
- corrupt (`.backup` exits 0 but writes junk / `integrity_check` != ok) → exits 1, removes the bad file, and preserves pre-existing good backups (retention skipped).

## Validation (from repo root)

- `shellcheck scripts/backup.sh` — clean
- `npm run typecheck` — pass
- `npx vitest run test/unit/backup-script.test.ts` — 2/2 pass

Closes #2084
