### PR TITLE
fix(github): refresh timeout budget per page when fetching public contributor repos

### DIFF
--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -75,17 +75,18 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
     ...(env?.GITHUB_PUBLIC_TOKEN ? { authorization: `Bearer ${env.GITHUB_PUBLIC_TOKEN}` } : {}),
   };
   try {
-    const signal = AbortSignal.timeout(GITHUB_PUBLIC_FETCH_TIMEOUT_MS);
+    const fetchWithTimeout = (url: string): Promise<Response> =>
+      timeoutFetch(url, { headers, signal: AbortSignal.timeout(GITHUB_PUBLIC_FETCH_TIMEOUT_MS) });
     const [userResponse, reposResponse] = await Promise.all([
-      timeoutFetch(`https://api.github.com/users/${safeLogin}`, { headers, signal }),
-      timeoutFetch(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated`, { headers, signal }),
+      fetchWithTimeout(`https://api.github.com/users/${safeLogin}`),
+      fetchWithTimeout(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated`),
     ]);
     if (!userResponse.ok) throw new Error(`GitHub user lookup failed (${userResponse.status})`);
     const user = (await userResponse.json()) as GitHubUserResponse;
     const repos: GitHubRepoResponse[] = reposResponse.ok ? ((await reposResponse.json()) as GitHubRepoResponse[]) : [];
     let linkHeader = reposResponse.ok ? reposResponse.headers.get("link") : null;
     for (let page = 2; page <= MAX_REPO_PAGES && linkHeader?.includes('rel="next"'); page += 1) {
-      const nextResponse = await timeoutFetch(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated&page=${page}`, { headers, signal });
+      const nextResponse = await fetchWithTimeout(`https://api.github.com/users/${safeLogin}/repos?per_page=100&sort=updated&page=${page}`);
       if (!nextResponse.ok) break;
       const batch = (await nextResponse.json()) as GitHubRepoResponse[];
       repos.push(...batch);

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -165,6 +165,34 @@ describe("small adapters and normalizers", () => {
     expect(profile.topLanguages).toContain("Rust");
   });
 
+  it("uses a fresh timeout signal for each paginated public GitHub request", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/users/slowpager")) return Response.json({ login: "slowpager", public_repos: 220 });
+      if (url.includes("/slowpager/repos?") && !url.includes("page=2") && !url.includes("page=3")) {
+        return Response.json(Array.from({ length: 100 }, () => ({ language: "TypeScript" })), {
+          headers: { link: '<https://api.github.com/users/slowpager/repos?page=2>; rel="next"' },
+        });
+      }
+      if (url.includes("/slowpager/repos?") && url.includes("page=2")) {
+        return Response.json(Array.from({ length: 100 }, () => ({ language: "Rust" })), {
+          headers: { link: '<https://api.github.com/users/slowpager/repos?page=3>; rel="next"' },
+        });
+      }
+      if (url.includes("/slowpager/repos?") && url.includes("page=3")) {
+        return Response.json(Array.from({ length: 20 }, () => ({ language: "Go" })));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const profile = await fetchPublicContributorProfile("slowpager");
+    expect(profile.topLanguages).toEqual(expect.arrayContaining(["TypeScript", "Rust", "Go"]));
+    // One timeout per request: user + page1 + page2 + page3.
+    expect(timeoutSpy).toHaveBeenCalledTimes(4);
+    timeoutSpy.mockRestore();
+  });
+
   it("stops paginating repos when a subsequent page returns a non-ok response", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();


### PR DESCRIPTION
## Summary

- `fetchPublicContributorProfile` reused one AbortSignal timeout across all paginated repo requests.
- Slow early calls could consume the full timeout budget and abort later pages, skewing `topLanguages`.
- Use a fresh timeout signal per request so each page has a full timeout window.

## Validation

- `npx vitest run test/unit/adapters.test.ts -t "fresh timeout signal|paginates past 100 repos"`

## Safety

- Added regression coverage for three-page pagination and timeout call count (user + pages).