### PR TITLE
fix(enrichment): exclude official actions/github refs case-insensitively

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -7,7 +7,10 @@ import { isWorkflowPath } from "../workflow-path.js";
 
 const USES_RE = /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
 const FULL_SHA = /^[0-9a-f]{40}$/;
-const OFFICIAL = /^(actions|github)\//;
+// GitHub org/user names are case-insensitive (mirrors isWorkflowPath's case-insensitive path match), so the
+// official-action exclusion matches case-insensitively — otherwise `Actions/checkout` would be mis-flagged as a
+// mutable third-party action. GitHub reserves the `actions`/`github` orgs, so this can never over-match a real one.
+const OFFICIAL = /^(actions|github)\//i;
 
 /** Scan one workflow patch's added lines for unpinned third-party `uses:` refs, line-cited via hunk headers. Pure. */
 export function scanWorkflowPins(

--- a/review-enrichment/test/actions-pin.test.ts
+++ b/review-enrichment/test/actions-pin.test.ts
@@ -36,6 +36,25 @@ test("scanWorkflowPins flags mutable third-party action refs with line citations
   ]);
 });
 
+test("scanWorkflowPins excludes official actions/github refs case-insensitively", () => {
+  const findings = scanWorkflowPins(
+    workflowPath,
+    [
+      "@@ -1,0 +5,4 @@",
+      "+    - uses: Actions/checkout@v4",
+      "+    - uses: GitHub/codeql-action/init@v3",
+      "+    - uses: ACTIONS/setup-node@v4",
+      "+    - uses: pnpm/action-setup@v3",
+    ].join("\n"),
+  );
+
+  // GitHub org names are case-insensitive, so official actions/* and github/* refs are excluded regardless of
+  // casing; only the genuine mutable third-party ref is flagged.
+  assert.deepEqual(findings, [
+    { file: workflowPath, line: 8, action: "pnpm/action-setup", ref: "v3" },
+  ]);
+});
+
 test("scanWorkflowPins accepts quoted uses keys and ignores unchanged uses lines", () => {
   const findings = scanWorkflowPins(
     workflowPath,


### PR DESCRIPTION
## What

The unpinned-Actions analyzer excludes official `actions/*` and `github/*` refs from its findings (lowest-risk, extremely common). The exclusion regex `/^(actions|github)\//` is case-sensitive.

## Why it is a bug

GitHub org/user names are case-insensitive (`github.com/Actions` is `github.com/actions`). A workflow line like `uses: Actions/checkout@v4` (or `GitHub/codeql-action/init@v3`) references the official action, but the case-sensitive exclusion fails to match it — so the analyzer mis-flags an official action as a mutable third-party supply-chain risk. That is a false positive in a security signal.

It is also inconsistent with the same analyzer's own path handling: `isWorkflowPath` already matches GitHub workflow paths case-insensitively (`workflow-path.ts`: *"GitHub workflow paths are case-insensitive"*, `.toLowerCase()`). The official-org exclusion should be case-insensitive for the same reason.

## Fix

Add the `i` flag: `/^(actions|github)\//i`. GitHub reserves the `actions` and `github` orgs, so this can never over-match a real third-party org.

## Test

Adds a case-variant scenario (`Actions/checkout`, `GitHub/codeql-action`, `ACTIONS/setup-node`) asserting that only the genuine mutable third-party ref is flagged. It fails on the pre-fix regex (which flags the official refs) and passes after.

## No linked issue

No linked issue because this is a maintenance fix for a case-sensitivity inconsistency within the analyzer; there is no tracking issue to link.
