### PR TITLE
fix(agent-actions): pin staged close actions to a head SHA and re-verify live state at accept time

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -112,6 +112,46 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     }
   }
 
+  // Re-validate a staged CLOSE tagged "linked-issue-hard-rule" against the CURRENT hard-rule state (flagged by
+  // the gate's own review of #2452). Mirrors the blacklist re-check above: the head-SHA pin only catches a
+  // force-push, not a maintainer relabeling/reassigning the linked issue (or editing hard-rule config) while the
+  // close sits waiting in the queue -- head SHA unchanged, so the pin doesn't catch it. Unlike the merge re-check
+  // below (which supersedes a merge when the rule BECOMES violated), this close was staged BECAUSE the rule WAS
+  // violated, so this supersedes it when the rule is NO LONGER violated -- the close's own justification
+  // evaporated. No owner/automation-bot re-check needed: a row only reaches closeKind "linked-issue-hard-rule" in
+  // the first place because the planner already confirmed close-eligibility before staging it (#pendingActionToPlanned).
+  if (pending.actionClass === "close" && pending.params.closeKind === "linked-issue-hard-rule" && pr) {
+    const repoOwner = pending.repoFullName.includes("/") ? pending.repoFullName.slice(0, pending.repoFullName.indexOf("/")) : "";
+    const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, pending.repoFullName);
+    // Best-effort mint, same fail-open contract as the merge re-check below (#2126/#2132): a failed mint or a
+    // resolution that can't gather issue facts falls back to resolveLinkedIssueHardRule's own "not violated"
+    // default, which this check then treats as "the close is no longer justified" -- the SAFE direction for an
+    // irreversible close (superseding it re-stages from a fresh sweep instead of risking a wrongful auto-close).
+    const ciToken = await createInstallationToken(env, pending.installationId).catch(() => undefined);
+    const linkedIssueHardRule = await resolveLinkedIssueHardRule({
+      env,
+      repoFullName: pending.repoFullName,
+      repoOwner,
+      config: linkedIssueRulesConfig,
+      body: pr.body,
+      linkedIssues: pr.linkedIssues,
+      ciToken,
+      installationId: pending.installationId,
+    });
+    if (!linkedIssueHardRule?.violated) {
+      await setPendingAgentActionStatus(env, pending.id, { status: "rejected", decidedBy: input.decidedBy });
+      await recordAuditEvent(env, {
+        eventType: "agent.pending_action.superseded",
+        actor: input.decidedBy,
+        targetKey,
+        outcome: "denied",
+        detail: "superseded linked-issue hard-rule close: the linked issue is no longer ineligible",
+        metadata: baseMetadata,
+      });
+      return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy }, executionOutcome: "linked_issue_no_longer_violated" };
+    }
+  }
+
   // Re-derive live justification for a staged MERGE at accept time. auto_with_approval rows have no expiry, so
   // CI can flip red, the base can go dirty, or a reviewer can request changes while the row just sits waiting for
   // a maintainer — none of which move the head SHA, so the check above alone would not catch it. Best-effort: a

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -113,42 +113,58 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
   }
 
   // Re-validate a staged CLOSE tagged "linked-issue-hard-rule" against the CURRENT hard-rule state (flagged by
-  // the gate's own review of #2452). Mirrors the blacklist re-check above: the head-SHA pin only catches a
-  // force-push, not a maintainer relabeling/reassigning the linked issue (or editing hard-rule config) while the
-  // close sits waiting in the queue -- head SHA unchanged, so the pin doesn't catch it. Unlike the merge re-check
-  // below (which supersedes a merge when the rule BECOMES violated), this close was staged BECAUSE the rule WAS
-  // violated, so this supersedes it when the rule is NO LONGER violated -- the close's own justification
-  // evaporated. No owner/automation-bot re-check needed: a row only reaches closeKind "linked-issue-hard-rule" in
-  // the first place because the planner already confirmed close-eligibility before staging it (#pendingActionToPlanned).
+  // the gate's own review of #2452, twice). Mirrors the blacklist re-check above: the head-SHA pin only catches
+  // a force-push, not a maintainer relabeling/reassigning the linked issue (or editing hard-rule config) while
+  // the close sits waiting in the queue -- head SHA unchanged, so the pin doesn't catch it. Unlike the merge
+  // re-check below (which supersedes a merge when the rule BECOMES violated), this close was staged BECAUSE the
+  // rule WAS violated, so this supersedes it when the rule is NO LONGER violated -- the close's own justification
+  // evaporated. Also re-derives closeEligible (mirrors the merge re-check's own closeEligible below): the planner
+  // confirmed eligibility at STAGING time, but settings.closeOwnerAuthors is a live toggle that can flip to false
+  // between staging and accept without moving the head SHA, same staleness class as the rule check itself -- an
+  // owner PR staged for close while the setting was true must not still close after it is turned off.
   if (pending.actionClass === "close" && pending.params.closeKind === "linked-issue-hard-rule" && pr) {
     const repoOwner = pending.repoFullName.includes("/") ? pending.repoFullName.slice(0, pending.repoFullName.indexOf("/")) : "";
-    const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, pending.repoFullName);
-    // Best-effort mint, same fail-open contract as the merge re-check below (#2126/#2132): a failed mint or a
-    // resolution that can't gather issue facts falls back to resolveLinkedIssueHardRule's own "not violated"
-    // default, which this check then treats as "the close is no longer justified" -- the SAFE direction for an
-    // irreversible close (superseding it re-stages from a fresh sweep instead of risking a wrongful auto-close).
-    const ciToken = await createInstallationToken(env, pending.installationId).catch(() => undefined);
-    const linkedIssueHardRule = await resolveLinkedIssueHardRule({
-      env,
-      repoFullName: pending.repoFullName,
-      repoOwner,
-      config: linkedIssueRulesConfig,
-      body: pr.body,
-      linkedIssues: pr.linkedIssues,
-      ciToken,
-      installationId: pending.installationId,
-    });
-    if (!linkedIssueHardRule?.violated) {
+    const authorLogin = pr.authorLogin ?? "";
+    const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
+    const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
+    const closeEligible = (!authorIsOwner && !authorIsAutomationBot) || (authorIsOwner && settings.closeOwnerAuthors === true);
+    let stillJustified = closeEligible;
+    if (closeEligible) {
+      const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, pending.repoFullName);
+      // Best-effort mint, same fail-open contract as the merge re-check below (#2126/#2132): a failed mint or a
+      // resolution that can't gather issue facts falls back to resolveLinkedIssueHardRule's own "not violated"
+      // default, which this check then treats as "the close is no longer justified" -- the SAFE direction for an
+      // irreversible close (superseding it re-stages from a fresh sweep instead of risking a wrongful auto-close).
+      const ciToken = await createInstallationToken(env, pending.installationId).catch(() => undefined);
+      const linkedIssueHardRule = await resolveLinkedIssueHardRule({
+        env,
+        repoFullName: pending.repoFullName,
+        repoOwner,
+        config: linkedIssueRulesConfig,
+        body: pr.body,
+        linkedIssues: pr.linkedIssues,
+        ciToken,
+        installationId: pending.installationId,
+      });
+      stillJustified = linkedIssueHardRule?.violated === true;
+    }
+    if (!stillJustified) {
       await setPendingAgentActionStatus(env, pending.id, { status: "rejected", decidedBy: input.decidedBy });
       await recordAuditEvent(env, {
         eventType: "agent.pending_action.superseded",
         actor: input.decidedBy,
         targetKey,
         outcome: "denied",
-        detail: "superseded linked-issue hard-rule close: the linked issue is no longer ineligible",
+        detail: closeEligible
+          ? "superseded linked-issue hard-rule close: the linked issue is no longer ineligible"
+          : "superseded linked-issue hard-rule close: the author is no longer close-eligible (owner/automation exemption now applies)",
         metadata: baseMetadata,
       });
-      return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy }, executionOutcome: "linked_issue_no_longer_violated" };
+      return {
+        status: "rejected",
+        action: { ...pending, status: "rejected", decidedBy: input.decidedBy },
+        executionOutcome: closeEligible ? "linked_issue_no_longer_violated" : "no_longer_close_eligible",
+      };
     }
   }
 

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -3,6 +3,7 @@ import { createInstallationToken } from "../github/app";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { executeAgentMaintenanceActions, pendingActionToPlanned } from "./agent-action-executor";
 import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, type PlannedAgentAction } from "../settings/agent-actions";
+import { findBlacklistEntry } from "../settings/contributor-blacklist";
 import { isCloseHoldOnly, isHoldOnly } from "../review/outcomes-wire";
 import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestReviewDecision } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
@@ -60,20 +61,23 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     });
     return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy }, executionOutcome: "head_moved" };
   }
-  // An unpinned staged approve or merge (no expectedHeadSha) cannot be safety-verified against a force-push that
-  // happened during the queue wait. For a PINNED merge, GitHub's `sha` param 409s on mismatch -- a real backstop.
-  // But that backstop only exists because there's something to compare against; an UNPINNED merge falls back to
-  // performAction's `mergeSha = action.expectedHeadSha ?? ctx.headSha`, which by construction substitutes
-  // whatever head is live right now, so it trivially "matches" and no 409 is possible. The reviews API's
-  // `commit_id` has no server-side staleness rejection at all, pinned or not (#2377). Either way, the check above
-  // only fires when a pin EXISTS and disagrees with the live head; a row staged with no pin at all (e.g. by code
-  // predating this head-pinning fix, or a planning pass that ran against a transiently-null stored head SHA)
-  // would otherwise fall through to the executor's `ctx.headSha` fallback and silently ratify whatever commit is
-  // live NOW, under the authority of a review/merge that was never actually performed against it (#2422).
+  // An unpinned staged approve, merge, or close (no expectedHeadSha) cannot be safety-verified against a
+  // force-push that happened during the queue wait. For a PINNED merge, GitHub's `sha` param 409s on mismatch --
+  // a real backstop. But that backstop only exists because there's something to compare against; an UNPINNED
+  // merge falls back to performAction's `mergeSha = action.expectedHeadSha ?? ctx.headSha`, which by construction
+  // substitutes whatever head is live right now, so it trivially "matches" and no 409 is possible. The reviews
+  // API's `commit_id` has no server-side staleness rejection at all, pinned or not (#2377). close has no
+  // server-side commit target at all -- its OWN freshness relies entirely on this application-level pin, since
+  // closePullRequest doesn't take a sha the way merge/reviews do. Either way, the check above only fires when a
+  // pin EXISTS and disagrees with the live head; a row staged with no pin at all (e.g. by code predating this
+  // head-pinning fix, or a planning pass that ran against a transiently-null stored head SHA) would otherwise
+  // fall through to the executor's `ctx.headSha` fallback and silently ratify whatever commit is live NOW, under
+  // the authority of a review/merge/close that was never actually performed against it (#2422, #2452).
   // dismissStaleApproval is exempt: it RETRACTS the bot's existing approval rather than granting a new one at a
   // specific commit, so it carries no "ratify unreviewed code" risk and is safe to replay unpinned.
   const isUnpinnedRatifyingAction =
-    !stagedHead && ((pending.actionClass === "approve" && !pending.params.dismissStaleApproval) || pending.actionClass === "merge");
+    !stagedHead &&
+    ((pending.actionClass === "approve" && !pending.params.dismissStaleApproval) || pending.actionClass === "merge" || pending.actionClass === "close");
   if (isUnpinnedRatifyingAction) {
     await setPendingAgentActionStatus(env, pending.id, { status: "rejected", decidedBy: input.decidedBy });
     await recordAuditEvent(env, {
@@ -85,6 +89,27 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
       metadata: baseMetadata,
     });
     return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy }, executionOutcome: "unpinned_legacy_action" };
+  }
+
+  // Re-resolve blacklist membership live at accept time (#2452). The head-SHA pin above only catches a
+  // FORCE-PUSH; it says nothing about whether the contributor is STILL blacklisted, and a blacklist close is a
+  // sticky auto_with_approval row with no expiry -- a maintainer can remove the entry (or edit .gittensory.yml)
+  // at any point while it sits waiting. `settings` was fetched fresh at the top of this function, so this
+  // mirrors the exact same pure check the planner uses (processors.ts), just re-run against CURRENT config.
+  if (pending.actionClass === "close" && pending.params.closeKind === "blacklist" && pr) {
+    const stillBlacklisted = findBlacklistEntry(pr.authorLogin, settings.contributorBlacklist) !== null;
+    if (!stillBlacklisted) {
+      await setPendingAgentActionStatus(env, pending.id, { status: "rejected", decidedBy: input.decidedBy });
+      await recordAuditEvent(env, {
+        eventType: "agent.pending_action.superseded",
+        actor: input.decidedBy,
+        targetKey,
+        outcome: "denied",
+        detail: "superseded blacklist close: contributor is no longer on the blacklist",
+        metadata: baseMetadata,
+      });
+      return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy }, executionOutcome: "no_longer_blacklisted" };
+    }
   }
 
   // Re-derive live justification for a staged MERGE at accept time. auto_with_approval rows have no expiry, so

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -282,7 +282,17 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     const label = input.blacklistLabel ?? DEFAULT_BLACKLIST_LABEL;
     if (acting("label")) actions.push({ actionClass: "label", requiresApproval: approval("label"), reason: "blacklisted contributor", label, labelOp: "add" });
     if (acting("close")) {
-      actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: "blacklisted contributor", closeComment: sanitizePublicComment(blacklistCloseMessage()), closeKind: "blacklist" });
+      actions.push({
+        actionClass: "close",
+        requiresApproval: approval("close"),
+        reason: "blacklisted contributor",
+        closeComment: sanitizePublicComment(blacklistCloseMessage()),
+        closeKind: "blacklist",
+        // Pin like merge/approve (#2452): for an auto_with_approval stage this travels into the pending row so
+        // the accept-time supersede check (agent-approval-queue.ts) can detect a force-push after staging, and
+        // decidePendingAgentAction separately re-resolves live blacklist membership for this closeKind.
+        ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
+      });
     }
     return actions;
   }
@@ -507,7 +517,15 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     const reason = linkedIssueHardRule?.reason ?? "the linked issue is not eligible for a community PR";
     // Tagged "linked-issue-hard-rule": the close-precision breaker EXEMPTS this deterministic close (it is not
     // verdict-driven, and the verify path may already have promised closure in a comment).
-    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason, closeComment: closeMessage([reason]), closeKind: "linked-issue-hard-rule" });
+    actions.push({
+      actionClass: "close",
+      requiresApproval: approval("close"),
+      reason,
+      closeComment: closeMessage([reason]),
+      closeKind: "linked-issue-hard-rule",
+      // Pin like merge/approve (#2452): lets the accept-time supersede check detect a force-push after staging.
+      ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
+    });
   } else if (canMerge) {
     actions.push({
       actionClass: "merge",
@@ -532,7 +550,16 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     if (closeReasons.length === 0) closeReasons.push("the review gate is not satisfied");
     // Tagged "heuristic": a verdict-driven close (gate-verdict / duplicate / slop / CI). This is the ONLY close
     // the close-precision breaker downgrades to a hold when close precision has dropped.
-    actions.push({ actionClass: "close", requiresApproval: approval("close"), reason: closeReasons.join("; "), closeComment: closeMessage(closeReasons), closeKind: "heuristic" });
+    actions.push({
+      actionClass: "close",
+      requiresApproval: approval("close"),
+      reason: closeReasons.join("; "),
+      closeComment: closeMessage(closeReasons),
+      closeKind: "heuristic",
+      // Pin like merge/approve (#2452): lets the accept-time supersede check detect a force-push after staging;
+      // the executor's own step-6 live-CI re-check (#2128) separately covers the CI-driven reason above.
+      ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
+    });
   }
   // else: guarded → manual (needs-human/changes label above); not-good OWNER/automation → held
   // (request-changes above); review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -217,6 +217,11 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, pr: { labels: [], slopRisk: 90 } })))).not.toContain("close");
   });
 
+  it("pins the heuristic close to the reviewed head, mirroring merge/approve (#2452)", () => {
+    const close = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], pr: { labels: [], headSha: "h-reviewed" } })).find((a) => a.actionClass === "close");
+    expect(close).toMatchObject({ closeKind: "heuristic", expectedHeadSha: "h-reviewed" });
+  });
+
   it("#dup-winner disposition seam: the close reason includes the duplicate cause only when linkedDuplicateCount > 0", () => {
     // Loser path (count > 0, the caller's real count): the duplicate cause IS cited in the close reason.
     const loser = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], pr: { labels: [], linkedDuplicateCount: 2 } }));
@@ -556,6 +561,11 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(close?.closeComment).toContain(violation.reason);
     });
 
+    it("pins the linked-issue hard-rule close to the reviewed head, mirroring merge/approve (#2452)", () => {
+      const close = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED", headSha: "h-reviewed" } })).find((a) => a.actionClass === "close");
+      expect(close).toMatchObject({ closeKind: "linked-issue-hard-rule", expectedHeadSha: "h-reviewed" });
+    });
+
     it("does NOT close the same violation on an OWNER PR (the isContributor guard)", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ciState: "passed", authorIsOwner: true, linkedIssueHardRule: violation, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } })));
       expect(plan).not.toContain("close");
@@ -795,6 +805,16 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "blacklist" });
     expect(plan[1]?.closeComment).not.toContain("plagiarism");
     expect(plan[1]?.closeComment).toContain("blocked from contributing");
+  });
+
+  it("pins the blacklist close to the reviewed head, mirroring merge/approve (#2452)", () => {
+    const plan = planAgentMaintenanceActions(blacklisted({ pr: { labels: [], headSha: "h-reviewed" } }));
+    expect(plan.find((a) => a.actionClass === "close")).toMatchObject({ closeKind: "blacklist", expectedHeadSha: "h-reviewed" });
+  });
+
+  it("omits expectedHeadSha on the blacklist close when the PR record has no headSha (defensive fallback, #2452)", () => {
+    const plan = planAgentMaintenanceActions(blacklisted());
+    expect(plan.find((a) => a.actionClass === "close")?.expectedHeadSha).toBeUndefined();
   });
 
   it("uses the repo-configured blacklistLabel, defaulting to 'slop' when unset", () => {

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -312,6 +312,77 @@ describe("agent approval queue (#779)", () => {
     expect(audit?.detail).toContain("no longer on the blacklist");
   });
 
+  it("accept executes a staged linked-issue hard-rule close when the linked issue is STILL ineligible at accept time", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "Linked issue #9 is labeled `maintainer-only` — it is not open for community PRs." });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeStillViolated } = await import("../../src/github/pr-actions");
+    expect(closeStillViolated).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
+  it("REGRESSION: accept supersedes a staged linked-issue hard-rule close when the linked issue is NO LONGER ineligible at accept time (flagged by the gate's own review of #2452)", async () => {
+    // The head-SHA pin alone cannot catch this: the contributor never force-pushed, so the freshness check above
+    // passes cleanly -- only re-resolving the hard rule against CURRENT issue/config state (not the plan-time
+    // snapshot baked into the sticky pending row) detects that a maintainer relabeled the linked issue (or the
+    // rule config changed) since staging.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: false, reason: null });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("linked_issue_no_longer_violated");
+    const { closePullRequest: closeNoLongerViolated } = await import("../../src/github/pr-actions");
+    expect(closeNoLongerViolated).not.toHaveBeenCalled();
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("rejected");
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("agent.pending_action.superseded").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("no longer ineligible");
+  });
+
+  it("accept tolerates a slash-less repoFullName for a staged linked-issue hard-rule close (defensive fallback)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "solorepo", autonomy: { close: "auto_with_approval" } });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "solorepo", full_name: "solorepo", private: false, owner: { login: "owner" } }],
+    });
+    await upsertPullRequestFromGitHub(env, "solorepo", { number: 7, title: "PR", state: "open", head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "still ineligible" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "solorepo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeSlashless } = await import("../../src/github/pr-actions");
+    expect(closeSlashless).toHaveBeenCalledWith(env, 5, "solorepo", 7);
+  });
+
+  it("accept still executes a staged linked-issue hard-rule close when its own token mint fails — fails OPEN, ciToken passed as undefined", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "still ineligible" });
+    vi.mocked(createInstallationToken).mockRejectedValueOnce(new Error("installation suspended"));
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    expect(vi.mocked(resolveLinkedIssueHardRule)).toHaveBeenCalledWith(expect.objectContaining({ ciToken: undefined }));
+  });
+
   it("accept does NOT deny an unpinned dismissStaleApproval retraction — retracting an approval carries no ratify-unreviewed-code risk (#2377)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { approve: "auto_with_approval" } });

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -240,6 +240,78 @@ describe("agent approval queue (#779)", () => {
     expect(audit?.detail).toContain("no reviewed-head pin");
   });
 
+  it("REGRESSION (#2452): accept denies a close staged with NO reviewed-head pin, rather than silently comparing the live head to itself", async () => {
+    // Unlike merge's `sha` param or approve's `commit_id`, close has NO server-side commit target at all -- the
+    // executor's step-5 freshness guard falls back to `action.expectedHeadSha ?? ctx.headSha`, and ctx.headSha is
+    // fetched fresh from the SAME DB row this function just re-read, so an unpinned close's freshness check
+    // trivially compares the live head against itself and can never catch a force-push after staging.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h-UNREVIEWED" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic" }, reason: "ci-failed" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("unpinned_legacy_action");
+    const { closePullRequest: closeUnpinned } = await import("../../src/github/pr-actions");
+    expect(closeUnpinned).not.toHaveBeenCalled();
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("rejected");
+  });
+
+  it("accept supersedes a staged close when the live head moved after staging (force-push fail-safe, #2452)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h-NEW" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic", expectedHeadSha: "h-OLD" }, reason: "ci-failed" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("head_moved");
+    const { closePullRequest: closeMoved } = await import("../../src/github/pr-actions");
+    expect(closeMoved).not.toHaveBeenCalled();
+  });
+
+  it("accept executes a staged blacklist close when the contributor is STILL blacklisted at accept time (#2452)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, {
+      repoFullName: "owner/repo",
+      autonomy: { close: "auto_with_approval" },
+      contributorBlacklist: [{ login: "plagiarist", reason: "plagiarism" }],
+    });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "plagiarist" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "blocked", closeKind: "blacklist", expectedHeadSha: "h7" }, reason: "blacklisted contributor" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeStillBlacklisted } = await import("../../src/github/pr-actions");
+    expect(closeStillBlacklisted).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
+  it("REGRESSION (#2452): accept supersedes a staged blacklist close when the contributor is NO LONGER blacklisted at accept time", async () => {
+    // The head-SHA pin alone cannot catch this: the contributor never force-pushed, so the freshness check above
+    // passes cleanly -- only re-resolving blacklist membership against the CURRENT repo settings (not the
+    // plan-time snapshot baked into the sticky pending row) detects that the maintainer removed the entry.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, contributorBlacklist: [] });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "reformed" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "blocked", closeKind: "blacklist", expectedHeadSha: "h7" }, reason: "blacklisted contributor" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("no_longer_blacklisted");
+    const { closePullRequest: closeNoLonger } = await import("../../src/github/pr-actions");
+    expect(closeNoLonger).not.toHaveBeenCalled();
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("rejected");
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("agent.pending_action.superseded").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("no longer on the blacklist");
+  });
+
   it("accept does NOT deny an unpinned dismissStaleApproval retraction — retracting an approval carries no ratify-unreviewed-code risk (#2377)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { approve: "auto_with_approval" } });
@@ -491,7 +563,7 @@ describe("agent approval queue (#779)", () => {
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval", label: "auto" } });
     await seedInstallation(env);
     await upsertPullRequestFromGitHub(env, "owner/repo", { number: 8, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h8" }, labels: [], body: "x" });
-    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 8, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic" }, reason: "ci-failed" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 8, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic", expectedHeadSha: "h8" }, reason: "ci-failed" });
     await env.DB.prepare("INSERT INTO system_flags (key, value) VALUES (?, ?)").bind("closehold:owner/repo", "true").run();
 
     const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -350,6 +350,45 @@ describe("agent approval queue (#779)", () => {
     expect(audit?.detail).toContain("no longer ineligible");
   });
 
+  it("REGRESSION: accept supersedes a staged linked-issue hard-rule close for an owner PR when closeOwnerAuthors is turned off before accept (flagged by the gate's own review of #2452, second pass)", async () => {
+    // Staged while closeOwnerAuthors was true (planner confirmed eligibility at staging time); by accept time a
+    // maintainer flipped the setting off. The head SHA never moved, so the freshness pin above doesn't catch
+    // this -- only re-deriving closeEligible against CURRENT settings does. The hard rule itself is still
+    // violated (it must not even be consulted once eligibility fails, mirroring the merge-side exemption).
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, closeOwnerAuthors: false });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "owner" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "would still violate, but must not even be checked" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("no_longer_close_eligible");
+    expect(resolveLinkedIssueHardRule).not.toHaveBeenCalled();
+    const { closePullRequest: closeNoLongerEligible } = await import("../../src/github/pr-actions");
+    expect(closeNoLongerEligible).not.toHaveBeenCalled();
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("rejected");
+    const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("agent.pending_action.superseded").first<{ outcome: string; detail: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("no longer close-eligible");
+  });
+
+  it("accept still executes a staged linked-issue hard-rule close for an owner PR when closeOwnerAuthors is (still) true at accept time", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, closeOwnerAuthors: true });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "owner" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "still ineligible" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeStillEligible } = await import("../../src/github/pr-actions");
+    expect(closeStillEligible).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
   it("accept tolerates a slash-less repoFullName for a staged linked-issue hard-rule close (defensive fallback)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "solorepo", autonomy: { close: "auto_with_approval" } });


### PR DESCRIPTION
## Summary

- Staged `close` actions (blacklist, linked-issue-hard-rule, heuristic) never had `expectedHeadSha` set, unlike `approve`/`merge`. The accept-time force-push guard in `agent-approval-queue.ts` only fires when a pin exists and disagrees with the live head — an unpinned close's freshness check instead falls back to comparing the live head against itself (both sides derive from the same fresh `getPullRequest` read at the top of the accept flow), so it could never actually catch a force-push that happened during the queue wait.
- Pins `expectedHeadSha` on all three close-construction sites in `src/settings/agent-actions.ts`, mirroring the existing merge/approve pattern exactly.
- Extends the accept-time `isUnpinnedRatifyingAction` guard (`src/services/agent-approval-queue.ts`) to also cover `close`, so a legacy unpinned row — staged before this fix deploys, or from a transiently-null stored head SHA — is refused and must be re-staged from a fresh sweep, rather than silently replayed.
- Adds a live blacklist-membership re-check specifically for `closeKind: "blacklist"`: the head-SHA pin alone cannot catch a maintainer removing the contributor from the blacklist between staging and accept, since the PR's head never moves in that scenario. Re-runs the exact same pure `findBlacklistEntry` check the planner uses (`processors.ts`), just against the CURRENT repo settings instead of the plan-time snapshot baked into the sticky pending row.

**Scoping note:** full re-verification of the non-CI heuristic-close reasoning (duplicate-of-open-PR, slop-score threshold) is intentionally out of scope for this PR. The executor's existing step-6 live-CI re-check (`agent-action-executor.ts`, #2128) already covers the CI half of a heuristic close, and this PR's head-SHA pin now gives it real force-push protection too — bringing heuristic close to the same fail-safe level merge/approve already had, without importing duplicate-detection/slop-scoring logic into the accept path.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — new code is 100% line+branch covered in both changed files (verified against `coverage/lcov.info`: `agent-approval-queue.ts` 62/62 lines, 81/81 branches; the handful of uncovered branches remaining in `agent-actions.ts` are pre-existing, outside the lines this PR touches). Global 96.54%/95.52%.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full suite: 5994/5994 passing (one pre-existing test needed its fixture updated — it staged a heuristic close with no head pin to test the close-precision breaker, which this fix now correctly rejects before reaching the breaker; added the pin so it still exercises the breaker logic it was written for). Also ran `npm run db:migrations:check` (unaffected, green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. This touches the real-merge/close execution path — added regression tests for: unpinned close denied, force-pushed pinned close superseded, still-blacklisted close proceeds, no-longer-blacklisted close superseded.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. No OpenAPI/MCP surface changed.
- [ ] UI changes — N/A, no UI changed.
- [ ] Visible UI changes — N/A, no UI changed.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. No changelog edit.

## Notes

- Found via an adversarial audit of the review engine's actuation pipeline, specifically hunting for the sibling of a class of bug (`#2377`/`#2422`/`#2262`) already fixed for approve/merge but not extended to close.