### PR TITLE
fix(rees): dont report an ambiguous OSV "fixed in" version

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -167,15 +167,21 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
         : "low";
 }
 
-function fixedOf(vuln: OsvVuln): string | null {
+export function fixedOf(vuln: OsvVuln): string | null {
+  const fixes = new Set<string>();
   for (const affected of vuln.affected ?? []) {
     for (const range of affected.ranges ?? []) {
       for (const event of range.events ?? []) {
-        if (event.fixed) return event.fixed;
+        if (event.fixed) fixes.add(event.fixed);
       }
     }
   }
-  return null;
+  // Report a fixed version only when it is UNAMBIGUOUS. A CVE with multiple version-lines patched separately
+  // (e.g. fixed in `1.5.0` for the 1.x line AND `2.3.0` for the 2.x line) exposes more than one `fixed` version;
+  // returning the first would tell a 2.x user to "upgrade" to `1.5.0`, which does not fix their line. Without
+  // per-range version matching we cannot pick the right one, so report none rather than a wrong remediation.
+  const list = [...fixes];
+  return list.length === 1 ? list[0]! : null;
 }
 
 function mapOsvVulns(vulns: OsvVuln[] | undefined): Cve[] {

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -79,15 +79,21 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
         : "low";
 }
 
-function fixedOf(vuln: OsvVuln): string | null {
+export function fixedOf(vuln: OsvVuln): string | null {
+  const fixes = new Set<string>();
   for (const affected of vuln.affected ?? []) {
     for (const range of affected.ranges ?? []) {
       for (const event of range.events ?? []) {
-        if (event.fixed) return event.fixed;
+        if (event.fixed) fixes.add(event.fixed);
       }
     }
   }
-  return null;
+  // Report a fixed version only when it is UNAMBIGUOUS. A CVE with multiple version-lines patched separately
+  // (e.g. fixed in `1.5.0` for the 1.x line AND `2.3.0` for the 2.x line) exposes more than one `fixed` version;
+  // returning the first would tell a 2.x user to "upgrade" to `1.5.0`, which does not fix their line. Without
+  // per-range version matching we cannot pick the right one, so report none rather than a wrong remediation.
+  const list = [...fixes];
+  return list.length === 1 ? list[0]! : null;
 }
 
 function toCves(vulns: OsvVuln[] | undefined): Cve[] {

--- a/review-enrichment/test/osv-fixed-version.test.ts
+++ b/review-enrichment/test/osv-fixed-version.test.ts
@@ -1,0 +1,32 @@
+// Units for the OSV "fixed in X" remediation version reported by the dependency-scan and lockfile-drift
+// analyzers. Own file so concurrent analyzer PRs don't collide. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fixedOf as fixedOfLockfile } from "../dist/analyzers/lockfile-drift.js";
+import { fixedOf as fixedOfDependency } from "../dist/analyzers/dependency-scan.js";
+
+// The bug fix is identical in both analyzers, so assert the same contract against each exported helper.
+for (const [name, fixedOf] of [
+  ["lockfile-drift", fixedOfLockfile],
+  ["dependency-scan", fixedOfDependency],
+] as const) {
+  test(`${name} fixedOf: reports a single unambiguous fix, null when a CVE lists multiple version-line fixes`, () => {
+    // One affected range with one fix → report it (the common single-line CVE).
+    assert.equal(fixedOf({ id: "GHSA-1", affected: [{ ranges: [{ events: [{ fixed: "1.5.0" }] }] }] }), "1.5.0");
+    // The SAME fixed version appearing in two ranges is still unambiguous → report it.
+    assert.equal(
+      fixedOf({ id: "GHSA-2", affected: [{ ranges: [{ events: [{ fixed: "2.3.0" }] }] }, { ranges: [{ events: [{ fixed: "2.3.0" }] }] }] }),
+      "2.3.0",
+    );
+    // Two DIFFERENT fixes across version lines (a CVE patched separately per major) → ambiguous → null, NOT the
+    // first fix "1.5.0" (which would tell a 2.x user to downgrade to a version that doesn't fix their line).
+    assert.equal(
+      fixedOf({ id: "GHSA-3", affected: [{ ranges: [{ events: [{ fixed: "1.5.0" }] }] }, { ranges: [{ events: [{ fixed: "2.3.0" }] }] }] }),
+      null,
+    );
+    // No fix advertised → null.
+    assert.equal(fixedOf({ id: "GHSA-4", affected: [{ ranges: [{ events: [{}] }] }] }), null);
+    // Empty / missing affected → null.
+    assert.equal(fixedOf({ id: "GHSA-5" }), null);
+  });
+}


### PR DESCRIPTION
## Summary

The `dependency-scan` and `lockfile-drift` analyzers report each CVE's remediation version as `Cve.fixedIn` ("fixed in X"), computed by `fixedOf(vuln)`. It walked the OSV record's `affected[].ranges[].events[]` and returned the **first** `fixed` event it found — ignoring which affected version-line the queried dependency actually belongs to.

For a CVE that is patched **separately per major** — e.g. `fixed: 1.5.0` for the `0.x–1.x` line **and** `fixed: 2.3.0` for the `2.x` line — a maintainer on `2.0.0` was told to "upgrade to **1.5.0**", i.e. to *downgrade* to a version that does not fix their line. Since `fixedOf` is called from `toCves`/`mapOsvVulns` with no queried version in scope, it can't match the version to a range.

**Fix (conservative + correct):** collect the distinct `fixed` versions and report one **only when it is unambiguous** — a single distinct fix across all ranges. When a CVE lists more than one fixed version, return `null` (no "fixed in" shown) rather than an arbitrary, possibly-wrong one. This never names a version that doesn't fix the queried line; the common single-line CVE is unchanged. Applied identically to both analyzers, and `fixedOf` is exported for direct unit testing (matching the file's existing `export`ed helpers).

**No linked issue:** small, self-contained correctness fix to a pure helper in two analyzers; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment run build` (tsc clean)
- [x] `npm --prefix review-enrichment run test` — the full suite passes (393/393 excluding two **pre-existing, environment-only** `upload-sourcemaps` failures that require `sentry-cli` and also fail on unmodified `main`). A new `test/osv-fixed-version.test.ts` asserts, for **both** exported `fixedOf` functions: a single fix is reported, the same fix across two ranges is reported, two different fixes → `null` (not the first), and no-fix/empty → `null`. It was confirmed to FAIL against the unpatched code (multi-range returned the first fix instead of `null`).
- [x] New behavior has unit tests

If any required check was skipped, explain why:

- Change to a pure helper in two `review-enrichment` analyzers; it adds/changes no analyzer descriptor, so `analyzer-metadata.json` is unaffected. Codecov's `src/**` patch gate does not apply to `review-enrichment/**`; this package's own `node --test` suite covers it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This strictly prevents a wrong remediation version from being shown.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal CVE reporting only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: `fixedOf({ id, affected: [{ ranges: [{ events: [{ fixed: "1.5.0" }] }] }, { ranges: [{ events: [{ fixed: "2.3.0" }] }] }] })` returned `"1.5.0"` before the fix and returns `null` after. A single-fix CVE (`[{ ranges: [{ events: [{ fixed: "1.5.0" }] }] }]`) still returns `"1.5.0"`.
- A full per-range version match (reporting `2.3.0` for a `2.x` dependency) would need a semver/PEP-440 comparator threaded through the call site; that's deliberately out of scope here — this PR just stops the *wrong* version from being shown.
