### PR TITLE
fix(signals): match contributor opportunity labels case-insensitively

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1382,7 +1382,7 @@ export function buildContributorOpportunities(
 ): ContributorOpportunity[] {
   const opportunities: ContributorOpportunity[] = [];
   const touchedRepos = new Set(profile.registeredRepoActivity.reposTouched.map((repoFullName) => repoFullName.toLowerCase()));
-  const labelHistory = new Set(profile.registeredRepoActivity.dominantLabels);
+  const labelHistory = new Set(profile.registeredRepoActivity.dominantLabels.map((label) => label.toLowerCase()));
   const bountyByIssue = indexBountiesByIssue(bounties);
   const qualityByKey = issueQualityByRepo
     ? new Map(Array.from(issueQualityByRepo.entries()).map(([key, value]) => [key.toLowerCase(), value]))
@@ -1413,7 +1413,7 @@ export function buildContributorOpportunities(
       // Never steer contributors toward completed, cancelled, or otherwise historical bounty work.
       if (bountyLifecycle && isHistoricalBountyLifecycle(bountyLifecycle)) continue;
       const bountyPenalty = bountyLifecycle === "stale" || bountyLifecycle === "ambiguous" ? 30 : 0;
-      const labelFit = issue.labels.filter((label) => labelHistory.has(label)).length;
+      const labelFit = issue.labels.filter((label) => labelHistory.has(label.toLowerCase())).length;
       const qualityAdjustment =
         quality?.status === "ready"
           ? 10
@@ -1460,7 +1460,7 @@ export function buildContributorOpportunities(
           lane.summary,
           ...(maintainerAuthored && !maintainerWip ? ["Maintainer-created issue — typically the highest contribution multiplier on Gittensor."] : []),
           ...(touchedRepos.has(repo.fullName.toLowerCase()) ? ["Contributor has prior activity in this registered repo."] : []),
-          ...(labelFit > 0 ? [`Issue labels overlap contributor history: ${issue.labels.filter((label) => labelHistory.has(label)).join(", ")}.`] : []),
+          ...(labelFit > 0 ? [`Issue labels overlap contributor history: ${issue.labels.filter((label) => labelHistory.has(label.toLowerCase())).join(", ")}.`] : []),
           ...(bountyLifecycle === "active" ? ["An active bounty is attached as contribution context (not guaranteed payout)."] : []),
           ...(quality?.status === "ready" ? ["Issue quality report rates this issue as ready."] : []),
         ],

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -178,6 +178,34 @@ describe("world-class backend signals", () => {
     expect(opportunities[0]?.score).toBeGreaterThanOrEqual(70);
   });
 
+  it("matches contributor label history case-insensitively when scoring opportunities", () => {
+    const profile = buildContributorProfile(
+      "oktofeesh1",
+      { login: "oktofeesh1", topLanguages: ["TypeScript"], source: "github" },
+      [],
+      [],
+      [{ login: "oktofeesh1", repoFullName: repo.fullName, pullRequests: 3, mergedPullRequests: 2, openPullRequests: 1, issues: 0, stalePullRequests: 0, unlinkedPullRequests: 0, dominantLabels: ["Bug", "CI"], lastActivityAt: "2026-05-25T00:00:00.000Z" }],
+    );
+    const caseVariantIssue: IssueRecord = {
+      ...issues[0]!,
+      number: 88,
+      title: "Crash on duplicate webhook delivery",
+      labels: ["bug"],
+      linkedPrs: [],
+    };
+    const unrelatedIssue: IssueRecord = {
+      ...issues[0]!,
+      number: 89,
+      title: "Polish contributor onboarding docs",
+      labels: ["docs"],
+      linkedPrs: [],
+    };
+    const opportunities = buildContributorOpportunities(profile, [repo], [unrelatedIssue, caseVariantIssue], []);
+    expect(opportunities[0]?.issueNumber).toBe(88);
+    expect(opportunities[0]?.reasons).toEqual(expect.arrayContaining([expect.stringMatching(/labels overlap contributor history: bug/i)]));
+    expect(opportunities[0]?.score).toBeGreaterThan(opportunities.find((entry) => entry.issueNumber === 89)?.score ?? 0);
+  });
+
   it("ranks grabbable maintainer-created issues above community issues and downgrades maintainer WIP (#699/#186)", () => {
     const profile = buildContributorProfile("scout", { login: "scout", topLanguages: ["TypeScript"], source: "github" }, [], []);
     const maintainerOpen: IssueRecord = {


### PR DESCRIPTION
## Summary

- buildContributorOpportunities compared dominantLabels to issue.labels with case-sensitive Set membership.
- GitHub labels are case-insensitive, so Bug versus bug missed labelFit scoring, reasons, and opportunity ranking.
- Normalize label history to lowercase for overlap checks (mirrors focus-manifest and maintainer WIP label handling).

## Scope

Focused change in src/signals/engine.ts plus regression test. No guarded paths. No linked issue (upstream issue filing requires write access this account no longer has).

## Validation

npx vitest run test/unit/signals.test.ts -t "label history case"

## Safety

No secrets. Regression test covers dominantLabels Bug with issue label bug.