### PR TITLE
feat(rees): report the OSV fix version for the queried dependency's range

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -9,6 +9,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { fixedOf } from "./osv-fixed.js";
 
 export interface DepChange {
   ecosystem: string;
@@ -142,7 +143,7 @@ interface OsvVuln {
   details?: string;
   severity?: Array<{ type: string; score: string }>;
   database_specific?: { severity?: string };
-  affected?: Array<{ ranges?: Array<{ events?: Array<{ fixed?: string }> }> }>;
+  affected?: Array<{ ranges?: Array<{ events?: Array<{ introduced?: string; fixed?: string }> }> }>;
 }
 
 function severityOf(vuln: OsvVuln): Cve["severity"] {
@@ -167,25 +168,14 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
         : "low";
 }
 
-function fixedOf(vuln: OsvVuln): string | null {
-  for (const affected of vuln.affected ?? []) {
-    for (const range of affected.ranges ?? []) {
-      for (const event of range.events ?? []) {
-        if (event.fixed) return event.fixed;
-      }
-    }
-  }
-  return null;
-}
-
-function mapOsvVulns(vulns: OsvVuln[] | undefined): Cve[] {
+function mapOsvVulns(vulns: OsvVuln[] | undefined, queriedVersion?: string): Cve[] {
   return (vulns ?? []).map((vuln) => ({
     id: vuln.id,
     severity: severityOf(vuln),
     summary: (vuln.summary ?? vuln.details ?? "")
       .replace(/\s+/g, " ")
       .slice(0, 180),
-    fixedIn: fixedOf(vuln),
+    fixedIn: fixedOf(vuln, queriedVersion),
   }));
 }
 
@@ -222,7 +212,7 @@ async function fetchOsvDirect(
         fetchOptions,
       );
   if (!response.ok) return [];
-  return mapOsvVulns(response.data.vulns);
+  return mapOsvVulns(response.data.vulns, version);
 }
 
 /* Legacy direct path kept for tests and injected callers that do not have request context. */
@@ -329,7 +319,7 @@ export async function queryOsvBatch(
     chunk.forEach((change, index) => {
       results.set(
         osvCacheKey(change),
-        mapOsvVulns(response.data.results?.[index]?.vulns),
+        mapOsvVulns(response.data.results?.[index]?.vulns, change.to),
       );
     });
   }

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -10,6 +10,7 @@ import type {
 import type { AnalysisContext } from "../analysis-context.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { fixedOf } from "./osv-fixed.js";
 
 interface LockfileChange {
   file: string;
@@ -45,7 +46,7 @@ interface OsvVuln {
   details?: string;
   severity?: Array<{ type: string; score: string }>;
   database_specific?: { severity?: string };
-  affected?: Array<{ ranges?: Array<{ events?: Array<{ fixed?: string }> }> }>;
+  affected?: Array<{ ranges?: Array<{ events?: Array<{ introduced?: string; fixed?: string }> }> }>;
 }
 
 const MAX_LOCKFILE_FILES = 12;
@@ -79,25 +80,14 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
         : "low";
 }
 
-function fixedOf(vuln: OsvVuln): string | null {
-  for (const affected of vuln.affected ?? []) {
-    for (const range of affected.ranges ?? []) {
-      for (const event of range.events ?? []) {
-        if (event.fixed) return event.fixed;
-      }
-    }
-  }
-  return null;
-}
-
-function toCves(vulns: OsvVuln[] | undefined): Cve[] {
+function toCves(vulns: OsvVuln[] | undefined, queriedVersion?: string): Cve[] {
   return (vulns ?? []).map((vuln) => ({
     id: vuln.id,
     severity: severityOf(vuln),
     summary: (vuln.summary ?? vuln.details ?? "")
       .replace(/\s+/g, " ")
       .slice(0, 180),
-    fixedIn: fixedOf(vuln),
+    fixedIn: fixedOf(vuln, queriedVersion),
   }));
 }
 
@@ -401,7 +391,7 @@ export async function queryOsvBatch(
   changes.forEach((change, index) => {
     results.set(
       `${change.ecosystem}::${change.package}@${change.to}`,
-      toCves(response.data.results?.[index]?.vulns),
+      toCves(response.data.results?.[index]?.vulns, change.to),
     );
   });
   return results;

--- a/review-enrichment/src/analyzers/osv-fixed.ts
+++ b/review-enrichment/src/analyzers/osv-fixed.ts
@@ -1,0 +1,85 @@
+// Shared OSV "fixed in X" remediation-version resolver for the dependency-scan and lockfile-drift analyzers
+// (deduped from two identical copies). Given a CVE's OSV `affected` ranges and the queried dependency version,
+// it reports the version that closes the vulnerable range CONTAINING that version — so a CVE patched separately
+// per major (fixed in 1.5.0 for the 1.x line AND 2.3.0 for the 2.x line) tells a 2.x user to upgrade to 2.3.0,
+// not 1.5.0. When the versions are not cleanly comparable (prerelease/non-numeric) or no range matches, it falls
+// back to reporting a fix only when it is UNAMBIGUOUS (a single distinct `fixed` across all ranges), else null —
+// so it never names a version that does not fix the queried line.
+
+interface OsvEvent {
+  introduced?: string;
+  fixed?: string;
+}
+export interface OsvAffected {
+  ranges?: Array<{ events?: Array<OsvEvent> }>;
+}
+
+/** Compare two dotted-numeric versions (e.g. `2.0.0` vs `2.3.0`) segment by segment. Returns -1/0/1, or null
+ *  when either side is not a clean dotted-numeric release (a leading `v` is tolerated; prerelease/build/other
+ *  text makes it incomparable). Callers treat null as "incomparable" and fall back, so a version is never
+ *  mis-ordered by this heuristic. */
+export function compareNumericVersion(a: string, b: string): number | null {
+  const pa = parseNumericVersion(a);
+  const pb = parseNumericVersion(b);
+  if (pa === null || pb === null) return null;
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i += 1) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da < db ? -1 : 1;
+  }
+  return 0;
+}
+
+function parseNumericVersion(version: string): number[] | null {
+  const core = version.trim().replace(/^v/i, "");
+  if (!/^\d+(\.\d+)*$/.test(core)) return null;
+  return core.split(".").map(Number);
+}
+
+/** The `fixed` version that closes the `[introduced, fixed)` segment CONTAINING `version`, walking each range's
+ *  ordered events (OSV emits alternating `introduced`/`fixed` events per range). Null when no segment contains
+ *  the version or the versions are incomparable. */
+function fixedForVersion(affected: OsvAffected[], version: string): string | null {
+  for (const entry of affected) {
+    for (const range of entry.ranges ?? []) {
+      let introduced: string | null = null;
+      for (const event of range.events ?? []) {
+        if (event.introduced !== undefined) {
+          introduced = event.introduced;
+        } else if (event.fixed) {
+          const atOrAfterIntroduced = introduced === null || isAtLeast(version, introduced);
+          if (atOrAfterIntroduced && compareNumericVersion(version, event.fixed) === -1) return event.fixed;
+          introduced = null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function isAtLeast(version: string, floor: string): boolean {
+  const cmp = compareNumericVersion(version, floor);
+  return cmp === 0 || cmp === 1;
+}
+
+/** Resolve the OSV remediation version to surface as `Cve.fixedIn`. Prefers the fix for the range containing
+ *  `queriedVersion`; falls back to a single unambiguous fix (else null) when no version is supplied, the versions
+ *  are incomparable, or no range matches — never returning a version that does not fix the queried line. */
+export function fixedOf(vuln: { affected?: OsvAffected[] }, queriedVersion?: string): string | null {
+  const affected = vuln.affected ?? [];
+  if (queriedVersion) {
+    const matched = fixedForVersion(affected, queriedVersion);
+    if (matched !== null) return matched;
+  }
+  const fixes = new Set<string>();
+  for (const entry of affected) {
+    for (const range of entry.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event.fixed) fixes.add(event.fixed);
+      }
+    }
+  }
+  const list = [...fixes];
+  return list.length === 1 ? list[0]! : null;
+}

--- a/review-enrichment/test/osv-fixed.test.ts
+++ b/review-enrichment/test/osv-fixed.test.ts
@@ -1,0 +1,43 @@
+// Units for the shared OSV "fixed in X" resolver used by dependency-scan and lockfile-drift. Own file so
+// concurrent analyzer PRs don't collide. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compareNumericVersion, fixedOf } from "../dist/analyzers/osv-fixed.js";
+
+test("compareNumericVersion: orders dotted-numeric releases, null when incomparable", () => {
+  assert.equal(compareNumericVersion("2.0.0", "2.3.0"), -1);
+  assert.equal(compareNumericVersion("2.3.0", "2.0.0"), 1);
+  assert.equal(compareNumericVersion("2.0.0", "2.0.0"), 0);
+  assert.equal(compareNumericVersion("2", "2.0.0"), 0); // shorter is zero-padded
+  assert.equal(compareNumericVersion("1.10.0", "1.9.0"), 1); // numeric, not lexicographic (10 > 9)
+  assert.equal(compareNumericVersion("v2.0.0", "2.1.0"), -1); // a leading v is tolerated
+  assert.equal(compareNumericVersion("2.0.0-rc1", "2.0.0"), null); // prerelease → incomparable
+  assert.equal(compareNumericVersion("1.0", "abc"), null); // non-numeric → incomparable
+});
+
+test("fixedOf: reports the fix for the range containing the queried version (CVE patched per major)", () => {
+  // Fixed in 1.5.0 for the 0.x–1.x line AND 2.3.0 for the 2.x line, as two affected entries.
+  const vuln = {
+    id: "GHSA-multi",
+    affected: [
+      { ranges: [{ events: [{ introduced: "0" }, { fixed: "1.5.0" }] }] },
+      { ranges: [{ events: [{ introduced: "2.0.0" }, { fixed: "2.3.0" }] }] },
+    ],
+  };
+  assert.equal(fixedOf(vuln, "2.0.0"), "2.3.0"); // 2.x line → 2.3.0, NOT the first fix 1.5.0
+  assert.equal(fixedOf(vuln, "1.2.0"), "1.5.0"); // 1.x line → 1.5.0
+  assert.equal(fixedOf(vuln, "3.0.0"), null); // above every fixed segment → no applicable fix here
+
+  // The same segments expressed as one range with alternating introduced/fixed events resolve identically.
+  const oneRange = { id: "GHSA-seg", affected: [{ ranges: [{ events: [{ introduced: "0" }, { fixed: "1.5.0" }, { introduced: "2.0.0" }, { fixed: "2.3.0" }] }] }] };
+  assert.equal(fixedOf(oneRange, "2.0.0"), "2.3.0");
+});
+
+test("fixedOf: falls back to a single unambiguous fix (else null) when no version match", () => {
+  const single = { id: "GHSA-1", affected: [{ ranges: [{ events: [{ introduced: "0" }, { fixed: "1.5.0" }] }] }] };
+  assert.equal(fixedOf(single), "1.5.0"); // no queried version → the single distinct fix
+  assert.equal(fixedOf(single, "0.0.0-rc"), "1.5.0"); // incomparable version → fall back to the single fix
+  const multi = { id: "GHSA-2", affected: [{ ranges: [{ events: [{ fixed: "1.5.0" }] }] }, { ranges: [{ events: [{ fixed: "2.3.0" }] }] }] };
+  assert.equal(fixedOf(multi), null); // ambiguous, no version to disambiguate → null (never a wrong version)
+  assert.equal(fixedOf({ id: "GHSA-3" }), null); // no affected data → null
+});


### PR DESCRIPTION
## Summary

The `dependency-scan` and `lockfile-drift` analyzers report each CVE's remediation version as `Cve.fixedIn` ("fixed in X"). Both computed it with an identical `fixedOf(vuln)` that returned the **first** `fixed` event across *all* of the vuln's affected ranges — ignoring which version line the queried dependency actually belongs to. For a CVE patched **separately per major** (e.g. `fixed: 1.5.0` for the `0.x–1.x` line **and** `fixed: 2.3.0` for the `2.x` line), a maintainer on `2.0.0` was told to "upgrade to **1.5.0**" — i.e. to *downgrade* to a version that does not fix their line.

This PR makes the reported fix **correct for the queried version**:

- New shared **`osv-fixed.ts`** module (deduping the two identical `fixedOf` copies — a genuine consolidation):
  - `compareNumericVersion(a, b)` — a small, safe dotted-numeric comparator (tolerates a leading `v`; returns `null` for prerelease/non-numeric versions rather than guessing).
  - `fixedOf(vuln, queriedVersion?)` — resolves the fix for the `[introduced, fixed)` range **segment containing** the queried version (walking OSV's ordered `introduced`/`fixed` events).
- Both analyzers now thread the queried dependency version (`change.to` / `version`, already in scope at every call site) into the resolver.

**Safe by construction:** when the versions are not cleanly comparable, or no range contains the queried version, it falls back to reporting a fix **only when it is unambiguous** (a single distinct `fixed` across all ranges), else `null`. So it never names a version that doesn't fix the queried line — it's a strict improvement over both the old (wrong-version) and the purely-conservative behavior.

**No linked issue:** self-contained accuracy improvement + de-duplication in the review-enrichment package; per this repo's `linkedIssuePolicy: preferred`, a direct PR with this rationale is appropriate. (Supersedes my open #2609, which applied only the conservative single-fix-or-null fallback; this PR keeps that fallback and adds the correct per-range match.)

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm --prefix review-enrichment run build` (tsc clean)
- [x] `npm --prefix review-enrichment run test` — the full suite passes (394/394 excluding two **pre-existing, environment-only** `upload-sourcemaps` failures that need `sentry-cli` and also fail on unmodified `main`). A new `test/osv-fixed.test.ts` covers the comparator (numeric ordering, `v` prefix, prerelease/non-numeric → `null`), the per-major range match (`2.0.0 → 2.3.0`, `1.2.0 → 1.5.0`), and the fallbacks (no version / incomparable → single distinct fix; ambiguous → `null`; no data → `null`).
- [x] New behavior has unit tests

If any required check was skipped, explain why:

- The new module is a plain helper (not an analyzer descriptor), so `analyzer-metadata.json` is unaffected. Codecov's `src/**` patch gate does not apply to `review-enrichment/**`; this package's own `node --test` suite covers it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (This strictly improves remediation accuracy.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (Internal CVE reporting only; no schema change.)
- [x] No visible UI change in this PR.

## Notes

- Reproduction: for a CVE with `affected` fixed in `1.5.0` (1.x line) and `2.3.0` (2.x line), `fixedOf(vuln, "2.0.0")` returned `"1.5.0"` before and returns `"2.3.0"` now; `fixedOf(vuln, "1.2.0")` returns `"1.5.0"`. A single-line CVE is unchanged.
