### PR TITLE
refactor(selfhost): remove or wire the dead checkAndMarkDelivery helper

### DIFF
--- a/src/selfhost/redis-cache.ts
+++ b/src/selfhost/redis-cache.ts
@@ -27,21 +27,3 @@ export function createRedisCache(redis: Redis) {
 }
 
 export type RedisCache = ReturnType<typeof createRedisCache>;
-
-/**
- * Idempotency check for GitHub webhook deliveries. Returns true if the delivery was
- * already seen (caller should short-circuit with 204). Marks the delivery as seen
- * for `ttlSeconds` (default 5 min — covers GitHub's retry window) on the FIRST call.
- * Best-effort: a Redis error is swallowed to avoid blocking webhook processing.
- */
-export async function checkAndMarkDelivery(cache: RedisCache, deliveryId: string, ttlSeconds = 300): Promise<boolean> {
-  try {
-    const seen = await cache.get(`delivery:${deliveryId}`);
-    if (seen) return true;
-    await cache.set(`delivery:${deliveryId}`, "1", ttlSeconds);
-    return false;
-  } catch {
-    // Redis unavailable → treat as first-time (never block processing on cache failure)
-    return false;
-  }
-}

--- a/test/unit/selfhost-redis-cache.test.ts
+++ b/test/unit/selfhost-redis-cache.test.ts
@@ -1,6 +1,6 @@
 import type { Redis } from "ioredis";
 import { describe, expect, it } from "vitest";
-import { checkAndMarkDelivery, createRedisCache } from "../../src/selfhost/redis-cache";
+import { createRedisCache } from "../../src/selfhost/redis-cache";
 
 /** Minimal in-memory stand-in for the ioredis methods the cache uses. Emulates real Redis SET NX
  *  semantics (refuse + return null when NX is requested and the key already exists) so a test
@@ -62,40 +62,5 @@ describe("createRedisCache (#1216 webhook dedup cache)", () => {
     const brokenRedis = { async set() { throw new Error("connection refused"); } } as unknown as Redis;
     const cache = createRedisCache(brokenRedis);
     await expect(cache.claim("lock", "1", 60)).rejects.toThrow("connection refused");
-  });
-});
-
-describe("checkAndMarkDelivery (#1216 webhook idempotency)", () => {
-  it("returns false (first-time) for a new delivery ID and marks it as seen", async () => {
-    const cache = createRedisCache(fakeRedis());
-    const result = await checkAndMarkDelivery(cache, "delivery-abc", 300);
-    expect(result).toBe(false);
-    // second call with the same ID should be a duplicate
-    const duplicate = await checkAndMarkDelivery(cache, "delivery-abc", 300);
-    expect(duplicate).toBe(true);
-  });
-
-  it("returns true (duplicate) for an already-seen delivery ID", async () => {
-    const r = fakeRedis();
-    r._store.set("delivery:existing-id", "1");
-    const cache = createRedisCache(r);
-    expect(await checkAndMarkDelivery(cache, "existing-id")).toBe(true);
-  });
-
-  it("different delivery IDs are tracked independently", async () => {
-    const cache = createRedisCache(fakeRedis());
-    expect(await checkAndMarkDelivery(cache, "id-A")).toBe(false);
-    expect(await checkAndMarkDelivery(cache, "id-B")).toBe(false); // different ID → first-time
-    expect(await checkAndMarkDelivery(cache, "id-A")).toBe(true);  // id-A seen before
-  });
-
-  it("swallows Redis errors and returns false (never blocks processing)", async () => {
-    const brokenRedis = {
-      async get() { throw new Error("connection refused"); },
-      async set() { throw new Error("connection refused"); },
-    } as unknown as Redis;
-    const cache = createRedisCache(brokenRedis);
-    // Must not throw — error is swallowed, returns false (first-time / let it through)
-    expect(await checkAndMarkDelivery(cache, "any-id")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `checkAndMarkDelivery` (the documented webhook-delivery-dedup helper in `src/selfhost/redis-cache.ts`) was exported but never called anywhere in `src/`. The real webhook dedup path in `src/server.ts` implements its own get-then-set inline instead, duplicating the same logic with a deliberate and **correct** mark-after-success ordering difference: it marks a delivery ID as seen only once the response is confirmed `ok`, so a failed/rejected webhook stays retryable.
- `checkAndMarkDelivery` marked as seen on the FIRST call regardless of outcome — a real (if unreachable, since it had zero call sites) bug: had anything called it, it would have incorrectly suppressed GitHub's retry of a webhook whose processing actually failed.
- Deleted it rather than refactoring `server.ts` to call it: the inline version is already correct and live, and fixing `checkAndMarkDelivery`'s mark-timing to match it first (per the issue's option 2) would be strictly more code for no behavior change, when option 1 is the smaller, safer change.
- Removed its now-unreachable test suite (`test/unit/selfhost-redis-cache.test.ts`); the still-live `createRedisCache` coverage (`get`/`set`/`del`/`claim`) is untouched and stays at 100%.

Closes #2506.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; `codecov/patch` requires ≥99% coverage of the lines AND branches you changed (aim for 100% on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. (A pure deletion — `createRedisCache` stays at 100%.)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, webhook dedup behavior is unchanged (the live inline implementation is untouched).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.