### PR TITLE
fix(review): keep close-rate stats from skipping AI review

### DIFF
--- a/src/review/reputation-wire.ts
+++ b/src/review/reputation-wire.ts
@@ -32,11 +32,8 @@ export function isReputationEnabled(env: { GITTENSORY_REVIEW_REPUTATION?: string
 // burstFloor: a submitter who has flooded the project with at least this many submissions while landing
 //   almost none of them is treated as a burst abuser (the #submitter-burst anti-abuse pattern).
 // burstMaxMerged: …and has merged fewer than this many (so a high-volume GOOD contributor is never caught).
-// closeRateFloor: an established submitter (>= burstFloor submissions) whose close-rate is at/above this is
-//   low-reputation regardless of the windowed signal (the all-time aggregate backstop).
 const REPUTATION_BURST_SUBMISSION_FLOOR = 8;
 const REPUTATION_BURST_MAX_MERGED = 1;
-const REPUTATION_CLOSE_RATE_FLOOR = 0.85;
 
 /**
  * Decide whether this submitter's reputation should DOWNGRADE the review to deterministic-only (skip the AI
@@ -44,20 +41,15 @@ const REPUTATION_CLOSE_RATE_FLOOR = 0.85;
  *   • `signal === "low"` — the windowed, quality-weighted reputation signal (genuine recent abuse / serial
  *     quality-failure). Live once the review_targets source lands; "neutral" until then (fail-safe).
  *   • a BURST pattern — many recent submissions, almost none merged (the #submitter-burst anti-abuse signal).
- *   • a high all-time close-rate on an established submitter — the aggregate backstop.
- * A submitter with little history, or a healthy merge record, is NEVER downgraded (returns false).
+ * A submitter with little history, an established merge record, or a non-low windowed signal outside the
+ * burst shape is NEVER downgraded (returns false).
  */
 export function shouldDowngradeToDeterministic(stats: SubmitterStats): boolean {
   if (stats.signal === "low") return true;
   const burst = stats.submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && stats.merged < REPUTATION_BURST_MAX_MERGED;
   if (burst) return true;
-  // The all-time close-rate backstop is INDEPENDENT of the burst pattern (see closeRateFloor above): an
-  // established submitter whose close-rate is at/above the floor is low-reputation regardless of a few merges.
-  // The prior extra `&& merged < REPUTATION_BURST_MAX_MERGED` made this a strict subset of the burst check
-  // above (dead code), so an established submitter with a high close-rate but ≥1 merge was never downgraded.
-  // `closeRate = closed/(merged+closed)`, so `closeRate >= floor` already means the merge record is not
-  // healthy — consistent with "a healthy merge record is NEVER downgraded".
-  if (stats.submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && stats.closeRate >= REPUTATION_CLOSE_RATE_FLOOR) return true;
+  // `submitter_stats` is operator/statistics data and can be influenced by ordinary PR closes, so the
+  // all-time close-rate aggregate must not independently skip AI review for established submitters.
   return false;
 }
 

--- a/test/unit/reputation-wiring.test.ts
+++ b/test/unit/reputation-wiring.test.ts
@@ -75,12 +75,12 @@ describe("shouldDowngradeToDeterministic (pure)", () => {
     // trusted → never downgraded.
     expect(shouldDowngradeToDeterministic({ submissions: 10, merged: 10, closed: 0, manual: 0, closeRate: 0, signal: "trusted" })).toBe(false);
   });
-  it("downgrades an established submitter on a high all-time close-rate even with a few merges (the aggregate backstop)", () => {
-    // >= burstFloor submissions AND closeRate >= floor → low-reputation regardless of a couple of merges. The
-    // burst check above does NOT catch this (merged >= 1), so it is the independent close-rate backstop firing.
-    // closeRate = closed/(merged+closed), so 0.85+ already means the merge record is not healthy.
-    expect(shouldDowngradeToDeterministic({ submissions: 20, merged: 2, closed: 17, manual: 0, closeRate: 17 / 19, signal: "neutral" })).toBe(true);
-    // Just below the close-rate floor → not downgraded on the aggregate alone.
+  it("does not let all-time close-rate independently skip AI review for established submitters", () => {
+    // Regression: all-time submitter_stats are operator/statistics data. A high aggregate close-rate must not
+    // override a neutral or trusted windowed signal once the submitter has an established merge record.
+    expect(shouldDowngradeToDeterministic({ submissions: 20, merged: 2, closed: 17, manual: 0, closeRate: 17 / 19, signal: "neutral" })).toBe(false);
+    expect(shouldDowngradeToDeterministic({ submissions: 34, merged: 5, closed: 29, manual: 0, closeRate: 29 / 34, signal: "trusted" })).toBe(false);
+    // Just below the former close-rate floor → not downgraded on the aggregate alone.
     expect(shouldDowngradeToDeterministic({ submissions: 20, merged: 5, closed: 14, manual: 0, closeRate: 14 / 19, signal: "neutral" })).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent a reputation bypass where an attacker-influenced all-time `submitter_stats.closeRate` could suppress the AI review path for established submitters. 
- The all-time aggregate is operator/statistics data and must not independently route PRs to deterministic-only review when the recent/windowed signal is neutral or trusted.

### Description

- Stop treating the all-time close-rate aggregate as an independent downgrade condition in `shouldDowngradeToDeterministic`; downgrades now only occur for a windowed `signal === "low"` or the burst pattern (`submissions >= REPUTATION_BURST_SUBMISSION_FLOOR && merged < REPUTATION_BURST_MAX_MERGED`).
- Remove the independent close-rate backstop from the reputation wiring and clarify comments that `submitter_stats` is operator-visible statistics, not a standalone signal for skipping AI review. 
- Add/adjust regression assertions in `test/unit/reputation-wiring.test.ts` to ensure neutral/trusted established submitters with high all-time close rates are not downgraded to deterministic-only review.
- Files changed: `src/review/reputation-wire.ts`, `test/unit/reputation-wiring.test.ts`.

### Testing

- Ran the targeted unit suite with `npx vitest run test/unit/reputation-wiring.test.ts` and all tests passed (`17/17`).
- Typechecking with `npm run typecheck` succeeded.
- A scoped coverage run for the updated test file completed and tests passed, but a repository-wide coverage gate was not exercised locally; the full `npm run test:coverage` / `npm run test:ci` flow could not be completed due to environment/network limitations (see notes).
- Attempted `npm run test:ci` was stopped in `actionlint` due to DNS/setup errors in the environment and `npm audit --audit-level=moderate` returned `403 Forbidden` from the registry, so the full CI gate was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4639b2af50832cb88d65bc8edbc7aa)