### PR TITLE
feat(miner): add deterministic rejection message templates

### DIFF
--- a/packages/gittensory-miner/lib/rejection-templates.d.ts
+++ b/packages/gittensory-miner/lib/rejection-templates.d.ts
@@ -4,6 +4,6 @@ export type RejectionReasonBucket =
   | "superseded_by_duplicate"
   | "ci_failed";
 
-export function listRejectionTemplateReasons(): string[];
+export function listRejectionTemplateReasons(): RejectionReasonBucket[];
 export function renderRejectionTemplate(reason: RejectionReasonBucket): string;
 

--- a/packages/gittensory-miner/lib/rejection-templates.d.ts
+++ b/packages/gittensory-miner/lib/rejection-templates.d.ts
@@ -1,0 +1,9 @@
+export type RejectionReasonBucket =
+  | "gate_close"
+  | "maintainer_close_no_reason"
+  | "superseded_by_duplicate"
+  | "ci_failed";
+
+export function listRejectionTemplateReasons(): string[];
+export function renderRejectionTemplate(reason: RejectionReasonBucket): string;
+

--- a/packages/gittensory-miner/lib/rejection-templates.js
+++ b/packages/gittensory-miner/lib/rejection-templates.js
@@ -1,0 +1,51 @@
+const REJECTION_TEMPLATE_MAP = {
+  gate_close:
+    "This attempt is closed by the project gate for now. We will address the listed checks and only retry with a clean, fully validated update.",
+  maintainer_close_no_reason:
+    "This attempt is closed by maintainers. We will pause, re-check repository expectations, and only continue when we can satisfy the project standards.",
+  superseded_by_duplicate:
+    "This attempt is closed because overlapping work already exists. We will avoid duplicate effort and align future updates with the active thread.",
+  ci_failed:
+    "This attempt is closed after CI failure. We will resolve every failing check and only retry when validation is fully green.",
+};
+
+const FORBIDDEN_PUBLIC_TOKENS = [
+  "wallet",
+  "hotkey",
+  "coldkey",
+  "mnemonic",
+  "reward",
+  "score",
+  "farming",
+  "payout",
+  "ranking",
+  "trust score",
+  "reviewability",
+];
+
+const unresolvedPlaceholderPattern = /\{\{[^}]+\}\}/;
+
+const forbiddenPublicPattern = new RegExp(
+  `\\b(?:${FORBIDDEN_PUBLIC_TOKENS.map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+")).join("|")})\\b`,
+  "i",
+);
+
+export function listRejectionTemplateReasons() {
+  return Object.keys(REJECTION_TEMPLATE_MAP);
+}
+
+export function renderRejectionTemplate(reason) {
+  const template = REJECTION_TEMPLATE_MAP[reason];
+  if (!template) {
+    throw new Error(`unknown_rejection_reason:${reason}`);
+  }
+  const message = template.trim().replace(/\s+/g, " ");
+  if (unresolvedPlaceholderPattern.test(message)) {
+    throw new Error(`unresolved_placeholder:${reason}`);
+  }
+  if (forbiddenPublicPattern.test(message)) {
+    throw new Error(`private_language_token:${reason}`);
+  }
+  return message;
+}
+

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js && node --check lib/rejection-templates.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -10,6 +10,8 @@ import {
 type MinerCli = typeof import("../../packages/gittensory-miner/lib/cli.js");
 type MinerUpdateCheck =
   typeof import("../../packages/gittensory-miner/lib/update-check.js");
+type MinerRejectionTemplates =
+  typeof import("../../packages/gittensory-miner/lib/rejection-templates.js");
 
 let printHelp: MinerCli["printHelp"];
 let printVersion: MinerCli["printVersion"];
@@ -22,11 +24,15 @@ let resolveUpgradeCommand: MinerUpdateCheck["resolveUpgradeCommand"];
 let shouldSkipUpdateCheck: MinerUpdateCheck["shouldSkipUpdateCheck"];
 let startUpdateCheck: MinerUpdateCheck["startUpdateCheck"];
 let awaitOpportunisticUpdateCheck: MinerUpdateCheck["awaitOpportunisticUpdateCheck"];
+let listRejectionTemplateReasons: MinerRejectionTemplates["listRejectionTemplateReasons"];
+let renderRejectionTemplate: MinerRejectionTemplates["renderRejectionTemplate"];
 
 beforeAll(async () => {
   const cli = await import("../../packages/gittensory-miner/lib/cli.js");
   const updateCheck =
     await import("../../packages/gittensory-miner/lib/update-check.js");
+  const rejectionTemplates =
+    await import("../../packages/gittensory-miner/lib/rejection-templates.js");
   ({ printHelp, printVersion, runCli } = cli);
   ({
     compareSemver,
@@ -38,6 +44,7 @@ beforeAll(async () => {
     startUpdateCheck,
     awaitOpportunisticUpdateCheck,
   } = updateCheck);
+  ({ listRejectionTemplateReasons, renderRejectionTemplate } = rejectionTemplates);
 });
 
 afterEach(async () => {
@@ -328,5 +335,24 @@ describe("gittensory-miner startup update check (#2331)", () => {
     expect(Date.now() - startedAt).toBeLessThan(2000);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("Unknown command: mystery");
+  });
+});
+
+describe("gittensory-miner rejection templates (#2324)", () => {
+  it("renders every reason bucket with deterministic, placeholder-free text", () => {
+    for (const reason of listRejectionTemplateReasons()) {
+      const message = renderRejectionTemplate(reason);
+      expect(message).toBeTruthy();
+      expect(message).not.toMatch(/\{\{[^}]+\}\}/);
+      expect(message).not.toMatch(
+        /\b(wallet|hotkey|coldkey|mnemonic|reward|score|farming|payout|ranking|trust score|reviewability)\b/i,
+      );
+    }
+  });
+
+  it("rejects unknown reason buckets", () => {
+    expect(() => renderRejectionTemplate("not_a_bucket" as never)).toThrow(
+      "unknown_rejection_reason:not_a_bucket",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds deterministic, CoC-safe rejection message templates for local miner summaries.

- Introduces ejection-templates with static reason buckets (gate_close, maintainer_close_no_reason, superseded_by_duplicate, ci_failed).
- Enforces placeholder-free and private-language-safe output before returning template text.
- Adds unit coverage to assert every bucket renders, no unresolved placeholders remain, forbidden private/economic vocabulary is absent, and unknown buckets fail closed.

Fixes #2324

## Scope

- [x] The PR title follows 	ype(scope): short summary Conventional Commit format, for example ix(api): restore profile access checks.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows CONTRIBUTING.md and does not reintroduce GitHub Pages, VitePress, site/, or CNAME.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] git diff --check
- [x] 
pm --workspace @jsonbored/gittensory-miner run build
- [x] 
px vitest run test/unit/miner-cli.test.ts
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full 
pm run test:ci is still noisy on local Windows shell-script checks unrelated to this diff; package build + focused unit tests were run.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a UI Evidence section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| N/A - CLI/template logic only | |

## Notes

- Messages are deterministic static strings (no LLM call), matching issue requirements.