### PR TITLE
ci(selfhost): add a concurrency cancel-in-progress group to selfhost.yml

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -38,6 +38,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Same push/pr split as ci.yml's group, and for the same reason: pull requests stay in one ref-scoped
+  # group so newer commits cancel superseded PR runs (this job boots a Postgres service container, does a
+  # full npm ci, builds the self-host bundle, and runs two docker buildx builds plus a boot smoke test --
+  # letting a superseded push run to completion wastes real minutes). github.sha for push runs keeps
+  # distinct main commits from cancelling each other's validation.
+  group: selfhost-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}
+  # NB: keep this a literal boolean, not an expression — see ci.yml for why (startup_failure).
+  cancel-in-progress: true
+
 jobs:
   build-boot:
     name: build + boot smoke test

--- a/test/unit/workflow-runner-labels.test.ts
+++ b/test/unit/workflow-runner-labels.test.ts
@@ -39,6 +39,20 @@ describe("workflow runner labels", () => {
     expect(workflow).toContain("runs-on: [self-hosted, gittensory]");
     expect(workflow).not.toContain("|| 'self-hosted'");
   });
+
+  it("cancels a superseded selfhost.yml run instead of letting it run to completion (#2496)", () => {
+    const workflow = read(".github/workflows/selfhost.yml");
+
+    // Same push/pr split as ci.yml's own group, for the same reason: distinct main-branch pushes must not
+    // cancel each other's validation, only a superseded run on the SAME ref/PR should be cancelled.
+    expect(workflow).toContain(
+      "group: selfhost-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}",
+    );
+    expect(workflow).toContain("cancel-in-progress: true");
+    // Must be a literal boolean, not an expression -- ci.yml's own comment documents that an expression here
+    // causes GitHub to fail the workflow at startup (startup_failure).
+    expect(workflow).not.toMatch(/cancel-in-progress:\s*\$\{\{/);
+  });
 });
 
 function escapeRegExp(value: string): string {


### PR DESCRIPTION
## Summary

- `.github/workflows/selfhost.yml` had no `concurrency:` group, so superseded runs on the same PR/branch were never cancelled and all ran to completion — unlike `ci.yml` (lines 12–18) and `upstream-contract.yml` (lines 11–13), which both already have `cancel-in-progress: true`.
- Each run spins up a Postgres service container, does a full `npm ci --ignore-scripts`, runs a Postgres integration test, builds the self-host bundle, and does two `docker buildx build` invocations plus a container boot/smoke test inside a 20-minute budget — all wasted work for commits that get immediately superseded by the next push.
- Added the same push/pr-split concurrency group `ci.yml` uses: `selfhost-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}`, so distinct main-branch pushes don't cancel each other's validation (only a superseded run on the *same* ref/PR does), and kept `cancel-in-progress` a literal boolean per `ci.yml`'s own documented gotcha (an expression there causes GitHub to fail the workflow at startup with `startup_failure`).

Closes #2496.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a `.github/workflows/**`/`test/**` change with no `src/**` lines, so it carries no Codecov patch obligation; the new workflow-structure assertion passes.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch.
- Touches `.github/workflows/**`, a guarded path — expect this to be held for owner review rather than auto-merged, which is fine since I'm the repo owner.