### PR TITLE
fix(review): stop labeling an advisory-only AI consensus defect a "Blocker"

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -169,8 +169,23 @@ export function buildDualReviewNotes(args: {
   const { main: assessment, nits: aiNitLines } = splitAiReviewNits(
     args.aiReview?.notes?.trim() ?? "",
   );
-  const consensusBlocker = args.consensusDefect
+  // The consensus defect is a REAL blocker only when the gate itself promoted it (aiReviewGateMode: "block" —
+  // see src/rules/advisory.ts). When aiReviewGateMode is off/advisory (the default), `ai_consensus_defect` is
+  // still unconditionally added to advisory.findings (so it's always recoverable here), but the gate
+  // conclusion stays "success" and the PR still merges — labeling it a "Blocker" then is actively misleading
+  // (a green, auto-merging check-run next to a "1 blocker" chip). Fold it into the non-blocking Nits instead,
+  // clearly framed as advisory-only, so the comment never claims a merge is blocked when it will not be.
+  // (#2592 — the gate's own block/advisory decision is unchanged; this only fixes how the comment labels it.)
+  const consensusIsGateBlocking = (args.gateBlockers ?? []).some(
+    (finding) => finding.code === "ai_consensus_defect",
+  );
+  const consensusBlocker = args.consensusDefect && consensusIsGateBlocking
     ? [formatConsensusDefectBlocker(args.consensusDefect)]
+    : [];
+  const consensusAdvisoryNits = args.consensusDefect && !consensusIsGateBlocking
+    ? [publicSafeNit(`${formatConsensusDefectBlocker(args.consensusDefect)} (advisory only — not configured to block merge)`)].filter(
+        (line): line is string => line !== null,
+      )
     : [];
   // FIX D1: fold the gate's own hard blockers into the reviewer blockers (so a non-AI gate failure populates
   // "Why this is blocked"). Exclude `ai_consensus_defect` (already surfaced via consensusDefect → appears once)
@@ -198,8 +213,9 @@ export function buildDualReviewNotes(args: {
   const aiNits = aiNitLines
     .map((line) => publicSafeNit(line))
     .filter((line): line is string => line !== null);
-  const nits = [...aiNits, ...gateNits];
-  if (!assessment && blockers.length === 0) return [];
+  // The advisory-only consensus defect leads the list (it's the most severe item even though non-blocking).
+  const nits = [...consensusAdvisoryNits, ...aiNits, ...gateNits];
+  if (!assessment && blockers.length === 0 && nits.length === 0) return [];
   const notes: ReviewNotes = {
     assessment,
     suggestions: [],

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -97,6 +97,8 @@ describe("buildDualReviewNotes", () => {
     const reviews = buildDualReviewNotes({
       aiReview: { notes: "The refactor looks correct." },
       consensusDefect: { title: "Off-by-one", detail: "Loop bound is wrong." },
+      // Present in gateBlockers ⇒ aiReviewGateMode: "block" actually promoted it — a REAL blocker (#2592).
+      gateBlockers: [{ code: "ai_consensus_defect", severity: "critical", title: "Off-by-one", detail: "Loop bound is wrong." }],
       warnings: [{ code: "w1", severity: "warning", title: "Missing test", detail: "...", action: "Add a test." }],
       recommendation: "close",
       verdict: "close",
@@ -114,6 +116,7 @@ describe("buildDualReviewNotes", () => {
   it("omits the ': detail' and ' — action' suffixes when the defect has no detail and the warning has no action", () => {
     const reviews = buildDualReviewNotes({
       consensusDefect: { title: "Null deref", detail: "" },
+      gateBlockers: [{ code: "ai_consensus_defect", severity: "critical", title: "Null deref", detail: "" }],
       warnings: [{ code: "w1", severity: "warning", title: "No test", detail: "..." }], // no `action`
       recommendation: "close",
       verdict: "close",
@@ -128,10 +131,59 @@ describe("buildDualReviewNotes", () => {
         title: "AI reviewers agree on a likely critical defect: src/types.ts:111 leaves `Finding` unclosed",
         detail: "src/types.ts:111 leaves `Finding` unclosed",
       },
+      gateBlockers: [
+        {
+          code: "ai_consensus_defect",
+          severity: "critical",
+          title: "AI reviewers agree on a likely critical defect: src/types.ts:111 leaves `Finding` unclosed",
+          detail: "src/types.ts:111 leaves `Finding` unclosed",
+        },
+      ],
       recommendation: "close",
       verdict: "close",
     });
     expect(reviews[0]?.notes?.blockers).toEqual(["src/types.ts:111 leaves `Finding` unclosed"]);
+  });
+
+  // #2592: aiReviewGateMode defaults to advisory, so a consensus defect DOES NOT reach gate.blockers by
+  // default even though it is unconditionally added to advisory.findings (see queue/processors.ts). The
+  // comment must not then label it a "Blocker" — that claims a merge is blocked when it will not be.
+  describe("consensus defect NOT promoted by the gate (aiReviewGateMode off/advisory — #2592)", () => {
+    it("routes the defect into Nits, clearly labeled advisory-only, instead of Blockers", () => {
+      const reviews = buildDualReviewNotes({
+        aiReview: { notes: "Looks mostly fine." },
+        consensusDefect: { title: "Off-by-one", detail: "Loop bound is wrong." },
+        // No gateBlockers containing ai_consensus_defect ⇒ the gate did NOT promote it (advisory mode).
+        recommendation: "merge",
+        verdict: "merge",
+      });
+      expect(reviews[0]?.notes?.blockers).toEqual([]);
+      expect(reviews[0]?.notes?.nits).toEqual(["Off-by-one: Loop bound is wrong. (advisory only — not configured to block merge)"]);
+    });
+
+    it("still surfaces the note when the defect is the ONLY reviewer-side content (no assessment, no blockers)", () => {
+      // Regression guard: before #2592 the early-return only checked `blockers.length === 0`, so an
+      // advisory-only defect with no aiReview.notes and no gate blockers would silently vanish entirely.
+      const reviews = buildDualReviewNotes({
+        consensusDefect: { title: "Null deref", detail: "src/foo.ts:12" },
+        recommendation: "merge",
+        verdict: "merge",
+      });
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]?.notes?.blockers).toEqual([]);
+      expect(reviews[0]?.notes?.nits).toEqual(["Null deref: src/foo.ts:12 (advisory only — not configured to block merge)"]);
+    });
+
+    it("a gateBlockers list present but NOT containing ai_consensus_defect still treats the defect as advisory-only", () => {
+      const reviews = buildDualReviewNotes({
+        consensusDefect: { title: "Off-by-one", detail: "Loop bound is wrong." },
+        gateBlockers: [{ code: "missing_linked_issue", severity: "critical", title: "No linked issue", detail: "..." }],
+        recommendation: "merge",
+        verdict: "merge",
+      });
+      expect(reviews[0]?.notes?.blockers).toEqual(["No linked issue"]); // the real (non-AI) gate blocker still blocks
+      expect(reviews[0]?.notes?.nits).toEqual(["Off-by-one: Loop bound is wrong. (advisory only — not configured to block merge)"]);
+    });
   });
 
   it("demotes self-host environmental/process warnings out of the nits, keeping real code nits (#review-accuracy)", () => {


### PR DESCRIPTION
## Summary

Investigated #2592 end-to-end (supersedes #2002):

- `aiReviewGateMode` (`src/rules/advisory.ts`) already exists and already provides a real, config-driven way for a maintainer to make an AI consensus defect actually block merge — `block` mode promotes `ai_consensus_defect`/`ai_review_split` into the gate's own hard blockers. It's off by default.
- The check-run conclusion that actually drives GitHub's merge decision (`gateEvaluation.conclusion`, posted via the check-run) is completely independent of `deriveUnifiedStatus`'s comment-only rendering — confirmed by tracing both paths in `src/queue/processors.ts`.
- The real, narrower bug: `runGittensoryAiReview` (`src/queue/processors.ts:5378`) unconditionally pushes an `ai_consensus_defect` finding into `advisory.findings` whenever the two AI reviewers agree on a critical defect, **regardless of `aiReviewGateMode`**. The unified-comment bridge (`consensusDefectFromFindings` in `src/review/unified-comment-bridge.ts`) unconditionally recovered it into the comment's "Blockers" section. Net effect: by default (mode unset/advisory), a PR's check-run reports `success` (auto-merges) while the SAME PR's own comment lists a "critical defect" under "Blockers" — internally contradictory.

## Decision

Chose **option 3** from the issue (confirm the gate's block/advisory decision is correct as designed) — `aiReviewGateMode: block` already exists for maintainers who want this to be real; a blanket default change (option 1) risks fleet-wide false-positive closes, and a comment-only veto (option 2, downgrading `deriveUnifiedStatus` to "held") would be *worse* than today given the check-run/comment split: the comment would claim manual review is needed while the check-run still silently auto-merges.

**Plus a scoped accuracy fix**, distinct from the three enumerated options: only surface the AI consensus defect under "Blockers" when the gate itself actually promoted it (present in `gate.blockers`, i.e. `aiReviewGateMode: "block"` is configured). Otherwise fold it into the non-blocking Nits section, clearly labeled `(advisory only — not configured to block merge)`, so the comment never claims a merge is blocked when it will not be. The gate's own decision logic is completely untouched.

Closes #2592

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/unified-comment-bridge.test.ts` — 59/59 pass, including 3 updated tests (now pass `gateBlockers` to keep asserting the real-blocker path) and 3 new tests covering the advisory-only path (routes to Nits, survives as the sole reviewer-side content, coexists with an unrelated real gate blocker)
- [x] `npx vitest run test/unit/queue.test.ts` — 368/368 pass unmodified (full processors.ts wiring unaffected)
- [x] `npm run test:ci` (full local gate, unsharded)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] 100% branch coverage on every changed line