### PR TITLE
fix(signals): redact macOS /private/ paths on the public boundary

### DIFF
--- a/src/signals/redaction.ts
+++ b/src/signals/redaction.ts
@@ -30,7 +30,7 @@ export const PUBLIC_UNSAFE_TERMS = String.raw`(?:reward|score|wallet|hotkey|cold
 // drive letter is matched case-insensitively at the source (`[A-Za-z]`, not `[A-Z]`) so a consumer that omits
 // the `i` flag (e.g. the case-sensitive `/g` scrubber in miner-dashboard-recommendations.ts) still redacts a
 // lower-case drive like `c:\Users\...`; the unix roots stay literal so case-sensitivity there is the caller's.
-export const PUBLIC_LOCAL_PATH_INLINE = String.raw`/Users/|/home/|/root/|/var/|/opt/|/tmp/|[A-Za-z]:[\\/]Users[\\/]|[A-Za-z]:[\\/]Program Files[\\/]`;
+export const PUBLIC_LOCAL_PATH_INLINE = String.raw`/Users/|/home/|/root/|/var/|/opt/|/tmp/|/private/|[A-Za-z]:[\\/]Users[\\/]|[A-Za-z]:[\\/]Program Files[\\/]`;
 
 // Global scrubber for `.replace()` surfaces that swap an absolute local path for a placeholder: matches a
 // root from `PUBLIC_LOCAL_PATH_INLINE` plus the rest of the path segment (stopping at whitespace or a common

--- a/test/unit/redaction.test.ts
+++ b/test/unit/redaction.test.ts
@@ -49,6 +49,7 @@ describe("isPublicSafeText (#542 shared public/private boundary)", () => {
     expect(isPublicSafeText("/var/log/app.log")).toBe(false);
     expect(isPublicSafeText("/var/folders/alice/work/private-repo/cache.ts")).toBe(false);
     expect(isPublicSafeText("/tmp/scratch")).toBe(false);
+    expect(isPublicSafeText("/private/tmp/gittensory/cache")).toBe(false);
     expect(isPublicSafeText("C:\\Users\\carol\\repo")).toBe(false);
     expect(isPublicSafeText("C:/Users/carol/repo")).toBe(false);
     expect(isPublicSafeText("/opt/homebrew/var/log")).toBe(false);
@@ -79,6 +80,7 @@ describe("shared local-path constants (#1418 drift fix)", () => {
     expect("log at /var/log/app.log done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("log at <p> done");
     expect("brew at /opt/homebrew/var/log done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("brew at <p> done");
     expect("tmp at /tmp/build done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("tmp at <p> done");
+    expect("mac at /private/tmp/build done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("mac at <p> done");
     expect("win at C:\\Users\\me\\repo done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("win at <p> done");
     expect("win at C:/Users/me/repo done".replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<p>")).toBe("win at <p> done");
     // Lower-case drive letter: the source matches it case-insensitively, so a consumer that omits the `i`


### PR DESCRIPTION
## Summary
- Add `/private/` to the canonical local-path redaction vocabulary (macOS temp paths like `/private/tmp/...`)

## Test plan
- [x] `npx vitest run test/unit/redaction.test.ts`

Made with [Cursor](https://cursor.com)