### PR TITLE
fix(queue): record the real outcome when a reopen-reclose fails

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8016,6 +8016,7 @@ async function maybeRecloseDisallowedReopen(
     }).catch(() => undefined);
     return true; // handled (decision made); a superseded/ambiguous reopener still counts as handled
   }
+  // The comment is a courtesy notice; its failure must not mask whether the close itself succeeded (below).
   await createIssueComment(
     env,
     installationId,
@@ -8023,16 +8024,23 @@ async function maybeRecloseDisallowedReopen(
     pr.number,
     "This pull request was closed by Gittensory and can't be reopened — reviews are one-shot. Please open a new pull request with the issues resolved.",
   ).catch(() => undefined);
-  await closePullRequest(env, installationId, repoFullName, pr.number).catch(
-    () => undefined,
-  );
+  // #2260: the audit outcome must reflect whether the close actually happened on GitHub, not just whether this
+  // handler ran. A swallowed 403/404/5xx here previously still recorded outcome:"completed", so an operator
+  // trusting the audit trail believed a one-shot close was enforced when it may not have been.
+  const closeError = await closePullRequest(env, installationId, repoFullName, pr.number)
+    .then(() => null)
+    .catch((error: unknown) => error);
+  const originallyClosedBy = closer ?? "Gittensory (close beyond the inspected event window)";
   await recordAuditEvent(env, {
     eventType: "github_app.reopen_reclosed",
     actor: "gittensory",
     targetKey: `${repoFullName}#${pr.number}`,
-    outcome: "completed",
-    detail: `re-closed a disallowed reopen by ${reopener} (originally closed by ${closer ?? "Gittensory (close beyond the inspected event window)"}) — one-shot; resubmit a new PR`,
-    metadata: { deliveryId, repoFullName },
+    outcome: closeError === null ? "completed" : "error",
+    detail:
+      closeError === null
+        ? `re-closed a disallowed reopen by ${reopener} (originally closed by ${originallyClosedBy}) — one-shot; resubmit a new PR`
+        : `FAILED to re-close a disallowed reopen by ${reopener} (originally closed by ${originallyClosedBy}) — the close API call did not succeed; the PR may still be open`,
+    metadata: closeError === null ? { deliveryId, repoFullName } : { deliveryId, repoFullName, error: errorMessage(closeError) },
   }).catch(() => undefined);
   return true;
 }

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -11688,7 +11688,9 @@ describe("one-shot reopen prevention", () => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
       if (url.endsWith("/collaborators/maintainer/permission")) return Response.json({ permission: "write" });
-      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
+      // "contributor" (the payload's reopener) must be the MOST RECENT "reopened" actor in the timeline, or the
+      // #2369 live-recheck #3 (reopenerSuperseded) denies before ever reaching the close attempt this test targets.
+      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }, { event: "reopened", actor: { login: "contributor" } }]);
       if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 }); // the courtesy comment succeeds
       if (url.endsWith("/pulls/42") && method === "PATCH") return new Response("forbidden", { status: 403 }); // the close itself fails
       return new Response("not found", { status: 404 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -11415,7 +11415,8 @@ describe("one-shot reopen prevention", () => {
     expect(calls.some((call) => call.url.endsWith("/collaborators/maintainer/permission"))).toBe(true);
     expect(calls.some((call) => call.method === "POST" && call.url.endsWith("/issues/42/comments"))).toBe(true);
     expect(calls.some((call) => call.method === "PATCH" && call.url.endsWith("/pulls/42"))).toBe(true);
-    const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ detail: string }>();
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("completed"); // #2260: a successful close is unaffected
     expect(audit?.detail).toContain("originally closed by maintainer");
     // #review-audit: the early return after a re-close stamps the delivery processed (was left "queued").
     const webhookRow = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("reopen-write-collab-close").first<{ status: string }>();
@@ -11676,6 +11677,41 @@ describe("one-shot reopen prevention", () => {
       processJob(env, { type: "github-webhook", deliveryId: "reopen-promoted-audit-fail", eventName: "pull_request", payload: reopenedPayload("contributor") }),
     ).resolves.toBeUndefined();
     expect(contributorPermissionCalls).toBe(2);
+  });
+
+  it("records outcome:error (not completed) when the reclose PATCH call itself fails (#2260)", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
+      if (url.endsWith("/collaborators/maintainer/permission")) return Response.json({ permission: "write" });
+      if (url.includes("/issues/42/events")) return Response.json([{ event: "closed", actor: { login: "maintainer" } }]);
+      if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 }); // the courtesy comment succeeds
+      if (url.endsWith("/pulls/42") && method === "PATCH") return new Response("forbidden", { status: 403 }); // the close itself fails
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    await repositoriesModule.upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", autonomy: { merge: "auto", request_changes: "auto" } });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "reopen-close-fails",
+      eventName: "pull_request",
+      payload: reopenedPayload("contributor"),
+    });
+
+    expect(calls.some((call) => call.method === "PATCH" && call.url.endsWith("/pulls/42"))).toBe(true); // the close WAS attempted
+    const audit = await env.DB.prepare("select outcome, detail, metadata_json from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("error"); // NOT "completed" — the close did not actually succeed
+    expect(audit?.detail).toContain("FAILED to re-close");
+    expect(JSON.parse(audit?.metadata_json ?? "{}").error).toBeTruthy();
+    // The handler still owns the decision (never falls through to normal re-review) even though the API call failed.
+    const webhookRow = await env.DB.prepare("select status from webhook_events where delivery_id = ?").bind("reopen-close-fails").first<{ status: string }>();
+    expect(webhookRow?.status).toBe("processed");
   });
 
   it("does NOT re-close a disallowed reopen on an OBSERVE-only / un-opted-in repo (autonomy floor, #review-audit)", async () => {


### PR DESCRIPTION
## What

In `maybeRecloseDisallowedReopen`, both the warning comment and the actual close call were wrapped in `.catch(() => undefined)`. Regardless of whether either GitHub API call succeeded or failed (403 from reduced permissions, 404, 5xx), the function unconditionally wrote a `github_app.reopen_reclosed` audit event with `outcome: "completed"`, describing the PR as re-closed. This mirrors the already-fixed draft-dodge audit-fidelity gap (#2134), on the reopen-abuse path instead.

The practical impact is bounded (the next sweep still picks the PR back up and runs it through the full guard stack regardless of this path's own state), but the audit trail becomes misleading — an operator or dashboard reading `github_app.reopen_reclosed` / `outcome: "completed"` believes the one-shot close was enforced when it may not have been.

## Fix

Captures the close call's settled result (`.then(() => null).catch((error) => error)`) and branches the audit outcome on it: `"completed"` only when `closePullRequest` actually resolves, `"error"` otherwise (the `recordAuditEvent` outcome enum doesn't have a `"failed"` literal — `"error"` is the closest valid match), with the underlying error captured in `metadata`. The courtesy comment's own failure is independent and still swallowed unconditionally — a failed notice doesn't change whether the close itself worked, and shouldn't be conflated with it.

The handler's `return true` (meaning "I own this decision, don't fall through to normal re-review") is unchanged either way — the issue's own scope is specifically the audit outcome, not the control-flow decision.

## Tests

- New test: the close PATCH call returns 403 → the audit event records `outcome: "error"`, a detail string starting with "FAILED to re-close", and the underlying error in `metadata_json`. Confirms the close was still attempted and the webhook delivery is still marked processed (the handler still owns the decision).
- Added an `outcome: "completed"` assertion to the pre-existing success-path test (previously only checked `detail`) to lock in "a successful close is unaffected."
- `npx tsc --noEmit` clean.
- Scoped: full `queue.test.ts` — 203 passed.
- Diff-range coverage-gap check on `src/queue/processors.ts`: fully covered.
- Full unsharded `npm run test:coverage`: 5631 passed, 4 skipped (pre-existing/unrelated), 0 failed.
- `npm audit --audit-level=moderate`: 0 vulnerabilities.

Advances #1936. Closes #2260.