### PR TITLE
fix(queue): treat ambiguous bounded reopener scans as fail-closed

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8606,17 +8606,14 @@ async function recloseDisallowedReopenIfNeeded(
     pr.number,
   );
   const latestReopenerLogin = latestReopener.login?.toLowerCase() ?? null;
-  // A bounded scan that RAN TO COMPLETION and cannot see any reopened event must NOT deny the re-close: otherwise
-  // a contributor can pad the event timeline until their disallowed reopen falls outside the inspected window.
-  // Only a fully covered timeline with no reopen, or a visible different latest reopener, proves this webhook was
-  // superseded. A timeline read that ERRORED is different — it proves nothing — so it must still fail CLOSED, the
-  // opposite of the closer-lookup's fail-open bias above, because wrongly re-closing a maintainer-authorized PR
-  // is the worse failure mode than leaving a disallowed reopen unclosed for one more tick. (#2369)
+  // A bounded scan that ran to completion but did NOT cover every page is still ambiguous when it finds no
+  // reopened event: an unread older page may contain either the original contributor reopen or a later maintainer
+  // reopen hidden by padding. Only a visible matching reopener proves this webhook is still the live disallowed
+  // reopen; every other shape fails closed, because wrongly re-closing a maintainer-authorized PR is worse than
+  // leaving a disallowed reopen open for one more tick. (#2369)
   const reopenerSuperseded =
     latestReopener.errored ||
-    (latestReopener.coveredAllPages
-      ? latestReopenerLogin !== reopener
-      : latestReopenerLogin != null && latestReopenerLogin !== reopener);
+    latestReopenerLogin !== reopener;
   if (reopenerSuperseded) {
     await recordAuditEvent(env, {
       eventType: "github_app.reopen_reclosed",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -13652,8 +13652,9 @@ describe("one-shot reopen prevention", () => {
     expect(audit?.outcome).toBe("completed");
   });
 
-  it("REGRESSION: re-closes when the reopener is hidden beyond the inspected event window", async () => {
+  it("REGRESSION: denies when a maintainer reopener is hidden beyond the inspected event window", async () => {
     const calls: Array<{ url: string; method: string }> = [];
+    const eventPages: number[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
@@ -13662,11 +13663,13 @@ describe("one-shot reopen prevention", () => {
       if (url.endsWith("/collaborators/contributor/permission")) return Response.json({ permission: "read" });
       if (url.includes("/issues/42/events")) {
         const page = Number(new URL(url).searchParams.get("page") ?? "1");
+        eventPages.push(page);
         if (page === 1) {
           return Response.json([{ event: "closed", actor: { login: "maintainer" } }, { event: "reopened", actor: { login: "contributor" } }], {
-            headers: { link: '<https://api.github.com/repos/owner/repo/issues/42/events?per_page=100&page=12>; rel="last"' },
+            headers: { link: '<https://api.github.com/repos/owner/repo/issues/42/events?per_page=100&page=22>; rel="last"' },
           });
         }
+        if (page === 12) return Response.json([{ event: "reopened", actor: { login: "second-maintainer" } }]);
         return Response.json([{ event: "renamed", actor: { login: "contributor" } }]);
       }
       if (url.endsWith("/issues/42/comments")) return Response.json({ id: 99 }, { status: 201 });
@@ -13678,11 +13681,13 @@ describe("one-shot reopen prevention", () => {
 
     await processJob(env, { type: "github-webhook", deliveryId: "reopen-window-stuffed", eventName: "pull_request", payload: reopenedPayload("contributor") });
 
-    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/issues/42/comments"))).toBe(true);
-    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
+    expect(eventPages).toContain(22);
+    expect(eventPages).not.toContain(12);
+    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/issues/42/comments"))).toBe(false);
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
     const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string }>();
-    expect(audit?.outcome).toBe("completed");
-    expect(audit?.detail).toContain("beyond the inspected event window");
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toContain("the current reopener is now unknown, not contributor");
   });
 
   it("REGRESSION: fails CLOSED (denies the re-close) when the reopener-timeline read errors (#2369)", async () => {


### PR DESCRIPTION
### Motivation
- Prevent a timing/padding exploit where an uncovered bounded timeline scan with no visible `reopened` actor could allow the app to close a PR even though a later maintainer reopen may be hidden on an unread page.

### Description
- Change the reopener supersede check in `recloseDisallowedReopenIfNeeded` so that any ambiguous/partial scan (not fully covered) that yields no visible reopener does not authorize a re-close, by requiring the latest visible reopener to exactly match the webhook actor unless the read errored. 
- Update the explanatory comments in `src/queue/processors.ts` to document the fail-closed semantics for ambiguous scans.
- Adjust the one-shot reopen regression in `test/unit/queue.test.ts` to simulate a padded timeline that hides a later maintainer reopen and assert the handler denies the re-close (no comment posted and no `PATCH /pulls` call).

### Testing
- Ran `npm run typecheck` and it succeeded.
- Ran targeted unit tests with `npx vitest run test/unit/github-pr-actions.test.ts test/unit/queue.test.ts -t "getLastReopenerLogin|one-shot reopen prevention"` and the relevant tests passed. 
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate` but they could not complete in this environment due to external network/actionlint and npm-audit access issues; these failures are environmental and unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46e371ae54832c86f28c7461d3edc3)