### PR TITLE
fix(scoring): treat startup_failure checks as failing in pending-pr scenarios

### DIFF
--- a/src/scoring/pending-pr-scenarios.ts
+++ b/src/scoring/pending-pr-scenarios.ts
@@ -184,7 +184,14 @@ export function classifyOpenPullRequest(args: {
   const approvalCount = args.reviews.filter((review) => review.state.toUpperCase() === "APPROVED").length;
   const changeRequestCount = args.reviews.filter((review) => review.state.toUpperCase() === "CHANGES_REQUESTED").length;
   const checkFailureCount = args.checks.filter(
-    (check) => check.conclusion === "failure" || check.conclusion === "timed_out" || check.conclusion === "cancelled",
+    // Mirror the gate's CI-failing set (CI_FAILING_CONCLUSIONS in github/backfill.ts): a workflow that failed
+    // to start reports `startup_failure`, so an approved PR whose CI never ran must be blocked, not treated as
+    // merge-ready. `action_required` stays excluded (fork PR awaiting "Approve and run", not a failure).
+    (check) =>
+      check.conclusion === "failure" ||
+      check.conclusion === "timed_out" ||
+      check.conclusion === "cancelled" ||
+      check.conclusion === "startup_failure",
   ).length;
   const ageDays = daysSince(args.pr.updatedAt ?? args.pr.createdAt);
 

--- a/test/unit/pending-pr-scenarios.test.ts
+++ b/test/unit/pending-pr-scenarios.test.ts
@@ -99,6 +99,31 @@ describe("pending PR scenario detection", () => {
     expect(classified.reasons.join(" ")).toMatch(/failing or cancelled check/i);
   });
 
+  it("counts failure and startup_failure checks as failing, matching the gate CI-failing set (regression)", () => {
+    // startup_failure (a workflow that failed to start) was previously omitted, so an approved PR whose CI
+    // never ran was optimistically classified merge_ready instead of blocked.
+    for (const conclusion of ["failure", "startup_failure"]) {
+      const classified = classifyOpenPullRequest({
+        pr: pr({ number: 78 }),
+        roleContext: outsideContributorRole,
+        reviews: [approvedReview(78)],
+        checks: [{ id: "c78", repoFullName: "entrius/allways-ui", pullNumber: 78, name: "ci", status: "completed", conclusion, payload: {} }],
+      });
+      expect(classified.classification).toBe("blocked");
+      expect(classified.reasons.join(" ")).toMatch(/failing or cancelled check/i);
+    }
+  });
+
+  it("does not count a passing check as a failing one", () => {
+    const classified = classifyOpenPullRequest({
+      pr: pr({ number: 79 }),
+      roleContext: outsideContributorRole,
+      reviews: [approvedReview(79)],
+      checks: [{ id: "c79", repoFullName: "entrius/allways-ui", pullNumber: 79, name: "ci", status: "completed", conclusion: "success", payload: {} }],
+    });
+    expect(classified.classification).toBe("merge_ready");
+  });
+
   it("counts stale approved PRs as pending closes and projects the post-cleanup open count", () => {
     const staleDate = new Date(Date.now() - 30 * 86_400_000).toISOString();
     const detection = detectPendingPrScenario({


### PR DESCRIPTION
## Summary

`classifyOpenPullRequest` in `src/scoring/pending-pr-scenarios.ts` counts failing checks with an inline conclusion list — `conclusion === "failure" || "timed_out" || "cancelled"`. That is the gate's own CI-failing set, `CI_FAILING_CONCLUSIONS` (`src/github/backfill.ts:2123` = `{failure, timed_out, cancelled, startup_failure}`), **minus `startup_failure`**.

Both classifiers read the same persisted check-run rows. A GitHub Actions workflow that fails to start reports `conclusion: "startup_failure"` (REST, lowercase), and the gate treats it as a CI failure — but this scoring copy did not. So `checkFailureCount` stayed `0` and an approved PR whose CI never ran was optimistically classified `merge_ready` instead of `blocked`, overstating projected merges.

```
classifyOpenPullRequest({ reviews: [approved], checks: [{ conclusion: "startup_failure" }] })
// actual:   classification "merge_ready"
// expected: classification "blocked"   (as it already is for timed_out / cancelled)
```

Fix: add `startup_failure` so the inline list matches `CI_FAILING_CONCLUSIONS` exactly. `action_required` stays excluded — a fork PR awaiting "Approve and run" is deliberately not a failure (per `backfill.ts`), and `CI_FAILING_CONCLUSIONS` omits it too — so this preserves that behavior while closing the one genuinely-reachable gap. Pure scoring classifier — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this is a small, self-evident correctness fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped: `test/unit/pending-pr-scenarios.test.ts` — 17 pass; the changed predicate's four conclusion operands are each exercised true and false by the `failure`/`startup_failure`/`timed_out`/`cancelled`/`success` cases)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change confined to `src/scoring/pending-pr-scenarios.ts`. `typecheck` clean; `test/unit/pending-pr-scenarios.test.ts` passes (17), including the added regression that pins `failure`/`startup_failure` → `blocked` and a passing `success` check → `merge_ready` (covering both sides of every conclusion operand on the changed line). I did not run the full UI/workers/MCP steps (unrelated to this diff), and the local Windows tree has pre-existing unrelated failures (CRLF, missing CLI binaries, Node 24 vs pinned 22). CI runs the full matrix on a clean checkout.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/cookie/CORS/session changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI/MCP surface changed; this is an internal scoring classifier.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A: no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs/changelog change needed.)

## Notes

- The change deliberately matches `CI_FAILING_CONCLUSIONS` (the live gate's set) rather than the broader `isFailingCheckSummary` / `FAILING_CHECK_STATES` in `signals/local-branch.ts`, because the latter additionally treats `action_required` as failing — which would wrongly block a fork PR awaiting "Approve and run" in this scoring surface. The other states that set carries (`failed`, case-folding, the `conclusion ?? status` fallback) are not reachable for these persisted check-run rows (REST supplies lowercase conclusions and a failing check always carries `conclusion`), so `startup_failure` is the only genuinely-reachable gap.
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
