### PR TITLE
fix(health): probe GitHub App auth and AI-provider reachability in /ready

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -79,7 +79,7 @@ curl http://localhost:8787/ready`}
           {
             title: "/ready",
             description:
-              "Readiness. It returns 200 only after database access and migrations are healthy.",
+              "Readiness. It returns 200 only after database access, migrations, and every configured backend (Redis, GitHub App auth, the AI provider, and any of Qdrant/Postgres you've enabled) are healthy.",
           },
           {
             title: "/metrics",

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -422,7 +422,12 @@ function expireCachedAppJwt(appId: string): void {
   appJwtCache.delete(appId);
 }
 
-async function createAppJwt(env: Env): Promise<string> {
+/** Exported for the /ready GitHub App auth probe (#2497): a successful mint proves GITHUB_APP_PRIVATE_KEY is
+ *  set and parses as a valid signing key (importPkcs8PrivateKey/crypto.subtle.sign both throw on a malformed
+ *  key) without spending a live GitHub API call on every health-check tick. It can't detect a key that GitHub
+ *  has since revoked (only a real API call would), but it catches the common "unset/invalid key" failure mode
+ *  that otherwise leaves /ready reporting 200 while the review pipeline is completely dead. */
+export async function createAppJwt(env: Env): Promise<string> {
   if (!env.GITHUB_APP_PRIVATE_KEY) {
     throw new Error("GitHub App credentials are not configured.");
   }

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -604,6 +604,15 @@ export function resetAiProviderHealthForTest(): void {
   aiConsecutiveFailures = 0;
 }
 
+/** Force the streak straight to the unhealthy threshold (#2497 follow-up): for a REQUIRED CLI-subscription
+ *  provider's binary missing from PATH, caught at boot (server.ts's own fail-loud CLI-presence check) --
+ *  a real, immediately-known misconfiguration that shouldn't need three real AI-call failures to surface in
+ *  /ready, unlike a bad HTTP-provider API key or an unreachable endpoint, which can only be confirmed by a
+ *  real call and so still rely on the historical streak above. */
+export function markAiProviderUnhealthyAtBoot(): void {
+  aiConsecutiveFailures = AI_UNHEALTHY_FAILURE_STREAK;
+}
+
 /** Try each provider in order until one returns; if all throw, rethrow the last error so the caller degrades
  *  (AI summary → "unavailable"; the review still runs deterministically). The fallback chain is what makes a
  *  BYOK setup robust — e.g. AI_PROVIDER="anthropic,ollama" uses the API first and a local model if it's down. */

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -604,11 +604,32 @@ export function resetAiProviderHealthForTest(): void {
   aiConsecutiveFailures = 0;
 }
 
+/** Whether a missing-CLI boot check should force /ready unhealthy: only when EVERY configured provider is
+ *  among the missing-CLI set, i.e. the whole AI_PROVIDER chain has zero chance of working -- not just one
+ *  provider within a chain that has a working fallback (another present CLI, or an HTTP-based provider,
+ *  unverifiable this cheaply at boot but not KNOWN-broken either). Flagged by the gate's own review: an
+ *  earlier version force-marked the whole probe unhealthy for ANY missing CLI, which was a false positive
+ *  for a chain like "claude-code,anthropic" where claude-code's CLI is missing but anthropic can still serve
+ *  every request via routeProviders' fallback (#2497 follow-up). Pure so the boundary is unit-testable
+ *  independent of server.ts, which has no test harness. */
+export function shouldMarkAiProviderUnhealthyAtBoot(
+  configuredProviders: readonly string[],
+  missingCliProviders: readonly string[],
+): boolean {
+  if (missingCliProviders.length === 0) return false;
+  const configured = new Set(configuredProviders);
+  if (configured.size === 0) return false;
+  const missing = new Set(missingCliProviders);
+  return [...configured].every((provider) => missing.has(provider));
+}
+
 /** Force the streak straight to the unhealthy threshold (#2497 follow-up): for a REQUIRED CLI-subscription
  *  provider's binary missing from PATH, caught at boot (server.ts's own fail-loud CLI-presence check) --
  *  a real, immediately-known misconfiguration that shouldn't need three real AI-call failures to surface in
  *  /ready, unlike a bad HTTP-provider API key or an unreachable endpoint, which can only be confirmed by a
- *  real call and so still rely on the historical streak above. */
+ *  real call and so still rely on the historical streak above. Callers should gate this with
+ *  shouldMarkAiProviderUnhealthyAtBoot so a chain with a working fallback provider isn't force-marked
+ *  unhealthy just because one sibling provider's CLI is missing. */
 export function markAiProviderUnhealthyAtBoot(): void {
   aiConsecutiveFailures = AI_UNHEALTHY_FAILURE_STREAK;
 }

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -585,6 +585,25 @@ export function createCodexAi(parentEnv: Record<string, string | undefined>, spa
   };
 }
 
+// Readiness tracking (#2497): /ready has no way to tell "every configured AI provider is unreachable" (bad
+// API key, CLI missing auth, provider outage) from healthy — a live per-request reachability check would cost
+// a real API/CLI call on every health-check tick, so instead track a consecutive-exhaustion streak here and
+// let /ready read it. A single threshold absorbs one-off transient failures (a bad request, a momentary
+// network blip) without flapping readiness; only a SUSTAINED run of total chain exhaustion degrades it.
+const AI_UNHEALTHY_FAILURE_STREAK = 3;
+let aiConsecutiveFailures = 0;
+
+/** False once the chain has exhausted every provider AI_UNHEALTHY_FAILURE_STREAK times in a row; true otherwise
+ *  (including when no AI call has happened yet, or the most recent one succeeded). */
+export function isAiProviderHealthy(): boolean {
+  return aiConsecutiveFailures < AI_UNHEALTHY_FAILURE_STREAK;
+}
+
+/** Test-only reset so streak state from one test can't leak into the next (module-level counter). */
+export function resetAiProviderHealthForTest(): void {
+  aiConsecutiveFailures = 0;
+}
+
 /** Try each provider in order until one returns; if all throw, rethrow the last error so the caller degrades
  *  (AI summary → "unavailable"; the review still runs deterministically). The fallback chain is what makes a
  *  BYOK setup robust — e.g. AI_PROVIDER="anthropic,ollama" uses the API first and a local model if it's down. */
@@ -595,13 +614,16 @@ export function createChainAi(providers: Array<{ name: string; ai: SelfHostAi }>
       const failures: Array<{ provider: string; error: string }> = [];
       for (const p of providers) {
         try {
-          return await runProviderWithOtel(p, model, options);
+          const result = await runProviderWithOtel(p, model, options);
+          aiConsecutiveFailures = 0;
+          return result;
         } catch (error) {
           lastError = error;
           failures.push({ provider: p.name, error: errorMessage(error) });
           console.error(JSON.stringify({ level: "warn", event: "selfhost_ai_provider_failed_in_chain", provider: p.name, error: errorMessage(error) }));
         }
       }
+      aiConsecutiveFailures += 1;
       console.error(
         JSON.stringify({
           level: "error",

--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -86,6 +86,29 @@ export async function readiness(db: D1Database, probes: ReadinessProbe[] = []): 
   return { ok: Object.values(checks).every(Boolean), checks, durationsMs };
 }
 
+/** Decide whether the GitHub App auth readiness probe should be registered, and how its check() behaves, from
+ *  the two config vars (#2497). Registered whenever EITHER var is set -- gating registration on BOTH being set
+ *  would silently skip the probe entirely for a partial config (e.g. the App ID set but the private key unset
+ *  or a load failure), letting /ready report ready anyway even though GitHub App auth cannot mint a JWT. The
+ *  returned check() itself re-verifies both are present before minting, so a partial config fails closed
+ *  (false) in EITHER direction — not just the one a JWT-mint helper's own internal validation happens to catch.
+ *  Neither var set is the legitimate brokered-mode deployment (central Orb App, no own App credentials):
+ *  correctly returns null (no probe registered, since there is nothing of this instance's own to check). */
+export function githubAppReadinessProbe(
+  githubAppId: string | undefined,
+  githubAppPrivateKey: string | undefined,
+  mintAppJwt: () => Promise<unknown>,
+): ReadinessProbe | null {
+  if (!githubAppId && !githubAppPrivateKey) return null;
+  return {
+    name: "github_app",
+    check: () =>
+      githubAppId && githubAppPrivateKey
+        ? mintAppJwt().then(() => true).catch(() => false)
+        : Promise.resolve(false),
+  };
+}
+
 /** Boot-time DATA-SAFETY advisory. A single SQLite file with no acknowledged backup is a data-loss SPOF — yet
  *  `/ready` would still answer 200, so an operator can run with zero durability believing they're healthy. Returns
  *  the warning to log at boot (or null on Postgres, or once the operator sets `BACKUP_ACKNOWLEDGED=true` after

--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -93,7 +93,11 @@ export async function readiness(db: D1Database, probes: ReadinessProbe[] = []): 
  *  returned check() itself re-verifies both are present before minting, so a partial config fails closed
  *  (false) in EITHER direction — not just the one a JWT-mint helper's own internal validation happens to catch.
  *  Neither var set is the legitimate brokered-mode deployment (central Orb App, no own App credentials):
- *  correctly returns null (no probe registered, since there is nothing of this instance's own to check). */
+ *  correctly returns null (no probe registered, since there is nothing of this instance's own to check).
+ *  Scope: a successful mint only proves the private key is present and locally well-formed (importable +
+ *  signable) -- it does NOT call GitHub, so it can't catch a valid key paired with the wrong App ID, or a
+ *  key GitHub has since revoked. Those still surface (via the executor's own token mint) on the next real
+ *  write, just not here. */
 export function githubAppReadinessProbe(
   githubAppId: string | undefined,
   githubAppPrivateKey: string | undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { exportOrbBatch } from "./selfhost/orb-collector";
 import { createD1Adapter, nodeSqliteDriver } from "./selfhost/d1-adapter";
 import {
   buildHealthBody,
+  githubAppReadinessProbe,
   readiness,
   resolveHealthVersion,
   sqliteBackupAdvisory,
@@ -445,14 +446,18 @@ async function main(): Promise<void> {
   setInstallationTokenStore(createRedisTokenCache(redisClient));
   // GitHub App auth: a successful JWT mint proves GITHUB_APP_PRIVATE_KEY is set and parses as a valid signing
   // key. Without this, an invalid/expired key leaves the review pipeline completely dead while /ready still
-  // reports 200 — detection otherwise requires SENTRY_DSN or grepping stdout for auth errors (#2497).
-  if (process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY) {
+  // reports 200 — detection otherwise requires SENTRY_DSN or grepping stdout for auth errors (#2497). The
+  // register/fail-closed decision lives in githubAppReadinessProbe (unit-tested there); withTimeout here is
+  // only the hung-mint guard shared with the other probes.
+  const githubAppProbe = githubAppReadinessProbe(
+    process.env.GITHUB_APP_ID,
+    process.env.GITHUB_APP_PRIVATE_KEY,
+    () => createAppJwt(env),
+  );
+  if (githubAppProbe) {
     readinessProbes.push({
-      name: "github_app",
-      check: () =>
-        withTimeout(
-          createAppJwt(env).then(() => true).catch(() => false),
-        ),
+      name: githubAppProbe.name,
+      check: () => withTimeout(githubAppProbe.check()),
     });
   }
   // Configured AI provider: gate on the chain's own consecutive-exhaustion streak (isAiProviderHealthy) rather

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
   createOpenAiCompatibleAi,
   createSelfHostAi,
   isAiProviderHealthy,
+  markAiProviderUnhealthyAtBoot,
   resolveAiReviewerPlan,
   resolveRequiredCliProviders,
   resolveSubscriptionCliPath,
@@ -387,6 +388,10 @@ async function main(): Promise<void> {
         message: `AI_PROVIDER=${process.env.AI_PROVIDER} includes ${provider} but '${cli}' is not on PATH — every ${provider} AI review will produce NO output. Rebuild the image with --build-arg INSTALL_AI_CLIS=true (or use the published image) and authenticate the CLI.`,
       }),
     );
+    // Feed this into the ai_provider /ready probe (#2497): unlike an HTTP-provider bad API key, a missing
+    // required CLI binary is a real, immediately-known misconfiguration -- /ready should report it from the
+    // first check, not wait for three real webhook-triggered AI-call failures to exhaust the chain.
+    markAiProviderUnhealthyAtBoot();
   }
   // Dedicated RAG embed provider (keeps the review chain frontier-only): when AI_EMBED_BASE_URL is set, embeddings
   // route to a SEPARATE openai-compatible endpoint (e.g. ollama at http://ollama:11434/v1, model bge-m3) instead of
@@ -463,9 +468,13 @@ async function main(): Promise<void> {
   // Configured AI provider: gate on the chain's own consecutive-exhaustion streak (isAiProviderHealthy) rather
   // than a live reachability probe, which would cost a real API/CLI call on every health-check tick. Only
   // registered when a provider is actually configured -- without AI_PROVIDER reviews run deterministically,
-  // which is not a degraded state (#2497). Historical, not live: the streak only updates as real review
-  // traffic exercises the chain, so a freshly booted instance reports healthy before its first AI call, and
-  // a fix (credentials restored) only clears after a subsequent success, not instantly.
+  // which is not a degraded state (#2497). A missing required CLI binary is caught immediately at boot (see
+  // markAiProviderUnhealthyAtBoot above) -- for everything else (a bad HTTP-provider API key, an unreachable
+  // endpoint), the streak is historical, not live: it only updates as real review traffic exercises the
+  // chain, so a freshly booted instance with those specific misconfigurations reports healthy before its
+  // first AI call, and a fix only clears after a subsequent success, not instantly. Verifying an HTTP
+  // provider's credentials cheaply at boot would mean spending a real network call, which this probe design
+  // deliberately avoids paying on every health-check tick.
   if (ai) {
     readinessProbes.push({
       name: "ai_provider",

--- a/src/server.ts
+++ b/src/server.ts
@@ -455,22 +455,6 @@ async function main(): Promise<void> {
   const { createRedisTokenCache } = await import("./selfhost/redis-token-cache");
   const { createAppJwt, setInstallationTokenStore, setGitHubResponseCache } = await import("./github/app");
   setInstallationTokenStore(createRedisTokenCache(redisClient));
-  // GitHub App auth: a successful JWT mint proves GITHUB_APP_PRIVATE_KEY is set and parses as a valid signing
-  // key. Without this, an invalid/expired key leaves the review pipeline completely dead while /ready still
-  // reports 200 — detection otherwise requires SENTRY_DSN or grepping stdout for auth errors (#2497). The
-  // register/fail-closed decision lives in githubAppReadinessProbe (unit-tested there); withTimeout here is
-  // only the hung-mint guard shared with the other probes.
-  const githubAppProbe = githubAppReadinessProbe(
-    process.env.GITHUB_APP_ID,
-    process.env.GITHUB_APP_PRIVATE_KEY,
-    () => createAppJwt(env),
-  );
-  if (githubAppProbe) {
-    readinessProbes.push({
-      name: githubAppProbe.name,
-      check: () => withTimeout(githubAppProbe.check()),
-    });
-  }
   // Configured AI provider: gate on the chain's own consecutive-exhaustion streak (isAiProviderHealthy) rather
   // than a live reachability probe, which would cost a real API/CLI call on every health-check tick. Only
   // registered when a provider is actually configured -- without AI_PROVIDER reviews run deterministically,
@@ -558,6 +542,27 @@ async function main(): Promise<void> {
       ? { REVIEW_AUDIT: createFsBlobStore(process.env.REVIEW_AUDIT_DIR) }
       : {}),
   } as unknown as Env;
+
+  // GitHub App auth: a successful JWT mint proves GITHUB_APP_PRIVATE_KEY is set and parses as a valid signing
+  // key. Without this, an invalid/expired key leaves the review pipeline completely dead while /ready still
+  // reports 200 — detection otherwise requires SENTRY_DSN or grepping stdout for auth errors (#2497). The
+  // register/fail-closed decision lives in githubAppReadinessProbe (unit-tested there); withTimeout here is
+  // only the hung-mint guard shared with the other probes. Reads from `env` (not process.env) -- the SAME
+  // object createAppJwt(env) actually mints against below -- so the registration decision and the live mint
+  // can never diverge; registered here, after env is fully constructed, rather than off the raw process.env
+  // snapshot read earlier in this function (flagged by the gate's own review as a real risk: two different
+  // sources of truth for the same credential, even if they happen to agree today).
+  const githubAppProbe = githubAppReadinessProbe(
+    env.GITHUB_APP_ID,
+    env.GITHUB_APP_PRIVATE_KEY,
+    () => createAppJwt(env),
+  );
+  if (githubAppProbe) {
+    readinessProbes.push({
+      name: githubAppProbe.name,
+      check: () => withTimeout(githubAppProbe.check()),
+    });
+  }
 
   gauge("gittensory_queue_pending", () => backend.queue.size());
   gauge("gittensory_queue_dead", () => backend.queue.deadCount());

--- a/src/server.ts
+++ b/src/server.ts
@@ -463,7 +463,9 @@ async function main(): Promise<void> {
   // Configured AI provider: gate on the chain's own consecutive-exhaustion streak (isAiProviderHealthy) rather
   // than a live reachability probe, which would cost a real API/CLI call on every health-check tick. Only
   // registered when a provider is actually configured -- without AI_PROVIDER reviews run deterministically,
-  // which is not a degraded state (#2497).
+  // which is not a degraded state (#2497). Historical, not live: the streak only updates as real review
+  // traffic exercises the chain, so a freshly booted instance reports healthy before its first AI call, and
+  // a fix (credentials restored) only clears after a subsequent success, not instantly.
   if (ai) {
     readinessProbes.push({
       name: "ai_provider",

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,8 +20,10 @@ import {
   isAiProviderHealthy,
   markAiProviderUnhealthyAtBoot,
   resolveAiReviewerPlan,
+  resolveProviderNames,
   resolveRequiredCliProviders,
   resolveSubscriptionCliPath,
+  shouldMarkAiProviderUnhealthyAtBoot,
 } from "./selfhost/ai";
 import {
   cookieValue,
@@ -377,8 +379,10 @@ async function main(): Promise<void> {
   // subprocess; if the binary is absent (image built without INSTALL_AI_CLIS=true) the spawn ENOENTs and EVERY AI
   // review silently degrades to "no usable output". Shout at boot so the misconfig is obvious, never invisible.
   const pathDirs = resolveSubscriptionCliPath(process.env).split(delimiter);
+  const missingCliProviders = new Set<string>();
   for (const { provider, cli } of resolveRequiredCliProviders(process.env)) {
     if (pathDirs.some((d) => d && existsSync(join(d, cli)))) continue;
+    missingCliProviders.add(provider);
     console.error(
       JSON.stringify({
         level: "error",
@@ -388,9 +392,11 @@ async function main(): Promise<void> {
         message: `AI_PROVIDER=${process.env.AI_PROVIDER} includes ${provider} but '${cli}' is not on PATH — every ${provider} AI review will produce NO output. Rebuild the image with --build-arg INSTALL_AI_CLIS=true (or use the published image) and authenticate the CLI.`,
       }),
     );
-    // Feed this into the ai_provider /ready probe (#2497): unlike an HTTP-provider bad API key, a missing
-    // required CLI binary is a real, immediately-known misconfiguration -- /ready should report it from the
-    // first check, not wait for three real webhook-triggered AI-call failures to exhaust the chain.
+  }
+  // Feed into the ai_provider /ready probe (#2497) -- see shouldMarkAiProviderUnhealthyAtBoot for why this is
+  // gated on the WHOLE chain being unavailable, not just one missing CLI within a chain that has a working
+  // fallback provider.
+  if (shouldMarkAiProviderUnhealthyAtBoot(resolveProviderNames(process.env), [...missingCliProviders])) {
     markAiProviderUnhealthyAtBoot();
   }
   // Dedicated RAG embed provider (keeps the review chain frontier-only): when AI_EMBED_BASE_URL is set, embeddings

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { processJob } from "./queue/processors";
 import {
   createOpenAiCompatibleAi,
   createSelfHostAi,
+  isAiProviderHealthy,
   resolveAiReviewerPlan,
   resolveRequiredCliProviders,
   resolveSubscriptionCliPath,
@@ -440,8 +441,30 @@ async function main(): Promise<void> {
   // Persist the installation-token cache in Redis so warm GitHub App tokens survive restarts/deploys and are
   // shared across replicas (the in-isolate Map otherwise re-mints — an Orb round-trip — per replica/cold start).
   const { createRedisTokenCache } = await import("./selfhost/redis-token-cache");
-  const { setInstallationTokenStore, setGitHubResponseCache } = await import("./github/app");
+  const { createAppJwt, setInstallationTokenStore, setGitHubResponseCache } = await import("./github/app");
   setInstallationTokenStore(createRedisTokenCache(redisClient));
+  // GitHub App auth: a successful JWT mint proves GITHUB_APP_PRIVATE_KEY is set and parses as a valid signing
+  // key. Without this, an invalid/expired key leaves the review pipeline completely dead while /ready still
+  // reports 200 — detection otherwise requires SENTRY_DSN or grepping stdout for auth errors (#2497).
+  if (process.env.GITHUB_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY) {
+    readinessProbes.push({
+      name: "github_app",
+      check: () =>
+        withTimeout(
+          createAppJwt(env).then(() => true).catch(() => false),
+        ),
+    });
+  }
+  // Configured AI provider: gate on the chain's own consecutive-exhaustion streak (isAiProviderHealthy) rather
+  // than a live reachability probe, which would cost a real API/CLI call on every health-check tick. Only
+  // registered when a provider is actually configured -- without AI_PROVIDER reviews run deterministically,
+  // which is not a degraded state (#2497).
+  if (ai) {
+    readinessProbes.push({
+      name: "ai_provider",
+      check: () => Promise.resolve(isAiProviderHealthy()),
+    });
+  }
   // Enable/disable gate for the GitHub GET-response cache (dedups the ~24 reads per review); NOT a per-entry
   // TTL — each cached class (branch-protection/metadata/commit/GraphQL) resolves its own TTL env var, so the
   // value here only matters as >0 (enabled) vs 0 (disabled) (#2505).

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
+import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, markAiProviderUnhealthyAtBoot, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
 import { labelSelfHostReviewerModel } from "../../src/selfhost/ai-config";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
@@ -220,6 +220,23 @@ describe("isAiProviderHealthy (readiness streak, #2497)", () => {
     for (let i = 0; i < 3; i += 1) {
       await expect(createChainAi([failing]).run("m", { prompt: "x" })).rejects.toThrow();
     }
+    expect(isAiProviderHealthy()).toBe(false);
+
+    await expect(createChainAi([working]).run("m", { prompt: "x" })).resolves.toEqual({ response: "ok" });
+    expect(isAiProviderHealthy()).toBe(true);
+  });
+
+  it("regression: markAiProviderUnhealthyAtBoot reports unhealthy immediately, before any AI call (#2497 follow-up)", () => {
+    // The original gap: a missing required CLI binary is a real, immediately-known misconfiguration, but the
+    // pure call-streak design only reported it after 3 real (webhook-triggered) AI-call failures -- a fresh
+    // process with a broken CLI provider and no traffic yet stayed "healthy" indefinitely.
+    expect(isAiProviderHealthy()).toBe(true);
+    markAiProviderUnhealthyAtBoot();
+    expect(isAiProviderHealthy()).toBe(false);
+  });
+
+  it("a success after markAiProviderUnhealthyAtBoot still recovers the streak normally", async () => {
+    markAiProviderUnhealthyAtBoot();
     expect(isAiProviderHealthy()).toBe(false);
 
     await expect(createChainAi([working]).run("m", { prompt: "x" })).resolves.toEqual({ response: "ok" });

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -253,6 +253,14 @@ describe("shouldMarkAiProviderUnhealthyAtBoot (#2497 follow-up)", () => {
     expect(shouldMarkAiProviderUnhealthyAtBoot([], [])).toBe(false);
   });
 
+  it("returns false when missingCliProviders is nonempty but nothing is actually configured (defensive branch)", () => {
+    // Shouldn't happen by construction (resolveRequiredCliProviders is derived from resolveProviderNames), but
+    // the function must not treat "some missing set exists" as "the configured chain is broken" when there is
+    // no configured chain at all -- covers the configured.size === 0 branch independently of the earlier
+    // missingCliProviders.length === 0 short-circuit.
+    expect(shouldMarkAiProviderUnhealthyAtBoot([], ["claude-code"])).toBe(false);
+  });
+
   it("returns true for a single configured CLI provider whose CLI is missing", () => {
     expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code"], ["claude-code"])).toBe(true);
   });

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, markAiProviderUnhealthyAtBoot, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
+import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, markAiProviderUnhealthyAtBoot, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, shouldMarkAiProviderUnhealthyAtBoot, subscriptionCliEnv } from "../../src/selfhost/ai";
 import { labelSelfHostReviewerModel } from "../../src/selfhost/ai-config";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
@@ -241,6 +241,39 @@ describe("isAiProviderHealthy (readiness streak, #2497)", () => {
 
     await expect(createChainAi([working]).run("m", { prompt: "x" })).resolves.toEqual({ response: "ok" });
     expect(isAiProviderHealthy()).toBe(true);
+  });
+});
+
+describe("shouldMarkAiProviderUnhealthyAtBoot (#2497 follow-up)", () => {
+  it("returns false when nothing is missing", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code"], [])).toBe(false);
+  });
+
+  it("returns false when no provider is configured at all", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot([], [])).toBe(false);
+  });
+
+  it("returns true for a single configured CLI provider whose CLI is missing", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code"], ["claude-code"])).toBe(true);
+  });
+
+  it("regression: returns false for a mixed chain where only ONE provider's CLI is missing and a fallback exists", () => {
+    // The bug the gate's review caught: an earlier version force-marked the whole ai_provider probe
+    // unhealthy for ANY missing CLI, even when AI_PROVIDER listed a working non-CLI (or another
+    // present-CLI) fallback that routeProviders would actually fall through to.
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code", "anthropic"], ["claude-code"])).toBe(false);
+  });
+
+  it("returns false for a mixed chain of two CLI providers when only one is missing", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code", "codex"], ["codex"])).toBe(false);
+  });
+
+  it("returns true when EVERY configured provider is a missing CLI (the whole chain has zero chance of working)", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["claude-code", "codex"], ["claude-code", "codex"])).toBe(true);
+  });
+
+  it("returns false for an HTTP-only chain, since resolveRequiredCliProviders never reports one as missing", () => {
+    expect(shouldMarkAiProviderUnhealthyAtBoot(["anthropic"], [])).toBe(false);
   });
 });
 

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
+import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, subscriptionCliEnv } from "../../src/selfhost/ai";
 import { labelSelfHostReviewerModel } from "../../src/selfhost/ai-config";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
@@ -66,6 +66,7 @@ describe("provider-specific CLI timeouts (#selfhost — no shared timeout ambigu
 afterEach(() => {
   vi.unstubAllGlobals();
   resetMetrics();
+  resetAiProviderHealthForTest();
 });
 
 type SpawnResult = { stdout: string; code: number | null; stderr?: string };
@@ -191,6 +192,38 @@ describe("createChainAi (fallback)", () => {
     const a = { name: "a", ai: { run: async () => { throw new Error("err-a"); } } };
     const b = { name: "b", ai: { run: async () => { throw new Error("err-b"); } } };
     await expect(createChainAi([a, b]).run("m", { prompt: "x" })).rejects.toThrow(/err-b/);
+  });
+});
+
+describe("isAiProviderHealthy (readiness streak, #2497)", () => {
+  const failing = { name: "a", ai: { run: async () => { throw new Error("down"); } } };
+  const working = { name: "a", ai: { run: async () => ({ response: "ok" }) } };
+
+  it("reports healthy before any AI call has happened", () => {
+    expect(isAiProviderHealthy()).toBe(true);
+  });
+
+  it("absorbs fewer than 3 consecutive full-chain exhaustions without going unhealthy", async () => {
+    await expect(createChainAi([failing]).run("m", { prompt: "x" })).rejects.toThrow();
+    await expect(createChainAi([failing]).run("m", { prompt: "x" })).rejects.toThrow();
+    expect(isAiProviderHealthy()).toBe(true);
+  });
+
+  it("goes unhealthy after 3 consecutive full-chain exhaustions", async () => {
+    for (let i = 0; i < 3; i += 1) {
+      await expect(createChainAi([failing]).run("m", { prompt: "x" })).rejects.toThrow();
+    }
+    expect(isAiProviderHealthy()).toBe(false);
+  });
+
+  it("a success resets the streak back to healthy", async () => {
+    for (let i = 0; i < 3; i += 1) {
+      await expect(createChainAi([failing]).run("m", { prompt: "x" })).rejects.toThrow();
+    }
+    expect(isAiProviderHealthy()).toBe(false);
+
+    await expect(createChainAi([working]).run("m", { prompt: "x" })).resolves.toEqual({ response: "ok" });
+    expect(isAiProviderHealthy()).toBe(true);
   });
 });
 

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import {
   buildHealthBody,
+  githubAppReadinessProbe,
   readiness,
   resolveHealthVersion,
   sqliteBackupAdvisory,
@@ -75,6 +76,39 @@ function expectDurations(result: Awaited<ReturnType<typeof readiness>>, names: s
     expect(result.durationsMs[name]).toBeGreaterThanOrEqual(0);
   }
 }
+
+describe("githubAppReadinessProbe (#2497)", () => {
+  it("registers no probe when neither var is set (legitimate brokered-mode deployment)", () => {
+    expect(githubAppReadinessProbe(undefined, undefined, async () => "jwt")).toBeNull();
+  });
+
+  it("regression: registers a probe (and fails closed) when the App ID is set but the private key is not", async () => {
+    // The original bug: gating registration on `githubAppId && githubAppPrivateKey` skipped the probe
+    // entirely here, so /ready never reported this partial config as unhealthy.
+    const probe = githubAppReadinessProbe("app-123", undefined, async () => "jwt");
+    expect(probe).not.toBeNull();
+    expect(probe!.name).toBe("github_app");
+    await expect(probe!.check()).resolves.toBe(false);
+  });
+
+  it("fails closed when the private key is set but the App ID is not (the mirror partial config)", async () => {
+    const probe = githubAppReadinessProbe(undefined, "-----BEGIN PRIVATE KEY-----", async () => "jwt");
+    expect(probe).not.toBeNull();
+    await expect(probe!.check()).resolves.toBe(false);
+  });
+
+  it("reports healthy when both are set and the mint succeeds", async () => {
+    const probe = githubAppReadinessProbe("app-123", "-----BEGIN PRIVATE KEY-----", async () => "jwt");
+    await expect(probe!.check()).resolves.toBe(true);
+  });
+
+  it("reports unhealthy when both are set but the mint throws (an invalid/malformed key)", async () => {
+    const probe = githubAppReadinessProbe("app-123", "not-a-real-key", async () => {
+      throw new Error("invalid key");
+    });
+    await expect(probe!.check()).resolves.toBe(false);
+  });
+});
 
 describe("sqliteBackupAdvisory (#8 data-safety)", () => {
   it("warns on SQLite without an acknowledged backup, and is silent otherwise", () => {

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -92,13 +92,13 @@ describe("githubAppReadinessProbe (#2497)", () => {
   });
 
   it("fails closed when the private key is set but the App ID is not (the mirror partial config)", async () => {
-    const probe = githubAppReadinessProbe(undefined, "-----BEGIN PRIVATE KEY-----", async () => "jwt");
+    const probe = githubAppReadinessProbe(undefined, "test-configured-private-key", async () => "jwt");
     expect(probe).not.toBeNull();
     await expect(probe!.check()).resolves.toBe(false);
   });
 
   it("reports healthy when both are set and the mint succeeds", async () => {
-    const probe = githubAppReadinessProbe("app-123", "-----BEGIN PRIVATE KEY-----", async () => "jwt");
+    const probe = githubAppReadinessProbe("app-123", "test-configured-private-key", async () => "jwt");
     await expect(probe!.check()).resolves.toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- `/ready` (`src/server.ts`) only pushed `redis` and, conditionally, `qdrant` into `readinessProbes`. If the GitHub App private key was invalid/unset or every configured AI provider was unreachable (bad API key, CLI missing auth, provider outage), the review pipeline was completely dead, but `GET /ready` still returned `200 {ok:true}` — any load balancer/orchestrator trusting `/ready` kept routing traffic to (and an operator believed healthy) an instance that reviews nothing. Detection otherwise required `SENTRY_DSN` or manually grepping stdout for auth errors.
- **GitHub App probe**: attempts an App JWT mint (`createAppJwt`, now exported from `src/github/app.ts`) with a short timeout. `crypto.subtle.importKey`/`sign` both throw on a malformed key, so a successful mint proves `GITHUB_APP_PRIVATE_KEY` is set and parses as a valid signing key. Only registered when `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` are configured. (Can't detect a key GitHub has since revoked — only a live API call would — but catches the common unset/malformed-key failure mode without spending an API call on every health-check tick.)
- **AI provider probe**: tracks a consecutive-full-chain-exhaustion streak inside `createChainAi` (`isAiProviderHealthy`) rather than a live reachability check per provider, which would cost a real API/CLI call on every health-check tick. A threshold of 3 absorbs one-off transient failures (a single bad request) without flapping readiness; only a sustained run of total-chain exhaustion degrades it. Only registered when an AI provider is actually configured — no `AI_PROVIDER` is a supported deterministic-review mode, not a degraded one.
- Regression tests cover both: a stubbed provider chain that fails 1–2 times stays healthy, 3 consecutive full-chain failures go unhealthy, and a subsequent success resets the streak.

Closes #2497.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; `codecov/patch` requires ≥99% coverage of the lines AND branches you changed (aim for 100% on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. (`src/server.ts` is Codecov-ignored; `src/selfhost/ai.ts` and `src/github/app.ts` are fully covered on the changed lines.)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — the GitHub App JWT-mint-failure path is covered by a stubbed-rejection test.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, `/ready`'s response shape (`{ok, checks}`) is unchanged; it just gains two more `checks` keys.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.