### PR TITLE
test: cover REES render contract

### DIFF
--- a/review-enrichment/test/render-contract.test.ts
+++ b/review-enrichment/test/render-contract.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildBrief } from "../dist/brief.js";
+import { renderBrief } from "../dist/render.js";
+import type { AnalyzerRegistry } from "../dist/analyzers/types.js";
+
+test("renderBrief renders descriptor-owned sections and built-in fallback sections", () => {
+  const dependency = {
+    ecosystem: "npm",
+    package: "left-pad",
+    from: null,
+    to: "1.3.0",
+    direction: "add" as const,
+    cves: [
+      {
+        id: "GHSA-render-test",
+        severity: "high" as const,
+        summary: "fixture vulnerability",
+        fixedIn: "1.3.1",
+      },
+    ],
+  };
+  const actionPin = {
+    file: ".github/workflows/ci.yml",
+    line: 12,
+    action: "actions/checkout",
+    ref: "v4",
+  };
+
+  const { promptSection, systemSuffix } = renderBrief({
+    dependency: [dependency],
+    actionPin: [actionPin],
+  });
+
+  assert.match(promptSection, /Dependency vulnerabilities/);
+  assert.match(promptSection, /left-pad@1\.3\.0/);
+  assert.match(promptSection, /Unpinned GitHub Actions/);
+  assert.match(promptSection, /actions\/checkout@v4/);
+  assert.match(systemSuffix, /EXTERNAL REVIEW BRIEF/);
+});
+
+test("renderBrief omits descriptor-owned and fallback sections for empty finding lists", () => {
+  const { promptSection, systemSuffix } = renderBrief({
+    dependency: [],
+    actionPin: [],
+  });
+
+  assert.equal(promptSection, "");
+  assert.equal(systemSuffix, "");
+});
+
+test("buildBrief reports partial analyzer results as degraded", async () => {
+  const analyzers: AnalyzerRegistry = {
+    dependency: async () => [
+      {
+        ecosystem: "npm",
+        package: "fixture-lib",
+        from: null,
+        to: "2.0.0",
+        direction: "add",
+        partial: true,
+        cves: [
+          {
+            id: "GHSA-partial-test",
+            severity: "medium",
+            summary: "fixture partial vulnerability",
+            fixedIn: null,
+          },
+        ],
+      },
+    ],
+  };
+
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 2037,
+      analyzers: ["dependency"],
+      files: [
+        {
+          path: "package.json",
+          patch: '@@ -1,0 +1,1 @@\n+{"dependencies":{"fixture-lib":"2.0.0"}}',
+        },
+      ],
+      budget: { timeoutMs: 1000 },
+    },
+    analyzers,
+  );
+
+  assert.equal(brief.partial, true);
+  assert.equal(brief.analyzerStatus.dependency, "degraded");
+  assert.equal(brief.telemetry.analyzers.dependency?.partialStatus, "partial");
+  assert.equal(
+    brief.telemetry.analyzers.dependency?.partialReason,
+    "analyzer_partial",
+  );
+  assert.match(brief.promptSection, /GHSA-partial-test/);
+});


### PR DESCRIPTION
Closes #2037.

## Summary
- Adds a REES render contract test covering descriptor-owned rendering via dependency and the built-in fallback section path via ctionPin.
- Asserts empty finding lists produce no rendered prompt section.
- Adds a pure uildBrief fixture with an injected analyzer registry to prove partial analyzer results surface as degraded with partial telemetry.

## Verification
- 
pm run build
- 
ode --test --experimental-strip-types "test/render-contract.test.ts"
- 
pm run validate:sourcemaps
- 
ode --test --experimental-strip-types "test/**/*.test.ts" passes the new render-contract test and 360/362 tests overall; the two failures are existing local sentry-upload.test.ts failures where sentry-cli releases ... new gittensory-rees@abc123 exits 1 in this environment.
- 
pm test also currently stops early because generated analyzer metadata is stale in main; I did not include generated metadata drift in this test-only PR.