### PR TITLE
fix(analytics): redact npm tokens in weekly value report rollups

### DIFF
--- a/src/services/weekly-value-report.ts
+++ b/src/services/weekly-value-report.ts
@@ -411,7 +411,7 @@ function normalizeReportDays(value: number | null | undefined): number {
 function sanitizeReportText(value: string): string {
   const redacted = value
     .replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<redacted-path>")
-    .replace(/\b(?:ghp_|github_pat_|gts_|glpat-|sk-|xox[baprs]-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
+    .replace(/\b(?:ghp_|github_pat_|gts_|glpat-|sk-|npm_|xox[baprs]-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer <redacted-token>");
   if (
     /\b(seed phrase|mnemonic|private key|raw[-\s]?trust|trust[-\s]?score|wallet|hotkey|coldkey|payout|reward(?:[-\s]?(?:estimate|prediction|claim|score|payout|risk))?|farming|private[-\s]?reviewability|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)|score[-\s]?(?:estimate|prediction|preview))\b/i.test(

--- a/test/unit/weekly-value-report.test.ts
+++ b/test/unit/weekly-value-report.test.ts
@@ -243,6 +243,38 @@ describe("weekly value reports", () => {
     expect(JSON.stringify(report)).not.toMatch(new RegExp(slackToken.slice(0, 4), "i"));
   });
 
+  it("redacts npm tokens in operator rollup dimensions", () => {
+    const npmToken = ["npm", "abcdefghijklmnopqrstuvwxyz0123"].join("_");
+    const report = buildWeeklyValueReport({
+      generatedAt: "2026-06-01T12:00:00.000Z",
+      variant: "operator",
+      days: 7,
+      repositories: [repo("JSONbored/gittensory", true, true)],
+      installations: [installation(1)],
+      health: [health(1, "healthy")],
+      registry: registry([]),
+      scoring: scoring([]),
+      upstreamDrift: upstream({ status: "current", openReportCount: 0 }),
+      usageSummary: usageSummary({ totalEvents: 1, activeActors: 1 }),
+      usageRollups: [
+        rollup("2026-05-31", {
+          totalEvents: 1,
+          activeActors: 1,
+          activeRepos: 1,
+          repos: [{ key: npmToken, count: 1 }],
+          events: [],
+          surfaces: [],
+          commands: [],
+          tools: [],
+        }),
+      ],
+      usageRollupStatus: rollupStatus({ status: "ready" }),
+    });
+
+    expect(report.operatorDetails?.topRepos).toEqual([{ key: "<redacted-token>", count: 1 }]);
+    expect(JSON.stringify(report)).not.toMatch(/npm_[A-Za-z0-9]{20,}/);
+  });
+
   it("keeps clean complete windows marked ready", () => {
     const report = buildWeeklyValueReport({
       generatedAt: "2026-06-01T12:00:00.000Z",


### PR DESCRIPTION
## Summary
- Extend `sanitizeReportText` to redact `npm_` tokens in operator rollup dimensions (sibling to merged Slack/GitHub token redaction)

## Test plan
- [x] `npx vitest run test/unit/weekly-value-report.test.ts -t \"npm tokens\"`

Made with [Cursor](https://cursor.com)