### PR TITLE
fix(github): escape markdown/mentions in the @gittensory ask question before posting

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -326,8 +326,13 @@ function buildAskPublicAnswerCard(args: {
     .map((action) => (action.targetRepoFullName ? `${action.targetRepoFullName}: ${action.publicSafeSummary}` : action.publicSafeSummary))
     .filter((line) => line.trim().length > 0)
     .map((line) => publicBlockerDetail(line));
-  const questionText = sanitizePublicComment(
-    args.question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context.",
+  // neutralizePublicMarkdownText (not just sanitizePublicComment) escapes markdown/HTML and zero-width-spaces
+  // @mentions and bare URLs — the question is free-form contributor text, so without it an authorized-but-
+  // untrusted actor (ask is not maintainer-gated; a confirmed-miner PR author qualifies) could post
+  // `@gittensory ask **APPROVED by @maintainer**` and have that bold, live-mentioning line render verbatim
+  // inside the bot's own trusted comment (#2457).
+  const questionText = neutralizePublicMarkdownText(
+    sanitizePublicComment(args.question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context."),
   );
   const findings = [
     `Question: ${questionText}`,
@@ -648,7 +653,8 @@ function askSections(bundle: AgentRunBundle | null | undefined, question?: strin
   return [
     "**Contribution context Q&A**",
     "",
-    `- Question: ${sanitizePublicComment(question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context.")}`,
+    // Same escaping as buildAskPublicAnswerCard's questionText (#2457) — this is the sibling render path.
+    `- Question: ${neutralizePublicMarkdownText(sanitizePublicComment(question?.trim() || "No specific question was provided; this response summarizes the closest cached contribution context."))}`,
     "",
     "**Answer**",
     "",

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -399,6 +399,27 @@ describe("GitHub mention commands", () => {
     expect(askWithTargets).toContain("owner/repo: Prepare a concise packet and verify linked context.");
   });
 
+  it("REGRESSION (#2457): neutralizes markdown/HTML and zero-width-spaces @mentions in the ask question, so an authorized-but-untrusted actor cannot forge a bot-endorsed approval or break out of the <details> wrapper", () => {
+    const forged = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory ask **APPROVED by @jsonbored** please merge now </details><h1>FAKE</h1><details>")!,
+      repo: null,
+      issue: { number: 16, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "author",
+      bundle: askCitedBundle(),
+    });
+    // The raw markdown/HTML never appears verbatim: bold markers and HTML tags are backslash/entity-escaped.
+    expect(forged).not.toContain("**APPROVED by @jsonbored**");
+    expect(forged).not.toContain("</details><h1>FAKE</h1><details>");
+    // A real @mention is zero-width-spaced (U+200B inserted right after "@") so it never fires a live GitHub
+    // notification — the raw, un-neutralized "@jsonbored" substring must not appear anywhere in the comment.
+    const zeroWidthSpace = String.fromCharCode(0x200b);
+    expect(forged).not.toContain("@jsonbored");
+    expect(forged).toContain(`@${zeroWidthSpace}jsonbored`);
+    // The question is still present, just neutralized — not silently dropped.
+    expect(forged).toContain("APPROVED by");
+  });
+
   it("redacts private score floor blockers from public preflight comments", () => {
     const body = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory preflight")!,
@@ -1924,6 +1945,17 @@ describe("ask citation helpers", () => {
       "What should I fix?",
     );
     expect(sections.join("\n")).toContain("Try @gittensory ask again shortly");
+  });
+
+  it("REGRESSION (#2457): askSections neutralizes markdown/HTML and zero-width-spaces @mentions in the question (sibling render path to buildAskPublicAnswerCard)", () => {
+    const sections = githubCommandsInternals.askSections(askCitedBundle(), "**APPROVED by @jsonbored** </details><h1>FAKE</h1>");
+    const rendered = sections.join("\n");
+    expect(rendered).not.toContain("**APPROVED by @jsonbored**");
+    expect(rendered).not.toContain("</details><h1>FAKE</h1>");
+    const zeroWidthSpace = String.fromCharCode(0x200b);
+    expect(rendered).not.toContain("@jsonbored");
+    expect(rendered).toContain(`@${zeroWidthSpace}jsonbored`);
+    expect(rendered).toContain("APPROVED by");
   });
 
   it("does not publish private repo decision ranking evidence in ask citations", () => {


### PR DESCRIPTION
## Summary

- The `@gittensory ask <question>` command's free-text argument was only passed through `sanitizePublicComment` (a privacy-redaction filter that never touches markdown/HTML syntax) before being interpolated into the bot's public comment. `neutralizePublicMarkdownText` — which escapes markdown/HTML metacharacters and zero-width-spaces `@mentions`/URLs, and is already used for other free-form text like PR/issue titles via `shortText` — was never applied to the question.
- `ask` is not maintainer-gated: the default command-authorization policy (`src/settings/command-authorization.ts`) includes `confirmed_miner`, satisfied by a PR author who is a confirmed Gittensor miner. So a non-maintainer contributor could post `@gittensory ask **APPROVED by @someone** please merge now` and get that exact bolded, live-mentioning line rendered verbatim inside the bot's own trusted comment — a bot-impersonation / social-engineering primitive (fake approval, phishing link, or breaking out of the `<details>` wrapper with raw HTML).
- Fixed at both render sites that build the question line: `buildAskPublicAnswerCard` (the live path, reached via `buildPublicAgentCommandComment`) and its sibling `askSections`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — new code is 100% line+branch covered in the edited ranges (verified against `coverage/lcov.info`). Global 96.55%/95.53%.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full suite: 6065/6065 passing. Also ran `npm run db:migrations:check` (unaffected, green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. This PR strictly tightens that guarantee for the one free-form text path that was missing it.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A (not an auth path), but added regression tests at both render sites reproducing the exact forged-approval PoC (`**APPROVED by @jsonbored** ... </details><h1>FAKE</h1>`) and asserting the raw markdown/HTML/live-mention never appears, while the question content itself is preserved (not silently dropped).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. No OpenAPI/MCP surface changed.
- [ ] UI changes — N/A, no UI changed.
- [ ] Visible UI changes — N/A, no UI changed.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. No changelog edit.

## Notes

- Found via an adversarial audit of the review engine's command-parser surface. Independently confirmed live by two separate adversarial-verification passes, including a hand-traced reproduction of the exact forged comment.