### PR TITLE
fix(content-lane): canonicalize changed paths when classifying registry PR scope

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -11,6 +11,7 @@
 // used with the taostats/registry identity in the live merge gate), registry dedup keys, freshness,
 // functional-surface probing, and PR scope classification.
 import { isSafeEndpointUrl, isSafeHttpUrl } from "./safe-url";
+import { canonicalize } from "../../signals/change-guardrail";
 
 /** The gate's final verdict vocabulary (reviewbot core/types.ts). */
 export type Verdict = "merge" | "close" | "manual" | "comment" | "ignore";
@@ -735,8 +736,13 @@ export interface RegistryScopeResult {
  */
 export function classifyRegistryPrScope(spec: RegistryLaneSpec, changedFiles: string[]): RegistryScopeResult {
   const files = (changedFiles ?? []).map((f) => String(f || "").trim()).filter(Boolean);
-  const entryFiles = files.filter((f) => spec.entryFilePattern.test(f));
-  const providerFiles = spec.providerFilePattern ? files.filter((f) => spec.providerFilePattern!.test(f)) : [];
+  // globToRegExp compiles the spec patterns against a CANONICALIZED path (lowercased + `./`-stripped + `\`→`/`),
+  // exactly as matchesAny does for guardrails — so match on canonicalize(f), or an uppercase / `./`-prefixed /
+  // `\`-separated changed path silently fails to classify as a registry submission. Keep the ORIGINAL path in the
+  // returned files: directFile/companion flow to case-sensitive content fetches (orchestrator loadFile).
+  const matchesPattern = (pattern: RegExp | undefined, f: string): boolean => pattern?.test(canonicalize(f)) ?? false;
+  const entryFiles = files.filter((f) => matchesPattern(spec.entryFilePattern, f));
+  const providerFiles = files.filter((f) => matchesPattern(spec.providerFilePattern, f));
   const tooManyEntryFiles = entryFiles.length > 1;
   const tooManyProviderFilesWithNoEntry = entryFiles.length === 0 && providerFiles.length > 1;
   if (tooManyEntryFiles || tooManyProviderFilesWithNoEntry) {
@@ -748,7 +754,7 @@ export function classifyRegistryPrScope(spec: RegistryLaneSpec, changedFiles: st
     return { scope: "not-direct-submission", directFile: null, isProvider: false, providerCompanionFile: null };
   }
   const isAllowed = (f: string): boolean =>
-    spec.entryFilePattern.test(f) || (spec.providerFilePattern?.test(f) ?? false) || (spec.artifactPattern?.test(f) ?? false);
+    matchesPattern(spec.entryFilePattern, f) || matchesPattern(spec.providerFilePattern, f) || matchesPattern(spec.artifactPattern, f);
   if (files.some((f) => !isAllowed(f))) {
     return { scope: "mixed-files", directFile: null, isProvider: false, providerCompanionFile: null };
   }

--- a/src/signals/change-guardrail.ts
+++ b/src/signals/change-guardrail.ts
@@ -8,7 +8,7 @@
 // leading `./` or `/`, and case-fold. Mirrors signals/focus-manifest `normalizePathForMatch` — without it a
 // guarded path is evaded with `.github/Workflows/` (capital W), a `./`-prefix, or a `\` separator, turning a
 // mandatory human hold on CI/policy files into an auto-merge.
-function canonicalize(value: string): string {
+export function canonicalize(value: string): string {
   return value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").toLowerCase();
 }
 

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -302,6 +302,21 @@ describe("classifyRegistryPrScope (generic surface model, metagraphed spec)", ()
     expect(r.providerCompanionFile).toBeNull();
   });
 
+  it("matches changed paths against the canonicalized form while preserving the original-case directFile (regression)", () => {
+    // The spec patterns are compiled by globToRegExp against a canonicalized (lowercased, `./`-stripped) path, so
+    // a mixed-case / dot-prefixed changed path must still classify — but directFile keeps original case because it
+    // flows to a case-sensitive content fetch (orchestrator loadFile).
+    const mixed = classifyRegistryPrScope(spec, ["Registry/Subnets/Actual.json"]);
+    expect(mixed.scope).toBe("entry-submission");
+    expect(mixed.directFile).toBe("Registry/Subnets/Actual.json");
+
+    // Entry-only spec (no provider/artifact patterns) still classifies a canonicalized match.
+    const entryOnly = { entryFilePattern: /^data\/[^/]*\.json$/ } as unknown as Parameters<typeof classifyRegistryPrScope>[0];
+    const dotPrefixed = classifyRegistryPrScope(entryOnly, ["./Data/Item.json"]);
+    expect(dotPrefixed.scope).toBe("entry-submission");
+    expect(dotPrefixed.directFile).toBe("./Data/Item.json");
+  });
+
   // Symmetric case explicitly documented: an entry file present alongside a provider file ALWAYS resolves to
   // entry-submission scope with the provider file as its companion — there is no "provider-submission scope with
   // a companion entry file" (the entry file's presence forecloses isProviderPr, which requires zero entry files).


### PR DESCRIPTION
## Summary

`classifyRegistryPrScope` tested the spec's `globToRegExp`-compiled patterns (`entryFilePattern` / `providerFilePattern` / `artifactPattern`) against changed paths that were only `.trim()`ed. `globToRegExp` compiles a glob against a **canonicalized** path (lowercased + `./`-stripped + `\`→`/`) — as its own docstring states, and as `matchesAny` already does for guardrails (`const canonicalPath = canonicalize(path)`). So an **uppercase, `./`-prefixed, or `\`-separated** changed path silently failed to classify as a registry submission, and a genuine entry/provider submission fell out of its content lane (`runSurfaceReview` returns `null`).

Fix: match on `canonicalize(f)` via a small shared helper, exporting `canonicalize` from `change-guardrail.ts`. **Crucially, the returned `directFile` / `providerCompanionFile` keep the ORIGINAL path** (canonicalize is applied only inside `.test()`), because they flow to case-sensitive content fetches (the orchestrator's `loadFile(directFile, …)`) and must not be lowercased.

```
classifyRegistryPrScope(spec, ["Registry/Subnets/Actual.json"])
// before: { scope: "not-direct-submission" }                       (pattern is lowercased; raw path misses)
// after:  { scope: "entry-submission", directFile: "Registry/Subnets/Actual.json" }  (matched; original case kept)
```

No issue because issue creation is restricted on this repo for outside accounts; this aligns the registry scope classifier with `globToRegExp`'s canonicalized-path contract.

## Scope
- [x] Conventional Commit title; focused; follows CONTRIBUTING; small self-evident fix (no linked issue).

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped: `test/unit/content-lane-registry-logic.test.ts` — 133 pass; `registry-logic.ts` at 100% branch coverage. Added a regression for a mixed-case path (original-case `directFile` preserved) and a `./`-prefixed path under an entry-only spec, covering the helper's present/undefined branches.)
- [ ] `npm run test:workers` / `build:mcp` / `ui:*` — unrelated to this backend diff (see note)
- [x] `npm audit --audit-level=moderate`
- [x] New/changed behavior has tests

If any required check was skipped, explain why:
- Backend-only change in `src/review/content-lane/registry-logic.ts` + a one-line export in `src/signals/change-guardrail.ts` (its 19 tests still pass). `typecheck` clean. I did not run the full UI/workers/MCP steps (unrelated), and the local Windows tree has pre-existing unrelated failures (CRLF, missing CLI binaries, Node 24 vs pinned 22). CI runs the full matrix on a clean checkout.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward/private terms exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth/cookie/CORS/session negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. (No such surface changed.)
- [ ] UI changes use live API data. — N/A.
- [ ] UI Evidence. — N/A (no visible UI change).
- [x] Docs/changelog updated where needed. (None needed.)

## Notes
- `matchesAny` (guardrails) and `globToRegExp`'s docstring both establish the canonicalized-path contract; this brings the registry scope classifier onto it. `directFile` staying original-case is verified by the regression so downstream content fetches keep working.
