### PR TITLE
feat(health): add readiness probe durations

### DIFF
--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -5,6 +5,7 @@
 export interface Readiness {
   ok: boolean;
   checks: Record<string, boolean>;
+  durationsMs: Record<string, number>;
 }
 
 export type HealthBackend = "sqlite" | "postgres";
@@ -49,34 +50,40 @@ export function buildHealthBody(opts: {
  *  stop routing to it — so every probe gates readiness. */
 export type ReadinessProbe = { name: string; check: () => Promise<boolean> };
 
+async function timedReadinessCheck(
+  name: string,
+  durationsMs: Record<string, number>,
+  check: () => Promise<boolean>,
+): Promise<boolean> {
+  const startedAt = Date.now();
+  try {
+    return await check();
+  } catch {
+    return false;
+  } finally {
+    durationsMs[name] = Math.max(0, Date.now() - startedAt);
+  }
+}
+
 /** Readiness: the DB answers a trivial query, the migrations table shows applied rows, and every configured
  *  optional-backend probe (Redis/Qdrant, when wired) answers. An instance can no longer report ready while a
  *  backend it actually depends on is down. */
 export async function readiness(db: D1Database, probes: ReadinessProbe[] = []): Promise<Readiness> {
-  let dbOk = false;
-  let migrations = false;
-  try {
+  const durationsMs: Record<string, number> = {};
+  const dbOk = await timedReadinessCheck("db", durationsMs, async () => {
     await db.prepare("SELECT 1 AS one").first();
-    dbOk = true;
-  } catch {
-    /* db down */
-  }
-  try {
+    return true;
+  });
+  const migrations = await timedReadinessCheck("migrations", durationsMs, async () => {
     const row = await db.prepare("SELECT COUNT(*) AS c FROM _selfhost_migrations").first<{ c: number }>();
     // COUNT(*) always returns one row on D1/SQLite; if an adapter violates that, this try/catch fails closed.
-    migrations = Number(row!.c) > 0;
-  } catch {
-    /* migrations table missing */
-  }
+    return Number(row!.c) > 0;
+  });
   const checks: Record<string, boolean> = { db: dbOk, migrations };
   for (const probe of probes) {
-    try {
-      checks[probe.name] = await probe.check();
-    } catch {
-      checks[probe.name] = false; // an unreachable / erroring backend is not ready
-    }
+    checks[probe.name] = await timedReadinessCheck(probe.name, durationsMs, probe.check);
   }
-  return { ok: Object.values(checks).every(Boolean), checks };
+  return { ok: Object.values(checks).every(Boolean), checks, durationsMs };
 }
 
 /** Boot-time DATA-SAFETY advisory. A single SQLite file with no acknowledged backup is a data-loss SPOF — yet

--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -55,13 +55,13 @@ async function timedReadinessCheck(
   durationsMs: Record<string, number>,
   check: () => Promise<boolean>,
 ): Promise<boolean> {
-  const startedAt = Date.now();
+  const startedAt = performance.now();
   try {
     return await check();
   } catch {
     return false;
   } finally {
-    durationsMs[name] = Math.max(0, Date.now() - startedAt);
+    durationsMs[name] = Math.max(0, performance.now() - startedAt);
   }
 }
 

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -70,7 +70,10 @@ describe("resolveHealthVersion (#2077)", () => {
 
 function expectDurations(result: Awaited<ReturnType<typeof readiness>>, names: string[]): void {
   expect(Object.keys(result.durationsMs).sort()).toEqual([...names].sort());
-  for (const name of names) expect(result.durationsMs[name]).toEqual(expect.any(Number));
+  for (const name of names) {
+    expect(Number.isFinite(result.durationsMs[name])).toBe(true);
+    expect(result.durationsMs[name]).toBeGreaterThanOrEqual(0);
+  }
 }
 
 describe("sqliteBackupAdvisory (#8 data-safety)", () => {
@@ -151,14 +154,23 @@ describe("readiness (#982)", () => {
     expectDurations(result, ["db", "migrations", "qdrant"]);
   });
 
-  it("records per-probe durations for db, migrations, false probes, and throwing probes (#2078)", async () => {
+  it("records monotonic per-probe durations for db, migrations, false probes, and throwing probes (#2078)", async () => {
     const driver = nodeSqliteDriver(new DatabaseSync(":memory:") as never);
     const db = createD1Adapter(driver);
     driver.exec("CREATE TABLE _selfhost_migrations (name TEXT, applied_at INTEGER)");
     driver.query("INSERT INTO _selfhost_migrations (name, applied_at) VALUES (?, ?)", ["0001", 0]);
     vi.spyOn(Date, "now")
+      .mockReturnValueOnce(5000)
       .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(999)
+      .mockReturnValueOnce(5000)
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(5000)
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(5000)
+      .mockReturnValueOnce(1000);
+    vi.spyOn(performance, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1004)
       .mockReturnValueOnce(2000)
       .mockReturnValueOnce(2007)
       .mockReturnValueOnce(3000)
@@ -179,7 +191,7 @@ describe("readiness (#982)", () => {
     expect(result).toEqual({
       ok: false,
       checks: { db: true, migrations: true, redis: false, qdrant: false },
-      durationsMs: { db: 0, migrations: 7, redis: 2, qdrant: 9 },
+      durationsMs: { db: 4, migrations: 7, redis: 2, qdrant: 9 },
     });
   });
 });

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -68,6 +68,11 @@ describe("resolveHealthVersion (#2077)", () => {
   });
 });
 
+function expectDurations(result: Awaited<ReturnType<typeof readiness>>, names: string[]): void {
+  expect(Object.keys(result.durationsMs).sort()).toEqual([...names].sort());
+  for (const name of names) expect(result.durationsMs[name]).toEqual(expect.any(Number));
+}
+
 describe("sqliteBackupAdvisory (#8 data-safety)", () => {
   it("warns on SQLite without an acknowledged backup, and is silent otherwise", () => {
     expect(sqliteBackupAdvisory({ usingSqlite: true, backupAcknowledged: false })).toMatch(/single SQLite file with no acknowledged backup/);
@@ -77,17 +82,27 @@ describe("sqliteBackupAdvisory (#8 data-safety)", () => {
 });
 
 describe("readiness (#982)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("is not ready until the migrations table has applied rows", async () => {
     const driver = nodeSqliteDriver(new DatabaseSync(":memory:") as never);
     const db = createD1Adapter(driver);
     // db answers but no migrations table yet → not ready
-    expect(await readiness(db)).toEqual({ ok: false, checks: { db: true, migrations: false } });
+    let result = await readiness(db);
+    expect(result).toMatchObject({ ok: false, checks: { db: true, migrations: false } });
+    expectDurations(result, ["db", "migrations"]);
     // empty migrations table → still not ready
     driver.exec("CREATE TABLE _selfhost_migrations (name TEXT, applied_at INTEGER)");
-    expect((await readiness(db)).ok).toBe(false);
+    result = await readiness(db);
+    expect(result.ok).toBe(false);
+    expectDurations(result, ["db", "migrations"]);
     // an applied migration → ready
     driver.query("INSERT INTO _selfhost_migrations (name, applied_at) VALUES (?, ?)", ["0001", 0]);
-    expect(await readiness(db)).toEqual({ ok: true, checks: { db: true, migrations: true } });
+    result = await readiness(db);
+    expect(result).toMatchObject({ ok: true, checks: { db: true, migrations: true } });
+    expectDurations(result, ["db", "migrations"]);
   });
 
   it("reports db=false and migrations=false when the SELECT 1 probe throws (db down)", async () => {
@@ -105,7 +120,9 @@ describe("readiness (#982)", () => {
       batch: () => Promise.resolve([]),
       dump: () => Promise.resolve(new ArrayBuffer(0)),
     } as unknown as D1Database;
-    expect(await readiness(throwingDb)).toEqual({ ok: false, checks: { db: false, migrations: false } });
+    const result = await readiness(throwingDb);
+    expect(result).toMatchObject({ ok: false, checks: { db: false, migrations: false } });
+    expectDurations(result, ["db", "migrations"]);
   });
 
   it("gates readiness on configured backend probes (#4) and reports each in checks", async () => {
@@ -114,10 +131,55 @@ describe("readiness (#982)", () => {
     driver.exec("CREATE TABLE _selfhost_migrations (name TEXT, applied_at INTEGER)");
     driver.query("INSERT INTO _selfhost_migrations (name, applied_at) VALUES (?, ?)", ["0001", 0]);
     // A healthy probe → still ready, reported in checks.
-    expect(await readiness(db, [{ name: "redis", check: async () => true }])).toEqual({ ok: true, checks: { db: true, migrations: true, redis: true } });
+    let result = await readiness(db, [{ name: "redis", check: async () => true }]);
+    expect(result).toMatchObject({ ok: true, checks: { db: true, migrations: true, redis: true } });
+    expectDurations(result, ["db", "migrations", "redis"]);
     // A failing probe → NOT ready (a configured backend that's down means the instance is degraded).
-    expect(await readiness(db, [{ name: "redis", check: async () => false }])).toEqual({ ok: false, checks: { db: true, migrations: true, redis: false } });
+    result = await readiness(db, [{ name: "redis", check: async () => false }]);
+    expect(result).toMatchObject({ ok: false, checks: { db: true, migrations: true, redis: false } });
+    expectDurations(result, ["db", "migrations", "redis"]);
     // A throwing probe → caught → false → not ready.
-    expect(await readiness(db, [{ name: "qdrant", check: async () => { throw new Error("unreachable"); } }])).toEqual({ ok: false, checks: { db: true, migrations: true, qdrant: false } });
+    result = await readiness(db, [
+      {
+        name: "qdrant",
+        check: async () => {
+          throw new Error("unreachable");
+        },
+      },
+    ]);
+    expect(result).toMatchObject({ ok: false, checks: { db: true, migrations: true, qdrant: false } });
+    expectDurations(result, ["db", "migrations", "qdrant"]);
+  });
+
+  it("records per-probe durations for db, migrations, false probes, and throwing probes (#2078)", async () => {
+    const driver = nodeSqliteDriver(new DatabaseSync(":memory:") as never);
+    const db = createD1Adapter(driver);
+    driver.exec("CREATE TABLE _selfhost_migrations (name TEXT, applied_at INTEGER)");
+    driver.query("INSERT INTO _selfhost_migrations (name, applied_at) VALUES (?, ?)", ["0001", 0]);
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(999)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2007)
+      .mockReturnValueOnce(3000)
+      .mockReturnValueOnce(3002)
+      .mockReturnValueOnce(4000)
+      .mockReturnValueOnce(4009);
+
+    const result = await readiness(db, [
+      { name: "redis", check: async () => false },
+      {
+        name: "qdrant",
+        check: async () => {
+          throw new Error("unreachable");
+        },
+      },
+    ]);
+
+    expect(result).toEqual({
+      ok: false,
+      checks: { db: true, migrations: true, redis: false, qdrant: false },
+      durationsMs: { db: 0, migrations: 7, redis: 2, qdrant: 9 },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Closes #2078 by adding per-check `durationsMs` to the self-host `/ready` response.
- Times the built-in DB and migration checks plus every configured readiness probe with the same wrapper.
- Preserves the existing readiness contract: `ok` is still `true` only when every boolean check is `true`, and false or throwing probes still fail closed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; `codecov/patch` requires >=99% coverage of the lines and branches changed.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None. Also ran the full `npm run test:ci` gate and focused `npx vitest run test/unit/selfhost-health.test.ts --coverage.enabled true --coverage.include src/selfhost/health.ts --coverage.reporter text`, which reported 100% statements, branches, functions, and lines for `src/selfhost/health.ts`.

## Safety

- [x] No sensitive credentials, private keys, raw private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI, frontend, docs, or extension changes.

## Notes

- `durationsMs` is additive response metadata for operators debugging slow or flaky readiness probes.
- Boolean readiness remains unchanged for existing load balancer integrations.
