### PR TITLE
fix(mcp): parse http and git protocol GitHub remotes

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -16,6 +16,8 @@ export function parseGitRemote(remoteUrl) {
   const patterns = [
     /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
     /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^http:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
+    /^git:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
     /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?$/,
   ];
   for (const pattern of patterns) {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1775,6 +1775,8 @@ describe("local MCP git metadata collection", () => {
     const { collectLocalBranchMetadata, parseGitRemote } = await import("../../packages/gittensory-mcp/lib/local-branch.js");
     expect(parseGitRemote("git@github.com:entrius/allways-ui.git")).toBe("entrius/allways-ui");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("http://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
+    expect(parseGitRemote("git://github.com/JSONbored/gittensory.git")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory/")).toBe("JSONbored/gittensory");
     expect(parseGitRemote("https://github.com/JSONbored/gittensory////")).toBe("JSONbored/gittensory");
     expect(parseGitRemote(`x${"/".repeat(32_000)}x`)).toBeUndefined();


### PR DESCRIPTION
## Summary
- Teach `parseGitRemote` to normalize `http://github.com/...` and `git://github.com/...` origin URLs to `owner/repo`

## Test plan
- [x] `npx vitest run test/unit/local-branch.test.ts -t \"parses remotes\"`

Made with [Cursor](https://cursor.com)