### PR TITLE
fix(github): honor shared cache TTL as default fallback (#2505)

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -135,13 +135,26 @@ function positiveEnvSeconds(env: EnvLookup, name: string, fallback: number): num
 }
 
 export function githubResponseCacheTtlSeconds(cls: GitHubCacheClass, env: EnvLookup = process.env): number {
+  const defaultTtl = positiveEnvSeconds(env, "GITHUB_CACHE_TTL_SECONDS", 0);
   if (cls === "branch_protection") {
-    return positiveEnvSeconds(env, "GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS", DEFAULT_BRANCH_PROTECTION_TTL_SECONDS);
+    return positiveEnvSeconds(
+      env,
+      "GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS",
+      defaultTtl || DEFAULT_BRANCH_PROTECTION_TTL_SECONDS,
+    );
   }
   if (cls === "commit") {
-    return positiveEnvSeconds(env, "GITHUB_COMMIT_CACHE_TTL_SECONDS", DEFAULT_COMMIT_TTL_SECONDS);
+    return positiveEnvSeconds(
+      env,
+      "GITHUB_COMMIT_CACHE_TTL_SECONDS",
+      defaultTtl || DEFAULT_COMMIT_TTL_SECONDS,
+    );
   }
-  return positiveEnvSeconds(env, "GITHUB_METADATA_CACHE_TTL_SECONDS", DEFAULT_METADATA_TTL_SECONDS);
+  return positiveEnvSeconds(
+    env,
+    "GITHUB_METADATA_CACHE_TTL_SECONDS",
+    defaultTtl || DEFAULT_METADATA_TTL_SECONDS,
+  );
 }
 
 function isCacheableGithubResponseStatus(cls: GitHubCacheClass, status: number): boolean {

--- a/src/github/graphql-cache.ts
+++ b/src/github/graphql-cache.ts
@@ -52,7 +52,8 @@ function positiveEnvSeconds(env: Record<string, string | undefined>, name: strin
 }
 
 export function githubGraphQlCacheTtlSeconds(cls: GitHubGraphQlCacheClass, env: Record<string, string | undefined> = process.env): number {
-  return positiveEnvSeconds(env, "GITHUB_GRAPHQL_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_TTL_SECONDS);
+  const sharedDefault = positiveEnvSeconds(env, "GITHUB_CACHE_TTL_SECONDS", DEFAULT_GRAPHQL_TTL_SECONDS);
+  return positiveEnvSeconds(env, "GITHUB_GRAPHQL_CACHE_TTL_SECONDS", sharedDefault);
 }
 
 async function sha256Hex(value: string): Promise<string> {

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -586,9 +586,13 @@ describe("timeoutFetch", () => {
     expect(githubResponseCacheTtlSeconds("branch_protection", {})).toBe(20 * 60);
     expect(githubResponseCacheTtlSeconds("metadata", {})).toBe(10 * 60);
     expect(githubResponseCacheTtlSeconds("commit", {})).toBe(15 * 60);
+    expect(githubResponseCacheTtlSeconds("branch_protection", { GITHUB_CACHE_TTL_SECONDS: "45" })).toBe(45);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_CACHE_TTL_SECONDS: "45" })).toBe(45);
+    expect(githubResponseCacheTtlSeconds("commit", { GITHUB_CACHE_TTL_SECONDS: "45" })).toBe(45);
     expect(githubResponseCacheTtlSeconds("branch_protection", { GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS: "3600" })).toBe(3600);
     expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "90.8" })).toBe(90);
     expect(githubResponseCacheTtlSeconds("commit", { GITHUB_COMMIT_CACHE_TTL_SECONDS: "300" })).toBe(300);
+    expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_CACHE_TTL_SECONDS: "45", GITHUB_METADATA_CACHE_TTL_SECONDS: "120" })).toBe(120);
     expect(githubResponseCacheTtlSeconds("commit", { GITHUB_COMMIT_CACHE_TTL_SECONDS: "0" })).toBe(15 * 60);
     expect(githubResponseCacheTtlSeconds("branch_protection", { GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS: "" })).toBe(20 * 60);
     expect(githubResponseCacheTtlSeconds("metadata", { GITHUB_METADATA_CACHE_TTL_SECONDS: "0" })).toBe(10 * 60);

--- a/test/unit/github-graphql-cache.test.ts
+++ b/test/unit/github-graphql-cache.test.ts
@@ -90,6 +90,9 @@ describe("graphql cache allowlist", () => {
     expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(600);
     vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "not-a-number");
     expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(600);
+    vi.stubEnv("GITHUB_GRAPHQL_CACHE_TTL_SECONDS", "");
+    vi.stubEnv("GITHUB_CACHE_TTL_SECONDS", "45");
+    expect(githubGraphQlCacheTtlSeconds("repo_totals")).toBe(45);
   });
 });
 


### PR DESCRIPTION
## Summary

- Wires `GITHUB_CACHE_TTL_SECONDS` back into the real cache TTL path as the shared default fallback for GitHub REST and GraphQL cache classes.
- Keeps per-class TTL env vars authoritative when set, while making the documented shared default knob load-bearing again.
- Adds unit coverage for shared-default fallback and per-class override precedence.
- Fixes #2505.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ?99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran focused cache suites: `npx vitest run test/unit/github-client.test.ts test/unit/github-graphql-cache.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A (no visible UI changes).

## Notes

- `GITHUB_CACHE_TTL_SECONDS` now acts as the shared default while preserving class-specific overrides for branch protection, commit, metadata, and GraphQL cache paths.