### PR TITLE
fix(scoring): cap labelPatternToRegExp wildcard groups to prevent ReDoS

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -933,6 +933,21 @@ export function labelMatchesPattern(label: string, pattern: string): boolean {
 // safe and byte-identical to recompiling on every call.
 const labelPatternRegExpCache = new Map<string, RegExp>();
 
+// labelPatternToRegExp compiles each `*` to `.*`, so chained wildcards in a registry-supplied
+// label_multipliers key can backtrack catastrophically on .test() — the same class of ReDoS
+// globToRegExp guards against in change-guardrail.ts (#2445). fnmatch label patterns only
+// use single-segment `*` wildcards (no `**` globstar), so each `*` is one wildcard group.
+const MAX_LABEL_PATTERN_WILDCARD_GROUPS = 2;
+const NEVER_MATCHES_LABEL_PATTERN = /^(?!)$/;
+
+function countLabelPatternWildcardGroups(pattern: string): number {
+  let count = 0;
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (pattern.charAt(i) === "*") count += 1;
+  }
+  return count;
+}
+
 // Upstream resolves label multipliers by matching each configured key as a Python `fnmatch` GLOB, not a
 // literal string: `fnmatch(label.lower(), pattern.lower())` in
 // gittensor/validator/oss_contributions/label_resolution.py, so a repo can configure `type:*`, `kind/*`, or
@@ -946,6 +961,10 @@ const labelPatternRegExpCache = new Map<string, RegExp>();
 function labelPatternToRegExp(pattern: string): RegExp {
   const cached = labelPatternRegExpCache.get(pattern);
   if (cached !== undefined) return cached;
+  if (countLabelPatternWildcardGroups(pattern) > MAX_LABEL_PATTERN_WILDCARD_GROUPS) {
+    labelPatternRegExpCache.set(pattern, NEVER_MATCHES_LABEL_PATTERN);
+    return NEVER_MATCHES_LABEL_PATTERN;
+  }
   let regex = "";
   let i = 0;
   while (i < pattern.length) {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1913,4 +1913,15 @@ describe("label pattern matcher memoization (#2106)", () => {
     expect(labelMatchesPattern("bug", "bug")).toBe(true);
     expect(labelMatchesPattern("bugfix", "bug")).toBe(false);
   });
+
+  it("rejects over-complex wildcard label patterns instead of compiling a ReDoS-prone RegExp (#2456)", () => {
+    const overComplex = "*:*:*:*:*";
+    expect(labelMatchesPattern("type:bug-fix", overComplex)).toBe(false);
+    expect(labelMatchesPattern("anything", overComplex)).toBe(false);
+    // Repeated calls hit the cached never-match matcher.
+    expect(labelMatchesPattern("type:bug-fix", overComplex)).toBe(false);
+    // Two wildcards (at the cap) still compile and match normally.
+    expect(labelMatchesPattern("a:b", "*:*")).toBe(true);
+    expect(labelMatchesPattern("type:bug-fix", "type:*")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2456

`labelPatternToRegExp` in `src/scoring/preview.ts` compiles registry-supplied `label_multipliers` keys into anchored RegExps with unbounded chained `*` wildcards. A malicious or accidental key with too many `*` groups can make `.test()` catastrophically backtrack — the same ReDoS class `globToRegExp` in `change-guardrail.ts` already guards against (#2445).

This caps fnmatch label patterns at two wildcard groups (each `*` counts as one group). Over-complex patterns compile to a cached never-match RegExp instead of a pathological matcher, mirroring the fail-safe direction used elsewhere in scoring path compilation.

## Scope

- [x] Conventional Commit title (`fix(scoring): …`).
- [x] Focused change in `labelPatternToRegExp` + regression tests only.
- [x] Follows `CONTRIBUTING.md`; no UI/API/schema/migration changes.
- [x] Linked issue #2456.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` — extended `label pattern matcher memoization` with over-complex wildcard rejection and cap-boundary cases.
- [ ] `npm run test:ci`

If any required check was skipped, explain why:

- Node/npm is unavailable in this environment; CI will run the full gate on the PR.

## Safety

- [x] No secrets/wallets/hotkeys; over-complex registry keys fail closed to never-match instead of hanging request handling.
- [x] No auth/API/UI change.

## Notes

- Reproduction: `labelMatchesPattern("type:bug-fix", "*:*:*:*:*")` previously compiled a ReDoS-prone RegExp; after the fix it returns `false` immediately via the cached never-match matcher. Two-wildcard patterns like `*:*` and `type:*` still match normally.