### PR TITLE
fix(selfhost): log the root cause when a queue job's DB query fails

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -12,6 +12,7 @@ import {
   consumingRetryDelayMs,
   deterministicJitterMs,
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
+  errorMessageWithCause,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionTargetForJob,
   githubRateLimitMetricContext,
@@ -440,7 +441,7 @@ export function createPgQueue(
         }, jobTraceParent);
       } catch (error) {
         const attempts = Number(job.attempts) + 1;
-        const errMsg = error instanceof Error ? error.message : "unknown error";
+        const errMsg = errorMessageWithCause(error);
         const rateLimitDelayMs = githubRateLimitRetryDelayMs(error);
         if (rateLimitDelayMs !== null) {
           const now = Date.now();

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -476,6 +476,23 @@ function githubWebhookPriority(payload: string): number {
   return 10;
 }
 
+/** A diagnosable message for a job failure, including the ROOT CAUSE — not just the wrapper's own text.
+ *  Drizzle's DrizzleQueryError (thrown on every failed query, both queue backends) sets its OWN `.message` to a
+ *  generic "Failed query: <sql>\nparams: <params>" and stashes the actual driver error — a Postgres SQLSTATE
+ *  deadlock/serialization failure, a SQLite busy/constraint code, a connection reset, etc. — on `.cause`.
+ *  Logging only `error.message` for a query failure is undiagnosable: every failure looks identical (the same
+ *  query + params) regardless of the actual reason, which is exactly the information needed to tell a transient
+ *  lock/connection blip apart from a genuine data or schema bug. Includes the cause's `.code` (Postgres SQLSTATE
+ *  / SQLite result code) when present, since that is the canonical, greppable identifier for the failure class. */
+export function errorMessageWithCause(error: unknown): string {
+  if (!(error instanceof Error)) return "unknown error";
+  const cause = error.cause;
+  if (!(cause instanceof Error)) return error.message;
+  const code = (cause as { code?: unknown }).code;
+  const codeSuffix = typeof code === "string" && code.length > 0 ? ` [${code}]` : "";
+  return `${error.message} — caused by: ${cause.message}${codeSuffix}`;
+}
+
 const DEFAULT_GITHUB_RATE_LIMIT_RETRY_MS = 5 * 60_000;
 const MAX_GITHUB_RATE_LIMIT_RETRY_MS = 65 * 60_000;
 

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -15,6 +15,7 @@ import {
   FOREGROUND_QUEUE_PRIORITY_FLOOR,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionTargetForJob,
+  errorMessageWithCause,
   githubRateLimitMetricContext,
   githubRateLimitRetryDelayMs,
   buildSelfHostQueueSnapshot,
@@ -380,7 +381,7 @@ export function createSqliteQueue(
         }, jobTraceParent);
       } catch (error) {
         const attempts = job.attempts + 1;
-        const errMsg = error instanceof Error ? error.message : "unknown error";
+        const errMsg = errorMessageWithCause(error);
         const rateLimitDelayMs = githubRateLimitRetryDelayMs(error);
         if (rateLimitDelayMs !== null) {
           const now = Date.now();

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -4,6 +4,7 @@ import {
   buildSelfHostQueueSnapshot,
   consumingRetryDelayMs,
   deterministicJitterMs,
+  errorMessageWithCause,
   githubRateLimitAdmissionDelayMs,
   githubRateLimitAdmissionKeyScope,
   githubRateLimitAdmissionKeyForJob,
@@ -1078,5 +1079,33 @@ describe("self-host queue common helpers", () => {
       if (old === undefined) delete process.env.SCHEDULED_ENQUEUE_JITTER_MS;
       else process.env.SCHEDULED_ENQUEUE_JITTER_MS = old;
     }
+  });
+
+  describe("errorMessageWithCause (#confirmed-bug: job_error/job_dead logs were undiagnosable)", () => {
+    it("returns the wrapper's own message when there is no cause", () => {
+      expect(errorMessageWithCause(new Error("Failed query: select 1"))).toBe("Failed query: select 1");
+    });
+
+    it("REGRESSION: appends the root-cause message and its error code — the exact DrizzleQueryError shape every failed query throws", () => {
+      const cause = new Error("deadlock detected");
+      (cause as { code?: string }).code = "40P01";
+      const wrapper = new Error("Failed query: insert into ...\nparams: 1,2,3", { cause });
+      expect(errorMessageWithCause(wrapper)).toBe("Failed query: insert into ...\nparams: 1,2,3 — caused by: deadlock detected [40P01]");
+    });
+
+    it("omits the code suffix when the cause has no `.code` (e.g. a plain network error)", () => {
+      const wrapper = new Error("Failed query: select 1", { cause: new Error("connection terminated unexpectedly") });
+      expect(errorMessageWithCause(wrapper)).toBe("Failed query: select 1 — caused by: connection terminated unexpectedly");
+    });
+
+    it("falls back to the wrapper's own message when `.cause` is not an Error (e.g. a string or undefined)", () => {
+      const wrapper = new Error("Failed query: select 1", { cause: "not an error object" });
+      expect(errorMessageWithCause(wrapper)).toBe("Failed query: select 1");
+    });
+
+    it("returns 'unknown error' for a non-Error thrown value", () => {
+      expect(errorMessageWithCause("a raw string throw")).toBe("unknown error");
+      expect(errorMessageWithCause(undefined)).toBe("unknown error");
+    });
   });
 });


### PR DESCRIPTION
## What

Investigated a VPS log entry: a `pull_request_files` upsert failed (`job_error`, attempt 1) then succeeded on retry 16 seconds later with the byte-identical query and params. Cross-referenced against Loki's job-id history to confirm this — same job (`60435`), `job_error` → `job_complete` on attempt 2, no code changes possible in between. This rules out a data/schema/SQL-syntax bug (which would fail identically on every retry) and confirms a transient failure (most likely Postgres lock/connection contention, given the self-host deployment runs against Postgres via the `pg-adapter.ts`/`pg-dialect.ts` SQLite→Postgres translation layer).

Root-caused why the logs couldn't say WHY it failed: `errMsg = error instanceof Error ? error.message : "unknown error"` in both `sqlite-queue.ts` and `pg-queue.ts` only reads `error.message`. Every failed Drizzle query throws a `DrizzleQueryError` whose own `.message` is a generic `"Failed query: <sql>\nparams: <params>"` — the ACTUAL reason (a Postgres SQLSTATE deadlock/serialization failure, a SQLite busy/constraint code, a connection reset, etc.) is attached as `.cause` and was silently discarded. Every DB query failure logs identically regardless of cause, which is exactly what made this specific incident undiagnosable from the logs alone.

## Fix

Added `errorMessageWithCause()` to `queue-common.ts` (shared by both queue backends) and wired it into both `catch` blocks, replacing the bare `error.message` read. Appends the cause's message and its `.code` (Postgres SQLSTATE / SQLite result code) when present — e.g. `"Failed query: ... — caused by: deadlock detected [40P01]"` — so a future occurrence (of this or any other query failure) is diagnosable from the log line alone instead of requiring log archaeology.

No behavior change for non-Error throws or errors without a `.cause` — falls back to the exact same message as before.

## Test plan

- [x] `npx tsc --noEmit -p .` clean
- [x] New unit tests for `errorMessageWithCause`: no cause, Error cause with/without `.code`, non-Error cause, non-Error thrown value — 5/5 pass
- [x] Targeted suites (`selfhost-queue-common.test.ts`, `selfhost-sqlite-queue.test.ts`, `selfhost-pg-queue.test.ts`): 142/142 passing
- [x] Full unsharded `npm run test:coverage`: 315 files / 5973 tests passing, 0 failures
- [x] Per-file patch coverage: all three changed files — zero uncovered added lines/branches
- [x] Stash/revert proof: reverting the source changes makes all 5 new tests fail (`errorMessageWithCause is not a function`); restoring makes them pass again
- [x] `git diff --check` clean; `npm audit --audit-level=moderate`: 0 vulnerabilities