### PR TITLE
fix(selfhost): strip a query-string password even with an encoded key name

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -121,21 +121,33 @@ prepare_pg_env() {
       ;;
   esac
 
-  # A malformed (but not rejected by libpq's own parser) URL could repeat `password=` -- loop until none
-  # remain rather than stripping only the first, so a leftover second occurrence can never survive into
-  # $PG_SANITIZED_URL. Each iteration overwrites PGPASSWORD_VALUE, so the LAST occurrence wins; which one
-  # libpq itself would actually authenticate with is unspecified for a duplicate key, but every occurrence
-  # is a credential either way and none may reach argv.
-  pg_query_wrapped="&$pg_query&"
-  while case "$pg_query_wrapped" in *"&password="*"&"*) true ;; *) false ;; esac; do
-    pg_before_pw=${pg_query_wrapped%%&password=*}
-    pg_from_pw=${pg_query_wrapped#*&password=}
-    PGPASSWORD_VALUE=$(url_decode "${pg_from_pw%%&*}")
-    pg_after_pw=${pg_from_pw#*&}
-    pg_query_wrapped="${pg_before_pw}&${pg_after_pw}"
+  # libpq percent-decodes query KEY NAMES before matching them against connection keywords, so
+  # `pass%77ord=secret` (%77 = 'w') is just as much a password as a literal `password=secret` -- a literal
+  # string match against "&password=" (an earlier version of this loop) would miss it entirely, leaving a
+  # real credential in $PG_SANITIZED_URL. Walk each '&'-separated pair individually (a trailing '&' is
+  # appended so the last real pair is terminated the same as every other), decode ONLY the key half of
+  # each to compare it against "password", and rebuild the query from every pair whose decoded key isn't
+  # "password" -- in original order, values left percent-encoded exactly as given (they're not being
+  # re-parsed, just passed through to libpq, which decodes them itself). A malformed (but not rejected by
+  # libpq's own parser) URL repeating the key is handled naturally: each match overwrites PGPASSWORD_VALUE,
+  # so the LAST occurrence wins -- which one libpq itself would authenticate with is unspecified for a
+  # duplicate key, but every occurrence is a credential either way, so none may reach argv.
+  pg_remaining="$pg_query&"
+  pg_query=""
+  while [ -n "$pg_remaining" ]; do
+    pg_pair=${pg_remaining%%&*}
+    pg_remaining=${pg_remaining#*&}
+    if [ -z "$pg_pair" ]; then continue; fi
+    case "$pg_pair" in
+      *=*) pg_key_raw=${pg_pair%%=*}; pg_val_raw=${pg_pair#*=} ;;
+      *) pg_key_raw=$pg_pair; pg_val_raw="" ;;
+    esac
+    if [ "$(url_decode "$pg_key_raw")" = "password" ]; then
+      PGPASSWORD_VALUE=$(url_decode "$pg_val_raw")
+    else
+      if [ -n "$pg_query" ]; then pg_query="$pg_query&$pg_pair"; else pg_query=$pg_pair; fi
+    fi
   done
-  pg_query=${pg_query_wrapped#&}
-  pg_query=${pg_query%&}
 
   pg_suffix=$pg_path
   if [ -n "$pg_query" ]; then pg_suffix="$pg_suffix?$pg_query"; fi

--- a/test/unit/selfhost-backup-script.test.ts
+++ b/test/unit/selfhost-backup-script.test.ts
@@ -215,6 +215,31 @@ describe("self-host backup script", () => {
     expect(args).toContain("postgresql://u@h/db?sslmode=require");
   });
 
+  it("strips a query-string password even when its KEY NAME is percent-encoded", () => {
+    const root = tmpRoot();
+    const pgBin = fakePgDump(root);
+    const argsFile = join(root, "pg-dump.args");
+    const envFile = join(root, "pg-dump.env");
+
+    // libpq percent-decodes query KEY NAMES before matching them against connection keywords, so
+    // pass%77ord (%77 = 'w') is just as much `password` as the literal spelling -- a literal string match
+    // against "password=" would miss it entirely, leaving a real credential in argv.
+    runBackup(root, {
+      DATABASE_URL: "postgresql://u@h/db?sslmode=require&pass%77ord=SuperSecret123%21&application_name=app",
+      PATH: `${pgBin}:${process.env.PATH ?? ""}`,
+      PG_DUMP_ARGS_FILE: argsFile,
+      PG_DUMP_ENV_FILE: envFile,
+    });
+
+    const args = execFileSync("cat", [argsFile], { encoding: "utf8" });
+    const [, passfileContent] = execFileSync("cat", [envFile], { encoding: "utf8" }).trim().split("|");
+    expect(args).not.toContain("SuperSecret123");
+    expect(args).not.toContain("pass%77ord");
+    expect(args).not.toContain("password=");
+    expect(args).toContain("postgresql://u@h/db?sslmode=require&application_name=app");
+    expect(passfileContent).toBe("*:*:*:*:SuperSecret123!");
+  });
+
   it("does not mistake a query value merely containing the substring 'password' for the password key", () => {
     const root = tmpRoot();
     const pgBin = fakePgDump(root);


### PR DESCRIPTION
## Summary

- Follow-up finding on #2459's own review: libpq percent-decodes query **key names**, not just values, before matching them against connection keywords — so `pass%77ord=secret` (`%77` = `w`) is just as much a `password` parameter as the literal spelling, and libpq will authenticate with it. The previous fix's literal string match against `&password=` never saw this: the raw text is `pass%77ord=`, not `password=`, so it survived untouched into `$PG_SANITIZED_URL`, still a real credential in `pg_dump`'s argv.
- Replaced the literal-match loop with one that walks each `&`-separated query pair individually, decodes **only the key half** of each, and compares that against `password` — rebuilding the query from every pair whose decoded key isn't a match, in original order, with values left percent-encoded exactly as given (they're not being re-parsed, just handed to `libpq`, which decodes them itself). A repeated key is handled the same way as before: each match overwrites the stored password, so the last occurrence wins.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one script + its test file, no product code changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] No issue is linked — this is a direct follow-up to #2459's own review findings, not a pre-filed bug.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — full unsharded run green on Node 22.23.1 (matching CI's pinned `.nvmrc`): 321 passed / 2 skipped, 6092 tests passed, 0 failures.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] Verified against the exact encoded-key case (`pass%77ord=secret`) from the review, plus every prior regression case from #2459 (duplicate keys, userinfo password, query-string-only host, `+` in password, fake `@`/`:` in a query value, percent-encoded values, the substring-only negative case) — all still passing via a standalone shell harness before wiring into the vitest suite.
- [x] Reverting just this change reproduces the exact leak, confirming the new test actually exercises the behavior change.

If any required check was skipped, explain why:

- N/A — everything ran.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A — no API/OpenAPI/MCP behavior change.
- [x] N/A — no UI code changes.
- [x] N/A — no visible UI change.
- [x] N/A — no docs/changelog changes needed.

## Notes

- Direct follow-up to #2459 (merged) — the AI review on that PR's final round flagged this exact gap after the PR had already merged its previous round of fixes.
- The identical fix is being applied to `scripts/verify-backup.sh` in #2512, which shares this logic.
