### PR TITLE
fix(selfhost): target public-token admission for background jobs

### DIFF
--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -368,9 +368,10 @@ export function githubRateLimitAdmissionTargetForJob(
     };
   }
   if (!isGitHubBudgetBackgroundJob(message)) return null;
+  const admissionKey = githubRateLimitAdmissionKeyForJob(message);
   return {
     kind: "background",
-    admissionKey: githubRateLimitAdmissionKeyForJob(message),
+    admissionKey: admissionKey ?? githubRateLimitAdmissionKeyForPublicToken(),
   };
 }
 

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -615,14 +615,14 @@ describe("createPgQueue (durable #977)", () => {
     }
   });
 
-  it("pre-yields GitHub-budget background jobs without repo fields from global REST observations", async () => {
+  it("pre-yields public-token GitHub-budget background jobs without installation ids", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
     const oldJitter = process.env.QUEUE_RATE_LIMIT_JITTER_MS;
     process.env.QUEUE_RATE_LIMIT_JITTER_MS = "0";
     try {
       const m = makePool();
-      m.setRateLimitRows([{ admission_key: null, repo_full_name: "owner/repo", remaining: "120", reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" }]);
+      m.setRateLimitRows([{ admission_key: "public-token", repo_full_name: "owner/repo", remaining: "120", reset_at: "2026-06-24T12:10:00.000Z", observed_at: "2026-06-24T12:00:00.000Z" }]);
       m.enqueueJob("background", {
         type: "agent-regate-sweep",
         requestedBy: "schedule",
@@ -637,6 +637,7 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("SET status='pending', run_after=GREATEST"),
         [Date.parse("2026-06-24T12:10:15.000Z"), "github rate-limit background admission", "background"],
       );
+      expect(await renderMetrics()).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="agent-regate-sweep",key_scope="public",kind="background"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -1062,7 +1063,7 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
         expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-same"]),
       );
-      expect(fn).toHaveBeenCalledWith(
+      expect(fn).not.toHaveBeenCalledWith(
         expect.stringContaining("SET run_after=GREATEST(run_after, $1), last_error=COALESCE"),
         expect.arrayContaining([expect.any(Number), "github rate-limit budget deferred", "pending-legacy"]),
       );

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -7,6 +7,7 @@ import {
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionKeyScope,
   githubRateLimitAdmissionKeyForJob,
+  githubRateLimitAdmissionTargetForJob,
   githubRateLimitMetricContext,
   githubRateLimitMetricLabels,
   githubBackgroundRateLimitDelayMs,
@@ -175,6 +176,21 @@ describe("self-host queue common helpers", () => {
     expect(githubRateLimitAdmissionKeyForJob({ type: "agent-regate-pr", deliveryId: "sweep:owner/repo#1", repoFullName: "owner/repo", prNumber: 1, installationId: 123 })).toBe("installation:123");
     expect(githubRateLimitAdmissionKeyForJob({ type: "github-webhook", deliveryId: "d1", eventName: "pull_request", payload: { installation: { id: 456 } } })).toBe("installation:456");
     expect(githubRateLimitAdmissionKeyForJob({ type: "github-webhook", deliveryId: "d2", eventName: "pull_request", payload: {} })).toBeNull();
+  });
+
+  it("targets public-token admission for GitHub-budget background jobs without an installation", () => {
+    expect(githubRateLimitAdmissionTargetForJob({ type: "rag-index-repo", repoFullName: "owner/repo", requestedBy: "schedule" } as JobMessage)).toEqual({
+      kind: "background",
+      admissionKey: githubRateLimitAdmissionKeyForPublicToken(),
+    });
+    expect(githubRateLimitAdmissionTargetForJob({ type: "agent-regate-pr", deliveryId: "sweep:owner/repo#1", repoFullName: "owner/repo", prNumber: 1, installationId: 123 })).toEqual({
+      kind: "background",
+      admissionKey: "installation:123",
+    });
+    expect(githubRateLimitAdmissionTargetForJob({ type: "github-webhook", deliveryId: "d2", eventName: "pull_request", payload: {} })).toEqual({
+      kind: "webhook",
+      admissionKey: null,
+    });
   });
 
   it("computes background admission delays from persisted GitHub REST observations", () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -161,8 +161,8 @@ describe("createSqliteQueue (durable #980)", () => {
       );
       driver.query(
         `INSERT INTO github_rate_limit_observations (id, repo_full_name, admission_key, resource, path, status_code, limit_value, remaining, reset_at, observed_at)
-         VALUES (?, ?, NULL, 'rest', ?, 200, 5000, 120, ?, ?)`,
-        ["rl-bg-legacy", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T12:00:00.000Z"],
+         VALUES (?, ?, 'public-token', 'rest', ?, 200, 5000, 120, ?, ?)`,
+        ["rl-bg-public", "owner/repo", "/x", "2026-06-24T12:10:00.000Z", "2026-06-24T12:00:00.000Z"],
       );
       const seen: string[] = [];
       const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
@@ -191,7 +191,7 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(q.stats()).toMatchObject({ gittensory_jobs_rate_limit_deferred_total: 2 });
       const metrics = await renderMetrics();
       expect(metrics).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="agent-regate-pr",key_scope="installation",kind="background"} 1');
-      expect(metrics).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="rag-index-repo",key_scope="unknown",kind="background"} 1');
+      expect(metrics).toContain('gittensory_jobs_rate_limit_admission_deferred_total{job_type="rag-index-repo",key_scope="public",kind="background"} 1');
     } finally {
       if (oldJitter === undefined) delete process.env.QUEUE_RATE_LIMIT_JITTER_MS;
       else process.env.QUEUE_RATE_LIMIT_JITTER_MS = oldJitter;
@@ -1342,8 +1342,8 @@ describe("createSqliteQueue (durable #980)", () => {
       "SELECT status, last_error FROM _selfhost_jobs WHERE payload=?",
       ["{not json"],
     ).rows[0] as { status: string; last_error: string };
-    expect(seen).toEqual(["blocked-installation", "other-installation", "local-cleanup"]);
-    expect(rows).toHaveLength(3);
+    expect(seen).toEqual(["blocked-installation", "other-installation", "agent-regate-pr", "local-cleanup"]);
+    expect(rows).toHaveLength(2);
     expect(deadMalformed).toEqual({ status: "dead", last_error: "unparseable payload" });
     expect(rows.every((row) => row.status === "pending")).toBe(true);
     expect(rows.every((row) => row.attempts === 0)).toBe(true);
@@ -1358,14 +1358,14 @@ describe("createSqliteQueue (durable #980)", () => {
     }));
     expect(byType.get("blocked-installation")?.last_error).toBe("API rate limit exceeded for installation ID 123");
     expect(byType.get("agent-regate-pr:9")?.last_error).toBe("github rate-limit budget deferred");
-    expect(byType.get("agent-regate-pr:10")?.last_error).toBe("github rate-limit budget deferred");
+    expect(byType.has("agent-regate-pr:10")).toBe(false);
     expect(q.stats()).toMatchObject({
-      gittensory_jobs_processed_total: 2,
+      gittensory_jobs_processed_total: 3,
       gittensory_jobs_rate_limited_total: 1,
-      gittensory_jobs_rate_limit_deferred_total: 2,
+      gittensory_jobs_rate_limit_deferred_total: 1,
     });
     const metrics = await renderMetrics();
-    expect(metrics).toContain('gittensory_jobs_rate_limit_budget_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 2');
+    expect(metrics).toContain('gittensory_jobs_rate_limit_budget_deferred_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
     expect(metrics).toContain('gittensory_jobs_rate_limited_by_type_total{job_type="github-webhook",key_scope="installation",kind="webhook"} 1');
   });
 


### PR DESCRIPTION
### Motivation
- Public GitHub REST observations for the shared `GITHUB_PUBLIC_TOKEN` are now persisted with the `public-token` admission key, but self-host queue admission still only matched installation keys or legacy NULL rows, causing public-token-depleted observations to be ignored for no-installation background jobs.
- The change ensures background jobs that run against the shared public token are pre-yielded when the public-token bucket is exhausted, preventing unnecessary queue/API churn.

### Description
- Route GitHub-budget background jobs without an installation id to the shared public-token admission bucket by updating `githubRateLimitAdmissionTargetForJob` in `src/selfhost/queue-common.ts` to use `admissionKey ?? githubRateLimitAdmissionKeyForPublicToken()` for background jobs.
- Add unit coverage for the new targeting behavior and for preserving webhook semantics in `test/unit/selfhost-queue-common.test.ts`.
- Update SQLite queue tests to assert `admission_key='public-token'` observations pre-yield public-token background work and update metric expectations in `test/unit/selfhost-sqlite-queue.test.ts`.
- Update Postgres queue tests to assert public-token admission behavior and adjust keyed-rate-limit retry expectations in `test/unit/selfhost-pg-queue.test.ts`.

### Testing
- Ran focused unit tests: `npx vitest run test/unit/selfhost-queue-common.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts` and the suite passed (all tests in those files passed).
- Ran quick repository checks: `git diff --check` and `npm run typecheck` which succeeded locally.
- Attempted full local gate `npm run test:ci` and `npm audit --audit-level=moderate` but these were blocked by environment/network limitations (actionlint setup could not reach github.com and `npm audit` returned 403 from the registry), so the full `test:ci` run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44de395530832cbc5039c9ed136ffe)