### PR TITLE
fix(github): reject multi-segment repo slugs in PR action helpers

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -17,9 +17,11 @@ const REVIEW_PAGE_LIMIT = 10;
 // recorded, not swallowed.
 
 function splitRepo(repoFullName: string): { owner: string; repo: string } {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
-  return { owner, repo };
+  const parts = repoFullName.trim().split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  return { owner: parts[0], repo: parts[1] };
 }
 
 export type PullRequestReviewEvent = "REQUEST_CHANGES" | "APPROVE" | "COMMENT";

--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -17,7 +17,10 @@ const REVIEW_PAGE_LIMIT = 10;
 // recorded, not swallowed.
 
 function splitRepo(repoFullName: string): { owner: string; repo: string } {
-  const parts = repoFullName.trim().split("/");
+  if (repoFullName !== repoFullName.trim()) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  const parts = repoFullName.split("/");
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
     throw new Error(`Invalid repository full name: ${repoFullName}`);
   }

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -18,12 +18,18 @@ describe("GitHub PR action primitives (#778)", () => {
     await expect(closePullRequest(createTestEnv(), 1, "owner/repo/extra", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
+    await expect(closePullRequest(createTestEnv(), 1, " owner/repo ", 4)).rejects.toThrow(
+      /Invalid repository full name/,
+    );
     let called = false;
     vi.stubGlobal("fetch", async () => {
       called = true;
       return Response.json({ token: "t" });
     });
     await expect(closePullRequest(envWithKey(), 1, "owner/repo/extra", 4)).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    await expect(closePullRequest(envWithKey(), 1, " owner/repo ", 4)).rejects.toThrow(
       /Invalid repository full name/,
     );
     expect(called).toBe(false);

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -15,6 +15,18 @@ describe("GitHub PR action primitives (#778)", () => {
 
   it("validates the repo name before any GitHub call", async () => {
     await expect(closePullRequest(createTestEnv(), 1, "invalid", 4)).rejects.toThrow(/Invalid repository full name/);
+    await expect(closePullRequest(createTestEnv(), 1, "owner/repo/extra", 4)).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return Response.json({ token: "t" });
+    });
+    await expect(closePullRequest(envWithKey(), 1, "owner/repo/extra", 4)).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    expect(called).toBe(false);
   });
 
   it("posts a request-changes review with the body", async () => {


### PR DESCRIPTION
## Summary

- Require exactly `owner/repo` in `splitRepo` before maintainer auto-maintain GitHub mutations run.
- Reject padded and multi-segment slugs so malformed identifiers fail closed instead of targeting the wrong repository.

## Test plan

- [x] `npx vitest run test/unit/github-pr-actions.test.ts`