### PR TITLE
fix(rees): match lockfile paths case-insensitively like workflow paths

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -18,6 +18,7 @@ import {
   type BoundedFetchResult,
 } from "./external-fetch.js";
 import { isWorkflowPath } from "./workflow-path.js";
+import { isSupportedLockfile } from "./lockfile-path.js";
 
 type ChangedFile = NonNullable<EnrichRequest["files"]>[number];
 
@@ -425,11 +426,7 @@ function categorizeFile(path: string): FileCategory {
   if (["package.json", "requirements.txt", "go.mod"].includes(basename)) {
     return { path, extension, category: "dependency-manifest" };
   }
-  if (
-    ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock", "go.sum"].includes(
-      basename,
-    )
-  ) {
+  if (isSupportedLockfile(path)) {
     return { path, extension, category: "lockfile" };
   }
   if (isWorkflowPath(path)) {

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -10,7 +10,7 @@ import type {
 import type { AnalysisContext } from "../analysis-context.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
 import { boundedFetchJson } from "../external-fetch.js";
-import { isSupportedLockfile, lockfileBasename } from "../lockfile-path.js";
+import { isParseableLockfile, lockfileBasename } from "../lockfile-path.js";
 
 interface LockfileChange {
   file: string;
@@ -350,7 +350,7 @@ export function extractLockfileChanges(
   const changes: LockfileChange[] = [];
   let scannedFiles = 0;
   for (const file of files) {
-    if (!file.patch || !isSupportedLockfile(file.path)) continue;
+    if (!file.patch || !isParseableLockfile(file.path)) continue;
     scannedFiles += 1;
     if (scannedFiles > maxFiles) break;
     for (const change of parseLockfile(file.path, file.patch, maxLines)) {

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -10,6 +10,7 @@ import type {
 import type { AnalysisContext } from "../analysis-context.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { isSupportedLockfile, lockfileBasename } from "../lockfile-path.js";
 
 interface LockfileChange {
   file: string;
@@ -51,7 +52,6 @@ interface OsvVuln {
 const MAX_LOCKFILE_FILES = 12;
 const MAX_PATCH_LINES_PER_FILE = 1200;
 const MAX_OSV_QUERIES = 40;
-const SUPPORTED_LOCKFILES = new Set(["package-lock.json", "yarn.lock", "poetry.lock"]);
 const VERSION_SAFE_RE = /^[0-9][0-9A-Za-z._+-]*$/;
 const MAX_PACKAGE_LEN = 200;
 const MAX_VERSION_LEN = 100;
@@ -330,7 +330,7 @@ function parsePoetryLock(path: string, patch: string, maxLines: number): Lockfil
 }
 
 function parseLockfile(path: string, patch: string, maxLines: number): LockfileChange[] {
-  const name = path.split("/").pop() ?? path;
+  const name = lockfileBasename(path).toLowerCase();
   if (name === "package-lock.json") return parsePackageLock(path, patch, maxLines);
   if (name === "yarn.lock") return parseYarnLock(path, patch, maxLines);
   if (name === "poetry.lock") return parsePoetryLock(path, patch, maxLines);
@@ -350,8 +350,7 @@ export function extractLockfileChanges(
   const changes: LockfileChange[] = [];
   let scannedFiles = 0;
   for (const file of files) {
-    const name = file.path.split("/").pop() ?? file.path;
-    if (!file.patch || !SUPPORTED_LOCKFILES.has(name)) continue;
+    if (!file.patch || !isSupportedLockfile(file.path)) continue;
     scannedFiles += 1;
     if (scannedFiles > maxFiles) break;
     for (const change of parseLockfile(file.path, file.patch, maxLines)) {

--- a/review-enrichment/src/lockfile-path.ts
+++ b/review-enrichment/src/lockfile-path.ts
@@ -1,0 +1,18 @@
+const SUPPORTED_LOCKFILE_NAMES = new Set([
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "poetry.lock",
+  "go.sum",
+]);
+
+/** Lockfile basenames are case-insensitive on common filesystems — normalize separators first. */
+export function lockfileBasename(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const slash = normalized.lastIndexOf("/");
+  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
+}
+
+export function isSupportedLockfile(path: string): boolean {
+  return SUPPORTED_LOCKFILE_NAMES.has(lockfileBasename(path).toLowerCase());
+}

--- a/review-enrichment/src/lockfile-path.ts
+++ b/review-enrichment/src/lockfile-path.ts
@@ -1,10 +1,13 @@
-const SUPPORTED_LOCKFILE_NAMES = new Set([
+const LOCKFILE_NAMES = new Set([
   "package-lock.json",
   "yarn.lock",
   "pnpm-lock.yaml",
   "poetry.lock",
   "go.sum",
 ]);
+
+/** Lockfiles the drift analyzer can actually parse today — narrower than categorization. */
+const PARSEABLE_LOCKFILE_NAMES = new Set(["package-lock.json", "yarn.lock", "poetry.lock"]);
 
 /** Lockfile basenames are case-insensitive on common filesystems — normalize separators first. */
 export function lockfileBasename(path: string): string {
@@ -13,6 +16,12 @@ export function lockfileBasename(path: string): string {
   return slash >= 0 ? normalized.slice(slash + 1) : normalized;
 }
 
+/** Broad lockfile classification for scheduler/category gating (includes pnpm/go). */
 export function isSupportedLockfile(path: string): boolean {
-  return SUPPORTED_LOCKFILE_NAMES.has(lockfileBasename(path).toLowerCase());
+  return LOCKFILE_NAMES.has(lockfileBasename(path).toLowerCase());
+}
+
+/** Lockfiles extractLockfileChanges can parse — must stay aligned with parseLockfile(). */
+export function isParseableLockfile(path: string): boolean {
+  return PARSEABLE_LOCKFILE_NAMES.has(lockfileBasename(path).toLowerCase());
 }

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -472,3 +472,20 @@ test("createAnalysisContext classifies workflow paths case-insensitively", () =>
     ],
   );
 });
+
+test("createAnalysisContext classifies lockfile paths case-insensitively", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 2611,
+    files: [
+      {
+        path: "frontend/Package-Lock.JSON",
+        patch: "@@ -1,0 +1,1 @@\n+{}",
+      },
+    ],
+  });
+
+  assert.deepEqual(context.fileCategories.map((file) => [file.path, file.category]), [
+    ["frontend/Package-Lock.JSON", "lockfile"],
+  ]);
+});

--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -26,3 +26,31 @@ test("extractLockfileChanges matches lockfile basenames case-insensitively", () 
     },
   ]);
 });
+
+test("extractLockfileChanges does not let unparsed lockfiles consume the scan budget", () => {
+  const yarnPatch = [
+    "@@ -1,0 +1,2 @@",
+    "+lodash@^4.17.21:",
+    '+  version "4.17.21"',
+  ].join("\n");
+  const filler = Array.from({ length: 12 }, (_, index) => ({
+    path: `pkg-${index}/pnpm-lock.yaml`,
+    patch: "@@ -1,0 +1,1 @@\n+lockfileVersion: 6.0",
+  }));
+
+  const changes = extractLockfileChanges([
+    ...filler,
+    { path: "frontend/Yarn.lock", patch: yarnPatch },
+  ]);
+
+  assert.deepEqual(changes, [
+    {
+      file: "frontend/Yarn.lock",
+      line: 2,
+      ecosystem: "npm",
+      package: "lodash",
+      from: null,
+      to: "4.17.21",
+    },
+  ]);
+});

--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractLockfileChanges } from "../dist/analyzers/lockfile-drift.js";
+
+test("extractLockfileChanges matches lockfile basenames case-insensitively", () => {
+  const changes = extractLockfileChanges([
+    {
+      path: "frontend/Yarn.lock",
+      patch: [
+        "@@ -1,0 +1,2 @@",
+        "+lodash@^4.17.21:",
+        '+  version "4.17.21"',
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    {
+      file: "frontend/Yarn.lock",
+      line: 2,
+      ecosystem: "npm",
+      package: "lodash",
+      from: null,
+      to: "4.17.21",
+    },
+  ]);
+});

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -273,3 +273,30 @@ test("actionPin runs for mixed-case workflow paths", async () => {
   assert.equal(brief.analyzerStatus.actionPin, "ok");
   assert.notEqual(brief.telemetry.analyzers.actionPin.skipReason, "no_workflow");
 });
+
+test("lockfileDrift runs for mixed-case lockfile paths", async () => {
+  let lockfileDriftRan = false;
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 2611,
+      analyzers: ["lockfileDrift"],
+      files: [
+        {
+          path: "frontend/Package-Lock.JSON",
+          patch: "@@ -1,0 +1,1 @@\n+{}",
+        },
+      ],
+    },
+    {
+      lockfileDrift: async () => {
+        lockfileDriftRan = true;
+        return [];
+      },
+    },
+  );
+
+  assert.equal(lockfileDriftRan, true);
+  assert.equal(brief.analyzerStatus.lockfileDrift, "ok");
+  assert.notEqual(brief.telemetry.analyzers.lockfileDrift.skipReason, "no_lockfile");
+});


### PR DESCRIPTION
## Summary

- #2525 fixed mixed-case workflow paths in review-enrichment, but lockfile handling still used exact-case basename checks.
- Paths like `frontend/Package-Lock.JSON` were not categorized as `"lockfile"`, so `lockfileDrift` was skipped with `no_lockfile`, and `extractLockfileChanges` ignored them even when invoked.
- Extract shared `isSupportedLockfile()` mirroring `workflow-path.ts`, used by `analysis-context`, `lockfile-drift`, and the scheduler regression test.

## Scope

- [x] Focused `review-enrichment/` change with regression tests only.
- [x] No linked issue — small parity fix following #2525.

## Validation

- [x] `git diff --check`
- [x] `review-enrichment` build + node tests — 24/24 passing (analysis-context, scheduler, lockfile-drift)

## Safety

- [x] No secrets or public scoring leakage. Enrichment analyzer parity only.
