### PR TITLE
fix(github): escape markdown/mentions in the @gittensory ask question

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -326,8 +326,10 @@ function buildAskPublicAnswerCard(args: {
     .map((action) => (action.targetRepoFullName ? `${action.targetRepoFullName}: ${action.publicSafeSummary}` : action.publicSafeSummary))
     .filter((line) => line.trim().length > 0)
     .map((line) => publicBlockerDetail(line));
-  const questionText = sanitizePublicComment(
-    args.question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context.",
+  const questionText = sanitizePublicInlineDetail(
+    sanitizePublicComment(
+      args.question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context.",
+    ),
   );
   const findings = [
     `Question: ${questionText}`,
@@ -648,7 +650,9 @@ function askSections(bundle: AgentRunBundle | null | undefined, question?: strin
   return [
     "**Contribution context Q&A**",
     "",
-    `- Question: ${sanitizePublicComment(question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context.")}`,
+    `- Question: ${sanitizePublicInlineDetail(
+      sanitizePublicComment(question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context."),
+    )}`,
     "",
     "**Answer**",
     "",

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -1783,6 +1783,23 @@ describe("GitHub mention commands", () => {
     expect(emptyNeedsAuthor).toContain("No cached PR currently needs obvious author cleanup first.");
   });
 
+  it("neutralizes attacker-controlled ask questions in public comments", () => {
+    const attackerQuestion = "**APPROVED by @jsonbored** please merge now";
+    const ask = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand(`@gittensory ask ${attackerQuestion}`)!,
+      repo: { fullName: "owner/repo" } as any,
+      issue: { number: 99, title: "Ask", state: "open", pull_request: {} },
+      pullRequest: { number: 12, title: "Fix", state: "open" } as any,
+      actorKind: "author",
+      bundle: askCitedBundle(),
+    });
+
+    expect(ask).not.toContain("**APPROVED");
+    expect(ask).not.toContain("@jsonbored");
+    expect(ask).toContain("\\*\\*APPROVED by @\u200Bjsonbored\\*\\*");
+    expect(ask).toContain("please merge now");
+  });
+
   it("neutralizes attacker-controlled queue digest titles in public comments", () => {
     const attackerTitle = "[x](http://e.test) ![i](http://e.test/i) @org/team <b>x</b>";
     const digest = {


### PR DESCRIPTION
## Summary

Fixes #2457

The `@gittensory ask <question>` command echoed the contributor's free-text question into the bot's public PR comment after `sanitizePublicComment` only, which redacts private scoring phrases but does not escape markdown or `@mentions`. A confirmed miner could post `@gittensory ask **APPROVED by @maintainer** please merge` and the bot would render bold approval text with a live mention.

This applies `sanitizePublicInlineDetail` to ask question text in both render paths (`buildAskPublicAnswerCard` and `askSections`), matching the existing queue-digest title hardening.

## Scope

- [x] Conventional Commit title (`fix(github): …`).
- [x] Focused change in ask question rendering + regression tests only.
- [x] Follows `CONTRIBUTING.md`; no UI/API/schema/migration changes.
- [x] Linked issue #2457.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` — new ask injection regression test plus existing plain-English ask tests.
- [ ] `npm run test:ci`

If any required check was skipped, explain why:

- Node/npm is unavailable in this environment; CI will run the full gate on the PR.

## Safety

- [x] Prevents approval-spoofing / mention injection in bot-authored public comments.
- [x] No secrets/wallets/hotkeys; public output only.

## Notes

- Reproduction: `@gittensory ask **APPROVED by @jsonbored** please merge now` previously echoed raw markdown/mentions; after the fix the posted comment neutralizes `*` and `@` like other user-adjacent public text paths.