### PR TITLE
fix(signals): scan full open-issue sample for pre-start title matching

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -3177,9 +3177,6 @@ export type PreStartCheckReport = {
 const DUPLICATE_RISK_RANK: Record<DuplicateClusterRisk, number> = { none: 0, low: 1, medium: 2, high: 3 };
 // Minimum Jaccard token overlap for a supplied title to resolve to a cached open issue.
 const TITLE_MATCH_MIN_JACCARD = 0.5;
-// Cap the title-matching scan so it stays cheap on repos with very large open-issue counts
-// (matches the bound used by the issue lifecycle report).
-const TITLE_MATCH_MAX_ISSUES = 300;
 
 /**
  * Pre-start duplicate/solvability check. Answers, before any branch exists, whether an issue is
@@ -3206,10 +3203,11 @@ export function buildPreStartCheck(
   } else if (target.title) {
     const wanted = new Set(tokenize(target.title));
     let best: { number: number; score: number } | undefined;
-    // An all-stopword/short title has no meaningful tokens to match against. Bound the scan to a
-    // fixed number of open issues so title matching stays cheap on repos with very large queues.
+    // An all-stopword/short title has no meaningful tokens to match against. Callers pass a bounded
+    // issue sample (listIssueSignalSample default 400); scan the full open set so stale issues beyond
+    // the old 300-cap are not invisible to title-only pre-start checks (#1920 pinned lifecycle by number only).
     if (wanted.size > 0) {
-      for (const issue of openIssues.slice(0, TITLE_MATCH_MAX_ISSUES)) {
+      for (const issue of openIssues) {
         const have = new Set(tokenize(issue.title));
         const shared = [...wanted].filter((term) => have.has(term)).length;
         const score = shared / new Set([...wanted, ...have]).size;

--- a/test/unit/pre-start-check.test.ts
+++ b/test/unit/pre-start-check.test.ts
@@ -209,6 +209,24 @@ describe("buildPreStartCheck", () => {
     assertPublicSafe(report);
   });
 
+  it("resolves title targets beyond the 300-issue title scan cap (regression for stale open issues)", () => {
+    const manyIssues = Array.from({ length: 301 }, (_, index) =>
+      issue(index + 1, `Cached maintenance task ${index + 1}`, {
+        updatedAt: new Date(Date.now() - index * 60_000).toISOString(),
+      }),
+    );
+    manyIssues[300] = issue(301, "Fix flaky retry backoff in queue worker pipeline", {
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    });
+    const report = buildPreStartCheck(repo("owner/repo"), manyIssues, [], [], "owner/repo", {
+      title: "flaky retry backoff queue worker pipeline",
+    });
+    expect(report.target.matchedBy).toBe("title");
+    expect(report.target.resolvedIssueNumber).toBe(301);
+    expect(report.found).toBe(true);
+    assertPublicSafe(report);
+  });
+
   it("raises on a direct-PR-first repository", () => {
     const r = repo("owner/repo", { issueDiscoveryShare: 0 });
     const report = buildPreStartCheck(r, [issue(1, "Fix parser crash on empty input handling")], [], [], "owner/repo", { issueNumber: 1 });


### PR DESCRIPTION
## Summary

Title-only check-before-start capped Jaccard matching at openIssues.slice(0, 300). Stale issues beyond index 300 were invisible to title resolution. Scan the full bounded open-issue set callers pass.

## Scope

Focused engine + regression test. No guarded paths.

## Validation

npx vitest run test/unit/pre-start-check.test.ts -t title scan cap