### PR TITLE
fix(selfhost): wire or remove the dead gittensory_jobs_deferred_total metric

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -525,7 +525,6 @@ async function main(): Promise<void> {
     "gittensory_jobs_dead_total",
     "gittensory_jobs_rate_limited_total",
     "gittensory_jobs_rate_limit_deferred_total",
-    "gittensory_jobs_deferred_total",
     "gittensory_jobs_coalesced_total",
     "gittensory_jobs_recovered_total",
   ]) {

--- a/test/unit/server-persisted-job-metrics.test.ts
+++ b/test/unit/server-persisted-job-metrics.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+// Regression for #2508: gittensory_jobs_deferred_total was registered as a persisted gauge in server.ts
+// but no queue driver ever called recordQueueMetric with that name -- dead instrumentation that always
+// reported 0. Pin the invariant the fix establishes: every metric name in server.ts's persisted-gauge list
+// must have a real recordQueueMetric call site in BOTH queue drivers, so a future dead entry can't sneak
+// back in the same way. Source-text assertions, not a runtime harness: server.ts has no test harness
+// (it's Codecov-ignored) and this is a static wiring invariant, not runtime behavior.
+describe("server.ts persisted job-queue metrics (#2508)", () => {
+  it("registers only metric names both sqlite-queue.ts and pg-queue.ts actually record", () => {
+    const server = read("src/server.ts");
+    const sqliteQueue = read("src/selfhost/sqlite-queue.ts");
+    const pgQueue = read("src/selfhost/pg-queue.ts");
+
+    const listMatch = server.match(
+      /const durableJobMetric[\s\S]*?for \(const name of \[([\s\S]*?)\]\) \{/,
+    );
+    expect(listMatch, "persisted-gauge metric list not found in server.ts").not.toBeNull();
+    const registered = [...listMatch![1]!.matchAll(/"([a-z_]+)"/g)].map((m) => m[1]!);
+    expect(registered.length).toBeGreaterThan(0);
+
+    for (const name of registered) {
+      const callSite = `recordQueueMetric(driver, "${name}"`;
+      expect(sqliteQueue.includes(callSite), `sqlite-queue.ts never calls recordQueueMetric for "${name}"`).toBe(true);
+      expect(pgQueue.includes(`recordQueueMetric("${name}"`), `pg-queue.ts never calls recordQueueMetric for "${name}"`).toBe(true);
+    }
+
+    expect(registered).not.toContain("gittensory_jobs_deferred_total");
+  });
+});


### PR DESCRIPTION
## Summary

- `gittensory_jobs_deferred_total` was registered as a persisted gauge in `src/server.ts` (reading `backend.queue.stats()["gittensory_jobs_deferred_total"]`), but no code path in `sqlite-queue.ts` or `pg-queue.ts` ever calls `recordQueueMetric(driver, "gittensory_jobs_deferred_total", ...)` — confirmed both queue drivers only ever record `enqueued/processed/failed/dead/rate_limited/rate_limit_deferred/coalesced/recovered`, never a bare `deferred`. Dead instrumentation that always reports 0, giving a false sense that no deferrals are happening.
- The similarly-named (and actually incremented) `gittensory_jobs_rate_limit_deferred_total` / `gittensory_jobs_rate_limit_admission_deferred_total` / `gittensory_jobs_rate_limit_budget_deferred_total` exist and ARE recorded, so this reads as a leftover/renamed metric from an earlier iteration rather than something intentionally deferred.
- Confirmed no self-host Grafana dashboard JSON references this metric name (`grep -rn "gittensory_jobs_deferred_total"` across the repo only matched the one dead registration), so removed the registration rather than inventing new call sites for a metric name nothing currently depends on.

Closes #2508.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `src/server.ts` is Codecov-ignored, so this one-line removal carries no patch coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, a pure removal with no behavior change to verify.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, internal metrics registration only.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.