### PR TITLE
fix(config): parse gate tri-state modes case-insensitively in manifest

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -418,7 +418,10 @@ function normalizeSource(raw: FocusManifestSource | undefined, value: JsonValue 
 
 function normalizeOptionalGateMode(value: JsonValue | undefined, field: string, warnings: string[]): GateRuleMode | null {
   if (value === undefined || value === null) return null;
-  if (value === "off" || value === "advisory" || value === "block") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "off" || normalized === "advisory" || normalized === "block") return normalized;
+  }
   warnings.push(`Manifest gate field "${field}" must be one of off, advisory, block; ignoring "${String(value)}".`);
   return null;
 }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1543,6 +1543,18 @@ describe("parseFocusManifest review config", () => {
     expect(parseFocusManifest({ review: reviewConfigToJson(chill.review) }).review).toEqual(chill.review);
   });
 
+  it("parses gate tri-state modes case-insensitively like review.profile", () => {
+    const manifest = parseFocusManifest({
+      gate: { linkedIssue: "BLOCK", duplicates: "Advisory", size: { mode: "OFF" } },
+      settings: { linkedIssueGateMode: "Block" },
+    });
+    expect(manifest.gate.linkedIssue).toBe("block");
+    expect(manifest.gate.duplicates).toBe("advisory");
+    expect(manifest.gate.sizeMode).toBe("off");
+    expect(manifest.settings.linkedIssueGateMode).toBe("block");
+    expect(resolveEffectiveSettings({ linkedIssueGateMode: "off" } as RepositorySettings, manifest).linkedIssueGateMode).toBe("block");
+  });
+
   it("ignores an invalid review.profile with a warning", () => {
     const m = parseFocusManifest({ review: { profile: "spicy" } });
     expect(m.review.profile).toBeNull();


### PR DESCRIPTION
## Summary

- `review.profile` is parsed case-insensitively (`ASSERTIVE` → `assertive`), but gate tri-state modes (`block`/`advisory`/`off`) used exact string equality in `normalizeOptionalGateMode`.
- Values like `gate.linkedIssue: BLOCK` or `settings.linkedIssueGateMode: Advisory` were silently dropped with a warning, breaking live gate and predicted-gate parity.
- Normalize gate mode strings with `trim().toLowerCase()` before comparison, matching the profile parser pattern from #2598-class config hardening.

## Scope

- [x] Single function change in `focus-manifest.ts` plus unit tests.
- [x] No linked issue — self-evident parser parity fix.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/focus-manifest.test.ts -t "gate tri-state"` — passing

## Safety

- [x] No secrets or behavior change for repos already using lowercase modes.
