### PR TITLE
test(enrichment): add flaky-test retry to the review-enrichment suite

### DIFF
--- a/review-enrichment/package.json
+++ b/review-enrichment/package.json
@@ -14,7 +14,7 @@
     "validate:sourcemaps": "node scripts/validate-sourcemaps.mjs",
     "start": "node dist/server.js",
     "dev": "node --experimental-strip-types --watch src/server.ts",
-    "test": "npm run build && npm run validate:sourcemaps && node scripts/generate-analyzer-metadata.mjs --check && node --test --experimental-strip-types \"test/**/*.test.ts\""
+    "test": "npm run build && npm run validate:sourcemaps && node scripts/generate-analyzer-metadata.mjs --check && (node --test --experimental-strip-types \"test/**/*.test.ts\" || node --test --experimental-strip-types \"test/**/*.test.ts\")"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/review-enrichment/package.json
+++ b/review-enrichment/package.json
@@ -14,7 +14,8 @@
     "validate:sourcemaps": "node scripts/validate-sourcemaps.mjs",
     "start": "node dist/server.js",
     "dev": "node --experimental-strip-types --watch src/server.ts",
-    "test": "npm run build && npm run validate:sourcemaps && node scripts/generate-analyzer-metadata.mjs --check && (node --test --experimental-strip-types \"test/**/*.test.ts\" || node --test --experimental-strip-types \"test/**/*.test.ts\")"
+    "test": "npm run build && npm run validate:sourcemaps && node scripts/generate-analyzer-metadata.mjs --check && (npm run test:node || npm run test:node)",
+    "test:node": "node --test --experimental-strip-types \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/review-enrichment/test/sentry-degradation.test.ts
+++ b/review-enrichment/test/sentry-degradation.test.ts
@@ -216,7 +216,7 @@ test("buildBrief stays fail-open and captures a degraded analyzer", async () => 
       headSha: "head-sha",
       analyzers: ["dependency"],
       files: [{ path: "package.json", patch: '+    "lodash": "4.17.20",' }],
-      budget: { timeoutMs: 200 },
+      budget: { timeoutMs: 2000 },
     },
     {
       dependency: async () => {
@@ -242,7 +242,7 @@ test("buildBrief stays fail-open and captures a degraded analyzer", async () => 
   const analyzerContext = sentry.contexts.rees_analyzer as Record<string, unknown>;
   const capturedTimeoutMs = Number(analyzerContext.timeoutMs);
   assert.ok(capturedTimeoutMs > 0);
-  assert.ok(capturedTimeoutMs <= 200);
+  assert.ok(capturedTimeoutMs <= 2000);
 });
 
 test("captureRouteError applies the route-level fingerprint and allowlisted tags", () => {


### PR DESCRIPTION
## Summary

Closes #2425.

**What changed:**
- Added a shell-level retry to the REES test script (reruns the full suite once on failure), matching the main vitest suite's one-retry-before-fail policy. Node's built-in test runner doesn't support \--test-retries=N\ (the issue's assumption was incorrect for Node 22/24), so the retry is implemented via \
ode --test ... || node --test ...\ in the npm script.
- Fixed the root cause of the observed flake in \uildBrief stays fail-open and captures a degraded analyzer\: the test used \udget.timeoutMs=200\, but the balanced profile's \esponseReserveMs\ floors at 150ms, leaving only ~50ms of execution headroom. Under CI load, the pre-flight budget gate in \unAnalyzer\ (\rief.ts:248-262\) short-circuits to \capped\ before the analyzer runs at all, so the expected \degraded\ status is never reached. Raising the budget to 2000ms gives ~1600ms of headroom, deterministically reaching the analyzer throw path.

**Rationale:** A single transient flake must not red a required check and one-shot-close a contributor PR. The main vitest suite already has \etry: 1\ for this; the REES suite (Node's built-in test runner) had no equivalent.

**Files changed:**
- \eview-enrichment/package.json\ — added shell-level retry to the \	est\ script
- \eview-enrichment/test/sentry-degradation.test.ts\ — raised \udget.timeoutMs\ from 200 to 2000 and updated the \capturedTimeoutMs\ assertion bound

**Validation:**
- \
pm --prefix review-enrichment test\ — 358/360 pass (2 sentry-upload tests fail locally due to missing sentry-cli binary; pass in CI)
- \git diff --check\ clean

**Linked issue:** Closes #2425