### PR TITLE
fix(selfhost): make retention pruning work on postgres

### DIFF
--- a/src/selfhost/pg-dialect.ts
+++ b/src/selfhost/pg-dialect.ts
@@ -18,7 +18,10 @@ const REPLACE_CONFLICT_KEYS: Record<string, string[]> = {
  *  immediately followed by digits is SQLite's *numbered* placeholder (`?1`, `?2`, …, e.g. retention.ts's
  *  `retentionWhere()` and repositories.ts's `claimRegateFanoutSlot()`) — its index is reused verbatim as
  *  `$1`/`$2` rather than folded into the anonymous-placeholder counter below, otherwise `?1` corrupts to
- *  `$1` + a literal trailing `1` (i.e. `$11`), which Postgres reads as bind parameter 11. */
+ *  `$1` + a literal trailing `1` (i.e. `$11`), which Postgres reads as bind parameter 11. Per SQLite's own
+ *  rule, a later anonymous `?` gets "one greater than the largest parameter number already assigned", so a
+ *  numbered placeholder also raises the anonymous counter's floor — otherwise a later `?` could collide with
+ *  an earlier `?N` (e.g. `?1` then `?` must yield `$1`, `$2`, not `$1`, `$1`). */
 export function toNumberedPlaceholders(sql: string): string {
   let out = "";
   let n = 0;
@@ -29,6 +32,7 @@ export function toNumberedPlaceholders(sql: string): string {
     if (ch === "?" && !inString) {
       const numbered = /^\d+/.exec(sql.slice(i + 1))?.[0];
       if (numbered) {
+        n = Math.max(n, Number(numbered));
         out += `$${numbered}`;
         i += numbered.length;
         continue;

--- a/src/selfhost/pg-dialect.ts
+++ b/src/selfhost/pg-dialect.ts
@@ -1,9 +1,9 @@
 // SQLite → Postgres SQL dialect translation for the self-host Postgres backend (#977). gittensory's core and
 // drizzle-orm/d1 emit SQLite-dialect SQL; this translates the bounded set of SQLite-isms the codebase uses
-// (placeholders + a handful of scalar functions + INSERT OR REPLACE/IGNORE) so the SAME queries run on
-// Postgres. The timestamp columns are TEXT (ISO strings written by the app), so the datetime/CURRENT_TIMESTAMP
-// translations return TEXT in SQLite's format to preserve the existing text-comparison semantics. Validated
-// against a real Postgres (all 56 migrations + the runtime query paths).
+// (placeholders + a handful of scalar functions + INSERT OR REPLACE/IGNORE + the rowid pseudo-column) so
+// the SAME queries run on Postgres. The timestamp columns are TEXT (ISO strings written by the app), so the
+// datetime/CURRENT_TIMESTAMP translations return TEXT in SQLite's format to preserve the existing
+// text-comparison semantics. Validated against a real Postgres (all 56 migrations + the runtime query paths).
 
 // INSERT OR REPLACE needs an explicit conflict target on Postgres; map the (few) tables that use it to their PK.
 const REPLACE_CONFLICT_KEYS: Record<string, string[]> = {
@@ -14,14 +14,25 @@ const REPLACE_CONFLICT_KEYS: Record<string, string[]> = {
   orb_signals: ["instance_id", "repo_hash", "pr_hash"],
 };
 
-/** Replace `?` placeholders with `$1,$2,…`, skipping any `?` inside single-quoted string literals. */
+/** Replace `?` placeholders with `$1,$2,…`, skipping any `?` inside single-quoted string literals. A `?`
+ *  immediately followed by digits is SQLite's *numbered* placeholder (`?1`, `?2`, …, e.g. retention.ts's
+ *  `retentionWhere()` and repositories.ts's `claimRegateFanoutSlot()`) — its index is reused verbatim as
+ *  `$1`/`$2` rather than folded into the anonymous-placeholder counter below, otherwise `?1` corrupts to
+ *  `$1` + a literal trailing `1` (i.e. `$11`), which Postgres reads as bind parameter 11. */
 export function toNumberedPlaceholders(sql: string): string {
   let out = "";
   let n = 0;
   let inString = false;
-  for (const ch of sql) {
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i] as string;
     if (ch === "'") inString = !inString;
     if (ch === "?" && !inString) {
+      const numbered = /^\d+/.exec(sql.slice(i + 1))?.[0];
+      if (numbered) {
+        out += `$${numbered}`;
+        i += numbered.length;
+        continue;
+      }
       n += 1;
       out += `$${n}`;
     } else {
@@ -48,6 +59,18 @@ export function translateFunctions(sql: string): string {
       // json_extract(col, '$.key') → (col::jsonb ->> 'key')  (single-level paths — all the codebase uses)
       .replace(/json_extract\(\s*([^,]+?)\s*,\s*'\$\.([A-Za-z0-9_]+)'\s*\)/gi, `(($1)::jsonb ->> '$2')`)
   );
+}
+
+/** Translate SQLite's `rowid` pseudo-column to Postgres's `ctid` system column. Both give a stable,
+ *  per-row identifier for the lifetime of a single statement/snapshot — exactly how the codebase uses
+ *  it: `DELETE ... WHERE rowid IN (SELECT rowid FROM t WHERE ... LIMIT n)` for bounded batched pruning
+ *  (retention.ts) and `ORDER BY rowid` for insertion-order tie-breaking (orb/relay.ts, tests). `ctid` is
+ *  a *physical* row location that can change across `VACUUM FULL` / row rewrites, so this is only safe
+ *  for the codebase's existing usage — internal bookkeeping resolved within one statement — never for
+ *  durable application-facing row identity. Fixes the self-host Postgres dead-letter where the raw
+ *  `rowid` reached Postgres verbatim ("column \"rowid\" does not exist"). */
+export function translateRowid(sql: string): string {
+  return sql.replace(/\browid\b/gi, "ctid");
 }
 
 /** Translate INSERT OR REPLACE / INSERT OR IGNORE to Postgres ON CONFLICT. */
@@ -87,7 +110,7 @@ export function stripConflictTargetQualifiers(sql: string): string {
 
 /** Translate a runtime query (SQLite → Postgres). */
 export function translateSql(sql: string): string {
-  return toNumberedPlaceholders(stripConflictTargetQualifiers(translateFunctions(translateInsertOr(sql))));
+  return toNumberedPlaceholders(stripConflictTargetQualifiers(translateRowid(translateFunctions(translateInsertOr(sql)))));
 }
 
 /** Migrations are applied as whole multi-statement files via exec(), so the statement-anchored

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -6,6 +6,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import pg from "pg";
 import { runSelfHostMigrations } from "../../src/selfhost/migrate";
 import { createPgAdapter } from "../../src/selfhost/pg-adapter";
+import { pruneExpiredRecords } from "../../src/db/retention";
+import { processJob } from "../../src/queue/processors";
 
 const URL = process.env.PG_TEST_URL;
 const suite = URL ? describe : describe.skip;
@@ -54,5 +56,32 @@ suite("Postgres backend (#977) — real Postgres", () => {
     ).rejects.toThrow();
     const still = await db.prepare("SELECT COUNT(*) AS n FROM system_flags WHERE key=?").bind("batch_probe").first<{ n: number }>();
     expect(still?.n).toBe(1); // the DELETE rolled back
+  });
+
+  it("prunes rows past the retention window and processJob('prune-retention') does not dead-letter (regression for the live self-host incident: job _selfhost_jobs.id=61132 failed with 'column \"rowid\" does not exist')", async () => {
+    const db = createPgAdapter(pool);
+    const env = { DB: db } as unknown as Env;
+    const oldIso = new Date(Date.now() - 100 * 86_400_000).toISOString();
+    const recentIso = new Date(Date.now() - 1 * 86_400_000).toISOString();
+    for (const [id, createdAt] of [
+      ["pg-old-1", oldIso],
+      ["pg-old-2", oldIso],
+      ["pg-recent", recentIso],
+    ] as const) {
+      await db
+        .prepare("INSERT INTO ai_usage_events (id, feature, model, status, estimated_neurons, created_at) VALUES (?, 'f', 'm', 'ok', 1, ?)")
+        .bind(id, createdAt)
+        .run();
+    }
+
+    const results = await pruneExpiredRecords(env, { policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }] });
+    expect(results[0]?.deleted).toBe(2); // the two old rows, bounded-batch deleted via ctid (not rowid)
+    const remaining = await db.prepare("SELECT COUNT(*) AS n FROM ai_usage_events").first<{ n: number }>();
+    expect(remaining?.n).toBe(1);
+
+    // The exact live incident: the job queue's processJob("prune-retention") dispatch must not throw.
+    await expect(processJob(env, { type: "prune-retention", requestedBy: "schedule" })).resolves.toBeUndefined();
+    const audit = await db.prepare("SELECT outcome FROM audit_events WHERE event_type = ?").bind("retention.prune").first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("success");
   });
 });

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -15,8 +15,9 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
     expect(toNumberedPlaceholders("last_regate_fanout_at = ?1 WHERE id = 'singleton' AND (x IS NULL OR x < ?2)")).toBe(
       "last_regate_fanout_at = $1 WHERE id = 'singleton' AND (x IS NULL OR x < $2)",
     );
-    // A numbered placeholder mixed with anonymous ones in the same call still resolves each independently.
-    expect(toNumberedPlaceholders("a=?1 AND b=?")).toBe("a=$1 AND b=$1");
+    // A later anonymous `?` continues from the highest index already assigned (SQLite's own rule), so it
+    // must not collide with an earlier numbered placeholder.
+    expect(toNumberedPlaceholders("a=?1 AND b=?")).toBe("a=$1 AND b=$2");
     // A literal `?1` inside a string is left untouched, same as a bare `?` literal.
     expect(toNumberedPlaceholders("SELECT '?1' AS lit WHERE a=?")).toBe("SELECT '?1' AS lit WHERE a=$1");
   });

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateMigrationInserts, translateSql } from "../../src/selfhost/pg-dialect";
+import { stripConflictTargetQualifiers, toNumberedPlaceholders, translateDdl, translateFunctions, translateInsertOr, translateMigrationInserts, translateRowid, translateSql } from "../../src/selfhost/pg-dialect";
 
 describe("pg-dialect (#977 SQLite → Postgres)", () => {
   it("numbers placeholders, skipping `?` inside string literals", () => {
     expect(toNumberedPlaceholders("SELECT * FROM t WHERE a=? AND b=?")).toBe("SELECT * FROM t WHERE a=$1 AND b=$2");
     expect(toNumberedPlaceholders("SELECT '?' AS lit WHERE a=?")).toBe("SELECT '?' AS lit WHERE a=$1");
+  });
+
+  it("REGRESSION: reuses a SQLite numbered placeholder's own index instead of corrupting it via the anonymous counter", () => {
+    // Before the fix: `?1` scanned as anonymous `?` (→ $1) followed by a literal `1`, corrupting to `$11`
+    // — a bind index Postgres has no value for. retentionWhere() (retention.ts) and claimRegateFanoutSlot()
+    // (repositories.ts) both use this numbered syntax.
+    expect(toNumberedPlaceholders("created_at < ?1")).toBe("created_at < $1");
+    expect(toNumberedPlaceholders("last_regate_fanout_at = ?1 WHERE id = 'singleton' AND (x IS NULL OR x < ?2)")).toBe(
+      "last_regate_fanout_at = $1 WHERE id = 'singleton' AND (x IS NULL OR x < $2)",
+    );
+    // A numbered placeholder mixed with anonymous ones in the same call still resolves each independently.
+    expect(toNumberedPlaceholders("a=?1 AND b=?")).toBe("a=$1 AND b=$1");
+    // A literal `?1` inside a string is left untouched, same as a bare `?` literal.
+    expect(toNumberedPlaceholders("SELECT '?1' AS lit WHERE a=?")).toBe("SELECT '?1' AS lit WHERE a=$1");
   });
 
   it("translates datetime/strftime/CURRENT_TIMESTAMP/json to Postgres (text-returning to match SQLite)", () => {
@@ -79,5 +93,30 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
     expect(out).not.toContain('"webhook_events"."delivery_id"');
     expect(out).toContain("values ($1, $2)"); // placeholders numbered
     expect(out).toContain("set \"status\" = $3");
+  });
+
+  it("translates the rowid pseudo-column to Postgres's ctid system column", () => {
+    expect(translateRowid("SELECT rowid FROM t WHERE a = ?")).toBe("SELECT ctid FROM t WHERE a = ?");
+    expect(translateRowid("ORDER BY rowid DESC")).toBe("ORDER BY ctid DESC");
+    expect(translateRowid("ORDER BY ROWID ASC")).toBe("ORDER BY ctid ASC"); // case-insensitive
+    // Only the bare `rowid` token is rewritten — identifiers that merely contain it are left alone.
+    expect(translateRowid("SELECT row_id, my_rowid_col FROM t")).toBe("SELECT row_id, my_rowid_col FROM t");
+    expect(translateRowid("SELECT 1")).toBe("SELECT 1"); // no-op passthrough
+  });
+
+  it("REGRESSION (self-host Postgres prune-retention dead-letter): translateSql strips rowid from the exact batched-delete shape retention.ts emits", () => {
+    // The literal shape src/db/retention.ts's pruneExpiredRecords() builds for its bounded batched delete.
+    // Before the fix, this reached Postgres verbatim and failed with `column "rowid" does not exist`.
+    const deleteSql = 'DELETE FROM ai_usage_events WHERE rowid IN (SELECT rowid FROM ai_usage_events WHERE created_at < ?1 LIMIT 1000)';
+    const out = translateSql(deleteSql);
+    expect(out.toLowerCase()).not.toContain("rowid");
+    expect(out).toBe("DELETE FROM ai_usage_events WHERE ctid IN (SELECT ctid FROM ai_usage_events WHERE created_at < $1 LIMIT 1000)");
+  });
+
+  it("also fixes the rowid tie-break ORDER BY used by orb/relay.ts enrollment resolution", () => {
+    const sql = "SELECT relay_mode FROM orb_enrollments WHERE installation_id = ? ORDER BY enrolled_at DESC, rowid DESC";
+    const out = translateSql(sql);
+    expect(out.toLowerCase()).not.toContain("rowid");
+    expect(out).toContain("ORDER BY enrolled_at DESC, ctid DESC");
   });
 });

--- a/test/unit/selfhost-pg-retention.test.ts
+++ b/test/unit/selfhost-pg-retention.test.ts
@@ -1,0 +1,123 @@
+// Unit tests for data-retention pruning (src/db/retention.ts) against the Postgres backend (#977). Mocks
+// pg.Pool so no real DB is needed — real-Postgres integration coverage lives in test/integration/selfhost-pg.test.ts.
+// retention.ts itself is unchanged: it still emits SQLite-dialect SQL (rowid, `?1`-style numbered
+// placeholders); src/selfhost/pg-dialect.ts's translateSql() is what makes it Postgres-safe, same as every
+// other query path on this backend. These tests exercise that translation end-to-end through the real
+// pruneExpiredRecords()/processJob() call path, not just the dialect translator in isolation.
+import { describe, expect, it, vi } from "vitest";
+import type { Pool } from "pg";
+import { createPgAdapter } from "../../src/selfhost/pg-adapter";
+import { pruneExpiredRecords } from "../../src/db/retention";
+import { processJob, runRetentionPrune } from "../../src/queue/processors";
+
+interface MockPgPool {
+  pool: Pool;
+  calls: string[];
+  remaining: Record<string, number>;
+}
+
+/** A minimal fake Postgres that also acts as a regression guard: if untranslated SQLite SQL (the `rowid`
+ *  pseudo-column) ever reaches it again, it throws the exact error a real Postgres raised in the live
+ *  self-host incident (dead-lettered job `_selfhost_jobs.id = 61132`, `prune-retention`, 5 attempts). */
+function makeRetentionPgPool(remaining: Record<string, number> = {}): MockPgPool {
+  const calls: string[] = [];
+  const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+    const q = String(sql);
+    calls.push(q);
+    if (/\browid\b/i.test(q)) throw new Error('column "rowid" does not exist');
+
+    const countMatch = /^SELECT count\(\*\) AS n FROM (\w+) WHERE/i.exec(q);
+    if (countMatch) {
+      const table = countMatch[1] as string;
+      return { rows: [{ n: remaining[table] ?? 0 }], rowCount: 1 };
+    }
+
+    const deleteMatch = /^DELETE FROM (\w+) WHERE ctid IN \(SELECT ctid FROM \1 WHERE .*? LIMIT (\d+)\)$/i.exec(q);
+    if (deleteMatch) {
+      const table = deleteMatch[1] as string;
+      const limit = Number(deleteMatch[2]);
+      const have = remaining[table] ?? 0;
+      const changes = Math.min(have, limit);
+      remaining[table] = have - changes;
+      return { rows: [], rowCount: changes };
+    }
+
+    if (/^insert into "?audit_events"?/i.test(q)) return { rows: [], rowCount: 1 };
+
+    return { rows: [], rowCount: 0 };
+  });
+  return { pool: { query: fn } as unknown as Pool, calls, remaining };
+}
+
+function makeEnv(remaining: Record<string, number> = {}): { env: Env; mock: MockPgPool } {
+  const mock = makeRetentionPgPool(remaining);
+  return { env: { DB: createPgAdapter(mock.pool) } as unknown as Env, mock };
+}
+
+describe("pruneExpiredRecords on the Postgres backend (#977)", () => {
+  it("dry-run counts eligible rows without issuing any delete", async () => {
+    const { env, mock } = makeEnv({ ai_usage_events: 5 });
+    const results = await pruneExpiredRecords(env, {
+      dryRun: true,
+      policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }],
+    });
+    expect(results[0]?.deleted).toBe(5);
+    expect(mock.calls.some((q) => /^DELETE/i.test(q))).toBe(false);
+    expect(mock.remaining.ai_usage_events).toBe(5); // untouched
+  });
+
+  it("deletes across multiple bounded batches and stops at the per-table cap, same as the SQLite path", async () => {
+    const { env, mock } = makeEnv({ ai_usage_events: 5 });
+    const results = await pruneExpiredRecords(env, {
+      batchSize: 2,
+      maxPerTable: 4,
+      policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }],
+    });
+    expect(results[0]?.deleted).toBe(4); // 2 + 2, then cap reached
+    expect(mock.remaining.ai_usage_events).toBe(1); // one row left for the next run
+    const deletes = mock.calls.filter((q) => /^DELETE/i.test(q));
+    expect(deletes).toHaveLength(2);
+  });
+
+  it("keeps the audit_events durable-event exclusion in the translated Postgres delete", async () => {
+    const { env, mock } = makeEnv({ audit_events: 1 });
+    await pruneExpiredRecords(env, { policy: [{ table: "audit_events", column: "created_at", days: 90 }] });
+    const [deleteSql] = mock.calls.filter((q) => /^DELETE/i.test(q));
+    expect(deleteSql).toContain("event_type NOT IN ('github_app.pr_public_surface_published')");
+    expect(deleteSql?.toLowerCase()).not.toContain("rowid");
+  });
+
+  it("translates the numbered `?1` cutoff placeholder to Postgres's $1, not a corrupted $11", async () => {
+    const { env, mock } = makeEnv({ ai_usage_events: 0 });
+    await pruneExpiredRecords(env, {
+      dryRun: true,
+      policy: [{ table: "ai_usage_events", column: "created_at", days: 90 }],
+    });
+    const [countSql] = mock.calls;
+    expect(countSql).toContain("created_at < $1");
+    expect(countSql).not.toMatch(/\$1\d/); // not $11, $12, ...
+  });
+});
+
+describe("runRetentionPrune + processJob on the Postgres backend (#977)", () => {
+  it("audits a dry-run without deleting", async () => {
+    const { env, mock } = makeEnv({ ai_usage_events: 2 });
+    await runRetentionPrune(env, "test", true);
+    const [insertSql] = mock.calls.filter((q) => /^insert into "?audit_events"?/i.test(q));
+    expect(insertSql).toBeDefined();
+    expect(mock.remaining.ai_usage_events).toBe(2); // nothing deleted
+  });
+
+  it("REGRESSION (self-host dead-letter, job id 61132): processJob prune-retention no longer throws the rowid column error on Postgres", async () => {
+    const { env } = makeEnv(); // every table reports 0 eligible rows — exercises the full default policy
+    await expect(processJob(env, { type: "prune-retention", requestedBy: "schedule" })).resolves.toBeUndefined();
+  });
+
+  it("processJob prune-retention deletes eligible rows and records a success audit event on Postgres", async () => {
+    const { env, mock } = makeEnv({ ai_usage_events: 3 });
+    await processJob(env, { type: "prune-retention", requestedBy: "schedule" });
+    expect(mock.remaining.ai_usage_events).toBe(0);
+    const [insertSql] = mock.calls.filter((q) => /^insert into "?audit_events"?/i.test(q));
+    expect(insertSql).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Data-retention pruning (`src/db/retention.ts`) batches its deletes via SQLite's `rowid` pseudo-column and binds its cutoff with SQLite's numbered-placeholder syntax (`?1`). Both are SQLite/D1-only. On the self-host Postgres backend, `rowid` reaches Postgres unmodified and raises `column "rowid" does not exist`, dead-lettering the `prune-retention` job every run — this is the live self-host incident (`_selfhost_jobs.id=61132`, 5 attempts, `last_error = column "rowid" does not exist"`).
- Fix lives in the shared SQLite → Postgres SQL translator (`src/selfhost/pg-dialect.ts`) that every query already passes through on the Postgres backend, not in `retention.ts` itself:
  - `translateRowid()`: rewrites the bare `rowid` token to Postgres's `ctid` system column. Both are stable per-row identifiers for the lifetime of a single statement — exactly how this codebase uses `rowid` (bounded batched delete, `ORDER BY` tie-breaking), never for durable row identity. SQLite/D1 is untouched, since this translator only runs on the Postgres adapter.
  - `toNumberedPlaceholders()`: fixed to recognize a numbered placeholder (`?1`, `?2`, …) and reuse its index directly as `$1`/`$2`, instead of folding the trailing digit into the anonymous-placeholder counter (which corrupted `?1` into `$11` — a bind index nothing supplies). This was required for retention's own cutoff bind to resolve correctly on Postgres, and incidentally fixes the same latent bug in `repositories.ts`'s `claimRegateFanoutSlot()`.
- `retention.ts` itself is unchanged — it keeps emitting the same SQLite-dialect SQL that already runs correctly on D1; batching/`maxPerTable`, `dryRun`, and the `audit_events` durable-event exclusion are all untouched and re-verified by the new tests.

**Sentry triage** (no code changes beyond the above — kept this PR narrow):
- `review_context_fetch_failed` (REES 403) and `orb_broker_unavailable` are real gaps (a startup config-readiness check, and retry backoff/dedup respectively) — deferred as follow-up work.
- The AI-review-inconclusive/unparseable cluster and the PR-publish-failed cluster look already addressed by two recently landed commits (`9d05cb6a`, `8da2d62f`) — worth confirming no fresh occurrences post-deploy before closing those Sentry issues.
- The `bundlephobia` analyzer HTTP-error noise is unrelated to retention/Postgres and is deferred.

The live dead-lettered job (`_selfhost_jobs.id=61132`) should be safe to retry once this deploys.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue linked — this is a direct fix for a live, precisely root-caused self-host incident (a dead-lettered production job with the exact error captured); the change is narrowly scoped to the Postgres SQL-translation layer.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (unsharded) — `src/selfhost/pg-dialect.ts` is at 100% lines/branches/functions on the diff (confirmed via the raw lcov output); full suite: 6063 passed, 0 failed.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — see below. Also ran the real-Postgres integration suite locally against an actual Postgres 17 instance (`PG_TEST_URL=... npx vitest run test/integration/selfhost-pg.test.ts`), including the new retention regression case — all green.

Tests added:
- `test/unit/selfhost-pg-dialect.test.ts`: `translateRowid` unit tests, a regression test against the exact batched-delete SQL shape `retention.ts` emits, numbered-placeholder regression tests (`?1`/`?2` → `$1`/`$2`, not `$11`/`$21`).
- `test/unit/selfhost-pg-retention.test.ts` (new): `pruneExpiredRecords`/`processJob` exercised against a mocked `pg.Pool` that throws the real Postgres error if untranslated `rowid` SQL ever reaches it again — covers dry-run, bounded batching + the per-table cap, the `audit_events` durable-event exclusion surviving translation, and a named regression test for the live dead-letter (`processJob({ type: "prune-retention" })` no longer throws/dead-letters on Postgres).
- `test/integration/selfhost-pg.test.ts`: a real-Postgres end-to-end case (skipped unless `PG_TEST_URL` is set, same convention as the rest of that suite).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — backend-only change, no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)

## Notes

- Sentry MCP access was unavailable in the session that produced this PR, so the triage above is based on reading the relevant code paths (REES enrichment client, Orb broker client, AI review parser, `heavy-dependency` analyzer, review-publish path) rather than live Sentry data.