### PR TITLE
fix(selfhost): guard the dead-letter revive interval against unhandled errors

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -253,6 +253,27 @@ export function createPgQueue(
     return revived;
   }
 
+  /** Wraps reviveDeadLetterJobs() for the setInterval callback below, which has no rejection handler of its
+   *  own -- a transient pool/driver/metric failure here would otherwise surface as an unhandled promise
+   *  rejection and can terminate the process (fatal when SENTRY_DSN is unset, since server.ts only installs
+   *  the handler when Sentry is configured), exactly the failure mode pump()'s own try/catch above guards
+   *  against for the main poll loop. A failed revive tick just waits for the next interval, same as a failed
+   *  poll tick waits for the next poll. */
+  async function reviveDeadLetterJobsSafely(): Promise<void> {
+    try {
+      await reviveDeadLetterJobs();
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_dead_letter_revive_crashed",
+          error: errorMessageWithCause(error),
+        }),
+      );
+      captureError(error, { kind: "queue_dead_letter_revive_crashed" });
+    }
+  }
+
   async function spreadDueJobsOnStartup(): Promise<number> {
     const now = Date.now();
     const res = await pool.query(
@@ -666,7 +687,7 @@ export function createPgQueue(
       // Separate, much slower interval than the poll tick above -- reviving a dead job every second would
       // recreate the retry storm this feature exists to bound. The interval itself is the cooldown between
       // auto-retry rounds for any one job.
-      deadLetterReviveTimer = setInterval(() => void reviveDeadLetterJobs(), queueDeadLetterReviveIntervalMs());
+      deadLetterReviveTimer = setInterval(() => void reviveDeadLetterJobsSafely(), queueDeadLetterReviveIntervalMs());
     },
     async stop() {
       running = false;

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -187,6 +187,26 @@ export function createSqliteQueue(
     return revived;
   }
 
+  /** Wraps reviveDeadLetterJobs() for the setInterval callback below, which has no error handler of its own --
+   *  a transient driver/metric failure here would otherwise surface as an uncaught exception and can terminate
+   *  the process (fatal when SENTRY_DSN is unset, since server.ts only installs the handler when Sentry is
+   *  configured), exactly the failure mode pump()'s own try/catch above guards against for the main poll loop.
+   *  A failed revive tick just waits for the next interval, same as a failed poll tick waits for the next poll. */
+  function reviveDeadLetterJobsSafely(): void {
+    try {
+      reviveDeadLetterJobs();
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_queue_dead_letter_revive_crashed",
+          error: errorMessageWithCause(error),
+        }),
+      );
+      captureError(error, { kind: "queue_dead_letter_revive_crashed" });
+    }
+  }
+
   function enqueue(message: JobMessage, delaySeconds: number): void {
     const now = Date.now();
     const payload = JSON.stringify(message);
@@ -576,7 +596,7 @@ export function createSqliteQueue(
       // Separate, much slower interval than the poll tick above -- reviving a dead job every second would
       // recreate the retry storm this feature exists to bound. The interval itself is the cooldown between
       // auto-retry rounds for any one job.
-      deadLetterReviveTimer = setInterval(reviveDeadLetterJobs, queueDeadLetterReviveIntervalMs());
+      deadLetterReviveTimer = setInterval(reviveDeadLetterJobsSafely, queueDeadLetterReviveIntervalMs());
     },
     async stop() {
       running = false;

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1006,6 +1006,32 @@ describe("createPgQueue (durable #977)", () => {
       );
       expect(await renderMetrics()).toContain("gittensory_jobs_dead_letter_revived_total 1");
     });
+
+    // REGRESSION (#2581 review defect): the revive interval had no error handler of its own, so a thrown
+    // pool/metric failure on that tick would surface as an unhandled promise rejection and could terminate the
+    // process -- exactly the failure mode pump()'s own try/catch already guards against for the main poll loop.
+    it("survives a reviveDeadLetterJobs() pool failure on the interval tick instead of crashing the process", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      try {
+        const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+          if (String(sql).includes("WHERE status='dead' AND attempts<$1")) throw new Error("connection terminated unexpectedly");
+          return { rows: [], rowCount: 0 };
+        });
+        const pool = { query: fn } as unknown as Pool;
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const q = createPgQueue(pool, async () => undefined, { maxRetries: 1 });
+
+        q.start();
+        await vi.advanceTimersByTimeAsync(1000); // the revive interval fires once
+
+        const logged = errorSpy.mock.calls.map(([line]) => String(line));
+        expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("connection terminated unexpectedly"))).toBe(true);
+        await q.stop();
+      } finally {
+        delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
+      }
+    });
   });
 
   it("reschedules GitHub rate-limit failures without consuming the dead-letter budget", async () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1310,6 +1310,29 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(calls).toBe(1); // the auto-revived job was actually re-attempted
       await q.stop();
     });
+
+    // REGRESSION (#2581 review defect): the revive interval had no error handler of its own, so a thrown
+    // driver/metric failure on that tick would surface as an uncaught exception and could terminate the
+    // process -- exactly the failure mode pump()'s own try/catch already guards against for the main poll loop.
+    it("survives a reviveDeadLetterJobs() driver failure on the interval tick instead of crashing the process", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      const driver = makeDriver();
+      const realQuery = driver.query.bind(driver);
+      vi.spyOn(driver, "query").mockImplementation((sql: string, params: unknown[]) => {
+        if (sql.includes("WHERE status='dead' AND attempts<?")) throw new Error("disk I/O error");
+        return realQuery(sql, params);
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const q = createSqliteQueue(driver, async () => undefined, { maxRetries: 1 });
+
+      q.start();
+      await vi.advanceTimersByTimeAsync(1000); // the revive interval fires once -- would throw here if uncaught
+
+      const logged = errorSpy.mock.calls.map(([line]) => String(line));
+      expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("disk I/O error"))).toBe(true);
+      await q.stop();
+    });
   });
 
   it("reschedules GitHub rate-limit failures without consuming the dead-letter budget", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2581 (already merged), which shipped automatic dead-letter job revival for both self-host queue backends. A later review pass on that PR flagged a second real defect that landed after the PR's blocking race-condition issue was already fixed and merged, so this is a fresh PR against current `main` rather than an amendment to the closed one.

**The defect:** both backends scheduled `reviveDeadLetterJobs` directly from `setInterval` with no error handler of its own:

```ts
// pg-queue.ts
deadLetterReviveTimer = setInterval(() => void reviveDeadLetterJobs(), queueDeadLetterReviveIntervalMs());
// sqlite-queue.ts
deadLetterReviveTimer = setInterval(reviveDeadLetterJobs, queueDeadLetterReviveIntervalMs());
```

A transient pool/driver/metric failure on that background tick surfaces as an **unhandled promise rejection** (Postgres — the function is `async` and its rejection is discarded via `void`) or an **uncaught exception** (SQLite — the function is synchronous). Either can terminate the self-host process, turning a feature meant to *bound* retry storms into a process-crash vector of its own.

## What changed

Both backends now wrap the interval callback in a new `reviveDeadLetterJobsSafely()` that mirrors the exact try/catch + structured `console.error` + `captureError` pattern `pump()` already uses for the main poll loop (see `selfhost_queue_pump_crashed` — this fix adds the analogous `selfhost_queue_dead_letter_revive_crashed`). A failed revive tick now just waits for the next interval, same as a failed poll tick waits for the next poll.

The **public** `reviveDeadLetterJobs()` — the one tests and any future operator-triggered repair path call directly — is untouched; only the internal `setInterval` callback is rewired to the safe wrapper, so direct callers still see real errors/rejections if they want to handle them themselves.

## Tests

Added one regression test per backend that injects a pool/driver failure specifically on the revive interval's own tick (via fake timers + `vi.advanceTimersByTimeAsync`) and asserts the process survives and the failure is logged — mirroring the existing `"pump absorbs a ... failure instead of crashing"` tests already in both suites for the main poll loop.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue is linked — this is a direct maintainer follow-up from a review on the now-merged #2581, not tied to a filed issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — both changed `src/**` files (`pg-queue.ts`, `sqlite-queue.ts`) are 100% line-covered; the remaining uncovered branches are pre-existing and unrelated (cross-checked directly against the diff).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no OpenAPI/MCP surface touched; `ui:openapi:check` confirms no drift.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, backend-only change.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, backend-only change.
- [ ] Public docs/changelogs are updated where needed. — N/A, no user-facing docs affected.