### PR TITLE
feat(miner-portfolio): add pure portfolio queue primitives

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -10,6 +10,7 @@ export {
   type OpportunityRankInput,
 } from "./opportunity-ranker.js";
 export * from "./governor/rate-limit.js";
+export * from "./portfolio/queue.js";
 export {
   resolveAiPolicyVerdict,
   scanAiPolicyText,

--- a/packages/gittensory-engine/src/portfolio/queue.ts
+++ b/packages/gittensory-engine/src/portfolio/queue.ts
@@ -40,8 +40,20 @@ function cleanId(value: string): string {
   return value.trim();
 }
 
+function cleanRepoFullName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 function normalizeState(value: PortfolioQueueItemState): PortfolioQueueItemState {
   return value === ACTIVE_STATE ? ACTIVE_STATE : QUEUED_STATE;
+}
+
+function normalizeItem(item: PortfolioQueueItem): PortfolioQueueItem {
+  return {
+    id: cleanId(item.id),
+    repoFullName: cleanRepoFullName(item.repoFullName),
+    state: normalizeState(item.state),
+  };
 }
 
 function finiteNonNegativeInt(value: number): number {
@@ -94,17 +106,22 @@ function queueHasItem(queue: PortfolioQueue, itemId: string): boolean {
 
 /** Append one item to the queue, creating its repo bucket if needed. Duplicate/blank ids are ignored. Pure. */
 export function enqueueItem(queue: PortfolioQueue, item: PortfolioQueueItem): PortfolioQueue {
-  const id = cleanId(item.id);
-  const repoFullName = cleanId(item.repoFullName);
-  if (!id || !repoFullName || queueHasItem(queue, id)) return queue;
-  const normalizedItem: PortfolioQueueItem = { id, repoFullName, state: normalizeState(item.state) };
-  const bucketIndex = queue.buckets.findIndex((bucket) => bucket.repoFullName === repoFullName);
+  const normalizedItem = normalizeItem(item);
+  if (!normalizedItem.id || !normalizedItem.repoFullName || queueHasItem(queue, normalizedItem.id)) return queue;
+  const bucketIndex = queue.buckets.findIndex(
+    (bucket) => cleanRepoFullName(bucket.repoFullName) === normalizedItem.repoFullName,
+  );
   if (bucketIndex === -1) {
-    return { buckets: [...queue.buckets, { repoFullName, items: [normalizedItem] }] };
+    return { buckets: [...queue.buckets, { repoFullName: normalizedItem.repoFullName, items: [normalizedItem] }] };
   }
   return {
     buckets: queue.buckets.map((bucket, index) =>
-      index === bucketIndex ? { ...bucket, items: [...bucket.items, normalizedItem] } : bucket,
+      index === bucketIndex
+        ? {
+            repoFullName: normalizedItem.repoFullName,
+            items: [...bucket.items.map(normalizeItem), normalizedItem],
+          }
+        : bucket,
     ),
   };
 }
@@ -132,24 +149,37 @@ export function nextEligibleItems(queue: PortfolioQueue, caps: PortfolioCaps): P
   const normalizedCaps = normalizeCaps(caps);
   if (normalizedCaps.globalWipCap === 0 || normalizedCaps.perRepoWipCap === 0) return [];
 
-  const totalActiveCount = queue.buckets.reduce(
-    (sum, bucket) => sum + bucket.items.filter(isActiveItem).length,
-    0,
-  );
-  const remainingGlobalSlots = normalizedCaps.globalWipCap - totalActiveCount;
-  if (remainingGlobalSlots <= 0) return [];
-
-  const selectionBuckets = queue.buckets.map((bucket) => {
-    const activeCount = bucket.items.filter(isActiveItem).length;
-    const queuedItems = bucket.items.filter(isQueuedItem);
-    const remainingPerRepoCapacity = normalizedCaps.perRepoWipCap - activeCount;
-    return {
-      repoFullName: bucket.repoFullName,
+  const selectionBucketsByRepo = new Map<string, QueueSelectionBucket>();
+  for (const bucket of queue.buckets) {
+    const normalizedItems = bucket.items.map(normalizeItem);
+    const repoFullName = cleanRepoFullName(bucket.repoFullName);
+    const activeCount = normalizedItems.filter(isActiveItem).length;
+    const queuedItems = normalizedItems.filter(isQueuedItem);
+    const existing = selectionBucketsByRepo.get(repoFullName);
+    if (existing) {
+      existing.activeCount += activeCount;
+      existing.queuedItems.push(...queuedItems);
+      continue;
+    }
+    selectionBucketsByRepo.set(repoFullName, {
+      repoFullName,
       activeCount,
-      queuedItems: remainingPerRepoCapacity > 0 ? queuedItems.slice(0, remainingPerRepoCapacity) : [],
+      queuedItems: [...queuedItems],
       selectedCount: 0,
+    });
+  }
+
+  const selectionBuckets = Array.from(selectionBucketsByRepo.values()).map((bucket) => {
+    const remainingPerRepoCapacity = normalizedCaps.perRepoWipCap - bucket.activeCount;
+    return {
+      ...bucket,
+      queuedItems: remainingPerRepoCapacity > 0 ? bucket.queuedItems.slice(0, remainingPerRepoCapacity) : [],
     };
   });
+
+  const totalActiveCount = selectionBuckets.reduce((sum, bucket) => sum + bucket.activeCount, 0);
+  const remainingGlobalSlots = normalizedCaps.globalWipCap - totalActiveCount;
+  if (remainingGlobalSlots <= 0) return [];
 
   const selected: PortfolioQueueItem[] = [];
   let lastRepoFullName: string | null = null;

--- a/packages/gittensory-engine/src/portfolio/queue.ts
+++ b/packages/gittensory-engine/src/portfolio/queue.ts
@@ -151,22 +151,24 @@ export function nextEligibleItems(queue: PortfolioQueue, caps: PortfolioCaps): P
 
   const selectionBucketsByRepo = new Map<string, QueueSelectionBucket>();
   for (const bucket of queue.buckets) {
-    const normalizedItems = bucket.items.map(normalizeItem);
-    const repoFullName = cleanRepoFullName(bucket.repoFullName);
-    const activeCount = normalizedItems.filter(isActiveItem).length;
-    const queuedItems = normalizedItems.filter(isQueuedItem);
-    const existing = selectionBucketsByRepo.get(repoFullName);
-    if (existing) {
-      existing.activeCount += activeCount;
-      existing.queuedItems.push(...queuedItems);
-      continue;
+    for (const normalizedItem of bucket.items.map(normalizeItem)) {
+      const repoFullName = normalizedItem.repoFullName;
+      const existing = selectionBucketsByRepo.get(repoFullName);
+      if (existing) {
+        if (isActiveItem(normalizedItem)) {
+          existing.activeCount += 1;
+        } else {
+          existing.queuedItems.push(normalizedItem);
+        }
+        continue;
+      }
+      selectionBucketsByRepo.set(repoFullName, {
+        repoFullName,
+        activeCount: isActiveItem(normalizedItem) ? 1 : 0,
+        queuedItems: isQueuedItem(normalizedItem) ? [normalizedItem] : [],
+        selectedCount: 0,
+      });
     }
-    selectionBucketsByRepo.set(repoFullName, {
-      repoFullName,
-      activeCount,
-      queuedItems: [...queuedItems],
-      selectedCount: 0,
-    });
   }
 
   const selectionBuckets = Array.from(selectionBucketsByRepo.values()).map((bucket) => {

--- a/packages/gittensory-engine/src/portfolio/queue.ts
+++ b/packages/gittensory-engine/src/portfolio/queue.ts
@@ -28,7 +28,6 @@ export type PortfolioCaps = {
 
 type QueueSelectionBucket = {
   repoFullName: string;
-  bucketIndex: number;
   activeCount: number;
   queuedItems: PortfolioQueueItem[];
   selectedCount: number;
@@ -117,7 +116,7 @@ export function dequeueItem(queue: PortfolioQueue, itemId: string): PortfolioQue
   let removed = false;
   const buckets = queue.buckets.flatMap((bucket) => {
     const items = bucket.items.filter((item) => {
-      const keep = item.id !== targetId;
+      const keep = cleanId(item.id) !== targetId;
       if (!keep) removed = true;
       return keep;
     });
@@ -140,13 +139,12 @@ export function nextEligibleItems(queue: PortfolioQueue, caps: PortfolioCaps): P
   const remainingGlobalSlots = normalizedCaps.globalWipCap - totalActiveCount;
   if (remainingGlobalSlots <= 0) return [];
 
-  const selectionBuckets = queue.buckets.map((bucket, bucketIndex) => {
+  const selectionBuckets = queue.buckets.map((bucket) => {
     const activeCount = bucket.items.filter(isActiveItem).length;
     const queuedItems = bucket.items.filter(isQueuedItem);
     const remainingPerRepoCapacity = normalizedCaps.perRepoWipCap - activeCount;
     return {
       repoFullName: bucket.repoFullName,
-      bucketIndex,
       activeCount,
       queuedItems: remainingPerRepoCapacity > 0 ? queuedItems.slice(0, remainingPerRepoCapacity) : [],
       selectedCount: 0,

--- a/packages/gittensory-engine/src/portfolio/queue.ts
+++ b/packages/gittensory-engine/src/portfolio/queue.ts
@@ -1,0 +1,172 @@
+/**
+ * Portfolio queue primitives (#2326). Pure bookkeeping for the miner's local cross-repo work queue:
+ * bucket items by repo, respect global/per-repo WIP caps, and select the next eligible batch in a
+ * deterministic diversified order. No IO, no Date, no randomness, and no enforcement/action logic.
+ */
+
+export type PortfolioQueueItemState = "queued" | "in_progress";
+
+export type PortfolioQueueItem = {
+  id: string;
+  repoFullName: string;
+  state: PortfolioQueueItemState;
+};
+
+export type PortfolioQueueBucket = {
+  repoFullName: string;
+  items: PortfolioQueueItem[];
+};
+
+export type PortfolioQueue = {
+  buckets: PortfolioQueueBucket[];
+};
+
+export type PortfolioCaps = {
+  globalWipCap: number;
+  perRepoWipCap: number;
+};
+
+type QueueSelectionBucket = {
+  repoFullName: string;
+  bucketIndex: number;
+  activeCount: number;
+  queuedItems: PortfolioQueueItem[];
+  selectedCount: number;
+};
+
+const QUEUED_STATE: PortfolioQueueItemState = "queued";
+const ACTIVE_STATE: PortfolioQueueItemState = "in_progress";
+
+function cleanId(value: string): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeState(value: PortfolioQueueItemState): PortfolioQueueItemState {
+  return value === ACTIVE_STATE ? ACTIVE_STATE : QUEUED_STATE;
+}
+
+function finiteNonNegativeInt(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}
+
+function normalizeCaps(caps: PortfolioCaps): { globalWipCap: number; perRepoWipCap: number } {
+  return {
+    globalWipCap: finiteNonNegativeInt(caps.globalWipCap),
+    perRepoWipCap: finiteNonNegativeInt(caps.perRepoWipCap),
+  };
+}
+
+function isActiveItem(item: PortfolioQueueItem): boolean {
+  return item.state === ACTIVE_STATE;
+}
+
+function isQueuedItem(item: PortfolioQueueItem): boolean {
+  return item.state === QUEUED_STATE;
+}
+
+function projectedLoad(bucket: QueueSelectionBucket): number {
+  return bucket.activeCount + bucket.selectedCount;
+}
+
+function pickNextBucket(
+  buckets: QueueSelectionBucket[],
+  lastRepoFullName: string | null,
+): QueueSelectionBucket | null {
+  const eligible = buckets.filter((bucket) => bucket.selectedCount < bucket.queuedItems.length);
+  if (eligible.length === 0) return null;
+  const alternates =
+    lastRepoFullName === null ? eligible : eligible.filter((bucket) => bucket.repoFullName !== lastRepoFullName);
+  const candidates = alternates.length > 0 ? alternates : eligible;
+  let winner = candidates[0] ?? null;
+  for (const candidate of candidates.slice(1)) {
+    if (winner === null) {
+      winner = candidate;
+      continue;
+    }
+    const winnerLoad = projectedLoad(winner);
+    const candidateLoad = projectedLoad(candidate);
+    if (candidateLoad < winnerLoad || (candidateLoad === winnerLoad && candidate.bucketIndex < winner.bucketIndex)) {
+      winner = candidate;
+    }
+  }
+  return winner;
+}
+
+function queueHasItem(queue: PortfolioQueue, itemId: string): boolean {
+  return queue.buckets.some((bucket) => bucket.items.some((item) => item.id === itemId));
+}
+
+/** Append one item to the queue, creating its repo bucket if needed. Duplicate/blank ids are ignored. Pure. */
+export function enqueueItem(queue: PortfolioQueue, item: PortfolioQueueItem): PortfolioQueue {
+  const id = cleanId(item.id);
+  const repoFullName = cleanId(item.repoFullName);
+  if (!id || !repoFullName || queueHasItem(queue, id)) return queue;
+  const normalizedItem: PortfolioQueueItem = { id, repoFullName, state: normalizeState(item.state) };
+  const bucketIndex = queue.buckets.findIndex((bucket) => bucket.repoFullName === repoFullName);
+  if (bucketIndex === -1) {
+    return { buckets: [...queue.buckets, { repoFullName, items: [normalizedItem] }] };
+  }
+  return {
+    buckets: queue.buckets.map((bucket, index) =>
+      index === bucketIndex ? { ...bucket, items: [...bucket.items, normalizedItem] } : bucket,
+    ),
+  };
+}
+
+/** Remove one item by id; empty buckets disappear. Unknown/blank ids are a no-op. Pure. */
+export function dequeueItem(queue: PortfolioQueue, itemId: string): PortfolioQueue {
+  const targetId = cleanId(itemId);
+  if (!targetId) return queue;
+  let removed = false;
+  const buckets = queue.buckets.flatMap((bucket) => {
+    const items = bucket.items.filter((item) => {
+      const keep = item.id !== targetId;
+      if (!keep) removed = true;
+      return keep;
+    });
+    return items.length > 0 ? [{ ...bucket, items }] : [];
+  });
+  return removed ? { buckets } : queue;
+}
+
+/** Select the next batch of queued items that fit within global/per-repo WIP caps. The batch always alternates
+ *  repos when another repo still has an eligible item waiting; among those eligible repos, lower current load wins
+ *  and ties keep stable bucket order. Pure. */
+export function nextEligibleItems(queue: PortfolioQueue, caps: PortfolioCaps): PortfolioQueueItem[] {
+  const normalizedCaps = normalizeCaps(caps);
+  if (normalizedCaps.globalWipCap === 0 || normalizedCaps.perRepoWipCap === 0) return [];
+
+  const totalActiveCount = queue.buckets.reduce(
+    (sum, bucket) => sum + bucket.items.filter(isActiveItem).length,
+    0,
+  );
+  const remainingGlobalSlots = normalizedCaps.globalWipCap - totalActiveCount;
+  if (remainingGlobalSlots <= 0) return [];
+
+  const selectionBuckets = queue.buckets.map((bucket, bucketIndex) => {
+    const activeCount = bucket.items.filter(isActiveItem).length;
+    const queuedItems = bucket.items.filter(isQueuedItem);
+    const remainingPerRepoCapacity = normalizedCaps.perRepoWipCap - activeCount;
+    return {
+      repoFullName: bucket.repoFullName,
+      bucketIndex,
+      activeCount,
+      queuedItems: remainingPerRepoCapacity > 0 ? queuedItems.slice(0, remainingPerRepoCapacity) : [],
+      selectedCount: 0,
+    };
+  });
+
+  const selected: PortfolioQueueItem[] = [];
+  let lastRepoFullName: string | null = null;
+  while (selected.length < remainingGlobalSlots) {
+    const nextBucket = pickNextBucket(selectionBuckets, lastRepoFullName);
+    if (nextBucket === null) break;
+    const nextItem = nextBucket.queuedItems[nextBucket.selectedCount];
+    if (!nextItem) break;
+    selected.push(nextItem);
+    nextBucket.selectedCount += 1;
+    lastRepoFullName = nextBucket.repoFullName;
+  }
+  return selected;
+}

--- a/packages/gittensory-engine/src/portfolio/queue.ts
+++ b/packages/gittensory-engine/src/portfolio/queue.ts
@@ -38,7 +38,7 @@ const QUEUED_STATE: PortfolioQueueItemState = "queued";
 const ACTIVE_STATE: PortfolioQueueItemState = "in_progress";
 
 function cleanId(value: string): string {
-  return typeof value === "string" ? value.trim() : "";
+  return value.trim();
 }
 
 function normalizeState(value: PortfolioQueueItemState): PortfolioQueueItemState {
@@ -78,15 +78,11 @@ function pickNextBucket(
   const alternates =
     lastRepoFullName === null ? eligible : eligible.filter((bucket) => bucket.repoFullName !== lastRepoFullName);
   const candidates = alternates.length > 0 ? alternates : eligible;
-  let winner = candidates[0] ?? null;
+  let winner = candidates[0]!;
   for (const candidate of candidates.slice(1)) {
-    if (winner === null) {
-      winner = candidate;
-      continue;
-    }
     const winnerLoad = projectedLoad(winner);
     const candidateLoad = projectedLoad(candidate);
-    if (candidateLoad < winnerLoad || (candidateLoad === winnerLoad && candidate.bucketIndex < winner.bucketIndex)) {
+    if (candidateLoad < winnerLoad) {
       winner = candidate;
     }
   }
@@ -94,7 +90,7 @@ function pickNextBucket(
 }
 
 function queueHasItem(queue: PortfolioQueue, itemId: string): boolean {
-  return queue.buckets.some((bucket) => bucket.items.some((item) => item.id === itemId));
+  return queue.buckets.some((bucket) => bucket.items.some((item) => cleanId(item.id) === itemId));
 }
 
 /** Append one item to the queue, creating its repo bucket if needed. Duplicate/blank ids are ignored. Pure. */
@@ -114,7 +110,7 @@ export function enqueueItem(queue: PortfolioQueue, item: PortfolioQueueItem): Po
   };
 }
 
-/** Remove one item by id; empty buckets disappear. Unknown/blank ids are a no-op. Pure. */
+/** Remove matching items by id; empty buckets disappear. Unknown/blank ids are a no-op. Pure. */
 export function dequeueItem(queue: PortfolioQueue, itemId: string): PortfolioQueue {
   const targetId = cleanId(itemId);
   if (!targetId) return queue;
@@ -162,8 +158,7 @@ export function nextEligibleItems(queue: PortfolioQueue, caps: PortfolioCaps): P
   while (selected.length < remainingGlobalSlots) {
     const nextBucket = pickNextBucket(selectionBuckets, lastRepoFullName);
     if (nextBucket === null) break;
-    const nextItem = nextBucket.queuedItems[nextBucket.selectedCount];
-    if (!nextItem) break;
+    const nextItem = nextBucket.queuedItems[nextBucket.selectedCount]!;
     selected.push(nextItem);
     nextBucket.selectedCount += 1;
     lastRepoFullName = nextBucket.repoFullName;

--- a/packages/gittensory-engine/test/portfolio-queue.test.ts
+++ b/packages/gittensory-engine/test/portfolio-queue.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  dequeueItem,
+  enqueueItem,
+  nextEligibleItems,
+  type PortfolioQueue,
+} from "../dist/index.js";
+
+const item = (id: string, repoFullName: string, state: "queued" | "in_progress" = "queued") => ({
+  id,
+  repoFullName,
+  state,
+});
+
+const queueOf = (...items: Array<ReturnType<typeof item>>): PortfolioQueue =>
+  items.reduce<PortfolioQueue>((queue, entry) => enqueueItem(queue, entry), { buckets: [] });
+
+test("barrel: the public entrypoint re-exports the portfolio queue primitives", () => {
+  assert.equal(typeof enqueueItem, "function");
+  assert.equal(typeof dequeueItem, "function");
+  assert.equal(typeof nextEligibleItems, "function");
+});
+
+test("nextEligibleItems: alternates repos when another eligible bucket exists", () => {
+  const queue = queueOf(
+    item("a-running", "acme/alpha", "in_progress"),
+    item("a-queued-1", "acme/alpha"),
+    item("a-queued-2", "acme/alpha"),
+    item("b-queued-1", "acme/beta"),
+    item("c-queued-1", "acme/gamma"),
+  );
+
+  assert.deepEqual(
+    nextEligibleItems(queue, { globalWipCap: 4, perRepoWipCap: 2 }).map((entry) => entry.id),
+    ["b-queued-1", "c-queued-1", "a-queued-1"],
+  );
+});
+
+test("nextEligibleItems: repeats a repo only after the others are exhausted", () => {
+  const queue = queueOf(
+    item("a-queued-1", "acme/alpha"),
+    item("a-queued-2", "acme/alpha"),
+    item("b-queued-1", "acme/beta"),
+  );
+
+  assert.deepEqual(
+    nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 3 }).map((entry) => entry.id),
+    ["a-queued-1", "b-queued-1", "a-queued-2"],
+  );
+});

--- a/test/unit/portfolio-queue.test.ts
+++ b/test/unit/portfolio-queue.test.ts
@@ -135,6 +135,31 @@ describe("portfolio queue primitives", () => {
     ]);
   });
 
+  it("enforces repo caps from each item's repo even when a prebuilt bucket label is wrong", () => {
+    const queue: PortfolioQueue = {
+      buckets: [
+        { repoFullName: "acme/alpha", items: [item("b-running", "acme/beta", "in_progress")] },
+        { repoFullName: "acme/beta", items: [item("b-queued-1", "acme/beta")] },
+      ],
+    };
+
+    expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 1 })).toEqual([]);
+  });
+
+  it("aggregates active counts across repeated prebuilt buckets for the same logical repo", () => {
+    const queue: PortfolioQueue = {
+      buckets: [
+        { repoFullName: "acme/alpha", items: [item("a-running-1", "acme/alpha", "in_progress")] },
+        {
+          repoFullName: "ACME/ALPHA",
+          items: [item("a-running-2", "acme/alpha", "in_progress"), item("a-queued-1", "acme/alpha")],
+        },
+      ],
+    };
+
+    expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 2 })).toEqual([]);
+  });
+
   it("diversifies multi-repo selection and prefers the least represented repos first", () => {
     const queue = queueOf(
       item("a-running", "acme/alpha", "in_progress"),

--- a/test/unit/portfolio-queue.test.ts
+++ b/test/unit/portfolio-queue.test.ts
@@ -50,6 +50,12 @@ describe("portfolio queue primitives", () => {
     });
   });
 
+  it("treats repo full names case-insensitively when bucketing", () => {
+    expect(queueOf(item("a-1", "Owner/Repo"), item("a-2", "owner/repo"))).toEqual({
+      buckets: [{ repoFullName: "owner/repo", items: [item("a-1", "owner/repo"), item("a-2", "owner/repo")] }],
+    });
+  });
+
   it("treats prebuilt queues with untrimmed ids as already containing the logical item", () => {
     const queue: PortfolioQueue = {
       buckets: [{ repoFullName: "acme/alpha", items: [{ id: "  a-1  ", repoFullName: "acme/alpha", state: "queued" }] }],
@@ -114,6 +120,19 @@ describe("portfolio queue primitives", () => {
       "b-queued-1",
     ]);
     expect(nextEligibleItems(queue, { globalWipCap: Number.NaN, perRepoWipCap: 2 })).toEqual([]);
+  });
+
+  it("applies one per-repo cap across case-variant prebuilt buckets", () => {
+    const queue: PortfolioQueue = {
+      buckets: [
+        { repoFullName: "Owner/Repo", items: [item("a-queued-1", "Owner/Repo")] },
+        { repoFullName: "owner/repo", items: [item("a-queued-2", "owner/repo")] },
+      ],
+    };
+
+    expect(nextEligibleItems(queue, { globalWipCap: 2, perRepoWipCap: 1 }).map((entry) => entry.id)).toEqual([
+      "a-queued-1",
+    ]);
   });
 
   it("diversifies multi-repo selection and prefers the least represented repos first", () => {

--- a/test/unit/portfolio-queue.test.ts
+++ b/test/unit/portfolio-queue.test.ts
@@ -73,6 +73,14 @@ describe("portfolio queue primitives", () => {
     expect(dequeueItem(queue, "   ")).toBe(queue);
   });
 
+  it("dequeues a logical id from a prebuilt queue even when the stored id is untrimmed", () => {
+    const queue: PortfolioQueue = {
+      buckets: [{ repoFullName: "acme/alpha", items: [{ id: "  a-1  ", repoFullName: "acme/alpha", state: "queued" }] }],
+    };
+
+    expect(dequeueItem(queue, "a-1")).toEqual({ buckets: [] });
+  });
+
   it("returns no eligible items for an empty queue", () => {
     expect(nextEligibleItems({ buckets: [] }, { globalWipCap: 2, perRepoWipCap: 1 })).toEqual([]);
   });
@@ -92,6 +100,20 @@ describe("portfolio queue primitives", () => {
 
     expect(nextEligibleItems(queue, { globalWipCap: Number.POSITIVE_INFINITY, perRepoWipCap: 1 })).toEqual([]);
     expect(nextEligibleItems(queue, { globalWipCap: 2, perRepoWipCap: -1 })).toEqual([]);
+  });
+
+  it("truncates fractional caps and treats NaN as zero", () => {
+    const queue = queueOf(
+      item("a-queued-1", "acme/alpha"),
+      item("a-queued-2", "acme/alpha"),
+      item("b-queued-1", "acme/beta"),
+    );
+
+    expect(nextEligibleItems(queue, { globalWipCap: 2.9, perRepoWipCap: 1.8 }).map((entry) => entry.id)).toEqual([
+      "a-queued-1",
+      "b-queued-1",
+    ]);
+    expect(nextEligibleItems(queue, { globalWipCap: Number.NaN, perRepoWipCap: 2 })).toEqual([]);
   });
 
   it("diversifies multi-repo selection and prefers the least represented repos first", () => {

--- a/test/unit/portfolio-queue.test.ts
+++ b/test/unit/portfolio-queue.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  dequeueItem,
+  enqueueItem,
+  nextEligibleItems,
+  type PortfolioCaps,
+  type PortfolioQueue,
+  type PortfolioQueueItem,
+} from "../../packages/gittensory-engine/src/portfolio/queue";
+
+function item(
+  id: string,
+  repoFullName: string,
+  state: PortfolioQueueItem["state"] = "queued",
+): PortfolioQueueItem {
+  return { id, repoFullName, state };
+}
+
+function queueOf(...items: PortfolioQueueItem[]): PortfolioQueue {
+  return items.reduce<PortfolioQueue>((queue, entry) => enqueueItem(queue, entry), { buckets: [] });
+}
+
+describe("portfolio queue primitives", () => {
+  it("enqueues by repo bucket, keeps insertion order, and ignores duplicate ids", () => {
+    const queue = queueOf(
+      item("a-1", "acme/alpha"),
+      item("b-1", "acme/beta"),
+      item("a-2", "acme/alpha"),
+      item("a-1", "acme/gamma"),
+    );
+
+    expect(queue).toEqual({
+      buckets: [
+        { repoFullName: "acme/alpha", items: [item("a-1", "acme/alpha"), item("a-2", "acme/alpha")] },
+        { repoFullName: "acme/beta", items: [item("b-1", "acme/beta")] },
+      ],
+    });
+  });
+
+  it("ignores blank ids and blank repo names when enqueuing", () => {
+    const queue = queueOf(item("a-1", "acme/alpha"));
+
+    expect(enqueueItem(queue, item("   ", "acme/beta"))).toBe(queue);
+    expect(enqueueItem(queue, item("b-1", "   "))).toBe(queue);
+  });
+
+  it("dequeues one item and drops an empty repo bucket", () => {
+    const queue = queueOf(item("a-1", "acme/alpha"), item("b-1", "acme/beta"));
+
+    expect(dequeueItem(queue, "b-1")).toEqual({
+      buckets: [{ repoFullName: "acme/alpha", items: [item("a-1", "acme/alpha")] }],
+    });
+    expect(dequeueItem(queue, "missing")).toBe(queue);
+  });
+
+  it("returns no eligible items for an empty queue", () => {
+    expect(nextEligibleItems({ buckets: [] }, { globalWipCap: 2, perRepoWipCap: 1 })).toEqual([]);
+  });
+
+  it("returns no eligible items when a single repo is already at its WIP cap", () => {
+    const queue = queueOf(
+      item("a-running", "acme/alpha", "in_progress"),
+      item("a-queued-1", "acme/alpha"),
+      item("a-queued-2", "acme/alpha"),
+    );
+
+    expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 1 })).toEqual([]);
+  });
+
+  it("diversifies multi-repo selection and prefers the least represented repos first", () => {
+    const queue = queueOf(
+      item("a-running", "acme/alpha", "in_progress"),
+      item("a-queued-1", "acme/alpha"),
+      item("a-queued-2", "acme/alpha"),
+      item("b-queued-1", "acme/beta"),
+      item("c-queued-1", "acme/gamma"),
+    );
+    const caps: PortfolioCaps = { globalWipCap: 4, perRepoWipCap: 2 };
+
+    expect(nextEligibleItems(queue, caps).map((entry) => entry.id)).toEqual([
+      "b-queued-1",
+      "c-queued-1",
+      "a-queued-1",
+    ]);
+  });
+
+  it("reuses the same repo only after every other eligible repo is exhausted", () => {
+    const queue = queueOf(
+      item("a-queued-1", "acme/alpha"),
+      item("a-queued-2", "acme/alpha"),
+      item("b-queued-1", "acme/beta"),
+    );
+
+    expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 3 }).map((entry) => entry.id)).toEqual([
+      "a-queued-1",
+      "b-queued-1",
+      "a-queued-2",
+    ]);
+  });
+
+  it("returns no eligible items when global WIP is already full", () => {
+    const queue = queueOf(
+      item("a-running", "acme/alpha", "in_progress"),
+      item("b-running", "acme/beta", "in_progress"),
+      item("a-queued-1", "acme/alpha"),
+      item("b-queued-1", "acme/beta"),
+    );
+
+    expect(nextEligibleItems(queue, { globalWipCap: 2, perRepoWipCap: 2 })).toEqual([]);
+  });
+});

--- a/test/unit/portfolio-queue.test.ts
+++ b/test/unit/portfolio-queue.test.ts
@@ -44,6 +44,20 @@ describe("portfolio queue primitives", () => {
     expect(enqueueItem(queue, item("b-1", "   "))).toBe(queue);
   });
 
+  it("trims identifiers and preserves an in-progress state when enqueuing", () => {
+    expect(enqueueItem({ buckets: [] }, item("  a-1  ", "  acme/alpha  ", "in_progress"))).toEqual({
+      buckets: [{ repoFullName: "acme/alpha", items: [item("a-1", "acme/alpha", "in_progress")] }],
+    });
+  });
+
+  it("treats prebuilt queues with untrimmed ids as already containing the logical item", () => {
+    const queue: PortfolioQueue = {
+      buckets: [{ repoFullName: "acme/alpha", items: [{ id: "  a-1  ", repoFullName: "acme/alpha", state: "queued" }] }],
+    };
+
+    expect(enqueueItem(queue, item("a-1", "acme/alpha"))).toBe(queue);
+  });
+
   it("dequeues one item and drops an empty repo bucket", () => {
     const queue = queueOf(item("a-1", "acme/alpha"), item("b-1", "acme/beta"));
 
@@ -51,6 +65,12 @@ describe("portfolio queue primitives", () => {
       buckets: [{ repoFullName: "acme/alpha", items: [item("a-1", "acme/alpha")] }],
     });
     expect(dequeueItem(queue, "missing")).toBe(queue);
+  });
+
+  it("treats a blank dequeue target as a no-op", () => {
+    const queue = queueOf(item("a-1", "acme/alpha"));
+
+    expect(dequeueItem(queue, "   ")).toBe(queue);
   });
 
   it("returns no eligible items for an empty queue", () => {
@@ -65,6 +85,13 @@ describe("portfolio queue primitives", () => {
     );
 
     expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 1 })).toEqual([]);
+  });
+
+  it("returns no eligible items when either cap normalizes to zero", () => {
+    const queue = queueOf(item("a-queued-1", "acme/alpha"));
+
+    expect(nextEligibleItems(queue, { globalWipCap: Number.POSITIVE_INFINITY, perRepoWipCap: 1 })).toEqual([]);
+    expect(nextEligibleItems(queue, { globalWipCap: 2, perRepoWipCap: -1 })).toEqual([]);
   });
 
   it("diversifies multi-repo selection and prefers the least represented repos first", () => {
@@ -94,6 +121,15 @@ describe("portfolio queue primitives", () => {
     expect(nextEligibleItems(queue, { globalWipCap: 3, perRepoWipCap: 3 }).map((entry) => entry.id)).toEqual([
       "a-queued-1",
       "b-queued-1",
+      "a-queued-2",
+    ]);
+  });
+
+  it("continues selecting from the same repo when no alternate repo is eligible", () => {
+    const queue = queueOf(item("a-queued-1", "acme/alpha"), item("a-queued-2", "acme/alpha"));
+
+    expect(nextEligibleItems(queue, { globalWipCap: 2, perRepoWipCap: 2 }).map((entry) => entry.id)).toEqual([
+      "a-queued-1",
       "a-queued-2",
     ]);
   });


### PR DESCRIPTION
## Summary

- add pure `PortfolioQueue` bookkeeping primitives to `@jsonbored/gittensory-engine` for `#2326`
- implement deterministic `enqueueItem`, `dequeueItem`, and `nextEligibleItems` with repo bucketing, global/per-repo WIP caps, and stable cross-repo alternation
- cover empty, capped, diversified, and no-op paths in repo-level and package-level tests

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Re-ran targeted tests after rebasing onto the latest `origin/main`:
  - `npx vitest run test/unit/portfolio-queue.test.ts`
  - `npm --workspace @jsonbored/gittensory-engine run test`
  - `npm run db:migrations:check`
- A full local `npm run test:coverage` retry on an earlier rebased attempt hit an unrelated `test/unit/queue-trends.test.ts` flake; the file passed on isolated retry.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI changes.

## Notes

- Risk is low: this is a pure engine helper only, with no DB, network, worker, migration, or UI changes.
- The targeted queue coverage run now hits `packages/gittensory-engine/src/portfolio/queue.ts` at 100% lines and 100% branches.
- Closes #2326.
