### PR TITLE
ci: route the security dependency-review job off the self-hosted runner pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
   # On push to main everything runs regardless (keeps the coverage baseline solid).
   changes:
     name: changes
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
+    # Just actions/checkout + git diff --check + dorny/paths-filter -- no build/test work, and it runs FIRST
+    # to decide whether validate-code needs to run at all, so gating it behind the same contended self-hosted
+    # queue it's meant to protect was circular (#2507).
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -364,7 +367,10 @@ jobs:
   security:
     name: security
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
+    # actions/dependency-review-action needs no self-hosted toolchain/cache (checkout + a lockfile diff), so
+    # this always runs on ubuntu-latest -- keeping it self-hosted for same-repo PRs only competed for the
+    # scarce self-hosted pool with validate-code, the one job that actually benefits from it (#2501).
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -386,7 +392,9 @@ jobs:
     name: validate
     needs: [changes, validate-code, security]
     if: ${{ always() }}
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true) && '["ubuntu-latest"]' || '["self-hosted","gittensory"]') }}
+    # Pure result-aggregation (reads needs.*.result, echoes pass/fail) -- no build/test work, so it never
+    # needed the self-hosted pool's cached toolchain (#2507).
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: All required jobs passed

--- a/test/unit/workflow-runner-labels.test.ts
+++ b/test/unit/workflow-runner-labels.test.ts
@@ -4,12 +4,16 @@ import { describe, expect, it } from "vitest";
 const read = (path: string) => readFileSync(path, "utf8");
 
 describe("workflow runner labels", () => {
-  it("keeps trusted CI jobs on the gittensory runner pool and fork PRs on GitHub-hosted runners", () => {
+  it("keeps only the build/test job on the gittensory runner pool; non-build jobs run on GitHub-hosted runners", () => {
     const workflow = read(".github/workflows/ci.yml");
     const trustedRunnerExpression =
       '${{ fromJSON((github.event_name == \'pull_request\' && github.event.pull_request.head.repo.fork == true) && \'["ubuntu-latest"]\' || \'["self-hosted","gittensory"]\') }}';
 
-    expect(workflow.match(new RegExp(escapeRegExp(trustedRunnerExpression), "g")) ?? []).toHaveLength(4);
+    // Only validate-code (the npm/build/test job that benefits from the self-hosted VPS's cached toolchain)
+    // stays on the fork-aware trusted-pool expression. changes/security/validate do no build/test work, so
+    // they're unconditionally ubuntu-latest -- fanning them out to self-hosted only competed with
+    // validate-code for the same scarce runner pool (#2501, #2507).
+    expect(workflow.match(new RegExp(escapeRegExp(trustedRunnerExpression), "g")) ?? []).toHaveLength(1);
     expect(workflow).toContain("validate-code:");
     expect(workflow).toContain("needs: [changes, validate-code, security]");
     expect(workflow).not.toContain("\n  lint:\n");
@@ -20,6 +24,13 @@ describe("workflow runner labels", () => {
     expect(workflow).not.toContain("\n  ui:\n");
     expect(workflow).not.toContain("|| 'self-hosted'");
     expect(workflow).not.toContain('"fork-ci"');
+
+    const changesJob = workflow.slice(workflow.indexOf("\n  changes:\n"), workflow.indexOf("\n  validate-code:\n"));
+    expect(changesJob).toContain("runs-on: ubuntu-latest");
+    const securityJob = workflow.slice(workflow.indexOf("\n  security:\n"), workflow.indexOf("\n  validate:\n"));
+    expect(securityJob).toContain("runs-on: ubuntu-latest");
+    const validateJob = workflow.slice(workflow.indexOf("\n  validate:\n"));
+    expect(validateJob).toContain("runs-on: ubuntu-latest");
   });
 
   it("keeps scheduled audit work on the trusted self-hosted pool", () => {


### PR DESCRIPTION
## Summary

- `changes`, `security`, and `validate` in `.github/workflows/ci.yml` all used the same fork-aware `self-hosted`/`ubuntu-latest` `runs-on` expression as `validate-code`, even though none of them do any build/test work that benefits from the self-hosted VPS's cached toolchain.
- `changes` is just `actions/checkout` + `git diff --check` + `dorny/paths-filter`. It runs FIRST and its own output decides whether `validate-code` needs to run at all, so gating it behind the same contended self-hosted queue it's meant to protect was circular — a busy self-hosted pool delayed even discovering that a doc-only PR needed no heavy job.
- `security` (`actions/dependency-review-action`) needs no self-hosted capability — just checkout + a lockfile diff.
- `validate` only reads `needs.*.result` and echoes a pass/fail message (2-minute timeout).
- A single same-repo PR was consuming 4 self-hosted runner slots (these three plus `validate-code`) when only `validate-code` actually needed one, directly contradicting `validate-code`'s own comment about keeping CI to one runner slot per PR instead of fanning out into competing installs on the same VPS. Observed this firsthand while pushing this batch's other PRs — several sat `pending` on `changes`/`security` for extended periods purely from self-hosted queue contention, exactly the failure mode this fixes.
- Routed all three unconditionally to `ubuntu-latest`; `validate-code` keeps the fork-aware self-hosted/ubuntu-latest expression unchanged.
- Updated `test/unit/workflow-runner-labels.test.ts`, which asserted the exact count (4) of trusted-runner expressions in `ci.yml` and now expects 1 (`validate-code` only), plus new assertions that the three routed jobs are unconditionally `ubuntu-latest`.

Closes #2501. Closes #2507.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a `.github/workflows/**`/`test/**` change with no `src/**` lines, so it carries no Codecov patch obligation; the updated workflow-structure assertions pass.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.
- Touches `.github/workflows/**`, a guarded path — expect this to be held for owner review rather than auto-merged, which is fine since I'm the repo owner.