### PR TITLE
fix(selfhost): add a healthcheck to the ollama service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,6 +222,14 @@ services:
     profiles: ["ollama"]
     volumes:
       - ollama-models:/root/.ollama
+    # The image ships the ollama CLI but no curl/wget, so probe the daemon through it directly instead of a
+    # raw HTTP request: `ollama list` only succeeds once the server is accepting API calls.
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      start_period: 15s
+      retries: 5
 
   # ── Litestream (--profile litestream) ─────────────────────────────────────
   # Continuous WAL backup of the SQLite DB to S3/B2/R2. Copy litestream.yml.example

--- a/test/unit/selfhost-compose-ollama-health.test.ts
+++ b/test/unit/selfhost-compose-ollama-health.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  const value = parse(readFileSync(path, "utf8"));
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${path} must be a YAML object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+// Pure structural checks only (no `docker` CLI invocation): the self-hosted runner container this actually
+// runs on does not have Docker-in-Docker access, so a test that shells out to `docker compose config`
+// would be unreliable/environment-dependent here (same constraint as docker-compose-override-example.test.ts).
+describe("docker-compose.yml — ollama healthcheck (#2504)", () => {
+  it("gives ollama a healthcheck so docker compose ps and a future depends_on can gate on it", () => {
+    const compose = readYaml("docker-compose.yml");
+    const services = (compose.services as Record<string, Record<string, unknown>>) ?? {};
+    const ollama = services.ollama ?? {};
+    const healthcheck = ollama.healthcheck as { test?: unknown[]; retries?: number };
+
+    // The image ships the ollama CLI but no curl/wget/nc, so `ollama list` is the only in-image probe that
+    // only succeeds once the daemon is actually serving API calls.
+    expect(healthcheck.test).toEqual(["CMD", "ollama", "list"]);
+    expect(healthcheck.retries).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- The `ollama` service in `docker-compose.yml` had no `healthcheck:` block, unlike every other optional backend (`qdrant`, `postgres`, `tempo`, the backup-exporter). Operators following the in-file `--profile ollama` instructions got no compose-level signal that Ollama finished starting and is accepting API calls before the app starts using it, and there was no way to add a `depends_on: ollama: condition: service_healthy` gate even if desired later.
- Added a healthcheck using `ollama list` — the image ships the `ollama` CLI but no curl/wget/nc, and `ollama list` only succeeds once the daemon is actually serving; verified locally against a running `ollama/ollama:0.30.10` container.

Closes #2504.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a `docker-compose.yml`/`test/**` change with no `src/**` lines, so it carries no Codecov patch obligation; the new structural YAML assertion passes.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.