### PR TITLE
feat(mcp): add windsurf host to init-client config

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.mcp-clients.tsx
+++ b/apps/gittensory-ui/src/routes/docs.mcp-clients.tsx
@@ -39,7 +39,8 @@ function McpClients() {
         code={`gittensory-mcp init-client --print codex
 gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
-gittensory-mcp init-client --print mcp`}
+gittensory-mcp init-client --print mcp
+gittensory-mcp init-client --print windsurf`}
       />
       <p>
         <code>--print mcp</code> uses the same JSON snippet as Claude Desktop and Cursor for other

--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -48,6 +48,7 @@ gittensory-mcp init-client --print codex
 gittensory-mcp init-client --print claude
 gittensory-mcp init-client --print cursor
 gittensory-mcp init-client --print vscode
+gittensory-mcp init-client --print windsurf
 gittensory-mcp init-client --print codex --agent-profile miner-planner
 gittensory-mcp completion bash
 gittensory-mcp completion zsh
@@ -159,7 +160,7 @@ The same capabilities are exposed to MCP clients as:
 
 ### Client config
 
-`init-client --print <host>` prints the stdio MCP config for a host: `codex` (TOML), `claude`, `cursor`, and `mcp` (the shared `mcpServers` JSON shape), and `vscode` (VS Code's native `servers` map with `"type": "stdio"`, for `.vscode/mcp.json`). It prints config only; it never edits client files.
+`init-client --print <host>` prints the stdio MCP config for a host: `codex` (TOML), `claude`, `cursor`, `mcp`, and `windsurf` (the shared `mcpServers` JSON shape; Windsurf reads `~/.codeium/windsurf/mcp_config.json`), and `vscode` (VS Code's native `servers` map with `"type": "stdio"`, for `.vscode/mcp.json`). It prints config only; it never edits client files.
 
 ### Agent profiles
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1860,7 +1860,7 @@ function printHelp() {
   gittensory-mcp changelog [--json]
   gittensory-mcp doctor [--profile name] [--cwd path] [--exit-code] [--json]
   gittensory-mcp cache status|list|clear [--json]
-  gittensory-mcp init-client --print codex|claude|cursor|mcp|vscode [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
+  gittensory-mcp init-client --print codex|claude|cursor|mcp|vscode|windsurf [--agent-profile miner-planner|maintainer-triage|repo-owner-intake] [--json]
   gittensory-mcp decision-pack --login <github-login> [--json]
   gittensory-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   gittensory-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--json]
@@ -2402,7 +2402,7 @@ function shellArg(value) {
 
 function initClient(options) {
   const client = String(options.print ?? options.client ?? "").toLowerCase();
-  if (!client) throw new Error("Pass --print codex, --print claude, --print cursor, --print mcp, or --print vscode.");
+  if (!client) throw new Error("Pass --print codex, --print claude, --print cursor, --print mcp, --print vscode, or --print windsurf.");
   const command = options.command ?? "gittensory-mcp";
   const snippet = clientSnippet(client, command);
   const agentProfile = resolveAgentProfile(options.agentProfile);
@@ -2801,7 +2801,9 @@ function redactPrivateValidationMetrics(text) {
 
 function clientSnippet(client, command) {
   if (client === "codex") return `[mcp_servers.gittensory]\ncommand = ${JSON.stringify(command)}\nargs = ["--stdio"]`;
-  if (client === "claude" || client === "cursor" || client === "mcp") {
+  // claude/cursor/mcp and Windsurf all consume the shared `mcpServers` JSON shape (Windsurf reads
+  // ~/.codeium/windsurf/mcp_config.json), so they share one snippet.
+  if (client === "claude" || client === "cursor" || client === "mcp" || client === "windsurf") {
     return JSON.stringify(
       {
         mcpServers: {
@@ -2832,7 +2834,7 @@ function clientSnippet(client, command) {
       2,
     );
   }
-  throw new Error(`Unsupported client: ${client}. Use codex, claude, cursor, mcp, or vscode.`);
+  throw new Error(`Unsupported client: ${client}. Use codex, claude, cursor, mcp, vscode, or windsurf.`);
 }
 
 async function getDecisionPackWithCache(login) {

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -28,6 +28,10 @@ describe("gittensory-mcp CLI — basics", () => {
     const generic = JSON.parse(run(["init-client", "--print", "mcp", "--json"])) as { snippet: string };
     expect(generic.snippet).toBe(claude.snippet);
 
+    // Windsurf consumes the same shared `mcpServers` JSON shape (~/.codeium/windsurf/mcp_config.json).
+    const windsurf = JSON.parse(run(["init-client", "--print", "windsurf", "--json"])) as { snippet: string };
+    expect(windsurf.snippet).toBe(claude.snippet);
+
     const vscode = JSON.parse(run(["init-client", "--print", "vscode", "--json"])) as { snippet: string };
     // VS Code uses a `servers` map with an explicit transport type, not the `mcpServers` shape.
     expect(vscode.snippet).toContain('"servers"');


### PR DESCRIPTION
## Summary

Adds `windsurf` to `gittensory-mcp init-client --print`, so Windsurf users can generate their MCP config like the other supported hosts.

Windsurf reads `~/.codeium/windsurf/mcp_config.json` using the same shared `mcpServers` JSON shape as `claude` / `cursor` / `mcp`, so it reuses that snippet branch (no new snippet, unlike `vscode`'s `servers` / `"type": "stdio"` shape).

```
$ gittensory-mcp init-client --print windsurf
{ "mcpServers": { "gittensory": { "command": "gittensory-mcp", "args": ["--stdio"] } } }
```

Mirrors the merged `vscode` host addition (#1770): CLI usage text, the empty-client and unsupported-client error messages, the README example + host description, and — for docs parity — the public MCP-clients docs page (`docs.mcp-clients.tsx`) generate-config command list. A test asserts the `windsurf` snippet equals the shared `mcpServers` snippet.

No issue because issue creation is restricted on this repo for outside accounts; this is a small additive host with no schema or API change.

## Scope
- [x] Conventional Commit title; focused; follows CONTRIBUTING; small self-evident change (no linked issue).

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp` (`node --check` clean)
- [x] `npm run ui:typecheck` (clean)
- [x] `npm run test:coverage` (scoped: `test/unit/mcp-cli-basics.test.ts` — 20 pass, incl. the added `windsurf` snippet assertion; CLI exercised by spawning `init-client --print windsurf`)
- [ ] `npm run test:mcp-pack` / `ui:lint` / `ui:build` (see note)
- [x] `npm audit --audit-level=moderate`
- [x] New/changed behavior has tests

If any required check was skipped, explain why:
- MCP package CLI/README/test + a one-line addition to the `docs.mcp-clients.tsx` generate-config command list. `build:mcp` and `ui:typecheck` pass; `prettier --check` on the changed docs file passes; `mcp-cli-basics.test.ts` passes (20). The MCP-package JS is outside Codecov's `src/**/*.ts` include (no patch-coverage obligation). I could not run `test:mcp-pack` locally (Node 24 vs the repo's pinned Node 22 — `check-mcp-package.mjs` throws `ERR_INVALID_ARG_TYPE`, identically on unmodified `main`), and `ui:lint`/`ui:build` are dominated by pre-existing CRLF noise on this Windows checkout (`core.autocrlf`); CI runs both on a clean LF, pinned-Node checkout.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward/private terms exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth/cookie/CORS/session negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. (Additive CLI host + docs parity; covered by the added test. No request/response schema changed.)
- [ ] UI changes use live API data. — N/A: static docs command-list line.
- [ ] UI Evidence. — N/A: the only UI change is one text line added to an existing bash code-block on the docs page (no visual/layout change), so a screenshot adds nothing.
- [x] Docs/changelog updated where needed. (README + MCP-clients docs updated; changelogs are release-prep artifacts.)

## Notes
- This is the complete follow-up to a prior attempt that was closed for missing docs parity: the `docs.mcp-clients.tsx` generate-config list now includes `windsurf` alongside codex/claude/cursor/mcp.
