### PR TITLE
feat(miner): add laptop-mode init and doctor commands

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -11,6 +11,7 @@ Current scope is intentionally small:
 - workspace package wiring
 - CLI entry point
 - `--help` and `version` commands
+- `init` and `doctor` laptop-mode bootstrap commands
 - startup npm version nudge (override with `--no-update-check` or `GITTENSORY_MINER_NO_UPDATE_CHECK=1`)
 
 Real miner commands land in follow-up issues.
@@ -31,7 +32,23 @@ gittensory-miner --help
 gittensory-miner help
 gittensory-miner --version
 gittensory-miner version
+gittensory-miner init
+gittensory-miner doctor
+gittensory-miner doctor --json
 ```
+
+## Laptop Mode Quickstart
+
+```sh
+npm install -g @jsonbored/gittensory-miner
+gittensory-miner init
+gittensory-miner doctor
+```
+
+The CLI uses a local SQLite state file with no Docker/Redis/Postgres requirement:
+
+- config dir: `GITTENSORY_MINER_CONFIG_DIR`, else `XDG_CONFIG_HOME/gittensory-miner`, else `~/.config/gittensory-miner`
+- state file: `<config-dir>/state.sqlite3`
 
 ## Version check
 

--- a/packages/gittensory-miner/lib/cli.d.ts
+++ b/packages/gittensory-miner/lib/cli.d.ts
@@ -1,3 +1,19 @@
 export function printVersion(input: { packageName: string; packageVersion: string }): void;
 export function printHelp(input: { packageName: string }): void;
+export function resolveMinerConfigDir(env?: Record<string, string | undefined>): string;
+export function resolveMinerStatePath(env?: Record<string, string | undefined>): string;
+export function initMinerState(env?: Record<string, string | undefined>): {
+  configDir: string;
+  statePath: string;
+  createdConfigDir: boolean;
+  createdStateFile: boolean;
+};
+export function inspectDoctor(env?: Record<string, string | undefined>): {
+  nodeVersion: string;
+  configDir: string;
+  statePath: string;
+  stateExists: boolean;
+  stateWritable: boolean;
+  dockerPresent: boolean;
+};
 export function runCli(cliArgs: string[], input: { packageName: string }): number;

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -1,3 +1,10 @@
+import { accessSync, constants, existsSync, mkdirSync, openSync, closeSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const defaultStateFileName = "state.sqlite3";
+
 export function printVersion(input) {
   console.log(`${input.packageName}/${input.packageVersion} (node ${process.version})`);
 }
@@ -14,6 +21,9 @@ export function printHelp(input) {
       "  gittensory-miner --version",
       "  gittensory-miner help",
       "  gittensory-miner version",
+      "  gittensory-miner init",
+      "  gittensory-miner doctor",
+      "  gittensory-miner doctor --json",
       "",
       "Options:",
       "  --no-update-check  Skip the npm registry version nudge (also GITTENSORY_MINER_NO_UPDATE_CHECK=1)",
@@ -21,8 +31,87 @@ export function printHelp(input) {
   );
 }
 
+export function resolveMinerConfigDir(env = process.env) {
+  if (env.GITTENSORY_MINER_CONFIG_DIR) return env.GITTENSORY_MINER_CONFIG_DIR;
+  const xdgConfigHome = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(xdgConfigHome, "gittensory-miner");
+}
+
+export function resolveMinerStatePath(env = process.env) {
+  return join(resolveMinerConfigDir(env), defaultStateFileName);
+}
+
+export function initMinerState(env = process.env) {
+  const configDir = resolveMinerConfigDir(env);
+  const statePath = resolveMinerStatePath(env);
+  const createdConfigDir = !existsSync(configDir);
+  mkdirSync(configDir, { recursive: true });
+  const createdStateFile = !existsSync(statePath);
+  if (createdStateFile) {
+    const fd = openSync(statePath, "w");
+    closeSync(fd);
+  }
+  return { configDir, statePath, createdConfigDir, createdStateFile };
+}
+
+export function inspectDoctor(env = process.env) {
+  const configDir = resolveMinerConfigDir(env);
+  const statePath = resolveMinerStatePath(env);
+  const stateExists = existsSync(statePath);
+  let stateWritable = false;
+  if (stateExists) {
+    try {
+      accessSync(statePath, constants.W_OK);
+      stateWritable = true;
+    } catch {
+      stateWritable = false;
+    }
+  }
+
+  const dockerProbe = spawnSync("docker", ["--version"], {
+    encoding: "utf8",
+    timeout: 2000,
+  });
+
+  const dockerPresent = dockerProbe.status === 0 && !dockerProbe.error;
+  return {
+    nodeVersion: process.version,
+    configDir,
+    statePath,
+    stateExists,
+    stateWritable,
+    dockerPresent,
+  };
+}
+
 export function runCli(cliArgs, input) {
   const command = cliArgs[0] ?? "";
+  if (command === "init") {
+    const initialized = initMinerState();
+    console.log(`config_dir=${initialized.configDir}`);
+    console.log(`state_file=${initialized.statePath}`);
+    console.log(
+      initialized.createdStateFile
+        ? "state initialized (created)"
+        : "state initialized (already exists)",
+    );
+    return 0;
+  }
+  if (command === "doctor") {
+    const report = inspectDoctor();
+    const asJson = cliArgs.includes("--json");
+    if (asJson) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(`node=${report.nodeVersion}`);
+      console.log(`config_dir=${report.configDir}`);
+      console.log(`state_file=${report.statePath}`);
+      console.log(`state_exists=${report.stateExists}`);
+      console.log(`state_writable=${report.stateWritable}`);
+      console.log(`docker_present=${report.dockerPresent}`);
+    }
+    return 0;
+  }
   console.error(`Unknown command: ${command}. Run ${input.packageName} --help.`);
   return 1;
 }

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -1,7 +1,8 @@
-import { accessSync, constants, existsSync, mkdirSync, openSync, closeSync } from "node:fs";
+import { accessSync, constants, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { DatabaseSync } from "node:sqlite";
 
 const defaultStateFileName = "state.sqlite3";
 
@@ -48,8 +49,20 @@ export function initMinerState(env = process.env) {
   mkdirSync(configDir, { recursive: true });
   const createdStateFile = !existsSync(statePath);
   if (createdStateFile) {
-    const fd = openSync(statePath, "w");
-    closeSync(fd);
+    const db = new DatabaseSync(statePath);
+    db.exec(
+      [
+        "PRAGMA journal_mode = WAL;",
+        "CREATE TABLE IF NOT EXISTS miner_state_meta (",
+        "  key TEXT PRIMARY KEY,",
+        "  value TEXT NOT NULL",
+        ");",
+        "INSERT INTO miner_state_meta(key, value)",
+        "VALUES ('schema_version', '1')",
+        "ON CONFLICT(key) DO NOTHING;",
+      ].join("\n"),
+    );
+    db.close();
   }
   return { configDir, statePath, createdConfigDir, createdStateFile };
 }

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -1,4 +1,14 @@
 import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   bin,
@@ -13,6 +23,10 @@ type MinerUpdateCheck =
 
 let printHelp: MinerCli["printHelp"];
 let printVersion: MinerCli["printVersion"];
+let resolveMinerConfigDir: MinerCli["resolveMinerConfigDir"];
+let resolveMinerStatePath: MinerCli["resolveMinerStatePath"];
+let initMinerState: MinerCli["initMinerState"];
+let inspectDoctor: MinerCli["inspectDoctor"];
 let runCli: MinerCli["runCli"];
 let compareSemver: MinerUpdateCheck["compareSemver"];
 let fetchLatestPackageVersion: MinerUpdateCheck["fetchLatestPackageVersion"];
@@ -27,7 +41,15 @@ beforeAll(async () => {
   const cli = await import("../../packages/gittensory-miner/lib/cli.js");
   const updateCheck =
     await import("../../packages/gittensory-miner/lib/update-check.js");
-  ({ printHelp, printVersion, runCli } = cli);
+  ({
+    printHelp,
+    printVersion,
+    resolveMinerConfigDir,
+    resolveMinerStatePath,
+    initMinerState,
+    inspectDoctor,
+    runCli,
+  } = cli);
   ({
     compareSemver,
     fetchLatestPackageVersion,
@@ -77,6 +99,62 @@ describe("gittensory-miner CLI helpers", () => {
     expect(error).toHaveBeenCalledWith(
       "Unknown command: mystery. Run @jsonbored/gittensory-miner --help.",
     );
+  });
+
+  it("resolves laptop-mode config/state paths with the mcp-style fallback chain (#2329)", () => {
+    const home = mkdtempSync(join(tmpdir(), "miner-home-"));
+    const xdg = mkdtempSync(join(tmpdir(), "miner-xdg-"));
+    expect(resolveMinerConfigDir({ GITTENSORY_MINER_CONFIG_DIR: "C:/custom/miner" })).toBe(
+      "C:/custom/miner",
+    );
+    expect(resolveMinerConfigDir({ XDG_CONFIG_HOME: xdg, HOME: home })).toBe(
+      join(xdg, "gittensory-miner"),
+    );
+    expect(resolveMinerStatePath({ XDG_CONFIG_HOME: xdg })).toBe(
+      join(xdg, "gittensory-miner", "state.sqlite3"),
+    );
+  });
+
+  it("init creates a local state file and stays idempotent (#2329)", () => {
+    const root = mkdtempSync(join(tmpdir(), "miner-init-"));
+    const configDir = join(root, "cfg");
+    const env = { GITTENSORY_MINER_CONFIG_DIR: configDir };
+    const first = initMinerState(env);
+    expect(first.createdConfigDir).toBe(true);
+    expect(first.createdStateFile).toBe(true);
+    expect(existsSync(first.statePath)).toBe(true);
+
+    writeFileSync(first.statePath, "sentinel");
+    const second = initMinerState(env);
+    expect(second.createdConfigDir).toBe(false);
+    expect(second.createdStateFile).toBe(false);
+    expect(readFileSync(second.statePath, "utf8")).toBe("sentinel");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("doctor reports local state and absent Docker gracefully (#2329)", () => {
+    const root = mkdtempSync(join(tmpdir(), "miner-doctor-"));
+    const configDir = join(root, "cfg");
+    mkdirSync(configDir, { recursive: true });
+    const statePath = join(configDir, "state.sqlite3");
+    writeFileSync(statePath, "");
+    const doctor = inspectDoctor({ GITTENSORY_MINER_CONFIG_DIR: configDir });
+    expect(doctor.stateExists).toBe(true);
+    expect(doctor.stateWritable).toBe(true);
+    expect(typeof doctor.dockerPresent).toBe("boolean");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("bin init + doctor --json work end-to-end (#2329)", () => {
+    const root = mkdtempSync(join(tmpdir(), "miner-bin-"));
+    const env = { GITTENSORY_MINER_CONFIG_DIR: join(root, "cfg") };
+    const initOutput = runCapture(["init", "--no-update-check"], env);
+    expect(initOutput).toContain("state initialized");
+    const doctorOutput = runCapture(["doctor", "--json", "--no-update-check"], env);
+    const parsed = JSON.parse(doctorOutput);
+    expect(parsed.stateExists).toBe(true);
+    expect(parsed.stateWritable).toBe(true);
+    rmSync(root, { recursive: true, force: true });
   });
 
   it("keeps the CLI version source aligned with package metadata", async () => {

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -123,12 +123,16 @@ describe("gittensory-miner CLI helpers", () => {
     expect(first.createdConfigDir).toBe(true);
     expect(first.createdStateFile).toBe(true);
     expect(existsSync(first.statePath)).toBe(true);
+    expect(readFileSync(first.statePath).subarray(0, 16).toString("utf8")).toBe(
+      "SQLite format 3\u0000",
+    );
 
-    writeFileSync(first.statePath, "sentinel");
     const second = initMinerState(env);
     expect(second.createdConfigDir).toBe(false);
     expect(second.createdStateFile).toBe(false);
-    expect(readFileSync(second.statePath, "utf8")).toBe("sentinel");
+    expect(readFileSync(second.statePath).subarray(0, 16).toString("utf8")).toBe(
+      "SQLite format 3\u0000",
+    );
     rmSync(root, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Implements laptop-mode bootstrap plumbing for @jsonbored/gittensory-miner.

- Adds gittensory-miner init to create local config/state paths (GITTENSORY_MINER_CONFIG_DIR -> XDG_CONFIG_HOME -> ~/.config) and initialize state.sqlite3 idempotently.
- Adds gittensory-miner doctor (+ --json) to report node version, config/state paths, state existence/writability, and Docker presence as informational-only.
- Expands miner CLI unit coverage for path resolution, idempotent init behavior, doctor output shape, and end-to-end bin command behavior.

Fixes #2329

## Scope

- [x] The PR title follows 	ype(scope): short summary Conventional Commit format, for example ix(api): restore profile access checks.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows CONTRIBUTING.md and does not reintroduce GitHub Pages, VitePress, site/, or CNAME.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] git diff --check
- [x] 
pm run typecheck
- [x] 
pm run test:coverage locally; **codecov/patch requires ?97% coverage of the lines AND branches you changed** (aim for **98%+** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full 
pm run test:ci is still running/failing locally on Windows due unrelated shell-script environment tests; scoped typecheck + miner CLI tests were run for this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a UI Evidence section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| N/A - CLI-only change | |

## Notes

- doctor treats Docker as informational and does not fail when Docker is unavailable.