### PR TITLE
fix(queue): recheck blacklist closes using effective repository settings

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -1,4 +1,5 @@
-import { getInstallation, getPullRequest, getRepositorySettings, getPendingAgentAction, recordAuditEvent, setPendingAgentActionStatus } from "../db/repositories";
+import { getInstallation, getPullRequest, getPendingAgentAction, recordAuditEvent, setPendingAgentActionStatus } from "../db/repositories";
+import { resolveRepositorySettings } from "../settings/repository-settings";
 import { createInstallationToken } from "../github/app";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
 import { executeAgentMaintenanceActions, pendingActionToPlanned } from "./agent-action-executor";
@@ -39,7 +40,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
 
   // accept → execute the staged action live, then record the result.
   const [settings, pr, installation] = await Promise.all([
-    getRepositorySettings(env, pending.repoFullName),
+    resolveRepositorySettings(env, pending.repoFullName),
     getPullRequest(env, pending.repoFullName, pending.pullNumber),
     getInstallation(env, pending.installationId),
   ]);
@@ -95,7 +96,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
   // FORCE-PUSH; it says nothing about whether the contributor is STILL blacklisted, and a blacklist close is a
   // sticky auto_with_approval row with no expiry -- a maintainer can remove the entry (or edit .gittensory.yml)
   // at any point while it sits waiting. `settings` was fetched fresh at the top of this function, so this
-  // mirrors the exact same pure check the planner uses (processors.ts), just re-run against CURRENT config.
+  // mirrors the exact same pure check the planner uses (processors.ts), just re-run against CURRENT effective config.
   if (pending.actionClass === "close" && pending.params.closeKind === "blacklist" && pr) {
     const stillBlacklisted = findBlacklistEntry(pr.authorLogin, settings.contributorBlacklist) !== null;
     if (!stillBlacklisted) {

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -59,6 +59,7 @@ import {
   listNotificationDeliveriesForRecipient,
   listPendingAgentActions,
   setPendingAgentActionStatus,
+  upsertGlobalContributorBlacklist,
   upsertInstallation,
   upsertPullRequestFromGitHub,
   upsertRepositorySettings,
@@ -289,6 +290,23 @@ describe("agent approval queue (#779)", () => {
     expect(result.executionOutcome).toBe("completed");
     const { closePullRequest: closeStillBlacklisted } = await import("../../src/github/pr-actions");
     expect(closeStillBlacklisted).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
+  it("REGRESSION: accept rechecks blacklist closes against the effective global blacklist", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await Promise.all([
+      upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, contributorBlacklist: [] }),
+      upsertGlobalContributorBlacklist(env, { contributorBlacklist: [{ login: "fleet-banned", reason: "global" }] }),
+    ]);
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "fleet-banned" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "blocked", closeKind: "blacklist", expectedHeadSha: "h7" }, reason: "blacklisted contributor" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeGloballyBlacklisted } = await import("../../src/github/pr-actions");
+    expect(closeGloballyBlacklisted).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
   });
 
   it("REGRESSION (#2452): accept supersedes a staged blacklist close when the contributor is NO LONGER blacklisted at accept time", async () => {


### PR DESCRIPTION
### Motivation
- The accept-time blacklist revalidation in the approval queue read raw DB settings and could ignore manifest-configured or global blacklist entries, causing legitimate staged blacklist closes to be mistakenly superseded.
- Ensure the accept-time logic mirrors the planner's policy source so rechecks observe `.gittensory.yml` and the shared/global contributor blacklist.

### Description
- Change `decidePendingAgentAction` to resolve effective settings by calling `resolveRepositorySettings` instead of `getRepositorySettings` so the accept-time recheck uses the same effective config the planner used (`src/services/agent-approval-queue.ts`).
- Update imports to add `resolveRepositorySettings` and adjust a clarifying comment about the recheck using the effective config.
- Add a regression test that stages a blacklist close for a contributor present only in the global blacklist and verifies the accept path still executes the close (`test/unit/agent-approval-queue.test.ts`).

### Testing
- Ran `npx vitest run test/unit/agent-approval-queue.test.ts` and the agent-approval-queue tests (including the new regression) passed. 
- Ran `npm run typecheck` and it completed successfully. 
- Ran `git diff --check` (no issues). 
- `npm audit --audit-level=moderate` could not complete in this environment due to registry access returning `403 Forbidden` (external audit endpoint blocked), so that step was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46db7e84b8832c8e398590b2410439)