### PR TITLE
feat(review): add issue-centric RAG query builder for the analyze phase

### DIFF
--- a/src/review/issue-rag-wire.ts
+++ b/src/review/issue-rag-wire.ts
@@ -1,0 +1,45 @@
+// Issue-centric RAG query composer (#2320). The miner's ANALYZE phase reasons about an ISSUE before any diff
+// exists, so — unlike the review path, which composes its retrieval query from a PR's changed files + diff
+// (`buildRagQuery` in `./rag-wire`) — there is no patch to embed, only the issue's title + body (+ labels). This
+// module is the issue-centric analogue of `buildRagQuery`: it composes the retrieval QUERY TEXT that a later
+// analyze-phase caller feeds to the SAME `retrieveContextWithMetrics` engine (`./rag`) unchanged, so the miner can
+// pull the most relevant existing code/docs for an issue the same way the reviewer pulls them for a PR.
+//
+// PURE — no IO, no adapters, no vector query here: this file builds the query STRING only (retrieval itself is
+// reused unchanged from `./rag`), mirroring how `buildRagQuery` is a pure composer separate from
+// `buildReviewRagContext`'s wiring.
+
+/** Cap on how much of the issue body feeds the query — bounds query length / embed cost. Mirrors
+ *  `MAX_QUERY_DIFF_CHARS` in `./rag-wire` (the PR path's diff-sample budget), renamed for the body input. */
+const MAX_QUERY_BODY_CHARS = 4000;
+/** Trivially-short queries aren't worth an embed + a vector query (the matches would be noise), so a query below
+ *  this floor degrades to "" and the caller skips retrieval — exactly like the PR path, where
+ *  `retrieveContextWithMetrics` drops a sub-floor query (the private `MIN_QUERY_CHARS = 40` at `./rag`:358). We
+ *  apply the SAME floor here so a one-line issue produces no query at all rather than an embed that returns noise. */
+const MIN_QUERY_CHARS = 40;
+
+/**
+ * Compose the retrieval QUERY TEXT for an issue from its TITLE + BODY (+ optional LABELS). We PREPEND the issue
+ * title (the intent in natural language — recall parity with `buildRagQuery`'s title-led PR query), then append a
+ * bounded slice of the body so the embedder sees real tokens (identifiers, API names) and not just the title, then
+ * append the labels as a short hint line. Returns "" when the composed query falls below the shared
+ * `MIN_QUERY_CHARS` floor (a one-line issue): the caller then degrades to no-context, exactly like the PR path.
+ * Pure — same input always yields the same query text.
+ */
+export function buildIssueRagQuery(input: {
+  title: string;
+  body?: string;
+  labels?: string[];
+}): { queryText: string } {
+  const title = input.title.trim();
+  // A bounded slice of the body gives the embedder real tokens to match on; over-budget bodies are truncated so the
+  // query stays focused (the embedder truncates anyway).
+  const body = (typeof input.body === "string" ? input.body : "").trim().slice(0, MAX_QUERY_BODY_CHARS);
+  const labels = (input.labels ?? []).map((label) => label.trim()).filter(Boolean);
+  // Title leads the query (before the body) so the embedder sees the issue's intent first; a blank/whitespace title
+  // is omitted cleanly so the query still starts with the body — mirroring `buildRagQuery`'s blank-title handling.
+  const titleLine = title ? `${title}\n\n` : "";
+  const labelLine = labels.length > 0 ? `\n\nLabels: ${labels.join(", ")}` : "";
+  const queryText = `${titleLine}${body}${labelLine}`.trim();
+  return { queryText: queryText.length >= MIN_QUERY_CHARS ? queryText : "" };
+}

--- a/test/unit/issue-rag-wire.test.ts
+++ b/test/unit/issue-rag-wire.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildIssueRagQuery } from "../../src/review/issue-rag-wire";
+
+// ── buildIssueRagQuery (the issue-centric query composer, #2320) ────────────────────────────────────
+// The ANALYZE-phase analogue of buildRagQuery: it composes the retrieval query from an ISSUE's title + body
+// (+ labels) instead of a PR's changed files + diff. Pure, so every case is a plain input→output assertion.
+
+describe("buildIssueRagQuery composes the retrieval query from an issue's title + body + labels", () => {
+  it("PREPENDS the title, appends the body, then a labels hint line", () => {
+    const { queryText } = buildIssueRagQuery({
+      title: "Fix the OAuth device-flow token refresh",
+      body: "The refresh call drops the scope parameter, so the second call 401s.",
+      // A blank label is dropped so the hint line only carries real labels.
+      labels: ["bug", "", "help wanted"],
+    });
+    expect(queryText).toContain("Fix the OAuth device-flow token refresh");
+    expect(queryText).toContain("drops the scope parameter");
+    expect(queryText).toContain("Labels: bug, help wanted");
+    // The title LEADS the query (before the body), recall parity with buildRagQuery's title-led PR query.
+    expect(queryText.indexOf("Fix the OAuth")).toBeLessThan(queryText.indexOf("drops the scope"));
+  });
+
+  it("emits just the title when there is no body and no labels", () => {
+    const { queryText } = buildIssueRagQuery({
+      title: "Refactor the review-enrichment circuit breaker to fail closed",
+    });
+    expect(queryText).toBe("Refactor the review-enrichment circuit breaker to fail closed");
+    expect(queryText).not.toContain("Labels:");
+  });
+
+  it("omits a blank/whitespace title cleanly (the query then starts with the body, no leading newlines)", () => {
+    const { queryText } = buildIssueRagQuery({
+      title: "   ",
+      body: "The public stats endpoint returns null when the SUM aggregates over an empty set.",
+    });
+    expect(queryText.startsWith("The public stats endpoint")).toBe(true);
+    expect(queryText.startsWith("\n")).toBe(false);
+  });
+
+  it("degrades to an empty query below the MIN_QUERY_CHARS floor (a one-line issue isn't worth an embed)", () => {
+    expect(buildIssueRagQuery({ title: "Typo in README" }).queryText).toBe("");
+    // Whitespace-only title AND body → nothing to query on.
+    expect(buildIssueRagQuery({ title: "  ", body: "   " }).queryText).toBe("");
+  });
+
+  it("truncates an over-budget body so the query stays within the bounded budget", () => {
+    const { queryText } = buildIssueRagQuery({
+      title: "Investigate the slow cross-repo fan-out",
+      body: "y".repeat(4000) + "TAIL_BEYOND_THE_BUDGET",
+    });
+    expect(queryText).toContain("yyy");
+    expect(queryText).not.toContain("TAIL_BEYOND_THE_BUDGET");
+  });
+
+  it("drops labels that are blank/whitespace, omitting the hint line when none survive", () => {
+    const { queryText } = buildIssueRagQuery({
+      title: "Add a per-repo max-concurrent-claims cap to the miner goal spec",
+      labels: ["", "   "],
+    });
+    expect(queryText).not.toContain("Labels:");
+  });
+});
+
+describe("buildIssueRagQuery invariants", () => {
+  it("treats an absent labels field and an empty labels array identically", () => {
+    const title = "Wire the issue-centric RAG query into the analyze phase";
+    expect(buildIssueRagQuery({ title }).queryText).toBe(buildIssueRagQuery({ title, labels: [] }).queryText);
+  });
+
+  it("treats an absent body and a whitespace-only body identically", () => {
+    const title = "Cache bare PR reads mirroring the head-SHA sync-state pattern";
+    expect(buildIssueRagQuery({ title }).queryText).toBe(buildIssueRagQuery({ title, body: "   " }).queryText);
+  });
+
+  it("is pure: identical inputs always yield identical query text", () => {
+    const input = { title: "Deterministic ranker ordering for opportunities", body: "Sort by descending score.", labels: ["feature"] };
+    expect(buildIssueRagQuery(input).queryText).toBe(buildIssueRagQuery(input).queryText);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `buildIssueRagQuery` in `src/review/issue-rag-wire.ts` — the issue-centric analogue of the review path's `buildRagQuery` (`src/review/rag-wire.ts:144`). The miner's ANALYZE phase reasons about an issue *before* any diff exists, so it can't compose a retrieval query from changed files + a diff sample the way the PR path does; it has only the issue's title, body, and labels. This function composes that query text so a later analyze-phase caller can feed the **same** `retrieveContextWithMetrics` engine (`src/review/rag.ts`) unchanged and pull the most relevant existing code/docs for an issue — exactly how the reviewer pulls them for a PR.

It mirrors `buildRagQuery`'s conventions: the title leads the query (intent in natural language, recall parity), a bounded slice of the body follows so the embedder sees real tokens, and labels append a short hint line. It respects the same `MIN_QUERY_CHARS = 40` floor `retrieveContextWithMetrics` enforces (`rag.ts:358`), so a one-line issue produces `""` and the caller degrades to no-context — again mirroring the PR path. The function is pure (no IO, no adapters, no vector query) and does **not** modify `retrieveContext`/`retrieveContextWithMetrics`/`upsertChunks`; retrieval is reused unchanged. Wiring it into a miner CLI plan/analyze command is a follow-up (no such command exists yet).

Closes #2320.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` — this PR adds **no dependencies** (no `package.json`/lockfile change), so dependency-review has nothing new to evaluate.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

New tests in `test/unit/issue-rag-wire.test.ts` cover every branch of the composer (title present/blank, body present/absent/over-budget, labels present/absent/all-blank, and the sub-floor degrade-to-`""` path) at **100% line and branch coverage of the changed file**, plus invariants (absent vs. empty inputs are identical; the composer is pure).

If any required check was skipped, explain why:

- Every code-relevant check ran green locally: `git diff --check`, `actionlint`, `db:migrations:check`, `cf-typegen:check`, `typecheck`, `test:coverage` (6510 passed; the changed file at 100% line + branch coverage), `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:typecheck`, `ui:lint`, `ui:test`, `ui:build`. `npm audit` was not completed locally (this PR adds no dependencies); no code check was skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — n/a: this is a pure, side-effect-free query-string composer with no auth/cookie/CORS/session/App surface.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — n/a: no API route, OpenAPI schema, or MCP tool is added or changed; the function is not wired into any surface yet.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — n/a: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — n/a: no visible UI, frontend, docs, or extension change, so no UI Evidence is required.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

Backend-only, additive: one new module (`src/review/issue-rag-wire.ts`) and one new test file. No existing code is modified.
