### PR TITLE
perf(selfhost): tune Postgres autovacuum and document the observation-write batching decision

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3536,6 +3536,20 @@ function summarizeSegments(
   };
 }
 
+// #2543: this is the ONLY call site of recordGitHubRateLimitObservation -- one row per outbound GitHub REST/
+// GraphQL response. DELIBERATELY left un-batched (documented decision, not an oversight): the write rate is
+// bounded by GitHub's own REST budget for a single App installation (~5000/hour ≈ 1.4/s sustained, further
+// capped in practice by QUEUE_CONCURRENCY's small worker-pool size), nowhere near a volume where single-row
+// Postgres INSERTs meaningfully pressure the connection pool. shouldWaitForGitHubRateLimit (rate-limit.ts)
+// reads the LATEST row from this exact table for admission control across every self-host queue worker
+// (including in a multi-instance/shared-Postgres deployment, where a buffering instance would make its own
+// writes stale to every OTHER instance's reads, not just its own) -- a batching window here trades a real,
+// bounded-scale write-volume concern for a genuine risk to the admission-control freshness the #1936 rate-
+// limit-reliability campaign was built around: a stale "remaining: 500" observation would let a queue worker
+// admit a job it should have deferred, right when conserving the budget matters most. Revisit ONLY if this
+// table's write volume is ever independently measured to actually pressure the pool -- the table-level
+// autovacuum tuning (tuneGithubRateLimitObservationsAutovacuum, src/selfhost/pg-adapter.ts) already addresses
+// the dead-tuple-bloat half of this issue, which is the part that was actually observable/anticipated.
 async function recordGitHubResponse(
   env: Env,
   repoFullName: string | null,

--- a/src/selfhost/pg-adapter.ts
+++ b/src/selfhost/pg-adapter.ts
@@ -83,3 +83,34 @@ export function createPgAdapter(pool: Pool): D1Database {
   };
   return adapter as unknown as D1Database;
 }
+
+// #2543: github_rate_limit_observations receives one INSERT per outbound GitHub API response and is pruned in
+// daily bulk deletes by the retention job (pruneExpiredRecords) -- an insert-then-bulk-delete pattern that is
+// exactly the shape that causes dead-tuple bloat under Postgres's stock autovacuum settings (scale_factor 0.2,
+// i.e. autovacuum waits for 20% of the table to be dead before vacuuming -- fine for a slowly-growing table,
+// too lax for one that gets emptied in one daily burst). Lowering the scale factor makes autovacuum reclaim
+// space promptly after each day's bulk delete instead of letting dead tuples accumulate across cycles. A
+// storage-parameter ALTER is idempotent (re-applying the same value is a no-op), so this runs unconditionally
+// on every Postgres boot rather than needing its own migration-ledger tracking. SQLite has no autovacuum
+// concept at all, so this must never run there -- callers gate it behind the Postgres backend check, matching
+// PGPOOL_MAX/resolvePostgresPoolMax's own "server.ts wiring, tested logic elsewhere" split (src/selfhost/
+// queue-common.ts), since server.ts itself has no test harness (top-level main(), Codecov-ignored).
+export const GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL =
+  "ALTER TABLE github_rate_limit_observations SET (autovacuum_vacuum_scale_factor = 0.05, autovacuum_vacuum_threshold = 50)";
+
+/** Apply the autovacuum tuning above via the SAME D1Database.exec() surface runSelfHostMigrations already uses
+ *  for migrations -- so this reuses translateDdl's existing SQL path rather than a second raw-pool query
+ *  mechanism. Must be called AFTER migrations (the table has to exist first); best-effort by design (a
+ *  storage-parameter tweak is an optimization, never a correctness dependency -- a failure here must not stop
+ *  the self-host from booting). */
+export async function tuneGithubRateLimitObservationsAutovacuum(db: D1Database): Promise<void> {
+  await db.exec(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL).catch((error: unknown) => {
+    console.error(
+      JSON.stringify({
+        level: "warn",
+        event: "selfhost_autovacuum_tune_failed",
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,7 @@ import {
 } from "./selfhost/health";
 import { gauge, incr, observe, renderMetrics } from "./selfhost/metrics";
 import { runSelfHostMigrations } from "./selfhost/migrate";
-import { createPgAdapter } from "./selfhost/pg-adapter";
+import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "./selfhost/pg-adapter";
 import { createPgQueue } from "./selfhost/pg-queue";
 import { createPgVectorize, initPgVectorize } from "./selfhost/pg-vectorize";
 import { resolvePostgresPoolMax } from "./selfhost/queue-common";
@@ -370,6 +370,9 @@ async function main(): Promise<void> {
   console.log(
     JSON.stringify({ event: "selfhost_migrations_applied", count: applied }),
   );
+  // #2543: Postgres-only, applied AFTER migrations (the table must already exist). No-op on SQLite, which has
+  // no autovacuum concept at all -- gated on the same usePostgres check the backend was built from.
+  if (usePostgres) await tuneGithubRateLimitObservationsAutovacuum(backend.db);
 
   const ai = createSelfHostAi(process.env);
   if (ai)

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -5,7 +5,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import pg from "pg";
 import { runSelfHostMigrations } from "../../src/selfhost/migrate";
-import { createPgAdapter } from "../../src/selfhost/pg-adapter";
+import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "../../src/selfhost/pg-adapter";
 import { pruneExpiredRecords } from "../../src/db/retention";
 import { processJob } from "../../src/queue/processors";
 
@@ -83,5 +83,19 @@ suite("Postgres backend (#977) — real Postgres", () => {
     await expect(processJob(env, { type: "prune-retention", requestedBy: "schedule" })).resolves.toBeUndefined();
     const audit = await db.prepare("SELECT outcome FROM audit_events WHERE event_type = ?").bind("retention.prune").first<{ outcome: string }>();
     expect(audit?.outcome).toBe("success");
+  });
+
+  it("tunes github_rate_limit_observations autovacuum below Postgres's default, idempotently (#2543)", async () => {
+    const db = createPgAdapter(pool);
+
+    await tuneGithubRateLimitObservationsAutovacuum(db);
+    await tuneGithubRateLimitObservationsAutovacuum(db); // idempotent -- a second apply must not throw
+
+    const row = await pool.query<{ reloptions: string[] | null }>(
+      "SELECT reloptions FROM pg_class WHERE relname = 'github_rate_limit_observations'",
+    );
+    const options = row.rows[0]?.reloptions ?? [];
+    expect(options).toContain("autovacuum_vacuum_scale_factor=0.05");
+    expect(options).toContain("autovacuum_vacuum_threshold=50");
   });
 });

--- a/test/unit/selfhost-pg-adapter-autovacuum.test.ts
+++ b/test/unit/selfhost-pg-adapter-autovacuum.test.ts
@@ -1,0 +1,76 @@
+// Unit tests for the github_rate_limit_observations autovacuum tuning step (#2543). Uses a mock D1Database
+// (just the .exec() surface runSelfHostMigrations already relies on) so no real Postgres is required -- the
+// SQL itself is plain, already-Postgres-native syntax with no SQLite constructs for pg-dialect.ts to translate,
+// so a mocked interaction test is a faithful, fast substitute for a live ALTER TABLE.
+import { describe, expect, it, vi } from "vitest";
+import {
+  GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL,
+  tuneGithubRateLimitObservationsAutovacuum,
+} from "../../src/selfhost/pg-adapter";
+
+function mockDb(execImpl: (sql: string) => Promise<unknown>): D1Database {
+  return { exec: vi.fn(execImpl) } as unknown as D1Database;
+}
+
+describe("GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL (#2543)", () => {
+  it("targets the github_rate_limit_observations table with a scale factor below Postgres's 0.2 default", () => {
+    expect(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL).toContain("github_rate_limit_observations");
+    expect(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL).toContain("autovacuum_vacuum_scale_factor");
+    const match = GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL.match(/autovacuum_vacuum_scale_factor\s*=\s*([\d.]+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBeLessThan(0.2);
+    expect(Number(match?.[1])).toBeGreaterThan(0);
+  });
+
+  it("is a single idempotent storage-parameter ALTER, not an additive/destructive DDL statement", () => {
+    expect(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL.trim().toUpperCase()).toMatch(/^ALTER TABLE/);
+    expect(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL).not.toMatch(/DROP|DELETE|TRUNCATE/i);
+  });
+});
+
+describe("tuneGithubRateLimitObservationsAutovacuum (#2543)", () => {
+  it("applies the autovacuum SQL via db.exec()", async () => {
+    const db = mockDb(async () => ({ count: 1, duration: 0 }));
+
+    await tuneGithubRateLimitObservationsAutovacuum(db);
+
+    expect(db.exec).toHaveBeenCalledWith(GITHUB_RATE_LIMIT_OBSERVATIONS_AUTOVACUUM_SQL);
+    expect(db.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open (does not throw) when db.exec rejects -- an optimization, never a boot-blocking dependency", async () => {
+    const db = mockDb(async () => {
+      throw new Error("connection reset");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(tuneGithubRateLimitObservationsAutovacuum(db)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("selfhost_autovacuum_tune_failed"));
+    errorSpy.mockRestore();
+  });
+
+  it("logs the underlying error message on failure", async () => {
+    const db = mockDb(async () => {
+      throw new Error("relation does not exist");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await tuneGithubRateLimitObservationsAutovacuum(db);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("relation does not exist"));
+    errorSpy.mockRestore();
+  });
+
+  it("stringifies a non-Error rejection instead of throwing on error.message access", async () => {
+    const db = mockDb(async () => {
+      throw "a plain string rejection";
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(tuneGithubRateLimitObservationsAutovacuum(db)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("a plain string rejection"));
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2543.

`github_rate_limit_observations` receives one INSERT per outbound GitHub API response and is pruned in daily bulk deletes by the retention job — an insert-then-bulk-delete pattern that is exactly the shape known to cause dead-tuple bloat under Postgres's stock autovacuum settings (the codebase already has an alert rule watching for this general symptom, which implies the risk was anticipated but not pre-empted for this specific table). Explicitly framed by the issue as a before-larger-scale item, not an active production problem today.

## What changed

- **`src/selfhost/pg-adapter.ts`**: new `tuneGithubRateLimitObservationsAutovacuum(db)`, applying `ALTER TABLE github_rate_limit_observations SET (autovacuum_vacuum_scale_factor = 0.05, autovacuum_vacuum_threshold = 50)` — a lower scale factor than Postgres's 0.2 default, so autovacuum reclaims space promptly after each day's bulk delete instead of letting dead tuples accumulate across cycles. Uses the exact same `D1Database.exec()` surface `runSelfHostMigrations` already relies on for migrations, so it reuses the existing `translateDdl` SQL path rather than a second raw-pool mechanism.
- **`src/server.ts`**: calls the tuning step once at boot, immediately **after** `runSelfHostMigrations` (the table has to exist first) and gated behind the existing `usePostgres` check — a complete no-op on SQLite, which has no autovacuum concept at all. Best-effort: a failed tune logs a warning and continues rather than blocking boot, since this is an optimization, never a correctness dependency.
- **`src/github/backfill.ts`**: documented, in place at `recordGitHubResponse` (the single call site of `recordGitHubRateLimitObservation`), the decision **not** to implement write batching — see Correctness notes below.

## Correctness notes — why batching was evaluated and not implemented

The issue explicitly permits "either an implemented batching layer, or a documented decision that the current per-call INSERT pattern is acceptable... with the reasoning written down." I chose the latter:

- The write rate is bounded by GitHub's own REST budget for a single App installation (~5000/hour ≈ 1.4/s sustained, further capped in practice by `QUEUE_CONCURRENCY`'s small worker-pool size) — nowhere near a volume where single-row Postgres INSERTs meaningfully pressure a connection pool.
- `shouldWaitForGitHubRateLimit` (`src/github/rate-limit.ts`) reads the **latest row from this exact table** for admission control across every self-host queue worker — including in a multi-instance/shared-Postgres deployment, where a buffering instance's writes would go stale to every *other* instance's reads, not just its own.
- A batching window here would trade a real-but-currently-unmeasured write-volume concern for a genuine risk to the admission-control freshness the #1936 rate-limit-reliability campaign (this entire roadmap) was built to protect: a stale "remaining: 500" observation could let a queue worker admit a job it should have deferred, right when conserving the budget matters most.
- The autovacuum tuning above already addresses the dead-tuple-bloat half of the issue, which is the part that was actually observed/anticipated (an alert rule already exists for it).

## Verification

Spun up a real Postgres 16 container (`docker run postgres:16`) and ran the full `test/integration/selfhost-pg.test.ts` suite against it (normally CI-skipped, gated on `PG_TEST_URL`) — all 5 tests pass, including a new one asserting the exact `pg_class.reloptions` values after applying the tuning twice (idempotency).

## Tests

- `test/unit/selfhost-pg-adapter-autovacuum.test.ts` (new): the SQL constant targets the right table with a scale factor below Postgres's 0.2 default and is a single non-destructive `ALTER`; `tuneGithubRateLimitObservationsAutovacuum` calls `db.exec` with the exact SQL, fails open (does not throw) on a rejected `db.exec`, logs the underlying error message, and handles a non-`Error` rejection without throwing on `.message` access. Mutation-tested: reverting the scale factor to Postgres's 0.2 default correctly failed the "below default" assertion.
- `test/integration/selfhost-pg.test.ts`: new real-Postgres test verifying the autovacuum storage parameters are actually set on the table and that a second apply is a genuine no-op (not an error).

## Validation

- `npm run typecheck`
- `npx vitest run test/unit/selfhost-pg-adapter-autovacuum.test.ts`
- `PG_TEST_URL=... npx vitest run test/integration/selfhost-pg.test.ts` (real Postgres 16, Docker)
- `npm run test:changed`
- `npm run test:coverage` (unsharded, full suite — `src/selfhost/pg-adapter.ts`/`src/server.ts` are Codecov-ignored per `codecov.yml`, validated instead by the real-Postgres integration test above; `src/github/backfill.ts`'s change is comment-only)
- `npm run db:migrations:check` (no-op — no schema/migration file changes; this is a runtime storage-parameter tune, not DDL that needs migration-ledger tracking)
- `npm run test:ci` (the full local gate, exit 0)
- `npm audit --audit-level=moderate`
- `git diff --check`
- Manual mutation testing of the autovacuum SQL constant (see Tests above)

## Scope

- [x] Change is narrow and limited to the stated problem
- [x] No secrets, wallets, hotkeys, trust scores, or reward values added anywhere
- [x] No edits to `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`

## Safety

- [x] No auth/session/CORS surface touched
- [x] No behavior change on the SQLite backend (verified: the new call is gated behind `usePostgres`, never reached otherwise); no regression to rate-limit admission-control accuracy (no batching was introduced — the write path is unchanged, only a storage parameter on the target table)