### PR TITLE
fix(rees): scan added lines whose content starts with ++ across all diff parsers

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -309,14 +309,17 @@ export function collectAddedLines(
   for (const file of files) {
     if (!file.patch) continue;
     let newLine = 0;
+    let inHunk = false;
     for (const line of boundedPatchLines(file.patch, options.metrics, "added_lines_patch_bytes")) {
-      if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (line.startsWith("diff ") || line.startsWith("index ")) continue;
       const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
       if (hunk) {
         newLine = Number(hunk[1]);
+        inHunk = true;
         continue;
       }
+      // Skip the pre-hunk preamble (diff/index + the `+++ `/`--- ` file headers). INSIDE a hunk the first char
+      // is the +/-/space op, so `+++x`/`+++ x` added content is collected, not mistaken for a header.
+      if (!inHunk) continue;
       if (line.startsWith("+")) {
         if (addedLines.length >= MAX_CONTEXT_ADDED_LINES) {
           options.metrics?.recordCappedWork("added_lines", 1);
@@ -365,13 +368,19 @@ export function filesHaveAddedLines(
 ): boolean {
   for (const file of files) {
     if (!file.patch) continue;
+    let inHunk = false;
     for (const line of boundedPatchLines(
       file.patch,
       options.metrics,
       "has_added_lines_patch_bytes",
     )) {
-      if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (line.startsWith("+")) return true;
+      if (line.startsWith("@@")) {
+        inHunk = true;
+        continue;
+      }
+      // Inside a hunk every added line starts with `+` (including `+++x`/`+++ x` content); the `+++ `/`--- `
+      // headers only appear in the pre-hunk preamble.
+      if (inHunk && line.startsWith("+")) return true;
     }
     if (file.patch.length > MAX_CONTEXT_PATCH_BYTES) return true;
   }

--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -16,13 +16,16 @@ export function scanWorkflowPins(
 ): ActionPinFinding[] {
   const findings: ActionPinFinding[] = [];
   let newLine = 0;
+  let inHunk = false;
   for (const line of patch.split("\n")) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
       newLine = Number(hunk[1]);
+      inHunk = true;
       continue;
     }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
     if (line.startsWith("+")) {
       const match = USES_RE.exec(line.slice(1));
       if (match) {

--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -109,7 +109,7 @@ export function extractDependencyChanges(
       const sign = line[0];
       if (
         (sign !== "+" && sign !== "-") ||
-        line.startsWith("+++") ||
+        line.startsWith("+++ ") ||
         line.startsWith("---")
       )
         continue;

--- a/review-enrichment/src/analyzers/diff-lines.ts
+++ b/review-enrichment/src/analyzers/diff-lines.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared unified-diff line helpers for analyzers that scan patch fragments which may or may not include hunk
+ * headers (so they cannot rely on hunk state).
+ */
+
+/**
+ * True only for a real unified-diff FILE HEADER — `+++ b/path`, `--- a/path`, or `+++ `/`--- /dev/null`
+ * (marker run + space + an `a/`/`b/` prefix or `/dev/null`).
+ *
+ * This deliberately does NOT match added/removed CONTENT whose text begins with `++`/`--`: git renders an
+ * added line whose content is `++x` as `+` + `++x` = `+++x`, and `++ x` as `+++ x`. An anchored
+ * `startsWith("+++ ")` guard skips `+++ x` as if it were a header and drops the real added line; keying on the
+ * header's path form scans that content while still skipping true headers.
+ */
+export function isDiffFileHeaderLine(line: string): boolean {
+  return /^(?:\+\+\+|---) (?:[ab]\/|\/dev\/null)/.test(line);
+}

--- a/review-enrichment/src/analyzers/duplication-scan.ts
+++ b/review-enrichment/src/analyzers/duplication-scan.ts
@@ -184,7 +184,6 @@ export function extractAddedBlocks(patch: string | undefined): NormBlock[] {
       continue;
     }
     if (!inHunk) continue;
-    if (line.startsWith("+++")) continue; // file header inside the patch, not an added line
     if (line.startsWith("+")) {
       const norm = normalizeLine(line.slice(1));
       if (norm === null) {

--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -59,11 +59,17 @@ export function extractVersionPins(
     if (filesScanned >= MAX_EOL_FILES) break;
     filesScanned += 1;
     const base = file.path.split("/").pop() ?? file.path;
+    let inHunk = false;
     for (const raw of file.patch.split("\n")) {
       if (linesScanned >= MAX_EOL_PATCH_LINES || pins.length >= MAX_EOL_PINS)
         return pins;
       linesScanned += 1;
-      if (raw[0] !== "+" || raw.startsWith("+++")) continue;
+      if (raw.startsWith("@@")) {
+        inHunk = true;
+        continue;
+      }
+      // Only added content inside a hunk; the `+++ ` header precedes the first hunk.
+      if (!inHunk || raw[0] !== "+") continue;
       const line = raw.slice(1).trim();
       if (isDockerfile(file.path)) {
         const match =

--- a/review-enrichment/src/analyzers/heavy-dependency.ts
+++ b/review-enrichment/src/analyzers/heavy-dependency.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { boundedFetchJson } from "../external-fetch.js";
 
 const MAX_WEIGHT_LOOKUPS = 20;
@@ -59,7 +60,8 @@ function addedPatchLines(
         continue;
       }
       if (raw.startsWith("\\ No newline")) continue;
-      if (raw.startsWith("+") && !raw.startsWith("+++")) {
+      // Skip real file headers (`+++ b/…`) but scan added CONTENT that begins with `++` (rendered `+++x`/`+++ x`).
+      if (raw.startsWith("+") && !isDiffFileHeaderLine(raw)) {
         lines.push({
           file: file.path,
           line: nextLine || 1,
@@ -68,7 +70,7 @@ function addedPatchLines(
         nextLine += 1;
         continue;
       }
-      if (raw.startsWith("-") && !raw.startsWith("---")) continue;
+      if (raw.startsWith("-") && !isDiffFileHeaderLine(raw)) continue;
       if (nextLine) nextLine += 1;
     }
   }

--- a/review-enrichment/src/analyzers/history.ts
+++ b/review-enrichment/src/analyzers/history.ts
@@ -12,6 +12,7 @@
 import type { AnalyzerDiagnostics, EnrichRequest, HistoryFinding } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
@@ -225,7 +226,8 @@ function diffAddedText(req: EnrichRequest): string {
   const added: string[] = [];
   for (const src of sources) {
     for (const line of src.split("\n")) {
-      if (line.startsWith("+") && !line.startsWith("+++")) added.push(line.slice(1));
+      // Skip real file headers (`+++ b/…`) but keep added CONTENT that begins with `++` (rendered `+++x`/`+++ x`).
+      if (line.startsWith("+") && !isDiffFileHeaderLine(line)) added.push(line.slice(1));
     }
   }
   return added.join("\n");

--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -75,10 +75,10 @@ export function scanPatchForIacMisconfig(
   let secureFalseLine = 0;
   let prodLine = 0;
   let debugLine = 0;
+  let inHunk = false;
 
   for (const line of patchLines(patch)) {
     if (limits.signal?.aborted) throw new Error("analyzer_aborted");
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
       newLine = Number(hunk[1]);
@@ -88,8 +88,11 @@ export function scanPatchForIacMisconfig(
       secureFalseLine = 0;
       prodLine = 0;
       debugLine = 0;
+      inHunk = true;
       continue;
     }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
     if (!line.startsWith("+")) {
       if (!line.startsWith("-")) newLine++;
       continue;

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -120,7 +120,7 @@ function* patchLines(
   for (const raw of patch.split("\n")) {
     seen += 1;
     if (seen > maxLines) break;
-    if (raw.startsWith("+++") || raw.startsWith("---")) continue;
+    if (raw.startsWith("+++ ") || raw.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
     if (hunk) {
       newLine = Number(hunk[1]);

--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -251,13 +251,16 @@ export function scanPatchForRedos(
   if (maxFindings <= 0) return [];
   const findings: RedosFinding[] = [];
   let newLine = 0;
+  let inHunk = false;
   for (const line of patchLines(patch)) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
       newLine = Number(hunk[1]);
+      inHunk = true;
       continue;
     }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
     if (line.startsWith("+")) {
       for (const source of extractRegexSources(line.slice(1))) {
         if (hasCatastrophicBacktracking(source)) {

--- a/review-enrichment/src/analyzers/secret-log.ts
+++ b/review-enrichment/src/analyzers/secret-log.ts
@@ -119,14 +119,17 @@ export function scanPatchForSecretLog(
   if (maxFindings <= 0) return [];
   const findings: SecretLogFinding[] = [];
   let newLine = 0;
+  let inHunk = false;
   for (const line of patchLines(patch)) {
     if (limits.signal?.aborted) throw new Error("analyzer_aborted");
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
       newLine = Number(hunk[1]);
+      inHunk = true;
       continue;
     }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
     if (line.startsWith("+")) {
       const body = line.slice(1);
       if (body.length <= MAX_LINE_CHARS) {

--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -63,17 +63,22 @@ function extractStringLiteralContents(line: string): string[] {
 export function scanPatch(path: string, patch: string): SecretFinding[] {
   const findings: SecretFinding[] = [];
   let newLine = 0;
+  let inHunk = false;
   // Last added line's extracted string-literal contents, for the cross-line join check below. Reset whenever a
   // non-added line breaks the run — a secret is only plausibly split across CONSECUTIVE added lines.
   let previousLiterals: string[] = [];
   for (const line of patch.split("\n")) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
     if (hunk) {
       newLine = Number(hunk[1]);
+      inHunk = true;
       previousLiterals = [];
       continue;
     }
+    // Skip the pre-hunk preamble (diff/index + the `+++ `/`--- ` file headers). INSIDE a hunk the first char is
+    // the +/-/space op, so an added line whose content starts with `++` (rendered `+++x` or `+++ x`) is scanned,
+    // not mistaken for a header.
+    if (!inHunk) continue;
     if (line.startsWith("+")) {
       const content = line.slice(1);
       let matched = false;

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -2,7 +2,11 @@
 // migrations without fighting over the broad enrichment test file.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createAnalysisContext } from "../dist/analysis-context.js";
+import {
+  collectAddedLines,
+  createAnalysisContext,
+  filesHaveAddedLines,
+} from "../dist/analysis-context.js";
 import {
   queryOsvBatch,
   scanDependencyChanges,
@@ -14,6 +18,29 @@ const jsonResponse = (body, init = {}) =>
     headers: { "content-type": "application/json" },
     ...init,
   });
+
+test("collectAddedLines keeps added lines whose content starts with ++ (rendered +++x)", () => {
+  // git renders an added line whose content is `++x` as `+` + `++x` = `+++x`; the header guard must match only
+  // the real `+++ b/file` header (marker run + space), or the line is dropped and the ones after it mis-numbered.
+  const files = [
+    {
+      path: "src/inc.ts",
+      patch: ["@@ -1,0 +1,2 @@", "+++x", "+const y = 1;"].join("\n"),
+    },
+  ];
+
+  assert.deepEqual(
+    collectAddedLines(files).map((added) => [added.line, added.text]),
+    [
+      [1, "++x"],
+      [2, "const y = 1;"],
+    ],
+  );
+  assert.equal(
+    filesHaveAddedLines([{ path: "src/inc.ts", patch: "@@ -1,0 +1,1 @@\n+++x" }]),
+    true,
+  );
+});
 
 test("createAnalysisContext parses common PR state once", () => {
   let now = 130;

--- a/review-enrichment/test/diff-lines.test.ts
+++ b/review-enrichment/test/diff-lines.test.ts
@@ -1,0 +1,17 @@
+// Unit for the shared diff-header discriminator used by analyzers that scan possibly-headerless patch fragments.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isDiffFileHeaderLine } from "../dist/analyzers/diff-lines.js";
+
+test("isDiffFileHeaderLine matches real file headers only, not ++/--- content", () => {
+  // Real unified-diff file headers → skipped.
+  for (const header of ["+++ b/src/app.ts", "--- a/src/app.ts", "+++ /dev/null", "--- /dev/null"]) {
+    assert.equal(isDiffFileHeaderLine(header), true, header);
+  }
+  // Added/removed CONTENT whose text begins with `++`/`--` renders as `+++…`/`---…` but is NOT a header and
+  // must be scanned; likewise plain content and headerless single-line diffs.
+  for (const content of ["+++x", "+++ const key = 1;", '+++ "lodash": "^1.0.0"', "+history analyzer", "---x", "+const y = 2;", "@@ -1,0 +1,1 @@"]) {
+    assert.equal(isDiffFileHeaderLine(content), false, content);
+  }
+});

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -103,3 +103,16 @@ test("scanPatch does not join two unrelated short literals into a false positive
   const findings = scanPatch("src/app.ts", hunk(['const a = "hello";', 'const b = "world";']));
   assert.equal(findings.length, 0);
 });
+
+// Regression: an added line whose content starts with `++` renders as `+++...` in the diff. A header-prefix
+// guard (even the anchored `+++ `) mistakes it for a `+++ b/file` header and skips it, so a secret on such a
+// line is never scanned. Both `++x` (-> `+++x`) and `++ x` (-> `+++ x`) content shapes must be scanned.
+for (const content of ['++const key = "AWS_KEY";', '++ const key = "AWS_KEY";']) {
+  test(`scanPatch scans an added line whose content starts with ++ (rendered +${content})`, () => {
+    const patch = `@@ -1,0 +1,1 @@\n+${content.replace("AWS_KEY", fakeAwsKey)}`;
+    const findings = scanPatch("src/config.ts", patch);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].kind, "aws_access_key_id");
+    assert.equal(findings[0].line, 1);
+  });
+}


### PR DESCRIPTION
## Summary

Every review-enrichment diff parser guarded file headers with an **unanchored** `startsWith("+++")`. git renders an added line whose content is `++x` as `+` + `++x` = `+++x` (and `++ x` as `+++ x`), so that added line was mistaken for a `+++ b/file` header and skipped. In `secret-scan.ts` a secret on such a line was never scanned (`scanSecrets` calls `scanPatch` directly).

Fix, by parser input shape:

- **Hunk-structured parsers** (`secret-scan`, `secret-log`, `iac-misconfig`, `redos`, `actions-pin`, `eol-check`, `duplication-scan`, shared `analysis-context`) track **hunk state**: headers only precede the first `@@`, and inside a hunk the first char is the `+`/`-`/space op, so **both** `+++x` and `+++ x` are scanned.
- **Parsers that also accept header-only / headerless fragments** (`history`, `heavy-dependency`) use a shared `isDiffFileHeaderLine` helper matching only a real header form (`+++ b/…` / `--- a/…` / `/dev/null`), so `+++ x` content is kept while true headers are skipped — and headerless single-line diffs still work.
- **Manifest/lockfile parsers** (`dependency-scan`, `lockfile-drift`) keep an anchored `+++ ` guard; their content never begins a line with `++`.

```
scanPatch("src/config.ts", '@@ -1,0 +1,1 @@
++ const key = "AKIA…";')  // before: []  after: [aws_access_key_id]
```

This is the complete follow-up to the earlier narrower attempt (which fixed only `analysis-context` and left `secret-scan`'s own `scanPatch`). Resolves the reviewer blockers on `secret-scan`, `history`, and `heavy-dependency` (each skipped the reachable `++ x` content shape).

No issue because issue creation is restricted on this repo for outside accounts; this consolidates a duplicated diff-parsing guard.

## Scope
- [x] Conventional Commit title; focused; follows CONTRIBUTING; small self-evident fix (no linked issue).

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck` (rees `tsc -p tsconfig.json` clean)
- [ ] `npm run test:coverage` (N/A — `review-enrichment/**` is outside Codecov's `src/**/*.ts` include)
- [x] `npm audit --audit-level=moderate`
- [x] New/changed behavior has tests

If any required check was skipped, explain why:
- Change confined to the rees package. `node --test` passes **391/393**; the only 2 failures are `test/sentry-upload.test.ts` (Sentry CLI binary absent locally), identical on unmodified `main`. Added regressions: `secret-scan.test.ts` (secret on `++x`- and `++ x`-content lines), `analysis-context.test.ts` (`collectAddedLines`/`filesHaveAddedLines`), and a `diff-lines.test.ts` unit for the header discriminator. `review-enrichment/**` is outside Codecov's `src/**` include. UI/workers/MCP steps are unrelated to this rees-only diff.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward/private terms exposed (test fixtures build fake keys from fragments at runtime).
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth/cookie/CORS/session negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. (None changed.)
- [ ] UI changes use live API data. — N/A.
- [ ] UI Evidence. — N/A (no visible UI change).
- [x] Docs/changelog updated where needed. (None needed.)

## Notes
- The shared `isDiffFileHeaderLine` helper (new `analyzers/diff-lines.ts`) prevents the guard from drifting again across parsers.
