### PR TITLE
fix(rees): stop dropping added lines whose content starts with ++

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -308,14 +308,19 @@ export function collectAddedLines(
   for (const file of files) {
     if (!file.patch) continue;
     let newLine = 0;
+    let inHunk = false;
     for (const line of boundedPatchLines(file.patch, options.metrics, "added_lines_patch_bytes")) {
-      if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (line.startsWith("diff ") || line.startsWith("index ")) continue;
       const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
       if (hunk) {
         newLine = Number(hunk[1]);
+        inHunk = true;
         continue;
       }
+      // Only the diff preamble (diff/index/mode lines and the `+++ `/`--- ` file headers) precedes the first
+      // hunk; skip it until a hunk begins. INSIDE a hunk the first character is the +/-/space op, so a body
+      // line like `+++x` (an added line whose content starts with `++`) is an addition, not a header — the
+      // old unanchored `startsWith("+++")` guard dropped it and mis-numbered every following added line.
+      if (!inHunk) continue;
       if (line.startsWith("+")) {
         if (addedLines.length >= MAX_CONTEXT_ADDED_LINES) {
           options.metrics?.recordCappedWork("added_lines", 1);
@@ -364,13 +369,19 @@ export function filesHaveAddedLines(
 ): boolean {
   for (const file of files) {
     if (!file.patch) continue;
+    let inHunk = false;
     for (const line of boundedPatchLines(
       file.patch,
       options.metrics,
       "has_added_lines_patch_bytes",
     )) {
-      if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (line.startsWith("+")) return true;
+      if (line.startsWith("@@")) {
+        inHunk = true;
+        continue;
+      }
+      // Gate on inHunk so a body line such as `+++x` counts as an addition; the `+++ `/`--- ` file headers
+      // only appear in the pre-hunk preamble (mirrors collectAddedLines).
+      if (inHunk && line.startsWith("+")) return true;
     }
     if (file.patch.length > MAX_CONTEXT_PATCH_BYTES) return true;
   }

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -2,7 +2,11 @@
 // migrations without fighting over the broad enrichment test file.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createAnalysisContext } from "../dist/analysis-context.js";
+import {
+  collectAddedLines,
+  createAnalysisContext,
+  filesHaveAddedLines,
+} from "../dist/analysis-context.js";
 import {
   queryOsvBatch,
   scanDependencyChanges,
@@ -14,6 +18,29 @@ const jsonResponse = (body, init = {}) =>
     headers: { "content-type": "application/json" },
     ...init,
   });
+
+test("collectAddedLines keeps added lines whose content starts with ++ (rendered +++x)", () => {
+  // git renders an added line whose content is `++x` as `+` + `++x` = `+++x`; the old header guard skipped it
+  // as if it were a `+++ b/file` header, losing the line and mis-numbering the ones after it.
+  const files = [
+    {
+      path: "src/inc.ts",
+      patch: ["@@ -1,0 +1,2 @@", "+++x", "+const y = 1;"].join("\n"),
+    },
+  ];
+
+  assert.deepEqual(
+    collectAddedLines(files).map((added) => [added.line, added.text]),
+    [
+      [1, "++x"],
+      [2, "const y = 1;"],
+    ],
+  );
+  assert.equal(
+    filesHaveAddedLines([{ path: "src/inc.ts", patch: "@@ -1,0 +1,1 @@\n+++x" }]),
+    true,
+  );
+});
 
 test("createAnalysisContext parses common PR state once", () => {
   let now = 130;


### PR DESCRIPTION
## Summary

`collectAddedLines` and `filesHaveAddedLines` in `review-enrichment/src/analysis-context.ts` skipped any patch body line starting with `+++` or `---`. That guard is meant only for unified-diff **file headers** (`+++ b/file`, `--- a/file`), which always have the marker run followed by a space. Git renders an added line whose content is `++x` as `+` + `++x` = `+++x` (no space), so it was mistaken for a header:

- the `++x` added line was dropped from `addedLines`, and because `newLine` was not advanced for it, **every following added line in the hunk was numbered one too low**;
- `filesHaveAddedLines` returned `false` for a PR whose only addition starts with `++`;
- `addedLines` feeds analyzers such as `secret-scan.ts`, so a **secret on an added line whose content starts with `++` was silently skipped**.

```
collectAddedLines([{ path: "a.ts", patch: "@@ -1,0 +1,2 @@\n+++x\n+const y = 1;" }])
// actual:   [{ line: 1, text: "const y = 1;" }]                       (++x lost, next line mis-numbered)
// expected: [{ line: 1, text: "++x" }, { line: 2, text: "const y = 1;" }]
```

Fix: track whether the parser is inside a hunk. The diff preamble (`+++ `/`--- ` headers, `diff`/`index`/mode lines) only precedes the first `@@`; inside a hunk the first character is always the `+`/`-`/space op, so `+++x` is correctly read as an addition. This fixes the whole class (any content beginning with `++`/`--`, with or without a following space), not just one reproduction. Pure diff parser — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident correctness fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` (the rees package `tsc -p tsconfig.json` build is clean)
- [ ] `npm run test:coverage` (N/A — `review-enrichment/**` is outside Codecov's `src/**/*.ts` include; see note)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The change is confined to the `review-enrichment` (rees) package, which has its own build + test. I ran `npm --prefix review-enrichment run build` (clean) and `node --test test/analysis-context.test.ts` — **12/12 pass**, including the added regression and all pre-existing cases (byte-cap, context-only, dependency scans). `review-enrichment/**` is outside Codecov's `src/**` include, so it carries no patch-coverage obligation. I did not commit `review-enrichment/analyzer-metadata.json` or `apps/gittensory-ui/src/lib/rees-analyzers.ts`: `analysis-context.ts` is not an analyzer, so it does not affect the analyzer registry those files are generated from (the local `metadata:check` staleness is a pre-existing LF↔CRLF artifact that reproduces on unmodified `main` and passes in CI's Linux checkout). I did not run the UI/workers/MCP steps (unrelated to this rees-only diff).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI/MCP surface changed; this is an internal diff parser.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- Regression test in `review-enrichment/test/analysis-context.test.ts` asserts `collectAddedLines` returns `[[1, "++x"], [2, "const y = 1;"]]` for the `+++x` patch (recovered line + corrected numbering) and that `filesHaveAddedLines` returns `true` for a `+++x`-only patch.
- Both `collectAddedLines` and `filesHaveAddedLines` were fixed identically (the deletion side `---x` is likewise no longer mistaken for a `--- ` header).
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
