### PR TITLE
fix(rules): match label multipliers with scoring parity in advisory

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -15,6 +15,7 @@ import { isTestPath } from "../signals/test-evidence";
 import { nowIso } from "../utils/json";
 import { GITTENSORY_GATE_CHECK_NAME } from "../review/check-names";
 import { REVIEW_THREAD_BLOCKER_CODE } from "../review/review-thread-findings";
+import { labelMatchesPattern } from "../scoring/preview";
 
 export type GateCheckConclusion = "success" | "failure" | "action_required" | "neutral" | "skipped";
 
@@ -710,8 +711,8 @@ function addPullRequestFindings(
       publicText: "This repo has a busy review queue in the local Gittensory cache.",
     });
   }
-  const repoMultipliers = repo?.registryConfig?.labelMultipliers ?? {};
-  const matchedLabels = pr.labels.filter((label) => repoMultipliers[label] !== undefined);
+  const multiplierPatterns = Object.keys(repo?.registryConfig?.labelMultipliers ?? {});
+  const matchedLabels = pr.labels.filter((label) => multiplierPatterns.some((pattern) => labelMatchesPattern(label, pattern)));
   if (matchedLabels.length > 0) {
     findings.push({
       code: "label_context_found",

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -489,6 +489,51 @@ describe("advisory rules", () => {
     expect(codes).toEqual(expect.arrayContaining(["pr_not_open", "busy_pr_queue", "label_context_found", "maintainer_authored_pr"]));
   });
 
+  it("matches configured label multipliers case-insensitively and with glob patterns", () => {
+    const repoWithPatterns: RepositoryRecord = {
+      ...repo,
+      registryConfig: {
+        ...repo.registryConfig!,
+        labelMultipliers: { feature: 1.5, "type:*": 1.2 },
+      },
+    };
+    const caseMismatch = buildPullRequestAdvisory(repoWithPatterns, {
+      repoFullName: repo.fullName,
+      number: 16,
+      title: "Feature work",
+      state: "open",
+      authorLogin: "miner1",
+      authorAssociation: "NONE",
+      labels: ["Feature"],
+      linkedIssues: [7],
+    });
+    expect(caseMismatch.findings.some((finding) => finding.code === "label_context_found")).toBe(true);
+
+    const globMatch = buildPullRequestAdvisory(repoWithPatterns, {
+      repoFullName: repo.fullName,
+      number: 17,
+      title: "Bug fix",
+      state: "open",
+      authorLogin: "miner1",
+      authorAssociation: "NONE",
+      labels: ["type:bug-fix"],
+      linkedIssues: [7],
+    });
+    expect(globMatch.findings.some((finding) => finding.code === "label_context_found")).toBe(true);
+
+    const noMatch = buildPullRequestAdvisory(repoWithPatterns, {
+      repoFullName: repo.fullName,
+      number: 18,
+      title: "Docs only",
+      state: "open",
+      authorLogin: "miner1",
+      authorAssociation: "NONE",
+      labels: ["docs"],
+      linkedIssues: [7],
+    });
+    expect(noMatch.findings.some((finding) => finding.code === "label_context_found")).toBe(false);
+  });
+
   it("handles uncached PRs and closed issues", () => {
     const closedIssue: IssueRecord = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
## Summary

- `buildPullRequestAdvisory` surfaced `label_context_found` via exact `repoMultipliers[label]` lookup.
- Scoring and engine already use `labelMatchesPattern` (case-insensitive fnmatch glob semantics), so advisory missed labels like `Feature` when config had `feature`, or `type:bug-fix` when config had `type:*`.
- Reuse the exported `labelMatchesPattern` helper so predicted-gate and live gate advisories agree with scoring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/rules.test.ts -t "label multipliers"` — passing (case + glob regressions)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth/API/UI changes.

## Notes

- Distinct from #2469 (contributor opportunity label matching in signals engine) — this fixes advisory/gate metadata parity with `scoring/preview.ts`.

Made with [Cursor](https://cursor.com)