### PR TITLE
fix(decision): match label history against config labels case-insensitively

### DIFF
--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -616,7 +616,9 @@ function buildContributorDecisionPack(args: {
     ? new Map([...args.issueQualityByRepo.entries()].map(([repoFullName, report]) => [repoFullName.toLowerCase(), report]))
     : new Map<string, IssueQualityReport>();
   const languageSet = new Set((args.profile.github?.topLanguages ?? []).map((language) => language.toLowerCase()));
-  const labelHistory = new Set(args.profile.registeredRepoActivity?.dominantLabels ?? []);
+  // Case-insensitive, mirroring the opportunity engine (signals/engine.ts) and this file's own languageSet:
+  // GitHub labels compare case-insensitively, so a mixed-case dominant label must still overlap a config label.
+  const labelHistory = new Set((args.profile.registeredRepoActivity?.dominantLabels ?? []).map((label) => label.toLowerCase()));
   const roleContexts = registeredRepositories.map((repo) =>
     buildRoleContext({
       login: args.login,
@@ -773,7 +775,7 @@ function buildRepoDecision(args: {
   };
   const labelHistory = args.labelHistory;
   const labelFit = labelHistory
-    ? Object.keys(args.repo.registryConfig?.labelMultipliers ?? {}).filter((label) => labelHistory.has(label))
+    ? Object.keys(args.repo.registryConfig?.labelMultipliers ?? {}).filter((label) => labelHistory.has(label.toLowerCase()))
     : [];
   const copyContext: RepoCopyContext = {
     repoFullName: args.repo.fullName,

--- a/test/unit/decision-pack.test.ts
+++ b/test/unit/decision-pack.test.ts
@@ -1379,6 +1379,43 @@ describe("decision-pack service", () => {
     ).not.toMatch(FORBIDDEN_PUBLIC_TRADEOFF_LANGUAGE);
   });
 
+  it("matches label history against config labels case-insensitively (regression)", () => {
+    // A mixed-case dominant label must overlap a differently-cased config label, mirroring the opportunity
+    // engine and this file's own case-insensitive languageSet. Covers both the built Set and the lookup.
+    const profile = {
+      login: "jsonbored",
+      github: { topLanguages: [] },
+      source: {},
+      gittensor: null,
+      registeredRepoActivity: { reposTouched: ["owner/gfi"], dominantLabels: ["Good First Issue"] },
+      trustSignals: {},
+    } as any;
+    const pack = __decisionPackInternals.buildContributorDecisionPack({
+      login: "jsonbored",
+      profile,
+      outcomeHistory: { login: "jsonbored", totals: {}, repoOutcomes: [], successPatterns: [], failurePatterns: [], summary: "" } as any,
+      repositories: [repoWithLabels("owner/gfi", 0.04, 0, { "good first issue": 1.5 })],
+      syncStates: [],
+      syncSegments: [],
+      totals: [],
+      scoringModelSnapshotId: "scoring-1",
+      contributorPullRequests: [],
+      contributorIssues: [],
+      openPrMonitor: emptyOpenPrMonitor("jsonbored"),
+    });
+    const decision = pack.repoDecisions.find((d) => d.repoFullName === "owner/gfi")!;
+    expect(decision.labelFit).toEqual(["good first issue"]);
+
+    // Direct lookup-side check: a mixed-case config key overlaps a lowercased history entry.
+    const repoDecision = __decisionPackInternals.buildRepoDecision({
+      repo: repoWithLabels("owner/lang", 0.005, 0, { "Good First Issue": 1.5 }),
+      roleContext: { maintainerLane: false } as any,
+      outcome: { openPullRequests: 0, mergedPullRequests: 1, closedPullRequestRate: 0, credibility: 1 } as any,
+      labelHistory: new Set(["good first issue"]),
+    } as any);
+    expect(repoDecision.labelFit).toEqual(["Good First Issue"]);
+  });
+
   it("covers languageMatch true/false and labelFit empty/non-empty paths", () => {
     const ctx = (overrides: Record<string, unknown> = {}) =>
       __decisionPackInternals.buildRepoDecision({


### PR DESCRIPTION
## Summary

`buildContributorDecisionPack` built its label-history `Set` straight from `registeredRepoActivity.dominantLabels` (raw GitHub casing) and looked up config labels with a raw `.has(label)`:

```ts
// src/services/decision-pack.ts
const labelHistory = new Set(args.profile.registeredRepoActivity?.dominantLabels ?? []); // not lowercased
// ...
Object.keys(args.repo.registryConfig?.labelMultipliers ?? {}).filter((label) => labelHistory.has(label)) // raw
```

The canonical sibling — the opportunity engine — lowercases **both** sides (`src/signals/engine.ts:1385` builds `new Set(dominantLabels.map((l) => l.toLowerCase()))`, queried `labelHistory.has(label.toLowerCase())`), and **this same function's `languageSet` is already case-insensitive** (`:618` build + `:772` `toLowerCase()` lookup). Labels were the local outlier: a mixed-case dominant label (e.g. `"Good first issue"`) never overlapped a differently-cased config label (e.g. `"good first issue"`), so it was silently dropped from the decision-pack's user-facing label-overlap copy ("Label overlap with your history: …", "target labels: …").

Fix: lowercase both the built Set and the config-key lookup, so label overlap is case-insensitive — matching the engine and the `languageSet` handling.

```
dominantLabels ["Good first issue"] + config { "good first issue": 1.5 }
// before: labelFit []          (dropped)
// after:  labelFit ["good first issue"]
```

No issue because issue creation is restricted on this repo for outside accounts; this aligns a duplicated case-insensitive-label-overlap concept with its canonical sibling.

## Scope

- [x] Conventional Commit title; focused; follows CONTRIBUTING; small self-evident fix (no linked issue).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped: `test/unit/decision-pack.test.ts` — 45 pass; both changed lines and their branches are exercised by the added mixed-case regression plus the existing empty/absent cases)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change confined to `src/services/decision-pack.ts`. `typecheck` clean; `decision-pack.test.ts` passes (45), including the added regression that pins case-insensitive label overlap end-to-end (mixed-case dominant label) and on the lookup side (mixed-case config key). I did not run the full UI/workers/MCP steps (unrelated to this diff), and the local Windows tree has pre-existing unrelated failures (CRLF, missing CLI binaries, Node 24 vs pinned 22). CI runs the full matrix on a clean checkout.

## Safety

- [x] No secrets/wallets/hotkeys/trust/reward/private terms exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth/cookie/CORS/session negative-path tests. — N/A: no such changes.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. (No such surface changed; internal decision-pack copy only.)
- [ ] UI changes use live API data. — N/A: no UI change.
- [ ] UI Evidence. — N/A: no visible UI change.
- [x] Docs/changelog updated where needed. (None needed.)

## Notes

- The engine (`signals/engine.ts`) already lowercases label history for its opportunity `labelFit`; this brings the decision-pack path to the same case-insensitive behavior, so the two surfaces agree.
- No UI Evidence section: there is no visible UI, frontend, docs, or extension change.
