### PR TITLE
fix(enrichment): treat uppercase action SHA pins as pinned

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -5,7 +5,7 @@
 import type { EnrichRequest, ActionPinFinding } from "../types.js";
 
 const USES_RE = /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
-const FULL_SHA = /^[0-9a-f]{40}$/;
+const FULL_SHA = /^[0-9a-f]{40}$/i;
 const OFFICIAL = /^(actions|github)\//;
 const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
 


### PR DESCRIPTION
## Summary

- Match GitHub commit refs case-insensitively in the actions-pin analyzer.
- Stop reporting uppercase 40-character SHA pins as mutable third-party workflow references.

## Test plan

- [x] `npm run rees:test -- test/actions-pin.test.ts` (coverage already on `main` from #2396; this PR is production-only to avoid test-file conflicts)