### PR TITLE
fix(signals): classify .mjs/.cjs/.mts/.cts as code and test files

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -598,14 +598,14 @@ export function isTestFile(file) {
     /(^|\/)src\/test\//i.test(file) ||
     /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file) ||
-    /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|js|jsx)$/i.test(file) ||
+    /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
+    /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -26,7 +26,7 @@ import type { GittensorContributorSnapshot } from "../gittensor/api";
 import { nowIso } from "../utils/json";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { labelMatchesPattern, projectLinkedIssueMultiplierForPlannedSolve, type LinkedIssueMultiplierStatus } from "../scoring/preview";
-import { hasLocalTestEvidence } from "./test-evidence";
+import { hasLocalTestEvidence, isTestPath } from "./test-evidence";
 import { isFailingCheckSummary } from "./local-branch";
 import { isDuplicateClusterWinnerByClaim } from "./duplicate-winner";
 import { PREFLIGHT_LIMITS } from "./preflight-limits";
@@ -5500,17 +5500,13 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 }
 
 function isCodeFile(file: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
 }
 
 function isTestFile(file: string): boolean {
-  return (
-    /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
-    /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
-    /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file)
-  );
+  // Single-sourced with the canonical matcher (test-evidence.ts isTestPath), mirroring local-branch.ts's
+  // isTestFile — so cy/e2e, __snapshots__, and module extensions stay in sync and can't drift.
+  return isTestPath(file);
 }
 
 function riskRank(risk: CollisionCluster["risk"]): number {

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1267,7 +1267,7 @@ export function isTestFile(file: string): boolean {
 }
 
 export function isCodeFile(file: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
 }
 
 function sameRepo(left: string, right: string): boolean {

--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -4,8 +4,8 @@ export function isTestPath(file: string): boolean {
     /(^|\/)src\/test\//i.test(file) ||
     /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file) ||
-    /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|js|jsx)$/i.test(file) ||
+    /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
+    /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -55,6 +55,11 @@ describe("isTestFile", () => {
       "calc.test.py",
       "user.spec.rb",
       "engine.test.rs",
+      // .mts/.cts/.mjs/.cjs test files must count as tests (else a .test.mts is misclassified as source).
+      "loader.test.mts",
+      "config.spec.cts",
+      "widget.test.mjs",
+      "legacy.spec.cjs",
       "Engine.Test.TS",
     ]) {
       expect(isTestFile(path)).toBe(true);
@@ -106,6 +111,11 @@ describe("isCodeFile", () => {
       "server/Main.java",
       "cmd/server/main.go",
       "migrations/0001_init.sql",
+      // Node/TypeScript ESM + CommonJS module files are code (rag.ts's JS_TS_RE already recognizes .mjs/.cjs).
+      "src/loader.mjs",
+      "src/legacy.cjs",
+      "src/config.mts",
+      "src/setup.cts",
       "helper_test.ts",
     ]) {
       expect(isCodeFile(path)).toBe(true);
@@ -120,6 +130,9 @@ describe("isCodeFile", () => {
       "service_test.py",
       "models/account_test.rb",
       "__tests__/component.jsx",
+      // module-extension e2e tests must not count as code
+      "e2e/checkout.cy.mts",
+      "e2e/flow.e2e.mjs",
     ]) {
       expect(isCodeFile(path)).toBe(false);
     }

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1746,13 +1746,22 @@ describe("local MCP git metadata collection", () => {
     }
     // Regression: Cypress/e2e and snapshot files must count as tests; before this they fell through to
     // isCodeFile and were wrongly counted as source in the local packet.
-    for (const file of ["components/Button.cy.ts", "e2e/login.e2e.tsx", "src/__snapshots__/Button.snap.ts"]) {
+    for (const file of ["components/Button.cy.ts", "e2e/login.e2e.tsx", "src/__snapshots__/Button.snap.ts", "e2e/checkout.cy.mts", "e2e/flow.e2e.mjs"]) {
       expect(isTestFile(file)).toBe(true);
       expect(isCodeFile(file)).toBe(false);
     }
     // Plain source stays source.
     expect(isTestFile("src/app.ts")).toBe(false);
     expect(isCodeFile("src/app.ts")).toBe(true);
+    // Node/TypeScript ESM + CommonJS module files are code; their .test/.spec variants are tests.
+    for (const file of ["src/loader.mjs", "src/legacy.cjs", "src/config.mts", "src/setup.cts"]) {
+      expect(isCodeFile(file)).toBe(true);
+      expect(isTestFile(file)).toBe(false);
+    }
+    for (const file of ["src/loader.test.mts", "src/legacy.spec.cjs"]) {
+      expect(isTestFile(file)).toBe(true);
+      expect(isCodeFile(file)).toBe(false);
+    }
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -12,7 +12,15 @@ describe("test evidence helpers", () => {
     expect(isTestPath("integration/api_flow.cy.ts")).toBe(true);
     expect(isTestPath("playwright/smoke.spec.ts")).toBe(true);
     expect(isTestPath("cypress/e2e/checkout.cy.js")).toBe(true);
+    // Cypress/Playwright e2e tests in Node/TS module extensions.
+    expect(isTestPath("cypress/e2e/checkout.cy.mts")).toBe(true);
+    expect(isTestPath("e2e/flow.e2e.mjs")).toBe(true);
     expect(isTestPath("components/__snapshots__/Card.tsx.snap")).toBe(true);
+    // .test/.spec files in Node/TS ESM + CommonJS module extensions.
+    expect(isTestPath("src/loader.test.mts")).toBe(true);
+    expect(isTestPath("src/legacy.spec.cjs")).toBe(true);
+    expect(isTestPath("src/config.test.cts")).toBe(true);
+    expect(isTestPath("src/widget.spec.mjs")).toBe(true);
     expect(isTestPath("src/state.snap")).toBe(false);
     expect(isTestPath("src/widget.rs")).toBe(false);
   });


### PR DESCRIPTION
## Summary

`isCodeFile` omitted the Node/TypeScript ESM + CommonJS module extensions — `.mjs` / `.cjs` / `.mts` / `.cts` — even though the codebase's own `src/review/rag.ts` (`JS_TS_RE = /\.(ts|tsx|js|jsx|mjs|cjs)$/i`) already recognizes `.mjs`/`.cjs` as JS/TS. So a PR that changes only `.mjs`/`.mts` source was counted as having **no code files**, skewing:

- the "code changed without matching tests" slop signal (`signals/engine.ts`),
- `codeFileCount` / source-line inputs, and
- the AI-review code-path grounding (`services/ai-review.ts` → `local-branch` `isCodeFile`).

```
isCodeFile("src/loader.mjs")  // before: false → after: true
isCodeFile("src/config.mts")  // before: false → after: true
```

Fix: add the four module extensions to `isCodeFile` in **both** src copies (`signals/local-branch.ts` and the private one in `signals/engine.ts`) **and** the MCP client copy — and, consistently, to the `.test`/`.spec` group in `isTestPath` (`signals/test-evidence.ts`) and the MCP `isTestFile`, so a `foo.test.mts` still classifies as a **test** rather than as source (verified). Pure classifiers — no schema or API change.

No issue because issue creation is restricted on this repo for outside accounts; this aligns the code/test-file classifiers with the module extensions the codebase already uses.

## Scope
- [x] Conventional Commit title; focused; follows CONTRIBUTING; small self-evident fix (no linked issue).

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run build:mcp` (`node --check` clean)
- [x] `npm run test:coverage` (scoped: `test-evidence.test.ts` + `local-branch-file-classifiers.test.ts` + `local-branch.test.ts` — 75 pass; the changed regex lines add extension alternatives, not new branches, and are exercised by these tests and the engine slop tests — `engine.ts` `isCodeFile` statement confirmed hit.)
- [ ] `npm run test:workers` / `ui:*` — N/A (no UI/worker change)
- [x] `npm audit --audit-level=moderate`
- [x] New/changed behavior has tests

If any required check was skipped, explain why:
- Backend classifier change in `src/signals/**` plus the MCP client copy (plain JS, outside Codecov's `src/**/*.ts` include). `typecheck` + `build:mcp` clean; regression assertions added in the file-classifier, test-evidence, and MCP-lib tests (`.mjs/.cjs/.mts/.cts` are code; `.test.mts`/`.spec.cjs` are tests). I did not run the UI/workers steps (unrelated), and the local Windows tree has pre-existing unrelated failures (CRLF, missing CLI binaries, Node 24 vs pinned 22). CI runs the full matrix on a clean checkout.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward/private terms exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [ ] Auth/cookie/CORS/session negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested where needed. (Internal classifiers; covered by the added tests. No schema changed.)
- [ ] UI changes use live API data. — N/A: no UI change.
- [ ] UI Evidence. — N/A: no visible UI change.
- [x] Docs/changelog updated where needed. (None needed.)

## Notes
- The `.test`/`.spec` group is extended in lockstep with `isCodeFile` so a `foo.test.mts` is still a test, not source — a regression test pins this.
- Both `isCodeFile` copies (`local-branch.ts` exported + `engine.ts` private) and the MCP client copy are updated together so the classifier can't drift by extension.


---

**Update (addressing review):** also extended the Cypress/Playwright `.cy`/`.e2e` test-file group to the module extensions (so `checkout.cy.mts` / `flow.e2e.mjs` stay tests, not source), and replaced `engine.ts`'s stale private `isTestFile` (which lacked `.cy`/`.e2e` and `__snapshots__`) with a delegation to the canonical `isTestPath`, mirroring `local-branch.ts` — so all test/code classifiers are single-sourced and cannot drift by extension. Regression assertions added for the `.cy.mts`/`.e2e.mjs` cases; `engine.ts` delegation line confirmed covered.