### PR TITLE
fix(review): stop AI-judgment blockers from overriding a surface-lane merge

### DIFF
--- a/src/review/content-lane-wire.ts
+++ b/src/review/content-lane-wire.ts
@@ -9,14 +9,19 @@
 // fetch, and `gateEvaluation` is byte-identical to today. The verdict NEVER depends on an AI model, so this is
 // independent of the AI-reviewer accuracy work (the surface lane emits none of the AI_JUDGMENT_BLOCKER_CODES).
 //
-// SAFETY (two deliberate guards):
-//  1. A generic HARD blocker (e.g. a committed secret detected before this runs) is PRESERVED — a surface
-//     "merge" can never clear a real critical the generic gate already raised (applySurfaceGate unions them).
+// SAFETY (three deliberate guards):
+//  1. A generic HARD (non-AI-judgment) blocker — e.g. a committed secret detected before this runs — is PRESERVED:
+//     a surface "merge" can never clear a real critical the generic gate already raised (applySurfaceGate unions
+//     them).
 //  2. An unreadable head — or a null base on a file GitHub marks "modified" (whose base MUST exist, so a null
 //     read is a transient blip, not an absent base) — defers to the generic gate rather than auto-closing a good
 //     PR on a spurious "the submission looks empty/invalid" read. (A null base on an ADDED file is the expected
 //     brand-new-entry case and is not deferred.)
-import type { GateCheckEvaluation } from "../rules/advisory";
+//  3. A generic failure caused SOLELY by AI-judgment blockers (`ai_consensus_defect` / `ai_review_split`) does
+//     NOT override a decisive surface verdict (applySurfaceGate). The surface lane is the sole, AI-free
+//     adjudicator for this structured data — an AI opinion has no standing to veto it, only a real deterministic
+//     blocker does (see guard #1).
+import { AI_JUDGMENT_BLOCKER_CODES, type GateCheckEvaluation, isAiJudgmentOnlyFailure } from "../rules/advisory";
 import type { AdvisoryFinding, AdvisorySeverity } from "../types";
 import { type ContentLaneEnv, isContentLaneEnabled } from "./content-lane/flag";
 import { runSurfaceReview, type SurfaceReviewInput, type SurfaceReviewResult } from "./content-lane/orchestrator";
@@ -62,10 +67,19 @@ export function surfaceVerdictToGate(result: SurfaceReviewResult): {
   return { evaluation: { enabled: true, conclusion: "failure", title: SURFACE_TITLE, summary, blockers: [finding], warnings: [] }, finding };
 }
 
-/** Merge the surface override onto the generic gate while PRESERVING the generic gate's hard blockers. A surface
- *  "merge" must NOT clear a real critical (e.g. a committed secret) the generic gate already raised — so when the
- *  generic gate carries blockers, they survive and the conclusion stays a failure. `null` surface ⇒ defer (the
- *  generic gate is returned unchanged). PURE. */
+/** Merge the surface override onto the generic gate while PRESERVING the generic gate's hard (non-AI-judgment)
+ *  blockers. A surface "merge" must NOT clear a real critical (e.g. a committed secret) the generic gate already
+ *  raised — so when the generic gate carries such blockers, they survive and the conclusion stays a failure.
+ *  `null` surface ⇒ defer (the generic gate is returned unchanged). PURE.
+ *
+ *  EXCEPTION: when the generic gate's ONLY blockers are AI-judgment codes (`ai_consensus_defect` /
+ *  `ai_review_split`, see `isAiJudgmentOnlyFailure`), a decisive surface merge overrides them — the surface lane
+ *  is the sole, AI-free adjudicator for this structured registry data (its own secrets/shape/safety scan already
+ *  runs independently), so an AI opinion alone must never veto a verdict the deterministic lane already reached.
+ *  A real (non-AI) blocker in the mix still falls through to the union below and blocks. The generic gate's
+ *  OTHER (non-blocker) warnings are unrelated to the discarded AI blocker and are preserved onto the surface
+ *  result rather than silently dropped — see `evaluateWithSurfaceLane` for the companion `advisory.findings`
+ *  cleanup that keeps the public comment from re-surfacing the overridden AI defect via a separate path. */
 export function applySurfaceGate(
   generic: GateCheckEvaluation | undefined,
   surface: GateCheckEvaluation | null,
@@ -78,6 +92,9 @@ export function applySurfaceGate(
   if (generic.blockers.length === 0) {
     if (surface.conclusion === "success") return generic;
     return surface;
+  }
+  if (isAiJudgmentOnlyFailure(generic) && surface.conclusion === "success") {
+    return { ...surface, warnings: [...generic.warnings, ...surface.warnings] };
   }
   return {
     enabled: true,
@@ -149,7 +166,15 @@ export function resolveSurfaceRefs(
 
 /** The processor SEAM in one testable call: when the surface lane is wired for this repo, run it and merge its
  *  verdict onto the generic gate (preserving generic hard blockers); otherwise return the generic evaluation
- *  unchanged. `getChangedFiles` is a thunk so an unwired repo resolves no files (no extra diff load). */
+ *  unchanged. `getChangedFiles` is a thunk so an unwired repo resolves no files (no extra diff load).
+ *
+ *  When `applySurfaceGate`'s AI-judgment override fires (an AI-judgment-only generic failure is overridden by a
+ *  decisive surface merge), the AI-judgment finding(s) are ALSO removed from `args.advisory.findings` — that
+ *  array is a separate, raw feed the unified-comment bridge reads independently via `consensusDefectFromFindings`
+ *  (src/review/unified-comment-bridge.ts) to render the "Code review" reviewer note, bypassing the gate
+ *  evaluation entirely. Without this cleanup, the public comment would still show "Concerns raised — review
+ *  before merging" quoting the overridden AI defect even though the gate the same comment reports is a clean
+ *  merge — a visible, confusing contradiction of the override this function just made. */
 export async function evaluateWithSurfaceLane(
   env: Env,
   repoFullName: string,
@@ -171,5 +196,9 @@ export async function evaluateWithSurfaceLane(
     advisory: args.advisory,
     files: await args.getChangedFiles(),
   });
-  return applySurfaceGate(gateEvaluation, surfaceGate);
+  const result = applySurfaceGate(gateEvaluation, surfaceGate);
+  if (gateEvaluation && surfaceGate?.conclusion === "success" && isAiJudgmentOnlyFailure(gateEvaluation)) {
+    args.advisory.findings = args.advisory.findings.filter((finding) => !AI_JUDGMENT_BLOCKER_CODES.has(finding.code));
+  }
+  return result;
 }

--- a/test/unit/content-lane-wire.test.ts
+++ b/test/unit/content-lane-wire.test.ts
@@ -105,6 +105,43 @@ describe("applySurfaceGate", () => {
     expect(out?.conclusion).toBe("failure"); // the secret still blocks the merge
     expect(out?.blockers).toEqual([secret]); // the generic blocker survives the override
   });
+  it("REGRESSION: an AI-judgment-only blocker (e.g. a hallucinated grounding/RAG claim) does not veto a decisive surface merge, and the generic gate's OTHER warnings survive", () => {
+    const aiConsensusDefect: AdvisoryFinding = {
+      code: "ai_consensus_defect",
+      title: "AI reviewers agree on a likely critical defect",
+      severity: "critical",
+      detail: "the current registry context already tracks this netuid under a different slug",
+    };
+    // A warning unrelated to the (overridden) AI blocker — e.g. a quality-readiness note — must NOT vanish just
+    // because the AI blocker next to it gets overridden.
+    const qualityWarning: AdvisoryFinding = { code: "quality_readiness_low", title: "Readiness is low", severity: "warning", detail: "" };
+    const genericAiOnly = gate({ conclusion: "failure", blockers: [aiConsensusDefect], warnings: [qualityWarning] });
+    const surfaceMerge = gate({ conclusion: "success", title: "Surface", summary: "valid entry" });
+    const out = applySurfaceGate(genericAiOnly, surfaceMerge);
+    // The surface lane is the sole, AI-free adjudicator for this structured data — an AI-judgment-only blocker
+    // has no standing to override its merge (unlike the real secret_leak blocker in the test above).
+    expect(out?.conclusion).toBe("success");
+    expect(out?.blockers).toEqual([]);
+    // The overridden AI blocker must NOT reappear (demoted or otherwise) — it was simply wrong. Only the
+    // generic gate's unrelated warning, plus any surface warnings, survive.
+    expect(out?.warnings).toEqual([qualityWarning]);
+  });
+  it("an AI-judgment-only generic failure still fails when the surface ITSELF closes (both agree, no override needed)", () => {
+    const split: AdvisoryFinding = { code: "ai_review_split", title: "Split", severity: "critical", detail: "one reviewer flagged a defect" };
+    const genericAiOnly = gate({ conclusion: "failure", blockers: [split], warnings: [] });
+    const out = applySurfaceGate(genericAiOnly, surfaceClose);
+    expect(out?.conclusion).toBe("failure");
+    expect(out?.blockers).toEqual([split, ...surfaceClose.blockers]); // union — the AI-only exception only applies to a surface MERGE
+  });
+  it("a MIXED generic failure (an AI-judgment code plus a real blocker) is not AI-judgment-only — still overrides a surface merge", () => {
+    const secret: AdvisoryFinding = { code: "secret_leak", title: "Secret", severity: "critical", detail: "leaked key" };
+    const aiConsensusDefect: AdvisoryFinding = { code: "ai_consensus_defect", title: "AI defect", severity: "critical", detail: "" };
+    const genericMixed = gate({ conclusion: "failure", blockers: [aiConsensusDefect, secret], warnings: [] });
+    const surfaceMerge = gate({ conclusion: "success", title: "Surface", summary: "valid entry" });
+    const out = applySurfaceGate(genericMixed, surfaceMerge);
+    expect(out?.conclusion).toBe("failure"); // the real blocker means this is NOT an AI-judgment-only failure
+    expect(out?.blockers).toEqual([aiConsensusDefect, secret]);
+  });
 });
 
 describe("runMetagraphedSurfaceGate (injected loader — adapter logic)", () => {
@@ -194,5 +231,55 @@ describe("evaluateWithSurfaceLane (the processor seam helper)", () => {
       getChangedFiles: async () => [{ path: SUBNET, status: "modified" }],
     });
     expect(out?.conclusion).toBe("success"); // a clean append merges, overriding the generic gate
+  });
+
+  it("REGRESSION: overriding an AI-judgment-only failure also strips the stale AI finding from advisory.findings (so the public comment can't contradict the merge)", async () => {
+    const bodies: Record<string, string> = {
+      "HEAD:registry/subnets/foo.json": doc([existing, newEntry]),
+      "BASE:registry/subnets/foo.json": doc([existing]),
+    };
+    vi.stubGlobal("fetch", async (url: string | URL) => {
+      const m = /\/contents\/(.+)\?ref=(.+)$/.exec(String(url));
+      if (!m) return new Response("nope", { status: 404 });
+      const path = m[1]!.split("/").map(decodeURIComponent).join("/");
+      const body = bodies[`${decodeURIComponent(m[2]!)}:${path}`];
+      return body === undefined ? new Response("missing", { status: 404 }) : new Response(body);
+    });
+    const aiConsensusDefect: AdvisoryFinding = { code: "ai_consensus_defect", title: "AI defect", severity: "critical", detail: "hallucinated" };
+    const otherWarning: AdvisoryFinding = { code: "quality_readiness_low", title: "Readiness is low", severity: "warning", detail: "" };
+    // Simulates the real pipeline: `runAiReviewForAdvisory` already pushed the SAME finding into advisory.findings
+    // (consumed independently by the unified-comment bridge's consensusDefectFromFindings) before the generic gate
+    // was evaluated from it.
+    const advisory = { findings: [aiConsensusDefect, otherWarning] };
+    const genericAiOnly = gate({ conclusion: "failure", blockers: [aiConsensusDefect], warnings: [] });
+    const wiredEnv = { GITTENSORY_REVIEW_CONTENT_LANE: "true", GITTENSORY_REVIEW_REPOS: REPO } as unknown as Env;
+    const out = await evaluateWithSurfaceLane(wiredEnv, REPO, true, genericAiOnly, {
+      installationId: null,
+      pr: { headSha: "HEAD", baseRef: "BASE" },
+      repo: { defaultBranch: "main" },
+      advisory,
+      getChangedFiles: async () => [{ path: SUBNET, status: "modified" }],
+    });
+    expect(out?.conclusion).toBe("success");
+    // The overridden ai_consensus_defect must be gone from advisory.findings too — otherwise the unified-comment
+    // bridge would still recover it via consensusDefectFromFindings and render "Concerns raised" over a merge.
+    expect(advisory.findings).toEqual([otherWarning]);
+  });
+
+  it("does NOT touch advisory.findings when the surface lane defers or the generic gate isn't AI-judgment-only", async () => {
+    const aiConsensusDefect: AdvisoryFinding = { code: "ai_consensus_defect", title: "AI defect", severity: "critical", detail: "" };
+    const secret: AdvisoryFinding = { code: "secret_leak", title: "Secret", severity: "critical", detail: "leaked" };
+    const advisory = { findings: [aiConsensusDefect, secret] };
+    // A real (non-AI) blocker alongside the AI one means isAiJudgmentOnlyFailure is false — no cleanup should run.
+    const genericMixed = gate({ conclusion: "failure", blockers: [aiConsensusDefect, secret], warnings: [] });
+    const wiredEnv = { GITTENSORY_REVIEW_CONTENT_LANE: "true", GITTENSORY_REVIEW_REPOS: REPO } as unknown as Env;
+    await evaluateWithSurfaceLane(wiredEnv, REPO, true, genericMixed, {
+      installationId: null,
+      pr: { headSha: "HEAD", baseRef: "BASE" },
+      repo: { defaultBranch: "main" },
+      advisory,
+      getChangedFiles: async () => [{ path: "README.md", status: "modified" }], // not a registry submission → surface defers (null)
+    });
+    expect(advisory.findings).toEqual([aiConsensusDefect, secret]);
   });
 });


### PR DESCRIPTION
## Summary

- The deterministic content-lane surface adjudicator (`applySurfaceGate`) is documented as the sole, AI-free decision-maker for structured registry-submission PRs, but it still forced a failure whenever the generic gate carried *any* blocker — including an `ai_consensus_defect`/`ai_review_split` finding with no other backing evidence. Wire the existing (previously uncalled) `isAiJudgmentOnlyFailure` predicate into `applySurfaceGate` so a decisive surface merge now wins over a generic failure caused *solely* by AI-judgment codes, while a real non-AI blocker (secret, guardrail hold, etc.) still unions and blocks exactly as before.
- Two follow-on gaps found during review are fixed in the same change: the override now preserves the generic gate's *other* (non-AI) warnings instead of dropping them, and it strips the same AI-judgment finding from `advisory.findings` so the public comment's independent `consensusDefectFromFindings` path can't re-surface the overridden defect while the gate itself reports a clean merge.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue is linked — this is a narrow, fully-tested bugfix responding to an observed production false-positive on a self-hosted deployment (a valid registry-submission PR whose deterministic verdict was silently overridden by an AI-only blocker), not a pre-filed feature/bug report.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the two changed files are 100% lines/statements/functions, and full branch coverage on every changed line (the only uncovered branch in `content-lane-wire.ts` is a pre-existing, untouched line).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has unit tests for every new branch: AI-only-failure + decisive surface merge (override fires), AI-only-failure + surface close (both agree, union path), mixed AI+real blocker (not AI-only, union path), and the companion `advisory.findings` cleanup (fires only when the override fires; does not fire when the surface lane defers or the failure isn't AI-judgment-only).

All of the above ran via `npm run test:ci` (green, twice) plus `npm audit --audit-level=moderate` (0 vulnerabilities).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This PR changes what the gate/comment show for registry-submission PRs — reviewed the exact rendering path to confirm no private/unsanitized text is introduced.)
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/schema changes.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, backend-only.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, not a release-prep PR.

## Notes

- Root cause was found via direct forensic inspection of a live self-hosted deployment's review audit tables: a PR adding a new, valid registry manifest for a netuid with no existing entry was correctly assessed as mergeable by the deterministic surface lane, but a separate AI-review consensus pass asserted (incorrectly) that a manifest for that netuid already existed elsewhere, and that AI-only blocker silently overrode the correct merge under the old `applySurfaceGate` logic.
- `isAiJudgmentOnlyFailure` (src/rules/advisory.ts) already existed for exactly this purpose but had zero callers anywhere in the codebase before this change.