### PR TITLE
fix(orb): record gate_decision on self-host regardless of parity-audit flag

### DIFF
--- a/src/review/parity-wire.ts
+++ b/src/review/parity-wire.ts
@@ -6,13 +6,20 @@
 // other half: it RECORDS the gittensory-native gate decision into the `review_audit` audit-source table
 // (migration 0049) so the harness has data to read, and exposes the readiness rollup the endpoint serves.
 //
-// SHADOW CONTRACT (must hold under every path):
+// SHADOW CONTRACT on the CLOUD WORKER (must hold under every path there):
 //   • flag-OFF (default) → recordNativeGateDecision is an immediate no-op (NO D1 write) and the parity endpoint
 //     404s. The review path is BYTE-IDENTICAL to today: the recorder is the only new statement on the gate
 //     path and it returns before touching D1 when off.
 //   • flag-ON → SHADOW mode: the recorder writes ONE row per finalized gate decision with
 //     source='gittensory-native'. It records ONLY; it NEVER changes what the gate does. The write is
 //     best-effort (a failure is swallowed) so telemetry can never break finalization.
+//
+// SELF-HOSTED INSTANCES ALWAYS RECORD, regardless of the flag (#orb-telemetry-gate-decision-gap). The flag
+// exists to guard write volume/cost on the SHARED Cloudflare D1 for a now-historical pre-cutover comparison
+// use case -- a self-hosted instance's review_audit is its own local SQLite/Postgres, so there is no shared-
+// resource concern, and this is the ONLY writer of gate_decision rows: exportOrbBatch's fleet-telemetry query
+// (src/selfhost/orb-collector.ts) INNER JOINs gate_decision to pr_outcome, so without this row every self-host
+// export silently returns zero events forever, even though pr_outcome rows (written unconditionally) exist.
 //
 // WHAT THIS RECORDS vs WHAT IS DEFERRED: this writes the gittensory-native (SHADOW) side only. The actual
 // cross-system COMPARISON needs reviewbot's authoritative rows (source='reviewbot') in the SAME table — those
@@ -22,6 +29,7 @@
 
 import { computeGateParity, isParityCutoverReady, type GateAction, type GateParityRow } from "./parity";
 import type { GateCheckConclusion } from "../rules/advisory";
+import { isSelfHostedReviewRuntime } from "../selfhost/review-runtime";
 import { errorMessage, nowIso } from "../utils/json";
 
 /** True when the shadow-parity audit is enabled. Flag-OFF (default) → recordNativeGateDecision is a no-op and
@@ -69,27 +77,36 @@ export function nativeGateActionFromConclusion(conclusion: GateCheckConclusion):
   }
 }
 
-/** The minimal env shape the recorder needs (the D1 binding). */
-type ParityRecorderEnv = { DB: D1Database; GITTENSORY_REVIEW_PARITY_AUDIT?: string | undefined };
+/** The minimal env shape the recorder needs (the D1/local-DB binding, the flag, and the self-host signal). */
+type ParityRecorderEnv = {
+  DB: D1Database;
+  GITTENSORY_REVIEW_PARITY_AUDIT?: string | undefined;
+  SELFHOST_TRANSIENT_CACHE?: NonNullable<Env["SELFHOST_TRANSIENT_CACHE"]>;
+};
 
 /**
- * SHADOW-record one gittensory-native gate decision into `review_audit` (source='gittensory-native').
+ * Record one gittensory-native gate decision into `review_audit` (source='gittensory-native').
  *
- * flag-OFF (default) → returns immediately, NO D1 write (the review path is byte-identical). flag-ON → writes
- * ONE row keyed `gate:<source>:<project>#<pr>@<sha>` with decision/head_sha/summary so computeGateParity can
- * self-join it against the authoritative source on (project, target_id, head_sha). RECORD-ONLY — it never
- * changes the gate. Best-effort: a write failure is swallowed (telemetry must not break finalization). A
+ * On the cloud worker: flag-OFF (default) → returns immediately, NO D1 write (the review path is byte-
+ * identical); flag-ON → SHADOW-records for the pre-cutover parity comparison. On a self-hosted instance, this
+ * ALWAYS records regardless of the flag (see the module header) — it's the instance's own local DB, and
+ * exportOrbBatch's fleet-telemetry export depends on this data existing.
+ *
+ * Writes ONE row keyed `gate:<source>:<project>#<pr>@<sha>` with decision/head_sha/summary. RECORD-ONLY — it
+ * never changes the gate. Best-effort: a write failure is swallowed (telemetry must not break finalization). A
  * conclusion with no comparable action (neutral/skipped) records nothing.
  *
  * Caller passes the FINALIZED gate conclusion + the head_sha it was evaluated on. The caller should also guard
- * on {@link isParityAuditEnabled} for the byte-identical-when-off contract, but this function re-checks the
- * flag so it is safe to call unconditionally.
+ * on {@link isParityAuditEnabled} for the cloud-worker byte-identical-when-off contract, but this function
+ * re-checks both the flag and the self-host signal so it is safe to call unconditionally.
  */
 export async function recordNativeGateDecision(
   env: ParityRecorderEnv,
   input: { project: string; pullNumber: number; headSha: string | null | undefined; conclusion: GateCheckConclusion; reasonCode?: string | null | undefined },
 ): Promise<void> {
-  if (!isParityAuditEnabled(env)) return; // flag-OFF: no write, byte-identical review path
+  // Self-hosted instances always record (their own local DB; exportOrbBatch needs this data). The cloud
+  // worker keeps the exact flag-gated, byte-identical-when-off contract.
+  if (!isSelfHostedReviewRuntime(env) && !isParityAuditEnabled(env)) return;
   const action = nativeGateActionFromConclusion(input.conclusion);
   if (action === null) return; // not a comparable decision (neutral/skipped) → nothing to record
   if (!input.headSha) return; // parity REQUIRES head_sha to pair a decision to a commit; no sha → not comparable

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -109,14 +109,35 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(0);
   });
 
-  it("flag-OFF records NOTHING — no D1 write (byte-identical review path)", async () => {
+  it("flag-OFF records NOTHING on the CLOUD WORKER — no D1 write (byte-identical review path)", async () => {
     const env = createTestEnv(); // flag unset → OFF
+    delete env.SELFHOST_TRANSIENT_CACHE; // simulate the cloud worker (no self-host binding)
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "success", reasonCode: "all_clear" });
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(0);
     // ...and explicitly false-valued flags are OFF too.
     const envFalse = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "false" });
+    delete envFalse.SELFHOST_TRANSIENT_CACHE;
     await recordNativeGateDecision(envFalse, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "failure" });
     expect((await rawAll(envFalse, "SELECT * FROM review_audit")).length).toBe(0);
+  });
+
+  it("SELF-HOSTED instances ALWAYS record, regardless of the flag (#orb-telemetry-gate-decision-gap)", async () => {
+    // SELFHOST_TRANSIENT_CACHE present (createTestEnv's default) === a self-hosted instance. The flag stays
+    // unset/false — exactly the state of every self-hosted instance in production today (the flag has never
+    // been documented as something to enable for self-host) — yet the row must still be written, or
+    // exportOrbBatch's FLEET_QUERY INNER JOIN against pr_outcome permanently finds nothing to export.
+    const env = createTestEnv(); // flag unset → OFF, but SELFHOST_TRANSIENT_CACHE present → self-hosted
+    await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "success", reasonCode: "all_clear" });
+    const rows = await rawAll(env, "SELECT * FROM review_audit");
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ decision: "merge", source: GITTENSORY_NATIVE_SOURCE, summary: "all_clear" });
+
+    // ...and an explicit "false" flag value doesn't override the self-host signal either.
+    const envFalse = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "false" });
+    await recordNativeGateDecision(envFalse, { project: "owner/repo", pullNumber: 8, headSha: "def456", conclusion: "failure", reasonCode: "slop_risk" });
+    const falseRows = await rawAll(envFalse, "SELECT * FROM review_audit");
+    expect(falseRows.length).toBe(1);
+    expect(falseRows[0]).toMatchObject({ decision: "hold", source: GITTENSORY_NATIVE_SOURCE, summary: "slop_risk" });
   });
 
   it("fails safe: a D1 write error is swallowed + logged (telemetry never breaks finalization)", async () => {
@@ -360,8 +381,9 @@ describe("recordNativeGateDecision wired into the review FINALIZE path (GITTENSO
     expect(rows[0]!.summary).toBe("missing_linked_issue");
   });
 
-  it("FLAG-OFF (default): the finalize path records NOTHING — byte-identical review path, no native row", async () => {
+  it("FLAG-OFF (default) on the CLOUD WORKER: the finalize path records NOTHING — byte-identical review path, no native row", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // flag unset → OFF
+    delete env.SELFHOST_TRANSIENT_CACHE; // simulate the cloud worker (no self-host binding)
     await seedGateEnabledRepo(env);
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: parityMinerSnapshot("contributor") }, 60_000);
     stubFinalizeFetch("contributor");
@@ -371,5 +393,22 @@ describe("recordNativeGateDecision wired into the review FINALIZE path (GITTENSO
       vi.unstubAllGlobals();
     }
     expect(await nativeRows(env)).toEqual([]);
+  });
+
+  it("FLAG-OFF (default) on a SELF-HOSTED instance: the finalize path STILL records (fleet telemetry gap fix)", async () => {
+    // SELFHOST_TRANSIENT_CACHE present (createTestEnv's default) === a self-hosted instance; the flag stays
+    // unset, matching every self-hosted instance in production. exportOrbBatch needs this row to exist.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await seedGateEnabledRepo(env);
+    await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: parityMinerSnapshot("contributor") }, 60_000);
+    stubFinalizeFetch("contributor");
+    try {
+      await processJob(env, prWebhook("parity-finalize-selfhost", "contributor"));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    const rows = await nativeRows(env);
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ decision: "hold", source: GITTENSORY_NATIVE_SOURCE, summary: "missing_linked_issue" });
   });
 });


### PR DESCRIPTION
## Summary

- `exportOrbBatch` (`src/selfhost/orb-collector.ts`) is the always-on, anonymized fleet-telemetry exporter every self-hosted instance runs. Its `FLEET_QUERY` INNER JOINs `gate_decision` rows to `pr_outcome` rows in the instance's own `review_audit` table.
- `pr_outcome` rows are written unconditionally on every `pull_request closed` webhook (`src/review/outcomes-wire.ts`).
- `gate_decision` rows are written by `recordNativeGateDecision` (`src/review/parity-wire.ts`), but that function was gated behind `GITTENSORY_REVIEW_PARITY_AUDIT` — an obsolete, default-off, pre-cutover comparison flag from the reviewbot→gittensory-native migration trial. It's never mentioned as something to enable for self-host in any docs.
- Net effect: the INNER JOIN has always returned zero rows on every self-hosted instance, so central D1's `orb_signals`/`orb_instances` never receive data — confirmed empty in production (0 rows each).

## Fix

`recordNativeGateDecision` now always records on self-hosted instances (their own local DB — no shared-resource cost concern), regardless of the flag. The cloud worker's existing flag-gated, byte-identical-when-off contract is untouched, guarded by the existing `isSelfHostedReviewRuntime()` runtime-detection helper already used in `src/index.ts` / `src/github/webhook.ts`.

Advances #1825, #1668, #1826.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/parity-wire.test.ts` (19/19, incl. new self-host-always-records coverage for both the direct call and the processors.ts finalize wiring)
- [x] `npm run test:ci` (full local gate, unsharded)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] 100% line + branch coverage on every changed line (lcov confirms 20/20 lines, all branches on touched lines hit both sides)