### PR TITLE
fix(enrichment): classify workflow paths case-insensitively in analysis-context

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -17,6 +17,7 @@ import {
   type BoundedFetchOptions,
   type BoundedFetchResult,
 } from "./external-fetch.js";
+import { isWorkflowPath } from "./workflow-path.js";
 
 type ChangedFile = NonNullable<EnrichRequest["files"]>[number];
 
@@ -422,7 +423,7 @@ function categorizeFile(path: string): FileCategory {
   ) {
     return { path, extension, category: "lockfile" };
   }
-  if (/^\.github\/workflows\//i.test(path.replace(/\\/g, "/"))) {
+  if (isWorkflowPath(path)) {
     return { path, extension, category: "workflow" };
   }
   if (

--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -422,7 +422,7 @@ function categorizeFile(path: string): FileCategory {
   ) {
     return { path, extension, category: "lockfile" };
   }
-  if (path.startsWith(".github/workflows/")) {
+  if (/^\.github\/workflows\//i.test(path.replace(/\\/g, "/"))) {
     return { path, extension, category: "workflow" };
   }
   if (

--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -3,15 +3,11 @@
 // where a compromised upstream tag silently re-points and runs in your CI with your secrets. Pure compute, no network.
 // Official actions/* + github/* are excluded (lowest risk, extremely common) to keep the signal high. Line-cited.
 import type { EnrichRequest, ActionPinFinding } from "../types.js";
+import { isWorkflowPath } from "../workflow-path.js";
 
 const USES_RE = /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
 const FULL_SHA = /^[0-9a-f]{40}$/;
 const OFFICIAL = /^(actions|github)\//;
-const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
-
-function isWorkflowPath(path: string): boolean {
-  return WORKFLOW_PATH.test(path.replace(/\\/g, "/").toLowerCase());
-}
 
 /** Scan one workflow patch's added lines for unpinned third-party `uses:` refs, line-cited via hunk headers. Pure. */
 export function scanWorkflowPins(

--- a/review-enrichment/src/workflow-path.ts
+++ b/review-enrichment/src/workflow-path.ts
@@ -1,0 +1,6 @@
+const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
+
+/** GitHub workflow paths are case-insensitive; normalize separators before matching. */
+export function isWorkflowPath(path: string): boolean {
+  return WORKFLOW_PATH.test(path.replace(/\\/g, "/").toLowerCase());
+}

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -420,3 +420,28 @@ test("createAnalysisContext treats capped patch scans as added-line presence", (
     true,
   );
 });
+
+test("createAnalysisContext classifies workflow paths case-insensitively", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 2516,
+    files: [
+      {
+        path: ".github/Workflows/CI.YML",
+        patch: "@@ -1,0 +1,1 @@\n+    - uses: pnpm/action-setup@v3",
+      },
+      {
+        path: "docs/readme.md",
+        patch: "@@ -1,0 +1,1 @@\n+# docs",
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((file) => [file.path, file.category]),
+    [
+      [".github/Workflows/CI.YML", "workflow"],
+      ["docs/readme.md", "docs"],
+    ],
+  );
+});

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -246,3 +246,30 @@ test("added-line analyzers run when patch scan is capped before additions", asyn
   assert.equal(brief.telemetry.skippedWorkByCategory.analyzer_no_added_lines, undefined);
   assert.ok(brief.telemetry.cappedWorkByCategory.has_added_lines_patch_bytes > 0);
 });
+
+test("actionPin runs for mixed-case workflow paths", async () => {
+  let actionPinRan = false;
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 2516,
+      analyzers: ["actionPin"],
+      files: [
+        {
+          path: ".github/Workflows/CI.YML",
+          patch: "@@ -1,0 +5,1 @@\n+    - uses: pnpm/action-setup@v3",
+        },
+      ],
+    },
+    {
+      actionPin: async () => {
+        actionPinRan = true;
+        return [{ file: ".github/Workflows/CI.YML", line: 5, action: "pnpm/action-setup", ref: "v3" }];
+      },
+    },
+  );
+
+  assert.equal(actionPinRan, true);
+  assert.equal(brief.analyzerStatus.actionPin, "ok");
+  assert.notEqual(brief.telemetry.analyzers.actionPin.skipReason, "no_workflow");
+});


### PR DESCRIPTION
## Summary

- #2516 fixed `actions-pin` to scan mixed-case workflow paths, but the REES scheduler still gated `actionPin` on `file.category === "workflow"` from `categorizeFile`, which used case-sensitive `.github/workflows/` matching.
- PRs changing `.github/Workflows/CI.YML` were classified as non-workflow files, so `actionPin` was skipped with `no_workflow` even though the analyzer would scan them if invoked.
- Normalize paths before the workflow directory check, mirroring `actions-pin.ts`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `review-enrichment` build + `node --test test/analysis-context.test.ts` — 12/12 passing (includes mixed-case workflow path regression)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth/API/UI changes.

## Notes

- Completes scheduler → analyzer parity for the workflow path casing fix merged in #2516.

Made with [Cursor](https://cursor.com)