### PR TITLE
fix(review): defer automation while optional ci runs

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1680,6 +1680,7 @@ async function maybeRunAgentMaintenance(
     authorIsAutomationBot,
     closeOwnerAuthors: settings.closeOwnerAuthors,
     ciState: ciAggregate.ciState,
+    ciHasPending: ciAggregate.hasPending,
     failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
     ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),
     ...(blacklistEntry !== null

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -102,6 +102,9 @@ export type AgentActionPlanInput = {
   // failing checks) / HOLDS the owner's, and DEFERS every action while "pending" (settle-before-decide — the
   // check-completion webhook re-runs this planner once CI settles).
   ciState: "passed" | "failed" | "pending" | "unverified";
+  // True when any visible CI check/status is still queued or in progress, even when branch protection lets
+  // ciState stay "passed" because the pending context is non-required. The planner must still settle first.
+  ciHasPending?: boolean | undefined;
   // The names of the failing checks, surfaced in the close/request-changes reason so the contributor knows
   // WHY (e.g. "codecov/patch"). Empty unless ciState === "failed".
   failingCheckNames?: string[] | undefined;
@@ -282,7 +285,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   const ciPassed = input.ciState === "passed";
   const ciFailed = input.ciState === "failed";
   // Settle-before-decide: never approve / merge / close on a half-finished CI run.
-  if (input.ciState === "pending") return actions;
+  if (input.ciState === "pending" || input.ciHasPending === true) return actions;
 
   // The gate verdict is authoritative. Green CI is still required for merge/approve, but it does not rewrite an AI
   // or review-thread blocker into success once the gate has classified it as blocking.

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -423,6 +423,21 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto", approve: "auto", merge: "auto", close: "auto" }, ciState: "pending", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }))).toEqual([]);
     });
 
+    it("DEFERS every action when optional visible CI is still pending after required CI passed", () => {
+      expect(
+        planAgentMaintenanceActions(
+          input({
+            conclusion: "success",
+            autonomy: { label: "auto", approve: "auto", merge: "auto", close: "auto" },
+            autoMaintain: { requireApprovals: 0, mergeMethod: "squash" },
+            ciState: "passed",
+            ciHasPending: true,
+            pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" },
+          }),
+        ),
+      ).toEqual([]);
+    });
+
     it("HOLDS a contributor's gate-passing PR whose CI is UNVERIFIED — NEVER closes it (fork workflows awaiting approval) (#harm-stop)", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { label: "auto", approve: "auto", merge: "auto", close: "auto" }, ciState: "unverified", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);


### PR DESCRIPTION
### Motivation
- Optional but visible pending CI checks were being treated as non-blocking after the stale-CI cap because the auto-maintain planner received only `ciState` (which can be `"passed"`), allowing approve/merge actions while optional checks still ran.
- This contradicts the intended settle-before-decide policy that the planner must wait while any visible CI is still in progress.

### Description
- Thread `ciAggregate.hasPending` into the planner input as `ciHasPending` so the planner sees whether any visible CI is still unsettled and can act accordingly (`src/queue/processors.ts`).
- Add `ciHasPending` to the `AgentActionPlanInput` type and update the planner to defer actions when `ciHasPending === true` in addition to `ciState === "pending"` (`src/settings/agent-actions.ts`).
- Add a regression unit test that ensures the planner defers approve/merge/close/label actions when required contexts passed but optional visible CI remains pending (`test/unit/agent-actions.test.ts`).
- Files changed: `src/queue/processors.ts`, `src/settings/agent-actions.ts`, `test/unit/agent-actions.test.ts`.

### Testing
- Ran `npx vitest run test/unit/agent-actions.test.ts` and the suite passed.
- Ran `npm run typecheck` and the TypeScript check passed.
- Started `npm run test:coverage` locally, but the full coverage run did not complete in the interactive session; the change includes a focused regression test covering the new branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452c3f8fc4832cac65050784a62296)