### PR TITLE
fix(ci): stop regenerating the OpenAPI spec twice in the same UI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,15 @@ jobs:
       - name: UI tests
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run ui:test
+      # `npm run ui:build` also regenerates apps/gittensory-ui/public/openapi.json (needed for a
+      # standalone build), but this step's trigger condition is a strict subset of "OpenAPI drift
+      # check" above (push || ui==true, vs. push || ui==true || uiContract==true), so whenever this
+      # step runs, that check already ran and passed in this same job -- the committed spec is
+      # already byte-identical to what regenerating it here would produce. Run ui:build's other two
+      # steps directly instead of the aggregate script, skipping that redundant regen.
       - name: UI build
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
-        run: npm run ui:build
+        run: npm run extension:build && npm --workspace @jsonbored/gittensory-ui run build
 
   # Diff-scoped security gate: fails only on vulnerabilities this PR introduces.
   # Ambient advisories in untouched deps are handled by Renovate + the scheduled

--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `npm run ui:build` also regenerates apps/gittensory-ui/public/openapi.json, but `ui:openapi:check`
+      # just verified the committed spec is already byte-identical to what regenerating it would produce
+      # -- run ui:build's other two steps directly instead of the aggregate script, skipping that redundant
+      # regen (mirrors the same fix in .github/workflows/ci.yml's "UI build" step).
       - name: Validate frontend
         env:
           VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
-        run: npm run ui:openapi:check && npm run ui:lint && npm run ui:typecheck && npm run ui:build
+        run: npm run ui:openapi:check && npm run ui:lint && npm run ui:typecheck && npm run extension:build && npm --workspace @jsonbored/gittensory-ui run build

--- a/test/unit/ci-ui-build-openapi.test.ts
+++ b/test/unit/ci-ui-build-openapi.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+// `npm run ui:build` also regenerates apps/gittensory-ui/public/openapi.json. Both call sites below
+// chain it immediately after `ui:openapi:check`, which just proved the committed spec is already fresh --
+// regenerating it again is pure repeat work. These assert the two split commands stay in place instead of
+// the aggregate `ui:build` script sneaking back in (ui:build itself is untouched for standalone callers).
+describe("UI build steps skip the redundant OpenAPI regen", () => {
+  it("ci.yml's UI build step runs the split commands, not the aggregate ui:build script", () => {
+    const workflow = read(".github/workflows/ci.yml");
+    const stepStart = workflow.indexOf("- name: UI build");
+    expect(stepStart).toBeGreaterThan(-1);
+    const stepEnd = workflow.indexOf("\n\n", stepStart);
+    const step = workflow.slice(stepStart, stepEnd === -1 ? undefined : stepEnd);
+
+    expect(step).toContain("run: npm run extension:build && npm --workspace @jsonbored/gittensory-ui run build");
+    expect(step).not.toContain("npm run ui:build");
+  });
+
+  it("ui-deploy.yml's Validate frontend step runs the split commands after the openapi check", () => {
+    const workflow = read(".github/workflows/ui-deploy.yml");
+
+    expect(workflow).toContain(
+      "run: npm run ui:openapi:check && npm run ui:lint && npm run ui:typecheck && npm run extension:build && npm --workspace @jsonbored/gittensory-ui run build",
+    );
+    expect(workflow).not.toContain("&& npm run ui:build");
+  });
+});


### PR DESCRIPTION
## Summary

- `ui:build` (`extension:build && vite build`) also runs `ui:openapi`, which recomputes and rewrites `apps/gittensory-ui/public/openapi.json` unconditionally. Both places that chain it after `ui:openapi:check` in the same job/step — `ci.yml`'s "UI build" step, `ui-deploy.yml`'s "Validate frontend" step — pay for that regeneration twice: the check step immediately before it already proved the committed spec is byte-identical to what regenerating it would produce.
- Fixed by running `ui:build`'s other two steps (`extension:build`, the vite build) directly in both places instead of the aggregate script. `ui:build` itself is untouched, so anyone invoking it standalone (local dev, or any future call site without a preceding check) still gets a correct, freshly-generated spec — this is scoped to the two places that already verify freshness first.
- `ci.yml`'s "UI build" step's trigger condition (`push || ui==true`) is a strict subset of "OpenAPI drift check"'s (`push || ui==true || uiContract==true`), so the check step is guaranteed to have already run and passed whenever the build step runs — confirmed by reading both `if:` conditions.
- Added `test/unit/ci-ui-build-openapi.test.ts`: a small guardrail test (mirroring `workflow-runner-labels.test.ts`'s style) that fails if either step regresses back to invoking the aggregate `npm run ui:build`. Verified it actually catches the regression by reverting the fix locally and confirming the test fails, then restoring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue is linked — this is CI/test-infra maintenance found via direct profiling (a follow-up from #2426), not a pre-filed bug.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full unsharded run green (96.51% stmts / 95.49% branches), including the new guardrail test.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` green end to end.
- [x] Manually verified the fix's actual behavior: ran `ui:openapi:check` then the two split commands (`extension:build`, the vite build) directly — build succeeds, and `apps/gittensory-ui/public/openapi.json` is untouched (`git status` shows no diff) throughout, confirming no redundant regeneration and no behavior change to the output.
- [x] Manually verified the new regression test: reverted the fix locally, confirmed `test/unit/ci-ui-build-openapi.test.ts` fails, then restored the fix and confirmed it passes again.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A — no API/OpenAPI/MCP behavior change; this only changes *when* the (unchanged) generator script runs, not what it produces.
- [x] N/A — no UI code changes.
- [x] N/A — no visible UI change; this is CI-workflow-only.
- [x] N/A — no docs/changelog changes needed.

## Notes

- Follow-up from #2426 (found while auditing `validate-code`'s remaining cost after that PR merged).
