### PR TITLE
ci(release): cache Docker layers for the release-selfhost multi-arch build

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -167,6 +167,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
+          # Matches selfhost.yml's CI build (same Dockerfile, same default GHA cache scope), so a release
+          # can inherit layers selfhost.yml already built and cached for the identical commit -- without
+          # this, every release rebuilt runtime-base from scratch under QEMU emulation for arm64, the most
+          # expensive leg (#2502).
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Finalize Sentry release
         if: steps.sentry.outputs.enabled == 'true'

--- a/test/unit/release-selfhost-docker-cache.test.ts
+++ b/test/unit/release-selfhost-docker-cache.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("release-selfhost.yml Docker layer caching (#2502)", () => {
+  it("caches the multi-arch build-push-action step via the GHA backend, matching selfhost.yml's CI build", () => {
+    const releaseWorkflow = read(".github/workflows/release-selfhost.yml");
+    const selfhostWorkflow = read(".github/workflows/selfhost.yml");
+
+    const buildStep = releaseWorkflow.slice(
+      releaseWorkflow.indexOf("- name: Build + push (linux/amd64 + linux/arm64)"),
+    );
+    expect(buildStep).toContain("cache-from: type=gha");
+    expect(buildStep).toContain("cache-to: type=gha,mode=max");
+
+    // Neither workflow sets a custom `scope:`, so both land in the GHA cache backend's default scope --
+    // this is what lets the release build inherit layers selfhost.yml's own CI build already cached for
+    // the identical Dockerfile/commit, not just cache across its own releases.
+    expect(buildStep).not.toContain("scope=");
+    expect(selfhostWorkflow).toContain("--cache-from type=gha");
+    expect(selfhostWorkflow).toContain("--cache-to type=gha,mode=max");
+  });
+});


### PR DESCRIPTION
## Summary

- The multi-arch (linux/amd64 + linux/arm64, QEMU-emulated) `docker/build-push-action` step in `.github/workflows/release-selfhost.yml` had no `cache-from`/`cache-to`, so every Orb release build was fully cold with zero layer reuse across runs — unlike `selfhost.yml`'s own CI build of the *same* `Dockerfile`, which already sets `--cache-from type=gha --cache-to type=gha,mode=max`.
- Every tagged `orb-v*` release (and every `workflow_dispatch` run) rebuilt the entire image from scratch for both platforms, including the slow `apt-get install ca-certificates` and `npm install -g @anthropic-ai/claude-code @openai/codex` layers in `runtime-base` — especially costly under QEMU emulation for the arm64 leg, and unable to inherit the cache the same-commit `selfhost.yml` CI run already built and pushed to the GHA cache backend.
- Added `cache-from: type=gha` / `cache-to: type=gha,mode=max` to the `build-push-action` step. Neither workflow sets a custom cache `scope:`, so both land in the GHA cache backend's default scope — letting a release build reuse layers from prior releases **and** from `selfhost.yml`'s own build of the identical Dockerfile/commit.

Closes #2502.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a `.github/workflows/**`/`test/**` change with no `src/**` lines, so it carries no Codecov patch obligation; the new workflow-structure assertion passes.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Part of the #1936 self-host beta-stable release readiness batch. Last of the 13 filed sub-issues.
- Touches `.github/workflows/**`, a guarded path — expect this to be held for owner review rather than auto-merged, which is fine since I'm the repo owner.