### PR TITLE
fix(db): target the primary key in upsertPullRequestFile's ON CONFLICT clause

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3071,8 +3071,15 @@ export async function upsertPullRequestFile(env: Env, file: PullRequestFileRecor
       payloadJson: jsonString(file.payload),
       updatedAt: nowIso(),
     })
+    // Target the PRIMARY KEY, not the (repoFullName, pullNumber, path) unique index it's derived from. `id`
+    // is a pure function of those same 3 fields, so under a single execution the two are always in lockstep —
+    // but on the self-host Postgres backend, ON CONFLICT only protects against a race on the SPECIFIED arbiter
+    // index; a genuinely concurrent second writer (e.g. two overlapping detail-sync passes for the same PR,
+    // both racing past the "no existing row yet" check) can still hit a raw duplicate-key error on `id` because
+    // that constraint isn't the one Postgres is arbitrating. Targeting `id` directly makes Postgres's upsert
+    // machinery cover the constraint that's actually racing.
     .onConflictDoUpdate({
-      target: [pullRequestFiles.repoFullName, pullRequestFiles.pullNumber, pullRequestFiles.path],
+      target: pullRequestFiles.id,
       set: {
         status: file.status,
         additions: file.additions,

--- a/test/unit/db-persistence.test.ts
+++ b/test/unit/db-persistence.test.ts
@@ -193,6 +193,35 @@ describe("database persistence helpers", () => {
     const cappedPathSet = new Set(cappedPaths.map((entry) => entry.path));
     expect(graph.paths.every((entry) => cappedPathSet.has(entry.path))).toBe(true);
   });
+
+  it("REGRESSION: upsertPullRequestFile targets the id PRIMARY KEY in its ON CONFLICT clause, not the secondary unique index", async () => {
+    // `id` is a pure function of (repoFullName, pullNumber, path) — the exact same fields the secondary
+    // unique index covers — so targeting that index instead of `id` leaves the primary key unprotected by
+    // Postgres's upsert machinery on the self-host Postgres backend (see #977's pg-adapter): a genuinely
+    // concurrent second writer can still raise a raw duplicate-key error on `pull_request_files_pkey` even
+    // though the composite fields "agree." Asserting the generated SQL's conflict target pins the fix so a
+    // future revert back to the composite target doesn't silently reopen the race.
+    const env = createTestEnv();
+    const realPrepare = env.DB.prepare.bind(env.DB);
+    const conflictClauses: string[] = [];
+    env.DB.prepare = ((sql: string) => {
+      if (/insert\s+into\s+["'`]?pull_request_files/i.test(sql)) {
+        const match = /on\s+conflict\s*\(([^)]*)\)/i.exec(sql);
+        if (match) conflictClauses.push(match[1]!.trim());
+      }
+      return realPrepare(sql);
+    }) as typeof env.DB.prepare;
+
+    await upsertPullRequestFile(env, pullRequestFile("owner/repo", 1, "src/a.ts"));
+
+    expect(conflictClauses).toHaveLength(1);
+    expect(conflictClauses[0]).toMatch(/^["'`]?(pull_request_files["'`]?\.["'`]?)?id["'`]?$/i);
+
+    // Functional guard: a same-key upsert still updates the existing row in place rather than duplicating it.
+    await upsertPullRequestFile(env, { ...pullRequestFile("owner/repo", 1, "src/a.ts"), additions: 99 });
+    const rows = await listRepoPullRequestFilePaths(env, "owner/repo", { pullNumbers: [1] });
+    expect(rows).toHaveLength(1);
+  });
 });
 
 function pullRequestFile(repoFullName: string, pullNumber: number, path: string): PullRequestFileRecord {


### PR DESCRIPTION
## Summary

- Self-host job logs showed a `job_error` on `pull_request_files` upserts: `duplicate key value violates unique constraint "pull_request_files_pkey" [23505]` (Postgres, from the self-host `pg-adapter`).
- Root cause: `upsertPullRequestFile`'s `onConflictDoUpdate` targets the secondary `(repoFullName, pullNumber, path)` unique index, not the `id` primary key — even though `id` is a pure function of those same 3 fields. On SQLite this is harmless (a single execution never observes the mismatch), but Postgres's `ON CONFLICT` only arbitrates the SPECIFIED index; a genuinely concurrent second writer (e.g. two overlapping detail-sync passes for the same PR racing past the "no existing row yet" check) can still hit a raw duplicate-key error on `pull_request_files_pkey` because that constraint isn't the one being arbitrated.
- Fix: retarget the conflict clause to `pullRequestFiles.id` directly. Since `id` is bijective with the composite fields at every insert site, this is behavior-preserving for the non-racing case and makes Postgres's upsert machinery cover the constraint that's actually racing.
- No linked issue — small, self-evident fix driven directly by a production error log, not a tracked feature/bug ticket.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `src/db/repositories.ts` diff lines are 100% covered by a new regression test that asserts the generated SQL's `ON CONFLICT` target and a functional same-key-upsert-in-place check.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`) — no OpenAPI-visible change
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, this is a DB upsert conflict-target fix, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API-visible change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## Notes

- This is the same root-cause class the self-host Postgres adapter (`src/selfhost/pg-adapter.ts`, #977) is built around: Drizzle's SQLite-dialect SQL is translated and run against a real Postgres backend, so Postgres's stricter `ON CONFLICT`-arbiter semantics apply even though the schema is authored against SQLite.
- A broader audit found several other tables in `src/db/repositories.ts` follow the same "synthetic `id` derived from the same fields as the `onConflictDoUpdate` target" pattern (`pullRequests`, `issues`, `repoSyncSegments`, `pullRequestDetailSyncState`, `repoLabels`, `recentMergedPullRequests`, `contributorRepoStats`, `gateOutcomes`). This PR is scoped to the ONE table with a confirmed production error; the others are a separate, larger follow-up worth its own PR rather than bundling a wide, higher-risk data-layer change here.
