### PR TITLE
fix(review): ignore suppressed check-run writes

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -53,6 +53,7 @@ export {
 type CheckRunResponse = {
   id: number;
   html_url?: string;
+  dryRunSuppressed?: boolean;
 };
 
 type CheckRunListResponse = {
@@ -624,7 +625,7 @@ async function createOrUpdateNamedCheckRun(
     const detailsUrlBody = detailsUrl ? { details_url: detailsUrl } : {};
 
     // POST a fresh check-run THIS App owns. Used for a brand-new run AND as the cross-app fallback below.
-    const postNewCheckRun = async (): Promise<CheckRunOutcome> => {
+    const postNewCheckRun = async (): Promise<CheckRunOutcome | null> => {
       const response = await octokit.request(
         "POST /repos/{owner}/{repo}/check-runs",
         {
@@ -727,8 +728,8 @@ async function createOrUpdateNamedCheckRun(
         }
       }
     };
-    const finish = async (outcome: CheckRunOutcome): Promise<CheckRunOutcome> => {
-      await finalizeLegacyPendingCheckRuns();
+    const finish = async (outcome: CheckRunOutcome | null): Promise<CheckRunOutcome | null> => {
+      if (outcome) await finalizeLegacyPendingCheckRuns();
       return outcome;
     };
 
@@ -796,7 +797,8 @@ function outputForCheckRunUpdate(output: CheckRunOutput): CheckRunOutput {
   return safeOutput;
 }
 
-function publishedOutcome(data: CheckRunResponse): CheckRunOutcome {
+function publishedOutcome(data: CheckRunResponse): CheckRunOutcome | null {
+  if (data.dryRunSuppressed) return null;
   const outcome: { kind: "published"; id: number; html_url?: string } = {
     kind: "published",
     id: data.id,

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -108,6 +108,47 @@ describe("GitHub check runs", () => {
     ).toBe(true);
   });
 
+  it("returns no published check-run outcome for dry-run suppressed writes", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        calls.push(`${init?.method ?? "GET"} ${url}`);
+        if (url.includes("/access_tokens"))
+          return Response.json({ token: "installation-token" });
+        if (url.includes("/check-runs"))
+          return Response.json({ check_runs: [] });
+        return new Response("not found", { status: 404 });
+      },
+    );
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    const result = await createOrUpdateGateCheckRun(
+      env,
+      123,
+      "JSONbored/gittensory",
+      gateAdvisory("dry-run-gate"),
+      {},
+      {},
+      "dry_run",
+    );
+
+    expect(result).toBeNull();
+    expect(
+      calls.some(
+        (call) => call.startsWith("POST ") && call.includes("/check-runs"),
+      ),
+    ).toBe(false);
+    const audit = await env.DB.prepare(
+      "SELECT detail FROM audit_events WHERE event_type = ?",
+    )
+      .bind("github.write.suppressed")
+      .first<{ detail: string }>();
+    expect(audit?.detail).toContain("suppressed POST");
+  });
+
   it("accepts GitHub App RSA private key PEMs for installation tokens", async () => {
     const privateKey = generateRsaPrivateKeyPem();
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {


### PR DESCRIPTION
### Motivation
- Non-live modes (dry-run/paused) returned synthetic successful check-run responses that downstream code treated as real `published` outcomes, seeding local Gate publication state and hiding missing real GitHub writes. 
- The change prevents synthetic/dry-run responses from finalizing Gate publication state so sweeps and repair logic remain correct.

### Description
- Add a `dryRunSuppressed?: boolean` field to the `CheckRunResponse` type and make `publishedOutcome` return `null` when that flag is present so suppressed writes are not treated as `published` outcomes. 
- Allow check-run helpers to return `null` (changed `postNewCheckRun`/`finish` signatures) and only finalize legacy pending Gate checks when a real published outcome exists. 
- Add a regression unit test that exercises `createOrUpdateGateCheckRun` in `dry_run` mode and asserts the write was suppressed (no network POST to `/check-runs`), an audit event was written, and no `published` outcome was returned.

### Testing
- Ran the focused unit suite with `npx vitest run test/unit/github-app.test.ts test/unit/github-client.test.ts` and all tests passed (108 tests total). 
- Ran type checking with `npm run typecheck` and it passed. 
- Attempted the full gate `npm run test:ci` and `npm audit --audit-level=moderate` but those were blocked in this environment due to network/actionlint/npm registry access issues, so full CI was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4575d29ffc832c8edd80d3f58f210c)