### PR TITLE
fix(rules): scope predicted-gate siblings and match repo keys case-insensitively

### DIFF
--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -93,6 +93,11 @@ function publicSafeFinding(finding: { code: string; title: string; detail: strin
   };
 }
 
+/** GitHub full names are case-insensitive — mirror `sameRepo` in the live gate paths. */
+function sameRepoFullName(left: string | null | undefined, right: string | null | undefined): boolean {
+  return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+}
+
 export function buildPredictedGateVerdict(args: {
   input: PredictedGateInput;
   manifest: FocusManifest;
@@ -174,11 +179,16 @@ export function buildPredictedGateVerdict(args: {
   // finding too — evaluateGateCheck below already receives gate.selfAuthoredLinkedIssue, but without this finding it
   // had nothing to act on, so a configured self-authored gate never showed in the preview. Offline path: resolved
   // from the snapshot, never a live fetch. (#self-authored-parity)
-  const issueAuthorByNumber = new Map(issues.filter((issue) => issue.repoFullName === input.repoFullName).map((issue) => [issue.number, issue.authorLogin ?? null]));
+  const issueAuthorByNumber = new Map(issues.filter((issue) => sameRepoFullName(issue.repoFullName, input.repoFullName)).map((issue) => [issue.number, issue.authorLogin ?? null]));
   const linkedIssueAuthorLogins = syntheticPr.linkedIssues.map((issueNumber) => issueAuthorByNumber.get(issueNumber) ?? null);
-  // Mirror the live gate (listOtherOpenPullRequests): a closed/merged PR sharing a linked issue must not fire
-  // duplicate_pr_risk. authorHistory below still needs every state for its grace counts.
-  const openSiblings = pullRequests.filter((otherPr) => otherPr.state === "open");
+  // Mirror the live gate (listOtherOpenPullRequests): repo-scoped open siblings only; closed/merged PRs sharing a
+  // linked issue must not fire duplicate_pr_risk. authorHistory below still needs every state for its grace counts.
+  const openSiblings = pullRequests.filter(
+    (otherPr) =>
+      otherPr.state === "open" &&
+      sameRepoFullName(otherPr.repoFullName, input.repoFullName) &&
+      otherPr.number !== syntheticPr.number,
+  );
   const advisory = buildPullRequestAdvisory(repo, syntheticPr, { otherOpenPullRequests: openSiblings, requireLinkedIssue, linkedIssueAuthorLogins });
 
   // Deterministic pre-merge checks parity (#11/#18): the LIVE gate enforces the repo's `review.pre_merge_checks`
@@ -226,7 +236,7 @@ export function buildPredictedGateVerdict(args: {
   // Case-insensitive author match so the PREDICTOR agrees with the live gate (which matches case-insensitively).
   // First-time grace is retained as compatibility context, but blocker findings are no longer softened by it.
   const contributorLoginLc = input.contributorLogin?.toLowerCase();
-  const authorHistory = pullRequests.filter((pr) => pr.repoFullName === input.repoFullName && pr.authorLogin?.toLowerCase() === contributorLoginLc);
+  const authorHistory = pullRequests.filter((pr) => sameRepoFullName(pr.repoFullName, input.repoFullName) && pr.authorLogin?.toLowerCase() === contributorLoginLc);
 
   const evaluation = evaluateGateCheck(advisory, {
     linkedIssueGateMode: gate.linkedIssue ?? undefined,

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -67,6 +67,15 @@ describe("buildPredictedGateVerdict", () => {
     expect(result.title.toLowerCase()).toContain("gittensory orb review agent");
   });
 
+  it("does NOT raise duplicate_pr_risk for an open PR in a different repo sharing the same issue number (repo-scoped parity)", () => {
+    const result = verdict({
+      gate: { duplicates: "block" },
+      pullRequests: [{ ...openPr(42, "Other repo retry", [7], "someone-else"), repoFullName: "other/repo" }],
+    });
+    expect(result.blockers.some((b) => b.code === "duplicate_pr_risk")).toBe(false);
+    expect(result.conclusion).toBe("success");
+  });
+
   it("does NOT block on a duplicate when duplicates:off", () => {
     const result = verdict({ gate: { duplicates: "off" }, pullRequests: [openPr(42, "Retry uploads on 5xx responses", [7])] });
     expect(result.conclusion).not.toBe("failure");
@@ -102,6 +111,15 @@ describe("buildPredictedGateVerdict", () => {
     const blocked = verdict({ gate: { selfAuthoredLinkedIssue: "block" }, issues: [openIssue(7, "Uploads should retry on 5xx", "miner1")] });
     expect(blocked.conclusion).toBe("failure");
     expect(blocked.blockers.some((b) => b.code === "self_authored_linked_issue")).toBe(true);
+
+    // Repo full names are case-insensitive on GitHub — mixed-case snapshot must still resolve the author.
+    const mixedCaseRepo = verdict({
+      gate: { selfAuthoredLinkedIssue: "block" },
+      input: { repoFullName: "acme/widgets" },
+      issues: [{ ...openIssue(7, "Uploads should retry on 5xx", "miner1"), repoFullName: "Acme/Widgets" }],
+    });
+    expect(mixedCaseRepo.conclusion).toBe("failure");
+    expect(mixedCaseRepo.blockers.some((b) => b.code === "self_authored_linked_issue")).toBe(true);
 
     // Authored by someone else → no self-authored finding.
     const otherAuthor = verdict({ gate: { selfAuthoredLinkedIssue: "block" }, issues: [openIssue(7, "Uploads should retry on 5xx", "reporter")] });


### PR DESCRIPTION
## Summary

- The MCP pre-submit predictor (`buildPredictedGateVerdict`) compared `repoFullName` with case-sensitive `===`, so a snapshot issue stored as `Acme/Widgets` with input `acme/widgets` failed to resolve the linked-issue author and missed `self_authored_linked_issue` blocks.
- `openSiblings` included every open PR in the snapshot, but the live gate's `listOtherOpenPullRequests` is repo-scoped — an open PR in `other/repo` linking `#7` could falsely trigger `duplicate_pr_risk` for `acme/widgets` also linking `#7`.
- Fixed by mirroring the live gate: case-insensitive repo matching and repo-scoped open siblings (excluding the synthetic PR number).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/predicted-gate.test.ts` — 31/31 passing (includes cross-repo duplicate + mixed-case repo regressions)
- [ ] `npm run test:ci` — full gate pending CI on fork PR

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. Predictor parity only; no schema change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Parity with live gate `listOtherOpenPullRequests` and `sameRepo` case-insensitive matching used throughout `engine.ts`.
