### PR TITLE
fix(settings): cap review-nag cooldown

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -325,7 +325,7 @@ settings:
   # a dedicated closeIssue primitive lands) with a clear reason. Off by default.
   # reviewNagPolicy: off      # off | hold | close. Default: off.
   # reviewNagMaxPings: 3      # Positive integer. Pings above this within the cooldown window trigger the policy. Default: 3.
-  # reviewNagCooldownDays: 5  # Positive integer. Window the ping count is measured over. Default: 5.
+  # reviewNagCooldownDays: 5  # Positive integer up to 365. Window the ping count is measured over. Default: 5.
   # reviewNagLabel: review-nag-cooldown  # Label applied alongside the hold/close action. Default: review-nag-cooldown.
 
   # Shared repo-scoped exemption list (#2463): GitHub logins never throttled/closed by gittensory's

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -8618,7 +8618,8 @@
           "reviewNagCooldownDays": {
             "type": "integer",
             "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": true,
+            "maximum": 365
           },
           "reviewNagLabel": {
             "type": "string"

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -57,6 +57,7 @@ import {
   upstreamSourceSnapshots,
   webhookEvents,
 } from "./schema";
+import { MAX_REVIEW_NAG_COOLDOWN_DAYS } from "../settings/agent-actions";
 import type {
   Advisory,
   AdvisoryFinding,
@@ -562,7 +563,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     contributorCapLabel: row.contributorCapLabel,
     reviewNagPolicy: normalizeReviewNagPolicy(row.reviewNagPolicy),
     reviewNagMaxPings: normalizePositiveIntWithDefault(row.reviewNagMaxPings, 3),
-    reviewNagCooldownDays: normalizePositiveIntWithDefault(row.reviewNagCooldownDays, 5),
+    reviewNagCooldownDays: normalizeReviewNagCooldownDays(row.reviewNagCooldownDays, 5),
     reviewNagLabel: row.reviewNagLabel,
     autoCloseExemptLogins: parseAutoCloseExemptLogins(row.autoCloseExemptLoginsJson),
     requireFreshRebaseWindowMinutes: normalizeOpenItemCap(row.requireFreshRebaseWindowMinutes),
@@ -649,7 +650,7 @@ export async function upsertRepositorySettings(env: Env, settings: Partial<Repos
     contributorCapLabel: settings.contributorCapLabel ?? "over-contributor-limit",
     reviewNagPolicy: normalizeReviewNagPolicy(settings.reviewNagPolicy),
     reviewNagMaxPings: normalizePositiveIntWithDefault(settings.reviewNagMaxPings, 3),
-    reviewNagCooldownDays: normalizePositiveIntWithDefault(settings.reviewNagCooldownDays, 5),
+    reviewNagCooldownDays: normalizeReviewNagCooldownDays(settings.reviewNagCooldownDays, 5),
     reviewNagLabel: settings.reviewNagLabel ?? "review-nag-cooldown",
     autoCloseExemptLogins: normalizeAutoCloseExemptLogins(settings.autoCloseExemptLogins).logins,
     requireFreshRebaseWindowMinutes: normalizeOpenItemCap(settings.requireFreshRebaseWindowMinutes),
@@ -5796,6 +5797,11 @@ function normalizeReviewNagPolicy(value: string | null | undefined): "off" | "ho
 function normalizePositiveIntWithDefault(value: number | null | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) return fallback;
   return value;
+}
+
+function normalizeReviewNagCooldownDays(value: number | null | undefined, fallback: number): number {
+  const normalized = normalizePositiveIntWithDefault(value, fallback);
+  return Math.min(normalized, MAX_REVIEW_NAG_COOLDOWN_DAYS);
 }
 
 function parseAutonomyPolicy(value: string): AutonomyPolicy {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MAX_REVIEW_NAG_COOLDOWN_DAYS } from "../settings/agent-actions";
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 
 extendZodWithOpenApi(z);
@@ -647,7 +648,7 @@ export const RepositorySettingsSchema = z
     contributorCapLabel: z.string().optional(),
     reviewNagPolicy: z.enum(["off", "hold", "close"]).optional(),
     reviewNagMaxPings: z.number().int().positive().optional(),
-    reviewNagCooldownDays: z.number().int().positive().optional(),
+    reviewNagCooldownDays: z.number().int().positive().max(MAX_REVIEW_NAG_COOLDOWN_DAYS).optional(),
     reviewNagLabel: z.string().optional(),
     autoCloseExemptLogins: z.array(z.string()).optional(),
     accountAgeThresholdDays: z.number().int().positive().nullable().optional(),

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -235,6 +235,7 @@ import { aiReviewCacheInputFingerprint } from "../review/ai-review-cache-input";
 import {
   downgradeCloseToHold,
   downgradeMergeToHold,
+  MAX_REVIEW_NAG_COOLDOWN_DAYS,
   isProtectedAutomationAuthor,
   planAgentMaintenanceActions,
   type PlannedAgentAction,
@@ -8814,7 +8815,7 @@ async function maybeThrottleReviewNagPing(
   /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer (NOT NULL DEFAULT 3); the undefined side is defensive against the field's optional TS type. */
   const maxPings = settings.reviewNagMaxPings ?? 3;
   /* v8 ignore next -- resolveRepositorySettings always resolves a concrete positive integer (NOT NULL DEFAULT 5); the undefined side is defensive against the field's optional TS type. */
-  const cooldownDays = settings.reviewNagCooldownDays ?? 5;
+  const cooldownDays = Math.min(settings.reviewNagCooldownDays ?? 5, MAX_REVIEW_NAG_COOLDOWN_DAYS);
   const sinceIso = new Date(Date.now() - cooldownDays * 24 * 60 * 60 * 1000).toISOString();
   const priorPings = await countRecentAuditEventsForActorAndTarget(env, commenter, REVIEW_NAG_PING_EVENT_TYPE, targetKey, sinceIso);
   const pingCount = priorPings + 1; // this ping counts too

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -31,6 +31,8 @@ export const DEFAULT_CONTRIBUTOR_CAP_LABEL = "over-contributor-limit";
 // configurable per-repo via `.gittensory.yml` (`settings.reviewNagLabel`); the planner uses the resolved label
 // and falls back to this default, mirroring DEFAULT_BLACKLIST_LABEL's shape.
 export const DEFAULT_REVIEW_NAG_LABEL = "review-nag-cooldown";
+// Keep the review-nag lookback operationally bounded so repo-controlled config cannot overflow Date arithmetic.
+export const MAX_REVIEW_NAG_COOLDOWN_DAYS = 365;
 // A PR that PASSES the gate but touches a hard-guardrail path is NOT ready to auto-merge — it is withheld
 // for a human (the merge/approve/close dispositions are suppressed below). Labeling it `ready-to-merge`
 // would be misleading (the label promises an auto-merge that never happens), so a guarded passing PR gets

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -4,6 +4,7 @@ import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../setting
 import { normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
 import { mergeContributorBlacklists, normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { normalizeAutoCloseExemptLogins } from "../settings/auto-close-exempt";
+import { MAX_REVIEW_NAG_COOLDOWN_DAYS } from "../settings/agent-actions";
 import { hasUnsafeWildcardCount } from "./change-guardrail";
 import { PUBLIC_LOCAL_PATH_INLINE } from "./redaction";
 
@@ -859,7 +860,10 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   const reviewNagMaxPings = normalizeOptionalPositiveInteger(r.reviewNagMaxPings, "settings.reviewNagMaxPings", warnings);
   if (reviewNagMaxPings !== null) out.reviewNagMaxPings = reviewNagMaxPings;
   const reviewNagCooldownDays = normalizeOptionalPositiveInteger(r.reviewNagCooldownDays, "settings.reviewNagCooldownDays", warnings);
-  if (reviewNagCooldownDays !== null) out.reviewNagCooldownDays = reviewNagCooldownDays;
+  if (reviewNagCooldownDays !== null && reviewNagCooldownDays <= MAX_REVIEW_NAG_COOLDOWN_DAYS) out.reviewNagCooldownDays = reviewNagCooldownDays;
+  if (reviewNagCooldownDays !== null && reviewNagCooldownDays > MAX_REVIEW_NAG_COOLDOWN_DAYS) {
+    warnings.push(`Manifest field "settings.reviewNagCooldownDays" must be at most ${MAX_REVIEW_NAG_COOLDOWN_DAYS}; ignoring it.`);
+  }
   const reviewNagLabel = normalizeOptionalString(r.reviewNagLabel, "settings.reviewNagLabel", warnings);
   if (reviewNagLabel !== null) out.reviewNagLabel = reviewNagLabel;
   // Shared repo-scoped exemption list (#2463): only set it when at least one VALID login survives

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -4,7 +4,6 @@ import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../setting
 import { normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
 import { mergeContributorBlacklists, normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { normalizeAutoCloseExemptLogins } from "../settings/auto-close-exempt";
-import { MAX_REVIEW_NAG_COOLDOWN_DAYS } from "../settings/agent-actions";
 import { hasUnsafeWildcardCount } from "./change-guardrail";
 import { PUBLIC_LOCAL_PATH_INLINE } from "./redaction";
 
@@ -741,6 +740,13 @@ function normalizeOptionalString(value: JsonValue | undefined, field: string, wa
   warnings.push(`Manifest settings field "${field}" must be a non-empty string; ignoring it.`);
   return null;
 }
+
+// Keep the review-nag lookback operationally bounded so repo-controlled config cannot overflow Date
+// arithmetic. Duplicated from settings/agent-actions.ts's own MAX_REVIEW_NAG_COOLDOWN_DAYS (same value,
+// same rationale) rather than imported: this module is part of the UI package's typechecked closure, and
+// agent-actions.ts transitively imports github/commands.ts -> utils/crypto.ts, pulling a heavier
+// GitHub-App-specific dependency chain into the UI build for one small constant.
+const MAX_REVIEW_NAG_COOLDOWN_DAYS = 365;
 
 /**
  * Parse the optional `settings:` mapping — a partial repository-settings override. Only recognized

--- a/test/unit/data-spine.test.ts
+++ b/test/unit/data-spine.test.ts
@@ -366,6 +366,10 @@ describe("data spine repositories", () => {
     // back to its default rather than being silently coerced.
     await upsertRepositorySettings(env, { repoFullName: "owner/badnagrepo", reviewNagPolicy: "delete-everything" as never, reviewNagMaxPings: -1, reviewNagCooldownDays: 2.5 as never });
     expect(await getRepositorySettings(env, "owner/badnagrepo")).toMatchObject({ reviewNagPolicy: "off", reviewNagMaxPings: 3, reviewNagCooldownDays: 5 });
+    await upsertRepositorySettings(env, { repoFullName: "owner/bigwindowrepo", reviewNagMaxPings: 1_000, reviewNagCooldownDays: 1_000_000_000 });
+    expect(await getRepositorySettings(env, "owner/bigwindowrepo")).toMatchObject({ reviewNagMaxPings: 1_000, reviewNagCooldownDays: 365 });
+    await env.DB.prepare("update repository_settings set review_nag_cooldown_days = ? where repo_full_name = ?").bind(1_000_000_000, "owner/bigwindowrepo").run();
+    expect(await getRepositorySettings(env, "owner/bigwindowrepo")).toMatchObject({ reviewNagMaxPings: 1_000, reviewNagCooldownDays: 365 });
     expect(updated.slopAiAdvisory).toBe(false);
     expect(await getRepoSyncState(env, "missing/repo")).toBeNull();
     expect(await getPullRequest(env, "owner/repo", 404)).toBeNull();

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1382,6 +1382,9 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(invalid.warnings.some((w) => /settings\.reviewNagPolicy/.test(w))).toBe(true);
     expect(invalid.warnings.some((w) => /settings\.reviewNagMaxPings/.test(w))).toBe(true);
     expect(invalid.warnings.some((w) => /settings\.reviewNagCooldownDays/.test(w))).toBe(true);
+    const tooLarge = parseFocusManifest({ settings: { reviewNagCooldownDays: 366 } });
+    expect(tooLarge.settings.reviewNagCooldownDays).toBeUndefined();
+    expect(tooLarge.warnings.some((w) => /settings\.reviewNagCooldownDays/.test(w) && /365/.test(w))).toBe(true);
   });
 
   it("parses + resolves the account-age throttle settings from the settings: block, overlaying the DB (#2561)", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -11976,6 +11976,29 @@ describe("queue processors", () => {
       expect(seen.closed).toBe(false);
     });
 
+    it("caps an oversized review-nag cooldown before Date arithmetic (regression)", async () => {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "hold", reviewNagMaxPings: 3, reviewNagCooldownDays: 1_000_000_000 });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 206, title: "Huge cooldown", state: "open", user: { login: "chatty" }, author_association: "NONE", labels: [], body: "" });
+      const seen = { comments: [] as string[], labels: [] as string[], closed: false };
+      stubReviewNagFetch(206, seen);
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "nag-huge-cooldown",
+        eventName: "issue_comment",
+        payload: {
+          action: "created",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          issue: { number: 206, title: "Huge cooldown", state: "open", pull_request: {}, user: { login: "chatty" }, author_association: "NONE" },
+          comment: { id: 1, body: "@gittensory help", user: { login: "chatty", type: "User" }, author_association: "NONE" },
+        },
+      });
+      const pings = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.review_nag_ping'").first<{ n: number }>();
+      expect(pings?.n).toBe(1);
+      expect(seen.closed).toBe(false);
+    });
+
     it("records pings under the configured threshold without acting; the normal @gittensory reply still proceeds", async () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMaxPings: 3 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -11976,12 +11976,30 @@ describe("queue processors", () => {
       expect(seen.closed).toBe(false);
     });
 
-    it("caps an oversized review-nag cooldown before Date arithmetic (regression)", async () => {
+    it("REGRESSION (gate-flagged): caps an oversized review-nag cooldown at MAX_REVIEW_NAG_COOLDOWN_DAYS before Date arithmetic, even when the resolved settings object itself carries an oversized value", async () => {
+      // upsertRepositorySettings/getRepositorySettings both clamp reviewNagCooldownDays on write AND read, so
+      // seeding an oversized value through the normal repository layer (even via a raw DB update bypassing the
+      // write-time clamp) can never actually reach maybeThrottleReviewNagPing uncapped -- the read-time clamp in
+      // getRepositorySettings neutralizes it first. Mock resolveRepositorySettings directly so this test proves
+      // processors.ts's OWN Math.min(reviewNagCooldownDays, MAX_REVIEW_NAG_COOLDOWN_DAYS) guard, not the DB layer.
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
-      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "hold", reviewNagMaxPings: 3, reviewNagCooldownDays: 1_000_000_000 });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "hold", reviewNagMaxPings: 3 });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 206, title: "Huge cooldown", state: "open", user: { login: "chatty" }, author_association: "NONE", labels: [], body: "" });
+      // Three prior pings, all 400 DAYS ago -- outside the 365-day cap, but well within an uncapped
+      // "1,000,000,000-day" window. If the guard clamps correctly, these fall outside the window and don't
+      // count; if the guard were removed, the uncapped window would count all three, crossing maxPings=3.
+      vi.setSystemTime(new Date("2025-04-24T00:00:00.000Z"));
+      for (let i = 0; i < 3; i += 1) {
+        await repositoriesModule.recordAuditEvent(env, { eventType: "github_app.review_nag_ping", actor: "chatty", targetKey: "JSONbored/gittensory#206", outcome: "completed" });
+      }
+      vi.setSystemTime(new Date("2026-05-29T00:00:00.000Z")); // ~400 days later
+      const baseSettings = await repositorySettingsModule.resolveRepositorySettings(env, "JSONbored/gittensory");
+      const resolveSettingsSpy = vi
+        .spyOn(repositorySettingsModule, "resolveRepositorySettings")
+        .mockResolvedValueOnce({ ...baseSettings, reviewNagCooldownDays: 1_000_000_000 });
       const seen = { comments: [] as string[], labels: [] as string[], closed: false };
       stubReviewNagFetch(206, seen);
+
       await processJob(env, {
         type: "github-webhook",
         deliveryId: "nag-huge-cooldown",
@@ -11994,9 +12012,16 @@ describe("queue processors", () => {
           comment: { id: 1, body: "@gittensory help", user: { login: "chatty", type: "User" }, author_association: "NONE" },
         },
       });
-      const pings = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.review_nag_ping'").first<{ n: number }>();
-      expect(pings?.n).toBe(1);
+
+      // The 400-day-old pings fell outside the CAPPED 365-day window, so this is only the 1st ping this
+      // window — under maxPings=3, never throttled. An uncapped window would have counted all 3 prior pings
+      // (pingCount=4 > maxPings=3) and applied the cooldown instead.
+      const applied = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.review_nag_cooldown_applied'").first<{ n: number }>();
+      expect(applied?.n).toBe(0);
       expect(seen.closed).toBe(false);
+      expect(seen.comments.some((c) => c.includes("cooldown limit"))).toBe(false);
+      expect(resolveSettingsSpy).toHaveBeenCalled();
+      resolveSettingsSpy.mockRestore();
     });
 
     it("records pings under the configured threshold without acting; the normal @gittensory reply still proceeds", async () => {


### PR DESCRIPTION
### Motivation
- Prevent a repo-controlled `reviewNagCooldownDays` from overflowing `Date` arithmetic and throwing `RangeError` during `issue_comment` webhook processing by bounding the operational lookback window.
- Keep existing behavior and defaults while making manifest, DB, OpenAPI, and runtime usage resilient to malicious or accidental oversized values.

### Description
- Add a public constant `MAX_REVIEW_NAG_COOLDOWN_DAYS = 365` in `src/settings/agent-actions.ts` and use it as the system-wide cap.
- Reject oversized manifest values at parse time with a warning in `src/signals/focus-manifest.ts` so `.gittensory.yml` entries above the cap are ignored.
- Introduce `normalizeReviewNagCooldownDays` in `src/db/repositories.ts` to clamp persisted and DB-resolved values to the cap while preserving other normalization semantics.
- Clamp the resolved cooldown at runtime before computing the `sinceIso` Date in `src/queue/processors.ts` so `issue_comment` handling cannot throw even if an oversized value reaches the processor.
- Update `src/openapi/schemas.ts` and `.gittensory.yml.example` to document/enforce the 365-day maximum and regenerate the UI OpenAPI artifact (`apps/gittensory-ui/public/openapi.json`).
- Add regression tests covering manifest parsing rejection, DB normalization (including legacy raw DB value), and the webhook path to ensure a huge configured window does not crash processing (tests updated in `test/unit/focus-manifest.test.ts`, `test/unit/data-spine.test.ts`, and `test/unit/queue.test.ts`).

### Testing
- Ran `npm run typecheck` and it succeeded.
- Regenerated OpenAPI with `npm run ui:openapi` and validated with `npm run ui:openapi:check`, both succeeding and `apps/gittensory-ui/public/openapi.json` updated.
- Ran focused unit tests: `npx vitest run test/unit/focus-manifest.test.ts -t "review-nag cooldown settings"`, `npx vitest run test/unit/data-spine.test.ts -t "persists and reads"`, and `npx vitest run test/unit/queue.test.ts -t "oversized review-nag cooldown"`, and the new/affected tests passed.
- Note: a full run of the large `queue.test.ts` file in this container hit existing long-running sweep timeouts unrelated to this fix, so a targeted test invocation was used to validate the regression; `npm audit --audit-level=moderate` could not complete here due to the registry audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46d3a73248832c9dc9f5525df74d4a)