### PR TITLE
feat(signals): add MinerGoalSpec type contract

### DIFF
--- a/src/signals/miner-goal-spec.ts
+++ b/src/signals/miner-goal-spec.ts
@@ -1,0 +1,44 @@
+import type { FocusManifestIssueDiscoveryPolicy } from "./focus-manifest";
+
+/** Values carried over from `.gittensory.yml`'s focus-manifest discovery policy. */
+export type MinerGoalSpecIssueDiscoveryPolicy = FocusManifestIssueDiscoveryPolicy;
+
+/**
+ * Maintainer-authored miner targeting preferences declared in `.gittensory-miner.yml`.
+ *
+ * This is intentionally small in the foundation phase: it only captures whether autonomous miner
+ * work is allowed for the repo at all, which paths are preferred/blocked, which labels are preferred,
+ * how many concurrent claims a single miner should hold, and whether issue discovery is encouraged.
+ * Parsing and file discovery land in a follow-up issue.
+ */
+export type MinerGoalSpec = {
+  /** Whether autonomous miners may target this repo. Default: true. */
+  minerEnabled: boolean;
+  /** Preferred work areas for miner-created changes. Glob list. Default: []. */
+  wantedPaths: string[];
+  /** Paths miners should avoid touching. Glob list. Default: []. */
+  blockedPaths: string[];
+  /** Labels miners should prefer when selecting or filing work. Default: []. */
+  preferredLabels: string[];
+  /** Maximum concurrent claims a miner should hold against this repo. Default: 1. */
+  maxConcurrentClaims: number;
+  /** Whether issue discovery work is encouraged for the repo. Default: neutral. */
+  issueDiscoveryPolicy: MinerGoalSpecIssueDiscoveryPolicy;
+};
+
+/**
+ * Safe defaults for an absent `.gittensory-miner.yml`.
+ *
+ * - `minerEnabled: true` keeps public repos targetable unless the owner explicitly opts out.
+ * - empty path/label lists mean "no additional preference" rather than hidden policy.
+ * - `maxConcurrentClaims: 1` keeps a miner from claiming multiple issues in the same repo by default.
+ * - `issueDiscoveryPolicy: neutral` mirrors `.gittensory.yml`'s own default stance.
+ */
+export const DEFAULT_MINER_GOAL_SPEC: MinerGoalSpec = {
+  minerEnabled: true,
+  wantedPaths: [],
+  blockedPaths: [],
+  preferredLabels: [],
+  maxConcurrentClaims: 1,
+  issueDiscoveryPolicy: "neutral",
+};

--- a/test/unit/miner-goal-spec.test.ts
+++ b/test/unit/miner-goal-spec.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MINER_GOAL_SPEC, type MinerGoalSpec } from "../../src/signals/miner-goal-spec";
+
+describe("MinerGoalSpec", () => {
+  it("exports safe defaults matching the declared type contract", () => {
+    const typed: MinerGoalSpec = DEFAULT_MINER_GOAL_SPEC;
+    expect(typed).toEqual({
+      minerEnabled: true,
+      wantedPaths: [],
+      blockedPaths: [],
+      preferredLabels: [],
+      maxConcurrentClaims: 1,
+      issueDiscoveryPolicy: "neutral",
+    });
+  });
+
+  it("documents the default for every field in a co-located comment", async () => {
+    const source = await import("node:fs/promises").then((fs) => fs.readFile("src/signals/miner-goal-spec.ts", "utf8"));
+    expect(source).toMatch(/Whether autonomous miners may target this repo\. Default: true\./);
+    expect(source).toMatch(/Preferred work areas for miner-created changes\. Glob list\. Default: \[\]\./);
+    expect(source).toMatch(/Paths miners should avoid touching\. Glob list\. Default: \[\]\./);
+    expect(source).toMatch(/Labels miners should prefer when selecting or filing work\. Default: \[\]\./);
+    expect(source).toMatch(/Maximum concurrent claims a miner should hold against this repo\. Default: 1\./);
+    expect(source).toMatch(/Whether issue discovery work is encouraged for the repo\. Default: neutral\./);
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements `#2293` by adding the initial type surface for `.gittensory-miner.yml`.
It defines the foundation-phase `MinerGoalSpec` contract and a safe `DEFAULT_MINER_GOAL_SPEC`, covering:
- `minerEnabled`
- `wantedPaths`
- `blockedPaths`
- `preferredLabels`
- `maxConcurrentClaims`
- `issueDiscoveryPolicy`

This PR is intentionally types-only. It does **not** add parsing, file discovery, or CLI wiring yet.

## Related Issue
Closes: #2293 

## Change Type
- [x] New feature
- [x] Type contract
- [x] Foundation work
- [x] Test update
- [ ] Bug fix
- [ ] Database migration
- [ ] Docs-only change

## Real Behavior Proof
### Before
- There was no dedicated type contract for `.gittensory-miner.yml`
- Miner-goal config fields and defaults were not defined in a single typed module

### After
- The repo has a dedicated `MinerGoalSpec` type
- The repo has a safe `DEFAULT_MINER_GOAL_SPEC`
- The issue-discovery policy reuses the same semantic vocabulary as the existing focus-manifest side
- Every field has a co-located default documented in JSDoc

## Validation
- [x] Focused unit tests passed
- [x] Repo typecheck passed

### Commands Run
```bash
npx vitest run test/unit/miner-goal-spec.test.ts
npm run typecheck
```

## Key Files
- `src/signals/miner-goal-spec.ts`
- `test/unit/miner-goal-spec.test.ts`

## Checklist
- [x] `MinerGoalSpec` type added
- [x] `DEFAULT_MINER_GOAL_SPEC` added
- [x] Safe defaults documented
- [x] Focused tests added
- [x] Validation completed
- [x] Branch pushed