### PR TITLE
chore(rate-limit): remove unused RATE_LIMIT_TRUSTED_PROXY* env fields

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -155,8 +155,6 @@ declare global {
      *  secret, never a public var. When absent, BYOK is unavailable and review uses the configured instance
      *  reviewer when available. */
     TOKEN_ENCRYPTION_SECRET?: string;
-    RATE_LIMIT_TRUSTED_PROXIES?: string;
-    RATE_LIMIT_TRUSTED_PROXY_COUNT?: string;
     /** Convergence (Stage D): when truthy, the public PR comment is rendered by the unified-comment bridge
      *  (ONE in-place comment in the converged shape) instead of the legacy `buildPublicPrIntelligenceComment`
      *  panel. Default OFF — unset/false keeps the legacy panel byte-identical. */

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -209,7 +209,6 @@ describe("private-beta auth and rate limiting", () => {
     const observedKeys: string[] = [];
     const env = createTestEnv({
       RATE_LIMITER: rateLimiterNamespace({ status: 200, body: {} }, observedKeys) as unknown as DurableObjectNamespace,
-      RATE_LIMIT_TRUSTED_PROXIES: TEST_TRUSTED_PROXY,
     });
 
     await expect(
@@ -227,56 +226,6 @@ describe("private-beta auth and rate limiting", () => {
     expect(observedKeys).toHaveLength(2);
     expect(observedKeys[0]).toBe(observedKeys[1]);
     expect(observedKeys[0]).toMatch(/^strict:\/v1\/auth\/github\/session:ip:/);
-  });
-
-  it("ignores configured trusted proxy IPs without Cloudflare client IP", async () => {
-    const observedKeys: string[] = [];
-    const env = createTestEnv({
-      RATE_LIMITER: rateLimiterNamespace({ status: 200, body: {} }, observedKeys) as unknown as DurableObjectNamespace,
-      RATE_LIMIT_TRUSTED_PROXIES: "198.51.100.99",
-      RATE_LIMIT_TRUSTED_PROXY_COUNT: "2",
-    });
-
-    await expect(
-      enforceRateLimit(
-        fakeContext(env, "/v1/auth/github/session", {
-          "x-forwarded-for": "198.51.100.2, 198.51.100.99",
-          "x-real-ip": "198.51.100.2",
-        }),
-        "strict",
-      ),
-    ).resolves.toBeNull();
-    await expect(
-      enforceRateLimit(
-        fakeContext(env, "/v1/auth/github/session", {
-          "x-forwarded-for": "198.51.100.3, 198.51.100.99",
-        }),
-        "strict",
-      ),
-    ).resolves.toBeNull();
-    expect(observedKeys).toHaveLength(2);
-    expect(observedKeys[0]).toBe(observedKeys[1]);
-    expect(observedKeys[0]).toMatch(/^strict:\/v1\/auth\/github\/session:ip:/);
-  });
-
-  it("ignores forwarded headers when configured trusted proxy peer is absent", async () => {
-    const observedKeys: string[] = [];
-    const env = createTestEnv({
-      RATE_LIMITER: rateLimiterNamespace({ status: 200, body: {} }, observedKeys) as unknown as DurableObjectNamespace,
-      RATE_LIMIT_TRUSTED_PROXIES: "198.51.100.99",
-    });
-
-    await expect(enforceRateLimit(fakeContext(env, "/v1/auth/github/session"), "strict")).resolves.toBeNull();
-    const unknownIpKey = observedKeys[0];
-
-    observedKeys.length = 0;
-    await expect(
-      enforceRateLimit(
-        fakeContext(env, "/v1/auth/github/session", { "x-forwarded-for": "198.51.100.1, 198.51.100.2", "x-real-ip": "198.51.100.3" }),
-        "strict",
-      ),
-    ).resolves.toBeNull();
-    expect(observedKeys[0]).toBe(unknownIpKey);
   });
 
   it("ignores malformed client address headers when building rate-limit keys", async () => {
@@ -883,8 +832,6 @@ function rateLimiterNamespace(decision: { status: number; body: Record<string, u
 function rateLimitTestEnv(overrides: Partial<Env> = {}, observedKeys?: string[]) {
   return createTestEnv({
     RATE_LIMITER: rateLimiterNamespace({ status: 200, body: {} }, observedKeys) as unknown as DurableObjectNamespace,
-    RATE_LIMIT_TRUSTED_PROXIES: TEST_TRUSTED_PROXY,
-    RATE_LIMIT_TRUSTED_PROXY_COUNT: "2",
     ...overrides,
   });
 }


### PR DESCRIPTION
## Summary
- `RATE_LIMIT_TRUSTED_PROXIES`/`RATE_LIMIT_TRUSTED_PROXY_COUNT` were declared in `Env` and exercised in test scaffolding, but `clientIp()` (`src/auth/rate-limit.ts`) only ever reads `cf-connecting-ip` — zero other references anywhere in `src/`.
- **Owner decision: remove, not wire up.** The rate limiter is backed by a Cloudflare Durable Object, a Workers-only primitive that never instantiates on self-host (`env.RATE_LIMITER` is undefined there — confirmed via `src/selfhost/cf-workers-shim.ts`'s own comment: "That DO is NEVER instantiated on self-host"). So this code path only ever runs on the cloud worker, sitting behind Cloudflare's edge, where `cf-connecting-ip` is always trustworthy and there's no legitimate reverse-proxy scenario for these vars to serve. Self-host has its own separate rate-limiting implementation (`src/selfhost/redis-ratelimit.ts`).
- Removed the two `env.d.ts` fields and the test scaffolding (`test/unit/auth.test.ts`) that existed solely to assert the vars have no effect — redundant with the remaining header-spoofing regression coverage (cf-ray, x-forwarded-for, x-real-ip are all still asserted as ignored, just without a nonexistent config knob attached).

Closes #2645

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/auth.test.ts` — 19/19 pass
- [x] `npm run test:ci` (full local gate, unsharded)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities