### PR TITLE
fix(migrations): grandfather the shipped 0090 duplicate

### DIFF
--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -17,6 +17,8 @@
 //   • 0074 — both 0074_ai_review_cache (#1462) and 0074_orb_self_enrollment_disabled (#1465, a bare ADD COLUMN)
 //     merged + deployed before the collision surfaced; the column already exists in prod, so a rename would
 //     re-run the ALTER and fail. Grandfathered for the same reason as 0015/0017.
+//   • 0090 — both 0090_contributor_cap_label (#2479) and 0090_pull_request_detail_sync_head_sha (#2527, a bare
+//     ADD COLUMN) merged + deployed before the collision surfaced. Grandfathered for the same reason as 0074.
 import { readdirSync, readFileSync } from "node:fs";
 
 const DIR = process.env.CHECK_MIGRATIONS_DIR || "migrations";
@@ -25,6 +27,7 @@ const KNOWN_DUPLICATES = new Map([
   [15, new Set(["0015_github_agent_command_feedback.sql", "0015_product_usage_events.sql"])],
   [17, new Set(["0017_agent_recommendation_outcomes.sql", "0017_product_usage_role_retention_rollups.sql"])],
   [74, new Set(["0074_ai_review_cache.sql", "0074_orb_self_enrollment_disabled.sql"])],
+  [90, new Set(["0090_contributor_cap_label.sql", "0090_pull_request_detail_sync_head_sha.sql"])],
 ]);
 
 const fail = (message) => {

--- a/test/unit/check-migrations-script.test.ts
+++ b/test/unit/check-migrations-script.test.ts
@@ -31,7 +31,7 @@ describe("check-migrations script", () => {
   it("reports every grandfathered duplicate migration number in the success summary", () => {
     const output = execFileSync(process.execPath, ["scripts/check-migrations.mjs"], { encoding: "utf8" });
 
-    expect(output).toContain("(3 grandfathered duplicates: 0015, 0017, 0074)");
+    expect(output).toContain("(4 grandfathered duplicates: 0015, 0017, 0074, 0090)");
   });
 
   it("rejects a migration that creates a temporary object (the D1 remote authorizer blocks it)", () => {


### PR DESCRIPTION
## Summary

- `0090_contributor_cap_label.sql` (#2479) and `0090_pull_request_detail_sync_head_sha.sql` (#2527) both merged to `main` with the same migration number, so `npm run db:migrations:check` currently fails on `main` itself — and therefore fails the required `validate` check on every PR that touches `src/**` (the `backend` path filter), not just migration PRs.
- Both are bare `ALTER TABLE ... ADD COLUMN` statements already applied in production, so renumbering either now would make wrangler (and the self-host migrator) try to re-apply an already-shipped, non-idempotent migration and error the deploy. Per the script's own documented policy for this exact situation (see the `0015`/`0017`/`0074` precedents), the fix is to grandfather `0090` into `KNOWN_DUPLICATES`, not rename either file.
- Updated the one test that asserts the exact grandfathered-duplicates count in the success summary.

No issue filed for this — it's a small, self-evident infra fix blocking CI for unrelated PRs, following the exact precedent already established in `scripts/check-migrations.mjs` for prior duplicate collisions.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; `scripts/**` and `test/**` carry no Codecov patch obligation, but the affected test (`test/unit/check-migrations-script.test.ts`) was updated and passes.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Not part of the #1936 self-host readiness batch; this is a standalone fix for a `main`-breaking migration numbering collision discovered while running the local gate for that batch.