### PR TITLE
fix(selfhost): catch queue pump failures before they become unhandled rejections (#2498)

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -548,6 +548,17 @@ export function createPgQueue(
       while (await processOne()) {
         /* drain due jobs */
       }
+    } catch (error) {
+      const message = errorMessageWithCause(error);
+      captureError(error, { kind: "queue_pump_crash", backend: "postgres" });
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_pump_failed",
+          backend: "postgres",
+          error: message,
+        }),
+      );
     } finally {
       active--;
     }

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -491,6 +491,17 @@ export function createSqliteQueue(
       while (await processOne()) {
         /* keep draining due jobs */
       }
+    } catch (error) {
+      const message = errorMessageWithCause(error);
+      captureError(error, { kind: "queue_pump_crash", backend: "sqlite" });
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_pump_failed",
+          backend: "sqlite",
+          error: message,
+        }),
+      );
     } finally {
       active--;
     }

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1348,6 +1348,29 @@ describe("createPgQueue (durable #977)", () => {
     expect(seen.sort()).toEqual(["x", "y"]);
   });
 
+  it("logs and swallows pump failures from claim/reclaim paths so drain does not reject", async () => {
+    const claimSql = "UPDATE _selfhost_jobs SET status='processing'";
+    const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("SELECT id, payload, priority")) return { rows: [], rowCount: 0 };
+      if (q.includes("SELECT id, payload, job_key") && q.includes("status IN")) return { rows: [], rowCount: 0 };
+      if (q.includes("WHERE status='processing'")) return { rows: [], rowCount: 0 };
+      if (q.includes(claimSql)) throw new Error("claim failed");
+      return { rows: [], rowCount: 0 };
+    });
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const q = createPgQueue({ query: fn } as unknown as Pool, async () => undefined);
+    await q.init();
+
+    await expect(q.drain()).resolves.toBeUndefined();
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("\"event\":\"selfhost_queue_pump_failed\""),
+    );
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("\"backend\":\"postgres\""),
+    );
+  });
+
   it("uses default backoff lambda when backoffMs is not provided", async () => {
     // Trigger a retry without providing backoffMs so the default (attempt) => Math.min(60_000, 1000 * 2**attempt)
     // is actually called — covering the function body that would otherwise be created but never invoked.

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1846,4 +1846,29 @@ describe("createSqliteQueue (durable #980)", () => {
     await q.stop(); // waits for the in-flight consume to finish
     expect(done).toBe(true);
   });
+
+  it("logs and swallows pump failures from claim/reclaim paths so drain does not reject", async () => {
+    const base = makeDriver();
+    const query = vi.fn((sql: string, params: unknown[]) => {
+      if (sql.includes("UPDATE _selfhost_jobs SET status='processing'")) {
+        throw new Error("claim failed");
+      }
+      return base.query(sql, params);
+    });
+    const driver = {
+      exec: base.exec.bind(base),
+      query,
+    } as ReturnType<typeof nodeSqliteDriver>;
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const q = createSqliteQueue(driver, async () => undefined);
+
+    await q.binding.send(msg("pump-failure"));
+    await expect(q.drain()).resolves.toBeUndefined();
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("\"event\":\"selfhost_queue_pump_failed\""),
+    );
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("\"backend\":\"sqlite\""),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Catches queue `pump()` failures in both self-host queue backends so claim/reclaim DB exceptions are captured and logged instead of surfacing as unhandled promise rejections.
- Adds regression coverage proving `drain()` no longer rejects when claim-path failures occur and emits structured `selfhost_queue_pump_failed` diagnostics.
- Fixes #2498.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran focused queue suites: `npx vitest run test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A (no visible UI changes).

## Notes

- Fail-safe behavior is unchanged for successful queue processing; this only prevents process-level instability when internal claim/reclaim operations throw.