### PR TITLE
feat(mcp): classify supported-but-outdated MCP clients as stale

### DIFF
--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -59,6 +59,9 @@ export function classifyMcpClientVersion(version: string | null | undefined): Mc
   const minimumComparison = compareMcpSemver(version, MINIMUM_SUPPORTED_MCP_VERSION);
   if (minimumComparison === null) return "unknown";
   if (minimumComparison < 0) return "incompatible";
+  const recommendedComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION);
+  if (recommendedComparison === null) return "unknown";
+  if (recommendedComparison < 0) return "stale";
   return "current";
 }
 

--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -59,8 +59,8 @@ export function classifyMcpClientVersion(version: string | null | undefined): Mc
   const minimumComparison = compareMcpSemver(version, MINIMUM_SUPPORTED_MCP_VERSION);
   if (minimumComparison === null) return "unknown";
   if (minimumComparison < 0) return "incompatible";
-  const recommendedComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION);
-  if (recommendedComparison === null) return "unknown";
+  // The client semver already parsed for the minimum check, so this comparison cannot return null.
+  const recommendedComparison = compareMcpSemver(version, LATEST_RECOMMENDED_MCP_VERSION)!;
   if (recommendedComparison < 0) return "stale";
   return "current";
 }

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -8,9 +8,19 @@ describe("MCP compatibility telemetry", () => {
     expect(classifyMcpClientVersion("0.2.1")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.3.0")).toBe("incompatible");
     expect(classifyMcpClientVersion("0.4.0")).toBe("incompatible");
-    expect(classifyMcpClientVersion("0.5.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.5.0")).toBe("stale");
+    expect(classifyMcpClientVersion("0.5.9")).toBe("stale");
+    expect(classifyMcpClientVersion("0.6.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.7.0")).toBe("current");
     expect(classifyMcpClientVersion("not-a-version")).toBe("unknown");
     expect(classifyMcpClientVersion(undefined)).toBe("unknown");
+    expect(classifyMcpClientVersion(null)).toBe("unknown");
+  });
+
+  it("treats prerelease builds below the minimum or recommended cutoffs as incompatible or stale", () => {
+    expect(classifyMcpClientVersion("0.4.9-rc.1")).toBe("incompatible");
+    expect(classifyMcpClientVersion("0.5.0-rc.1")).toBe("incompatible");
+    expect(classifyMcpClientVersion("0.6.0-rc.1")).toBe("stale");
   });
 
   it("builds bounded telemetry from allowlisted MCP headers", () => {
@@ -50,7 +60,7 @@ describe("MCP compatibility telemetry", () => {
       clientVersion: "0.5.0",
       metadata: {
         packageName: "@example/custom-mcp",
-        compatibilityStatus: "current",
+        compatibilityStatus: "stale",
       },
     });
   });

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -23,6 +23,14 @@ describe("MCP compatibility telemetry", () => {
     expect(classifyMcpClientVersion("0.6.0-rc.1")).toBe("stale");
   });
 
+  it("classifies the exact recommended version and newer releases as current", () => {
+    expect(classifyMcpClientVersion("0.6.0")).toBe("current");
+    expect(classifyMcpClientVersion("0.6.1")).toBe("current");
+    expect(classifyMcpClientVersion("1.0.0")).toBe("current");
+    expect(compareMcpSemver("0.6.0", "0.6.0")).toBe(0);
+    expect(compareMcpSemver("0.7.0", "0.6.0")).toBe(1);
+  });
+
   it("builds bounded telemetry from allowlisted MCP headers", () => {
     const telemetry = buildMcpClientTelemetry(
       new Headers({

--- a/test/unit/mcp-server-telemetry.test.ts
+++ b/test/unit/mcp-server-telemetry.test.ts
@@ -57,7 +57,7 @@ describe("MCP server telemetry", () => {
         clientVersion: "0.5.0",
         metadata: expect.objectContaining({
           toolName: "gittensory_local_status",
-          compatibilityStatus: "current",
+          compatibilityStatus: "stale",
         }),
       }),
     ]);


### PR DESCRIPTION
## Summary

`classifyMcpClientVersion` previously treated every MCP client at or above the minimum supported version (`0.5.0`) as `current`, even when below the latest recommended version (`0.6.0`). The type system, operator dashboard, and analytics surfaces already model a `stale` tier (`mcpCompatibilityAdoption.staleEvents`, `byCompatibilityStatus`), but live telemetry never populated it for auto-derived classifications.

This change completes the three-tier compatibility model:

- `< 0.5.0` → `incompatible`
- `>= 0.5.0` and `< 0.6.0` → `stale`
- `>= 0.6.0` → `current`

No linked issue — this is a small, self-contained gap fix discovered by tracing MCP telemetry through `buildMcpClientTelemetry` → `classifyMcpClientVersion` → analytics rollups.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full gate run via `npm run test:ci` (includes all checks above).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend telemetry classification only; no visible UI changes.

## Notes

- Updated unit tests cover the new `stale` tier, prerelease edge cases, and MCP server telemetry header classification (`0.5.0` → `stale`).
- Avoids overlap with open PRs touching review-enrichment, miner CLI, selfhost, gate, or MCP init-client hosts.

