### PR TITLE
fix(github): avoid replaying truncated page resumes

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3232,16 +3232,13 @@ async function githubPaged<T>(
       lastModified = result.lastModified ?? lastModified;
       lastCursor = String(page);
       pageCount += 1;
-      const remaining = limit - items.length;
-      // A page can only overrun `remaining` once we have already consumed at least one full page (so `page`
-      // has advanced past the crawl's start): resume from THIS page to pick up its unconsumed tail. On the
-      // first page `remaining >= perPage >= result.data.length`, so this is false and the cursor advances,
-      // which is why a small-`limit` (per_page = limit) crawl can never stall on its own start page.
-      const truncatedPage = result.data.length > remaining;
-      items.push(...result.data.slice(0, remaining));
+      // Resume cursors only have page precision, so keep page consumption atomic: once we request a
+      // page, process the whole response before advancing the cursor. Slicing a mid-page cap would make a
+      // later resume replay the already-consumed prefix of that same page and inflate fetched counts.
+      items.push(...result.data);
       const hasNext = hasNextPage(result.link);
-      if (items.length >= limit && (hasNext || truncatedPage)) {
-        nextCursor = String(truncatedPage ? page : page + 1);
+      if (items.length >= limit && hasNext) {
+        nextCursor = String(page + 1);
         status = "capped";
         warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path}; next page cursor is ${nextCursor}.`);
         break;

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3190,6 +3190,12 @@ async function syncLabels(
   }
 }
 
+/**
+ * `limit` is a page-boundary threshold, not a strict maximum: page consumption is atomic (see the loop body),
+ * so the crawl always finishes the page it's on once `items.length` reaches `limit`, which can return up to
+ * `perPage - 1` more items than requested. Callers that need an exact cap must trim the returned `items`
+ * themselves; `fetchedCount`/`items.length` always reflect the true (possibly over-`limit`) count.
+ */
 async function githubPaged<T>(
   env: Env,
   repo: RepositoryRecord,

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3240,7 +3240,9 @@ async function githubPaged<T>(
       if (items.length >= limit && hasNext) {
         nextCursor = String(page + 1);
         status = "capped";
-        warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path}; next page cursor is ${nextCursor}.`);
+        // `items.length` (not `limit`) is the actual count: page consumption is atomic, so a whole final page
+        // can overrun the requested `limit` — `limit` is a page-boundary threshold, not a strict maximum.
+        warnings.push(`GitHub sync reached local cap of ${limit} item(s) for ${path} (fetched ${items.length} after completing page ${page}); next page cursor is ${nextCursor}.`);
         break;
       }
       if (result.data.length < perPage || !hasNext) break;

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1304,23 +1304,38 @@ describe("GitHub backfill", () => {
     );
   });
 
-  it("resumes from the same page when a cap truncates it mid-page", async () => {
+  it("consumes a whole final page instead of saving a same-page resume cursor", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);
     vi.stubGlobal("fetch", issuesOffsetFetch(200));
 
-    // Cap at 150 against a repo with 200 issues: page 1 (per_page=100) yields 1-100, page 2 yields 101-200
-    // but the cap leaves room for only 50, so page 2 is consumed partway. The resume cursor must point at
-    // page 2 (the partially consumed page), not page 3, so a later run picks up 151-200 rather than skipping
-    // them. All 150 within the cap are stored (a shrinking-per_page crawl would store only 100).
+    // Cap at 150 against a repo with 200 issues: page 1 (per_page=100) yields 1-100, page 2 yields 101-200.
+    // Because the cursor has only page precision, page 2 must be consumed atomically; saving cursor "2" after
+    // only 50 entries would replay issues 101-150 on resume and inflate the persisted fetched count.
     const result = await backfillRegisteredRepositories(env, {
       mode: "full",
       limits: { issues: 150, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
     });
 
-    expect(result.repos[0]).toMatchObject({ openIssues: 150 });
+    expect(result.repos[0]).toMatchObject({ openIssues: 200 });
     expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
-      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "capped", nextCursor: "2" })]),
+      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "complete", fetchedCount: 200, nextCursor: null })]),
+    );
+  });
+
+  it("advances to the next page when a whole-page cap still has more results", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", issuesOffsetFetch(250));
+
+    const result = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: 150, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    expect(result.repos[0]).toMatchObject({ openIssues: 200 });
+    expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "capped", fetchedCount: 200, nextCursor: "3" })]),
     );
   });
 

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1339,6 +1339,34 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("REGRESSION: resuming from a whole-page cap fetches exactly the remaining items, never replaying an already-consumed page", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    vi.stubGlobal("fetch", issuesOffsetFetch(250));
+
+    // First pass caps mid-crawl at cursor "3" (see the previous test) having consumed pages 1-2 (issues 1-200).
+    const first = await backfillRegisteredRepositories(env, {
+      mode: "full",
+      limits: { issues: 150, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+    expect(first.repos[0]).toMatchObject({ openIssues: 200 });
+
+    // Resume: the old (buggy) code saved a SAME-page cursor on a truncated final page, so a resume would
+    // re-fetch that same page and re-count its already-stored prefix, inflating fetchedCount past the true
+    // total. The fix consumes pages atomically and only advances the cursor to the NEXT page, so resuming
+    // must fetch exactly the 50 remaining issues (201-250) and land on the true total with no overcount.
+    const second = await backfillRegisteredRepositories(env, {
+      mode: "resume",
+      force: true,
+      limits: { issues: 100, pullRequests: 0, recentMergedPullRequests: 0, pullRequestDetails: 0 },
+    });
+
+    expect(second.repos[0]).toMatchObject({ openIssues: 250 });
+    expect(await listRepoSyncSegments(env, "JSONbored/gittensory")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ segment: "open_issues", status: "complete", fetchedCount: 250, nextCursor: null })]),
+    );
+  });
+
   it("runs a targeted labels segment refresh", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
### Motivation
- A mid-crawl local cap could slice a partially-fetched GitHub page and record a same-page resume cursor, causing a later resume to re-fetch and reprocess the already-consumed prefix and inflate fetched counts. 
- The change prevents this data-integrity regression by making page consumption atomic so page-precision cursors never point back into an already-processed page.

### Description
- Process each fetched GitHub page atomically instead of slicing a page to the remaining budget so a resumed page cannot replay a consumed prefix.  
- Only set a capped `nextCursor` to the following page when GitHub signals there are more results (`hasNext`), otherwise treat the run as drained/complete.  
- Retain stable `per_page` semantics for the crawl and update pagination regression tests in `test/unit/backfill.test.ts` to cover final-page and mid-cap more-results scenarios.

### Testing
- Ran `npm run typecheck -- --pretty false` and it completed successfully.  
- Ran the targeted unit tests with `npx vitest run test/unit/backfill.test.ts` (scoped patterns and full file runs) and the updated backfill tests passed.  
- Attempted full `npm run test:coverage` and a full-suite coverage run was attempted but encountered long-running/timeout issues in unrelated queue sweep tests in this environment; the scoped backfill coverage run validated the new pagination branches locally.  
- Attempted `npm audit --audit-level=moderate` but the registry returned `403 Forbidden`, so the audit could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46226eabf4832c8b0429e24da40efa)