### PR TITLE
feat(review): add inline finding suggestions (#2138)

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -217,6 +217,7 @@ export type InlineFinding = {
   line: number;
   severity: "blocker" | "nit";
   body: string;
+  suggestion?: string | undefined;
 };
 
 export type ModelReview = {
@@ -410,7 +411,8 @@ export function parseModelReview(text: string): ModelReview | null {
             .slice(0, 6)
         : [];
     // Fail-safe: a malformed/absent inlineFindings field degrades to []; each item missing a usable path / a
-    // positive line / a body is skipped, never partial. Severity defaults to "nit" unless it's exactly "blocker".
+    // positive line / a body is skipped, never partial. Severity defaults to "nit" unless it's exactly "blocker";
+    // a bad/blank suggestion is simply dropped while keeping the finding itself. (#2138)
     const toInlineFindings = (value: unknown): InlineFinding[] =>
       Array.isArray(value)
         ? value
@@ -422,10 +424,20 @@ export function parseModelReview(text: string): ModelReview | null {
               // float, and the `line > 0` guard below drops 0/negative anchors.
               const line = typeof o.line === "number" ? Math.trunc(o.line) : 0;
               const body = typeof o.body === "string" ? o.body.trim() : "";
+              const suggestion =
+                typeof o.suggestion === "string" ? o.suggestion.trim() : "";
               const severity: "blocker" | "nit" =
                 o.severity === "blocker" ? "blocker" : "nit";
               return path && line > 0 && body
-                ? [{ path, line, severity, body }]
+                ? [
+                    {
+                      path,
+                      line,
+                      severity,
+                      body,
+                      ...(suggestion ? { suggestion } : {}),
+                    },
+                  ]
                 : [];
             })
             .slice(0, 20)
@@ -494,7 +506,7 @@ const REVIEW_PROFILE_SUFFIX: Record<"chill" | "assertive", string> = {
 // quiet inline PR comments (#inline-comments). Absent/off appends nothing (byte-identical). The model keeps the
 // existing 4-field shape and simply ADDS an `inlineFindings` array.
 const INLINE_FINDINGS_SUFFIX =
-  '\n\nINLINE FINDINGS: ALSO include an additional top-level field "inlineFindings" in the SAME JSON object — an array (possibly empty) of your most important findings, each anchored to a specific changed line, for inline PR comments. Each item: {"path": the changed file path EXACTLY as shown in the diff, "line": the 1-based line number in the NEW file (count forward from the "+" start in the nearest "@@ -old +new @@" hunk header) of an ADDED ("+") line you are commenting on, "severity": "blocker" or "nit", "body": the one-sentence finding}. Include ONLY findings you can place on a specific added line; OMIT any you cannot anchor precisely (a wrong line is worse than none). At most ~10 items.';
+  '\n\nINLINE FINDINGS: ALSO include an additional top-level field "inlineFindings" in the SAME JSON object — an array (possibly empty) of your most important findings, each anchored to a specific changed line, for inline PR comments. Each item: {"path": the changed file path EXACTLY as shown in the diff, "line": the 1-based line number in the NEW file (count forward from the "+" start in the nearest "@@ -old +new @@" hunk header) of an ADDED ("+") line you are commenting on, "severity": "blocker" or "nit", "body": the one-sentence finding, "suggestion": optional replacement text for that line}. Include ONLY findings you can place on a specific added line; OMIT any you cannot anchor precisely (a wrong line is worse than none). If a suggestion is blank or you are not confident in an exact replacement, omit the suggestion field and keep the finding. At most ~10 items.';
 
 /** The effective reviewer SYSTEM prompt. Appends the grounding-discipline suffix when the caller supplied one
  *  (flag GITTENSORY_REVIEW_GROUNDING on), the `review.profile` tone suffix when set, then the inline-findings
@@ -848,7 +860,11 @@ export function composeInlineFindings(reviews: ModelReview[]): InlineFinding[] {
     const safeBody = toPublicSafe(finding.body);
     if (!safeBody) continue;
     seen.add(key);
-    out.push({ ...finding, body: safeBody });
+    out.push({
+      ...finding,
+      body: safeBody,
+      ...(finding.suggestion?.trim() ? { suggestion: finding.suggestion.trim() } : {}),
+    });
   }
   return out;
 }

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -859,11 +859,14 @@ export function composeInlineFindings(reviews: ModelReview[]): InlineFinding[] {
     if (seen.has(key)) continue;
     const safeBody = toPublicSafe(finding.body);
     if (!safeBody) continue;
+    const safeSuggestion = toPublicSafe(finding.suggestion);
     seen.add(key);
     out.push({
-      ...finding,
+      path: finding.path,
+      line: finding.line,
+      severity: finding.severity,
       body: safeBody,
-      ...(finding.suggestion?.trim() ? { suggestion: finding.suggestion.trim() } : {}),
+      ...(safeSuggestion ? { suggestion: safeSuggestion } : {}),
     });
   }
   return out;

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -25,6 +25,7 @@ type InlineFinding = {
   line: number;
   severity: "blocker" | "nit";
   body: string;
+  suggestion?: string;
 };
 type ModelReviewShape = {
   assessment: string;
@@ -376,7 +377,9 @@ describe("review.profile shapes the reviewer system prompt (#review-profile)", (
       await runGittensoryAiReview(env, { ...baseInput, inlineFindings });
       return systemPromptOf(run);
     };
-    expect(await runInline(true)).toContain("INLINE FINDINGS");
+    const withInline = await runInline(true);
+    expect(withInline).toContain("INLINE FINDINGS");
+    expect(withInline).toContain('"suggestion": optional replacement text');
     // Absent / false ⇒ byte-identical prompt (no inline instruction).
     expect(await runInline(false)).not.toContain("INLINE FINDINGS");
     expect(await runInline(undefined)).not.toContain("INLINE FINDINGS");
@@ -1405,7 +1408,7 @@ describe("pure helpers", () => {
     expect(withNits).toContain("Add coverage for the edge case.");
   });
 
-  it("parseModelReview parses well-formed inline findings; severity defaults to nit unless exactly 'blocker' (#inline-comments)", () => {
+  it("parseModelReview parses well-formed inline findings, including a trimmed optional suggestion; severity defaults to nit unless exactly 'blocker' (#inline-comments)", () => {
     const json = JSON.stringify({
       assessment: "ok",
       blockers: [],
@@ -1417,13 +1420,39 @@ describe("pure helpers", () => {
           line: 12,
           severity: "blocker",
           body: "Null deref.",
+          suggestion: "  const value = input ?? fallback;  ",
         },
         { path: "src/b.ts", line: 3, severity: "whatever", body: "Rename x." },
       ],
     });
     expect(parseModelReview(json)?.inlineFindings).toEqual([
-      { path: "src/a.ts", line: 12, severity: "blocker", body: "Null deref." },
+      {
+        path: "src/a.ts",
+        line: 12,
+        severity: "blocker",
+        body: "Null deref.",
+        suggestion: "const value = input ?? fallback;",
+      },
       { path: "src/b.ts", line: 3, severity: "nit", body: "Rename x." },
+    ]);
+  });
+
+  it("parseModelReview keeps findings but drops empty, whitespace-only, and malformed suggestions (#2138)", () => {
+    const json = JSON.stringify({
+      assessment: "ok",
+      blockers: [],
+      nits: [],
+      suggestions: [],
+      inlineFindings: [
+        { path: "src/a.ts", line: 2, severity: "nit", body: "Keep me.", suggestion: "" },
+        { path: "src/b.ts", line: 4, severity: "nit", body: "Keep me too.", suggestion: "   " },
+        { path: "src/c.ts", line: 6, severity: "nit", body: "Bad suggestion type.", suggestion: 42 },
+      ],
+    });
+    expect(parseModelReview(json)?.inlineFindings).toEqual([
+      { path: "src/a.ts", line: 2, severity: "nit", body: "Keep me." },
+      { path: "src/b.ts", line: 4, severity: "nit", body: "Keep me too." },
+      { path: "src/c.ts", line: 6, severity: "nit", body: "Bad suggestion type." },
     ]);
   });
 
@@ -1480,12 +1509,19 @@ describe("pure helpers", () => {
   it("composeInlineFindings dedupes by path+line (first wins) and drops public-unsafe bodies (#inline-comments)", () => {
     const out = composeInlineFindings([
       reviewWithFindings([
-        { path: "src/a.ts", line: 1, severity: "nit", body: "First." },
+        {
+          path: "src/a.ts",
+          line: 1,
+          severity: "nit",
+          body: "First.",
+          suggestion: "  const renamed = first;  ",
+        },
         {
           path: "src/a.ts",
           line: 1,
           severity: "blocker",
           body: "Duplicate line — dropped.",
+          suggestion: "const duplicate = true;",
         },
         {
           path: "src/a.ts",
@@ -1497,7 +1533,13 @@ describe("pure helpers", () => {
       ]),
     ]);
     expect(out).toEqual([
-      { path: "src/a.ts", line: 1, severity: "nit", body: "First." },
+      {
+        path: "src/a.ts",
+        line: 1,
+        severity: "nit",
+        body: "First.",
+        suggestion: "const renamed = first;",
+      },
       { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." },
     ]);
   });
@@ -1528,6 +1570,7 @@ describe("pure helpers", () => {
           line: 3,
           severity: "nit",
           body: "Guard the empty case.",
+          suggestion: "  if (!items.length) return;  ",
         },
       ],
     });
@@ -1550,6 +1593,7 @@ describe("pure helpers", () => {
           line: 3,
           severity: "nit",
           body: "Guard the empty case.",
+          suggestion: "if (!items.length) return;",
         },
       ]);
   });

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1506,7 +1506,7 @@ describe("pure helpers", () => {
     ).toEqual([]);
   });
 
-  it("composeInlineFindings dedupes by path+line (first wins) and drops public-unsafe bodies (#inline-comments)", () => {
+  it("composeInlineFindings dedupes by path+line (first wins) and keeps safe suggestions (#inline-comments)", () => {
     const out = composeInlineFindings([
       reviewWithFindings([
         {
@@ -1541,6 +1541,31 @@ describe("pure helpers", () => {
         suggestion: "const renamed = first;",
       },
       { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." },
+    ]);
+  });
+
+  it("composeInlineFindings drops blank or public-unsafe suggestions while keeping safe findings (#2138)", () => {
+    const out = composeInlineFindings([
+      reviewWithFindings([
+        {
+          path: "src/a.ts",
+          line: 1,
+          severity: "nit",
+          body: "Keep this finding.",
+          suggestion: "   ",
+        },
+        {
+          path: "src/b.ts",
+          line: 2,
+          severity: "blocker",
+          body: "Still safe.",
+          suggestion: "reward payout farming",
+        },
+      ]),
+    ]);
+    expect(out).toEqual([
+      { path: "src/a.ts", line: 1, severity: "nit", body: "Keep this finding." },
+      { path: "src/b.ts", line: 2, severity: "blocker", body: "Still safe." },
     ]);
   });
 
@@ -1593,7 +1618,7 @@ describe("pure helpers", () => {
           line: 3,
           severity: "nit",
           body: "Guard the empty case.",
-          suggestion: "if (!items.length) return;",
+          suggestion: "if \\(\\!items.length\\) return;",
         },
       ]);
   });


### PR DESCRIPTION
## Summary

- Adds optional `suggestion` parsing to AI inline findings, trimming valid values and dropping blank or malformed suggestions without discarding the finding.
- Threads `suggestion` through composed inline findings and updates the inline-findings prompt contract so models can emit replacement text for anchored lines.
- Adds regression coverage for prompt suffix presence, suggestion trim/drop branches, and end-to-end inline-finding propagation.

Closes #2138.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable.

## Notes

- Scope is intentionally limited to the InlineFinding schema/parser/prompt/composition path; inline suggestion rendering remains follow-up work.
