### PR TITLE
fix(selfhost): avoid postgres url argv leaks

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -96,7 +96,7 @@ QDRANT_URL=http://qdrant:6333`}
       </p>
       <CodeBlock
         lang="bash"
-        code={`DATABASE_URL=postgres://gittensory:<password>@pgbouncer:5432/gittensory
+        code={`export DATABASE_URL=postgres://gittensory:<password>@pgbouncer:5432/gittensory
 npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite
 npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite --execute`}
       />

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -96,8 +96,9 @@ QDRANT_URL=http://qdrant:6333`}
       </p>
       <CodeBlock
         lang="bash"
-        code={`npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite --postgres-url "$DATABASE_URL"
-npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite --postgres-url "$DATABASE_URL" --execute`}
+        code={`DATABASE_URL=postgres://gittensory:<password>@pgbouncer:5432/gittensory
+npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite
+npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite --execute`}
       />
 
       <h2>Restore checks</h2>

--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -41,7 +41,7 @@ pg_enabled() {
 }
 
 pg_scalar() {
-  psql "$PG_DB" -X -q -t -A -v ON_ERROR_STOP=1 -c "$1"
+  PGDATABASE="$PG_DB" psql -X -q -t -A -v ON_ERROR_STOP=1 -c "$1"
 }
 
 pg_table_exists() {
@@ -63,7 +63,7 @@ pg_column_exists() {
 pg_copy_csv() {
   query="$1"
   out="$2"
-  psql "$PG_DB" -X -q -v ON_ERROR_STOP=1 -c "COPY ($query) TO STDOUT WITH CSV" >"$out"
+  PGDATABASE="$PG_DB" psql -X -q -v ON_ERROR_STOP=1 -c "COPY ($query) TO STDOUT WITH CSV" >"$out"
 }
 
 sqlite_import_csv() {

--- a/scripts/migrate-selfhost-sqlite-to-postgres.ts
+++ b/scripts/migrate-selfhost-sqlite-to-postgres.ts
@@ -36,14 +36,15 @@ const TABLES_ALLOWED_AFTER_SCHEMA_INIT = new Set(["global_agent_controls", "glob
 const POSTGRES_TEXT_NUL_REPLACEMENT = "\uFFFD";
 
 function usage(): string {
-  return `Usage: npm run selfhost:postgres:migrate -- --sqlite <path> --postgres-url <url> [--execute]
+  return `Usage: DATABASE_URL=<postgres-url> npm run selfhost:postgres:migrate -- --sqlite <path> [--execute]
 
 Copies a self-host SQLite database into an empty Postgres backend. The default is a transactionally
-rolled-back dry run. Pass --execute to commit the copy.
+rolled-back dry run. Pass --execute to commit the copy. Prefer DATABASE_URL over --postgres-url so
+the Postgres credential is not exposed through process command lines.
 
 Options:
   --sqlite <path>          SQLite source file. Defaults to DATABASE_PATH or /data/gittensory.sqlite.
-  --postgres-url <url>     Postgres target URL. Defaults to DATABASE_URL.
+  --postgres-url <url>     Postgres target URL. Defaults to DATABASE_URL; avoid this on shared hosts.
   --migrations-dir <path>  Migration directory. Defaults to migrations.
   --execute                Commit the copy. Omit for a rollback dry run.
   --allow-non-empty        Allow non-empty target tables only when overlapping primary keys are identical.

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -50,6 +50,16 @@ function fakePsql(root: string): string {
     psql,
     `#!/bin/sh
 args="$*"
+case " $args " in
+  *" postgres://"*|*" postgresql://"*)
+    echo 'psql command line leaked postgres URL' >&2
+    exit 8
+    ;;
+esac
+if [ "\${PGDATABASE:-}" != "postgres://gittensory:pw@postgres:5432/gittensory" ]; then
+  echo 'psql did not receive postgres URL through PGDATABASE' >&2
+  exit 8
+fi
 case "$args" in
   *\\\\copy*)
     echo 'unexpected psql meta-command copy' >&2


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of Postgres credentials by removing expanded Postgres URLs from `psql` and process argv, since command-line arguments can be read by other local users on typical systems.

### Description
- Route Postgres calls in the Grafana reporting exporter through libpq environment variable `PGDATABASE` instead of passing the full URL as a `psql` positional argument in `scripts/export-grafana-reporting-db.sh`.
- Prefer environment-based usage by changing the self-host documentation example to `DATABASE_URL=…` and removing the expanded `--postgres-url "$DATABASE_URL"` command-line example in `apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx`.
- Update the migrator usage text in `scripts/migrate-selfhost-sqlite-to-postgres.ts` to recommend `DATABASE_URL` and warn against using `--postgres-url` on shared hosts.
- Add a regression assertion to the fake `psql` helper in `test/unit/selfhost-grafana-reporting.test.ts` that fails if a Postgres URL appears in `psql` argv or if the URL is not supplied via `PGDATABASE`.

### Testing
- Ran the unit suite for the modified exporter tests with `npx vitest run test/unit/selfhost-grafana-reporting.test.ts`, which passed (all tests green).
- Ran UI lint with `npm run ui:lint`, which completed successfully with existing warnings only (no errors).
- Ran type checking with `npm run typecheck`, which completed successfully.
- Ran `git diff --check` and local formatting commands, which reported no blocking issues; `npm run test:ci` and `npm audit --audit-level=moderate` could not complete due to external network/setup constraints and therefore were not fully exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45799f4588832cb0f350331402eb1d)