### PR TITLE
feat(miner): add calibration type scaffold and package build wiring

### DIFF
--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -23,15 +23,25 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "gittensory-miner": "bin/gittensory-miner.js"
   },
   "files": [
     "bin",
+    "dist",
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js"
+    "build": "tsc -p tsconfig.json && node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js",
+    "test": "npm run build && tsc -p tsconfig.test.json && node --test \"dist-test/**/*.test.js\""
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/packages/gittensory-miner/src/calibration/index.ts
+++ b/packages/gittensory-miner/src/calibration/index.ts
@@ -1,0 +1,1 @@
+export * from "./types.js";

--- a/packages/gittensory-miner/src/calibration/types.ts
+++ b/packages/gittensory-miner/src/calibration/types.ts
@@ -1,0 +1,52 @@
+// Shared calibration scaffold for the miner package (#2332). This module is intentionally structural only:
+// follow-up issues add the report builder, prediction ledger, and metrics exporter on top of these shared
+// shapes without re-deciding naming or module boundaries.
+
+/** The deterministic gate verdict a miner predicted for one target. */
+export type PredictedVerdict = "merge" | "close" | "hold";
+
+/** The realized terminal outcome used to grade a prediction. */
+export type ObservedOutcome = "merged" | "closed";
+
+/** One stored prediction to be graded later. `project` mirrors GateEvalRow.project; `targetId` and `headSha`
+ *  keep enough identity to build both per-target ledgers and per-commit reports in follow-up issues. */
+export interface PredictedVerdictRecord {
+  project: string;
+  targetId: string;
+  headSha: string | null;
+  source: string;
+  verdict: PredictedVerdict;
+  predictedAt: string;
+}
+
+/** The realized terminal outcome for a previously predicted target. `headSha` is nullable because the final
+ *  outcome may be known even when the terminal commit SHA is unavailable or not worth persisting. */
+export interface ObservedOutcomeRecord {
+  project: string;
+  targetId: string;
+  headSha: string | null;
+  outcome: ObservedOutcome;
+  observedAt: string;
+}
+
+/** Per-project confusion matrix + precisions for the miner's prediction vs the realized outcome. Field names
+ *  deliberately mirror src/review/parity.ts's GateEvalRow for easy mental mapping without importing app code. */
+export interface CalibrationRow {
+  project: string;
+  wouldMerge: number;
+  mergeConfirmed: number;
+  mergeFalse: number;
+  wouldClose: number;
+  closeConfirmed: number;
+  closeFalse: number;
+  hold: number;
+  decided: number;
+  mergePrecision: number | null;
+  closePrecision: number | null;
+}
+
+/** The miner package's calibration report: per-project rows plus a coarse enough-data flag. */
+export interface CalibrationReport {
+  rows: CalibrationRow[];
+  hasSignal: boolean;
+}

--- a/packages/gittensory-miner/src/index.ts
+++ b/packages/gittensory-miner/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./calibration/index.js";

--- a/packages/gittensory-miner/test/calibration/types.test.ts
+++ b/packages/gittensory-miner/test/calibration/types.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  CalibrationReport,
+  CalibrationRow,
+  ObservedOutcomeRecord,
+  PredictedVerdictRecord,
+} from "../../dist/index.js";
+
+test("calibration scaffold fixtures satisfy the shared miner shapes", () => {
+  const predicted: PredictedVerdictRecord = {
+    project: "octo/demo",
+    targetId: "pr:42",
+    headSha: "abc123",
+    source: "miner-shadow",
+    verdict: "merge",
+    predictedAt: "2026-07-01T00:00:00.000Z",
+  };
+  const observed: ObservedOutcomeRecord = {
+    project: predicted.project,
+    targetId: predicted.targetId,
+    headSha: predicted.headSha,
+    outcome: "merged",
+    observedAt: "2026-07-02T00:00:00.000Z",
+  };
+  const row: CalibrationRow = {
+    project: predicted.project,
+    wouldMerge: 1,
+    mergeConfirmed: 1,
+    mergeFalse: 0,
+    wouldClose: 0,
+    closeConfirmed: 0,
+    closeFalse: 0,
+    hold: 0,
+    decided: 1,
+    mergePrecision: 1,
+    closePrecision: null,
+  };
+  const report: CalibrationReport = {
+    rows: [row],
+    hasSignal: false,
+  };
+
+  assert.equal(observed.outcome, "merged");
+  assert.equal(report.rows[0]?.project, predicted.project);
+  assert.equal(report.rows[0]?.mergeConfirmed, 1);
+});

--- a/packages/gittensory-miner/tsconfig.json
+++ b/packages/gittensory-miner/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [],
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/gittensory-miner/tsconfig.test.json
+++ b/packages/gittensory-miner/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "rootDir": "test",
+    "outDir": "dist-test",
+    "declaration": false,
+    "noEmit": false
+  },
+  "include": ["test"]
+}

--- a/test/unit/gittensory-miner-calibration-scaffold.test.ts
+++ b/test/unit/gittensory-miner-calibration-scaffold.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import minerPkg from "../../packages/gittensory-miner/package.json";
+import type {
+  CalibrationReport,
+  CalibrationRow,
+  ObservedOutcomeRecord,
+  PredictedVerdictRecord,
+} from "../../packages/gittensory-miner/src/index";
+
+describe("gittensory-miner calibration scaffold", () => {
+  it("publishes the calibration types through the built dist entrypoint", () => {
+    expect(minerPkg.main).toBe("dist/index.js");
+    expect(minerPkg.types).toBe("dist/index.d.ts");
+    expect(minerPkg.exports["."]).toEqual({
+      types: "./dist/index.d.ts",
+      default: "./dist/index.js",
+    });
+    expect(minerPkg.files).toEqual(["bin", "dist", "lib"]);
+  });
+
+  it("wires package-local build and test scripts for the scaffold", () => {
+    expect(minerPkg.scripts?.build).toBe(
+      "tsc -p tsconfig.json && node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js",
+    );
+    expect(minerPkg.scripts?.test).toBe(
+      "npm run build && tsc -p tsconfig.test.json && node --test \"dist-test/**/*.test.js\"",
+    );
+  });
+
+  it("keeps minimal fixtures aligned with the shared calibration shapes", () => {
+    const predicted: PredictedVerdictRecord = {
+      project: "octo/demo",
+      targetId: "pr:42",
+      headSha: "abc123",
+      source: "miner-shadow",
+      verdict: "merge",
+      predictedAt: "2026-07-01T00:00:00.000Z",
+    };
+    const observed: ObservedOutcomeRecord = {
+      project: predicted.project,
+      targetId: predicted.targetId,
+      headSha: predicted.headSha,
+      outcome: "merged",
+      observedAt: "2026-07-02T00:00:00.000Z",
+    };
+    const row: CalibrationRow = {
+      project: predicted.project,
+      wouldMerge: 1,
+      mergeConfirmed: 1,
+      mergeFalse: 0,
+      wouldClose: 0,
+      closeConfirmed: 0,
+      closeFalse: 0,
+      hold: 0,
+      decided: 1,
+      mergePrecision: 1,
+      closePrecision: null,
+    };
+    const report: CalibrationReport = {
+      rows: [row],
+      hasSignal: false,
+    };
+
+    expect(observed.outcome).toBe("merged");
+    expect(report.rows[0]).toMatchObject({
+      project: "octo/demo",
+      mergeConfirmed: 1,
+      wouldMerge: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a minimal TypeScript calibration scaffold to `@jsonbored/gittensory-miner` so follow-up miner calibration work has a stable exported package surface.
- Export shared calibration record/report types from a new `src/calibration` subtree, aligned with the existing gate parity field shape.
- Wire the miner package for TS build output and package-local testing, and add regression coverage for the scaffold contract.

Closes #2332.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable. This PR does not introduce visible UI, frontend, docs, or extension changes.

## Notes

- `packages/gittensory-miner` previously had no exported TS calibration surface, no `src/` subtree, and no package-local scaffold test coverage.
- This PR keeps behavior intentionally minimal: it adds the shared types, package wiring, and regression tests without introducing premature calibration logic.
- Added package-local validation with `npm --workspace @jsonbored/gittensory-miner run test` in addition to the repo gate.
