### PR TITLE
fix(orb): sanitize pull relay limits to prevent unbounded SQLite fetches

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -243,7 +243,10 @@ export async function pullRelayPending(
       .run();
   }
 
-  const limit = Math.min(opts?.limit ?? RELAY_PENDING_BATCH_SIZE, RELAY_PENDING_BATCH_SIZE);
+  // SQLite interprets LIMIT -1 as "unbounded", so non-positive/non-integer values must
+  // fall back to the default batch size instead of passing through verbatim.
+  const requestedLimit = Number.isInteger(opts?.limit) && (opts?.limit ?? 0) > 0 ? (opts?.limit as number) : RELAY_PENDING_BATCH_SIZE;
+  const limit = Math.min(requestedLimit, RELAY_PENDING_BATCH_SIZE);
   const { results } = await env.DB
     .prepare("SELECT delivery_id, event_name, raw_body FROM orb_relay_pending WHERE installation_id = ? ORDER BY created_at, delivery_id LIMIT ?")
     .bind(installationId, limit)

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -245,7 +245,11 @@ export async function pullRelayPending(
 
   // SQLite interprets LIMIT -1 as "unbounded", so non-positive/non-integer values must
   // fall back to the default batch size instead of passing through verbatim.
-  const requestedLimit = Number.isInteger(opts?.limit) && (opts?.limit ?? 0) > 0 ? (opts?.limit as number) : RELAY_PENDING_BATCH_SIZE;
+  const requested = opts?.limit;
+  const requestedLimit =
+    typeof requested === "number" && Number.isInteger(requested) && requested > 0
+      ? requested
+      : RELAY_PENDING_BATCH_SIZE;
   const limit = Math.min(requestedLimit, RELAY_PENDING_BATCH_SIZE);
   const { results } = await env.DB
     .prepare("SELECT delivery_id, event_name, raw_body FROM orb_relay_pending WHERE installation_id = ? ORDER BY created_at, delivery_id LIMIT ?")

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -721,6 +721,9 @@ describe("pullRelayPending", () => {
     expect((await pullRelayPending(e, 9705, { limit: 1000 })).length).toBe(50); // clamped to RELAY_PENDING_BATCH_SIZE
     expect((await pullRelayPending(e, 9705)).length).toBe(50); // default limit is the batch too (opts undefined arm)
     expect((await pullRelayPending(e, 9705, { limit: 5 })).length).toBe(5); // a smaller requested limit is honoured
+    expect((await pullRelayPending(e, 9705, { limit: 0 })).length).toBe(50); // non-positive limits fall back to batch default
+    expect((await pullRelayPending(e, 9705, { limit: -1 })).length).toBe(50); // guards SQLite LIMIT -1 (unbounded)
+    expect((await pullRelayPending(e, 9705, { limit: Number.NaN })).length).toBe(50); // non-integer / non-finite fallback
   });
 
   it("PRUNES rows older than the TTL before returning the batch, and logs the drop at error level", async () => {

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -724,6 +724,7 @@ describe("pullRelayPending", () => {
     expect((await pullRelayPending(e, 9705, { limit: 0 })).length).toBe(50); // non-positive limits fall back to batch default
     expect((await pullRelayPending(e, 9705, { limit: -1 })).length).toBe(50); // guards SQLite LIMIT -1 (unbounded)
     expect((await pullRelayPending(e, 9705, { limit: Number.NaN })).length).toBe(50); // non-integer / non-finite fallback
+    expect((await pullRelayPending(e, 9705, { limit: 1.5 })).length).toBe(50); // finite fractional limits fall back to batch default
   });
 
   it("PRUNES rows older than the TTL before returning the batch, and logs the drop at error level", async () => {


### PR DESCRIPTION
## Summary

- `pullRelayPending` accepted non-positive `limit` values and only clamped the upper bound.
- In SQLite, `LIMIT -1` means unbounded, so a negative limit could drain the full pending backlog in one request.
- Sanitize requested limits: accept only positive integers, otherwise fall back to default batch size, then clamp to max batch.

## Validation

- `npx vitest run test/integration/orb-relay.test.ts -t "batch size|over-large requested limit"`

## Safety

- Regression checks cover `limit: 0`, `limit: -1`, and `limit: NaN` fallback behavior.