### PR TITLE
fix(selfhost): gate gittensory's depends_on on postgres/pgbouncer health

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,17 @@ services:
       qdrant:
         condition: service_healthy
         required: false
+      # Same pattern for --profile postgres / --profile pgbouncer: without this, compose starts gittensory
+      # in parallel with a cold Postgres initdb instead of waiting for it, and the app's own waitForPostgres()
+      # fallback (~30s hard cap) commonly loses that race on a slow disk/first pull, crash-looping the app via
+      # restart: unless-stopped before Postgres is reachable. required:false keeps the default SQLite path
+      # (no profile active) unaffected.
+      postgres:
+        condition: service_healthy
+        required: false
+      pgbouncer:
+        condition: service_healthy
+        required: false
     healthcheck:
       # Probe /ready (not /health): /health is a liveness stub that is 200 even when the DB is down,
       # whereas /ready returns 503 until the DB answers AND migrations are applied — so dependents that
@@ -161,6 +172,15 @@ services:
       MAX_CLIENT_CONN: "200"
       DEFAULT_POOL_SIZE: "20"
       AUTH_TYPE: md5
+    # The image ships the full postgresql-client toolchain (Alpine-based), so the same probe postgres itself
+    # uses works here: pg_isready only checks that the server accepts the startup packet, not that auth
+    # succeeds, so it reports "accepting connections" even before the upstream Postgres is reachable through
+    # the pooler — exactly the pooler-layer liveness signal gittensory's depends_on needs.
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "127.0.0.1", "-p", "5432"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # Postgres internals exporter. Starts with the Postgres profiles so Prometheus can scrape it when
   # observability is enabled, without starting against a missing DB on SQLite-only installs.

--- a/test/unit/selfhost-compose-db-health.test.ts
+++ b/test/unit/selfhost-compose-db-health.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  const value = parse(readFileSync(path, "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must be a YAML object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+// Pure structural checks only (no `docker` CLI invocation): the self-hosted runner container this actually
+// runs on does not have Docker-in-Docker access, so a test that shells out to `docker compose config`
+// would be unreliable/environment-dependent here (same constraint as docker-compose-override-example.test.ts).
+describe("docker-compose.yml — postgres/pgbouncer startup ordering (#2500, #2503)", () => {
+  it("gates the core app on a healthy postgres and pgbouncer without requiring either profile", () => {
+    const compose = readYaml("docker-compose.yml");
+    const services = (compose.services as Record<string, Record<string, unknown>>) ?? {};
+    const app = services.gittensory ?? {};
+    const dependsOn = app.depends_on as Record<string, { condition?: string; required?: boolean }>;
+
+    // redis stays required (always-on service); postgres/pgbouncer/qdrant are all required:false since only
+    // a subset of profiles start them — a default (no-profile) SQLite deployment must not wait on any of them.
+    expect(dependsOn.redis).toEqual({ condition: "service_healthy" });
+    expect(dependsOn.postgres).toEqual({ condition: "service_healthy", required: false });
+    expect(dependsOn.pgbouncer).toEqual({ condition: "service_healthy", required: false });
+    expect(dependsOn.qdrant).toEqual({ condition: "service_healthy", required: false });
+  });
+
+  it("gives pgbouncer a healthcheck so gittensory's depends_on has a real readiness signal to gate on", () => {
+    const compose = readYaml("docker-compose.yml");
+    const services = (compose.services as Record<string, Record<string, unknown>>) ?? {};
+    const pgbouncer = services.pgbouncer ?? {};
+    const healthcheck = pgbouncer.healthcheck as { test?: unknown[]; interval?: string; retries?: number };
+
+    // pg_isready only confirms the server accepts the startup packet, not that auth succeeds against the
+    // real upstream postgres -- correct for a pooler-layer liveness probe, mirroring the postgres service's
+    // own healthcheck shape (also pg_isready-based).
+    expect(healthcheck.test).toEqual(["CMD", "pg_isready", "-h", "127.0.0.1", "-p", "5432"]);
+    expect(healthcheck.retries).toBeGreaterThan(0);
+  });
+
+  it("still starts pgbouncer only after a healthy postgres (unaffected by the new gittensory dependency)", () => {
+    const compose = readYaml("docker-compose.yml");
+    const services = (compose.services as Record<string, Record<string, unknown>>) ?? {};
+    const pgbouncer = services.pgbouncer ?? {};
+    const dependsOn = pgbouncer.depends_on as Record<string, { condition?: string }>;
+
+    expect(dependsOn.postgres).toEqual({ condition: "service_healthy" });
+  });
+});


### PR DESCRIPTION
## Summary

- `gittensory`'s `depends_on` in `docker-compose.yml` only gated on `redis` and `qdrant`, never `postgres` or `pgbouncer`, even though `--profile postgres`/`--profile pgbouncer` are documented first-class deployment modes. On a cold Postgres volume, compose started `gittensory` in parallel with `postgres` initdb instead of waiting for the healthcheck; the app's own `waitForPostgres()` fallback (~30s hard cap) commonly lost that race on a slow disk/first pull, crash-looping the app via `restart: unless-stopped` before Postgres was reachable.
- `pgbouncer` had no `healthcheck:` block at all, so there was no readiness signal to gate on even conceptually.
- Added `postgres`/`pgbouncer` to `gittensory`'s `depends_on` with `condition: service_healthy, required: false` (mirroring the existing `qdrant` entry — `required: false` keeps the default no-profile SQLite path unaffected), and gave `pgbouncer` a `pg_isready`-based healthcheck (same approach `postgres` itself uses — verified locally against a running `edoburu/pgbouncer` container that `pg_isready` reports "accepting connections" purely from the pooler accepting the startup packet, independent of whether the upstream Postgres is reachable, which is the correct pooler-layer liveness signal).
- Validated with `docker compose --profile postgres --profile pgbouncer config` (and the full profile combination) — both parse clean.

Closes #2500. Closes #2503.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a `docker-compose.yml`/`test/**` change with no `src/**` lines, so it carries no Codecov patch obligation; the new structural YAML assertions pass.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.