### PR TITLE
fix(review): activate the independent close-rate reputation backstop

### DIFF
--- a/src/review/reputation-wire.ts
+++ b/src/review/reputation-wire.ts
@@ -51,7 +51,13 @@ export function shouldDowngradeToDeterministic(stats: SubmitterStats): boolean {
   if (stats.signal === "low") return true;
   const burst = stats.submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && stats.merged < REPUTATION_BURST_MAX_MERGED;
   if (burst) return true;
-  if (stats.submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && stats.closeRate >= REPUTATION_CLOSE_RATE_FLOOR && stats.merged < REPUTATION_BURST_MAX_MERGED) return true;
+  // The all-time close-rate backstop is INDEPENDENT of the burst pattern (see closeRateFloor above): an
+  // established submitter whose close-rate is at/above the floor is low-reputation regardless of a few merges.
+  // The prior extra `&& merged < REPUTATION_BURST_MAX_MERGED` made this a strict subset of the burst check
+  // above (dead code), so an established submitter with a high close-rate but ≥1 merge was never downgraded.
+  // `closeRate = closed/(merged+closed)`, so `closeRate >= floor` already means the merge record is not
+  // healthy — consistent with "a healthy merge record is NEVER downgraded".
+  if (stats.submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && stats.closeRate >= REPUTATION_CLOSE_RATE_FLOOR) return true;
   return false;
 }
 

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -75,6 +75,14 @@ describe("shouldDowngradeToDeterministic (pure)", () => {
     // trusted → never downgraded.
     expect(shouldDowngradeToDeterministic({ submissions: 10, merged: 10, closed: 0, manual: 0, closeRate: 0, signal: "trusted" })).toBe(false);
   });
+  it("downgrades an established submitter on a high all-time close-rate even with a few merges (the aggregate backstop)", () => {
+    // >= burstFloor submissions AND closeRate >= floor → low-reputation regardless of a couple of merges. The
+    // burst check above does NOT catch this (merged >= 1), so it is the independent close-rate backstop firing.
+    // closeRate = closed/(merged+closed), so 0.85+ already means the merge record is not healthy.
+    expect(shouldDowngradeToDeterministic({ submissions: 20, merged: 2, closed: 17, manual: 0, closeRate: 17 / 19, signal: "neutral" })).toBe(true);
+    // Just below the close-rate floor → not downgraded on the aggregate alone.
+    expect(shouldDowngradeToDeterministic({ submissions: 20, merged: 5, closed: 14, manual: 0, closeRate: 14 / 19, signal: "neutral" })).toBe(false);
+  });
 });
 
 describe("AI-spend gate: reputation downgrade", () => {


### PR DESCRIPTION
## Summary

`shouldDowngradeToDeterministic` in `src/review/reputation-wire.ts` decides whether a submitter's reputation should downgrade a review to deterministic-only. It has three documented triggers: a `low` windowed signal, a **burst** pattern (many submissions, almost none merged), and — per the `closeRateFloor` comment (lines 35-36) and docstring (line 47) — an **independent all-time close-rate backstop**: "an established submitter (≥ burstFloor submissions) whose close-rate is at/above [the floor] is low-reputation **regardless of the windowed signal**."

The close-rate backstop carried an extra `&& stats.merged < REPUTATION_BURST_MAX_MERGED` conjunct:

```ts
const burst = stats.submissions >= FLOOR && stats.merged < 1;
if (burst) return true;
if (stats.submissions >= FLOOR && stats.closeRate >= 0.85 && stats.merged < 1) return true;  // ← dead
```

That makes the backstop a **strict subset of the burst check** (both require `submissions >= FLOOR && merged < 1`), so line 3 is **dead code** — the `closeRate` term never does any work, and an established submitter with a high close-rate but **≥ 1 merge** is never downgraded, contrary to the documented independent backstop.

**Fix:** drop the redundant `&& merged < 1` so the close-rate backstop fires independently, as documented. Since `closeRate = closed / (merged + closed)` (see `submitter-reputation.ts`), `closeRate >= 0.85` already means merges are ≤ ~15% of decided outcomes — i.e. **not** a healthy merge record — so this stays consistent with the docstring's "a healthy merge record is NEVER downgraded" (line 48).

**Blast radius:** the whole reputation signal is behind `GITTENSORY_REVIEW_REPUTATION` (default **OFF**) and is strictly internal (never surfaces on any public comment, label, or check). For any repo that hasn't enabled the flag, this is inert.

**No linked issue:** small, self-contained correctness fix that makes the code match its own documented contract; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `reputation-wiring` suite (16 tests) passes. A new pure-function regression test asserts an established submitter with a high close-rate and a few merges is now downgraded (`{ submissions: 20, merged: 2, closed: 17, closeRate: 17/19 } → true`), plus a just-below-the-floor case that stays `false`; it was confirmed to FAIL against the unpatched code (`false` vs `true`). Both branches of the changed line are covered (verified via lcov `BRDA`). The existing "healthy high-volume contributor → never downgraded" case (`merged: 18, closeRate: 0.1`) still returns `false`.
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one condition in a pure helper in `src/review`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (The reputation signal is strictly internal — it never appears on any public surface.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal AI-spend routing only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Flag-OFF (default) behavior is byte-identical — every existing flag-OFF test still passes untouched.
- Reproduction: `shouldDowngradeToDeterministic({ submissions: 20, merged: 2, closed: 17, manual: 0, closeRate: 17/19, signal: "neutral" })` returned `false` before the fix (the documented backstop never fired) and returns `true` after.
