### PR TITLE
docs(review): document the mixed-files vs manual asymmetry for multi-provider companions

### DIFF
--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -185,6 +185,10 @@ export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceRev
     return { verdict: "close", summary: "A registry submission must not bundle other file changes — resubmit the entry on its own." };
   }
   // A submission scope (entry/provider) always carries a directFile (classifier invariant; see classifyRegistryPrScope).
+  // NOTE the deliberate asymmetry documented on classifyRegistryPrScope's own doc comment: an entry submission
+  // with an ambiguous companion shape (e.g. 2+ provider files riding along) lands HERE as a manual-review HOLD,
+  // not a close — unlike the entry-FREE "2+ provider files" case, which the classifier itself closes outright as
+  // mixed-files, since there's nothing else in that diff worth preserving.
   const directFile = scope.directFile as string;
   const companionProviderFile = scope.providerCompanionFile;
   // Anything besides the direct file must be a companion the classifier already approved: the recognized debut-

--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -718,14 +718,28 @@ export interface RegistryScopeResult {
 /**
  * Generic surface-model scope classifier: in scope when the PR edits exactly ONE entry file (or, entry-free,
  * one flat provider file); the spec's provider + artifact files are allowed companions. A registry-looking
- * submission with too many entry/provider files is malformed and stays in the lane as mixed-files; an unrelated
- * PR with no direct registry files remains not-direct-submission.
+ * submission with too many entry files, OR too many provider files with NO entry file at all, is malformed and
+ * stays in the lane as mixed-files (a hard close — there is no salvageable single submission in the diff at all);
+ * an unrelated PR with no direct registry files remains not-direct-submission.
+ *
+ * DELIBERATE ASYMMETRY: too many provider files ALONGSIDE a single well-formed entry file does NOT hit this early
+ * mixed-files guard, even though it's the same underlying "which provider file is the real companion?" ambiguity
+ * as the entry-free case. That's intentional, not an oversight: with zero entry files there is nothing else in
+ * the diff worth preserving, so a decisive close is correct; with one entry file present, the entry itself may
+ * still be a perfectly legitimate, valid submission — only its companion shape is unclear — so classification
+ * lets it through as "entry-submission", and the orchestrator's own companion-file handling (runSurfaceReview)
+ * routes it to a manual-review HOLD rather than throwing away potentially-good entry content with an outright
+ * close. If a future spec's needs change this trade-off, tighten THIS guard to `entryFiles.length > 1 ||
+ * providerFiles.length > 1` (dropping the `entryFiles.length === 0` qualifier) rather than special-casing it
+ * downstream.
  */
 export function classifyRegistryPrScope(spec: RegistryLaneSpec, changedFiles: string[]): RegistryScopeResult {
   const files = (changedFiles ?? []).map((f) => String(f || "").trim()).filter(Boolean);
   const entryFiles = files.filter((f) => spec.entryFilePattern.test(f));
   const providerFiles = spec.providerFilePattern ? files.filter((f) => spec.providerFilePattern!.test(f)) : [];
-  if (entryFiles.length > 1 || (entryFiles.length === 0 && providerFiles.length > 1)) {
+  const tooManyEntryFiles = entryFiles.length > 1;
+  const tooManyProviderFilesWithNoEntry = entryFiles.length === 0 && providerFiles.length > 1;
+  if (tooManyEntryFiles || tooManyProviderFilesWithNoEntry) {
     return { scope: "mixed-files", directFile: null, isProvider: false, providerCompanionFile: null };
   }
   const isEntryPr = entryFiles.length === 1;

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -208,6 +208,10 @@ describe("runSurfaceReview (deterministic + decisive: merge/close, rarely manual
     expect(r?.verdict).toBe("merge");
   });
 
+  // Deliberate asymmetry (documented on classifyRegistryPrScope's own doc comment in registry-logic.ts): this is
+  // a manual-review HOLD, not a close, unlike the entry-FREE "2+ provider files" case (which IS mixed-files/close
+  // — see content-lane-registry-logic.test.ts) — the entry itself may still be a legitimate submission even when
+  // its companion shape is ambiguous.
   it("does not recognize a companion when more than one provider file rides along an entry — falls back to manual (ambiguous shape)", async () => {
     const calls: string[] = [];
     const r = await runSurfaceReview(METAGRAPHED_LANE_SPEC, {

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -344,6 +344,22 @@ describe("classifyRegistryPrScope (generic surface model, metagraphed spec)", ()
     expect(isRegistrySubmissionScope("not-direct-submission")).toBe(false);
   });
 
+  // DELIBERATE ASYMMETRY (documented on classifyRegistryPrScope's own doc comment): 2+ provider files with NO
+  // entry file present is a hard mixed-files close (nothing else in the diff is worth preserving), but the SAME
+  // "which provider is the real companion?" ambiguity ALONGSIDE a single well-formed entry file is NOT mixed-
+  // files — the entry itself may still be a legitimate submission, so it classifies as entry-submission (the
+  // orchestrator then routes the ambiguous companion shape to a manual-review HOLD rather than an outright close
+  // — see content-lane-orchestrator.test.ts's own coverage of that downstream routing).
+  it("2+ provider companions alongside a single entry file is NOT mixed-files (unlike the entry-free case) — the entry's own scope still resolves", () => {
+    const r = classifyRegistryPrScope(spec, ["registry/subnets/actual.json", "registry/providers/a.json", "registry/providers/b.json"]);
+    expect(r.scope).toBe("entry-submission");
+    expect(r.directFile).toBe("registry/subnets/actual.json");
+  });
+
+  it("2+ provider companions with NO entry file present IS mixed-files (nothing salvageable in the diff at all)", () => {
+    expect(classifyRegistryPrScope(spec, ["registry/providers/a.json", "registry/providers/b.json", "registry/providers/c.json"]).scope).toBe("mixed-files");
+  });
+
   it("tolerates a nullish file list and falsy entries (the ?? [] / || '' guards)", () => {
     expect(classifyRegistryPrScope(spec, undefined as unknown as string[]).scope).toBe("not-direct-submission");
     expect(classifyRegistryPrScope(spec, [null as unknown as string, "registry/subnets/actual.json"]).scope).toBe("entry-submission");


### PR DESCRIPTION
## Summary

`classifyRegistryPrScope`'s early mixed-files guard is:

```ts
if (entryFiles.length > 1 || (entryFiles.length === 0 && providerFiles.length > 1)) {
  return { scope: "mixed-files", ... };
}
```

This only hard-closes 2+ provider files as `mixed-files` when there's **no entry file present**. When exactly one entry file rides alongside 2+ provider companion files, the PR instead falls through to `entry-submission` scope, and `runSurfaceReview` only catches the ambiguous companion shape later as a soft `manual` routing (companion-file-changes review), not a hard close.

This is a pre-existing asymmetry (it predates the registry surface-lane content-lane feature entirely — the guard and the orchestrator's companion loop are both unchanged by this PR) that was flagged as a real inconsistency during a recent adversarial code review of a separate surface-lane bugfix PR.

**Decision: keep the current behavior (manual, not mixed-files/close) — this is a deliberate trade-off, not a bug — and document it clearly + lock it in with regression tests.**

Rationale: with **zero** entry files, there is nothing else in the diff worth preserving if the provider-file shape is ambiguous, so a decisive close is correct. With **one** entry file present, the entry itself may still be a perfectly legitimate, valid submission — only its companion shape is unclear — so holding it for a human via `manual` is safer than throwing away potentially-good entry content with an outright close. Making the two shapes symmetric (i.e. also closing the entry+multi-provider case) would be a real behavior change with no clear product-safety win, and this PR does not make that call unilaterally.

### What changed

- `classifyRegistryPrScope`'s doc comment now explicitly states the two mixed-files conditions and calls out the asymmetry by name (`DELIBERATE ASYMMETRY`), including how to tighten it later (`entryFiles.length > 1 || providerFiles.length > 1`, dropping the `entryFiles.length === 0` qualifier) if a future spec's needs change this trade-off.
- The guard itself is refactored into two named booleans (`tooManyEntryFiles`, `tooManyProviderFilesWithNoEntry`) so the asymmetry is visible in the code, not just the comment.
- `runSurfaceReview`'s companion-file loop gets a cross-referencing comment.
- New regression tests in `test/unit/content-lane-registry-logic.test.ts` and `test/unit/content-lane-orchestrator.test.ts` lock in both sides: entry + 2 provider files → `entry-submission` scope → `manual`; 2+ provider files with no entry → `mixed-files` → `close`.

No runtime behavior changes — this is documentation + naming + regression tests only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue is linked — this is a direct maintainer follow-up from a recent adversarial code review, not tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — both touched `src/**` files (`registry-logic.ts`, `orchestrator.ts`) are 100% line- and branch-covered.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no OpenAPI/MCP surface touched; `ui:openapi:check` confirms no drift.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, backend-only change.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, backend-only, docs/tests-only change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal code comments only, no user-facing docs affected.

## Notes

- This PR is based on `main` and is independent of `#2586` (a separate, in-flight registry surface-lane bugfix PR touching the same two files for unrelated reasons). Expect a rebase on whichever of the two merges second.