### PR TITLE
fix(rees): categorize .env dotfiles as config, not unknown

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -427,6 +427,11 @@ function categorizeFile(path: string): FileCategory {
   }
   if (
     /^Dockerfile(?:\..*)?$/.test(basename) ||
+    // `.env` and its `.env.local` / `.env.production` variants are dotfiles, so `extensionOf` returns "" (or
+    // a variant suffix like ".local"); match them by basename so the canonical env-config files categorize as
+    // "config" (only a bare-extension `foo.env` was matched via the list below).
+    basename === ".env" ||
+    basename.startsWith(".env.") ||
     [".env", ".hcl", ".ini", ".json", ".tf", ".toml", ".yaml", ".yml"].includes(extension)
   ) {
     return { path, extension, category: "config" };

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -420,3 +420,24 @@ test("createAnalysisContext treats capped patch scans as added-line presence", (
     true,
   );
 });
+
+test("categorizes bare .env and .env.* dotfiles as config (not unknown)", () => {
+  // These dotfiles have no positive-index dot, so extensionOf() returns "" (or a variant suffix like
+  // ".local"); the config check must match them by basename or the canonical env-config files are missed.
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 2600,
+    headSha: "abcdef1234567890",
+    files: [
+      { path: ".env", patch: "@@ -0,0 +1 @@\n+API_KEY=x" },
+      { path: ".env.production", patch: "@@ -0,0 +1 @@\n+API_KEY=y" },
+      { path: "config/.env.local", patch: "@@ -0,0 +1 @@\n+API_KEY=z" },
+      { path: "settings.env", patch: "@@ -0,0 +1 @@\n+API_KEY=w" },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((f) => f.category),
+    ["config", "config", "config", "config"],
+  );
+});


### PR DESCRIPTION
## Summary

`categorizeFile` in `review-enrichment/src/analysis-context.ts` classifies each changed file. Its "config" branch matches by **extension** against a list that includes `".env"`:

```ts
[".env", ".hcl", ".ini", ".json", ".tf", ".toml", ".yaml", ".yml"].includes(extension)
```

But `extensionOf(basename)` returns `""` for a leading-dot basename (`if (index <= 0) return ""`), so a bare **`.env`** never matches — and `.env.local` / `.env.production` resolve to a variant extension (`.local` / `.production`) that isn't in the list either. All of these fall through to `category: "unknown"`.

So the canonical env-config files — the dotfile `.env` family — are miscategorized, even though the list clearly intends `.env` to be config (only a bare-extension `foo.env` was actually matched). Downstream, a PR whose changed file is `.env` gets the IaC/config analyzer wrongly skipped as `no_config_paths`.

**Fix:** also match the `.env` family by basename (`basename === ".env" || basename.startsWith(".env.")`), so `.env`, `.env.local`, `.env.production`, etc. categorize as `config`. `foo.env` continues to match via the extension list; non-env files are unaffected.

**No linked issue:** small, self-contained categorization fix in one helper; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment run build` (tsc clean)
- [x] `npm --prefix review-enrichment run test` — the review-enrichment suite passes with a new regression test in `test/analysis-context.test.ts` asserting `.env`, `.env.production`, `config/.env.local`, and `settings.env` all categorize as `config`. The test was confirmed to FAIL against the unpatched code (bare `.env` came back `unknown`).
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one condition in a pure helper in `review-enrichment/src`; it adds/changes no analyzer, so `analyzer-metadata.json` is unaffected. Codecov's `src/**` patch gate does not apply to `review-enrichment/**`; this package's own `node --test` suite covers it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal file categorization only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `createAnalysisContext({ files: [{ path: ".env", patch: "@@ -0,0 +1 @@\n+API_KEY=x" }], … }).fileCategories[0].category` returned `"unknown"` before the fix and returns `"config"` after.
