### PR TITLE
fix(github): evict a cached App JWT on rejection to stop fleet-wide token-minting poisoning

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -192,6 +192,21 @@ export async function withInstallationTokenRetry<T>(
   }
 }
 
+/** POST the App-installations access-token endpoint with a given JWT. Extracted so mintInstallationToken can
+ *  issue the same request twice — once with the cached JWT, once with a freshly-signed one on a 401 (#2453). */
+function requestInstallationTokenWithJwt(
+  jwt: string,
+  installationId: number,
+): Promise<Response> {
+  return timeoutFetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: githubHeaders(`Bearer ${jwt}`),
+    },
+  );
+}
+
 /** Mint a fresh installation token (broker or local App-JWT) and cache it. `cached` is the expired/absent prior
  *  entry, consulted only for the brokered stale-token grace. Extracted from createInstallationToken so that
  *  function can single-flight concurrent cold-cache callers onto one mint (see inFlightMints). */
@@ -242,13 +257,26 @@ async function mintInstallationToken(
     }
   }
   const jwt = await createAppJwt(env);
-  const response = await timeoutFetch(
-    `https://api.github.com/app/installations/${installationId}/access_tokens`,
-    {
-      method: "POST",
-      headers: githubHeaders(`Bearer ${jwt}`),
-    },
-  );
+  let response = await requestInstallationTokenWithJwt(jwt, installationId);
+  if (response.status === 401) {
+    // The cached App JWT itself was rejected (a transient GitHub-side validation hiccup, a clock-skew edge case,
+    // or a brief App suspend/reinstate) while env.GITHUB_APP_PRIVATE_KEY is unchanged. Unlike installation tokens
+    // (evicted + retried once by withInstallationTokenRetry), the App JWT had no eviction path at all: every mint
+    // attempt across EVERY installation on the instance kept reusing the SAME poisoned cache entry for up to
+    // APP_JWT_REUSE_MS (8 minutes), stalling merges/comments/check-runs/approvals fleet-wide (#2453). Evict + retry
+    // once with a freshly-signed JWT, mirroring withInstallationTokenRetry's identical bounded-once pattern.
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "github_app_jwt_rejected",
+        appId: env.GITHUB_APP_ID,
+        status: response.status,
+      }),
+    );
+    expireCachedAppJwt(env.GITHUB_APP_ID);
+    const freshJwt = await createAppJwt(env);
+    response = await requestInstallationTokenWithJwt(freshJwt, installationId);
+  }
   if (!response.ok) {
     const body = await response.text();
     throw new Error(
@@ -377,6 +405,13 @@ export async function getRepositoryCollaboratorPermission(
 // now-revoked old key (a stale-key JWT would fail every App-level read once the old key is revoked). (#1940)
 const APP_JWT_REUSE_MS = 8 * 60_000;
 const appJwtCache = new Map<string, { privateKey: string; jwt: string; expiresAtMs: number }>();
+
+/** Evict the cached App JWT for `appId` so the NEXT createAppJwt call re-signs, instead of continuing to serve a
+ *  JWT GitHub just rejected for up to APP_JWT_REUSE_MS more (#2453). Mirrors expireCachedInstallationToken's
+ *  identical eviction-on-rejection pattern for installation tokens. */
+function expireCachedAppJwt(appId: string): void {
+  appJwtCache.delete(appId);
+}
 
 async function createAppJwt(env: Env): Promise<string> {
   if (!env.GITHUB_APP_PRIVATE_KEY) {

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -276,6 +276,15 @@ async function mintInstallationToken(
     expireCachedAppJwt(env.GITHUB_APP_ID);
     const freshJwt = await createAppJwt(env);
     response = await requestInstallationTokenWithJwt(freshJwt, installationId);
+    if (response.status === 401) {
+      // The freshly-signed retry JWT was ALSO rejected. createAppJwt caches optimistically -- before this POST
+      // proves the JWT valid -- so without this the just-rejected JWT would sit in the cache and keep poisoning
+      // every mint fleet-wide for up to APP_JWT_REUSE_MS, exactly the bug this whole retry exists to fix
+      // (flagged by the gate's own review of #2453). Evict again; the throw below still surfaces this failure to
+      // the caller, but the NEXT mint attempt (this one or any other installation's) gets a fresh JWT instead of
+      // replaying the poisoned one.
+      expireCachedAppJwt(env.GITHUB_APP_ID);
+    }
   }
   if (!response.ok) {
     const body = await response.text();

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -190,6 +190,46 @@ describe("GitHub check runs", () => {
     expect(mints).toBe(1);
   });
 
+  it("REGRESSION (#2453): evicts a rejected App JWT and retries the mint once instead of failing outright", async () => {
+    // Unlike installation tokens (evicted + retried once by withInstallationTokenRetry), the App JWT itself had
+    // no eviction path before #2453: mintInstallationToken threw straight through on the first non-ok response,
+    // with no retry attempt at all, leaving the poisoned JWT cached for up to APP_JWT_REUSE_MS (8 min) and
+    // failing every installation-token mint on the instance in the meantime. Before this fix, mintCalls would be
+    // 1 and the overall call would reject; after it, exactly one retry recovers the mint.
+    const privateKey = await generatePrivateKeyPem();
+    let mintCalls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mintCalls += 1;
+        if (mintCalls === 1) return Response.json({ message: "Bad credentials" }, { status: 401 });
+        return Response.json({ token: "fresh-installation-token", expires_at: new Date(Date.now() + 60 * 60_000).toISOString() });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    await expect(createInstallationToken(env, 777)).resolves.toBe("fresh-installation-token");
+    expect(mintCalls).toBe(2); // exactly one bounded retry, not zero (old behavior) or unbounded
+  });
+
+  it("REGRESSION (#2453): does not infinite-loop when the retried App JWT is ALSO rejected", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    let mintCalls = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) {
+        mintCalls += 1;
+        return Response.json({ message: "Bad credentials" }, { status: 401 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+    await expect(createInstallationToken(env, 777)).rejects.toThrow(/Failed to create GitHub installation token \(401\)/);
+    expect(mintCalls).toBe(2); // bounded to exactly one retry, never an unbounded loop
+  });
+
   it("expires a rejected cached installation token and retries check-run publication once", async () => {
     const privateKey = await generatePrivateKeyPem();
     let mints = 0;

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -230,6 +230,47 @@ describe("GitHub check runs", () => {
     expect(mintCalls).toBe(2); // bounded to exactly one retry, never an unbounded loop
   });
 
+  it("REGRESSION (#2453, second pass — flagged by the gate's own review): evicts the App JWT again when the RETRIED JWT is ALSO rejected, so the NEXT mint attempt does not replay the poisoned JWT", async () => {
+    // createAppJwt caches optimistically (before the POST proves the JWT valid). Without a second eviction, the
+    // just-rejected retry JWT from the FIRST createInstallationToken call would sit in the cache and get replayed
+    // by a SECOND, independent createInstallationToken call — still failing every mint fleet-wide for up to
+    // APP_JWT_REUSE_MS, exactly the bug the eviction-on-401 fix exists to prevent. Fake timers advance the clock a
+    // few seconds between the two top-level calls (still far inside the 8-minute reuse window) so a genuinely
+    // fresh sign produces a different iat and a different Authorization header — RS256 signs an identical JWT for
+    // an identical iat/exp within the same second, so comparing headers without advancing the clock would be
+    // flaky (a false pass could occur even without eviction, purely from a same-second coincidence).
+    vi.useFakeTimers();
+    try {
+      const privateKey = await generatePrivateKeyPem();
+      const authHeaders: string[] = [];
+      let mintCalls = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        if (url.includes("/access_tokens")) {
+          mintCalls += 1;
+          authHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+          if (mintCalls <= 2) return Response.json({ message: "Bad credentials" }, { status: 401 });
+          return Response.json({ token: "recovered-token", expires_at: new Date(Date.now() + 60 * 60_000).toISOString() });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey });
+      await expect(createInstallationToken(env, 777)).rejects.toThrow(/Failed to create GitHub installation token \(401\)/);
+      expect(mintCalls).toBe(2);
+      const retryHeader = authHeaders[1];
+
+      await vi.advanceTimersByTimeAsync(5_000); // still well inside APP_JWT_REUSE_MS (8 min) — isolates eviction, not TTL expiry
+      await expect(createInstallationToken(env, 777)).resolves.toBe("recovered-token");
+      expect(mintCalls).toBe(3);
+      // If the retry-rejected JWT had NOT been evicted, this third call would replay the cached (still within its
+      // reuse window) poisoned JWT, producing the SAME Authorization header as the retry above.
+      expect(authHeaders[2]).not.toBe(retryHeader);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("expires a rejected cached installation token and retries check-run publication once", async () => {
     const privateKey = await generatePrivateKeyPem();
     let mints = 0;


### PR DESCRIPTION
## Summary

- `createAppJwt` (`src/github/app.ts`) caches the App-level JWT for ~8 minutes (`APP_JWT_REUSE_MS`) with no eviction path on rejection, unlike installation tokens — those are evicted and retried once by `withInstallationTokenRetry` (shipped in #2406). A single GitHub-side rejection of the currently-cached App JWT (a transient validation hiccup, a clock-skew edge case, or a brief App suspend/reinstate, with `env.GITHUB_APP_PRIVATE_KEY` unchanged) kept getting reused by `mintInstallationToken` on every subsequent installation-token mint attempt, across **every installation on the instance**, because the function threw straight through on the first non-ok response from the access-tokens endpoint with no retry at all.
- Adds `expireCachedAppJwt` (mirrors `expireCachedInstallationToken`'s exact eviction pattern) and has `mintInstallationToken` evict + re-sign + retry once on a 401 from `/app/installations/{id}/access_tokens`, bounded the same way `withInstallationTokenRetry` already bounds installation-token retries — a persistently-bad key (or a genuinely revoked App) still fails cleanly after the one retry, not an infinite loop.
- Extracted the POST call into a small `requestInstallationTokenWithJwt` helper so the retry can issue the identical request twice without duplicating the fetch/headers wiring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — new code is 100% line+branch covered (verified against `coverage/lcov.info` for the exact edited range in `src/github/app.ts`; file totals 181/181 lines, the 4 remaining uncovered branches are pre-existing, outside this PR's lines). Global 96.55%/95.53%.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full suite: 6062/6062 passing. Also ran `npm run db:migrations:check` (unaffected, green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. Added: a 401-then-success regression proving the eviction+retry recovers the mint, and a 401-then-401 regression proving the retry is bounded to exactly one attempt (no infinite loop) and still surfaces the failure.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. No OpenAPI/MCP surface changed.
- [ ] UI changes — N/A, no UI changed.
- [ ] Visible UI changes — N/A, no UI changed.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. No changelog edit.

## Notes

- Found via an adversarial audit of the review engine's caching layer, specifically checking whether the recent wave of GitHub-API caching work (App JWT reuse #1940, installation-token eviction #2406) left any asymmetry between the two — it did, on the App-JWT side.