### PR TITLE
fix(github): stop duplicating overflow ask citations across card sections

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -332,7 +332,10 @@ function buildAskPublicAnswerCard(args: {
   const findings = [
     `Question: ${questionText}`,
     ...(answerLines.length > 0 ? answerLines : ["No matching contribution-quality context is available in the current cached sources."]),
-    ...(citationLines.length > 0 ? citationLines : ["No concrete cached source reference is available for this response."]),
+    // Only the first 4 citations belong in Findings; citations 5+ overflow into safeDetails via
+    // `citationLines.slice(4)` below. Emitting the full list here duplicated those overflow citations in
+    // both sections of the same public comment when a run had 5+ contributing sources.
+    ...(citationLines.length > 0 ? citationLines.slice(0, 4) : ["No concrete cached source reference is available for this response."]),
   ];
   const sourceEvidence = contributingSources.slice(0, 3).map((source) => {
     const observed = source.generatedAt ? ` as of ${source.generatedAt}` : "";

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -341,7 +341,9 @@ describe("GitHub mention commands", () => {
     expect(askFindings).toContain("Source: cached GitHub open PR/issue queue; freshness: fresh");
     expect(askFindings).toContain("Source: cached GitHub issues, PRs, reviews, and checks; freshness: fresh");
     expect(askFindings).toContain("Source: official Gittensor API/cache; freshness: fresh");
-    expect(askFindings).toContain("signal data-quality status; freshness:");
+    // The 5th citation overflows into "Additional safe details", not Findings, and is not duplicated across both.
+    expect(ask.slice(ask.indexOf("Additional safe details"))).toContain("signal data-quality status; freshness:");
+    expect(askFindings).not.toContain("signal data-quality status");
     expect(ask).toMatch(/Connected source contributor decision pack snapshot: freshness fresh/);
     expect(ask).toContain("README/docs context is included only when connected repo sources");
     expect(ask).not.toContain("source: action choose_next_work");
@@ -756,7 +758,9 @@ describe("GitHub mention commands", () => {
     expect(askMetadata).toContain("repo sync freshness metadata");
     expect(askMetadata).toContain("branch eligibility metadata");
     expect(askMetadata).not.toContain("Contribution readiness status");
-    expect(publicCardFindings(askMetadata)).toContain("freshness: partial");
+    // The data-quality citation (freshness partial) is the 5th+ source, so it overflows into
+    // "Additional safe details" rather than being duplicated into Findings.
+    expect(askMetadata.slice(askMetadata.indexOf("Additional safe details"))).toContain("freshness: partial");
     expect(askMetadata).not.toContain("No concrete cached source reference is available for this response.");
 
     const askNoSources = buildPublicAgentCommandComment({
@@ -937,6 +941,62 @@ describe("GitHub mention commands", () => {
     expect(withPrFallbackScope).toContain("| Scope | owner/from-pr#5 |");
     expect(withPrFallbackScope).toContain("After tests pass.");
 
+  });
+
+  it("does not duplicate ask citations across Findings and Additional safe details when there are 5+ sources", () => {
+    // Five distinct contributing sources → five citations. The first four render under Findings and the
+    // overflow (citations 5+) under Additional safe details; no citation should appear in both sections.
+    const ask = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory ask what is missing?")!,
+      repo: null,
+      issue: { number: 61, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "author",
+      bundle: {
+        run: completedRun("run-ask-dup-citations"),
+        actions: [
+          {
+            id: "ask-dup-citations",
+            runId: "run-ask-dup-citations",
+            actionType: "choose_next_work",
+            status: "recommended",
+            recommendation: "Next",
+            why: [],
+            blockedBy: [],
+            publicSafeSummary: "Use cached queue context before opening new work.",
+            approvalRequired: false,
+            safetyClass: "private",
+            payload: {},
+          },
+        ],
+        contextSnapshots: [
+          {
+            id: "snap-ask-dup",
+            runId: "run-ask-dup-citations",
+            repoSignalSnapshotIds: [],
+            freshnessWarnings: [],
+            payload: {
+              evidenceGraph: {
+                sources: [
+                  { source: "github_cache", freshness: "fresh" },
+                  { source: "computed", freshness: "fresh" },
+                  { source: "mirror", freshness: "stale" },
+                  { source: "repo_focus_manifest", freshness: "fresh" },
+                  { source: "issue_quality", freshness: "partial" },
+                ],
+              },
+            },
+          },
+        ],
+        summary: "ask duplicate citations",
+      },
+    });
+
+    // Each citation line contains exactly one "; freshness: " and appears nowhere else, so the count of
+    // rendered citations must equal the five unique sources — not six (which a Findings/safeDetails overlap
+    // would produce by repeating the 5th citation).
+    const citationCount = (ask.match(/; freshness: /g) ?? []).length;
+    expect(citationCount).toBe(5);
   });
 
   it("covers blocker label fallbacks, rerun bullets, and duplicate-risk heuristics", () => {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -992,11 +992,18 @@ describe("GitHub mention commands", () => {
       },
     });
 
-    // Each citation line contains exactly one "; freshness: " and appears nowhere else, so the count of
-    // rendered citations must equal the five unique sources — not six (which a Findings/safeDetails overlap
-    // would produce by repeating the 5th citation).
+    // Each citation line contains exactly one "; freshness: " marker and it appears nowhere else in the
+    // card (the Evidence section renders "freshness <x>" without the "; freshness: " punctuation). So the
+    // total rendered citations must equal the five unique sources — not six, which a Findings/safeDetails
+    // overlap would produce by repeating the 5th citation.
     const citationCount = (ask.match(/; freshness: /g) ?? []).length;
     expect(citationCount).toBe(5);
+    // ...and the split is exact: the first four citations render under Findings, and citation 5 overflows
+    // into Additional safe details exactly once (not duplicated back into Findings).
+    const findingsSection = ask.slice(ask.indexOf("**Findings**"), ask.indexOf("**Evidence**"));
+    const safeDetailsSection = ask.slice(ask.indexOf("Additional safe details"));
+    expect((findingsSection.match(/; freshness: /g) ?? []).length).toBe(4);
+    expect((safeDetailsSection.match(/; freshness: /g) ?? []).length).toBe(1);
   });
 
   it("covers blocker label fallbacks, rerun bullets, and duplicate-risk heuristics", () => {


### PR DESCRIPTION
## Summary

`buildAskPublicAnswerCard` in `src/github/commands.ts` renders the `@gittensory ask` public answer card. It collects up to 8 citation lines (`citationLines`) and splits them across two sections — but the split overlapped:

- **Findings** was built with the **full** `citationLines` list.
- **Additional safe details** was built with `citationLines.slice(4)` (citations 5–8).

So when a run had **5 or more** contributing sources, citations 5–8 were emitted **twice** in the same public comment — once under Findings and again under Additional safe details. The `slice(4)` in the safe-details section shows the intended design is "first 4 citations in Findings, the rest overflow into safe details"; the Findings section simply wasn't capped.

**Fix:** cap the Findings citations to `citationLines.slice(0, 4)`, so the two sections form a clean, non-overlapping split (matching the non-ask card path, which already does `findings = slice(0, 5)` / `safeDetails = slice(5)`). No citation is lost — the overflow ones still render under Additional safe details, just once.

**No linked issue:** small, self-contained public-output-correctness fix in one card builder; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `github-commands` suite (24 tests) passes. A new regression test builds a 5-source `ask` bundle and asserts exactly 5 citations render (not 6) — **it was confirmed to FAIL against the unpatched code (6 vs 5)**. Both branches of the changed line are covered (verified via lcov `BRDA`). Two existing ask tests were updated to assert the overflow citation now lives in "Additional safe details" (its correct section) rather than Findings — the citation is still present, just no longer duplicated.
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one expression in a pure card builder in `src/github`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This fix reduces public-comment noise by removing duplicated lines.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Public comment rendering only; schema unchanged.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: a `@gittensory ask` run with 5 contributing sources previously rendered the 5th citation in both the Findings and Additional safe details sections of the posted comment; it now appears once (in Additional safe details), with the first 4 in Findings.
