### PR TITLE
fix(scoring): cap labelPatternToRegExp wildcard groups to prevent ReDoS

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -1,6 +1,7 @@
 import type { ContributorEvidenceRecord, JsonValue, RepositoryRecord, RepoTimeDecayOverrides, ScoringModelSnapshotRecord, ScorePreviewRecord } from "../types";
 import { DEFAULT_SCORING_CONSTANTS } from "./model";
 import { nowIso } from "../utils/json";
+import { hasUnsafeWildcardCount } from "../signals/change-guardrail";
 
 export type ScorePreviewInput = {
   repoFullName: string;
@@ -927,11 +928,20 @@ export function labelMatchesPattern(label: string, pattern: string): boolean {
 // Compiled fnmatch→RegExp matchers are memoized by pattern. The same small,
 // config-derived set of label keys is matched on every scored PR/issue, so the
 // per-call recompile inside the nested label loops in engine.ts is pure waste.
-// Keys are configured label patterns (bounded, not attacker-supplied), so the
-// cache needs no eviction bound. The compiled RegExp carries only the "i" flag
-// (no global/sticky `lastIndex` state), so sharing one instance across calls is
-// safe and byte-identical to recompiling on every call.
+// Keys come from a repo's registryConfig.labelMultipliers, sourced from the externally-fetched gittensor
+// registry (registry/sync.ts + registry/normalize.ts, not a value this repo's own maintainer directly controls
+// via .gittensory.yml) — so the pattern SET is small per repo, but individual pattern CONTENT is untrusted, not
+// literally attacker-supplied-per-request the way GitHub PR content is. The cache still needs no eviction bound
+// (the key set is bounded by real registry entries, not attacker-loop-controlled at request time), but the
+// wildcard-count cap below (#2456) matters regardless of that distinction. The compiled RegExp carries only the
+// "i" flag (no global/sticky `lastIndex` state), so sharing one instance across calls is safe and byte-identical
+// to recompiling on every call.
 const labelPatternRegExpCache = new Map<string, RegExp>();
+
+// A RegExp that never matches any input — mirrors change-guardrail.ts's identical NEVER_MATCHES fallback for an
+// over-complex pattern, so a pathological registry entry degrades to "this label multiplier never applies"
+// instead of hanging the scoring path that evaluates it.
+const LABEL_PATTERN_NEVER_MATCHES = /^(?!)$/;
 
 // Upstream resolves label multipliers by matching each configured key as a Python `fnmatch` GLOB, not a
 // literal string: `fnmatch(label.lower(), pattern.lower())` in
@@ -946,6 +956,16 @@ const labelPatternRegExpCache = new Map<string, RegExp>();
 function labelPatternToRegExp(pattern: string): RegExp {
   const cached = labelPatternRegExpCache.get(pattern);
   if (cached !== undefined) return cached;
+  // Reuses change-guardrail.ts's wildcard-GROUP counting (a `*` here matches the same "any run of chars"
+  // semantics as that glob compiler's `*`, so the same catastrophic-backtracking risk and the same empirically-
+  // safe threshold apply) — an over-complex registry-sourced label_multipliers key degrades to a safe never-match
+  // instead of hanging RegExp.test() on an adversarial near-miss label (#2456). Reachable via the public
+  // score-preview API, the MCP tool, and the per-PR label-audit signal, so one bad registry entry could otherwise
+  // hang scoring for every PR on that repo.
+  if (hasUnsafeWildcardCount(pattern)) {
+    labelPatternRegExpCache.set(pattern, LABEL_PATTERN_NEVER_MATCHES);
+    return LABEL_PATTERN_NEVER_MATCHES;
+  }
   let regex = "";
   let i = 0;
   while (i < pattern.length) {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1913,4 +1913,27 @@ describe("label pattern matcher memoization (#2106)", () => {
     expect(labelMatchesPattern("bug", "bug")).toBe(true);
     expect(labelMatchesPattern("bugfix", "bug")).toBe(false);
   });
+
+  it("SECURITY (ReDoS, #2456): a label pattern with too many chained wildcards no longer risks catastrophic backtracking — it fails SAFE TOWARD NO MULTIPLIER (never matches) instead of ever compiling the pathological pattern", () => {
+    // 3 chained wildcards is already empirically dangerous for the identical `.*`-chaining shape this reuses
+    // from change-guardrail.ts's globToRegExp (see MAX_GLOB_WILDCARD_GROUPS's rationale: over 2 seconds at a
+    // ~4,000-char adversarial input) — one over the cap, proving the boundary itself is safe, not just an
+    // extreme over-the-top example. Must resolve INSTANTLY even against that adversarial length. Unlike the
+    // guardrail glob (which fails toward MATCHING, the safe direction for a security hold), a label multiplier
+    // pattern fails toward NEVER matching — the safe direction here is "no multiplier applies", not "every label
+    // gets a multiplier".
+    const pathological = "*-*-*-final";
+    const adversarialLabel = "a-".repeat(2000) + "X"; // ~4,000 chars — the empirically dangerous length for 3 wildcards
+    const start = Date.now();
+    expect(labelMatchesPattern(adversarialLabel, pathological)).toBe(false);
+    expect(labelMatchesPattern("completely-unrelated-label", pathological)).toBe(false);
+    expect(labelMatchesPattern("", pathological)).toBe(false);
+    expect(labelMatchesPattern("a-b-c-final", pathological)).toBe(false); // even a "near miss" that would otherwise match
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it("a label pattern AT the safe cap (2 wildcards) still compiles and matches NORMALLY, not the fail-safe path — proves the cap is inclusive, not exclusive", () => {
+    expect(labelMatchesPattern("type-bug-fix", "type-*-*")).toBe(true);
+    expect(labelMatchesPattern("type-bug", "type-*-*")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- `labelPatternToRegExp` (`src/scoring/preview.ts`) compiled a registry-supplied `label_multipliers` key into a `RegExp` via unbounded chained-wildcard translation with no length/complexity cap — the exact class of bug #2445 fixed in `src/signals/change-guardrail.ts`'s `globToRegExp` (which caps chained wildcard groups at 2, after benchmarking confirmed catastrophic backtracking: over 2 seconds at ~4,000 chars for 3 chained groups). This sibling function was never patched.
- The pattern originates from a repo's `registryConfig.labelMultipliers`, sourced from the externally-fetched gittensor registry (`registry/sync.ts` + `registry/normalize.ts`) with no validation — **not** a value a repo's own maintainer directly controls via `.gittensory.yml`, despite an inaccurate in-code comment claiming the key set was "bounded, not attacker-supplied" (updated as part of this fix). Reachable via the public score-preview API, the MCP tool, and the per-PR label-audit signal (`labelMatchesPattern`), so one bad registry entry could hang scoring for every PR on that repo.
- Reuses `change-guardrail.ts`'s already-exported `hasUnsafeWildcardCount` directly (same `*`-group counting, same empirically-safe threshold) rather than reimplementing it — a `*` in this fnmatch-style pattern language has the identical "any run of chars" semantics as that glob compiler's `*`, so the same catastrophic-backtracking risk and safe boundary apply. An over-complex pattern now compiles to a safe never-match `RegExp` instead of a pathological one, mirroring `globToRegExp`'s own `NEVER_MATCHES` fallback design.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — new code is 100% line+branch covered in the edited range (verified against `coverage/lcov.info`). Global 96.56%/95.53%.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full suite: 6064/6064 passing. Also ran `npm run db:migrations:check` (unaffected, green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A (not an auth path), but added a timing-bound ReDoS regression test mirroring `change-guardrail.test.ts`'s exact pattern: a 3-wildcard pathological pattern resolves instantly (<1s) against a ~4,000-char adversarial label, plus a not-over-the-cap test proving normal 2-wildcard patterns still compile and match correctly.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. No OpenAPI/MCP surface changed (internal scoring logic).
- [ ] UI changes — N/A, no UI changed.
- [ ] Visible UI changes — N/A, no UI changed.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. No changelog edit.

## Notes

- Found via an adversarial audit of the review engine's signals/scoring layer, specifically hunting for other dynamically-constructed `RegExp`s fed by attacker-influenced input following directly from the #2445 fix pattern.