### PR TITLE
test(preview-url): cover parseRepo happy path and validation errors

### DIFF
--- a/test/unit/preview-url.test.ts
+++ b/test/unit/preview-url.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGitHubResponseCacheForTest, githubRateLimitAdmissionKeyForInstallation, latestGitHubRestRateLimitObservation } from "../../src/github/client";
-import { getPreviewBuildState } from "../../src/review/visual/preview-url";
+import { getPreviewBuildState, parseRepo } from "../../src/review/visual/preview-url";
 
 afterEach(() => {
   clearGitHubResponseCacheForTest();
   vi.unstubAllGlobals();
   vi.useRealTimers();
+});
+
+describe("parseRepo", () => {
+  it("parses owner/repo and rejects malformed input", () => {
+    expect(parseRepo(" JSONbored/gittensory ")).toEqual({ owner: "JSONbored", repo: "gittensory" });
+    expect(() => parseRepo("not-a-repo")).toThrow("Expected owner/repo repository name.");
+    expect(() => parseRepo("too/many/slashes")).toThrow("Expected owner/repo repository name.");
+    expect(() => parseRepo("/missing-owner")).toThrow("Expected owner/repo repository name.");
+  });
 });
 
 describe("preview-url GitHub reads", () => {


### PR DESCRIPTION
## Summary
- Unit tests for `parseRepo()` happy path and malformed-input errors used by preview discovery

## Test plan
- [x] `npx vitest run test/unit/preview-url.test.ts`

Made with [Cursor](https://cursor.com)