### PR TITLE
fix(selfhost): catch unhandled pump() rejections in sqlite-queue/pg-queue

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -553,6 +553,19 @@ export function createPgQueue(
       while (await processOne()) {
         /* drain due jobs */
       }
+    } catch (error) {
+      // claimNext()/reclaimExpiredProcessingJobs() run OUTSIDE processOne's own try/finally, so a raw pool
+      // failure (a dropped connection, a lock timeout) lands here. Every `void pump()` call site (kickOne/kickAll)
+      // is fire-and-forget, so an uncaught rejection here would surface as an unhandled promise rejection — fatal
+      // when SENTRY_DSN is unset (server.ts only installs the handler when Sentry is configured) (#2498).
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_pump_crashed",
+          error: errorMessageWithCause(error),
+        }),
+      );
+      captureError(error, { kind: "queue_pump_crashed" });
     } finally {
       active--;
     }

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -496,6 +496,19 @@ export function createSqliteQueue(
       while (await processOne()) {
         /* keep draining due jobs */
       }
+    } catch (error) {
+      // claimNext()/reclaimExpiredProcessingJobs() run OUTSIDE processOne's own try/finally, so a raw driver
+      // failure (e.g. a transient SQLite error) lands here. Every `void pump()` call site (kickOne/kickAll) is
+      // fire-and-forget, so an uncaught rejection here would surface as an unhandled promise rejection — fatal
+      // when SENTRY_DSN is unset (server.ts only installs the handler when Sentry is configured) (#2498).
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_pump_crashed",
+          error: errorMessageWithCause(error),
+        }),
+      );
+      captureError(error, { kind: "queue_pump_crashed" });
     } finally {
       active--;
     }

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1184,6 +1184,45 @@ describe("createPgQueue (durable #977)", () => {
     }
   });
 
+  it("pump absorbs a claimNext() pool failure instead of crashing the process (regression for #2498)", async () => {
+    const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+      if (String(sql).includes("RETURNING id, payload, attempts, job_key, priority")) throw new Error("connection terminated unexpectedly");
+      return { rows: [], rowCount: 0 };
+    });
+    const pool = { query: fn } as unknown as Pool;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const q = createPgQueue(pool, async () => undefined);
+    await q.init();
+
+    await expect(q.drain()).resolves.toBeUndefined();
+
+    const logged = errorSpy.mock.calls.map(([line]) => String(line));
+    expect(logged.some((line) => line.includes("selfhost_queue_pump_crashed") && line.includes("connection terminated unexpectedly"))).toBe(true);
+  });
+
+  it("pump absorbs a reclaimExpiredProcessingJobs() pool failure instead of crashing the process (regression for #2498)", async () => {
+    const oldTimeout = process.env.QUEUE_PROCESSING_TIMEOUT_MS;
+    process.env.QUEUE_PROCESSING_TIMEOUT_MS = "1";
+    try {
+      const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+        if (String(sql).includes("WHERE status='processing' AND run_after<=$1")) throw new Error("connection terminated unexpectedly");
+        return { rows: [], rowCount: 0 };
+      });
+      const pool = { query: fn } as unknown as Pool;
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const q = createPgQueue(pool, async () => undefined);
+      await q.init();
+
+      await expect(q.drain()).resolves.toBeUndefined();
+
+      const logged = errorSpy.mock.calls.map(([line]) => String(line));
+      expect(logged.some((line) => line.includes("selfhost_queue_pump_crashed") && line.includes("connection terminated unexpectedly"))).toBe(true);
+    } finally {
+      if (oldTimeout === undefined) delete process.env.QUEUE_PROCESSING_TIMEOUT_MS;
+      else process.env.QUEUE_PROCESSING_TIMEOUT_MS = oldTimeout;
+    }
+  });
+
   it("reschedules retryable incomplete review jobs while consuming attempts", async () => {
     const m = makePool();
     m.enqueueJob("1", { type: "agent-regate-pr" }, 0);

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1757,6 +1757,47 @@ describe("createSqliteQueue (durable #980)", () => {
     }
   });
 
+  it("pump absorbs a claimNext() driver failure instead of crashing the process (regression for #2498)", async () => {
+    const driver = makeDriver();
+    const realQuery = driver.query.bind(driver);
+    const q = createSqliteQueue(driver, async () => undefined);
+    // Only claimNextWhere's SELECT starts with this exact column list — spreadDueJobsOnStartup (which already
+    // ran during construction above) selects a different column set, so this doesn't clobber setup.
+    vi.spyOn(driver, "query").mockImplementation((sql: string, params: unknown[]) => {
+      if (sql.includes("SELECT id, payload, attempts, job_key, priority")) throw new Error("database is locked");
+      return realQuery(sql, params);
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(q.drain()).resolves.toBeUndefined();
+
+    const logged = errorSpy.mock.calls.map(([line]) => String(line));
+    expect(logged.some((line) => line.includes("selfhost_queue_pump_crashed") && line.includes("database is locked"))).toBe(true);
+  });
+
+  it("pump absorbs a reclaimExpiredProcessingJobs() driver failure instead of crashing the process (regression for #2498)", async () => {
+    const oldTimeout = process.env.QUEUE_PROCESSING_TIMEOUT_MS;
+    process.env.QUEUE_PROCESSING_TIMEOUT_MS = "1";
+    try {
+      const driver = makeDriver();
+      const realQuery = driver.query.bind(driver);
+      vi.spyOn(driver, "query").mockImplementation((sql: string, params: unknown[]) => {
+        if (sql.includes("WHERE status='processing' AND run_after<=?")) throw new Error("disk I/O error");
+        return realQuery(sql, params);
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const q = createSqliteQueue(driver, async () => undefined);
+
+      await expect(q.drain()).resolves.toBeUndefined();
+
+      const logged = errorSpy.mock.calls.map(([line]) => String(line));
+      expect(logged.some((line) => line.includes("selfhost_queue_pump_crashed") && line.includes("disk I/O error"))).toBe(true);
+    } finally {
+      if (oldTimeout === undefined) delete process.env.QUEUE_PROCESSING_TIMEOUT_MS;
+      else process.env.QUEUE_PROCESSING_TIMEOUT_MS = oldTimeout;
+    }
+  });
+
   it("records 'unknown error' when a consumer throws a non-Error", async () => {
     const q = createSqliteQueue(
       makeDriver(),


### PR DESCRIPTION
## Summary

- `kickOne()`/`kickAll()` in `sqlite-queue.ts`/`pg-queue.ts` fire `pump()` via bare `void pump()` with no `.catch()`. `claimNext()`/`reclaimExpiredProcessingJobs()` run OUTSIDE `processOne()`'s own try/finally, so a raw driver failure (a locked SQLite file, a dropped Postgres connection/lock timeout) propagated out of `pump()` uncaught.
- `server.ts` only registers `process.on('unhandledRejection', ...)` when `SENTRY_DSN` is set. Since Sentry is opt-in, a single transient DB error surfacing from `claimNext()`/`reclaimExpiredProcessingJobs()` could silently crash the entire self-host server — no metric bump, no Sentry event, no `/ready` degradation warning beforehand.
- Wrapped `pump()`'s body in a try/catch that logs (`selfhost_queue_pump_crashed`) and calls `captureError` instead of letting the exception propagate, in both queue drivers.
- Regression tests: mock the driver/pool to throw on the `claimNext()` query and separately on the `reclaimExpiredProcessingJobs()` query, in both `sqlite-queue.ts` and `pg-queue.ts`; assert `drain()` resolves cleanly (no unhandled rejection) and the failure is logged.

Closes #2498.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; `codecov/patch` requires ≥99% coverage of the lines AND branches you changed (aim for 100% on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.