### PR TITLE
fix(rees): stop dropping added `++`-prefixed lines in the duplication scan

### DIFF
--- a/review-enrichment/src/analyzers/duplication-scan.ts
+++ b/review-enrichment/src/analyzers/duplication-scan.ts
@@ -184,7 +184,10 @@ export function extractAddedBlocks(patch: string | undefined): NormBlock[] {
       continue;
     }
     if (!inHunk) continue;
-    if (line.startsWith("+++")) continue; // file header inside the patch, not an added line
+    // NOTE: no `+++` skip here — the `+++ b/file` header only appears in the patch preamble (before the first
+    // `@@`), which the `!inHunk` guard above already drops. Inside a hunk a line starting with `+++` is an
+    // added line whose content begins with `++` (e.g. a pre-increment `++x;`); skipping it dropped real code
+    // and shifted every following added line's number down by one.
     if (line.startsWith("+")) {
       const norm = normalizeLine(line.slice(1));
       if (norm === null) {

--- a/review-enrichment/test/duplication-scan.test.ts
+++ b/review-enrichment/test/duplication-scan.test.ts
@@ -129,6 +129,23 @@ test("extractAddedBlocks: groups consecutive added lines, breaks on context/remo
   assert.deepEqual(blocks[2].lineNos, [9]);
 });
 
+test("extractAddedBlocks: keeps an added line whose content starts with `++` (patch line `+++…`) and keeps line numbers aligned", () => {
+  // A pre-increment statement `++counterValueForLoop;` becomes the patch line `+++counterValueForLoop;`. The
+  // `+++` file-header marker only appears in the preamble (before the first `@@`), so inside a hunk this is a
+  // real added line — it must not be dropped, and it must not shift the following lines' numbers.
+  const patch = [
+    "@@ -1,0 +10,3 @@",
+    "+++counterValueForLoop;",
+    "+const secondSignificantLineHere = makeValue(2)",
+    "+const thirdSignificantLineHere = makeValue(3)",
+  ].join("\n");
+  const blocks = extractAddedBlocks(patch);
+  assert.equal(blocks.length, 1);
+  assert.deepEqual(blocks[0].lineNos, [10, 11, 12]); // not [10, 11] with the ++ line dropped
+  assert.equal(blocks[0].norm.length, 3);
+  assert.ok(blocks[0].norm[0].includes("counterValueForLoop")); // the ++ line survived
+});
+
 test("decodeBase64Utf8: decodes UTF-8 blob content without globalThis.Buffer (Cloudflare Worker deployment path)", () => {
   // The production decode must not depend on Node's Buffer. Encode while Buffer exists, then remove it and decode.
   const text = "const computedScore = weight * factor + base\nconst total = computedScore + bonusAmount + café";


### PR DESCRIPTION
## Summary

`extractAddedBlocks` in `review-enrichment/src/analyzers/duplication-scan.ts` parses a unified diff into blocks of added significant lines with their new-file line numbers (used to locate copy-paste duplication). Inside the hunk loop it had:

```ts
if (!inHunk) continue;
if (line.startsWith("+++")) continue; // file header inside the patch, not an added line
if (line.startsWith("+")) { … newLine++; }
```

The `+++` skip is meant to drop the `+++ b/file` diff header — but that header only appears in the patch **preamble**, before the first `@@`, which the `if (!inHunk) continue;` guard right above already drops. So **inside a hunk**, a line starting with `+++` is never a header: it is an added line whose content begins with `++` (e.g. a pre-increment statement `++counterValueForLoop;` → patch line `+++counterValueForLoop;`).

The stray skip therefore (a) **drops that real added line** from the block, and (b) since it `continue`s before `newLine++`, **shifts every following added line's number down by one**. Downstream, `scanDuplication` → `longestSharedRun` reports `DuplicationFinding.line` / `sourceLine` off by one for any run following such a line, and a copy-pasted run that starts with a `++`-line can be missed.

**Fix:** remove the redundant `+++` skip so `+++…` lines fall through to the normal `+` handling (normalized and counted). Headers remain handled by the `!inHunk` guard.

Note: this is the only analyzer where the `+++` skip is redundant — the others (`secret-scan`, `redos`, etc.) don't track `inHunk` and use the marker to skip preamble headers, so they have a different structure and are out of scope here.

**No linked issue:** small, self-contained diff-parsing fix in one helper; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment run build` (tsc clean)
- [x] `npm --prefix review-enrichment run test` — the `duplication-scan` suite passes (36 tests) with a new regression test asserting an added `++counterValueForLoop;` line is kept and the block's line numbers stay `[10, 11, 12]` (not `[10, 11]`). The test was confirmed to FAIL against the unpatched code (the line was dropped and numbers shifted).
- [x] New/changed behavior has a regression test

If any required check was skipped, explain why:

- The change is one branch in a pure helper in `review-enrichment/src`; it adds/changes no analyzer, so `analyzer-metadata.json` is unaffected. Codecov's `src/**` patch gate does not apply to `review-enrichment/**`; this package's own `node --test` suite covers it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal diff parsing only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `extractAddedBlocks("@@ -1,0 +10,3 @@\n+++counterValueForLoop;\n+const secondSignificantLineHere = makeValue(2)\n+const thirdSignificantLineHere = makeValue(3)")` previously returned one block with `lineNos [10, 11]` (the `++` line dropped, following lines shifted); it now returns `lineNos [10, 11, 12]` with all three lines.
