### PR TITLE
test(predicted-gate): add engine parity fixture corpus (#2285)

### DIFF
--- a/test/fixtures/engine-parity/predicted-gate/README.md
+++ b/test/fixtures/engine-parity/predicted-gate/README.md
@@ -1,0 +1,16 @@
+# Predicted Gate Parity Fixtures
+
+These fixtures are the scenario corpus for [issue #2285](https://github.com/JSONbored/gittensory/issues/2285).
+Each file exports one complete, self-contained `buildPredictedGateVerdict` input plus the expected high-level
+surface it should produce today. The follow-up parity runner can reuse the same inputs to snapshot full outputs.
+
+| Fixture | Scenario / branch | Expected conclusion | Expected finding codes |
+| --- | --- | --- | --- |
+| `clean-pass-gittensor.ts` | Clean pass under the default `gittensor` pack | `success` | none |
+| `clean-pass-oss-anti-slop.ts` | Clean pass under `oss-anti-slop`, including the public funnel | `success` | none |
+| `duplicate-pr-block.ts` | Open sibling PR sharing the linked issue | `failure` | `duplicate_pr_risk` |
+| `missing-linked-issue-block.ts` | `linkedIssue:block` with no linked issue in the body or metadata | `failure` | `missing_linked_issue` |
+| `manifest-blocked-path.ts` | `manifestPolicy:block` with a changed path that hits `blockedPaths` | `neutral` | `manifest_blocked_path` |
+| `readiness-warning.ts` | `gate.readiness.mode=advisory` with a threshold above the public readiness score | `success` | `readiness_score_below_threshold` |
+| `path-gated-check-with-paths.ts` | Enforced `review.pre_merge_checks` rule once matching `changedPaths` are supplied | `failure` | `pre_merge_check_required` |
+| `path-gated-check-without-paths.ts` | The same path-gated pre-merge rule before `changedPaths` are known | `success` | none |

--- a/test/fixtures/engine-parity/predicted-gate/_shared.ts
+++ b/test/fixtures/engine-parity/predicted-gate/_shared.ts
@@ -1,0 +1,82 @@
+import { parseFocusManifest, type FocusManifest } from "../../../../src/signals/focus-manifest";
+import type { PredictedGateInput, PredictedGateVerdict } from "../../../../src/rules/predicted-gate";
+import type { IssueRecord, PullRequestRecord, RepositoryRecord } from "../../../../src/types";
+
+export type PredictedGateFixture = {
+  id: string;
+  title: string;
+  branch: string;
+  input: PredictedGateInput;
+  manifest: FocusManifest;
+  repo: RepositoryRecord | null;
+  issues: IssueRecord[];
+  pullRequests: PullRequestRecord[];
+  changedPaths?: string[] | undefined;
+  expected: {
+    conclusion: PredictedGateVerdict["conclusion"];
+    pack: PredictedGateVerdict["pack"];
+    blockerCodes: string[];
+    warningCodes: string[];
+    funnelPresent: boolean;
+    noteIncludes?: string[] | undefined;
+    noteExcludes?: string[] | undefined;
+  };
+};
+
+export const BASE_INPUT: PredictedGateInput = {
+  repoFullName: "acme/widgets",
+  contributorLogin: "miner1",
+  title: "Add retry to the upload client",
+  body: "Closes #7",
+  linkedIssues: [7],
+};
+
+export const BASE_REPO: RepositoryRecord = {
+  fullName: "acme/widgets",
+  owner: "acme",
+  name: "widgets",
+  isInstalled: true,
+  isRegistered: true,
+  isPrivate: false,
+  registryConfig: {
+    repo: "acme/widgets",
+    emissionShare: 0.1,
+    issueDiscoveryShare: 0,
+    labelMultipliers: {},
+    maintainerCut: 0,
+    raw: {},
+  },
+};
+
+export function definePredictedGateFixture(fixture: PredictedGateFixture): PredictedGateFixture {
+  return fixture;
+}
+
+export function parseManifest(raw: Record<string, unknown>): FocusManifest {
+  return parseFocusManifest(raw);
+}
+
+export function openIssue(number: number, title: string, authorLogin: string | null = "reporter"): IssueRecord {
+  return {
+    repoFullName: "acme/widgets",
+    number,
+    title,
+    state: "open",
+    labels: [],
+    linkedPrs: [],
+    authorAssociation: null,
+    authorLogin,
+  };
+}
+
+export function openPr(number: number, title: string, linkedIssues: number[] = [], authorLogin = "someone"): PullRequestRecord {
+  return {
+    repoFullName: "acme/widgets",
+    number,
+    title,
+    state: "open",
+    authorLogin,
+    linkedIssues,
+    labels: [],
+  };
+}

--- a/test/fixtures/engine-parity/predicted-gate/clean-pass-gittensor.ts
+++ b/test/fixtures/engine-parity/predicted-gate/clean-pass-gittensor.ts
@@ -1,0 +1,21 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// Clean pass: linked issue present, no open duplicate cluster, and no path-gated or manifest blockers.
+export default definePredictedGateFixture({
+  id: "clean-pass-gittensor",
+  title: "Clean pass under the default gittensor pack",
+  branch: "success path with no duplicate_pr_risk, no missing_linked_issue, and no path-dependent findings",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { duplicates: "block", linkedIssue: "advisory" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: false,
+    noteIncludes: ["public .gittensory.yml", "slop score is NOT evaluated pre-submission"],
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/clean-pass-oss-anti-slop.ts
+++ b/test/fixtures/engine-parity/predicted-gate/clean-pass-oss-anti-slop.ts
@@ -1,0 +1,21 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// Pack branch: oss-anti-slop keeps the same deterministic pass path but surfaces the public funnel.
+export default definePredictedGateFixture({
+  id: "clean-pass-oss-anti-slop",
+  title: "Clean pass under the oss-anti-slop pack",
+  branch: "pack selection branch with a public funnel and no duplicate, linked-issue, or path-policy findings",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { pack: "oss-anti-slop", duplicates: "block", linkedIssue: "advisory" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "oss-anti-slop",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: true,
+    noteIncludes: ["public .gittensory.yml", "slop score is NOT evaluated pre-submission"],
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/duplicate-pr-block.ts
+++ b/test/fixtures/engine-parity/predicted-gate/duplicate-pr-block.ts
@@ -1,0 +1,20 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, openPr, parseManifest } from "./_shared";
+
+// Duplicate cluster branch: another OPEN PR already claims the same linked issue.
+export default definePredictedGateFixture({
+  id: "duplicate-pr-block",
+  title: "Duplicate open PR blocks the predicted gate",
+  branch: "duplicate_pr_risk via another open sibling sharing the linked issue",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { duplicates: "block" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [openPr(42, "Retry uploads on 5xx responses", [7])],
+  expected: {
+    conclusion: "failure",
+    pack: "gittensor",
+    blockerCodes: ["duplicate_pr_risk"],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/index.ts
+++ b/test/fixtures/engine-parity/predicted-gate/index.ts
@@ -1,0 +1,21 @@
+import cleanPassGittensor from "./clean-pass-gittensor";
+import cleanPassOssAntiSlop from "./clean-pass-oss-anti-slop";
+import duplicatePrBlock from "./duplicate-pr-block";
+import manifestBlockedPath from "./manifest-blocked-path";
+import missingLinkedIssueBlock from "./missing-linked-issue-block";
+import pathGatedCheckWithPaths from "./path-gated-check-with-paths";
+import pathGatedCheckWithoutPaths from "./path-gated-check-without-paths";
+import readinessWarning from "./readiness-warning";
+
+export type { PredictedGateFixture } from "./_shared";
+
+export const predictedGateFixtures = [
+  cleanPassGittensor,
+  cleanPassOssAntiSlop,
+  duplicatePrBlock,
+  missingLinkedIssueBlock,
+  manifestBlockedPath,
+  readinessWarning,
+  pathGatedCheckWithPaths,
+  pathGatedCheckWithoutPaths,
+];

--- a/test/fixtures/engine-parity/predicted-gate/manifest-blocked-path.ts
+++ b/test/fixtures/engine-parity/predicted-gate/manifest-blocked-path.ts
@@ -1,0 +1,22 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// Focus-manifest policy branch: a changed path hits a blocked glob and manifestPolicy:block downgrades to HOLD.
+export default definePredictedGateFixture({
+  id: "manifest-blocked-path",
+  title: "Blocked manifest path yields a neutral hold",
+  branch: "manifest_blocked_path with changedPaths supplied and manifestPolicy:block",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { manifestPolicy: "block" }, blockedPaths: ["dist/**"] }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  changedPaths: ["dist/bundle.js"],
+  expected: {
+    conclusion: "neutral",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: ["manifest_blocked_path"],
+    funnelPresent: false,
+    noteExcludes: ["Provide the PR's changed paths"],
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/missing-linked-issue-block.ts
+++ b/test/fixtures/engine-parity/predicted-gate/missing-linked-issue-block.ts
@@ -1,0 +1,20 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, parseManifest } from "./_shared";
+
+// Linked-issue branch: the repo's public config requires an issue, but none is linked or inferred from the body.
+export default definePredictedGateFixture({
+  id: "missing-linked-issue-block",
+  title: "Missing linked issue blocks the predicted gate",
+  branch: "missing_linked_issue when linkedIssue:block and the body carries no issue reference",
+  input: { ...BASE_INPUT, body: "No linked issue yet", linkedIssues: [] },
+  manifest: parseManifest({ gate: { linkedIssue: "block" } }),
+  repo: BASE_REPO,
+  issues: [],
+  pullRequests: [],
+  expected: {
+    conclusion: "failure",
+    pack: "gittensor",
+    blockerCodes: ["missing_linked_issue"],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/path-gated-check-with-paths.ts
+++ b/test/fixtures/engine-parity/predicted-gate/path-gated-check-with-paths.ts
@@ -1,0 +1,24 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// changedPaths supplied: a path-gated pre-merge check becomes enforceable and fails.
+export default definePredictedGateFixture({
+  id: "path-gated-check-with-paths",
+  title: "Path-gated pre-merge check fails once changedPaths are known",
+  branch: "pre_merge_check_required when an enforced whenPaths rule matches the supplied changedPaths",
+  input: BASE_INPUT,
+  manifest: parseManifest({
+    review: { pre_merge_checks: [{ name: "Tests for src", title_contains: "ZZZ-never", when_paths: ["src/**"], enforce: true }] },
+  }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  changedPaths: ["src/upload/client.ts"],
+  expected: {
+    conclusion: "failure",
+    pack: "gittensor",
+    blockerCodes: ["pre_merge_check_required"],
+    warningCodes: [],
+    funnelPresent: false,
+    noteExcludes: ["Provide the PR's changed paths"],
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/path-gated-check-without-paths.ts
+++ b/test/fixtures/engine-parity/predicted-gate/path-gated-check-without-paths.ts
@@ -1,0 +1,23 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// changedPaths absent: the same path-gated check cannot be predicted yet and must stay silent.
+export default definePredictedGateFixture({
+  id: "path-gated-check-without-paths",
+  title: "Path-gated pre-merge check stays unresolved without changedPaths",
+  branch: "same review.pre_merge_checks rule as the changedPaths case, but skipped pre-submission without file paths",
+  input: BASE_INPUT,
+  manifest: parseManifest({
+    review: { pre_merge_checks: [{ name: "Tests for src", title_contains: "ZZZ-never", when_paths: ["src/**"], enforce: true }] },
+  }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: false,
+    noteIncludes: ["Provide the PR's changed paths"],
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/readiness-warning.ts
+++ b/test/fixtures/engine-parity/predicted-gate/readiness-warning.ts
@@ -1,0 +1,20 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, parseManifest } from "./_shared";
+
+// Readiness branch: the public readiness score falls below the manifest threshold, but stays advisory.
+export default definePredictedGateFixture({
+  id: "readiness-warning",
+  title: "Low readiness stays advisory",
+  branch: "readiness_score_below_threshold from gate.readiness.mode=advisory and a high threshold",
+  input: { ...BASE_INPUT, body: "", linkedIssues: [] },
+  manifest: parseManifest({ gate: { readiness: { mode: "advisory", minScore: 90 } } }),
+  repo: BASE_REPO,
+  issues: [],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: ["readiness_score_below_threshold"],
+    funnelPresent: false,
+  },
+});

--- a/test/unit/engine-parity-fixtures.test.ts
+++ b/test/unit/engine-parity-fixtures.test.ts
@@ -1,0 +1,42 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildPredictedGateVerdict } from "../../src/rules/predicted-gate";
+import { predictedGateFixtures } from "../fixtures/engine-parity/predicted-gate";
+
+const FIXTURE_DIR = join(process.cwd(), "test", "fixtures", "engine-parity", "predicted-gate");
+
+describe("predicted-gate engine parity fixtures", () => {
+  it("exports every scenario file through the fixture index", () => {
+    const scenarioFiles = readdirSync(FIXTURE_DIR)
+      .filter((name) => name.endsWith(".ts") && name !== "index.ts" && !name.startsWith("_"))
+      .sort();
+
+    expect(predictedGateFixtures).toHaveLength(scenarioFiles.length);
+    expect(predictedGateFixtures.map((fixture) => `${fixture.id}.ts`).sort()).toEqual(scenarioFiles);
+  });
+
+  it.each(predictedGateFixtures)("keeps the $id fixture parseable and aligned with its documented surface", (fixture) => {
+    const result = buildPredictedGateVerdict({
+      input: fixture.input,
+      manifest: fixture.manifest,
+      repo: fixture.repo,
+      issues: fixture.issues,
+      pullRequests: fixture.pullRequests,
+      ...(fixture.changedPaths ? { changedPaths: fixture.changedPaths } : {}),
+    });
+
+    expect(result.conclusion).toBe(fixture.expected.conclusion);
+    expect(result.pack).toBe(fixture.expected.pack);
+    expect(result.blockers.map((finding) => finding.code).sort()).toEqual([...fixture.expected.blockerCodes].sort());
+    expect(result.warnings.map((finding) => finding.code).sort()).toEqual([...fixture.expected.warningCodes].sort());
+    expect(result.funnel !== null).toBe(fixture.expected.funnelPresent);
+
+    for (const snippet of fixture.expected.noteIncludes ?? []) {
+      expect(result.note).toContain(snippet);
+    }
+    for (const snippet of fixture.expected.noteExcludes ?? []) {
+      expect(result.note).not.toContain(snippet);
+    }
+  });
+});

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -57,7 +57,7 @@ describe("gittensory-mcp CLI — maintain (#784)", () => {
     await expect(runAsync(["maintain", "set-level", "merge", "--repo", "owner/repo"], e)).rejects.toThrow(/Usage: gittensory-mcp maintain set-level/);
     await expect(runAsync(["maintain", "set-level", "bogus", "auto", "--repo", "owner/repo"], e)).rejects.toThrow(/Unknown action/);
     await expect(runAsync(["maintain", "set-level", "merge", "bogus", "--repo", "owner/repo"], e)).rejects.toThrow(/Unknown level/);
-  });
+  }, 45_000);
 
   it("prints help when invoked with no subcommand", async () => {
     const e = await env();

--- a/test/unit/mcp-cli-profiles.test.ts
+++ b/test/unit/mcp-cli-profiles.test.ts
@@ -54,7 +54,7 @@ describe("gittensory-mcp CLI — profiles", () => {
       ]),
     );
     expect(JSON.stringify(list)).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|gittensory-cli-/);
-  });
+  }, 45_000);
 
   it("keeps environment tokens ahead of active profile sessions", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
@@ -143,7 +143,7 @@ describe("gittensory-mcp CLI — profiles", () => {
     expect(doctor.checks).toEqual(expect.arrayContaining([expect.objectContaining({ name: "auth", status: "fail" })]));
     expect(requests).toEqual(expect.arrayContaining([expect.objectContaining({ url: "/v1/auth/logout", authorization: "Bearer session-jsonbored" })]));
     expect(JSON.stringify({ logout, list, missingStatus, doctor })).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|gittensory-cli-/);
-  });
+  }, 45_000);
 
   it("reports package status and prints the packaged changelog", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));


### PR DESCRIPTION
## Summary

- Adds an engine-parity fixture corpus for predicted-gate covering clean passes, duplicate/linked-issue/path blockers, readiness warnings, and path-gated checks.
- Adds a parity unit suite that verifies every fixture is exported and stays aligned with `buildPredictedGateVerdict`.
- Gives two long-running MCP CLI subprocess tests explicit timeout headroom so the full local gate stays green under suite-wide concurrency.

Closes #2285.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable.

## Notes

- The timeout adjustments are limited to existing MCP CLI harness tests that were timing out under full-suite subprocess contention; they do not change shipped runtime behavior.
