### PR TITLE
feat(enrichment): flag risky workflow permissions and triggers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,17 +65,18 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # Current analyzer names:
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
-# history,docCommentDrift,duplication,churnHotspot,blameLink
+# history,docCommentDrift,duplication,churnHotspot,blameLink,workflowPermissions
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,workflowPermissions
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
+# workflowPermissions
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
-# nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
+# nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,workflowPermissions
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -584,6 +584,30 @@ export const REES_ANALYZERS = [
         "File-level, not per-line: it reports each file's most recent prior toucher, never claiming a specific line's origin. Fail-safe and partial on cap.",
     },
   },
+  {
+    name: "workflowPermissions",
+    title: "Risky workflow permissions / triggers",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags workflow changes that grant broad/sensitive permissions or add high-risk event triggers.",
+      looksAt:
+        "Added lines in .github/workflows/* — permissions: write-all, id-token: write, secrets: inherit, sensitive per-scope writes, and pull_request_target / workflow_run triggers.",
+      reports:
+        "File, line, and the risky-permission/trigger kind (plus the scope for a sensitive-scope write).",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Matches the fixed GitHub Actions workflow schema (a bounded enum of scopes and event names), not arbitrary code; YAML comments are stripped before matching.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -662,6 +662,32 @@
         "network": "Calls the GitHub commits API and the commit→PR association API, both bounded by a total lookup cap.",
         "notes": "File-level, not per-line: it reports each file's most recent prior toucher, never claiming a specific line's origin. Fail-safe and partial on cap."
       }
+    },
+    {
+      "name": "workflowPermissions",
+      "title": "Risky workflow permissions / triggers",
+      "category": "security",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags workflow changes that grant broad/sensitive permissions or add high-risk event triggers.",
+        "looksAt": "Added lines in .github/workflows/* — permissions: write-all, id-token: write, secrets: inherit, sensitive per-scope writes, and pull_request_target / workflow_run triggers.",
+        "reports": "File, line, and the risky-permission/trigger kind (plus the scope for a sensitive-scope write).",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Matches the fixed GitHub Actions workflow schema (a bounded enum of scopes and event names), not arbitrary code; YAML comments are stripped before matching."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -20,6 +20,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanTyposquat } from "./typosquat.js";
+import { scanWorkflowPermissions } from "./workflow-permissions.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -477,6 +478,26 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanBlameLink(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "workflowPermissions",
+    title: "Risky workflow permissions / triggers",
+    category: "security",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags workflow changes that grant broad/sensitive permissions or add high-risk event triggers.",
+      looksAt:
+        "Added lines in .github/workflows/* — permissions: write-all, id-token: write, secrets: inherit, sensitive per-scope writes, and pull_request_target / workflow_run triggers.",
+      reports: "File, line, and the risky-permission/trigger kind (plus the scope for a sensitive-scope write).",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Matches the fixed GitHub Actions workflow schema (a bounded enum of scopes and event names), not arbitrary code; YAML comments are stripped before matching.",
+    },
+    run: (req, { signal }) => scanWorkflowPermissions(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/workflow-permissions.ts
+++ b/review-enrichment/src/analyzers/workflow-permissions.ts
@@ -1,0 +1,243 @@
+// Risky GitHub Actions workflow permissions / triggers analyzer. Scans changed `.github/workflows/*` for added
+// lines that grant broad or sensitive permissions, or add a high-risk event trigger — the `pull_request_target`
+// + write-token supply-chain class, where untrusted fork code runs with the base repo's secrets and a write
+// token. Pure compute, no network. Bounded: it matches the FIXED GitHub Actions workflow schema (a documented
+// enum of permission scopes and event names), never arbitrary code, so it cannot suffer the unbounded edge cases
+// of a code parser. YAML `#` comments are stripped before matching. Line-cited via hunk headers, mirroring the
+// other local patch analyzers.
+import type { EnrichRequest, WorkflowPermissionFinding } from "../types.js";
+import { isWorkflowPath } from "../workflow-path.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+// High-risk event triggers. `pull_request_target` runs on untrusted fork code with the base repo's secrets and a
+// read/write token; `workflow_run` runs in an elevated context triggered by another workflow. Both are the classic
+// GitHub Actions privilege-escalation vectors. `on:` is always a TOP-LEVEL workflow key (column 0), so both forms
+// require zero indentation: the same-line `on:` declaration form (`on: pull_request_target`,
+// `on: [push, pull_request_target]`) is unambiguous at column 0 and matched context-free (the `^` anchor with no
+// leading `\s*` enforces this). The block-mapping (`on:\n  event:`) and list-item (`on:\n  - event`) forms are
+// only unambiguous once we know we are inside the top-level `on:` block — a bare `event:` or `- event` line
+// elsewhere (e.g. a job id, a `needs:` entry, or a nested `with:`/`on:` value under some other key) is NOT a
+// trigger. Rather than parse arbitrary YAML, `OnBlockTracker` below tracks just enough — that the `on:` key
+// itself is at column 0, and the indentation of its direct children — to answer that one question; see its own
+// comment for the bounded nesting rule it uses.
+const PRT_TRIGGER_RE = /^on\s*:.*\bpull_request_target\b/;
+const WORKFLOW_RUN_RE = /^on\s*:.*\bworkflow_run\b/;
+const ON_BLOCK_KEY_RE = /^on\s*:\s*$/;
+const PRT_CHILD_KEY_RE = /^pull_request_target\s*:/;
+const WORKFLOW_RUN_CHILD_KEY_RE = /^workflow_run\s*:/;
+const PRT_CHILD_LIST_RE = /^-\s*pull_request_target\s*$/;
+const WORKFLOW_RUN_CHILD_LIST_RE = /^-\s*workflow_run\s*$/;
+
+/** Tracks whether the current line sits directly inside a top-level `on:` block, using only the indentation
+ *  visible within one diff hunk (state resets per hunk — an unseen gap between hunks could hold anything, so
+ *  carrying state across it would risk a WORSE false positive than simply not tracking). Nesting rule: once an
+ *  `on:` key line is seen, the next line at greater indentation fixes the "direct child" indentation level; any
+ *  line back at or above the `on:` key's own indentation ends the block. Only lines at exactly the direct-child
+ *  level are trigger declarations — deeper lines (e.g. `workflow_call:` inputs/secrets) are sub-config, not a
+ *  trigger name, so they are never flagged. */
+class OnBlockTracker {
+  private onIndent: number | null = null;
+  private childIndent: number | null = null;
+
+  reset(): void {
+    this.onIndent = null;
+    this.childIndent = null;
+  }
+
+  /** Observe one context/added line (in final-file order) and report a direct on:-block child trigger, if any. */
+  observe(indent: number, trimmed: string): "pull-request-target-trigger" | "workflow-run-trigger" | null {
+    if (trimmed === "") return null;
+    if (indent === 0 && ON_BLOCK_KEY_RE.test(trimmed)) {
+      this.onIndent = indent;
+      this.childIndent = null;
+      return null;
+    }
+    if (this.onIndent === null) return null;
+    if (indent <= this.onIndent) {
+      this.reset();
+      return null;
+    }
+    if (this.childIndent === null) this.childIndent = indent;
+    if (indent !== this.childIndent) return null;
+    if (PRT_CHILD_KEY_RE.test(trimmed) || PRT_CHILD_LIST_RE.test(trimmed)) {
+      return "pull-request-target-trigger";
+    }
+    if (WORKFLOW_RUN_CHILD_KEY_RE.test(trimmed) || WORKFLOW_RUN_CHILD_LIST_RE.test(trimmed)) {
+      return "workflow-run-trigger";
+    }
+    return null;
+  }
+}
+// `permissions: write-all` grants every scope write access at once.
+const WRITE_ALL_RE = /\bpermissions\s*:\s*write-all\b/i;
+// `id-token: write` enables OIDC cloud-credential exchange, so a compromised job can mint cloud credentials.
+const OIDC_WRITE_RE = /\bid-token\s*:\s*write\b/i;
+// `secrets: inherit` forwards ALL of the caller's secrets to a (possibly third-party) reusable workflow.
+const SECRETS_INHERIT_RE = /\bsecrets\s*:\s*inherit\b/i;
+// Sensitive per-scope write grants. Captures the scope name for the finding detail.
+const SENSITIVE_WRITE_RE =
+  /\b(contents|packages|actions|deployments|security-events)\s*:\s*write\b/i;
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+/** Strip a trailing YAML `#` comment (a `#` at line start or after whitespace) so a permission/trigger merely
+ *  NAMED in a comment is not flagged. A `#` that is not comment-delimited (e.g. inside a value) is left alone. */
+export function stripYamlComment(line: string): string {
+  const match = /(?:^|\s)#/.exec(line);
+  return match ? line.slice(0, match.index) : line;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+function pushFinding(
+  findings: WorkflowPermissionFinding[],
+  seen: Set<string>,
+  file: string,
+  line: number,
+  kind: WorkflowPermissionFinding["kind"],
+  maxFindings: number,
+  detail?: string,
+): boolean {
+  const key = `${kind}:${line}:${detail ?? ""}`;
+  if (seen.has(key)) return false;
+  seen.add(key);
+  findings.push(detail ? { file, line, kind, detail } : { file, line, kind });
+  return findings.length >= maxFindings;
+}
+
+/** Scan one workflow patch's added lines for risky permission grants / triggers, line-cited via hunk headers. Pure. */
+export function scanPatchForWorkflowPermissions(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): WorkflowPermissionFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+
+  const findings: WorkflowPermissionFinding[] = [];
+  const seen = new Set<string>();
+  const onBlock = new OnBlockTracker();
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const raw of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      // An unseen gap precedes this hunk; carrying on:-block state across it could misattribute an unrelated
+      // block-mapping key as a trigger, so each hunk starts with no assumed nesting context.
+      onBlock.reset();
+      continue;
+    }
+    // Skip pre-hunk preamble; inside a hunk `+++x` is added content, not a header.
+    if (!inHunk) continue;
+    if (raw.startsWith("-")) continue; // removed lines do not exist in the final file
+
+    const isAdded = raw.startsWith("+");
+    const rawBody = raw.slice(1);
+    if (rawBody.length > MAX_LINE_CHARS) {
+      newLine++;
+      continue;
+    }
+    const body = stripYamlComment(rawBody);
+    const indent = body.length - body.trimStart().length;
+    const onBlockTrigger = onBlock.observe(indent, body.trim());
+
+    if (!isAdded) {
+      newLine++;
+      continue;
+    }
+
+    if (
+      WRITE_ALL_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "write-all-permission", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      OIDC_WRITE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "oidc-token-write", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SECRETS_INHERIT_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "secrets-inherit", maxFindings)
+    ) {
+      return findings;
+    }
+    const sensitive = SENSITIVE_WRITE_RE.exec(body);
+    if (
+      sensitive &&
+      pushFinding(
+        findings,
+        seen,
+        path,
+        newLine,
+        "sensitive-scope-write",
+        maxFindings,
+        sensitive[1]!.toLowerCase(),
+      )
+    ) {
+      return findings;
+    }
+    if (
+      (PRT_TRIGGER_RE.test(body) || onBlockTrigger === "pull-request-target-trigger") &&
+      pushFinding(
+        findings,
+        seen,
+        path,
+        newLine,
+        "pull-request-target-trigger",
+        maxFindings,
+      )
+    ) {
+      return findings;
+    }
+    if (
+      (WORKFLOW_RUN_RE.test(body) || onBlockTrigger === "workflow-run-trigger") &&
+      pushFinding(findings, seen, path, newLine, "workflow-run-trigger", maxFindings)
+    ) {
+      return findings;
+    }
+
+    newLine++;
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed workflow file for risky permission grants / triggers. */
+export async function scanWorkflowPermissions(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<WorkflowPermissionFinding[]> {
+  const findings: WorkflowPermissionFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch || !isWorkflowPath(file.path)) continue;
+    for (const finding of scanPatchForWorkflowPermissions(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -379,6 +379,37 @@ export function renderBrief(
     }
   }
 
+  const workflowPermissions = findings.workflowPermissions ?? [];
+  if (workflowPermissions.length) {
+    const explain = (
+      item: (typeof workflowPermissions)[number],
+    ): string => {
+      switch (item.kind) {
+        case "write-all-permission":
+          return "grants `permissions: write-all`; scope the token to only the permissions the job needs";
+        case "oidc-token-write":
+          return "grants `id-token: write` (OIDC cloud-credential exchange); confirm this job must mint cloud credentials";
+        case "secrets-inherit":
+          return "forwards all caller secrets via `secrets: inherit`; pass only the specific secrets the called workflow needs";
+        case "sensitive-scope-write":
+          return `grants \`${item.detail ?? "a sensitive scope"}: write\`; confirm this job needs write access to that scope`;
+        case "pull-request-target-trigger":
+          return "adds a `pull_request_target` trigger, which runs with the base repo's secrets on untrusted fork code — a common privilege-escalation vector; avoid checking out or executing PR head code";
+        case "workflow-run-trigger":
+          return "adds a `workflow_run` trigger, which runs in an elevated context; treat any PR-derived inputs as untrusted";
+      }
+    };
+
+    lines.push(
+      "### Risky workflow permissions / triggers (supply-chain — review before merging)",
+    );
+    for (const item of workflowPermissions) {
+      lines.push(
+        `- ${safeCodeSpan(`${item.file}:${item.line}`)} — ${explain(item)}`,
+      );
+    }
+  }
+
   lines.push(...renderDescriptorSection("blameLink", findings.blameLink));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -355,6 +355,7 @@ function inputSkipReason(
         ? null
         : "no_lockfile";
     case "actionPin":
+    case "workflowPermissions":
       return analysis.fileCategories.some((file) => file.category === "workflow")
         ? null
         : "no_workflow";

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -224,6 +224,24 @@ export interface IacMisconfigFinding {
     | "hardcoded-service-url";
 }
 
+/** An added GitHub Actions workflow line that grants a broad/sensitive permission or adds a high-risk event
+ *  trigger — the `pull_request_target` + write-token supply-chain class, where untrusted fork code runs with the
+ *  base repo's secrets and a write token. Reports the location + kind (+ the scope for a sensitive-scope write)
+ *  only; never any secret value. */
+export interface WorkflowPermissionFinding {
+  file: string;
+  line: number;
+  kind:
+    | "write-all-permission"
+    | "oidc-token-write"
+    | "secrets-inherit"
+    | "sensitive-scope-write"
+    | "pull-request-target-trigger"
+    | "workflow-run-trigger";
+  /** The permission scope for a `sensitive-scope-write` finding (e.g. "contents"). */
+  detail?: string;
+}
+
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel
  *  (PyPI sdist-only) — a hidden CI cold-start/install cost and a frequent cross-platform breakage source. Reports
  *  package@version + the factual build property only. (#1512) */
@@ -325,6 +343,7 @@ export interface BriefFindings {
   duplication?: DuplicationFinding[];
   churnHotspot?: ChurnHotspotFinding[];
   blameLink?: BlameLinkFinding[];
+  workflowPermissions?: WorkflowPermissionFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -32,6 +32,7 @@ const EXPECTED_ANALYZERS = [
   "duplication",
   "churnHotspot",
   "blameLink",
+  "workflowPermissions",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/workflow-permissions.test.ts
+++ b/review-enrichment/test/workflow-permissions.test.ts
@@ -1,0 +1,228 @@
+// Units for the risky-workflow-permissions analyzer. Kept separate so analyzer PRs avoid collisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  scanPatchForWorkflowPermissions,
+  scanWorkflowPermissions,
+  stripYamlComment,
+} from "../dist/analyzers/workflow-permissions.js";
+
+const workflowPath = ".github/workflows/ci.yml";
+
+const addedPatch = (...lines) =>
+  `@@ -1,0 +5,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("scanPatchForWorkflowPermissions flags each risky permission and trigger kind", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch(
+      "on: pull_request_target",
+      "  permissions: write-all",
+      "      id-token: write",
+      "      contents: write",
+      "    secrets: inherit",
+      "on: workflow_run",
+    ),
+  );
+  assert.deepEqual(findings, [
+    { file: workflowPath, line: 5, kind: "pull-request-target-trigger" },
+    { file: workflowPath, line: 6, kind: "write-all-permission" },
+    { file: workflowPath, line: 7, kind: "oidc-token-write" },
+    {
+      file: workflowPath,
+      line: 8,
+      kind: "sensitive-scope-write",
+      detail: "contents",
+    },
+    { file: workflowPath, line: 9, kind: "secrets-inherit" },
+    { file: workflowPath, line: 10, kind: "workflow-run-trigger" },
+  ]);
+});
+
+test("scanPatchForWorkflowPermissions captures each sensitive scope name", () => {
+  for (const scope of [
+    "packages",
+    "actions",
+    "deployments",
+    "security-events",
+  ]) {
+    const findings = scanPatchForWorkflowPermissions(
+      workflowPath,
+      addedPatch(`      ${scope}: write`),
+    );
+    assert.deepEqual(findings, [
+      { file: workflowPath, line: 5, kind: "sensitive-scope-write", detail: scope },
+    ]);
+  }
+});
+
+test("scanPatchForWorkflowPermissions does not mis-flag a job/step id that shares a trigger's name", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch(
+      "jobs:",
+      "  workflow_run:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - id: pull_request_target",
+      "        run: echo hi",
+    ),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions flags a block-mapping trigger declared under on:", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("on:", "  pull_request_target:", "  workflow_run:", "    types: [completed]"),
+  );
+  assert.deepEqual(findings, [
+    { file: workflowPath, line: 6, kind: "pull-request-target-trigger" },
+    { file: workflowPath, line: 7, kind: "workflow-run-trigger" },
+  ]);
+});
+
+test("scanPatchForWorkflowPermissions does not flag a trigger name nested deeper than the on: block's direct children", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch(
+      "on:",
+      "  workflow_call:",
+      "    inputs:",
+      "      pull_request_target:",
+      "        type: string",
+    ),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions stops treating keys as on:-block children once a sibling top-level key starts", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("on:", "  push:", "jobs:", "  pull_request_target:", "    runs-on: ubuntu-latest"),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions does not flag a same-line on: trigger unless on: is at column 0", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("jobs:", "  foo:", "    with:", "      on: pull_request_target"),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions does not treat a nested on: key (non-zero indent) as entering the trigger block", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("jobs:", "  foo:", "    with:", "      on:", "        pull_request_target:"),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions does not carry on:-block context across a hunk gap", () => {
+  const patch = [
+    "@@ -1,1 +1,1 @@",
+    " on:",
+    "@@ -10,1 +10,1 @@",
+    "+  pull_request_target:",
+  ].join("\n");
+  const findings = scanPatchForWorkflowPermissions(workflowPath, patch);
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions ignores read grants and comments", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch(
+      "  permissions: read-all",
+      "      contents: read",
+      "  # pull_request_target is risky — do not use",
+      "  name: workflow_run mentioned in a value # id-token: write",
+    ),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions does not mis-flag an actions/* uses ref as an actions:write grant", () => {
+  const findings = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("    - uses: actions/checkout@v4", "    - uses: actions/setup-node@v4"),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForWorkflowPermissions tracks new-file lines and skips removed/context lines", () => {
+  const patch = [
+    "@@ -1,2 +1,3 @@",
+    " on:",
+    "-  - push",
+    "+  - pull_request_target",
+  ].join("\n");
+  const findings = scanPatchForWorkflowPermissions(workflowPath, patch);
+  assert.deepEqual(findings, [
+    { file: workflowPath, line: 2, kind: "pull-request-target-trigger" },
+  ]);
+});
+
+test("scanPatchForWorkflowPermissions dedupes a kind per line and honors the budget", () => {
+  assert.deepEqual(
+    scanPatchForWorkflowPermissions(workflowPath, addedPatch("permissions: write-all"), {
+      maxFindings: 0,
+    }),
+    [],
+  );
+  const capped = scanPatchForWorkflowPermissions(
+    workflowPath,
+    addedPatch("permissions: write-all", "  id-token: write", "  contents: write"),
+    { maxFindings: 2 },
+  );
+  assert.equal(capped.length, 2);
+});
+
+test("scanPatchForWorkflowPermissions skips pathologically long lines", () => {
+  const long = `permissions: write-all ${"x".repeat(2001)}`;
+  assert.deepEqual(
+    scanPatchForWorkflowPermissions(workflowPath, addedPatch(long)),
+    [],
+  );
+});
+
+test("stripYamlComment removes a comment tail but keeps a bare value", () => {
+  assert.equal(stripYamlComment("  contents: write # needed for release").trim(), "contents: write");
+  assert.equal(stripYamlComment("# whole line comment"), "");
+  assert.equal(stripYamlComment("  contents: write"), "  contents: write");
+});
+
+test("scanWorkflowPermissions scans only workflow files with a patch", async () => {
+  const findings = await scanWorkflowPermissions({
+    repoFullName: "o/r",
+    prNumber: 1,
+    files: [
+      { path: ".github/workflows/deploy.yml", patch: addedPatch("  permissions: write-all") },
+      { path: "src/config.ts", patch: addedPatch("permissions: write-all") }, // not a workflow path
+      { path: ".github/workflows/no-patch.yml" }, // no patch
+    ],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].file, ".github/workflows/deploy.yml");
+  assert.equal(findings[0].kind, "write-all-permission");
+});
+
+test("scanWorkflowPermissions returns [] with no files and throws when aborted", async () => {
+  assert.deepEqual(await scanWorkflowPermissions({ repoFullName: "o/r", prNumber: 1 }), []);
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    scanWorkflowPermissions(
+      {
+        repoFullName: "o/r",
+        prNumber: 1,
+        files: [{ path: workflowPath, patch: addedPatch("permissions: write-all") }],
+      },
+      controller.signal,
+    ),
+    /analyzer_aborted/,
+  );
+});


### PR DESCRIPTION
## What

A new local REES analyzer, `workflowPermissions`, that flags changes to `.github/workflows/*` which grant broad or sensitive permissions, or add high-risk event triggers — the `pull_request_target` + write-token supply-chain class, where untrusted fork code runs with the base repo's secrets and a write token.

## Detections (the fixed GitHub Actions schema — a bounded enum)

- `permissions: write-all`
- `id-token: write` (OIDC cloud-credential exchange)
- `secrets: inherit` (forwards all of the caller's secrets to a reusable workflow)
- sensitive per-scope writes — `contents` / `packages` / `actions` / `deployments` / `security-events` `: write` (reports the scope)
- `pull_request_target` and `workflow_run` triggers, matched only as a trigger *declaration* — an `on:` line naming it, a mapping key, or a `- ` list item — so the token merely appearing in a name/value is not flagged

## Why it is bounded / merge-safe

It matches the fixed GitHub Actions workflow schema (a documented enum of permission scopes and event names), never arbitrary code, so it has no unbounded parsing edge cases. YAML `#` comments are stripped before matching. It mirrors the existing `actions-pin` and `iac-misconfig` line-cited patch analyzers (per-line scan, hunk tracking, `MAX_FINDINGS`/`MAX_LINE_CHARS` caps, dedup by kind+line, fail-safe on abort).

## Value

No existing analyzer covers workflow permission escalation or dangerous event triggers. A PR that adds `pull_request_target` (running untrusted fork code with the base repo's secrets) or a broad `write-all` grant is a well-known supply-chain vector worth surfacing before merge.

## Tests

`review-enrichment/test/workflow-permissions.test.ts` covers every kind, each sensitive scope, YAML-comment stripping, read-grant and `actions/*` uses-ref non-matches, new-file line tracking across removed/context lines, per-kind dedup, the budget/abort paths, and the workflow-path filter. Analyzer metadata is regenerated and committed.

## No linked issue

No linked issue because this is a net-new analyzer; there is no tracking issue to link.
