### PR TITLE
fix(signals): detect pytest test_*.py prefix as test evidence

### DIFF
--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -3,6 +3,7 @@ export function isTestPath(file: string): boolean {
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
     /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|js|jsx)$/i.test(file) ||

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -17,6 +17,15 @@ describe("test evidence helpers", () => {
     expect(isTestPath("src/widget.rs")).toBe(false);
   });
 
+  it("detects pytest's default test_*.py prefix convention, not just the *_test.py suffix", () => {
+    expect(isTestPath("mypackage/test_utils.py")).toBe(true); // pytest default, sitting next to source
+    expect(isTestPath("src/app/test_auth.py")).toBe(true);
+    expect(isTestPath("test_top_level.py")).toBe(true); // repo-root test file
+    expect(isTestPath("internal/cache_test.py")).toBe(true); // the pre-existing suffix form still matches
+    expect(isTestPath("src/app/latest_config.py")).toBe(false); // `test_` mid-segment ⇒ not a test
+    expect(isTestPath("src/app/testing.py")).toBe(false); // no `test_` boundary ⇒ not a test
+  });
+
   it("does not treat framework or integration directory names alone as test evidence", () => {
     expect(isTestPath("src/integration/auth.ts")).toBe(false);
     expect(isTestPath("src/playwright/client.ts")).toBe(false);


### PR DESCRIPTION
isTestPath recognized the `*_test.py` **suffix** but not pytest`s default and more common `test_*.py` **prefix**. A Python PR that adds test files next to source (e.g. `mypackage/test_utils.py`, `src/app/test_auth.py`) matched no branch of `isTestPath` and was scored as shipping **no** test evidence — tripping the missing-test slop finding and undercounting `classifyTestCoverage` / the local scorer.

`test_*.py` is the default `python_files` pattern for pytest (and matches unittest discovery), so this is the primary Python test convention, not an edge case. The existing dir-based branch only catches files that live under a `test/`, `tests/`, `spec/`, or `__tests__/` directory, which the flat pytest layout does not.

## Fix
Add one path-segment-anchored matcher next to the existing suffix rule:

```
/(^|\/)test_[^/]*\.py$/i.test(file)
```

The `(^|\/)` anchor keeps it precise: `latest_config.py` and `testing.py` remain non-tests (no `test_` at a segment boundary), while the pre-existing `*_test.py` suffix form is untouched.

## Tests
Adds a regression case covering the prefix form, the still-working suffix form, and both non-test negatives. Verified the new case FAILS on current `main` and PASSES with the fix; the full `test-evidence`, `slop`, and `path-matchers` suites stay green.

No linked issue: issue creation is unavailable for this account.