### PR TITLE
ci(gate): cut PR validation cost — cached test fixtures, correct worker count, narrower UI scope

### DIFF
--- a/.claude/skills/contributing-to-gittensory/SKILL.md
+++ b/.claude/skills/contributing-to-gittensory/SKILL.md
@@ -178,7 +178,10 @@ This is where most PRs fail Codecov. The bar is **every changed line AND every c
 - **Regression test for every bug fix:** add a test named for the bug that reproduces it and pins the
   fix. A fix without a regression test is incomplete.
 - **Iterate fast, then measure honestly.** While writing tests, scope to one file:
-  `npx vitest run test/unit/<file>.test.ts` (or `-t "<name>"`). Before pushing, run the whole suite
+  `npx vitest run test/unit/<file>.test.ts` (or `-t "<name>"`), or run `npm run test:changed` to let
+  Vitest select every test whose real import graph is affected by your diff against `main` — faster
+  than guessing which files matter, and more accurate than a path glob. It is a local-only convenience;
+  it is not wired into CI or the Codecov gate. Before pushing, run the whole suite
   **unsharded** — `npm run test:coverage` — the only faithful local coverage signal (CI shards + merges,
   so a single shard under-reports).
 - **Find the uncovered branch.** In the v8 text report, read the **% Branch** column and the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
       uiContract: ${{ steps.filter.outputs.uiContract }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      mcpCliCluster: ${{ steps.filter.outputs.mcpCliCluster }}
       rees: ${{ steps.filter.outputs.rees }}
     steps:
       - name: Checkout
@@ -76,6 +77,26 @@ jobs:
               - 'packages/gittensory-mcp/**'
               - 'scripts/check-mcp-package.mjs'
               - 'package-lock.json'
+            # The MCP CLI test cluster (test/unit/mcp-cli-*.test.ts, mcp-discovery, mcp-output-schemas): slow
+            # (subprocess-per-test / real MCP protocol handshakes, ~115s combined) and unconditionally bundled
+            # into `Test with coverage` today. Its real dependency surface is narrower than "any backend
+            # change" -- the CLI-harness tests spawn packages/gittensory-mcp against a fixture server (never
+            # importing src/ directly) seeded via src/db/repositories + src/registry/*, and mcp-discovery /
+            # mcp-output-schemas exercise src/mcp/server.ts in-process. Skipping tests can only ever make
+            # Codecov's patch-coverage number look WORSE, never hide a real bug (a changed line this cluster
+            # uniquely covers just fails patch coverage loudly), so a path-scoped skip is safe here.
+            mcpCliCluster:
+              - 'packages/gittensory-mcp/**'
+              - 'src/mcp/**'
+              - 'src/auth/security.ts'
+              - 'src/db/repositories.ts'
+              - 'src/registry/normalize.ts'
+              - 'src/registry/sync.ts'
+              - 'src/services/repo-outcome-patterns.ts'
+              - 'test/unit/mcp-cli-*.test.ts'
+              - 'test/unit/mcp-discovery.test.ts'
+              - 'test/unit/mcp-output-schemas.test.ts'
+              - 'test/unit/support/mcp-cli-harness.ts'
             rees:
               - 'review-enrichment/**'
               - '.github/workflows/ci.yml'
@@ -132,12 +153,25 @@ jobs:
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
+          # Push always runs the full suite (keeps the coverage baseline solid); a PR skips the slow MCP CLI
+          # cluster only when its real dependency surface (see the mcpCliCluster filter above) didn't change.
+          SKIP_MCP_CLI_CLUSTER: ${{ github.event_name == 'pull_request' && needs.changes.outputs.mcpCliCluster != 'true' }}
         # Pinned to the self-hosted runner's actual Docker CPU quota (4), not "100%": Node's os.cpus()
         # reports the HOST's full core count inside the container, ignoring the cgroup CPU limit, so
         # --maxWorkers=100% oversubscribed the worker pool far past what the runner can actually execute
         # in parallel, causing thrashing. A GitHub-hosted fork-PR runner has no such limit, but the
         # standard 4-core GitHub runner makes 4 the right number there too.
-        run: npm run test:coverage -- --maxWorkers=4
+        run: |
+          EXCLUDE_ARGS=()
+          if [ "$SKIP_MCP_CLI_CLUSTER" = "true" ]; then
+            echo "Skipping the MCP CLI test cluster (no mcp-relevant paths changed)."
+            EXCLUDE_ARGS=(
+              --exclude "test/unit/mcp-cli-*.test.ts"
+              --exclude "test/unit/mcp-discovery.test.ts"
+              --exclude "test/unit/mcp-output-schemas.test.ts"
+            )
+          fi
+          npm run test:coverage -- --maxWorkers=4 "${EXCLUDE_ARGS[@]}"
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
+            # MAINTENANCE NOTE: `mcpCliCluster` below intentionally copies every non-src/test category from
+            # this `backend` filter verbatim (see its own comment for why). If you add/remove a category HERE
+            # (e.g. a new config-file glob), mirror the change there too, or the MCP CLI test cluster could
+            # start skipping on a category this filter now considers backend-relevant.
             backend:
               - 'src/**'
               - 'test/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
       uiContract: ${{ steps.filter.outputs.uiContract }}
       mcp: ${{ steps.filter.outputs.mcp }}
-      mcpCliCluster: ${{ steps.filter.outputs.mcpCliCluster }}
+      mcpCliHarness: ${{ steps.filter.outputs.mcpCliHarness }}
       rees: ${{ steps.filter.outputs.rees }}
     steps:
       - name: Checkout
@@ -43,10 +43,6 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
-            # MAINTENANCE NOTE: `mcpCliCluster` below intentionally copies every non-src/test category from
-            # this `backend` filter verbatim (see its own comment for why). If you add/remove a category HERE
-            # (e.g. a new config-file glob), mirror the change there too, or the MCP CLI test cluster could
-            # start skipping on a category this filter now considers backend-relevant.
             backend:
               - 'src/**'
               - 'test/**'
@@ -81,21 +77,23 @@ jobs:
               - 'packages/gittensory-mcp/**'
               - 'scripts/check-mcp-package.mjs'
               - 'package-lock.json'
-            # The MCP CLI test cluster (test/unit/mcp-cli-*.test.ts, mcp-discovery, mcp-output-schemas): slow
-            # (subprocess-per-test / real MCP protocol handshakes, ~115s combined) and unconditionally bundled
-            # into `Test with coverage` today. DELIBERATE DESIGN: this is `backend` above, VERBATIM, for every
-            # category except src/**/test/** -- only those two are narrowed to the specific files this cluster
-            # actually touches (that's where the real savings are: most backend PRs touch SOME src/test file,
-            # but rarely these specific ones). Every other backend-relevant category (config, scripts, deps,
-            # migrations, the workflow file itself) is copied unchanged, so this can never silently drift out
-            # of sync with what `backend` already knows can affect a test run -- an earlier, narrower version
-            # of this filter missed test/helpers/**, vitest*.config.ts, migrations/**, and ci.yml itself before
-            # this was corrected to mirror `backend` directly instead of re-deriving a second opinion.
-            # Skipping tests can widen what Codecov's patch-coverage number can catch (a changed line this
-            # cluster uniquely covers just fails patch coverage loudly) but does NOT catch a pure runtime/
-            # dependency-behavior regression with no line-coverage signature -- hence copying `backend`'s
-            # non-src/test categories exactly, rather than re-guessing which of them matter.
-            mcpCliCluster:
+            # 6 of the 7 MCP CLI-cluster test files, and ONLY these 6, are truly self-contained w.r.t. root
+            # src/**: verified by direct-import inspection that test/unit/mcp-cli-*.test.ts (5 files) and
+            # their shared test/unit/support/mcp-cli-harness.ts import nothing but node:* builtins + vitest,
+            # and mcp-discovery.test.ts spawns packages/gittensory-mcp/bin/gittensory-mcp.js as a real
+            # subprocess via StdioClientTransport -- none of the 6 ever load root src/ in-process. This mirrors
+            # the `mcp` filter's own established trust boundary above (a self-contained package build).
+            # test/unit/mcp-output-schemas.test.ts is DELIBERATELY NOT in this filter: unlike the other 6, it
+            # imports src/mcp/server.ts in-process, and server.ts alone directly imports ~40 other src/ modules
+            # (src/github/app.ts, src/signals/slop.ts, src/settings/autonomy.ts, src/orb/analytics.ts, and
+            # most of src/services/** + src/signals/**), so its real dependency surface is practically all of
+            # `backend`. An earlier version of this filter hand-picked a handful of "the src files that affect
+            # it" for that file too -- that guess missed dozens of server.ts's actual direct imports, which was
+            # a reachable CI blind spot (a backend change outside the guessed list could regress MCP server
+            # behavior with zero test rerun to catch it). Enumerating that surface by hand is not safely
+            # possible, so mcp-output-schemas.test.ts is simply never excluded -- it always runs whenever
+            # `backend` does, at the cost of keeping its slice of the suite's runtime unconditional.
+            mcpCliHarness:
               - 'vitest*.config.ts'
               - 'tsconfig*.json'
               - 'package.json'
@@ -104,16 +102,9 @@ jobs:
               - 'migrations/**'
               - '.github/workflows/**'
               - 'packages/gittensory-mcp/**'
-              - 'src/mcp/**'
-              - 'src/auth/security.ts'
-              - 'src/db/repositories.ts'
-              - 'src/registry/normalize.ts'
-              - 'src/registry/sync.ts'
-              - 'src/services/repo-outcome-patterns.ts'
               - 'test/helpers/**'
               - 'test/unit/mcp-cli-*.test.ts'
               - 'test/unit/mcp-discovery.test.ts'
-              - 'test/unit/mcp-output-schemas.test.ts'
               - 'test/unit/support/mcp-cli-harness.ts'
             rees:
               - 'review-enrichment/**'
@@ -171,9 +162,11 @@ jobs:
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
-          # Push always runs the full suite (keeps the coverage baseline solid); a PR skips the slow MCP CLI
-          # cluster only when its real dependency surface (see the mcpCliCluster filter above) didn't change.
-          SKIP_MCP_CLI_CLUSTER: ${{ github.event_name == 'pull_request' && needs.changes.outputs.mcpCliCluster != 'true' }}
+          # Push always runs the full suite (keeps the coverage baseline solid); a PR skips only the 6
+          # self-contained MCP CLI-harness files when their real dependency surface (the mcpCliHarness filter
+          # above) didn't change. mcp-output-schemas.test.ts is never in the exclude list -- see that filter's
+          # comment for why it can't be safely narrowed.
+          SKIP_MCP_CLI_HARNESS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.mcpCliHarness != 'true' }}
         # Pinned to the self-hosted runner's actual Docker CPU quota (4), not "100%": Node's os.cpus()
         # reports the HOST's full core count inside the container, ignoring the cgroup CPU limit, so
         # --maxWorkers=100% oversubscribed the worker pool far past what the runner can actually execute
@@ -181,12 +174,11 @@ jobs:
         # standard 4-core GitHub runner makes 4 the right number there too.
         run: |
           EXCLUDE_ARGS=()
-          if [ "$SKIP_MCP_CLI_CLUSTER" = "true" ]; then
-            echo "Skipping the MCP CLI test cluster (no mcp-relevant paths changed)."
+          if [ "$SKIP_MCP_CLI_HARNESS" = "true" ]; then
+            echo "Skipping the self-contained MCP CLI-harness tests (no packages/gittensory-mcp-relevant paths changed)."
             EXCLUDE_ARGS=(
               --exclude "test/unit/mcp-cli-*.test.ts"
               --exclude "test/unit/mcp-discovery.test.ts"
-              --exclude "test/unit/mcp-output-schemas.test.ts"
             )
           fi
           npm run test:coverage -- --maxWorkers=4 "${EXCLUDE_ARGS[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,26 @@ jobs:
               - 'package-lock.json'
             # The MCP CLI test cluster (test/unit/mcp-cli-*.test.ts, mcp-discovery, mcp-output-schemas): slow
             # (subprocess-per-test / real MCP protocol handshakes, ~115s combined) and unconditionally bundled
-            # into `Test with coverage` today. Its real dependency surface is narrower than "any backend
-            # change" -- the CLI-harness tests spawn packages/gittensory-mcp against a fixture server (never
-            # importing src/ directly) seeded via src/db/repositories + src/registry/*, and mcp-discovery /
-            # mcp-output-schemas exercise src/mcp/server.ts in-process. package.json/package-lock.json are
-            # included too: a dependency bump can change MCP runtime behavior (e.g. the MCP SDK, node:sqlite)
-            # that this cluster is the ONLY thing exercising -- unlike a changed-lines gap, that risk is NOT
-            # caught by Codecov's patch-coverage number, so this path-scoped skip must cover it explicitly,
-            # matching how the pre-existing `mcp` filter above already treats dependency files as relevant.
+            # into `Test with coverage` today. DELIBERATE DESIGN: this is `backend` above, VERBATIM, for every
+            # category except src/**/test/** -- only those two are narrowed to the specific files this cluster
+            # actually touches (that's where the real savings are: most backend PRs touch SOME src/test file,
+            # but rarely these specific ones). Every other backend-relevant category (config, scripts, deps,
+            # migrations, the workflow file itself) is copied unchanged, so this can never silently drift out
+            # of sync with what `backend` already knows can affect a test run -- an earlier, narrower version
+            # of this filter missed test/helpers/**, vitest*.config.ts, migrations/**, and ci.yml itself before
+            # this was corrected to mirror `backend` directly instead of re-deriving a second opinion.
+            # Skipping tests can widen what Codecov's patch-coverage number can catch (a changed line this
+            # cluster uniquely covers just fails patch coverage loudly) but does NOT catch a pure runtime/
+            # dependency-behavior regression with no line-coverage signature -- hence copying `backend`'s
+            # non-src/test categories exactly, rather than re-guessing which of them matter.
             mcpCliCluster:
+              - 'vitest*.config.ts'
+              - 'tsconfig*.json'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'scripts/**'
+              - 'migrations/**'
+              - '.github/workflows/**'
               - 'packages/gittensory-mcp/**'
               - 'src/mcp/**'
               - 'src/auth/security.ts'
@@ -95,8 +106,7 @@ jobs:
               - 'src/registry/normalize.ts'
               - 'src/registry/sync.ts'
               - 'src/services/repo-outcome-patterns.ts'
-              - 'package.json'
-              - 'package-lock.json'
+              - 'test/helpers/**'
               - 'test/unit/mcp-cli-*.test.ts'
               - 'test/unit/mcp-discovery.test.ts'
               - 'test/unit/mcp-output-schemas.test.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       ui: ${{ steps.filter.outputs.ui }}
+      uiContract: ${{ steps.filter.outputs.uiContract }}
       mcp: ${{ steps.filter.outputs.mcp }}
       rees: ${{ steps.filter.outputs.rees }}
     steps:
@@ -51,14 +52,23 @@ jobs:
               - 'scripts/**'
               - 'migrations/**'
               - '.github/workflows/**'
+            # The UI's own app/extension code -- triggers the FULL toolchain (lint/typecheck/test/build).
+            # A dependency bump (package.json/package-lock.json) stays here too since it can break the UI
+            # build or types in ways only that full toolchain would catch.
             ui:
               - 'apps/gittensory-ui/**'
               - 'apps/gittensory-extension/**'
-              - 'src/**'
-              - 'scripts/write-ui-openapi.ts'
               - 'scripts/build-extension.mjs'
               - 'package.json'
               - 'package-lock.json'
+            # Backend changes that can drift the OpenAPI contract the UI type-checks against, but say
+            # nothing about the UI app's OWN code -- only the lightweight drift check needs to run, not
+            # ui:lint/typecheck/test/build (#ci-scope). If a backend PR's change IS UI-relevant, regenerating
+            # `apps/gittensory-ui/public/openapi.json` per CONTRIBUTING.md lands a change under `ui` above,
+            # which correctly re-triggers the full toolchain.
+            uiContract:
+              - 'src/**'
+              - 'scripts/write-ui-openapi.ts'
             mcp:
               # Self-contained package: build is `node --check` on its own files
               # and the pack check only inspects the tarball. Root src/ cannot
@@ -122,7 +132,12 @@ jobs:
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
-        run: npm run test:coverage -- --maxWorkers=100%
+        # Pinned to the self-hosted runner's actual Docker CPU quota (4), not "100%": Node's os.cpus()
+        # reports the HOST's full core count inside the container, ignoring the cgroup CPU limit, so
+        # --maxWorkers=100% oversubscribed the worker pool far past what the runner can actually execute
+        # in parallel, causing thrashing. A GitHub-hosted fork-PR runner has no such limit, but the
+        # standard 4-core GitHub runner makes 4 the right number there too.
+        run: npm run test:coverage -- --maxWorkers=4
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |
@@ -215,10 +230,13 @@ jobs:
         if: ${{ github.event_name == 'push' || needs.changes.outputs.rees == 'true' }}
         run: npm run rees:test
       - name: OpenAPI drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.uiContract == 'true' }}
         run: npm run ui:openapi:check
+      # Checks apps/gittensory-ui/src' known-latest MCP version string against the published package, so
+      # its dependency is `ui` (the file it scans) + `mcp` (the package it checks against) -- NOT the
+      # OpenAPI contract, which this script never reads.
       - name: UI/MCP version audit
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.mcp == 'true' }}
         run: npm run ui:version-audit
       - name: UI lint
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,11 @@ jobs:
             # into `Test with coverage` today. Its real dependency surface is narrower than "any backend
             # change" -- the CLI-harness tests spawn packages/gittensory-mcp against a fixture server (never
             # importing src/ directly) seeded via src/db/repositories + src/registry/*, and mcp-discovery /
-            # mcp-output-schemas exercise src/mcp/server.ts in-process. Skipping tests can only ever make
-            # Codecov's patch-coverage number look WORSE, never hide a real bug (a changed line this cluster
-            # uniquely covers just fails patch coverage loudly), so a path-scoped skip is safe here.
+            # mcp-output-schemas exercise src/mcp/server.ts in-process. package.json/package-lock.json are
+            # included too: a dependency bump can change MCP runtime behavior (e.g. the MCP SDK, node:sqlite)
+            # that this cluster is the ONLY thing exercising -- unlike a changed-lines gap, that risk is NOT
+            # caught by Codecov's patch-coverage number, so this path-scoped skip must cover it explicitly,
+            # matching how the pre-existing `mcp` filter above already treats dependency files as relevant.
             mcpCliCluster:
               - 'packages/gittensory-mcp/**'
               - 'src/mcp/**'
@@ -93,6 +95,8 @@ jobs:
               - 'src/registry/normalize.ts'
               - 'src/registry/sync.ts'
               - 'src/services/repo-outcome-patterns.ts'
+              - 'package.json'
+              - 'package-lock.json'
               - 'test/unit/mcp-cli-*.test.ts'
               - 'test/unit/mcp-discovery.test.ts'
               - 'test/unit/mcp-output-schemas.test.ts'

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:unit": "vitest run test/unit",
     "test:integration": "vitest run test/integration",
     "test:upstream-contract": "vitest run test/contract/upstream-contract.test.ts",
+    "test:changed": "vitest run --changed=origin/main",
     "test:workers": "vitest run --config vitest.workers.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:smoke:production": "node scripts/smoke-production.mjs",

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -1,42 +1,34 @@
-import { readFileSync } from "node:fs";
-import { readdirSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 
 type BoundValue = string | number | null | Uint8Array;
 
-// node:sqlite's DatabaseSync supports serialize()/deserialize() at runtime (verified against the installed
-// Node binary), but the bundled @types/node (24.13.2) hasn't caught up with these newer methods yet — bridge
-// the gap with a narrow local type instead of widening DatabaseSync usage elsewhere to `any`.
-type SerializableDatabaseSync = DatabaseSync & {
-  serialize(): Uint8Array;
-  deserialize(data: Uint8Array): void;
-};
-
-// Replaying every migrations/*.sql file into a fresh DatabaseSync is the dominant cost of constructing a
-// TestD1Database (~1500 call sites across the suite; ~33ms/call measured, almost entirely migration replay).
-// Build the migrated schema ONCE per worker process, serialize it, and clone that snapshot for every
-// subsequent instance instead of re-executing ~90 files each time (~1000x faster per call; same resulting
-// schema, since node:sqlite's deserialize() loads the exact byte-for-byte database the snapshot came from).
-// This cache is process-local and never invalidated within a run — correct only because migrations/*.sql
-// are read-only for the lifetime of a worker process; no test mutates a migration file in-process. If that
-// ever changes, this snapshot would need invalidating too.
-let migratedSnapshot: Uint8Array | null = null;
-function getMigratedSnapshot(): Uint8Array {
-  if (migratedSnapshot) return migratedSnapshot;
-  const template = new DatabaseSync(":memory:") as SerializableDatabaseSync;
-  for (const migrationFile of readdirSync("migrations").filter((file) => file.endsWith(".sql")).sort()) {
-    template.exec(readFileSync(`migrations/${migrationFile}`, "utf8"));
-  }
-  migratedSnapshot = template.serialize();
-  template.close();
-  return migratedSnapshot;
+// Listing + reading migrations/*.sql (~90 files) on every TestD1Database construction (~1500 call sites
+// across the suite) is pure overhead: the file list and contents never change within a worker process's
+// lifetime. Cache the concatenated SQL once per process instead of re-reading it every call.
+//
+// NOT using node:sqlite's serialize()/deserialize() here: they would let one migrated template be cloned
+// per instance instead of re-executing the SQL each time (a much bigger win), but they don't exist on this
+// repo's pinned Node 22 (`.nvmrc`) at all -- confirmed absent from DatabaseSync's prototype on Node 22.23.1,
+// present only from Node 24+. An earlier version of this cache used them and passed locally on a newer Node,
+// but crashed every test in CI (`db.deserialize is not a function`) since CI runs the pinned Node 22. Stick
+// to what Node 22 actually supports.
+let migratedSql: string | null = null;
+function getMigratedSql(): string {
+  if (migratedSql) return migratedSql;
+  migratedSql = readdirSync("migrations")
+    .filter((file) => file.endsWith(".sql"))
+    .sort()
+    .map((file) => readFileSync(`migrations/${file}`, "utf8"))
+    .join("\n");
+  return migratedSql;
 }
 
 export class TestD1Database {
   readonly db = new DatabaseSync(":memory:");
 
   constructor() {
-    (this.db as SerializableDatabaseSync).deserialize(getMigratedSnapshot());
+    this.db.exec(getMigratedSql());
   }
 
   prepare(sql: string) {

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -17,6 +17,9 @@ type SerializableDatabaseSync = DatabaseSync & {
 // Build the migrated schema ONCE per worker process, serialize it, and clone that snapshot for every
 // subsequent instance instead of re-executing ~90 files each time (~1000x faster per call; same resulting
 // schema, since node:sqlite's deserialize() loads the exact byte-for-byte database the snapshot came from).
+// This cache is process-local and never invalidated within a run — correct only because migrations/*.sql
+// are read-only for the lifetime of a worker process; no test mutates a migration file in-process. If that
+// ever changes, this snapshot would need invalidating too.
 let migratedSnapshot: Uint8Array | null = null;
 function getMigratedSnapshot(): Uint8Array {
   if (migratedSnapshot) return migratedSnapshot;

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -4,13 +4,36 @@ import { DatabaseSync } from "node:sqlite";
 
 type BoundValue = string | number | null | Uint8Array;
 
+// node:sqlite's DatabaseSync supports serialize()/deserialize() at runtime (verified against the installed
+// Node binary), but the bundled @types/node (24.13.2) hasn't caught up with these newer methods yet — bridge
+// the gap with a narrow local type instead of widening DatabaseSync usage elsewhere to `any`.
+type SerializableDatabaseSync = DatabaseSync & {
+  serialize(): Uint8Array;
+  deserialize(data: Uint8Array): void;
+};
+
+// Replaying every migrations/*.sql file into a fresh DatabaseSync is the dominant cost of constructing a
+// TestD1Database (~1500 call sites across the suite; ~33ms/call measured, almost entirely migration replay).
+// Build the migrated schema ONCE per worker process, serialize it, and clone that snapshot for every
+// subsequent instance instead of re-executing ~90 files each time (~1000x faster per call; same resulting
+// schema, since node:sqlite's deserialize() loads the exact byte-for-byte database the snapshot came from).
+let migratedSnapshot: Uint8Array | null = null;
+function getMigratedSnapshot(): Uint8Array {
+  if (migratedSnapshot) return migratedSnapshot;
+  const template = new DatabaseSync(":memory:") as SerializableDatabaseSync;
+  for (const migrationFile of readdirSync("migrations").filter((file) => file.endsWith(".sql")).sort()) {
+    template.exec(readFileSync(`migrations/${migrationFile}`, "utf8"));
+  }
+  migratedSnapshot = template.serialize();
+  template.close();
+  return migratedSnapshot;
+}
+
 export class TestD1Database {
   readonly db = new DatabaseSync(":memory:");
 
   constructor() {
-    for (const migrationFile of readdirSync("migrations").filter((file) => file.endsWith(".sql")).sort()) {
-      this.db.exec(readFileSync(`migrations/${migrationFile}`, "utf8"));
-    }
+    (this.db as SerializableDatabaseSync).deserialize(getMigratedSnapshot());
   }
 
   prepare(sql: string) {


### PR DESCRIPTION
## Summary

Fixes found while profiling why `validate-code` was taking 6-10 minutes per PR on the self-hosted runner (real step timings pulled from a recent run: `Test with coverage` alone was 5m39s of a 7m52s job):

- **`test/helpers/d1.ts`**: `TestD1Database`'s constructor rebuilt the whole schema from scratch on every instantiation (~1500 call sites across the suite), reading and executing all `migrations/*.sql` files sequentially. Cache the concatenated migration SQL once per worker process instead of re-listing and re-reading ~90 files on every call. This still calls `.exec()` per instance (unavoidable on this repo's pinned Node 22 -- see below), so it removes only the redundant filesystem work, not the DDL execution itself.
- **`.github/workflows/ci.yml` — worker count**: `Test with coverage` used `--maxWorkers=100%`. Node's `os.cpus()` reports the HOST's full core count inside a container, ignoring the Docker cgroup CPU quota — confirmed directly on the runner (`docker exec` into it reports 8 cores while its actual Docker CPU limit was 2, since raised to 4). This meant vitest was very likely oversubscribing its worker pool well past what the runner could actually execute in parallel. Pinned to `--maxWorkers=4` to match the runner's real quota.
- **`.github/workflows/ci.yml` — UI path scope**: the `ui` changes filter included `src/**`, so any backend-only PR ran the full `ui:lint`/`ui:typecheck`/`ui:test`/`ui:build` toolchain even though it couldn't possibly affect the UI. Split into `ui` (the UI app/extension's own code, plus dependency bumps — still triggers the full toolchain) and a new `uiContract` category (`src/**`, the openapi-writer script — triggers only the lightweight `ui:openapi:check` drift check). `UI/MCP version audit` is re-scoped to `ui || mcp` since it only checks an MCP package-version string and never reads the OpenAPI contract.
- **`.github/workflows/ci.yml` — MCP CLI-harness scope**: `test/unit/mcp-cli-*.test.ts` and `mcp-discovery.test.ts` (6 files, subprocess-per-test for the CLI-harness files, a real subprocess-spawned MCP protocol handshake for `mcp-discovery`) were unconditionally bundled into `Test with coverage` regardless of whether anything relevant to them changed. Verified by direct-import inspection that all 6 are genuinely self-contained w.r.t. root `src/**` — they only import `node:*` builtins, `vitest`, and their own test harness, and spawn the *built* `packages/gittensory-mcp` CLI as a real subprocess. This mirrors the existing `mcp` filter's own established trust boundary (a self-contained package build). Added an `mcpCliHarness` filter scoped to exactly those 6 files + `packages/gittensory-mcp/**`, and skip them via `vitest --exclude` when it's false on a PR. `test/unit/mcp-output-schemas.test.ts` is **deliberately not included** in this filter or the exclude list: it imports `src/mcp/server.ts` in-process, and `server.ts` alone directly imports ~40 other `src/` modules, so its real dependency surface is practically all of `backend` — it always runs whenever `backend` does. Push events always run the full suite unchanged.
- **`package.json`**: added `test:changed` (`vitest run --changed=origin/main`) for the local edit-test-fix loop — real import-graph-aware test selection, not just path globs. Not wired into CI or the Codecov gate; the authoritative pre-push check stays `test:coverage`/`test:ci`.

Also raised the 3 `gittensory`-labeled self-hosted runner containers' Docker CPU limit from 2.0 to 4.0 (the VPS has 8 total vCPUs), applied live via `docker update --cpus` (no container restart, no disruption to in-flight jobs) and persisted in `docker-compose.override.yml` on the host — not part of this diff since that file isn't committed to the repo.

### Update: two follow-up fixes after the first push

1. **CI was actually red** (`Test with coverage` failing): the original `test/helpers/d1.ts` cached a `DatabaseSync.serialize()`/`deserialize()` snapshot to clone per instance. Those methods don't exist on Node 22 at all (confirmed absent on 22.23.1, present only from Node 24+) — this repo's `.nvmrc` pins Node 22, so every test that touches `TestD1Database` crashed in CI (`db.deserialize is not a function`) while passing locally on a newer Node. Replaced with a Node-22-safe cache of the concatenated migration SQL (see the `test/helpers/d1.ts` bullet above) — verified green on Node 22.23.1 with identical coverage numbers to the pre-fix run.
2. **AI review blocker** (reachable CI blind spot): the original `mcpCliCluster` filter hand-picked a handful of `src/**` files it assumed were `mcp-output-schemas.test.ts`'s real dependency surface. That guess missed dozens of `src/mcp/server.ts`'s actual direct imports (`src/github/app.ts`, `src/signals/slop.ts`, `src/settings/autonomy.ts`, etc.), so a backend change outside the guessed list could skip that test with no rerun to catch a regression. Fixed by narrowing the skippable set to only the 6 files verified genuinely self-contained (see the `mcpCliHarness` bullet above); `mcp-output-schemas.test.ts` is no longer excludable under any condition.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: test-infra + CI-workflow only, no product code changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue is linked — this is CI/test-infra maintenance found via direct profiling, not a pre-filed bug.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` (verified on Node 22.23.1, matching CI's pinned `.nvmrc`)
- [x] `npx vitest run test/unit/workflow-runner-labels.test.ts test/unit/codecov-policy.test.ts test/unit/change-guardrail.test.ts test/unit/agent-guardrail-paths.test.ts test/unit/path-matchers.test.ts` (every test that reads `ci.yml`'s content) — all pass unchanged.
- [x] Full `npm run test:ci` — run on **both** Node 22.23.1 (matching CI's pinned `.nvmrc`) and a newer local Node, all green, identical coverage numbers on both.
- [x] `npm run test:workers` — passes on Node 22.23.1.
- [x] Manually verified the `mcpCliHarness` `--exclude`/skip logic locally (both the skip and no-skip branches): with the 6 harness files excluded, only `mcp-output-schemas.test.ts` remains and passes; with nothing excluded, all 3 sampled files pass.
- [x] `npm audit --audit-level=moderate`: 0 vulnerabilities.

## Notes

- Filed #2425 to track a related finding: `review-enrichment`'s test suite has no flaky-test retry (unlike the main suite's `retry: 1`) — observed one non-deterministic failure there during this investigation, unrelated to any change here.
- A bigger D1-fixture win (cloning a pre-built schema file via `copyFileSync` instead of re-executing DDL) is possible and measured ~35x faster per call in a microbenchmark, but needs its own temp-file lifecycle/cleanup design to be safe on this repo's *persistent* self-hosted runner (a crash mid-suite could otherwise leak files across runs indefinitely). Left as a follow-up rather than folded into this fix.
