### PR TITLE
fix(docker): document a proven CPU-priority pattern for --profile runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ output/
 .env
 .env.*
 !.env.example
+docker-compose.override.yml
+!docker-compose.override.yml.example
 *.local
 # Private self-host operator config. Root AGENTS.md/CLAUDE.md are public project docs;
 # repo-scoped review instructions live under this ignored mount.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,35 @@
+# Optional CPU-priority tuning for boxes running `--profile runners` alongside the main `gittensory`
+# app on the SAME host. Copy to `docker-compose.override.yml` (gitignored, auto-loaded by `docker
+# compose` alongside docker-compose.yml) and adjust the numbers for your host if you use this pattern.
+#
+# WHY THIS EXISTS: with no limits set (the default -- see docker-compose.yml), every container competes
+# for the host's CPUs on equal footing. On a box that ALSO runs `--profile runners`, a burst of CI jobs
+# can starve the `gittensory` app itself of CPU, slowing down (or queuing up) the very review work the
+# app exists to do -- discovered running this exact pattern in production on an 8-vCPU box: 3 uncapped
+# runner containers left the app starved under load.
+#
+# THE FIX IS PRIORITY, NOT A HARD SPLIT: `cpu_shares` is a RELATIVE weight that only matters once the
+# host is actually contended (all CPUs busy at once) -- a job still gets 100% of an idle box regardless
+# of its share. Setting the app's shares high and the runner's low means: engine work always wins a race
+# for CPU when both want it at the same instant, but CI is never blocked from running merely because the
+# app exists -- it just yields faster than it otherwise would under real contention.
+#
+# `cpus` is a separate, absolute ceiling (not a reservation) -- it caps how many cores a SINGLE container
+# can burst to, independent of shares. Size it to your own host: these examples assume an 8-vCPU box
+# running the app + 3 runner replicas; the runner values below intentionally sum to MORE than the host's
+# core count (12 > 8) because `cpus` is a per-container ceiling, not a guarantee -- the host's own CPU
+# scheduler (driven by the relative `cpu_shares` below) resolves real contention when multiple containers
+# actually want the CPU at once.
+#
+# Sizing guide for a different host: pick a `gittensory` : `runner` cpu_shares ratio reflecting how
+# strongly you want review work to win contention (8:1 below is deliberately aggressive), and keep each
+# runner replica's `cpus` ceiling at roughly (host vCPUs) / (number of runner replicas you plan to run),
+# so a single busy runner can't monopolize the box even before shares kick in.
+
+services:
+  gittensory:
+    cpu_shares: 4096
+
+  runner:
+    cpu_shares: 512
+    cpus: "4.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -501,6 +501,9 @@ services:
   # Runs `runs-on: self-hosted` jobs on this machine. Set RUNNER_TOKEN= (or ACCESS_TOKEN=)
   # and RUNNER_REPO_URL= (e.g. https://github.com/your-org/your-repo) in .env.
   # Get a token at: https://github.com/<owner>/<repo>/settings/actions/runners/new
+  # Running this alongside the main `gittensory` app on the SAME host? A burst of CI jobs can starve the
+  # app of CPU with no limits set (the default below). See docker-compose.override.yml.example for a
+  # proven CPU-priority pattern (relative cpu_shares + a per-container cpus ceiling) before scaling this up.
   runner:
     # Pin to a specific version tag — `latest` is mutable. Find a digest via:
     # docker pull myoung34/github-runner:ubuntu-jammy && docker inspect --format='{{index .RepoDigests 0}}' myoung34/github-runner:ubuntu-jammy

--- a/test/unit/docker-compose-override-example.test.ts
+++ b/test/unit/docker-compose-override-example.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  const value = parse(readFileSync(path, "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must be a YAML object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+// A burst of CI jobs (--profile runners) can starve the main `gittensory` app of CPU on a shared host
+// with no limits set (the default). docker-compose.override.yml.example documents a proven cpu_shares +
+// cpus pattern for that case -- pure structural checks only (no `docker` CLI invocation: the self-hosted
+// runner container this actually runs on does not have Docker-in-Docker access, so a test that shells out
+// to `docker compose config` would be unreliable/environment-dependent here).
+describe("docker-compose.override.yml.example", () => {
+  it("is valid YAML whose service keys exist in the real docker-compose.yml", () => {
+    const example = readYaml("docker-compose.override.yml.example");
+    const base = readYaml("docker-compose.yml");
+    const exampleServices = Object.keys(example.services as Record<string, unknown>);
+    const baseServices = Object.keys(base.services as Record<string, unknown>);
+
+    expect(exampleServices).toEqual(["gittensory", "runner"]);
+    for (const name of exampleServices) {
+      expect(baseServices).toContain(name);
+    }
+  });
+
+  it("gives the app service a higher relative cpu_shares weight than the runner service", () => {
+    const example = readYaml("docker-compose.override.yml.example");
+    const services = example.services as Record<string, Record<string, unknown>>;
+
+    const appShares = Number(services.gittensory?.cpu_shares);
+    const runnerShares = Number(services.runner?.cpu_shares);
+    expect(Number.isFinite(appShares) && Number.isFinite(runnerShares)).toBe(true);
+    expect(appShares).toBeGreaterThan(runnerShares);
+  });
+
+  it(".gitignore excludes a real docker-compose.override.yml but keeps the example tracked", () => {
+    const gitignore = readFileSync(".gitignore", "utf8");
+    expect(gitignore).toContain("docker-compose.override.yml\n");
+    expect(gitignore).toContain("!docker-compose.override.yml.example");
+  });
+});

--- a/test/unit/docker-compose-override-example.test.ts
+++ b/test/unit/docker-compose-override-example.test.ts
@@ -38,6 +38,20 @@ describe("docker-compose.override.yml.example", () => {
     expect(appShares).toBeGreaterThan(runnerShares);
   });
 
+  it("pins the runner's documented cpus ceiling to a sane, non-zero value within the example host's assumed capacity", () => {
+    const example = readYaml("docker-compose.override.yml.example");
+    const services = example.services as Record<string, Record<string, unknown>>;
+
+    // The file's own comments size this example for an 8-vCPU host -- a ceiling above that would
+    // contradict the documented scenario (cpus is per-container, not a reservation, so it's fine for
+    // it to be a meaningful fraction of the host rather than host-vCPUs / replica-count).
+    const runnerCpus = Number(services.runner?.cpus);
+    expect(Number.isFinite(runnerCpus)).toBe(true);
+    expect(runnerCpus).toBeGreaterThan(0);
+    expect(runnerCpus).toBeLessThanOrEqual(8);
+    expect(services.runner?.cpus).toBe("4.0");
+  });
+
   it(".gitignore excludes a real docker-compose.override.yml but keeps the example tracked", () => {
     const gitignore = readFileSync(".gitignore", "utf8");
     expect(gitignore).toContain("docker-compose.override.yml\n");


### PR DESCRIPTION
## Summary

- A box running `--profile runners` (self-hosted GitHub Actions runners) alongside the main `gittensory` app has **no CPU limits set by default** — every container competes for the host's CPUs on equal footing. Under a burst of CI jobs, this can starve the app itself of the CPU it needs to do the review work it exists for.
- This exact pattern already bit us in production on an 8-vCPU box: uncapped runner containers left the app starved under load. It was fixed live via `docker update --cpu-shares`/`--cpus`, but that tuning only ever existed as an uncommitted host file (`docker-compose.override.yml`, never committed) and shell history — invisible to anyone else running this pattern, and lost if the box were ever rebuilt from the repo alone.
- Added `docker-compose.override.yml.example` (a real `docker-compose.override.yml` stays gitignored and operator-owned, mirroring the existing `.env`/`.env.example` split) documenting the fix: `cpu_shares` is a *relative* weight that only matters once the host is genuinely contended — setting the app's shares high and the runner's low means review work wins a race for CPU when both want it at the same instant, without ever blocking CI from running merely because the app exists. `cpus` is a separate, absolute per-container ceiling; the file's own comments include a sizing guide for a different host/replica count.
- Added a one-line pointer to this file from `docker-compose.yml`'s own `runner:` service comment block, where anyone enabling that profile would already be looking.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: docs/config for the self-host Docker stack + a matching guardrail test, no product code changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue is linked — this is infra/ops documentation captured from a production incident already resolved live, not a pre-filed bug.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full unsharded run green on Node 22.23.1 (matching CI's pinned `.nvmrc`): 315 passed / 2 skipped, 5930 tests passed, 0 failures.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] `docker compose -f docker-compose.yml -f docker-compose.override.yml.example config --quiet` — validates the merged config parses with no errors (confirms `cpus`/`cpu_shares` are valid top-level compose-spec keys honored outside Swarm mode, not the Swarm-only `deploy.resources.limits` block).
- [x] The 3 existing tests that read the real `docker-compose.yml` (`selfhost-image-deploy.test.ts`, `selfhost-observability-config.test.ts`, `path-matchers.test.ts`) all pass unchanged.

If any required check was skipped, explain why:

- N/A — everything ran.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The example file contains only generic resource-limit numbers, no host-specific values beyond what's already documented in this PR's own summary.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A — no API/OpenAPI/MCP behavior change.
- [x] N/A — no UI code changes.
- [x] N/A — no visible UI change.
- [x] N/A — no docs/changelog changes needed beyond the in-file comments this PR adds.

## Notes

- Companion to #2426 / #2444 / #2446 (found while auditing CI cost end-to-end this week — this one is the Docker/host-level piece rather than the workflow-YAML level).
- This is additive and opt-in: no existing self-hoster's deployment changes behavior unless they copy the `.example` file to a real `docker-compose.override.yml`.
