### PR TITLE
fix(enrichment): match workflow paths case-insensitively in actions-pin

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -9,6 +9,10 @@ const FULL_SHA = /^[0-9a-f]{40}$/;
 const OFFICIAL = /^(actions|github)\//;
 const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
 
+function isWorkflowPath(path: string): boolean {
+  return WORKFLOW_PATH.test(path.replace(/\\/g, "/").toLowerCase());
+}
+
 /** Scan one workflow patch's added lines for unpinned third-party `uses:` refs, line-cited via hunk headers. Pure. */
 export function scanWorkflowPins(
   path: string,
@@ -46,7 +50,7 @@ export async function scanActionPins(
 ): Promise<ActionPinFinding[]> {
   const findings: ActionPinFinding[] = [];
   for (const file of req.files ?? []) {
-    if (WORKFLOW_PATH.test(file.path) && file.patch) {
+    if (isWorkflowPath(file.path) && file.patch) {
       findings.push(...scanWorkflowPins(file.path, file.patch));
     }
   }

--- a/review-enrichment/test/actions-pin.test.ts
+++ b/review-enrichment/test/actions-pin.test.ts
@@ -118,3 +118,29 @@ test("scanActionPins scans only changed workflow YAML files with patches", async
     },
   ]);
 });
+
+test("scanActionPins matches workflow paths case-insensitively", async () => {
+  const findings = await scanActionPins({
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      {
+        path: ".github/Workflows/CI.YML",
+        patch: "@@ -1,0 +5,1 @@\n+    - uses: pnpm/action-setup@v3",
+      },
+      {
+        path: "docs/workflow.yml",
+        patch: "@@ -1,0 +1,1 @@\n+    - uses: vendor/not-a-workflow@main",
+      },
+    ],
+  });
+
+  assert.deepEqual(findings, [
+    {
+      file: ".github/Workflows/CI.YML",
+      line: 5,
+      action: "pnpm/action-setup",
+      ref: "v3",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

- `scanActionPins` only scanned files matching a case-sensitive `.github/workflows/*.ya?ml` regex.
- Paths like `.github/Workflows/CI.YML` were skipped entirely, so mutable third-party `uses:` refs evaded detection.
- Normalize paths to lowercase (with backslash-to-slash) before matching, consistent with `isConfigFile` in `path-matchers.ts` and `change-guardrail` tests.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `review-enrichment` build + `node --test test/actions-pin.test.ts` — 5/5 passing (includes mixed-case workflow path regression)
- [ ] `npm run rees:test` — full enrichment gate pending CI on fork PR

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. Enrichment analyzer only.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Distinct from open PR #2492 (uppercase SHA pin refs) — this fixes workflow **path** gating only.
