### PR TITLE
feat(metrics): count DLQ dead-letter events

### DIFF
--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -1,6 +1,10 @@
 import { getWebhookEvent, recordAuditEvent } from "../db/repositories";
 import { delayUntil, shouldWaitForGitHubRateLimit } from "../github/rate-limit";
+import { incr } from "../selfhost/metrics";
 import type { JobMessage, JsonValue } from "../types";
+
+const DLQ_DEAD_LETTERED_METRIC = "gittensory_dlq_dead_lettered_total";
+const DLQ_REDRIVEN_METRIC = "gittensory_dlq_redriven_total";
 
 /**
  * DLQ consumer for both `gittensory-jobs-dlq` (maintenance lane) and `gittensory-webhooks-dlq` (the
@@ -20,6 +24,8 @@ export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env,
     const body = message.body as { type?: string } | null | undefined;
     const jobType = body?.type ?? "unknown";
     const webhook = jobType === "github-webhook" ? (message.body as Extract<JobMessage, { type: "github-webhook" }> & { redriven?: boolean }) : null;
+    const redriven = webhook?.redriven === true;
+    incr(DLQ_DEAD_LETTERED_METRIC, { jobType, redriven: redriven ? "true" : "false" });
     console.error(
       JSON.stringify({
         level: "error",
@@ -36,17 +42,25 @@ export async function processDlqBatch(batch: MessageBatch<JobMessage>, env: Env,
       targetKey: `dlq:${jobType}:${message.id}`,
       outcome: "error",
       detail: `Job of type '${jobType}' exhausted all retries and was dead-lettered.`,
-      metadata: { messageId: message.id, jobType, redriven: webhook?.redriven === true } satisfies Record<string, JsonValue>,
+      metadata: { messageId: message.id, jobType, redriven } satisfies Record<string, JsonValue>,
     }).catch(() => undefined);
     // Self-heal a recoverable webhook: re-drive ONCE (not already re-driven, and not already processed).
-    if (redriveWebhooks && webhook && webhook.redriven !== true && webhook.deliveryId) {
+    if (redriveWebhooks && webhook && !redriven && webhook.deliveryId) {
       const event = await getWebhookEvent(env, webhook.deliveryId).catch(() => null);
       if (event?.status !== "processed") {
         // If the webhook dead-lettered because the shared GitHub REST budget was exhausted, re-drive it AFTER the
         // reset (retry-until-recovered) rather than immediately re-failing it. (#audit-rate-headroom)
         const resetAt = await shouldWaitForGitHubRateLimit(env).catch(() => undefined);
         const options = resetAt ? { delaySeconds: delayUntil(resetAt) } : undefined;
-        await env.WEBHOOKS?.send({ type: "github-webhook", deliveryId: webhook.deliveryId, eventName: webhook.eventName, payload: webhook.payload, redriven: true }, options).catch(() => undefined);
+        const queue = env.WEBHOOKS;
+        if (queue) {
+          await queue
+            .send({ type: "github-webhook", deliveryId: webhook.deliveryId, eventName: webhook.eventName, payload: webhook.payload, redriven: true }, options)
+            .then(() => {
+              incr(DLQ_REDRIVEN_METRIC, { eventName: webhook.eventName });
+            })
+            .catch(() => undefined);
+        }
       }
     }
     message.ack();

--- a/test/unit/dlq.test.ts
+++ b/test/unit/dlq.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { processDlqBatch } from "../../src/queue/dlq";
 import { recordGitHubRateLimitObservation, recordWebhookEvent } from "../../src/db/repositories";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import type { JobMessage } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -27,6 +28,7 @@ function makeBatch(messages: Array<{ id: string; body: unknown }>, queue = "gitt
 describe("DLQ consumer (processDlqBatch)", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetMetrics();
   });
 
   it("acks every message — never retries", async () => {
@@ -85,6 +87,7 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
     await expect(processDlqBatch(batch as unknown as MessageBatch<never>, env)).resolves.toBeUndefined();
     expect(batch.acked).toEqual(["msg-6"]);
+    expect(await renderMetrics()).toContain('gittensory_dlq_dead_lettered_total{jobType="unknown",redriven="false"} 1');
   });
 
   it("is fail-safe when recordAuditEvent throws — the catch body runs and ack is not blocked", async () => {
@@ -95,6 +98,7 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
     await expect(processDlqBatch(batch as unknown as MessageBatch<never>, brokenEnv)).resolves.toBeUndefined();
     expect(batch.acked).toEqual(["msg-7"]);
+    expect(await renderMetrics()).toContain('gittensory_dlq_dead_lettered_total{jobType="github-webhook",redriven="false"} 1');
   });
 
   describe("webhook self-heal re-drive (#1276)", () => {
@@ -115,6 +119,9 @@ describe("DLQ consumer (processDlqBatch)", () => {
       expect(sent).toHaveLength(1);
       expect(sent[0]).toMatchObject({ type: "github-webhook", deliveryId: "fresh-1", eventName: "pull_request", redriven: true });
       expect(batch.acked).toEqual(["wh-1"]);
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_dlq_dead_lettered_total{jobType="github-webhook",redriven="false"} 1');
+      expect(metrics).toContain('gittensory_dlq_redriven_total{eventName="pull_request"} 1');
     });
 
     it("REGRESSION (idempotency): does NOT re-drive a webhook whose event row is already 'processed'", async () => {
@@ -127,6 +134,37 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
       expect(sent).toEqual([]); // already processed → no duplicate side effects
       expect(batch.acked).toEqual(["wh-2"]);
+      expect(await renderMetrics()).not.toContain("gittensory_dlq_redriven_total");
+    });
+
+    it("REGRESSION (metrics): failed webhook re-drive sends do not increment the redriven counter", async () => {
+      const env = createTestEnv();
+      env.WEBHOOKS = {
+        send: async () => {
+          throw new Error("queue unavailable");
+        },
+      } as unknown as Queue;
+      const batch = makeBatch([{ id: "wh-send-fail", body: { type: "github-webhook", deliveryId: "send-fail-1", eventName: "pull_request", payload: {} } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(batch.acked).toEqual(["wh-send-fail"]);
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_dlq_dead_lettered_total{jobType="github-webhook",redriven="false"} 1');
+      expect(metrics).not.toContain("gittensory_dlq_redriven_total");
+    });
+
+    it("REGRESSION (metrics): missing webhook queue binding does not increment the redriven counter", async () => {
+      const env = createTestEnv();
+      delete (env as Partial<Env>).WEBHOOKS;
+      const batch = makeBatch([{ id: "wh-no-queue", body: { type: "github-webhook", deliveryId: "no-queue-1", eventName: "pull_request", payload: {} } }], "gittensory-webhooks-dlq");
+
+      await processDlqBatch(batch as unknown as MessageBatch<never>, env);
+
+      expect(batch.acked).toEqual(["wh-no-queue"]);
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_dlq_dead_lettered_total{jobType="github-webhook",redriven="false"} 1');
+      expect(metrics).not.toContain("gittensory_dlq_redriven_total");
     });
 
     it("REGRESSION (no DLQ loop): does NOT re-drive a webhook that was already re-driven once", async () => {
@@ -138,6 +176,9 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
       expect(sent).toEqual([]); // bounded to a single re-drive
       expect(batch.acked).toEqual(["wh-3"]);
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_dlq_dead_lettered_total{jobType="github-webhook",redriven="true"} 1');
+      expect(metrics).not.toContain("gittensory_dlq_redriven_total");
     });
 
     it("REGRESSION (no re-drive of maintenance jobs): a backfill job is audited and dropped, never re-driven", async () => {
@@ -149,6 +190,9 @@ describe("DLQ consumer (processDlqBatch)", () => {
 
       expect(sent).toEqual([]); // cron self-heals maintenance jobs
       expect(batch.acked).toEqual(["mn-1"]);
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_dlq_dead_lettered_total{jobType="backfill-repo-segment",redriven="false"} 1');
+      expect(metrics).not.toContain("gittensory_dlq_redriven_total");
     });
 
     it("does not re-drive webhook jobs when webhook redrive is disabled for broker-only Cloudflare", async () => {


### PR DESCRIPTION
## Summary
- Add Prometheus counters for DLQ dead-lettered jobs and successful webhook re-drives.
- Mirror the DLQ audit metadata labels so operators can alert by job type and redrive state.

## What changed
- Increment `gittensory_dlq_dead_lettered_total{jobType,redriven}` once for every DLQ message.
- Increment `gittensory_dlq_redriven_total{eventName}` only after a webhook re-drive queue send succeeds.
- Add regression coverage for maintenance-only drops, recoverable webhook re-drives, already-redriven webhooks, failed sends, missing queue bindings, and malformed bodies.

## Why
Self-host operators can currently see DLQ drops in logs/audit rows, but not as first-class Prometheus counters. These metrics make dead-letter volume and webhook self-heal activity visible to dashboards and alerts.

Closes #2076

## Validation
- `npm exec vitest -- run test/unit/dlq.test.ts --coverage.enabled true --coverage.include src/queue/dlq.ts` (100% statements, branches, functions, and lines for `src/queue/dlq.ts`)
- `npm run test:ci`
- `npm audit --audit-level=moderate`
