### PR TITLE
fix(config): wire badgeEnabled into the .gittensory.yml manifest parser

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -120,6 +120,7 @@ export type FocusManifestSettings = Partial<
     | "aiReviewAllAuthors"
     | "closeOwnerAuthors"
     | "autoLabelEnabled"
+    | "badgeEnabled"
     | "gittensorLabel"
     | "createMissingLabel"
     | "publicSurface"
@@ -773,7 +774,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   if (blacklistLabel !== null) out.blacklistLabel = blacklistLabel;
   const publicSurface = normalizeOptionalEnum(r.publicSurface, "settings.publicSurface", ["off", "comment_and_label", "comment_only", "label_only"] as const, warnings);
   if (publicSurface !== null) out.publicSurface = publicSurface;
-  for (const key of ["aiReviewByok", "aiReviewAllAuthors", "closeOwnerAuthors", "autoLabelEnabled", "createMissingLabel", "includeMaintainerAuthors", "requireLinkedIssue", "backfillEnabled", "privateTrustEnabled", "agentPaused", "agentDryRun"] as const) {
+  for (const key of ["aiReviewByok", "aiReviewAllAuthors", "closeOwnerAuthors", "autoLabelEnabled", "badgeEnabled", "createMissingLabel", "includeMaintainerAuthors", "requireLinkedIssue", "backfillEnabled", "privateTrustEnabled", "agentPaused", "agentDryRun"] as const) {
     const flag = normalizeOptionalBoolean(r[key], `settings.${key}`, warnings);
     if (flag !== null) out[key] = flag;
   }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1426,6 +1426,18 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(eff.linkedIssueGateMode).toBe("block"); // gate: wins over settings:
   });
 
+  it("wires settings.badgeEnabled into the manifest parser and lets it override the DB value (#2555)", () => {
+    const parsedTrue = parseFocusManifest({ settings: { badgeEnabled: true } });
+    expect(parsedTrue.settings.badgeEnabled).toBe(true);
+    expect(parsedTrue.warnings).toEqual([]);
+    const parsedFalse = parseFocusManifest({ settings: { badgeEnabled: false } });
+    expect(parsedFalse.settings.badgeEnabled).toBe(false);
+
+    const db = { badgeEnabled: false } as unknown as RepositorySettings;
+    const eff = resolveEffectiveSettings(db, parseFocusManifest({ settings: { badgeEnabled: true } }));
+    expect(eff.badgeEnabled).toBe(true); // settings: override wins over the DB-stored value
+  });
+
   it("parses aiReview from settings: and lets gate.aiReview win in resolveEffectiveSettings", () => {
     const parsed = parseFocusManifest({ settings: { aiReviewMode: "advisory", aiReviewByok: true } });
     expect(parsed.settings.aiReviewMode).toBe("advisory");


### PR DESCRIPTION
## Summary
- `.gittensory.yml.example` documents `badgeEnabled` under `settings:` as a config-as-code-settable field, and it's fully wired everywhere else (DB column, `RepositorySettings` type, API, the badge consumer itself) — but `FocusManifestSettings`'s `Pick<RepositorySettings, ...>` list and `parseSettingsOverride` in `src/signals/focus-manifest.ts` both omitted it, so a maintainer setting `badgeEnabled` in `.gittensory.yml` had the value silently ignored.

## Scope
- `src/signals/focus-manifest.ts` — added `badgeEnabled` to the `FocusManifestSettings` Pick-list and to the existing boolean-field normalization loop in `parseSettingsOverride`, mirroring `autoLabelEnabled` exactly. `resolveEffectiveSettings` needs no change — it spreads `settings.*` generically, so the field now overrides the DB value automatically.
- `test/unit/focus-manifest.test.ts` — added a regression test proving `.gittensory.yml`'s `badgeEnabled` value actually overrides the DB-stored value.

## Validation
- `npx vitest run test/unit/focus-manifest.test.ts` — 163/163 passing
- `npm run typecheck` — clean
- `npm run test:ci` — full local gate green
- `npm audit --audit-level=moderate` — 0 vulnerabilities

## Safety
- Two-line wiring fix plus one new test; no behavior change for any repo not setting `badgeEnabled` in `.gittensory.yml`.
- Stays within `src/**` and `test/**`.

Closes #2555