### PR TITLE
chore(ui): add version/description to apps/gittensory-ui/package.json

### DIFF
--- a/apps/gittensory-ui/package.json
+++ b/apps/gittensory-ui/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@jsonbored/gittensory-ui",
+  "version": "0.0.0",
   "private": true,
+  "description": "Gittensory's public website, docs, and dashboard (TanStack Start SPA/SSR app).",
   "packageManager": "npm@10.9.8",
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
## Summary
`apps/gittensory-ui/package.json` had no `version` and no `description` field — every other workspace member (`gittensory-engine`, `gittensory-mcp`, `gittensory-miner`) has both. Purely cosmetic (the app is never published, still `private: true`); this was the one inconsistency in an otherwise uniform monorepo pattern.

Closes #2647

## Test plan
- [x] `npm run test:ci` (full local gate, unsharded)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] No functional change — still `private: true`