### PR TITLE
fix(review): charge the hunk-join separator N-1 times, not N, in the diff budget

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -61,9 +61,13 @@ export function keepHighSignalHunks(patch: string, budget: number): string {
   const keep = new Set<number>();
   let used = 0;
   for (const r of ranked) {
-    if (used + r.len + 1 > budget) continue;
+    // Kept hunks are emitted with `.join("\n")` below — N hunks use N-1 separators — so charge the
+    // separator only for hunks AFTER the first. Charging `+ 1` for every hunk over-counted the output by
+    // one and dropped a hunk that fit exactly at the budget boundary.
+    const sep = keep.size > 0 ? 1 : 0;
+    if (used + r.len + sep > budget) continue;
     keep.add(r.i);
-    used += r.len + 1;
+    used += r.len + sep;
   }
   const top = ranked[0];
   if (keep.size === 0 && top) keep.add(top.i); // always keep the single highest-signal hunk

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -50,4 +50,14 @@ describe("buildUnifiedReviewDiff — the #1528 fix: never silently drop the file
     expect(reduced).not.toContain("context"); // the low-signal hunk is dropped
     expect(reduced).toContain("dropped"); // and the drop is announced
   });
+
+  it("keeps every hunk when they fit exactly (the join uses N-1 separators, not N)", () => {
+    // Two 10-char hunks joined with one "\n" = 21 chars, exactly the budget. Charging a separator for
+    // BOTH hunks over-counts by one and wrongly drops the second even though it fits.
+    const patch = "@@ a\n+x\n+y\n@@ b\n+p\n+q";
+    expect(patch.length).toBe(21);
+    expect(keepHighSignalHunks(patch, 21)).toBe(patch); // no hunk dropped
+    // One char short → the second hunk genuinely does not fit and is announced as dropped.
+    expect(keepHighSignalHunks(patch, 20)).toContain("dropped");
+  });
 });


### PR DESCRIPTION
## Summary

`keepHighSignalHunks` in `src/review/review-diff.ts` greedily keeps the highest-signal hunks of an oversized patch that fit within a character `budget`, then emits them with `hunks.filter(...).join("\n")` — i.e. **N kept hunks use N-1 separators**. But the budget accounting charged a separator for **every** kept hunk:

```ts
if (used + r.len + 1 > budget) continue;   // charges a separator for hunk #1 too
used += r.len + 1;
```

So `used` over-counts the real emitted length by exactly one. At an **exact-fit** budget (the kept hunks' real joined length equals the budget), the last hunk is wrongly rejected and announced as dropped even though it fits.

**Fix:** charge the join separator only for hunks *after* the first (`keep.size > 0 ? 1 : 0`), so the accounting matches what `.join("\n")` actually emits.

**Reachability (honest scope):** `keepHighSignalHunks` is exported and directly unit-tested, but its only production caller — `buildUnifiedReviewDiff` — passes `remaining - header.length - 4`, i.e. a few chars of slack, so in practice the wrong-drop only triggers when a file's kept hunks land on the *exact* character budget, which is effectively never hit in real diffs. This PR fixes the exported function's boundary correctness (and removes the reliance on that magic slack absorbing the off-by-one); it is not a user-visible production regression today. I'm flagging this transparently rather than overstating impact.

**No linked issue:** small, self-contained off-by-one fix in one exported helper; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; the full `review-diff` suite (6 tests) passes. A new regression test keeps two hunks whose join length (21) equals the budget (21) and asserts nothing is dropped, plus a one-char-short case that still drops as expected; it was confirmed to FAIL against the unpatched code (it dropped a hunk that fit). Both branches of the changed line are covered (verified via lcov `BRDA`). The existing "keeps the highest-signal hunk / announces the drop" test still passes.
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one expression in a pure helper in `src/review`; it touches no API schema, wrangler binding, migration, or UI, so OpenAPI/cf-typegen/migration regeneration is not applicable.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal diff-trimming only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `keepHighSignalHunks("@@ a\n+x\n+y\n@@ b\n+p\n+q", 21)` (two 10-char hunks, joined length 21) previously returned only the first hunk plus "… (1 lower-signal hunk(s) dropped)"; it now returns both hunks, since 21 ≤ the budget of 21.
