### PR TITLE
fix(ci): cache node_modules across runs to skip npm ci on an exact hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,30 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      # actions/checkout wipes node_modules (git clean -ffdx) on every run regardless of the self-hosted
+      # runner's own persistence, and npm ci always deletes+reinstalls node_modules by design -- so
+      # neither the runner nor npm ci gives node_modules any real cross-run reuse on its own. This
+      # explicit restore/save pair (via GitHub's own cache service, not the wiped local disk) fills that
+      # gap: an exact package-lock.json match skips npm ci entirely. Keyed separately per fork/trusted
+      # (see the runs-on expression above) because self-hosted's Docker image and GitHub's ubuntu-latest
+      # image are not guaranteed binary-compatible for native modules (sharp, workerd, fsevents, ...) --
+      # crossing them could load an incompatible native binary. Fork PRs get read-only cache tokens (a
+      # documented actions/cache behavior), so a "fork"-keyed entry can never actually be written; that's
+      # fine, it just means fork PRs keep doing a full npm ci exactly as before -- no regression, no risk
+      # on the highest-stakes (no-retry) population.
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            node_modules
+            apps/gittensory-ui/node_modules
+          # hashFiles('.nvmrc') matters as much as the lockfile: a Node bump with no lockfile change
+          # would otherwise still hit and silently reuse node_modules whose native addons (sharp,
+          # workerd, fsevents) were compiled against the OLD Node's ABI.
+          key: npm-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies (retry on transient failures)
+        if: ${{ steps.node-modules-cache.outputs.cache-hit != 'true' }}
         run: |
           for attempt in 1 2 3; do
             if npm ci --prefer-offline --no-audit --no-fund; then
@@ -145,6 +168,17 @@ jobs:
           done
           echo "::error::npm ci failed after 3 attempts"
           exit 1
+      # Placed immediately after install (not as an automatic post-job hook) so a cache is only ever
+      # saved once npm ci has actually succeeded -- a job that fails here never reaches this step, so a
+      # broken/partial node_modules can never get written to the cache for a future run to inherit.
+      - name: Save node_modules cache
+        if: ${{ steps.node-modules-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            node_modules
+            apps/gittensory-ui/node_modules
+          key: ${{ steps.node-modules-cache.outputs.cache-primary-key }}
       - name: Lint workflows
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run actionlint
@@ -270,9 +304,29 @@ jobs:
       - name: MCP package check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
         run: npm run test:mcp-pack
+      # review-enrichment is not an npm workspace member (its own package-lock.json), so it needs its own
+      # cache entry -- same restore/save-after-success pattern and fork/trusted key split as the root
+      # install above, for the same reasons.
+      - name: Restore review-enrichment node_modules cache
+        id: rees-node-modules-cache
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.rees == 'true' }}
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: review-enrichment/node_modules
+          # Same Node-version guard as the root cache key above -- REES runs on the same pinned .nvmrc.
+          key: npm-rees-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('review-enrichment/package-lock.json') }}
+      - name: REES install
+        if: ${{ (github.event_name == 'push' || needs.changes.outputs.rees == 'true') && steps.rees-node-modules-cache.outputs.cache-hit != 'true' }}
+        run: npm run rees:install
+      - name: Save review-enrichment node_modules cache
+        if: ${{ (github.event_name == 'push' || needs.changes.outputs.rees == 'true') && steps.rees-node-modules-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: review-enrichment/node_modules
+          key: ${{ steps.rees-node-modules-cache.outputs.cache-primary-key }}
       - name: REES build, source-map validation, and tests
         if: ${{ github.event_name == 'push' || needs.changes.outputs.rees == 'true' }}
-        run: npm run rees:test
+        run: npm --prefix review-enrichment test
       - name: OpenAPI drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.uiContract == 'true' }}
         run: npm run ui:openapi:check

--- a/test/unit/ci-dependency-cache.test.ts
+++ b/test/unit/ci-dependency-cache.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  return record(parse(readFileSync(path, "utf8")), path);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function recordArray(value: unknown, label: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value.map((entry, index) => record(entry, `${label}[${index}]`));
+}
+
+function step(steps: Array<Record<string, unknown>>, name: string): Record<string, unknown> {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`step "${name}" not found`);
+  return found;
+}
+
+function jobSteps(workflow: Record<string, unknown>, jobName: string): Array<Record<string, unknown>> {
+  const job = record(record(workflow.jobs, "jobs")[jobName], jobName);
+  return recordArray(job.steps, `${jobName}.steps`);
+}
+
+// actions/checkout wipes node_modules on every run (git clean -ffdx) and npm ci always deletes+reinstalls
+// it by design, so neither gives node_modules any real cross-run reuse -- these restore/save pairs (via
+// GitHub's own cache service) fill that gap: an exact package-lock.json match skips the install step
+// entirely. Cache-save is placed right after a successful install (not as an automatic post-job hook), so
+// a job that fails installing never reaches the save step -- a broken node_modules can never get cached.
+describe("CI dependency-install caching", () => {
+  it("root npm ci is skipped only on an exact node_modules cache hit, and the cache is saved only after a successful install", () => {
+    const steps = jobSteps(readYaml(".github/workflows/ci.yml"), "validate-code");
+
+    const restore = step(steps, "Restore node_modules cache");
+    expect(restore.uses).toContain("actions/cache/restore@");
+    const restoreWith = record(restore.with, "restore.with");
+    expect(String(restoreWith.path)).toContain("node_modules");
+    expect(String(restoreWith.path)).toContain("apps/gittensory-ui/node_modules");
+    expect(String(restoreWith.key)).toContain("hashFiles('package-lock.json')");
+    // A Node bump (.nvmrc) with no lockfile change must still bust the cache -- otherwise a hit would
+    // silently reuse node_modules whose native addons were compiled against the OLD Node's ABI.
+    expect(String(restoreWith.key)).toContain("hashFiles('.nvmrc')");
+    expect(String(restoreWith.key)).toContain("fork");
+    expect(String(restoreWith.key)).toContain("trusted");
+
+    const install = step(steps, "Install dependencies (retry on transient failures)");
+    expect(String(install.if)).toContain("steps.node-modules-cache.outputs.cache-hit != 'true'");
+
+    const save = step(steps, "Save node_modules cache");
+    expect(String(save.if)).toContain("steps.node-modules-cache.outputs.cache-hit != 'true'");
+    expect(save.uses).toContain("actions/cache/save@");
+    const saveWith = record(save.with, "save.with");
+    expect(saveWith.key).toBe("${{ steps.node-modules-cache.outputs.cache-primary-key }}");
+
+    // Save must come after install (a broken/partial node_modules from a failed install step is never reached).
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames.indexOf("Save node_modules cache")).toBeGreaterThan(stepNames.indexOf("Install dependencies (retry on transient failures)"));
+  });
+
+  it("review-enrichment's install is cached separately (its own lockfile, not an npm workspace member)", () => {
+    const steps = jobSteps(readYaml(".github/workflows/ci.yml"), "validate-code");
+
+    const restore = step(steps, "Restore review-enrichment node_modules cache");
+    const restoreWith = record(restore.with, "restore.with");
+    expect(restoreWith.path).toBe("review-enrichment/node_modules");
+    expect(String(restoreWith.key)).toContain("hashFiles('review-enrichment/package-lock.json')");
+    expect(String(restoreWith.key)).toContain("hashFiles('.nvmrc')");
+
+    const install = step(steps, "REES install");
+    expect(String(install.if)).toContain("steps.rees-node-modules-cache.outputs.cache-hit != 'true'");
+    // Must still be gated by the same rees/push condition as the original single step, or it would run
+    // (or skip) independently of whether review-enrichment actually changed.
+    expect(String(install.if)).toContain("needs.changes.outputs.rees == 'true'");
+
+    const save = step(steps, "Save review-enrichment node_modules cache");
+    const saveWith = record(save.with, "save.with");
+    expect(saveWith.key).toBe("${{ steps.rees-node-modules-cache.outputs.cache-primary-key }}");
+
+    // The actual build/test step must run unconditionally (whenever rees applies), independent of
+    // whether this run needed a fresh install or restored one from cache.
+    const test = step(steps, "REES build, source-map validation, and tests");
+    expect(String(test.if)).not.toContain("cache-hit");
+    expect(test.run).toBe("npm --prefix review-enrichment test");
+  });
+});


### PR DESCRIPTION
## Summary

- `actions/checkout`'s default `clean: true` runs `git clean -ffdx` before every checkout, wiping `node_modules` on every run even though the self-hosted "gittensory" runner containers are persistent VPS processes, not fresh machines. `npm ci` also unconditionally deletes and reinstalls `node_modules` by design regardless of what's already on disk. Together these meant `node_modules` got zero cross-run reuse no matter how long the runner container stays alive.
- Added an `actions/cache/restore` + `actions/cache/save` pair (GitHub's own cache service, not local disk) around both the root `npm ci` and `review-enrichment`'s separate `npm ci` (it isn't an npm workspace member, so it has its own `package-lock.json` and needs its own cache entry). The install step is skipped entirely when the restore is an exact hit; the save step is placed immediately after a successful install (not as an automatic post-job hook), so a job that fails installing never reaches it — a broken/partial `node_modules` can never get written to the cache for a future run to inherit.
- Cache keys are scoped separately per fork-vs-trusted (mirroring the existing `runs-on` split): the self-hosted runner's Docker image and GitHub's `ubuntu-latest` are not guaranteed binary-compatible for native modules (`sharp`, `workerd`, `fsevents`, `@sentry/cli` all compile platform-specific binaries), so crossing them could load an incompatible binary. Fork PRs get read-only cache tokens (documented `actions/cache` behavior) and can never write a "fork"-keyed entry — they keep doing a full `npm ci` exactly as before, no regression on that no-retry population.
- **Adversarial review caught one real bug before this shipped**: the first draft's cache key only hashed the lockfile, so a Node version bump (`.nvmrc`) with no lockfile change would still hit and silently reuse `node_modules` whose native addons were compiled against the OLD Node's ABI. Both keys now also hash `.nvmrc`.
- Added `test/unit/ci-dependency-cache.test.ts` to pin the restore/skip/save wiring for both install paths, including the `.nvmrc` fix and that REES's build/test step still runs unconditionally (independent of whether install ran or was skipped this run).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: CI-workflow + a matching guardrail test only, no product code changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue is linked — this is CI/test-infra maintenance found via direct profiling (a follow-up from #2426 / #2444), not a pre-filed bug.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full unsharded run green on Node 22.23.1 (matching CI's pinned `.nvmrc`): 314 passed / 2 skipped, 5927 tests passed, 0 failures.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] The 5 existing guardrail tests that assert on `ci.yml`'s structure (`workflow-runner-labels`, `codecov-policy`, `change-guardrail`, `agent-guardrail-paths`, `path-matchers`) all pass unchanged.
- [x] Verified `node_modules` layout empirically: a fresh root `npm ci` also creates `apps/gittensory-ui/node_modules` (a small, gitignored, npm-workspaces hoisting-conflict artifact) — both paths are included in the root cache entry.
- [x] Verified `actions/cache`'s documented restore/save split semantics against its own README before implementing (not from memory): `cache-primary-key` output feeding `save`'s `key` input is the officially documented pattern; fork-PR read-only cache tokens are documented behavior, not an assumption.
- [x] Ran an independent adversarial review pass against this exact diff — see Summary for the one real bug it caught (missing `.nvmrc` in the cache key), which is fixed and now has a dedicated assertion in the new test.
- [x] One transient failure surfaced in an early local `test:coverage` run (`selfhost-sqlite-queue.test.ts`, unrelated to this diff) while the machine was heavily loaded from parallel background work; reran that file in isolation (52/52 passed) and reran the full suite cleanly (0 failures) to confirm it was local system-load flakiness, not a regression.

If any required check was skipped, explain why:

- N/A — everything ran.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A — no API/OpenAPI/MCP behavior change.
- [x] N/A — no UI code changes.
- [x] N/A — no visible UI change; this is CI-workflow-only.
- [x] N/A — no docs/changelog changes needed.

## Notes

- Follow-up from #2426 / #2444 (found while auditing `validate-code`'s remaining cost after both merged).
- The first run against a given `.nvmrc` + lockfile combination will still be a full `npm ci` (cache miss, then save) — the skip is only observable on a **second** run against the same combination.
- Out of scope here (considered and rejected/deferred, per the same audit): TypeScript incremental-build caching showed real but highly inconsistent local speedup (4.7x on one change, no benefit or worse on another, depending on which file changed) — not confident enough to ship; ESLint `--cache` was technically verified (~4x local speedup with `cache-strategy: content`) but the net win is marginal-to-negative once fork-PR risk and `actions/cache`'s own overhead are weighed in.
