### PR TITLE
fix(github): surface a warning when CI completeness can't be verified

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2176,6 +2176,14 @@ export type LiveCiAggregate = {
   failingDetails: Array<{ name: string; summary?: string; detailsUrl?: string }>;
   // Historical compatibility: non-required red checks are now folded into failingDetails so this stays empty.
   nonRequiredFailingDetails: Array<{ name: string; summary?: string; detailsUrl?: string }>;
+  // Informational-only (#2137): set when the aggregate resolved to "passed" with no branch-protection required
+  // contexts configured (`enforceRequiredOnly` false) — meaning a workflow that never triggers on this commit at
+  // all (e.g. path-filtered out, or a broken YAML trigger) is indistinguishable from one that doesn't exist, and
+  // would silently pass as long as at least one OTHER check ran and passed. NEVER changes ciState/disposition —
+  // a self-hosted repo without an expected-checks list would otherwise get stuck "pending" forever on a workflow
+  // that structurally can never complete. Surfaced to the operator as a nudge toward configuring branch
+  // protection or an expected-checks list, not a gate blocker.
+  ciCompletenessWarning: string | null;
 };
 
 /**
@@ -2331,7 +2339,17 @@ async function reduceLiveCiAggregate(
   // Fail CLOSED on incomplete visibility: an OBSERVED failure is authoritative and preserved.
   if ((checkRunsIncomplete || statusIncomplete) && ciState !== "failed") ciState = "pending";
   const hasPending = anyVisiblePending || anyPending || checkRunsIncomplete || statusIncomplete || ciState === "pending";
-  return { ciState, hasPending, hasVisiblePending: anyRequiredVisiblePending, failingDetails, nonRequiredFailingDetails };
+  // #2137 interim mitigation: without required-context branch protection, a workflow that never triggers at all
+  // (path-filtered, or a broken trigger) is indistinguishable from one that doesn't exist, and folds into
+  // "passed" as long as some OTHER check ran and passed. Never changes ciState (a self-hosted repo with no
+  // expected-checks config would otherwise get stuck "pending" forever on a workflow that can structurally never
+  // complete) — informational only, for the operator to notice and configure branch protection / an
+  // expected-checks list against.
+  const ciCompletenessWarning =
+    !enforceRequiredOnly && ciState === "passed"
+      ? "CI resolved to passed with no branch-protection required checks configured — gittensory cannot verify every expected workflow ran on this commit (a path-filtered or misconfigured workflow that never triggers is indistinguishable from one that doesn't exist). Configure branch protection or an expected-checks list for full CI-completeness verification."
+      : null;
+  return { ciState, hasPending, hasVisiblePending: anyRequiredVisiblePending, failingDetails, nonRequiredFailingDetails, ciCompletenessWarning };
 }
 
 /**
@@ -2353,7 +2371,7 @@ export async function fetchLiveCiAggregate(
   requiredContexts?: ReadonlySet<string> | null,
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<LiveCiAggregate> {
-  if (!headSha) return { ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] };
+  if (!headSha) return { ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [], ciCompletenessWarning: null };
   // Check-runs + classic statuses are accumulated across pages here; the single classification lives in
   // reduceLiveCiAggregate so the REST and GraphQL paths reach byte-identical verdicts (#1941).
   const checkRuns: LiveCiCheckRun[] = [];

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1627,6 +1627,27 @@ async function maybeRunAgentMaintenance(
     token,
     admissionKey,
   );
+  // #2137: informational-only nudge for the operator — never affects the disposition below (ciState is
+  // unchanged). recordAuditEvent is a DB write with its own internal failure handling; a failure here must
+  // never block the maintenance pass, hence the outer .catch().
+  if (ciAggregate.ciCompletenessWarning) {
+    /* v8 ignore next -- ciCompletenessWarning is only ever set when ciState === "passed", and
+     * fetchLiveCiAggregate/reduceLiveCiAggregate short-circuit to "unverified" for a falsy headSha before ever
+     * reaching that computation — so pr.headSha (the same value passed into refreshLiveCiAggregate above) is
+     * always truthy here; the fallback is defensive. */
+    const ciCompletenessHeadSha = pr.headSha ?? null;
+    await recordAuditEvent(env, {
+      eventType: "github_app.ci_completeness_unverified",
+      actor: "gittensory",
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail: ciAggregate.ciCompletenessWarning,
+      metadata: { deliveryId: args.deliveryId, repoFullName, headSha: ciCompletenessHeadSha },
+    }).catch(
+      /* v8 ignore next -- fail-safe: an audit write failure never blocks the handler */
+      () => undefined,
+    );
+  }
   const changedPaths = changedPathsForGuardrail(changedFiles);
   const repoOwner = repoFullName.includes("/")
     ? repoFullName.slice(0, repoFullName.indexOf("/"))

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -3611,7 +3611,7 @@ describe("GitHub backfill", () => {
 
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", null, "public-token", null);
 
-      expect(aggregate).toEqual({ ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [] });
+      expect(aggregate).toEqual({ ciState: "unverified", hasPending: false, hasVisiblePending: false, failingDetails: [], nonRequiredFailingDetails: [], ciCompletenessWarning: null });
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
@@ -3979,6 +3979,52 @@ describe("GitHub backfill", () => {
       });
       const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
       expect(aggregate.ciState).toBe("passed"); // a first-party run was observed and passed; do not over-pend
+    });
+
+    it("surfaces a completeness warning when CI resolves to passed with no branch-protection required contexts, without changing ciState (#2137)", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        // Workflow A ("test") ran and passed; workflow B (e.g. a path-filtered e2e-tests job) never triggered at
+        // all — no check-run, no check-suite entry, indistinguishable from a workflow that doesn't exist.
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      // Disposition is UNCHANGED (interim mitigation, not the full fix): a self-hosted repo with no
+      // expected-checks config would otherwise get stuck "pending" forever on a workflow that can structurally
+      // never complete. The gap is surfaced as an informational warning instead.
+      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.ciCompletenessWarning).toMatch(/branch-protection required checks/i);
+    });
+
+    it("does NOT surface a completeness warning when branch-protection required contexts ARE configured", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        if (url.includes("/check-suites?")) return Response.json({ check_suites: [{ status: "completed", app: { slug: "github-actions" } }] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", new Set(["test"]));
+      expect(aggregate.ciState).toBe("passed");
+      expect(aggregate.ciCompletenessWarning).toBeNull();
+    });
+
+    it("does NOT surface a completeness warning when ciState is anything other than passed", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "test", status: "completed", conclusion: "failure", app: { slug: "github-actions" } }] });
+        if (url.includes("/status?")) return Response.json({ statuses: [] });
+        return new Response("not found", { status: 404 });
+      });
+      const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", null);
+      expect(aggregate.ciState).toBe("failed");
+      expect(aggregate.ciCompletenessWarning).toBeNull();
     });
 
     it("fold-all: a non-completed THIRD-PARTY suite is ignored (only first-party GitHub-Actions suites gate)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1196,6 +1196,7 @@ describe("queue processors", () => {
       hasVisiblePending: false,
       failingDetails: [],
       nonRequiredFailingDetails: [],
+      ciCompletenessWarning: null,
     });
     let gateChecks = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1244,6 +1245,7 @@ describe("queue processors", () => {
       hasVisiblePending: false,
       failingDetails: [],
       nonRequiredFailingDetails: [],
+      ciCompletenessWarning: null,
     });
     let gateChecks = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1301,6 +1303,7 @@ describe("queue processors", () => {
       hasVisiblePending: false,
       failingDetails: [],
       nonRequiredFailingDetails: [],
+      ciCompletenessWarning: null,
     });
     let gateChecks = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1325,6 +1328,79 @@ describe("queue processors", () => {
         .bind("github_app.review_finalized_ci_stuck")
         .first<{ n: number }>();
       expect(finalized?.n).toBe(1);
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
+  it("records an informational audit event when the live CI aggregate carries a completeness warning (#2137)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "CI completeness unverified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(null);
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "passed",
+      hasPending: false,
+      hasVisiblePending: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      ciCompletenessWarning: "CI resolved to passed with no branch-protection required checks configured — cannot verify every expected workflow ran.",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "CI completeness unverified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "ci-completeness-unverified", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.ci_completeness_unverified").first<{ outcome: string; detail: string }>();
+      expect(audit?.outcome).toBe("completed"); // informational only — never a denial, never changes the disposition
+      expect(audit?.detail).toContain("branch-protection required checks");
+    } finally {
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
+  it("does NOT record the CI-completeness audit event when the live CI aggregate carries no warning", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "CI fully verified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(new Set(["trusted-required-ci"]));
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "passed",
+      hasPending: false,
+      hasVisiblePending: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      ciCompletenessWarning: null,
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "CI fully verified", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      return Response.json({});
+    });
+
+    try {
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "ci-fully-verified", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.ci_completeness_unverified").first<{ n: number }>();
+      expect(audit?.n).toBe(0);
     } finally {
       liveCiSpy.mockRestore();
       requiredContextsSpy.mockRestore();
@@ -5927,6 +6003,7 @@ describe("queue processors", () => {
         hasVisiblePending: false,
         failingDetails: [],
         nonRequiredFailingDetails: [],
+        ciCompletenessWarning: null,
       });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();


### PR DESCRIPTION
## What

When no branch-protection required contexts are resolvable (`enforceRequiredOnly === false` — common on repos without branch protection configured, or when the required-contexts fetch 403s), the only "absence" safety net in `reduceLiveCiAggregate` was `missingConventionalValidateAggregate` — hardcoded to this repo's own CI convention (a `validate` context gated behind `changes`/`security`/`validate-code`). For any other self-hosted repo with different job names, a workflow that never triggers for a given PR (path-filtered out, or a broken workflow YAML trigger) produces neither a check-run nor a check-suite entry — indistinguishable from "no such check exists" — and folds into `"passed"` as long as at least one *other* check ran and passed. A self-hosted maintainer expecting a non-required, path-filtered `e2e-tests` job to run on every PR would get no signal that it silently never ran.

## Fix

Ships the issue's own "lower-effort interim mitigation" rather than the full generalized fix (a learned-or-`.gittensory.yml`-declared expected-workflow-set comparison), which the issue itself frames as a separate, larger follow-up.

- Added a `ciCompletenessWarning: string | null` field to `LiveCiAggregate`. `reduceLiveCiAggregate` populates it when the aggregate resolves to `"passed"` with no branch-protection required contexts configured. `ciState`/disposition is **never** touched — forcing `"pending"` in this scenario would leave a self-hosted repo with no expected-checks config stuck waiting forever on a workflow that can structurally never complete (worse than the silent-pass it replaces).
- Since gittensory's own convention (`missingConventionalValidateAggregate`) already forces `"pending"` — not `"passed"` — when its aggregate check is legitimately missing, the new warning can never fire for a properly-configured gittensory-convention repo; it's mathematically orthogonal to the existing mechanism, not a replacement for it.
- The main planner (`maybeRunAgentMaintenance` in `src/queue/processors.ts`) records the warning as an informational `github_app.ci_completeness_unverified` audit event (`outcome: "completed"`, never `"denied"`) — a nudge for the operator, not a gate blocker.

## Tests

- Fixed one pre-existing test whose full-object `toEqual` assertion broke at runtime from the new field (not caught by `tsc` since `expect().toEqual()` isn't type-checked against the exact shape).
- 3 new direct tests on `fetchLiveCiAggregate`: the warning is set when CI resolves to passed with no required contexts (workflow A passes, workflow B never appears at all); the warning is absent when required contexts ARE configured; the warning is absent when `ciState` is anything other than `"passed"`.
- 2 new integration tests via `processJob`/`agent-regate-pr`: the audit event fires with the expected detail when the mocked aggregate carries a warning; it does NOT fire when the aggregate carries none.
- `npx tsc --noEmit` clean — widening `LiveCiAggregate`'s required fields surfaced 5 test-side mock objects needing the new field via the compiler.
- Scoped: `backfill.test.ts` — 143 passed; full `queue.test.ts` — 204 passed.
- Regression sweep: `graphql-status-rollup.test.ts` (the other `reduceLiveCiAggregate` call path) — 30 passed.
- Diff-range coverage-gap check on both changed source files: fully covered (two genuinely-defensive fallbacks marked `/* v8 ignore next */` with a verified, non-hand-wavy invariant justification — `ciCompletenessWarning` is only ever set when `ciState === "passed"`, which itself requires a truthy `headSha`).
- Full unsharded `npm run test:coverage`: 5605 passed, 4 skipped (pre-existing/unrelated), 0 failed.
- `npm audit --audit-level=moderate`: 0 vulnerabilities.

Advances #1936. Closes #2137.