### PR TITLE
feat(review): surface the test-evidence classifier in the AI review prompt

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5271,6 +5271,7 @@ export async function runAiReviewForAdvisory(
         files.map((file) => file.path),
       ),
       repoInstructions: args.reviewInstructions ?? null,
+      changedFiles: files,
     });
     if (result.status !== "ok") return undefined;
     const findings: AdvisoryFinding[] = [];

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -517,7 +517,7 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
  * change is not "zero evidence") — only a fully test-free PR touching real code files gets a section.
  */
 export function buildTestEvidencePromptSection(files: ReadonlyArray<{ path: string }>): string | undefined {
-  const codePaths = files.map((file) => file.path).filter(Boolean).filter(isCodeFile);
+  const codePaths = [...new Set(files.map((file) => file.path).filter(Boolean).filter(isCodeFile))];
   if (codePaths.length === 0) return undefined;
   if (files.some((file) => isTestPath(file.path))) return undefined;
   return `Test evidence (engine classifier): this PR has NO test-path changes. The following changed code file(s) have zero test-path evidence: ${codePaths.join(", ")}.`;

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -28,6 +28,8 @@ import { labelSelfHostReviewerModels, labelSelfHostReviewerNames, resolveConfigu
 import { incr } from "../selfhost/metrics";
 import { errorMessage } from "../utils/json";
 import type { ReviewProfile } from "../signals/focus-manifest";
+import { isCodeFile } from "../signals/local-branch";
+import { isTestPath } from "../signals/test-evidence";
 
 /**
  * The best free Workers-AI model pair for review accuracy — two different families for independence,
@@ -178,6 +180,14 @@ export type GittensoryAiReviewInput = {
    * (the default) ⇒ no instruction is appended, so the prompt is byte-identical and the model emits none.
    */
   inlineFindings?: boolean | undefined;
+  /**
+   * This PR's changed file paths (#2558) — reused to splice a concise "changed code files with zero
+   * test-path evidence" section into the user prompt via the engine's own deterministic classifier
+   * (src/signals/test-evidence.ts), so the reviewer can name specific untested files instead of guessing
+   * from the raw diff. Additional CONTEXT only, never a new blocker/nit rule. Absent/empty, or when the PR
+   * has ANY test-path changes ⇒ no section is appended (byte-identical to today).
+   */
+  changedFiles?: ReadonlyArray<{ path: string }> | null | undefined;
 };
 
 /** A consensus critical defect, already public-safe, ready to become a gate blocker finding. */
@@ -491,7 +501,26 @@ function buildUserPrompt(input: GittensoryAiReviewInput): string {
   // GITTENSORY_REVIEW_ENRICHMENT on AND REES_URL set). Absent/empty (the default) → the prompt is byte-identical.
   const enrichmentSection = input.enrichment?.promptSection;
   if (enrichmentSection) lines.push("", enrichmentSection);
+  // Test-evidence classifier (#2558): ground the reviewer's test-adequacy judgment in the engine's own
+  // deterministic classification instead of eyeballing the diff. Absent/no changed code files without test
+  // evidence ⇒ the prompt is byte-identical.
+  const testEvidenceSection = buildTestEvidencePromptSection(input.changedFiles ?? []);
+  if (testEvidenceSection) lines.push("", testEvidenceSection);
   return lines.join("\n");
+}
+
+/**
+ * A concise "changed code files with zero test-path evidence" section for the user prompt (#2558). Reuses the
+ * existing deterministic classifiers (isCodeFile, isTestPath) — no new signal, this is a wiring gap only.
+ * Mirrors slop.ts's buildMissingTestEvidenceFinding's whole-PR semantics: ANY changed path that already looks
+ * like a test file means there IS test evidence for this PR, so nothing is called out (a partial-but-real test
+ * change is not "zero evidence") — only a fully test-free PR touching real code files gets a section.
+ */
+export function buildTestEvidencePromptSection(files: ReadonlyArray<{ path: string }>): string | undefined {
+  const codePaths = files.map((file) => file.path).filter(Boolean).filter(isCodeFile);
+  if (codePaths.length === 0) return undefined;
+  if (files.some((file) => isTestPath(file.path))) return undefined;
+  return `Test evidence (engine classifier): this PR has NO test-path changes. The following changed code file(s) have zero test-path evidence: ${codePaths.join(", ")}.`;
 }
 
 // `.gittensory.yml` review.profile → an appended tone instruction (#review-profile). `balanced`/absent appends

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1892,4 +1892,12 @@ describe("buildTestEvidencePromptSection (#2558)", () => {
       ]),
     ).toBeUndefined();
   });
+
+  it("de-duplicates a repeated file path so the section doesn't get noisier than the actual changed-file set", () => {
+    const section = buildTestEvidencePromptSection([
+      { path: "src/a.ts" },
+      { path: "src/a.ts" },
+    ]);
+    expect(section?.match(/src\/a\.ts/g)).toHaveLength(1);
+  });
 });

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __aiReviewInternals,
   BEST_REVIEW_MODELS,
+  buildTestEvidencePromptSection,
   runGittensoryAiReview,
   type GittensoryAiReviewInput,
 } from "../../src/services/ai-review";
@@ -1783,5 +1784,112 @@ describe("pure helpers", () => {
       String(opts.messages[0]?.content);
     expect(user).toContain("## EXTERNAL REVIEW BRIEF");
     expect(system).toContain("untrusted advisory context");
+  });
+
+  it("splices the test-evidence classifier section into the user prompt when changed code files have zero test-path evidence (#2558)", async () => {
+    const run = vi.fn(
+      async (
+        _model: string,
+        _options: { messages: Array<{ content: string }> },
+      ) => ({ response: reviewJson() }),
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      changedFiles: [{ path: "src/a.ts" }, { path: "src/b.ts" }],
+    });
+    expect(result.status).toBe("ok");
+    const opts = run.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content: string }>;
+    };
+    const user =
+      opts.messages.find((m) => m.role === "user")?.content ??
+      String(opts.messages[1]?.content);
+    expect(user).toContain("Test evidence (engine classifier)");
+    expect(user).toContain("src/a.ts");
+    expect(user).toContain("src/b.ts");
+  });
+
+  it("does NOT splice a test-evidence section when the PR includes a test-path change (#2558)", async () => {
+    const run = vi.fn(
+      async (
+        _model: string,
+        _options: { messages: Array<{ content: string }> },
+      ) => ({ response: reviewJson() }),
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      changedFiles: [{ path: "src/a.ts" }, { path: "test/unit/a.test.ts" }],
+    });
+    expect(result.status).toBe("ok");
+    const opts = run.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content: string }>;
+    };
+    const user =
+      opts.messages.find((m) => m.role === "user")?.content ??
+      String(opts.messages[1]?.content);
+    expect(user).not.toContain("Test evidence (engine classifier)");
+  });
+
+  it("does NOT splice a test-evidence section when changedFiles is absent (byte-identical to today)", async () => {
+    const run = vi.fn(
+      async (
+        _model: string,
+        _options: { messages: Array<{ content: string }> },
+      ) => ({ response: reviewJson() }),
+    );
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, baseInput);
+    expect(result.status).toBe("ok");
+    const opts = run.mock.calls[0]?.[1] as {
+      messages: Array<{ role?: string; content: string }>;
+    };
+    const user =
+      opts.messages.find((m) => m.role === "user")?.content ??
+      String(opts.messages[1]?.content);
+    expect(user).not.toContain("Test evidence (engine classifier)");
+  });
+});
+
+describe("buildTestEvidencePromptSection (#2558)", () => {
+  it("returns undefined when there are no changed code files", () => {
+    expect(buildTestEvidencePromptSection([])).toBeUndefined();
+    expect(buildTestEvidencePromptSection([{ path: "README.md" }])).toBeUndefined();
+  });
+
+  it("lists changed code files with zero test-path evidence", () => {
+    const section = buildTestEvidencePromptSection([
+      { path: "src/a.ts" },
+      { path: "src/b.ts" },
+      { path: "README.md" },
+    ]);
+    expect(section).toContain("src/a.ts");
+    expect(section).toContain("src/b.ts");
+    expect(section).not.toContain("README.md");
+  });
+
+  it("returns undefined when ANY changed path already looks like a test file", () => {
+    expect(
+      buildTestEvidencePromptSection([
+        { path: "src/a.ts" },
+        { path: "test/unit/a.test.ts" },
+      ]),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `src/services/ai-review.ts`'s `buildUserPrompt`/`REVIEW_SYSTEM_PROMPT` never referenced the engine's own deterministic test-evidence classification (`src/signals/test-evidence.ts`), even though `src/signals/slop.ts` already reuses it for the `missingTestEvidence` finding. The AI reviewer judged test adequacy purely by eyeballing the raw diff.
- Adds `buildTestEvidencePromptSection` (exported, pure) to `ai-review.ts`, reusing the existing `isCodeFile`/`isTestPath` classifiers — no new signal. Splices a concise "changed code files with zero test-path evidence" section into the user prompt when applicable; additional context only, never a new blocker/nit rule.
- Wires `changedFiles` (the PR's already-loaded file list) through `GittensoryAiReviewInput` from the one real call site in `src/queue/processors.ts`.
- Absent when `changedFiles` isn't supplied, or when the PR has any test-path changes, so the prompt is byte-identical to today for the common case (a PR that already has tests, or any caller not yet passing `changedFiles`).

Closes #2558.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% coverage on the new `buildTestEvidencePromptSection` function and its wiring; a unit-test suite plus an integration test asserting the section is actually spliced into the real prompt sent to the model.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`) — no OpenAPI-visible change
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API-visible change (internal prompt construction only).
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## Notes

- First of a batch of independent maintainer-only roadmap items being worked one PR at a time.
