### PR TITLE
test(selfhost): add beta smoke matrix and release checklist

### DIFF
--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -57,6 +57,7 @@ export const docsNav: DocsGroup[] = [
         title: "Self-hosting: release & security",
         items: [
           { to: "/docs/self-hosting-releases", label: "Releases & images" },
+          { to: "/docs/self-hosting-release-checklist", label: "Beta release checklist" },
           { to: "/docs/self-hosting-security", label: "Security" },
         ],
       },

--- a/apps/gittensory-ui/src/routeTree.gen.ts
+++ b/apps/gittensory-ui/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as DocsTroubleshootingRouteImport } from './routes/docs.troublesh
 import { Route as DocsSelfHostingTroubleshootingRouteImport } from './routes/docs.self-hosting-troubleshooting'
 import { Route as DocsSelfHostingSecurityRouteImport } from './routes/docs.self-hosting-security'
 import { Route as DocsSelfHostingReleasesRouteImport } from './routes/docs.self-hosting-releases'
+import { Route as DocsSelfHostingReleaseChecklistRouteImport } from './routes/docs.self-hosting-release-checklist'
 import { Route as DocsSelfHostingReesAnalyzersRouteImport } from './routes/docs.self-hosting-rees-analyzers'
 import { Route as DocsSelfHostingReesRouteImport } from './routes/docs.self-hosting-rees'
 import { Route as DocsSelfHostingRagRouteImport } from './routes/docs.self-hosting-rag'
@@ -162,6 +163,12 @@ const DocsSelfHostingReleasesRoute = DocsSelfHostingReleasesRouteImport.update({
   path: '/self-hosting-releases',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsSelfHostingReleaseChecklistRoute =
+  DocsSelfHostingReleaseChecklistRouteImport.update({
+    id: '/self-hosting-release-checklist',
+    path: '/self-hosting-release-checklist',
+    getParentRoute: () => DocsRoute,
+  } as any)
 const DocsSelfHostingReesAnalyzersRoute =
   DocsSelfHostingReesAnalyzersRouteImport.update({
     id: '/self-hosting-rees-analyzers',
@@ -405,6 +412,7 @@ export interface FileRoutesByFullPath {
   '/docs/self-hosting-rag': typeof DocsSelfHostingRagRoute
   '/docs/self-hosting-rees': typeof DocsSelfHostingReesRoute
   '/docs/self-hosting-rees-analyzers': typeof DocsSelfHostingReesAnalyzersRoute
+  '/docs/self-hosting-release-checklist': typeof DocsSelfHostingReleaseChecklistRoute
   '/docs/self-hosting-releases': typeof DocsSelfHostingReleasesRoute
   '/docs/self-hosting-security': typeof DocsSelfHostingSecurityRoute
   '/docs/self-hosting-troubleshooting': typeof DocsSelfHostingTroubleshootingRoute
@@ -460,6 +468,7 @@ export interface FileRoutesByTo {
   '/docs/self-hosting-rag': typeof DocsSelfHostingRagRoute
   '/docs/self-hosting-rees': typeof DocsSelfHostingReesRoute
   '/docs/self-hosting-rees-analyzers': typeof DocsSelfHostingReesAnalyzersRoute
+  '/docs/self-hosting-release-checklist': typeof DocsSelfHostingReleaseChecklistRoute
   '/docs/self-hosting-releases': typeof DocsSelfHostingReleasesRoute
   '/docs/self-hosting-security': typeof DocsSelfHostingSecurityRoute
   '/docs/self-hosting-troubleshooting': typeof DocsSelfHostingTroubleshootingRoute
@@ -519,6 +528,7 @@ export interface FileRoutesById {
   '/docs/self-hosting-rag': typeof DocsSelfHostingRagRoute
   '/docs/self-hosting-rees': typeof DocsSelfHostingReesRoute
   '/docs/self-hosting-rees-analyzers': typeof DocsSelfHostingReesAnalyzersRoute
+  '/docs/self-hosting-release-checklist': typeof DocsSelfHostingReleaseChecklistRoute
   '/docs/self-hosting-releases': typeof DocsSelfHostingReleasesRoute
   '/docs/self-hosting-security': typeof DocsSelfHostingSecurityRoute
   '/docs/self-hosting-troubleshooting': typeof DocsSelfHostingTroubleshootingRoute
@@ -579,6 +589,7 @@ export interface FileRouteTypes {
     | '/docs/self-hosting-rag'
     | '/docs/self-hosting-rees'
     | '/docs/self-hosting-rees-analyzers'
+    | '/docs/self-hosting-release-checklist'
     | '/docs/self-hosting-releases'
     | '/docs/self-hosting-security'
     | '/docs/self-hosting-troubleshooting'
@@ -634,6 +645,7 @@ export interface FileRouteTypes {
     | '/docs/self-hosting-rag'
     | '/docs/self-hosting-rees'
     | '/docs/self-hosting-rees-analyzers'
+    | '/docs/self-hosting-release-checklist'
     | '/docs/self-hosting-releases'
     | '/docs/self-hosting-security'
     | '/docs/self-hosting-troubleshooting'
@@ -692,6 +704,7 @@ export interface FileRouteTypes {
     | '/docs/self-hosting-rag'
     | '/docs/self-hosting-rees'
     | '/docs/self-hosting-rees-analyzers'
+    | '/docs/self-hosting-release-checklist'
     | '/docs/self-hosting-releases'
     | '/docs/self-hosting-security'
     | '/docs/self-hosting-troubleshooting'
@@ -849,6 +862,13 @@ declare module '@tanstack/react-router' {
       path: '/self-hosting-releases'
       fullPath: '/docs/self-hosting-releases'
       preLoaderRoute: typeof DocsSelfHostingReleasesRouteImport
+      parentRoute: typeof DocsRoute
+    }
+    '/docs/self-hosting-release-checklist': {
+      id: '/docs/self-hosting-release-checklist'
+      path: '/self-hosting-release-checklist'
+      fullPath: '/docs/self-hosting-release-checklist'
+      preLoaderRoute: typeof DocsSelfHostingReleaseChecklistRouteImport
       parentRoute: typeof DocsRoute
     }
     '/docs/self-hosting-rees-analyzers': {
@@ -1184,6 +1204,7 @@ interface DocsRouteChildren {
   DocsSelfHostingRagRoute: typeof DocsSelfHostingRagRoute
   DocsSelfHostingReesRoute: typeof DocsSelfHostingReesRoute
   DocsSelfHostingReesAnalyzersRoute: typeof DocsSelfHostingReesAnalyzersRoute
+  DocsSelfHostingReleaseChecklistRoute: typeof DocsSelfHostingReleaseChecklistRoute
   DocsSelfHostingReleasesRoute: typeof DocsSelfHostingReleasesRoute
   DocsSelfHostingSecurityRoute: typeof DocsSelfHostingSecurityRoute
   DocsSelfHostingTroubleshootingRoute: typeof DocsSelfHostingTroubleshootingRoute
@@ -1218,6 +1239,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsSelfHostingRagRoute: DocsSelfHostingRagRoute,
   DocsSelfHostingReesRoute: DocsSelfHostingReesRoute,
   DocsSelfHostingReesAnalyzersRoute: DocsSelfHostingReesAnalyzersRoute,
+  DocsSelfHostingReleaseChecklistRoute: DocsSelfHostingReleaseChecklistRoute,
   DocsSelfHostingReleasesRoute: DocsSelfHostingReleasesRoute,
   DocsSelfHostingSecurityRoute: DocsSelfHostingSecurityRoute,
   DocsSelfHostingTroubleshootingRoute: DocsSelfHostingTroubleshootingRoute,

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -1,0 +1,241 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
+
+export const Route = createFileRoute("/docs/self-hosting-release-checklist")({
+  head: () => ({
+    meta: [
+      { title: "Beta release checklist — Gittensory docs" },
+      {
+        name: "description",
+        content:
+          "The smoke matrix to run before publishing a self-host RC image: direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant. Portable commands, expected log events, known-warnings table.",
+      },
+      { property: "og:title", content: "Beta release checklist — Gittensory docs" },
+      {
+        property: "og:description",
+        content:
+          "The smoke matrix to run before publishing a self-host RC image: direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant.",
+      },
+      { property: "og:url", content: "/docs/self-hosting-release-checklist" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/self-hosting-release-checklist" }],
+  }),
+  component: SelfHostingReleaseChecklist,
+});
+
+function SelfHostingReleaseChecklist() {
+  return (
+    <DocsPage
+      eyebrow="Self-hosting"
+      title="Beta release checklist"
+      description="Run this smoke matrix against a candidate image before tagging it orb-vX.Y.Z or an -rc/-beta prerelease. Each scenario is a mode a real operator will run; CI only exercises the plain SQLite + Redis + direct-App default."
+    >
+      <p>
+        Every scenario below shares the same core check — <code>scripts/smoke-selfhost.sh</code>{" "}
+        boots one container against a fresh Redis on an isolated network, waits for it to become
+        healthy, and asserts on <code>/health</code>, <code>/ready</code>, <code>/metrics</code>,
+        and startup log events. What changes per scenario is the env you pass in and which events
+        you expect (or forbid).
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`# Build (or use a published tag) once, then run each scenario against the same image:
+docker buildx build --load -t gittensory:rc-candidate .
+./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+      />
+
+      <h2>1. Direct GitHub App mode (default)</h2>
+      <p>
+        No <code>ORB_ENROLLMENT_SECRET</code> — the container uses its own GitHub App private key.
+        Telemetry export is always-on in this mode too; a clean run produces no export error.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`SELFHOST_SMOKE_EXTRA_ENV="GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY=\${TEST_APP_PRIVATE_KEY}" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_register" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+      />
+      <p>
+        <code>selfhost_orb_relay_register</code> must NOT appear here — relay registration is
+        brokered-only and silently skips in direct mode (see{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>).
+      </p>
+
+      <h2>2. Brokered mode (private / managed-beta only)</h2>
+      <p>
+        <code>ORB_ENROLLMENT_SECRET</code> set — the container gets tokens from the central Orb
+        instead of its own App key. A working push-mode registration logs{" "}
+        <code>selfhost_orb_relay_register</code>; a broken one is fatal for push mode (logged at{" "}
+        <code>error</code>, not <code>warn</code>).
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`SELFHOST_SMOKE_EXTRA_ENV="ORB_ENROLLMENT_SECRET=\${TEST_ENROLLMENT_SECRET}
+PUBLIC_API_ORIGIN=https://selfhost-smoke.example" \\
+SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_orb_relay_register" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_relay_register_failed" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+      />
+
+      <h2>3. Air-gapped / no-telemetry mode</h2>
+      <p>
+        <code>ORB_AIR_GAP=true</code> disables the fleet-calibration export entirely. There is no
+        "air-gap confirmed" log event — the export function returns before doing anything, so
+        silence (no export error, no export attempt) is the signal. Confirm at the network level
+        too: no outbound request to the collector URL.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`SELFHOST_SMOKE_EXTRA_ENV="ORB_AIR_GAP=true" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_register" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+      />
+
+      <h2>4. AI provider: Claude Code / Codex / both</h2>
+      <p>
+        Each provider choice must log <code>selfhost_ai_provider</code> and must NOT log{" "}
+        <code>selfhost_ai_cli_missing</code> (a CLI-subscription provider whose binary isn't on{" "}
+        <code>PATH</code> silently produces no review output — this must be caught here, not in
+        production).
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`# Claude Code only
+SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=claude-code
+CLAUDE_CODE_OAUTH_TOKEN=\${TEST_CLAUDE_TOKEN}" \\
+SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate
+
+# Codex only (requires the fail-closed opt-in)
+SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=codex
+GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER=1" \\
+SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate
+
+# Both, synthesized
+SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=claude-code,codex
+AI_COMBINE=synthesis
+CLAUDE_CODE_OAUTH_TOKEN=\${TEST_CLAUDE_TOKEN}
+GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER=1" \\
+SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
+SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+      />
+      <Callout variant="note">
+        These need real credentials to reach a genuinely healthy <code>/ready</code> (it probes the
+        configured AI provider). Where credentials aren't available for a given RC run, at minimum
+        confirm <code>selfhost_ai_cli_missing</code> does NOT appear — that alone catches the
+        release-blocking case (image built without <code>INSTALL_AI_CLIS=true</code>).
+      </Callout>
+
+      <h2>5. SQLite trial mode / Postgres production mode</h2>
+      <p>
+        SQLite is the default — the base smoke command above already covers it (no{" "}
+        <code>DATABASE_URL</code> set). For Postgres, boot a Postgres container on the same network
+        first and point <code>DATABASE_URL</code> at it.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`docker network create gt-pg-smoke
+docker run -d --name gt-pg --network gt-pg-smoke -e POSTGRES_PASSWORD=devpw -e POSTGRES_DB=gittensory postgres:16-alpine
+SELFHOST_SMOKE_NETWORK=gt-pg-smoke \\
+SELFHOST_SMOKE_EXTRA_ENV="DATABASE_URL=postgres://postgres:devpw@gt-pg:5432/gittensory" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate
+docker rm -f gt-pg && docker network rm gt-pg-smoke`}
+      />
+      <Callout variant="safety">
+        SQLite is the trial/single-node default; recommend Postgres for production in release notes
+        whenever this mode is what beta testers actually validated.
+      </Callout>
+
+      <h2>6. Redis cache + optional Qdrant RAG</h2>
+      <p>
+        Redis is always-on in every scenario above (the base script already boots it) — confirm{" "}
+        <code>selfhost_redis_ready</code> appears with <code>githubResponseCacheEnabled</code>{" "}
+        matching whatever <code>GITHUB_CACHE_TTL_SECONDS</code> you set. For the optional Qdrant RAG
+        path, boot Qdrant on the same network and point <code>QDRANT_URL</code> at it.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_redis_ready" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate
+
+# With Qdrant RAG:
+docker network create gt-rag-smoke
+docker run -d --name gt-qdrant --network gt-rag-smoke qdrant/qdrant:latest
+SELFHOST_SMOKE_NETWORK=gt-rag-smoke \\
+SELFHOST_SMOKE_EXTRA_ENV="QDRANT_URL=http://gt-qdrant:6333" \\
+SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_vectorize" \\
+./scripts/smoke-selfhost.sh gittensory:rc-candidate
+docker rm -f gt-qdrant && docker network rm gt-rag-smoke`}
+      />
+
+      <h2>Expected startup events</h2>
+      <FeatureRow
+        items={[
+          {
+            title: "selfhost_listening",
+            description: "Always. HTTP server bound and accepting connections.",
+          },
+          {
+            title: "selfhost_migrations_applied",
+            description: "Always. The smoke script asserts this on every scenario.",
+          },
+          {
+            title: "selfhost_redis_ready",
+            description: "Always. Confirms the mandatory Redis dependency is reachable.",
+          },
+          {
+            title: "selfhost_ai_provider",
+            description: "Only when AI_PROVIDER is set. Confirms the provider chain resolved.",
+          },
+          {
+            title: "selfhost_vectorize",
+            description: "Only when QDRANT_URL is set. Confirms the Qdrant RAG backend is wired.",
+          },
+          {
+            title: "selfhost_orb_relay_register",
+            description: "Only in brokered mode. Confirms relay registration with the central Orb.",
+          },
+        ]}
+      />
+
+      <h2>Known warnings: acceptable in beta vs. release-blocking</h2>
+      <FeatureRow
+        items={[
+          {
+            title: "selfhost_orb_relay_register_failed (pull mode)",
+            description:
+              "Acceptable in beta. Logged at warn — pull-mode relay still drains events outbound even when the announce fails.",
+          },
+          {
+            title: "selfhost_orb_relay_register_failed (push mode)",
+            description:
+              "Release-blocking. Logged at error — a failed push-mode announce means the container looks alive but never receives events.",
+          },
+          {
+            title: "selfhost_ai_cli_missing",
+            description:
+              "Release-blocking. A CLI-subscription provider that can't run silently produces zero review output in production.",
+          },
+          {
+            title: "selfhost_orb_export_error (isolated, one-off)",
+            description:
+              "Acceptable in beta if transient (e.g. a single collector timeout) — the hourly retry recovers. Persistent recurrence across the whole smoke run is release-blocking.",
+          },
+        ]}
+      />
+
+      <p>
+        After every applicable scenario passes, continue with the normal{" "}
+        <Link to="/docs/self-hosting-releases">upgrade flow</Link> to cut the tag and publish the
+        image.
+      </p>
+    </DocsPage>
+  );
+}

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -167,7 +167,7 @@ docker rm -f gt-pg && docker network rm gt-pg-smoke`}
 
 # With Qdrant RAG:
 docker network create gt-rag-smoke
-docker run -d --name gt-qdrant --network gt-rag-smoke qdrant/qdrant:latest
+docker run -d --name gt-qdrant --network gt-rag-smoke qdrant/qdrant:v1.18.2
 SELFHOST_SMOKE_NETWORK=gt-rag-smoke \\
 SELFHOST_SMOKE_EXTRA_ENV="QDRANT_URL=http://gt-qdrant:6333" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_vectorize" \\

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -53,8 +53,12 @@ docker buildx build --load -t gittensory:rc-candidate .
       </p>
       <CodeBlock
         lang="bash"
-        code={`SELFHOST_SMOKE_EXTRA_ENV="GITHUB_APP_ID=123456
-GITHUB_APP_PRIVATE_KEY=\${TEST_APP_PRIVATE_KEY}" \\
+        code={`# A private key is multiline PEM -- mount it as a file instead of an env value (SELFHOST_SMOKE_EXTRA_ENV
+# is line-delimited and would truncate it). GITHUB_APP_PRIVATE_KEY_FILE is loaded into
+# GITHUB_APP_PRIVATE_KEY at startup, same as every other *_FILE variable.
+SELFHOST_SMOKE_EXTRA_VOLUMES="\${TEST_APP_PRIVATE_KEY_PATH}:/run/secrets/github-app-private-key.pem:ro" \\
+SELFHOST_SMOKE_EXTRA_ENV="GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_register" \\
 ./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
       />

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
 import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
@@ -70,6 +70,12 @@ docker pull ghcr.io/jsonbored/gittensory-selfhost:latest`}
       <Callout variant="note">
         Stable release behavior is unchanged: a plain <code>X.Y.Z</code> tag still moves{" "}
         <code>latest</code> and publishes an unmarked (non-prerelease) GitHub Release.
+      </Callout>
+      <Callout variant="safety">
+        Before tagging any <code>orb-v*</code> release or prerelease, run the{" "}
+        <Link to="/docs/self-hosting-release-checklist">beta release checklist</Link> against the
+        built image — CI only smoke-tests the plain SQLite + Redis + direct-App default, not
+        brokered mode, air-gapped mode, or any AI provider.
       </Callout>
 
       <h2>Upgrade flow</h2>

--- a/scripts/smoke-selfhost.sh
+++ b/scripts/smoke-selfhost.sh
@@ -18,7 +18,16 @@
 set -euo pipefail
 
 IMAGE="${1:?usage: smoke-selfhost.sh <image>}"
-NETWORK_NAME="${SELFHOST_SMOKE_NETWORK:-gt-smoke-$$}"
+# A caller-supplied network (e.g. one already holding a Postgres or Qdrant container for a cross-service
+# scenario) is joined, not owned -- this script neither creates nor removes it. Only the default
+# self-generated network is created/removed here.
+NETWORK_OWNED=1
+if [ -n "${SELFHOST_SMOKE_NETWORK:-}" ]; then
+  NETWORK_NAME="$SELFHOST_SMOKE_NETWORK"
+  NETWORK_OWNED=0
+else
+  NETWORK_NAME="gt-smoke-$$"
+fi
 REDIS_NAME="${SELFHOST_SMOKE_REDIS_NAME:-gt-smoke-redis-$$}"
 APP_NAME="${SELFHOST_SMOKE_APP_NAME:-gt-smoke-app-$$}"
 PORT="${SELFHOST_SMOKE_PORT:-8787}"
@@ -36,17 +45,32 @@ require_cmd curl
 
 cleanup() {
   docker rm -f "$APP_NAME" "$REDIS_NAME" >/dev/null 2>&1 || true
-  docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+  if [ "$NETWORK_OWNED" = "1" ]; then
+    docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+  fi
 }
 trap cleanup EXIT
 
-echo "smoke-selfhost: booting Redis + $IMAGE on an isolated network"
-docker network create "$NETWORK_NAME" >/dev/null
+if [ "$NETWORK_OWNED" = "1" ]; then
+  echo "smoke-selfhost: booting Redis + $IMAGE on an isolated network ($NETWORK_NAME)"
+  docker network create "$NETWORK_NAME" >/dev/null
+else
+  echo "smoke-selfhost: booting Redis + $IMAGE on caller-supplied network ($NETWORK_NAME)"
+fi
 docker run -d --name "$REDIS_NAME" --network "$NETWORK_NAME" redis:7-alpine >/dev/null
+redis_ok=0
 for _ in $(seq 1 30); do
-  if docker exec "$REDIS_NAME" redis-cli ping | grep -q PONG; then break; fi
+  if docker exec "$REDIS_NAME" redis-cli ping | grep -q PONG; then
+    redis_ok=1
+    break
+  fi
   sleep 1
 done
+if [ "$redis_ok" != "1" ]; then
+  echo "::error::$REDIS_NAME never responded to PING" >&2
+  docker logs "$REDIS_NAME" >&2 || true
+  exit 1
+fi
 
 # Extra env, one KEY=VALUE per line -- turned into repeated -e flags. Deliberately whitespace/newline
 # separated (not comma) so values containing commas (e.g. AI_PROVIDER=claude-code,codex) are unambiguous.

--- a/scripts/smoke-selfhost.sh
+++ b/scripts/smoke-selfhost.sh
@@ -74,6 +74,8 @@ fi
 
 # Extra env, one KEY=VALUE per line -- turned into repeated -e flags. Deliberately whitespace/newline
 # separated (not comma) so values containing commas (e.g. AI_PROVIDER=claude-code,codex) are unambiguous.
+# NOT for multiline secrets like a PEM private key -- a newline inside a value is indistinguishable from
+# an entry boundary here. Use SELFHOST_SMOKE_EXTRA_VOLUMES + a _FILE env var instead (see below).
 EXTRA_ENV_ARGS=()
 if [ -n "${SELFHOST_SMOKE_EXTRA_ENV:-}" ]; then
   while IFS= read -r line; do
@@ -82,11 +84,23 @@ if [ -n "${SELFHOST_SMOKE_EXTRA_ENV:-}" ]; then
   done <<<"$SELFHOST_SMOKE_EXTRA_ENV"
 fi
 
+# Extra volumes, one "host_path:container_path[:opts]" per line -- turned into repeated -v flags. This is
+# how a multiline secret (e.g. GITHUB_APP_PRIVATE_KEY_FILE) reaches the container safely: mount the file,
+# then set the *_FILE env var to its container path via SELFHOST_SMOKE_EXTRA_ENV (a single-line value).
+EXTRA_VOLUME_ARGS=()
+if [ -n "${SELFHOST_SMOKE_EXTRA_VOLUMES:-}" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    EXTRA_VOLUME_ARGS+=(-v "$line")
+  done <<<"$SELFHOST_SMOKE_EXTRA_VOLUMES"
+fi
+
 docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" -p "${PORT}:8787" \
   -e "REDIS_URL=redis://${REDIS_NAME}:6379" \
   -e "SELFHOST_SETUP_TOKEN=${SELFHOST_SMOKE_SETUP_TOKEN:-selfhost-smoke-setup-token}" \
   -e "PUBLIC_API_ORIGIN=${SELFHOST_SMOKE_PUBLIC_API_ORIGIN:-https://selfhost-smoke.example}" \
   "${EXTRA_ENV_ARGS[@]}" \
+  "${EXTRA_VOLUME_ARGS[@]}" \
   "$IMAGE" >/dev/null
 
 ok=0

--- a/scripts/smoke-selfhost.sh
+++ b/scripts/smoke-selfhost.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Portable self-host smoke test (#1944): boot one container from a given image, wait for it to become
+# healthy, and assert on its /health, /ready, /metrics output plus its startup log events. Mode-agnostic --
+# the caller supplies which env vars configure the mode under test and which log events that mode should
+# (or must not) produce. See docs/self-hosting-release-checklist for the beta smoke matrix built on this.
+#
+# Defaults to a plain SQLite + Redis + direct-App boot:
+#   ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+#
+# Test a specific mode by passing extra env and the events it should produce:
+#   SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=claude-code
+#   CLAUDE_CODE_OAUTH_TOKEN=..." \
+#   SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \
+#   ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+#
+# Assert an event must NOT appear (e.g. no AI-CLI-missing warning, no failed relay registration):
+#   SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" ./scripts/smoke-selfhost.sh gittensory:selfhost-ci
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-selfhost.sh <image>}"
+NETWORK_NAME="${SELFHOST_SMOKE_NETWORK:-gt-smoke-$$}"
+REDIS_NAME="${SELFHOST_SMOKE_REDIS_NAME:-gt-smoke-redis-$$}"
+APP_NAME="${SELFHOST_SMOKE_APP_NAME:-gt-smoke-app-$$}"
+PORT="${SELFHOST_SMOKE_PORT:-8787}"
+HEALTH_TIMEOUT_SECONDS="${SELFHOST_SMOKE_HEALTH_TIMEOUT_SECONDS:-90}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd curl
+
+cleanup() {
+  docker rm -f "$APP_NAME" "$REDIS_NAME" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "smoke-selfhost: booting Redis + $IMAGE on an isolated network"
+docker network create "$NETWORK_NAME" >/dev/null
+docker run -d --name "$REDIS_NAME" --network "$NETWORK_NAME" redis:7-alpine >/dev/null
+for _ in $(seq 1 30); do
+  if docker exec "$REDIS_NAME" redis-cli ping | grep -q PONG; then break; fi
+  sleep 1
+done
+
+# Extra env, one KEY=VALUE per line -- turned into repeated -e flags. Deliberately whitespace/newline
+# separated (not comma) so values containing commas (e.g. AI_PROVIDER=claude-code,codex) are unambiguous.
+EXTRA_ENV_ARGS=()
+if [ -n "${SELFHOST_SMOKE_EXTRA_ENV:-}" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    EXTRA_ENV_ARGS+=(-e "$line")
+  done <<<"$SELFHOST_SMOKE_EXTRA_ENV"
+fi
+
+docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" -p "${PORT}:8787" \
+  -e "REDIS_URL=redis://${REDIS_NAME}:6379" \
+  -e "SELFHOST_SETUP_TOKEN=${SELFHOST_SMOKE_SETUP_TOKEN:-selfhost-smoke-setup-token}" \
+  -e "PUBLIC_API_ORIGIN=${SELFHOST_SMOKE_PUBLIC_API_ORIGIN:-https://selfhost-smoke.example}" \
+  "${EXTRA_ENV_ARGS[@]}" \
+  "$IMAGE" >/dev/null
+
+ok=0
+deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+while [ "$SECONDS" -le "$deadline" ]; do
+  if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  sleep 2
+done
+if [ "$ok" != "1" ]; then
+  echo "::error::$APP_NAME did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s" >&2
+  docker logs "$APP_NAME" >&2 || true
+  exit 1
+fi
+
+echo "smoke-selfhost: checking /health, /ready, /metrics"
+curl -sf "http://127.0.0.1:${PORT}/health" | grep -q '"status":"ok"'
+curl -sf "http://127.0.0.1:${PORT}/ready" | grep -q '"ok":true'
+curl -sf "http://127.0.0.1:${PORT}/metrics" | grep -q 'gittensory_uptime_seconds'
+
+LOGS="$(docker logs "$APP_NAME" 2>&1)"
+
+if [ -n "${SELFHOST_SMOKE_EXPECT_EVENTS:-}" ]; then
+  IFS=',' read -ra EXPECT <<<"$SELFHOST_SMOKE_EXPECT_EVENTS"
+  for event in "${EXPECT[@]}"; do
+    event="$(echo "$event" | xargs)" # trim
+    [ -z "$event" ] && continue
+    if ! echo "$LOGS" | grep -q "\"event\":\"${event}\""; then
+      echo "::error::expected log event '$event' did not appear" >&2
+      echo "$LOGS" >&2
+      exit 1
+    fi
+    echo "smoke-selfhost: found expected event '$event'"
+  done
+fi
+
+if [ -n "${SELFHOST_SMOKE_FORBID_EVENTS:-}" ]; then
+  IFS=',' read -ra FORBID <<<"$SELFHOST_SMOKE_FORBID_EVENTS"
+  for event in "${FORBID[@]}"; do
+    event="$(echo "$event" | xargs)" # trim
+    [ -z "$event" ] && continue
+    if echo "$LOGS" | grep -q "\"event\":\"${event}\""; then
+      echo "::error::forbidden log event '$event' appeared" >&2
+      echo "$LOGS" >&2
+      exit 1
+    fi
+    echo "smoke-selfhost: confirmed absent forbidden event '$event'"
+  done
+fi
+
+# Always required: migrations must have applied on every mode, every boot.
+if ! echo "$LOGS" | grep -q '"event":"selfhost_migrations_applied"'; then
+  echo "::error::selfhost_migrations_applied did not appear" >&2
+  echo "$LOGS" >&2
+  exit 1
+fi
+
+echo "smoke-selfhost: passed"

--- a/test/unit/docs-selfhost-release-checklist-event-names.test.ts
+++ b/test/unit/docs-selfhost-release-checklist-event-names.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// Drift guard (#1944): the beta release checklist and its smoke script reference exact selfhost_* log
+// event names. If an event is ever renamed/removed in src/, this test fails instead of the checklist
+// silently going stale -- mirrors docs-selfhost-troubleshooting-metric-names.test.ts's approach (#1943).
+
+const DOC_PATH = "apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx";
+const SCRIPT_PATH = "scripts/smoke-selfhost.sh";
+const doc = readFileSync(DOC_PATH, "utf8");
+const script = readFileSync(SCRIPT_PATH, "utf8");
+
+// The exact source files that emit every selfhost_* event referenced in the checklist/script, per an
+// audit against the real console.log/console.error({ event: "selfhost_..." }) call sites.
+const EVENT_SOURCE_FILES = ["src/server.ts", "src/selfhost/ai.ts"];
+const eventSource = EVENT_SOURCE_FILES.map((path) => readFileSync(path, "utf8")).join("\n");
+
+describe("self-hosting-release-checklist doc + smoke script: event names match source (#1944)", () => {
+  it("every selfhost_* event name referenced in the checklist doc is actually emitted by the code", () => {
+    const names = [...new Set([...doc.matchAll(/selfhost_[a-z_]+/g)].map((m) => m[0]))];
+    expect(names.length).toBeGreaterThan(5); // sanity: the extraction found the checklist's real content
+    const missing = names.filter((name) => !eventSource.includes(`event: "${name}"`) && !eventSource.includes(`event": "${name}"`));
+    expect(missing).toEqual([]);
+  });
+
+  it("every selfhost_* event name referenced in the smoke script is actually emitted by the code", () => {
+    const names = [...new Set([...script.matchAll(/selfhost_[a-z_]+/g)].map((m) => m[0]))];
+    expect(names.length).toBeGreaterThan(0);
+    const missing = names.filter((name) => !eventSource.includes(`event: "${name}"`) && !eventSource.includes(`event": "${name}"`));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1944

## Summary
- The existing CI "build + boot smoke test" only exercises one fixed configuration (SQLite + Redis + direct-App mode) — there was no repeatable way to validate brokered mode, air-gapped mode, or any AI provider before cutting an RC image.
- `scripts/smoke-selfhost.sh`: a portable, mode-agnostic smoke script. Boots one container against a fresh Redis on an isolated network, waits for health, and asserts on `/health`, `/ready`, `/metrics` plus caller-supplied expected/forbidden startup log events (`SELFHOST_SMOKE_EXPECT_EVENTS` / `_FORBID_EVENTS`). Always asserts `selfhost_migrations_applied` regardless of mode.
- New docs page "Beta release checklist" walks through all six required scenarios (direct App, brokered, air-gapped, each AI provider, SQLite vs. Postgres, Redis + optional Qdrant RAG) with the exact env + smoke-script invocation for each, an expected-events table, and a known-warnings table distinguishing acceptable-in-beta from release-blocking (e.g. a failed relay registration is a warning in pull mode but fatal in push mode).
- Linked from the Releases & images page's prerelease section and added to the self-hosting nav under "Self-hosting: release & security".
- Drift-guard test (mirrors #1943's pattern): every `selfhost_*` event name cited in the new doc and script is verified against the real `console.log`/`error` call sites in `src/server.ts` and `src/selfhost/ai.ts`.

## No dedicated tests for the shell script
`scripts/smoke-selfhost.sh` is a manually-invoked operator tool (like the existing `deploy-selfhost-image.sh`/`deploy-selfhost-prebuilt.sh`, which also have no unit tests) — it boots real Docker containers and isn't unit-testable. Verified with `shellcheck` (clean) and the drift-guard test above, which does cover its cited event names.

## Test plan
- [x] `shellcheck scripts/smoke-selfhost.sh` — clean
- [x] `npm run ui:typecheck`, `npm run ui:lint`, `npm run ui:test`, `npm run ui:build` — all clean
- [x] `npm run test:ci` (full local gate, unsharded) — green, including the new drift-guard test
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Manually verified in a running dev server: new page renders all 6 scenario sections + expected-events + known-warnings tables, docs nav shows "Beta release checklist" under "Self-hosting: release & security", Releases & images page links to it