### PR TITLE
fix(selfhost): strip surrounding quotes from a review skill's frontmatter name

### DIFF
--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -101,7 +101,10 @@ export function parseReviewSkill(filename: string, text: string): RepoReviewSkil
   const fm = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/.exec(text);
   const head = fm?.[1] ?? "";
   const body = (fm?.[2] ?? text).trim();
-  const name = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1]?.trim() || filename.replace(/\.md$/i, "");
+  // Strip surrounding quotes on `name` too, symmetric with `when` below — a quoted scalar
+  // (`name: "SQL Rubric"`) is ordinary YAML frontmatter, so the quotes must not survive into the label.
+  const nameRaw = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1]?.trim();
+  const name = (nameRaw ?? "").replace(/^["']|["']$/g, "") || filename.replace(/\.md$/i, "");
   const whenRaw = /(?:^|\n)when:\s*(.+)/.exec(head)?.[1]?.trim();
   const when = (whenRaw ?? "always").replace(/^["']|["']$/g, "") || "always";
   return { name, when, body };

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -116,6 +116,13 @@ describe("parseReviewSkill (#review-skills)", () => {
   it("treats a quotes-only/empty when as 'always'", () => {
     expect(parseReviewSkill("x.md", '---\nwhen: ""\n---\nbody').when).toBe("always");
   });
+  it("strips surrounding quotes from a quoted name, symmetric with when", () => {
+    // A quoted scalar is ordinary YAML frontmatter; the quotes must not survive into the skill label.
+    expect(parseReviewSkill("sql.md", '---\nname: "SQL Rubric"\nwhen: "**/*.sql"\n---\nBody.\n')).toEqual({ name: "SQL Rubric", when: "**/*.sql", body: "Body." });
+    // Single quotes strip too, and a quotes-only name falls back to the filename.
+    expect(parseReviewSkill("y.md", "---\nname: 'Voice Guide'\n---\nb").name).toBe("Voice Guide");
+    expect(parseReviewSkill("fallback.md", '---\nname: ""\n---\nb').name).toBe("fallback");
+  });
 });
 
 describe("makeLocalReviewContextReader (#review-skills)", () => {


### PR DESCRIPTION
## Summary

`parseReviewSkill` in `src/selfhost/private-config.ts` parses a self-host review-skill markdown file's YAML frontmatter into `{ name, when, body }`. It strips surrounding quotes from the `when` field (`(whenRaw ?? "always").replace(/^["']|["']$/g, "")`) but the sibling `name` field only got `.trim()` — no quote strip. So a perfectly ordinary quoted scalar like `name: "SQL Rubric"` kept its quotes, and the skill surfaced to the reviewer as `"SQL Rubric"` (with literal quote characters) instead of `SQL Rubric`.

**Fix:** apply the same quote-strip to `name`, symmetric with `when`, and keep the existing filename fallback when the value is empty or quotes-only. Unquoted names are unaffected.

**No linked issue:** small, self-contained parsing-consistency fix in one function; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `private-config` suite (20 tests) passes. A new regression test covers a double-quoted name, a single-quoted name, and a quotes-only name (which falls back to the filename); it was confirmed to FAIL against the unpatched code (`'"SQL Rubric"'` vs `'SQL Rubric'`). Both branches of the changed line are covered (verified via lcov `BRDA`).
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one expression in a pure parser in `src/selfhost`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Self-host review-skill parsing only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `parseReviewSkill("sql.md", '---\nname: "SQL Rubric"\nwhen: "**/*.sql"\n---\nBody.\n')` previously returned `name: '"SQL Rubric"'` (quotes kept) while `when` was correctly `**/*.sql` (quotes stripped); it now returns `name: 'SQL Rubric'`, symmetric with `when`.
