### PR TITLE
fix(ci): include package manifests in node_modules cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       # runner's own persistence, and npm ci always deletes+reinstalls node_modules by design -- so
       # neither the runner nor npm ci gives node_modules any real cross-run reuse on its own. This
       # explicit restore/save pair (via GitHub's own cache service, not the wiped local disk) fills that
-      # gap: an exact package-lock.json match skips npm ci entirely. Keyed separately per fork/trusted
+      # gap: an exact manifest+lockfile match skips npm ci entirely. Keyed separately per fork/trusted
       # (see the runs-on expression above) because self-hosted's Docker image and GitHub's ubuntu-latest
       # image are not guaranteed binary-compatible for native modules (sharp, workerd, fsevents, ...) --
       # crossing them could load an incompatible native binary. Fork PRs get read-only cache tokens (a
@@ -152,10 +152,12 @@ jobs:
           path: |
             node_modules
             apps/gittensory-ui/node_modules
-          # hashFiles('.nvmrc') matters as much as the lockfile: a Node bump with no lockfile change
-          # would otherwise still hit and silently reuse node_modules whose native addons (sharp,
-          # workerd, fsevents) were compiled against the OLD Node's ABI.
-          key: npm-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package-lock.json') }}
+          # hashFiles('.nvmrc') matters as much as the package manifests and lockfile: a Node bump
+          # with no lockfile change would otherwise still hit and silently reuse node_modules whose
+          # native addons (sharp, workerd, fsevents) were compiled against the OLD Node's ABI. The
+          # manifests matter too because npm ci validates package.json/package-lock.json consistency
+          # and runs lifecycle scripts from package.json; a package.json-only change must not skip it.
+          key: npm-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json') }}
       - name: Install dependencies (retry on transient failures)
         if: ${{ steps.node-modules-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -313,8 +315,9 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: review-enrichment/node_modules
-          # Same Node-version guard as the root cache key above -- REES runs on the same pinned .nvmrc.
-          key: npm-rees-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('review-enrichment/package-lock.json') }}
+          # Same Node-version and manifest guards as the root cache key above -- REES runs on the same
+          # pinned .nvmrc and has its own package.json lifecycle/install validation.
+          key: npm-rees-${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && 'fork' || 'trusted' }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('review-enrichment/package.json', 'review-enrichment/package-lock.json') }}
       - name: REES install
         if: ${{ (github.event_name == 'push' || needs.changes.outputs.rees == 'true') && steps.rees-node-modules-cache.outputs.cache-hit != 'true' }}
         run: npm run rees:install

--- a/test/unit/ci-dependency-cache.test.ts
+++ b/test/unit/ci-dependency-cache.test.ts
@@ -31,7 +31,7 @@ function jobSteps(workflow: Record<string, unknown>, jobName: string): Array<Rec
 
 // actions/checkout wipes node_modules on every run (git clean -ffdx) and npm ci always deletes+reinstalls
 // it by design, so neither gives node_modules any real cross-run reuse -- these restore/save pairs (via
-// GitHub's own cache service) fill that gap: an exact package-lock.json match skips the install step
+// GitHub's own cache service) fill that gap: an exact manifest+lockfile match skips the install step
 // entirely. Cache-save is placed right after a successful install (not as an automatic post-job hook), so
 // a job that fails installing never reaches the save step -- a broken node_modules can never get cached.
 describe("CI dependency-install caching", () => {
@@ -43,7 +43,11 @@ describe("CI dependency-install caching", () => {
     const restoreWith = record(restore.with, "restore.with");
     expect(String(restoreWith.path)).toContain("node_modules");
     expect(String(restoreWith.path)).toContain("apps/gittensory-ui/node_modules");
-    expect(String(restoreWith.key)).toContain("hashFiles('package-lock.json')");
+    expect(String(restoreWith.key)).toContain("hashFiles('package.json', 'apps/*/package.json', 'packages/*/package.json', 'package-lock.json')");
+    expect(String(restoreWith.key)).toContain("package.json");
+    expect(String(restoreWith.key)).toContain("apps/*/package.json");
+    expect(String(restoreWith.key)).toContain("packages/*/package.json");
+    expect(String(restoreWith.key)).toContain("package-lock.json");
     // A Node bump (.nvmrc) with no lockfile change must still bust the cache -- otherwise a hit would
     // silently reuse node_modules whose native addons were compiled against the OLD Node's ABI.
     expect(String(restoreWith.key)).toContain("hashFiles('.nvmrc')");
@@ -70,7 +74,9 @@ describe("CI dependency-install caching", () => {
     const restore = step(steps, "Restore review-enrichment node_modules cache");
     const restoreWith = record(restore.with, "restore.with");
     expect(restoreWith.path).toBe("review-enrichment/node_modules");
-    expect(String(restoreWith.key)).toContain("hashFiles('review-enrichment/package-lock.json')");
+    expect(String(restoreWith.key)).toContain("hashFiles('review-enrichment/package.json', 'review-enrichment/package-lock.json')");
+    expect(String(restoreWith.key)).toContain("review-enrichment/package.json");
+    expect(String(restoreWith.key)).toContain("review-enrichment/package-lock.json");
     expect(String(restoreWith.key)).toContain("hashFiles('.nvmrc')");
 
     const install = step(steps, "REES install");


### PR DESCRIPTION
### Motivation

- The node_modules cache key previously hashed only `.nvmrc` and lockfiles, allowing a `package.json`-only change to reuse stale or mutated `node_modules` and skip `npm ci` validation and lifecycle scripts.
- The same omission existed for the `review-enrichment` cache, introducing the same bypass risk for that separate install.

### Description

- Expand the root cache key in `.github/workflows/ci.yml` to include `package.json`, workspace manifests (`apps/*/package.json`, `packages/*/package.json`), and `package-lock.json`, and update the explanatory comment accordingly.
- Expand the `review-enrichment` cache key to include `review-enrichment/package.json` alongside its `package-lock.json`, and update its comment.
- Update `test/unit/ci-dependency-cache.test.ts` to assert the manifest-aware cache keys for both the root and `review-enrichment` cache entries and to reflect the amended comment text.
- Preserve the existing restore/skip/save wiring and the placement of the cache save step immediately after a successful install so only successful installs are cached.

### Testing

- Ran the targeted unit test: `npx vitest run test/unit/ci-dependency-cache.test.ts --reporter=dot`, which passed (2/2 tests).
- Ran `git diff --check`, which reported no issues in the modified files.
- `npm run actionlint` failed in this environment due to network/setup limitations reaching `github.com` and a WASM fallback reporting the repository's custom self-hosted label; this is an environment limitation and not caused by the change.
- `npm run test:ci` could not complete here because it stops at the same `actionlint` setup failure in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ef89afe0832ca398ee64d6cb0c9d)