### PR TITLE
fix(github): reject malformed repo slugs in comment helpers

### DIFF
--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -19,6 +19,17 @@ type IssueComment = {
   } | null;
 };
 
+function parseRepoFullName(repoFullName: string): { owner: string; repo: string } {
+  if (repoFullName !== repoFullName.trim()) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  const parts = repoFullName.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
 export async function createOrUpdatePrIntelligenceComment(
   env: Env,
   installationId: number,
@@ -50,8 +61,7 @@ async function createOrUpdateIssueCommentWithMarker(
   marker: string,
   options: { createIfMissing?: boolean | undefined; mode?: AgentActionMode } = {},
 ): Promise<{ id: number; html_url?: string } | null> {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
+  const { owner, repo } = parseRepoFullName(repoFullName);
 
   return await withInstallationTokenRetry(env, installationId, async (token) => {
     // Non-live mode suppresses the comment create/update writes; the GET marker-search probe below still runs.

--- a/test/unit/github-comments.test.ts
+++ b/test/unit/github-comments.test.ts
@@ -378,6 +378,22 @@ describe("GitHub PR intelligence comments", () => {
 
   it("rejects invalid repository names before calling GitHub", async () => {
     await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, "invalid", 12, "body")).rejects.toThrow(/Invalid repository full name/);
+    await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, "owner/repo/extra", 12, "body")).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    await expect(createOrUpdatePrIntelligenceComment(createTestEnv(), 123, " owner/repo ", 12, "body")).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return Response.json({ token: "t" });
+    });
+    const privateKey = await generatePrivateKeyPem();
+    await expect(
+      createOrUpdatePrIntelligenceComment(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo/extra", 12, "body"),
+    ).rejects.toThrow(/Invalid repository full name/);
+    expect(called).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Require exactly `owner/repo` in sticky comment helpers, matching the merged `pr-actions` fail-closed contract.
- Reject multi-segment and padded slugs before any GitHub comment create/update call.

## Test plan

- [x] `npx vitest run test/unit/github-comments.test.ts`

Made with [Cursor](https://cursor.com)