### PR TITLE
feat(mcp): thread size-gate and guardrail signals into the predicted-gate verdict

### DIFF
--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -7,9 +7,18 @@ import {
   type IssueQualityReport,
 } from "../signals/engine";
 import { buildFocusManifestGuidance, type FocusManifest } from "../signals/focus-manifest";
+import { isGuardrailHit } from "../signals/change-guardrail";
+import { CONFIG_AS_CODE_GUARDRAIL_GLOBS, DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ENGINE_DECISION_GUARDRAIL_GLOBS } from "../review/guardrail-config";
 import { sanitizePublicComment } from "../github/commands";
 import { GITTENSOR_HOME_URL } from "../github/footer";
 import type { BountyRecord, GatePolicyPack, IssueRecord, PullRequestRecord, RepositoryRecord } from "../types";
+
+// The live gate's hard-guardrail globs (src/review/guardrail-config.ts) are 100% hardcoded engine constants —
+// loadHardGuardrailGlobs there is only `async` for processor call-graph compatibility, its body just
+// concatenates these three exported arrays with no live fetch. Predicted-gate is metadata-only/synchronous by
+// design (its own docstring: sourced ONLY from the PUBLIC .gittensory.yml + safe defaults), so import the
+// constants directly rather than making this whole function async for a call that was never actually live.
+const PREDICTED_GATE_HARD_GUARDRAIL_GLOBS = [...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS, ...CONFIG_AS_CODE_GUARDRAIL_GLOBS, ...ENGINE_DECISION_GUARDRAIL_GLOBS];
 
 // Opt-in funnel (#694): a non-Gittensor adopter running the `oss-anti-slop` pack learns that Gittensor pays
 // contributors for OSS work like this. Public-safe "earn" wording only (never reward/payout/score).
@@ -62,16 +71,28 @@ const PREDICTED_GATE_NOTE_BASE =
 const PREDICTED_GATE_NOTE_SLOP = "The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. ";
 // Disclaimed only when the caller did NOT supply changed paths — then path-dependent gates can't be predicted.
 const PREDICTED_GATE_NOTE_NO_PATHS =
-  "Provide the PR's changed paths to also predict the focus-manifest path policy and any pre-merge check scoped " +
-  "to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. ";
+  "Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and " +
+  "any pre-merge check scoped to changed paths; without them only path-independent title/description/label " +
+  "pre-merge checks are predicted. ";
+// Shown instead of NO_PATHS once changed paths ARE supplied (#2458): the size hold can now be predicted, but only
+// from file COUNT — line-diff stats are never sent to this metadata-only predictor, so a PR with many changed
+// LINES across few files can still under-predict the hold the live gate would actually apply.
+const PREDICTED_GATE_NOTE_SIZE_FILES_ONLY =
+  "The size-hold prediction uses changed FILE count only, not changed LINE count (line-diff stats are not " +
+  "available pre-submission), so it may under-predict a hold for a PR with many changed lines across few files. ";
 const PREDICTED_GATE_NOTE_GATE_EQUALITY =
   "Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor " +
   "status (which affects only on-chain scoring).";
 
 /** Compose the predicted-gate note. Slop is always disclaimed; the path-policy/path-gated disclaimer drops once
- *  the caller supplies changed paths (#11-13/#18). */
+ *  the caller supplies changed paths (#11-13/#18), replaced by the size-prediction file-count-only caveat (#2458). */
 function predictedGateNote(hasChangedPaths: boolean): string {
-  return PREDICTED_GATE_NOTE_BASE + PREDICTED_GATE_NOTE_SLOP + (hasChangedPaths ? "" : PREDICTED_GATE_NOTE_NO_PATHS) + PREDICTED_GATE_NOTE_GATE_EQUALITY;
+  return (
+    PREDICTED_GATE_NOTE_BASE +
+    PREDICTED_GATE_NOTE_SLOP +
+    (hasChangedPaths ? PREDICTED_GATE_NOTE_SIZE_FILES_ONLY : PREDICTED_GATE_NOTE_NO_PATHS) +
+    PREDICTED_GATE_NOTE_GATE_EQUALITY
+  );
 }
 
 export type PredictedGateInput = {
@@ -245,6 +266,18 @@ export function buildPredictedGateVerdict(args: {
     firstTimeContributorGrace: gate.firstTimeContributorGrace ?? undefined,
     authorMergedPrCount: authorHistory.filter((pr) => pr.state === "merged" || pr.mergedAt).length,
     authorClosedUnmergedPrCount: authorHistory.filter((pr) => pr.state === "closed" && !pr.mergedAt).length,
+    // Size-hold + guardrail-hold parity (#2458): only meaningful when changed paths were supplied — changedPaths
+    // is the only size/guardrail input this metadata-only predictor ever receives, so without it neither can be
+    // evaluated (byte-identical to before). changedLineCount is deliberately left unset: line-diff stats are
+    // never sent to this predictor, so the size hold can only be predicted from file count (disclosed in the
+    // note above) — never claim a line count this function has no way to know.
+    sizeGateMode: gate.sizeMode ?? undefined,
+    ...(hasChangedPaths
+      ? {
+          changedFileCount: changedPaths.length,
+          guardrailHit: isGuardrailHit(changedPaths, PREDICTED_GATE_HARD_GUARDRAIL_GLOBS),
+        }
+      : {}),
   });
 
   return {

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -329,6 +329,53 @@ describe("buildPredictedGateVerdict", () => {
     expect(result.conclusion).not.toBe("failure");
     expect([...result.blockers, ...result.warnings].some((f) => f.code === "manifest_off_focus")).toBe(false);
   });
+
+  // Regression tests for #2458: the predictor previously never threaded size/guardrail signals into
+  // evaluateGateCheck, so it always predicted "success" even when the live gate would hold the same PR for
+  // manual review (neutral → "manual").
+  it("REGRESSION (#2458): predicts a size HOLD (neutral) when changedPaths exceeds the file-count threshold and gate.size.mode is on", () => {
+    const manyFiles = Array.from({ length: 12 }, (_, i) => `src/file${i}.ts`); // 12 > SIZE_HOLD_DEFAULT_MAX_FILES (10)
+    const result = verdict({ gate: { size: { mode: "advisory" }, duplicates: "block" }, changedPaths: manyFiles });
+    expect(result.conclusion).toBe("neutral");
+    expect(result.warnings.some((w) => w.code === "oversized_pr")).toBe(true);
+    expect(result.blockers).toHaveLength(0); // a HOLD, never a hard failure
+  });
+
+  it("does NOT predict a size hold when gate.size.mode is unset (off by default), even with many changed files", () => {
+    const manyFiles = Array.from({ length: 12 }, (_, i) => `src/file${i}.ts`);
+    const result = verdict({ gate: { duplicates: "block" }, changedPaths: manyFiles });
+    expect(result.conclusion).toBe("success");
+    expect(result.warnings.some((w) => w.code === "oversized_pr")).toBe(false);
+  });
+
+  it("does NOT predict a size hold for a PR within the file-count threshold even when gate.size.mode is on", () => {
+    const result = verdict({ gate: { size: { mode: "advisory" }, duplicates: "block" }, changedPaths: ["src/upload/client.ts"] });
+    expect(result.conclusion).toBe("success");
+    expect(result.warnings.some((w) => w.code === "oversized_pr")).toBe(false);
+  });
+
+  it("REGRESSION (#2458): predicts a guardrail HOLD (neutral) when changedPaths hits a hard-guardrail path — always-on, no gate config needed", () => {
+    const result = verdict({ gate: { duplicates: "block" }, changedPaths: [".github/workflows/ci.yml"] });
+    expect(result.conclusion).toBe("neutral");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
+    expect(result.blockers).toHaveLength(0);
+  });
+
+  it("does NOT predict a guardrail hold for an ordinary changed path", () => {
+    const result = verdict({ gate: { duplicates: "block" }, changedPaths: ["src/upload/client.ts"] });
+    expect(result.conclusion).toBe("success");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(false);
+  });
+
+  it("REGRESSION (#2458): the note discloses the file-count-only size caveat once changedPaths are supplied, replacing the no-paths disclaimer", () => {
+    const withoutPaths = verdict({ gate: {} });
+    expect(withoutPaths.note).toContain("Provide the PR's changed paths");
+    expect(withoutPaths.note).not.toContain("FILE count only");
+
+    const withPaths = verdict({ gate: {}, changedPaths: ["src/upload/client.ts"] });
+    expect(withPaths.note).not.toContain("Provide the PR's changed paths");
+    expect(withPaths.note).toContain("FILE count only");
+  });
 });
 
 describe("pack-aware prediction (#693)", () => {


### PR DESCRIPTION
## Summary

- `buildPredictedGateVerdict` never threaded `sizeGateMode`/`changedFileCount` or `guardrailHit` into `evaluateGateCheck`, so the pre-submission predictor (the `predict-gate` MCP tool + REST endpoint) could never predict the oversized-PR or guardrail-path manual-review HOLDs the live gate enforces. A miner supplying `changedPaths` that hit a hard-guardrail path, or that exceed the configured size threshold, was told `conclusion: "success"` ("will merge") while the live gate — running the identical `evaluateGateCheck` against the same real PR — would actually hold it for manual review (`neutral`, never auto-merged).
- `sizeGateMode` now reads directly from the manifest's public `gate.size.mode`, mirroring how every other gate mode is already read in this file.
- `changedFileCount` and `guardrailHit` are threaded only when `changedPaths` are supplied — the only size/guardrail input this metadata-only predictor ever receives, so behavior stays byte-identical without paths (matches the existing pattern for the manifest-policy block just above it).
- The hard-guardrail globs are imported directly as the constants they actually are — `loadHardGuardrailGlobs` is `async` only for processor call-graph compatibility; its body is 100% hardcoded arrays with no live fetch — keeping this function synchronous rather than threading a needless `await` through every caller.
- `changedLineCount` is deliberately left unset: line-diff stats are never sent to this predictor, so the size hold can only be predicted from file count. The note now discloses this once paths are supplied, replacing the no-paths disclaimer it superseded.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — new code is 100% line+branch covered (`src/rules/predicted-gate.ts`: 40/40 lines, 69/69 branches). Global 96.55%/95.53%.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` — no drift; the `PredictedGateVerdict` type shape is unchanged (only internal logic + the `note` string content changed)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full suite: 6070/6070 passing. Also ran `npm run db:migrations:check` (unaffected, green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A (not an auth path), but added regression tests: size-hold fires with `gate.size.mode` on + files over threshold, does NOT fire when the mode is off or the PR is within threshold; guardrail-hold fires for a hard-guardrail path (always-on, no config needed) and not for an ordinary path; the note text correctly swaps its disclaimer once paths are supplied.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. No schema shape changed, so no regeneration needed (verified via `ui:openapi:check`).
- [ ] UI changes — N/A, no UI changed.
- [ ] Visible UI changes — N/A, no UI changed.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. No changelog edit.

## Notes

- Lowest-severity finding from an adversarial audit of the review engine (the predictor giving an over-optimistic answer, not a live-gate correctness or security issue) — last of a 7-PR series from the same audit.