### PR TITLE
fix(rules): use the canonical isTestPath for advisory annotations

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -154,8 +154,8 @@ import {
   buildIssueAdvisory,
   buildPullRequestAdvisory,
   evaluateGateCheck,
-  isTestPath,
 } from "../rules/advisory";
+import { isTestPath } from "../signals/test-evidence";
 import { detectNotificationEvents } from "../notifications/events";
 import {
   deliverNotification,

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import type { CollisionCluster, CollisionReport } from "../signals/engine";
 import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
+import { isTestPath } from "../signals/test-evidence";
 import { nowIso } from "../utils/json";
 import { GITTENSORY_GATE_CHECK_NAME } from "../review/check-names";
 import { REVIEW_THREAD_BLOCKER_CODE } from "../review/review-thread-findings";
@@ -248,14 +249,6 @@ function severityToAnnotationLevel(severity: AdvisorySeverity): CheckRunAnnotati
 
 function isCodePath(path: string): boolean {
   return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|c|h|swift|kt|m|sql|yaml|yml|json|toml|md)$/i.test(path);
-}
-
-export function isTestPath(path: string): boolean {
-  return (
-    /(^|\/)(test|tests|spec|__tests__)\//i.test(path) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|go|rs)$/i.test(path) ||
-    /(^|\/)[^/]+_test\.go$/i.test(path)
-  );
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -17,7 +17,8 @@ const OSS_ANTI_SLOP_FUNNEL = {
   message: "This repo runs the Gittensor anti-slop gate. Gittensor lets GitHub contributors earn for open-source work like this — register to start earning.",
   registerUrl: GITTENSOR_HOME_URL,
 } as const;
-import { buildPullRequestAdvisory, evaluateGateCheck, isTestPath, type GateCheckConclusion } from "./advisory";
+import { buildPullRequestAdvisory, evaluateGateCheck, type GateCheckConclusion } from "./advisory";
+import { isTestPath } from "../signals/test-evidence";
 import { evaluatePreMergeChecks } from "../review/pre-merge-checks";
 
 /**

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -669,6 +669,36 @@ describe("advisory rules", () => {
     expect(JSON.stringify(annotations)).not.toMatch(/trust score|wallet|hotkey|reward estimate|reviewability/i);
   });
 
+  it("does not flag Missing test evidence when a Cypress/e2e test accompanies a code change (regression)", () => {
+    // isTestPath now delegates to the canonical src/signals/test-evidence matcher, which recognizes
+    // *.cy./*.e2e./__snapshots__/_spec.rb tests. A stale local copy dropped those branches, so a code
+    // change shipped with only a Cypress test was wrongly annotated "Missing test evidence".
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName,
+      number: 20,
+      title: "Guard the login route with a Cypress test",
+      state: "open",
+      authorLogin: "contributor",
+      authorAssociation: "NONE",
+      labels: [],
+      linkedIssues: [],
+    });
+    const files: PullRequestFileRecord[] = [
+      { repoFullName: repo.fullName, pullNumber: 20, path: "src/auth/login.ts", additions: 20, deletions: 0, changes: 20, payload: {} },
+      { repoFullName: repo.fullName, pullNumber: 20, path: "cypress/e2e/login.cy.ts", additions: 30, deletions: 0, changes: 30, payload: {} },
+    ];
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 },
+      clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 20 }, "standard");
+
+    expect(annotations.some((entry) => entry.title === "Missing test evidence")).toBe(false);
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
## Summary

`src/rules/advisory.ts` re-declared a local `isTestPath` with only **3** branches — a stale copy of the canonical **8**-branch matcher in `src/signals/test-evidence.ts`. The local copy was missing the `*.cy.`/`*.e2e.`, `__snapshots__/`, `_spec.rb`, `_test.(py|rb)`, `src/test/`, and `.(test|spec).rb` branches.

`buildCheckRunAnnotations` classifies changed files with it — `codeFiles = files.filter(f => !isTestPath(f.path))`, `testFiles = files.filter(isTestPath)` — and when `codeFiles.length > 0 && testFiles.length === 0` it emits a public **"Missing test evidence"** annotation on every code file. `src/rules/predicted-gate.ts` and `src/queue/processors.ts` imported the same stale copy for the `testFileCount` that drives the `manifest_missing_tests` policy finding.

So a PR that shipped a code change with only a Cypress/e2e test, a snapshot, or a Ruby `_spec.rb` was falsely told it had no test evidence — e.g. `src/auth/login.ts` + `cypress/e2e/login.cy.ts`: the canonical `isTestPath` counts the `.cy.ts` as a test, but the stale copy did not, so both files got the warning.

Fix: delete the local copy and import the canonical `isTestPath` in all three consumers, so every test-file classification is single-sourced (this fixes the whole class at once, not one path form). Pure classifier consolidation — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident consolidation.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped: the affected `test/unit/rules.test.ts` / `predicted-gate.test.ts` / `test-evidence.test.ts` / `gate-check-policy.test.ts` pass; the `src/**` change is an import swap + a deletion, so it adds no new coverable executable lines — see note)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change confined to `src/rules/**` and `src/queue/processors.ts` (import redirect). `typecheck` is clean (it caught and I fixed all three importers of the removed local export). I ran `test/unit/rules.test.ts` + `predicted-gate.test.ts` + `test-evidence.test.ts` + `gate-check-policy.test.ts` (190 passed) plus `processors`/`rules` (97 passed), including the new regression. The `src/**` diff is an import swap plus deletion of the duplicate function (the call sites are textually unchanged), so it introduces no new coverable lines; the canonical `isTestPath` it now points at is already covered by `test/unit/test-evidence.test.ts`. I did not run the full UI/workers/MCP steps (unrelated), and the local Windows tree has pre-existing unrelated failures (CRLF, missing CLI binaries, Node 24 vs pinned 22). CI runs the full matrix on a clean checkout.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI/MCP surface changed; this consolidates an internal classifier.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Regression test in `test/unit/rules.test.ts` asserts a PR changing `src/auth/login.ts` + `cypress/e2e/login.cy.ts` produces **no** "Missing test evidence" annotation (it did before this fix).
- All existing `isTestPath` consumers now resolve to the single canonical matcher in `src/signals/test-evidence.ts` (advisory, predicted-gate, processors, plus the signals modules that already imported it).
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
