### PR TITLE
docs(selfhost): close first-run onboarding gaps for admin access and GitHub App setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,8 +203,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # GITHUB_COMMIT_CACHE_TTL_SECONDS=900        # TTL for bare /commits/{ref} resolves; dedups the two hourly upstream ref→SHA reads.
 # GITHUB_WEBHOOK_MAX_BODY_BYTES=1048576      # max accepted GitHub webhook body size, in bytes (default 1 MiB).
 #                                            #   Larger deliveries are rejected before parsing. Raise only if you
-#                                            #   see legitimate webhooks rejected for size (e.g. very large PR diffs
-#                                            #   embedded in the payload); most installs never need to touch this.
+#                                            #   see legitimate webhooks rejected for size (e.g. a `push` event
+#                                            #   with a large `commits` array from a big force-push or merge);
+#                                            #   most installs never need to touch this.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
 # BROWSER_WS_ENDPOINT=                       # ws:// URL of a browserless/chrome instance for visual-review

--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,23 @@ GITTENSORY_REVIEW_DRAFT=false
 #                                            #   /setup returns 400; with it, /setup needs ?token=<value> (or an
 #                                            #   x-setup-token / Bearer header) so a freshly-booted, not-yet-configured
 #                                            #   instance can't be driven through App creation by a random visitor.
+# ADMIN_GITHUB_LOGINS=your-github-login      # REQUIRED for control-panel ("operator") access. A comma- or
+#                                            #   whitespace-separated allowlist of GitHub logins, case-insensitive.
+#                                            #   FAIL-CLOSED: unset/empty means NOBODY can sign into the dashboard,
+#                                            #   even the person who set up this instance — this is not a bug, add
+#                                            #   your own login here right after first-run setup. Also exempts these
+#                                            #   logins from the agent's own-PR auto-close rules (fleet-operator
+#                                            #   identity) and lets them bypass per-repo MCP scope.
+# MCP_READ_REPO_ALLOWLIST=                   # scopes the shared GITTENSORY_MCP_TOKEN identity's READ-only MCP
+#                                            #   tools (repo context, issue quality, watch subscriptions) to these
+#                                            #   owner/repo entries (comma/whitespace-separated). FAIL-CLOSED:
+#                                            #   unset/empty grants no repo access. `*` or `all` is an explicit
+#                                            #   escape hatch for full unscoped read access, incl. cross-repo
+#                                            #   contributor/operator tools that have no single repo to scope against.
+# MCP_ACTUATION_REPO_ALLOWLIST=              # same fail-closed/wildcard model as MCP_READ_REPO_ALLOWLIST, but for
+#                                            #   WRITE (merge/close/approve) MCP tools — kept separate so read and
+#                                            #   write trust can differ. Unrelated to ADMIN_GITHUB_LOGINS, which
+#                                            #   scopes dashboard sign-in, not the shared MCP token's per-repo reach.
 # PORT=8787
 # DATABASE_PATH=/data/gittensory.sqlite     # SQLite file on the mounted data volume; all migrations auto-apply
 # POSTGRES_PASSWORD=change-this-long-random-value  # used by the --profile postgres / --profile pgbouncer services
@@ -184,8 +201,15 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # GITHUB_BRANCH_PROTECTION_CACHE_TTL_SECONDS=1200  # TTL for required-status branch protection reads.
 # GITHUB_METADATA_CACHE_TTL_SECONDS=600      # TTL for stable repo/user/installation metadata reads.
 # GITHUB_COMMIT_CACHE_TTL_SECONDS=900        # TTL for bare /commits/{ref} resolves; dedups the two hourly upstream ref→SHA reads.
+# GITHUB_WEBHOOK_MAX_BODY_BYTES=1048576      # max accepted GitHub webhook body size, in bytes (default 1 MiB).
+#                                            #   Larger deliveries are rejected before parsing. Raise only if you
+#                                            #   see legitimate webhooks rejected for size (e.g. very large PR diffs
+#                                            #   embedded in the payload); most installs never need to touch this.
 # QDRANT_URL=                                # set to http://qdrant:6333 to use Qdrant as the RAG vector store
 #                                            #   (--profile qdrant). Overrides the built-in sqlite-vec / pgvector.
+# BROWSER_WS_ENDPOINT=                       # ws:// URL of a browserless/chrome instance for visual-review
+#                                            #   screenshot capture. Unset = visual review is fully inert (no
+#                                            #   screenshots, no error) — this feature is entirely optional.
 # DISCORD_WEBHOOK_URL=                        # one Discord channel for per-action notifications (merged/closed/
 #                                            #   manual) on ANY repo you review. Unset = no Discord notifications.
 #                                            #   Collection and schema are auto-created at startup. Off when unset.
@@ -324,6 +348,11 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   merged decision. single = one reviewer's verdict (auto when 1).
 # AI_ON_MERGE=either                         # synthesis merge rule: either (block if EITHER reviewer flags) |
 #                                            #   both (block only when both do). Ignored unless AI_COMBINE=synthesis.
+# AI_DAILY_NEURON_BUDGET=10000000            # daily spend cap (Cloudflare Workers AI "neurons") shared by AI
+#                                            #   summaries, the free consensus-defect reviewer pair, and the
+#                                            #   AI-slop scorer. Default 10,000,000/day; clamped to [0, 10000000].
+#                                            #   Only meters FREE Workers-AI calls — BYOK/provider calls above bill
+#                                            #   the maintainer's own account and are not counted against this.
 # Ollama reviewer (AI_PROVIDER=ollama). Defaults: OLLAMA_AI_BASE_URL=http://localhost:11434/v1,
 # OLLAMA_AI_MODEL=llama3.1, no API key. Set the base URL to http://ollama:11434/v1 when using the compose
 # --profile ollama service.

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -60,10 +60,8 @@ function SelfHostingGithubApp() {
       </p>
       <CodeBlock
         filename=".env"
-        code={`PUBLIC_API_ORIGIN=https://reviews.example.com  # your instance's exact public URL — embedded in the
-                                                # App manifest's redirect_url
-SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup so a random visitor can't drive
-                                                     # App creation on a freshly-booted instance`}
+        code={`PUBLIC_API_ORIGIN=https://reviews.example.com  # exact public URL, embedded in the manifest
+SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a freshly-booted instance`}
       />
       <CodeBlock
         lang="bash"

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -71,8 +71,8 @@ SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a fresh
         Manual App creation (below) is still fully supported — for an air-gapped instance, a
         stricter change-review process, or simply a preference for reviewing every permission by
         hand before it exists. Whichever path you take, the resulting App needs the SAME
-        permissions: this doc's manual list is generated from the identical source the wizard's
-        manifest uses, so the two can never drift apart again.
+        permissions: this doc's manual list is kept in sync with the wizard's manifest and checked
+        in CI, so the two can't silently drift apart.
       </Callout>
 
       <h2>Direct App permissions</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -48,18 +48,54 @@ function SelfHostingGithubApp() {
         ]}
       />
 
+      <h2>One-click App creation (recommended for a Direct App)</h2>
+      <p>
+        Before the App exists (no <code>GITHUB_APP_ID</code> set yet), the self-host serves a setup
+        wizard at <code>GET /setup</code>. It renders a form that POSTs a GitHub App{" "}
+        <em>manifest</em> — the exact permission and event set below, pre-filled — to GitHub's own
+        App-creation flow. GitHub creates the App with the correct configuration in one step and
+        redirects back to exchange credentials automatically; there is no manual permission
+        checklist to get right or wrong. The route is disabled once an App is configured, so it
+        can't rebind a live install.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`PUBLIC_API_ORIGIN=https://reviews.example.com  # your instance's exact public URL — embedded in the
+                                                # App manifest's redirect_url
+SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup so a random visitor can't drive
+                                                     # App creation on a freshly-booted instance`}
+      />
+      <CodeBlock
+        lang="bash"
+        code={`open "https://reviews.example.com/setup?token=<SELFHOST_SETUP_TOKEN>"`}
+      />
+      <Callout variant="note">
+        Manual App creation (below) is still fully supported — for an air-gapped instance, a
+        stricter change-review process, or simply a preference for reviewing every permission by
+        hand before it exists. Whichever path you take, the resulting App needs the SAME
+        permissions: this doc's manual list is generated from the identical source the wizard's
+        manifest uses, so the two can never drift apart again.
+      </Callout>
+
       <h2>Direct App permissions</h2>
       <ul>
-        <li>Pull requests: read/write.</li>
-        <li>Checks: read/write.</li>
-        <li>Issues: read/write.</li>
-        <li>Contents: read. Add write only if the self-host should merge.</li>
+        <li>Pull requests: write.</li>
+        <li>
+          Checks: write — the gate posts a check-run; <code>checks: read</code> alone 403s that
+          write (silently fails the first review with no obvious cause).
+        </li>
+        <li>Issues: write.</li>
+        <li>
+          Contents: write — required for BOTH merging and the auto-maintain{" "}
+          <code>update_branch</code> action. <code>contents: read</code> looks sufficient at
+          creation time but silently breaks auto-merge later with no error surfaced in the UI; there
+          is no lesser permission that keeps merge/update-branch working.
+        </li>
         <li>Commit statuses: read.</li>
         <li>Metadata: read.</li>
       </ul>
       <p>
-        Events should include pull request, pull request review, push, issues, check suite, check
-        run, and status.
+        Events: pull request, pull request review, push, issues, check suite, check run, and status.
       </p>
 
       <h2>Direct App env</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -70,6 +70,25 @@ function SelfHostingSecurity() {
         </li>
       </ul>
 
+      <h2>Control-panel access</h2>
+      <p>
+        GitHub sign-in to the control panel (the maintainer/owner dashboard) is gated by{" "}
+        <code>ADMIN_GITHUB_LOGINS</code> — a comma- or whitespace-separated, case-insensitive
+        allowlist of GitHub logins.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`ADMIN_GITHUB_LOGINS=your-github-login,a-second-maintainer`}
+      />
+      <Callout variant="warn" title="Fail-closed by design">
+        Unset or empty means NOBODY gets control-panel access — not even the person who just
+        finished setup. This is intentional, not a bug: add your own GitHub login here right after
+        first-run setup, or you will sign in successfully and see zero privileges with no
+        explanation. The same allowlist also exempts these logins from the agent's own-PR auto-close
+        rules and lets them bypass per-repo MCP scope (<code>MCP_READ_REPO_ALLOWLIST</code> /{" "}
+        <code>MCP_ACTUATION_REPO_ALLOWLIST</code>).
+      </Callout>
+
       <h2>AI credential boundaries</h2>
       <Callout variant="warn" title="Subscription CLI credentials">
         CLI auth files can be readable by the runtime. Do not mount a prompt-readable Claude Code or

--- a/test/unit/setup-wizard-docs-parity.test.ts
+++ b/test/unit/setup-wizard-docs-parity.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { buildManifest } from "../../src/selfhost/setup-wizard";
+
+const DOCS_PATH = "apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx";
+
+// docs.self-hosting-github-app.tsx claims its manual permission list "is generated from the identical
+// source the wizard's manifest uses, so the two can never drift apart again" (#2542). That claim is only
+// true if something actually catches drift — this test IS that something: it reads buildManifest's real
+// default_permissions/default_events and asserts the docs page's prose still names every one of them at the
+// right access level, so an editor who changes one without the other fails CI instead of shipping silently
+// wrong setup instructions.
+const PERMISSION_LABELS: Record<string, string> = {
+  pull_requests: "Pull requests",
+  checks: "Checks",
+  issues: "Issues",
+  contents: "Contents",
+  statuses: "Commit statuses",
+  metadata: "Metadata",
+};
+
+describe("self-host GitHub App manifest <-> docs parity (#2542)", () => {
+  it("the docs page's manual permission list names every buildManifest permission at the correct access level", () => {
+    const manifest = buildManifest("https://example.com", "state") as { default_permissions: Record<string, string> };
+    const docsSource = readFileSync(DOCS_PATH, "utf8");
+
+    expect(Object.keys(manifest.default_permissions).sort()).toEqual(Object.keys(PERMISSION_LABELS).sort());
+    for (const [key, level] of Object.entries(manifest.default_permissions)) {
+      const label = PERMISSION_LABELS[key];
+      expect(label, `no docs label mapped for manifest permission "${key}" — add one to PERMISSION_LABELS`).toBeDefined();
+      const pattern = new RegExp(`${label}:\\s*${level}\\b`, "i");
+      expect(docsSource, `docs page missing or wrong access level for "${label}" (expected "${level}")`).toMatch(pattern);
+    }
+  });
+
+  it("the docs page's events sentence names every buildManifest default_event, and only those", () => {
+    // Scoped to the "Events: ...." sentence specifically — a bare substring search (e.g. for "status")
+    // would false-pass by matching inside unrelated text like "Commit statuses" elsewhere on the page.
+    const manifest = buildManifest("https://example.com", "state") as { default_events: string[] };
+    const docsSource = readFileSync(DOCS_PATH, "utf8");
+    const sentenceMatch = /Events:\s*([^.]+)\./.exec(docsSource);
+    expect(sentenceMatch, "docs page has no \"Events: ...\" sentence to check").not.toBeNull();
+    const eventsSentence = sentenceMatch![1]!;
+    const docsEvents = eventsSentence
+      .split(",")
+      .map((s) => s.replace(/\band\b/i, "").trim().toLowerCase())
+      .filter(Boolean);
+
+    const manifestEvents = manifest.default_events.map((e) => e.replace(/_/g, " "));
+    expect(docsEvents.sort()).toEqual(manifestEvents.sort());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2542.

Three first-run operator experience gaps, distinct from the broader image-first onboarding work tracked in #1938:

1. **`ADMIN_GITHUB_LOGINS`** (the env var that grants control-panel access) was undocumented anywhere. It fails closed by design (`isAuthorizedGitHubSessionLogin` in `src/auth/security.ts` returns `false` when the allowlist is empty) — a first-time operator signs into their own dashboard and gets silently zero privileges, which reads as a bug rather than the intended next step.
2. A working one-click GitHub App setup wizard already exists (`GET /setup` in `src/selfhost/setup-wizard.ts`, POSTs a manifest to GitHub's own App-creation flow) but wasn't mentioned in the docs at all. The manually-documented permission set had also drifted from what the manifest actually requests: docs said `Contents: read, add write only if the self-host should merge`; the manifest unconditionally requests `contents: write` (needed for `update_branch`, not just merge). An operator who created their App manually per the old docs could unknowingly break auto-merge with no error surfaced anywhere.
3. Five env vars the app genuinely reads at runtime (`GITHUB_WEBHOOK_MAX_BODY_BYTES`, `BROWSER_WS_ENDPOINT`, `MCP_READ_REPO_ALLOWLIST`, `MCP_ACTUATION_REPO_ALLOWLIST`, `AI_DAILY_NEURON_BUDGET`) were absent from `.env.example`, discoverable only by grepping source.

## What changed

- **`.env.example`**: added `ADMIN_GITHUB_LOGINS` (with its fail-closed behavior spelled out) right after the setup-wizard vars, `MCP_READ_REPO_ALLOWLIST`/`MCP_ACTUATION_REPO_ALLOWLIST` alongside it, `GITHUB_WEBHOOK_MAX_BODY_BYTES` and `BROWSER_WS_ENDPOINT` in the self-host runtime section, and `AI_DAILY_NEURON_BUDGET` in the AI review backend section.
- **`docs.self-hosting-security.tsx`**: new "Control-panel access" section documenting `ADMIN_GITHUB_LOGINS`, framed explicitly as fail-closed-by-design (not a bug), right after the existing "put an auth layer in front of dashboards" bullet — the app already has its own built-in gate for this.
- **`docs.self-hosting-github-app.tsx`**: new "One-click App creation (recommended for a Direct App)" section documenting the `/setup` wizard as the primary path, with a note that manual creation is still fully supported. Corrected "Direct App permissions" to state `Contents: write` (matching `buildManifest` in `setup-wizard.ts` exactly) with an explanation of why read is insufficient, instead of the old, now-inaccurate "read, add write only if merging" guidance.

## Verification

Ran both changed doc pages through the local dev server (`vite dev`) at both viewport sizes used elsewhere in this doc set, and caught + fixed one real visual bug in the process: my first draft of the new "One-click App creation" `.env` code block had a multi-line inline comment that overflowed the `CodeBlock` component's right edge instead of wrapping (`overflow-x: visible` on the underlying `<code>` element) — shortened both comments to one line each in a follow-up commit, confirmed the fix visually. I'm not able to attach the actual screenshot images to this PR body from this environment (no browser session to drag-drop into, and the preview tool doesn't expose a file path for the captured images) — happy to attach them via a follow-up comment if that's needed for review, or you're welcome to run `npm --workspace @jsonbored/gittensory-ui run dev` and load `/docs/self-hosting-security` and `/docs/self-hosting-github-app` directly.

Both changed pages are documentation prose (new headings/paragraphs/lists) plus `CodeBlock`/`Callout` usages that are pre-existing, unmodified, already-used-elsewhere-in-this-doc-set components — no new visual components, styling, or layout were introduced.

## Validation

- `npm run ui:typecheck`
- `npm run ui:lint` (0 errors; only pre-existing, unrelated warnings)
- `npm run ui:build`
- `npm run ui:test`
- `npm run test:ci` (the full local gate, exit 0 — no `src/**` files changed, this PR is scoped to docs/env-example)
- `git diff --check`
- Duplicate-variable check across `.env.example` confirmed none of the 6 newly-added vars collide with an existing entry

## Scope

- [x] Change is narrow and limited to the stated problem
- [x] No secrets, wallets, hotkeys, trust scores, or reward values added anywhere
- [x] No edits to `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`

## Safety

- [x] No auth/session/CORS surface touched — documentation only, no behavior change
- [x] No secrets in `.env.example` — every new entry is a name + placeholder/description, consistent with the file's existing convention