### PR TITLE
fix(queue): opportunistically refresh installation health on a PR-write 403

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -142,7 +142,7 @@ export async function createInstallationToken(
   return mint;
 }
 
-function githubErrorStatus(error: unknown): number | null {
+export function githubErrorStatus(error: unknown): number | null {
   const err = error as {
     status?: number;
     response?: { status?: number } | null;

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -1,6 +1,8 @@
 import { bumpPullRequestMergeAttempt, createPendingAgentActionIfAbsent, insertNotificationDeliveryIfAbsent, isGlobalAgentFrozen, markPullRequestApproved, markPullRequestMergeBlocked, recordAuditEvent } from "../db/repositories";
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
+import { githubErrorStatus } from "../github/app";
+import { refreshInstallationHealthForInstallation } from "../github/backfill";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
 import { fetchPullRequestFreshness, pullRequestFreshnessDetail } from "../github/pr-freshness";
@@ -147,6 +149,16 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       // re-planning it every sweep. A possibly-transient failure is retried up to MERGE_RETRY_CAP then held.
       if (action.actionClass === "merge" && ctx.headSha) {
         await handleMergeFailure(env, ctx, error);
+      }
+      // #2265: a 403 on a PR-write mutation often means the LOCAL installations.permissions snapshot is stale —
+      // GitHub webhooks a consented permission UPGRADE but sends nothing for a maintainer-initiated downgrade, so
+      // the write-permission readiness gate (step 6 above) can keep reporting "ready" for up to the 30-minute
+      // health-refresh cron interval after a live downgrade. Opportunistically refresh now so the DB row (and
+      // therefore every later sweep/webhook read of it, for this or any other PR on the installation) self-heals
+      // immediately instead of waiting for the next cron tick. GitHub's own server-side enforcement (this very
+      // 403) is already the real backstop, so a failed refresh here is safe to swallow.
+      if (PR_WRITE_CLASSES.has(action.actionClass) && githubErrorStatus(error) === 403) {
+        await refreshInstallationHealthForInstallation(env, ctx.installationId).catch(() => undefined);
       }
     }
   }

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -22,10 +22,14 @@ vi.mock("../../src/github/pr-freshness", async (importOriginal) => {
     })),
   };
 });
+vi.mock("../../src/github/backfill", () => ({
+  refreshInstallationHealthForInstallation: vi.fn(async () => null),
+}));
 
 import { closePullRequest, createIssueComment, createPullRequestReview, mergePullRequest, updatePullRequestBranch } from "../../src/github/pr-actions";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
 import { fetchPullRequestFreshness } from "../../src/github/pr-freshness";
+import { refreshInstallationHealthForInstallation } from "../../src/github/backfill";
 import { actionParams, executeAgentMaintenanceActions, pendingClosureLabelApplied, type AgentActionExecutionContext, type AgentActionOutcome } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
@@ -319,6 +323,38 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(outcomes[0]?.outcome).toBe("error");
     expect(outcomes[0]?.detail).toMatch(/not mergeable/i);
     expect((await auditFor(env, "merge"))?.outcome).toBe("error");
+  });
+
+  it("opportunistically refreshes installation health when a PR-write mutation fails with a 403 (#2265)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(closePullRequest).mockRejectedValueOnce(Object.assign(new Error("Resource not accessible by integration"), { status: 403 }));
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [close]);
+    expect(outcomes[0]?.outcome).toBe("error");
+    expect(refreshInstallationHealthForInstallation).toHaveBeenCalledTimes(1);
+    expect(refreshInstallationHealthForInstallation).toHaveBeenCalledWith(env, 123);
+  });
+
+  it("does not refresh installation health for a non-403 mutation failure (#2265)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(closePullRequest).mockRejectedValueOnce(new Error("network timeout"));
+    await executeAgentMaintenanceActions(env, ctx(), [close]);
+    expect(refreshInstallationHealthForInstallation).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh installation health on a 403 from a non-PR-write action (label uses issues:write, not pull_requests) (#2265)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(ensurePullRequestLabel).mockRejectedValueOnce(Object.assign(new Error("Resource not accessible by integration"), { status: 403 }));
+    await executeAgentMaintenanceActions(env, ctx(), [label]);
+    expect(refreshInstallationHealthForInstallation).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed installation-health refresh — best-effort, does not affect the recorded outcome (#2265)", async () => {
+    const env = createTestEnv({});
+    vi.mocked(closePullRequest).mockRejectedValueOnce(Object.assign(new Error("Resource not accessible by integration"), { status: 403 }));
+    vi.mocked(refreshInstallationHealthForInstallation).mockRejectedValueOnce(new Error("refresh boom"));
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [close]);
+    expect(outcomes[0]?.outcome).toBe("error");
+    expect((await auditFor(env, "close"))?.outcome).toBe("error");
   });
 });
 


### PR DESCRIPTION
## What

`installationPermissions` is read once from the `installations` table at the top of the action loop and threaded through the whole pass. That DB row only self-heals via a consented permission-*upgrade* webhook (GitHub sends none for a maintainer-initiated *downgrade*) or the ~30-minute health-refresh cron. A live downgrade of `pull_requests` write access can therefore go undetected by the readiness gate for up to 30 minutes — during which the executor keeps attempting merge/close/review/update_branch calls that GitHub correctly rejects with 403.

This is a wasted-attempt/staleness gap, not an authorization bypass: GitHub enforces the live scope server-side on the actual mutation and returns 403, which the existing terminal-403 handling already catches and holds correctly.

## Fix

When a PR-write mutation (`request_changes`/`approve`/`merge`/`close`/`update_branch`) fails with a 403, opportunistically call `refreshInstallationHealthForInstallation` (already used by the 30-minute cron) so the DB row self-heals immediately instead of waiting for the next tick — every later sweep/webhook read of it, for this or any other PR on the installation, then reflects the corrected permissions. A failed refresh is swallowed (best-effort; GitHub's own enforcement is already the real backstop).

Exported the existing `githubErrorStatus` helper from `github/app.ts` to detect the 403 rather than duplicating status-reading logic.

## Tests

- New test: a 403 from a PR-write mutation calls `refreshInstallationHealthForInstallation(env, installationId)`.
- New test: a non-403 mutation failure does NOT trigger the refresh.
- New test: a 403 from `label` (uses `issues:write`, not `pull_requests:write` — not in the write-permission gate) does NOT trigger the refresh.
- New test: a failed refresh itself is swallowed and does not affect the recorded action outcome.
- `npx tsc --noEmit` clean.
- `npx vitest run test/unit/agent-action-executor.test.ts` — 33/33 pass.
- Diff-range coverage check: both changed files fully covered, zero gaps.
- Regression sweep across executor/app/approval-queue/merge-failure/queue suites — 360/360 pass.
- Full unsharded `npm run test:coverage` — 309 files / 5661 tests pass.
- `npm audit --audit-level=moderate` — 0 vulnerabilities.

Advances #1936. Closes #2265.