### PR TITLE
fix(queue): guard terminal PR resync races

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1943,7 +1943,10 @@ async function reReviewStoredPullRequest(
   // visible output — re-reviewing a PR that can no longer produce a valid outcome. Fail-open: only a live NON-open
   // state early-exits (a fetch hiccup leaves `live` undefined → proceed with the stored open PR).
   if (live && live.state !== "open") {
-    await upsertPullRequestFromGitHub(env, repoFullName, live).catch(() => undefined);
+    const current = await getPullRequest(env, repoFullName, prNumber);
+    if (current?.state === "open" && current.updatedAt === pr.updatedAt) {
+      await upsertPullRequestFromGitHub(env, repoFullName, live).catch(() => undefined);
+    }
     return;
   }
   if (live?.head?.sha && live.head.sha !== pr.headSha) {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -957,6 +957,34 @@ describe("queue processors", () => {
     expect(ciFetched).toBe(false);
   });
 
+  it("#regate-terminal-exit: skips a stale terminal upsert when a concurrent webhook already reopened the PR", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Open PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+    let webhookReplayApplied = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/pulls/7")) {
+        vi.setSystemTime(new Date("2026-05-28T02:00:01.000Z"));
+        await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Reopened PR", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, labels: [], body: "Closes #1" });
+        webhookReplayApplied = true;
+        return Response.json({ number: 7, title: "Stale closed PR", state: "closed", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      }
+      return Response.json({});
+    });
+
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "resync-stale-closed", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+    expect(webhookReplayApplied).toBe(true);
+    const stored = await getPullRequest(env, "owner/agent-repo", 7);
+    expect(stored?.state).toBe("open");
+    expect(stored?.headSha).toBe("b8");
+  });
+
   // REST-budget dedup (#audit-rate-headroom): one per-PR re-review threads request-local live GitHub facts through
   // readiness and auto-maintain, while post-gate planning refreshes facts that can change after the bot publishes
   // review/check state. Mergeability can advance to clean; CI can flip red and must still suppress merge.


### PR DESCRIPTION
### Motivation
- The per-PR regate path could unconditionally upsert a fetched live non-open PR payload and return, allowing a stale closed response to overwrite a concurrently-reopened stored row and cause a live-open PR to be skipped by future sweeps.

### Description
- Add a freshness guard in `reReviewStoredPullRequest` that re-reads the stored PR and only calls `upsertPullRequestFromGitHub` for a live non-open payload if the stored row is still `open` and its `updatedAt` matches the job's snapshot.
- This prevents a stale terminal upsert from winning a race against a concurrent reopen webhook while preserving the early-exit semantics for genuinely terminal PRs.
- Add a regression unit test that simulates a concurrent reopen webhook while the regate fetch returns a stale closed payload and asserts the stored PR remains open with the reopened head.
- Files changed: `src/queue/processors.ts`, `test/unit/queue.test.ts`.

### Testing
- Ran `npx vitest run test/unit/queue.test.ts -t "regate-terminal-exit"` and the targeted unit tests passed.
- Ran `npm run typecheck` and `git diff --check`, both succeeded.
- Ran `npm run test:coverage` with coverage enabled and the global coverage thresholds for the whole repo failed (expected given the focused unit change and repo-wide thresholds), so full coverage gate remains unsharded and must be green before pushing.
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate` but both were blocked by environmental/network issues (actionlint runner-label resolution and npm audit 403), not by the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4576131228832c8345a4d0c73de72d)