### PR TITLE
feat(dlq): add dead-letter job-type breakdown helper

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2238,6 +2238,25 @@ export async function countRecentDeadLetters(env: Env, sinceIso: string): Promis
   return row.count;
 }
 
+/** Observability for the DLQ dashboard (#1208): recent dead letters grouped by job type, using the jobType stored
+ *  in each `github_app.dlq_dead_lettered` audit event's metadata. Missing/blank jobType falls back to `unknown`,
+ *  and the returned object's keys are sorted deterministically for stable consumers/tests. */
+export async function countRecentDeadLettersByType(env: Env, sinceIso: string): Promise<Record<string, number>> {
+  const db = getDb(env.DB);
+  const jobTypeExpr =
+    sql<string>`coalesce(nullif(trim(cast(json_extract(${auditEvents.metadataJson}, '$.jobType') as text)), ''), 'unknown')`;
+  const rows = await db
+    .select({
+      jobType: jobTypeExpr,
+      count: sql<number>`count(*)`,
+    })
+    .from(auditEvents)
+    .where(and(eq(auditEvents.eventType, "github_app.dlq_dead_lettered"), gte(auditEvents.createdAt, sinceIso)))
+    .groupBy(jobTypeExpr)
+    .orderBy(asc(jobTypeExpr));
+  return Object.fromEntries(rows.map((row) => [row.jobType, Number(row.count ?? 0)]));
+}
+
 export type PrVisibilitySkipAuditEvent = {
   repoFullName: string;
   pullNumber: number;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2254,7 +2254,7 @@ export async function countRecentDeadLettersByType(env: Env, sinceIso: string): 
     .where(and(eq(auditEvents.eventType, "github_app.dlq_dead_lettered"), gte(auditEvents.createdAt, sinceIso)))
     .groupBy(jobTypeExpr)
     .orderBy(asc(jobTypeExpr));
-  return Object.fromEntries(rows.map((row) => [row.jobType, Number(row.count ?? 0)]));
+  return Object.fromEntries(rows.map((row) => [row.jobType, Number(row.count)]));
 }
 
 export type PrVisibilitySkipAuditEvent = {

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   claimRegateFanoutSlot,
   countRecentDeadLetters,
+  countRecentDeadLettersByType,
   countRecentAuditEventsForActorAndTarget,
   getLatestScorePreview,
   getRepoAuthorPullRequestHistory,
@@ -371,6 +372,101 @@ describe("database row parser hardening", () => {
     expect(await countRecentDeadLetters(env, "2026-06-24T09:00:00.000Z")).toBe(2); // both dead-letters in window
     expect(await countRecentDeadLetters(env, "2026-06-24T11:00:00.000Z")).toBe(1); // only the 12:00 one
     expect(await countRecentDeadLetters(env, "2026-06-24T13:00:00.000Z")).toBe(0); // none after the cutoff → count(*) returns 0
+  });
+
+  it("countRecentDeadLettersByType groups recent dead letters by job type in deterministic key order (#1208)", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:github-webhook:a",
+      outcome: "error",
+      createdAt: "2026-06-24T12:00:00.000Z",
+      metadata: { jobType: "github-webhook" },
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:backfill-repo-segment:b",
+      outcome: "error",
+      createdAt: "2026-06-24T10:00:00.000Z",
+      metadata: { jobType: "backfill-repo-segment" },
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:github-webhook:c",
+      outcome: "error",
+      createdAt: "2026-06-24T14:00:00.000Z",
+      metadata: { jobType: "github-webhook" },
+    });
+
+    const counts = await countRecentDeadLettersByType(env, "2026-06-24T09:00:00.000Z");
+    expect(counts).toEqual({
+      "backfill-repo-segment": 1,
+      "github-webhook": 2,
+    });
+    expect(Object.keys(counts)).toEqual(["backfill-repo-segment", "github-webhook"]);
+  });
+
+  it("countRecentDeadLettersByType returns a single grouped key when only one job type is present", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:refresh-registry:a",
+      outcome: "error",
+      createdAt: "2026-06-24T10:00:00.000Z",
+      metadata: { jobType: "refresh-registry" },
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:refresh-registry:b",
+      outcome: "error",
+      createdAt: "2026-06-24T11:00:00.000Z",
+      metadata: { jobType: "refresh-registry" },
+    });
+
+    expect(await countRecentDeadLettersByType(env, "2026-06-24T09:00:00.000Z")).toEqual({
+      "refresh-registry": 2,
+    });
+  });
+
+  it("countRecentDeadLettersByType returns an empty object when no recent dead letters exist", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, {
+      eventType: "agent.sweep.regate",
+      actor: "gittensory",
+      targetKey: "owner/repo",
+      outcome: "completed",
+      createdAt: "2026-06-24T12:00:00.000Z",
+    });
+
+    expect(await countRecentDeadLettersByType(env, "2026-06-24T09:00:00.000Z")).toEqual({});
+  });
+
+  it("countRecentDeadLettersByType falls back missing or blank job types to unknown", async () => {
+    const env = createTestEnv();
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:unknown:a",
+      outcome: "error",
+      createdAt: "2026-06-24T10:00:00.000Z",
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:unknown:b",
+      outcome: "error",
+      createdAt: "2026-06-24T11:00:00.000Z",
+      metadata: { jobType: "   " },
+    });
+
+    expect(await countRecentDeadLettersByType(env, "2026-06-24T09:00:00.000Z")).toEqual({
+      unknown: 2,
+    });
   });
 
   it("countRecentAuditEventsForActorAndTarget counts events scoped to ONE actor+eventType+targetKey since a cutoff (#2463)", async () => {

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -436,6 +436,14 @@ describe("database row parser hardening", () => {
   it("countRecentDeadLettersByType returns an empty object when no recent dead letters exist", async () => {
     const env = createTestEnv();
     await recordAuditEvent(env, {
+      eventType: "github_app.dlq_dead_lettered",
+      actor: "gittensory",
+      targetKey: "dlq:github-webhook:stale",
+      outcome: "error",
+      createdAt: "2026-06-24T08:59:59.000Z",
+      metadata: { jobType: "github-webhook" },
+    });
+    await recordAuditEvent(env, {
       eventType: "agent.sweep.regate",
       actor: "gittensory",
       targetKey: "owner/repo",


### PR DESCRIPTION
## Summary

- Add `countRecentDeadLettersByType` beside the existing DLQ counter so the dashboard can aggregate recent dead letters by `jobType`.
- Normalize missing or blank `jobType` metadata to `unknown` and return a deterministically sorted object shape for stable consumers.
- Add unit coverage for multi-type, single-type, empty-window, and unknown-fallback branches.

Closes #2082.
Part of #1208.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` was run end-to-end locally, which executed the lint, coverage, workers, MCP, REES, and UI validation steps above.
- `npx vitest run test/unit/db-parsers.test.ts` was also run while iterating on the new helper and tests.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable; this PR only adds a backend repository helper and unit tests.

## Notes

- The new helper reads `github_app.dlq_dead_lettered` audit metadata, groups by `jobType`, and keeps the key order deterministic with SQL ordering.
- The tests cover the deliverables from #2082 directly: multiple types, single type, empty result, and unknown fallback.
