### PR TITLE
fix(auth): block MCP token from app-role gates

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4948,7 +4948,11 @@ async function getRoleSummaryForIdentity(env: Env, identity: AuthIdentity) {
 async function requireAppRole(c: ProtectedRouteContext, allowedRoles: ControlPanelRoleName[]): Promise<Response | null> {
   const identity = await authenticateRequestIdentity(c);
   if (!identity) return c.json({ error: "unauthorized" }, 401);
-  if (identity.kind !== "session") return null;
+  if (identity.kind !== "session") {
+    // GITTENSORY_MCP_TOKEN is a shared end-user credential; it must not satisfy app-role gates implicitly.
+    if (identity.actor === "mcp") return c.json({ error: "insufficient_role" }, 403);
+    return null;
+  }
   const summary = await loadControlPanelRoleSummary(c.env, identity.actor);
   return summary.roles.some((role) => allowedRoles.includes(role)) ? null : c.json({ error: "insufficient_role" }, 403);
 }

--- a/test/unit/routes-kill-switch.test.ts
+++ b/test/unit/routes-kill-switch.test.ts
@@ -57,6 +57,20 @@ describe("kill-switch operator route (#2359)", () => {
     expect(res.status).toBe(401);
   });
 
+  it("rejects the shared MCP token without changing the global kill-switch", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const headers = { authorization: `Bearer ${env.GITTENSORY_MCP_TOKEN}`, "content-type": "application/json" };
+
+    const read = await app.request("/v1/app/kill-switch", { headers }, env);
+    expect(read.status).toBe(403);
+
+    const write = await app.request("/v1/app/kill-switch", { method: "POST", headers, body: JSON.stringify({ frozen: true }) }, env);
+    expect(write.status).toBe(403);
+    await expect(getGlobalAgentFrozenState(env)).resolves.toMatchObject({ frozen: false, updatedBy: null });
+    expect(setGlobalAgentFrozen).not.toHaveBeenCalled();
+  });
+
   it("GET surfaces a clear 503 (never a falsely reassuring unfrozen) when the singleton row is missing", async () => {
     const app = createApp();
     const env = createTestEnv();


### PR DESCRIPTION
### Motivation

- Close a high-severity authorization gap where the shared `GITTENSORY_MCP_TOKEN` static identity could flip the deployment-wide global agent kill-switch via the new operator route.

### Description

- Update `requireAppRole` to explicitly reject the `mcp` static identity so the shared MCP token cannot satisfy operator-only app-role gates (`src/api/routes.ts`).
- Add a regression test that asserts a request using `GITTENSORY_MCP_TOKEN` is forbidden for both `GET /v1/app/kill-switch` and `POST /v1/app/kill-switch`, does not call `setGlobalAgentFrozen`, and leaves the DB state unchanged (`test/unit/routes-kill-switch.test.ts`).
- Regenerated the OpenAPI snapshot via `npm run ui:openapi` as part of the change workflow (artifact created at `apps/gittensory-ui/public/openapi.json`).

### Testing

- Ran the targeted unit suite with `npx vitest run test/unit/routes-kill-switch.test.ts` and all tests in that file passed (11/11).
- Ran `npm run typecheck` and it completed with no type errors.
- Ran `npm run test:coverage -- --run test/unit/routes-kill-switch.test.ts` where the test file ran and passed, but the global coverage check failed as expected because the full test corpus was not executed in this targeted run; a full unsharded coverage run was attempted but did not complete in this environment.
- Attempts to run the full local gate (`npm run test:ci`) and `npm audit --audit-level=moderate` were blocked by external network/tooling issues (actionlint setup / npm audit endpoint) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a459c839e68832cbca90d7923353f92)