### PR TITLE
docs(ui): point maintainer CTAs and GitHub App docs at self-hosting as the default path

### DIFF
--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -28,14 +28,6 @@ export const docsNav: DocsGroup[] = [
     title: "Maintainers",
     subgroups: [
       {
-        title: "Hosted app",
-        items: [
-          { to: "/docs/maintainer-workflow", label: "Maintainer workflow" },
-          { to: "/docs/github-app", label: "GitHub App" },
-          { to: "/docs/maintainer-install-trust", label: "Maintainer install & trust" },
-        ],
-      },
-      {
         title: "Self-hosting: setup",
         items: [
           { to: "/docs/maintainer-self-hosting", label: "Overview" },
@@ -66,6 +58,14 @@ export const docsNav: DocsGroup[] = [
         items: [
           { to: "/docs/self-hosting-releases", label: "Releases & images" },
           { to: "/docs/self-hosting-security", label: "Security" },
+        ],
+      },
+      {
+        title: "GitHub App & managed beta",
+        items: [
+          { to: "/docs/github-app", label: "GitHub App configuration" },
+          { to: "/docs/maintainer-workflow", label: "Maintainer workflow" },
+          { to: "/docs/maintainer-install-trust", label: "Maintainer install & trust" },
         ],
       },
     ],

--- a/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
@@ -107,13 +107,14 @@ gittensory-mcp preflight --login your-login --json`}
 
       <h2>Maintainer journey</h2>
       <p>
-        Maintainers install the GitHub App, configure per-repo policy, preview what could appear on
-        a confirmed-miner PR, then pull context on demand.
+        Maintainers self-host the review stack and install a GitHub App, configure per-repo policy,
+        preview what could appear on a confirmed-miner PR, then pull context on demand.
       </p>
       <ol>
         <li>
-          <strong>Install the GitHub App.</strong> Choose repositories and approve permissions —
-          default posture is silence. Start with the{" "}
+          <strong>Self-host, then install the GitHub App.</strong> Choose repositories and approve
+          permissions — default posture is silence. Start with{" "}
+          <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>, then the{" "}
           <Link to="/docs/github-app">GitHub App first-10-minutes checklist</Link>.
         </li>
         <li>
@@ -241,7 +242,8 @@ GET /v1/readiness`}
           <Link to="/docs/miner-workflow">Miner workflow</Link>
         </li>
         <li>
-          Maintainers: <Link to="/docs/github-app">GitHub App</Link> →{" "}
+          Maintainers: <Link to="/docs/maintainer-self-hosting">Self-hosting</Link> →{" "}
+          <Link to="/docs/github-app">GitHub App</Link> →{" "}
           <Link to="/docs/maintainer-workflow">Maintainer workflow</Link>
         </li>
         <li>

--- a/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
@@ -112,10 +112,12 @@ gittensory-mcp preflight --login your-login --json`}
       </p>
       <ol>
         <li>
-          <strong>Self-host, then install the GitHub App.</strong> Choose repositories and approve
+          <strong>Self-host, then install your own App.</strong> Choose repositories and approve
           permissions — default posture is silence. Start with{" "}
-          <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>, then the{" "}
-          <Link to="/docs/github-app">GitHub App first-10-minutes checklist</Link>.
+          <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>, which covers the
+          direct App's install checklist, then{" "}
+          <Link to="/docs/github-app">GitHub App configuration</Link> for the review behavior (PR
+          panel, checks, gate modes).
         </li>
         <li>
           <strong>Configure settings.</strong> Opt in to at most one configured label and one sticky

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -8,13 +8,13 @@ const GITHUB_APP_INSTALL_URL = "https://github.com/apps/gittensory/installations
 export const Route = createFileRoute("/docs/github-app")({
   head: () => ({
     meta: [
-      { title: "GitHub App setup — Gittensory docs" },
+      { title: "GitHub App configuration — Gittensory docs" },
       {
         name: "description",
         content:
           "How the Gittensory GitHub App reviews pull requests once installed — self-hosted (recommended) or via the private managed-beta shared app. The Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
-      { property: "og:title", content: "GitHub App setup — Gittensory docs" },
+      { property: "og:title", content: "GitHub App configuration — Gittensory docs" },
       {
         property: "og:description",
         content:
@@ -31,7 +31,7 @@ function GithubApp() {
   return (
     <DocsPage
       eyebrow="Workflows"
-      title="GitHub App setup"
+      title="GitHub App configuration"
       description="Install a Gittensory GitHub App on a repo so it reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
     >
       <p>
@@ -41,16 +41,20 @@ function GithubApp() {
         managed-beta operators, the shared <code>gittensory</code> App below. Each review produces
         two surfaces: the <strong>Gittensory Orb Review Agent</strong> check run (and the advisory{" "}
         <strong>Gittensory Context</strong> check), and a single review comment posted by{" "}
-        <code>gittensory[bot]</code> that updates in place as the PR evolves. Everything on this
-        page configures that review, and applies identically whichever App you install.
+        <code>gittensory[bot]</code> that updates in place as the PR evolves. The review behavior
+        below this page's Install section (PR panel, checks, gate modes, config-as-code) applies
+        identically whichever App you install — but the App's{" "}
+        <em>install steps and required permissions differ</em>, since a self-hosted App needs write
+        access the shared App does not.
       </p>
 
       <h2>Install</h2>
       <p>
         <strong>Self-hosting is the recommended, default path.</strong> Run the review stack
         yourself, then install your own GitHub App on exactly the repos you choose using the
-        self-host setup wizard — see{" "}
-        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>.
+        self-host setup wizard. The direct App's required permissions and events are covered in{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link> — use that page's
+        checklist, not the one below, for a self-hosted install.
       </p>
       <p>
         The shared <code>gittensory</code> App is <strong>private / managed-beta only</strong> — it
@@ -76,6 +80,12 @@ function GithubApp() {
           <code>pull_request</code>, and <code>repository</code>.
         </li>
       </ol>
+      <Callout variant="note">
+        This checklist is for the shared managed-beta App only. A self-hosted App needs{" "}
+        <code>Pull requests: write</code> (not read) and <code>Checks: write</code> is mandatory,
+        not optional — see <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link> for
+        the direct App's exact permission and event list.
+      </Callout>
 
       <h2>First 10 minutes</h2>
       <ol>

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -12,13 +12,13 @@ export const Route = createFileRoute("/docs/github-app")({
       {
         name: "description",
         content:
-          "Install the Gittensory GitHub App so the gittensory app reviews your pull requests — the Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
+          "How the Gittensory GitHub App reviews pull requests once installed — self-hosted (recommended) or via the private managed-beta shared app. The Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
       { property: "og:title", content: "GitHub App setup — Gittensory docs" },
       {
         property: "og:description",
         content:
-          "Install the Gittensory GitHub App so the gittensory app reviews your pull requests — the Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
+          "How the Gittensory GitHub App reviews pull requests once installed — self-hosted (recommended) or via the private managed-beta shared app. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
       { property: "og:url", content: "/docs/github-app" },
     ],
@@ -32,20 +32,30 @@ function GithubApp() {
     <DocsPage
       eyebrow="Workflows"
       title="GitHub App setup"
-      description="Install Gittensory on a repo so the gittensory app reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
+      description="Install a Gittensory GitHub App on a repo so it reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
     >
       <p>
-        Once installed, the <strong>gittensory app reviews every pull request</strong> on the repos
-        you select. Each review produces two surfaces: the{" "}
-        <strong>Gittensory Orb Review Agent</strong> check run (and the advisory{" "}
+        Once installed, a <strong>Gittensory GitHub App reviews every pull request</strong> on the
+        repos you select — whether that's your own self-hosted App (recommended; see{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>) or, for private
+        managed-beta operators, the shared <code>gittensory</code> App below. Each review produces
+        two surfaces: the <strong>Gittensory Orb Review Agent</strong> check run (and the advisory{" "}
         <strong>Gittensory Context</strong> check), and a single review comment posted by{" "}
         <code>gittensory[bot]</code> that updates in place as the PR evolves. Everything on this
-        page configures that review.
+        page configures that review, and applies identically whichever App you install.
       </p>
 
       <h2>Install</h2>
       <p>
-        The hosted deployment uses the GitHub App slug <code>gittensory</code>. Start from{" "}
+        <strong>Self-hosting is the recommended, default path.</strong> Run the review stack
+        yourself, then install your own GitHub App on exactly the repos you choose using the
+        self-host setup wizard — see{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>.
+      </p>
+      <p>
+        The shared <code>gittensory</code> App is <strong>private / managed-beta only</strong> — it
+        is not open for general public install. If you've been invited into the managed beta, start
+        from{" "}
         <a href={GITHUB_APP_INSTALL_URL} target="_blank" rel="noreferrer">
           the GitHub App install flow
         </a>
@@ -332,11 +342,13 @@ GITTENSORY_REVIEW_REPOS="JSONbored/gittensory"`}
       </p>
       <p>
         If the install route changes, check the deployed <code>GITHUB_APP_SLUG</code> before
-        publishing setup copy. For the hosted app, the expected slug is <code>gittensory</code>.
+        publishing setup copy. Self-hosted deployments use whatever slug you chose during setup; for
+        the shared managed-beta app the expected slug is <code>gittensory</code>.
       </p>
 
       <p>
-        New maintainers should continue with{" "}
+        New maintainers should start with{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>, then continue with{" "}
         <Link to="/docs/maintainer-workflow">Maintainer workflow</Link> or the{" "}
         <Link to="/docs/beta-onboarding">beta onboarding checklist</Link> after the health endpoint
         reports clean permissions and events.

--- a/apps/gittensory-ui/src/routes/docs.index.tsx
+++ b/apps/gittensory-ui/src/routes/docs.index.tsx
@@ -70,10 +70,10 @@ const AUDIENCES: Audience[] = [
     description: "Install, tune, or self-host the review system for your repos.",
     primary: { to: "/docs/beta-onboarding", label: "Beta onboarding" },
     links: [
-      { to: "/docs/maintainer-install-trust", label: "Install & trust guide" },
-      { to: "/docs/github-app", label: "Install the GitHub App" },
-      { to: "/docs/maintainer-workflow", label: "Maintainer workflow" },
       { to: "/docs/maintainer-self-hosting", label: "Self-host reviews" },
+      { to: "/docs/maintainer-install-trust", label: "Install & trust guide" },
+      { to: "/docs/github-app", label: "GitHub App configuration" },
+      { to: "/docs/maintainer-workflow", label: "Maintainer workflow" },
       { to: "/docs/self-hosting-rees-analyzers", label: "REES analyzers" },
       { to: "/docs/upstream-drift", label: "Upstream drift" },
       { to: "/docs/ai-summaries", label: "AI summaries policy" },

--- a/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -43,7 +43,9 @@ function MaintainerInstallTrust() {
 
       <h2>Install the GitHub App</h2>
       <p>
-        Start from <Link to="/docs/github-app">GitHub App setup</Link>, then keep the first rollout
+        Start from <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link> (the
+        recommended, default path — you install your own App) or{" "}
+        <Link to="/docs/github-app">GitHub App configuration</Link>, then keep the first rollout
         narrow until the repo owner has verified permissions, webhook delivery, and public copy.
       </p>
       <ol>

--- a/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -33,7 +33,7 @@ function MaintainerInstallTrust() {
     <DocsPage
       eyebrow="Launch guide"
       title="Maintainer install and trust guide"
-      description="A maintainer-first checklist for installing the GitHub App, keeping public output safe, authorizing commands, using the browser extension, and rejecting weak Gittensory-driven PRs."
+      description="A maintainer-first checklist for self-hosting and installing a GitHub App, keeping public output safe, authorizing commands, using the browser extension, and rejecting weak Gittensory-driven PRs."
     >
       <Callout variant="safety" title="Trust posture">
         Gittensory is advisory-first. It may help you review contribution readiness, but it does not

--- a/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -41,12 +41,18 @@ function MaintainerInstallTrust() {
         payout, wallet, hotkey, or trust-score claims in public surfaces.
       </Callout>
 
-      <h2>Install the GitHub App</h2>
+      <h2>Install the App</h2>
       <p>
-        Start from <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link> (the
-        recommended, default path — you install your own App) or{" "}
-        <Link to="/docs/github-app">GitHub App configuration</Link>, then keep the first rollout
-        narrow until the repo owner has verified permissions, webhook delivery, and public copy.
+        <strong>Self-hosting is the recommended, default path.</strong> Start from{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link> — the direct App's
+        required permissions and events are covered in{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>, not the checklist below.
+        Either way, keep the first rollout narrow until the repo owner has verified permissions,
+        webhook delivery, and public copy.
+      </p>
+      <p>
+        The checklist below is for the shared <strong>private / managed-beta only</strong> App — see{" "}
+        <Link to="/docs/github-app">GitHub App configuration</Link> for the install flow.
       </p>
       <ol>
         <li>Install Gittensory on one test repository or a selected repository set.</li>
@@ -64,6 +70,11 @@ function MaintainerInstallTrust() {
           preview output matches the repo's maintainer policy.
         </li>
       </ol>
+      <Callout variant="note">
+        A self-hosted direct App needs <code>Pull requests: write</code> (not read) and{" "}
+        <code>Checks: write</code> is mandatory, not optional — this checklist's permissions are
+        scoped to the shared managed-beta App only.
+      </Callout>
       <CodeBlock
         lang="http"
         code={`GET /v1/installations

--- a/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/docs/maintainer-install-trust")({
       {
         name: "description",
         content:
-          "Install Gittensory as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable.",
+          "Self-host and install a Gittensory GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the recommended default path; the shared App is private managed-beta only.",
       },
       {
         property: "og:title",
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/docs/maintainer-install-trust")({
       {
         property: "og:description",
         content:
-          "Install Gittensory as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable.",
+          "Self-host and install a Gittensory GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the recommended default path; the shared App is private managed-beta only.",
       },
       { property: "og:url", content: "/docs/maintainer-install-trust" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.maintainer-workflow.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-workflow.tsx
@@ -114,7 +114,7 @@ GET /v1/repos/:owner/:repo/registration-readiness`}
       ),
       nextStep: {
         miner: { label: "PR packet format", to: "/docs/miner-workflow" },
-        maintainer: { label: "Install the GitHub App", to: "/docs/github-app" },
+        maintainer: { label: "Self-host reviews", to: "/docs/maintainer-self-hosting" },
       },
     },
   ];
@@ -131,15 +131,17 @@ GET /v1/repos/:owner/:repo/registration-readiness`}
         the contributor is doing privately via MCP at the same point.
       </p>
       <p>
-        New installations should start with <Link to="/docs/github-app">GitHub App setup</Link>:
-        install on one repo, verify installation health, preview the public panel, then decide
-        whether <strong>Gittensory Orb Review Agent</strong> should become a required check.
+        New installations should start with{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>, then{" "}
+        <Link to="/docs/github-app">GitHub App configuration</Link>: install on one repo, verify
+        installation health, preview the public panel, then decide whether{" "}
+        <strong>Gittensory Orb Review Agent</strong> should become a required check.
       </p>
       <WorkflowMirror
         role="maintainer"
         steps={steps}
         minerCta={{ label: "See the contributor side", to: "/docs/miner-workflow" }}
-        maintainerCta={{ label: "Install the GitHub App", to: "/docs/github-app" }}
+        maintainerCta={{ label: "Self-host reviews", to: "/docs/maintainer-self-hosting" }}
       />
 
       <h2>On-demand commands</h2>

--- a/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
@@ -103,7 +103,7 @@ function MinerWorkflow() {
       ),
       nextStep: {
         miner: { label: "Set up your MCP client", to: "/docs/mcp-clients" },
-        maintainer: { label: "Install the GitHub App", to: "/docs/github-app" },
+        maintainer: { label: "Self-host reviews", to: "/docs/maintainer-self-hosting" },
       },
     },
   ];

--- a/apps/gittensory-ui/src/routes/index.tsx
+++ b/apps/gittensory-ui/src/routes/index.tsx
@@ -14,9 +14,6 @@ import { TrustStrip } from "@/components/site/trust-strip";
 import { describeApiStatus, pingHealth, useApiStatus } from "@/lib/api/status";
 import { MCP_PACKAGE_NAME, getLatestMcpVersion, useMcpPackageMetadata } from "@/lib/mcp-package";
 
-/** Canonical GitHub App install URL (app slug `gittensory`) — dead-simple one-click maintainer onboarding. */
-const GITHUB_APP_INSTALL_URL = "https://github.com/apps/gittensory/installations/new";
-
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
@@ -80,14 +77,12 @@ function Hero() {
             Plan better work, preflight branches, and keep maintainer review surfaces quiet.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-2">
-            <a
-              href={GITHUB_APP_INSTALL_URL}
-              target="_blank"
-              rel="noreferrer"
+            <Link
+              to="/docs/maintainer-self-hosting"
               className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
             >
-              Install the GitHub App →
-            </a>
+              Self-host reviews →
+            </Link>
             <Link
               to="/docs/quickstart"
               className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"

--- a/apps/gittensory-ui/src/routes/maintainers.tsx
+++ b/apps/gittensory-ui/src/routes/maintainers.tsx
@@ -50,16 +50,16 @@ function MaintainersPage() {
             Quiet by default. Loud only when you ask.
           </h1>
           <p className="mt-4 text-token-lg text-muted-foreground">
-            Install Gittensory on a repo and your review surface stays calm. No always-on check
+            Self-host Gittensory on a repo and your review surface stays calm. No always-on check
             runs. No public scoring. You opt into confirmed-miner context, packets, and diagnostics
             with explicit commands.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
-              to="/docs/github-app"
+              to="/docs/maintainer-self-hosting"
               className="inline-flex items-center gap-2 rounded-token bg-mint px-4 py-2 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
             >
-              Install the GitHub App <ArrowRight className="size-4" />
+              Self-host reviews <ArrowRight className="size-4" />
             </Link>
             <Link
               to="/docs/maintainer-workflow"
@@ -230,10 +230,10 @@ GET /v1/repos/:owner/:repo/registration-readiness`}
               Open the preview <ArrowRight className="size-4" />
             </Link>
             <Link
-              to="/docs/github-app"
+              to="/docs/maintainer-self-hosting"
               className="inline-flex items-center gap-2 rounded-token border border-border bg-transparent px-4 py-2 text-token-sm hover:border-foreground/30"
             >
-              Install the GitHub App
+              Self-host reviews
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Self-hosting is now the only way to get real, live PR reviews — the shared `gittensory` GitHub App + brokered relay is private/managed-beta only (#1939). Docs and CTAs across the site still presented installing the shared App as the primary/first onboarding step, which doesn't work for the general public.
- Homepage hero + closing CTAs, `/maintainers` primary + closing CTAs now point at self-hosting setup instead of the shared App install URL.
- `docs/github-app.tsx` now leads with self-hosting as the recommended path and reframes the shared App as private/managed-beta only; the rest of the page (settings, gate modes, config-as-code) is unchanged since it applies identically to either App.
- `docs/maintainer-workflow.tsx`, `docs/maintainer-install-trust.tsx`, `docs/beta-onboarding.tsx`, `docs/miner-workflow.tsx`, `docs/index.tsx`: CTAs and "next step" links now point to self-hosting first.
- `docs-nav.tsx`: removed the "Hosted app" subgroup label (implied hosted was the default); the same three pages now live in a "GitHub App & managed beta" subgroup listed after the self-hosting subgroups instead of before them.
- Two gate-review rounds caught a real permission mismatch: the shared-App install checklist (`Pull requests: read`, optional `Checks: write`) was being routed to as if it also covered self-hosted installs, which actually need `Pull requests: write` and mandatory `Checks: write` (per `docs/self-hosting-github-app.tsx`). Both `docs/github-app.tsx` and `docs/maintainer-install-trust.tsx` now explicitly split the two paths and point self-hosted installs at the authoritative checklist.

## No linked issue
This is a maintainer-lane docs/CTA correction discovered directly (not filed as its own issue) while investigating and fixing the homepage stats-counter bug this session — it implements the product-narrative shift already described in open issue #1939 ("shared App is private/managed-beta only, direct App install is the default").

## No dedicated tests
Docs-only content/routing changes in `apps/gittensory-ui` (not `src/**`, not measured by Codecov). Verified manually in a running dev server (see below) rather than adding tests, consistent with how other docs-only PRs in this repo are validated.

## Test plan
- [x] `npm run ui:typecheck`, `npm run ui:lint`, `npm run ui:test`, `npm run ui:build` — all clean
- [x] `npm run test:ci` (full local gate, unsharded) — green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Manually verified in a running dev server: homepage hero CTA → `/docs/maintainer-self-hosting`, `/maintainers` CTAs → self-hosting, docs sidebar nav shows self-hosting subgroups first with the renamed "GitHub App & managed beta" subgroup last, `/docs/github-app` and `/docs/maintainer-install-trust` both correctly split self-hosted vs. shared-App permission guidance