### PR TITLE
feat(selfhost): add layered private repo configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,12 @@ CMD ["node", "dist/server.mjs"]
 FROM runtime-base AS runtime-prebuilt
 COPY --chown=node:node dist/server.mjs ./dist/server.mjs
 COPY --chown=node:node migrations ./migrations
+# Generic, safe self-host private-config templates (config/examples/, #layered-private-config) — reference only.
+# GITTENSORY_REPO_CONFIG_DIR still points at the operator-mounted /config, so shipping these activates nothing.
+COPY --chown=node:node config/examples ./config/examples
 
 # Default local/operator builds still build the bundle inside Docker, but only the JS bundle reaches runtime.
 FROM runtime-base AS runtime
 COPY --from=build --chown=node:node /app/dist/server.mjs ./dist/server.mjs
 COPY --from=build --chown=node:node /app/migrations ./migrations
+COPY --from=build --chown=node:node /app/config/examples ./config/examples

--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -11,11 +11,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:416",
+    firstReference: "src/server.ts:417",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:413",
+    firstReference: "src/server.ts:414",
   },
   {
     name: "AI_EMBED_MODEL",
@@ -43,7 +43,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:355",
+    firstReference: "src/server.ts:356",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -75,7 +75,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:818",
+    firstReference: "src/server.ts:819",
   },
   {
     name: "DATABASE_PATH",
@@ -103,11 +103,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:484",
+    firstReference: "src/server.ts:485",
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:272",
+    firstReference: "src/server.ts:273",
   },
   {
     name: "GITTENSORY_VERSION",
@@ -115,7 +115,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:368",
+    firstReference: "src/server.ts:369",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -175,7 +175,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:862",
+    firstReference: "src/server.ts:863",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -191,7 +191,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:864",
+    firstReference: "src/server.ts:865",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -227,7 +227,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:622",
+    firstReference: "src/server.ts:623",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -243,7 +243,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:503",
+    firstReference: "src/server.ts:504",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
@@ -255,7 +255,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:548",
+    firstReference: "src/server.ts:549",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -291,7 +291,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:739",
+    firstReference: "src/server.ts:740",
   },
 ];
 
@@ -299,15 +299,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
   "| `AI_COMBINE` | `src/selfhost/ai.ts:848` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:416` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:413` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:417` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:414` |",
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:744` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts:850` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:748` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:57` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:747` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:355` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:356` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:108` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:49` |",
@@ -315,17 +315,17 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_EFFORT` | `src/selfhost/ai.ts:112` |",
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:53` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:112` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:818` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:819` |",
   "| `DATABASE_PATH` | `src/server.ts:239` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/selfhost/discord-notify.ts:31` |",
   "| `DISCORD_WEBHOOK_URL` | `src/selfhost/discord-notify.ts:40` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:484` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:272` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:485` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:273` |",
   "| `GITTENSORY_VERSION` | `src/selfhost/health.ts:29` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:368` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:369` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
   "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:741` |",
@@ -340,11 +340,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:862` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:863` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:864` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:865` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -353,14 +353,14 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
   "| `PGVECTOR_ENABLED` | `src/server.ts:219` |",
-  "| `PORT` | `src/server.ts:622` |",
+  "| `PORT` | `src/server.ts:623` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:503` |",
+  "| `QDRANT_URL` | `src/server.ts:504` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:102` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:548` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:549` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
@@ -369,5 +369,5 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
   "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:373` |",
   "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:161` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:739` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:740` |",
 ].join("\n");

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -1,0 +1,129 @@
+# Self-host private config — layout, precedence, and examples
+
+This directory ships **generic, safe** examples for the self-host **private** config directory
+(`GITTENSORY_REPO_CONFIG_DIR`, default `/config` in the Docker image / `docker-compose.yml`). It
+contains no real policy, thresholds, logins, or repo names — copy what you need into your own
+mounted config directory and edit it there (never in this repo).
+
+The private config directory is read by `src/selfhost/private-config.ts` and is kept **out of the
+public GitHub repo** on purpose: contributors can read a public `.gittensory.yml`, so anti-abuse
+thresholds, maintainer/admin allowlists, autonomy dials, and model/effort settings belong here
+instead, where only the self-host operator can see them.
+
+## Directory layout
+
+For a repo `owner/repo`, the reader tries, in priority order:
+
+```
+${GITTENSORY_REPO_CONFIG_DIR}/owner__repo/.gittensory.yml   # 1. owner-qualified folder (recommended)
+${GITTENSORY_REPO_CONFIG_DIR}/repo/.gittensory.yml          # 2. bare repo-name folder
+${GITTENSORY_REPO_CONFIG_DIR}/owner__repo.yml               # 3. flat file (back-compat)
+${GITTENSORY_REPO_CONFIG_DIR}/.gittensory.yml               # 4. global default, shared by every repo
+```
+
+`.yaml` and `.json` are accepted everywhere `.yml` is. Every one of these files uses the **exact
+same schema** as the public `.gittensory.yml` — see [`.gittensory.yml.example`](../../.gittensory.yml.example)
+at the repo root for the exhaustive, field-by-field reference (not duplicated here, so the two
+never drift out of sync).
+
+## Precedence chain
+
+From highest to lowest priority:
+
+1. **Private per-repo file**, deep-merged over **2** when both exist (see below) — or used alone
+   when only a per-repo file exists.
+2. **Private global default** (`${GITTENSORY_REPO_CONFIG_DIR}/.gittensory.yml`) — used alone when
+   a repo has no per-repo file of its own.
+3. When **neither** a private per-repo nor a private global file exists, the loader falls back to
+   the **public repo `.gittensory.yml`** (or `.github/gittensory.yml`) fetched from GitHub.
+4. **Dashboard/API-stored settings** for the repo.
+5. **Built-in safe defaults.**
+
+Layers 1-2 are evaluated together as one private-config layer: if *either* a per-repo or a global
+file exists privately, the public file in layer 3 is **never consulted** for that repo. This is
+unchanged from the original private-config behavior (#1390) — only the interaction *between* the
+private per-repo and private global layers is new.
+
+## Overlay (deep-merge) semantics
+
+When **both** a per-repo file and a global default exist for a repo, they are merged — the
+per-repo file overlaid onto the global default:
+
+- **Nested mappings** (`gate`, `settings`, `review`, `features`, `contentLane`, and their own
+  nested blocks like `gate.readiness` or `gate.aiReview`) merge **key by key**. A per-repo file
+  only needs to mention the keys it wants to change; everything else is inherited from global.
+- **Arrays** (`wantedPaths`, `blockedPaths`, `preferredLabels`, `testExpectations`,
+  `review.pathInstructions`, `review.excludePaths`, `contentLane.duplicateKeyFields`, etc.)
+  **replace wholesale** — a per-repo array is never concatenated with the global one.
+- An **explicit `null`** at a key in the per-repo file always overrides the global value there.
+  This clears a setting wherever the manifest parser already treats an explicit `null` as
+  "off"/"clear" — e.g. `settings.contributorOpenPrCap`, `settings.contributorOpenIssueCap`, and
+  `settings.accountAgeThresholdDays` — and is a harmless no-op (equivalent to omitting the key)
+  everywhere else.
+- If either file fails to parse (or is malformed/oversized), the merge is skipped and the
+  still-valid file is used alone; a still-good sibling's policy is never silently discarded just
+  because the other file is broken.
+
+### Example 1 — global defaults + a per-repo override
+
+`.gittensory.yml` (global default, at the config dir root):
+
+```yaml
+settings:
+  contributorOpenPrCap: 3
+  autoCloseExemptLogins:
+    - your-admin-login
+gate:
+  enabled: true
+  duplicates: block
+```
+
+`owner__repo/.gittensory.yml` (per-repo override — only touches what's different for this repo):
+
+```yaml
+gate:
+  enabled: true
+  # duplicates is inherited from global (still "block") — not repeated here.
+  aiReview:
+    mode: advisory
+```
+
+The effective config for `owner/repo` has `gate.duplicates: block` (from global),
+`gate.aiReview.mode: advisory` and `gate.enabled: true` (from the per-repo file), and
+`settings.contributorOpenPrCap: 3` plus the exempt login (both from global).
+
+### Example 2 — disabling a global setting for one high-trust repo
+
+```yaml
+# owner__repo/.gittensory.yml
+settings:
+  contributorOpenPrCap: null   # explicitly clears the global cap of 3 for this repo only
+```
+
+### Example 3 — an admin/maintainer exemption list
+
+Shared anti-abuse mechanisms (the review-request-nag cooldown, the contributor open-item cap)
+exempt configured logins on top of the standing owner/admin/automation-bot exemption:
+
+```yaml
+# .gittensory.yml (global default)
+settings:
+  autoCloseExemptLogins:
+    - your-trusted-regular
+```
+
+## What belongs here vs. in the public `.gittensory.yml`
+
+- **Private config** (this directory): anti-abuse thresholds, the contributor cap, maintainer/
+  admin exemption logins, autonomy dials, model/effort overrides, and anything else you don't want
+  a contributor reading and gaming.
+- **Public `.gittensory.yml`** (repo root, contributor-visible): work-area guidance
+  (`wantedPaths`/`blockedPaths`), test expectations, and review-panel presentation — nothing here
+  should describe your private enforcement strategy.
+
+## Safety
+
+Never commit real policy into this directory or into these example files: no maintainer usernames,
+no repo names, no thresholds beyond illustrative placeholders, no secrets or tokens. The two
+`.gittensory.yml` files shipped alongside this README are deliberately generic and inert — copy
+them into your own mounted `GITTENSORY_REPO_CONFIG_DIR` and edit the copy, not this one.

--- a/config/examples/global.gittensory.yml
+++ b/config/examples/global.gittensory.yml
@@ -1,0 +1,31 @@
+# ============================================================================
+# Self-host PRIVATE global default — GENERIC EXAMPLE, safe to publish
+# ============================================================================
+#
+# Copy this file to the ROOT of your own GITTENSORY_REPO_CONFIG_DIR mount (e.g.
+# `./gittensory-config/.gittensory.yml` for the default docker-compose.yml mount) and edit your
+# copy — never this one. It applies to every repo that has no per-repo file of its own, and is
+# deep-merged UNDER any per-repo file that does exist (see ../README.md for the precedence chain
+# and merge semantics; see ../../.gittensory.yml.example at the repo root for every supported
+# field — this file uses the exact same schema, just a private location).
+#
+# Every value below is an illustrative placeholder. Replace the login and thresholds with your
+# own before using this file for real; do not commit your edited copy to a public repo.
+# ============================================================================
+
+# Baseline gate policy shared by every repo unless a per-repo file overrides it.
+gate:
+  enabled: true
+  duplicates: block
+  linkedIssue: advisory
+
+# Anti-abuse + presentation defaults shared by every repo.
+settings:
+  # Max PRs a single non-owner/non-admin/non-bot contributor may have open at once, instance-wide
+  # default. A per-repo file can override this per repo, or set it to `null` to disable it there.
+  contributorOpenPrCap: 3
+
+  # GitHub logins exempt from the shared anti-abuse mechanisms above (on top of the standing
+  # owner/admin/automation-bot exemption). Replace with your own maintainer/admin logins.
+  autoCloseExemptLogins:
+    - your-admin-login

--- a/config/examples/repo-override.gittensory.yml
+++ b/config/examples/repo-override.gittensory.yml
@@ -1,0 +1,27 @@
+# ============================================================================
+# Self-host PRIVATE per-repo override — GENERIC EXAMPLE, safe to publish
+# ============================================================================
+#
+# Copy this file to `${GITTENSORY_REPO_CONFIG_DIR}/{owner}__{repo}/.gittensory.yml` (or the bare
+# `{repo}/.gittensory.yml` folder, or the flat `{owner}__{repo}.yml` file — see ../README.md) and
+# edit your copy for a SPECIFIC repo. It is deep-merged OVER global.gittensory.yml: any key it
+# doesn't mention is inherited from the global default unchanged.
+#
+# Replace `owner`/`repo` in the destination path with the real values before using this file.
+# ============================================================================
+
+# Overrides ONLY `gate.enabled` for this repo — every other `gate.*` key (e.g. `duplicates`,
+# `linkedIssue`) is inherited from the global default untouched.
+gate:
+  enabled: true
+
+# Array fields REPLACE the global default wholesale, never concatenate with it — this repo's
+# wanted-paths guidance is exactly this list, not global's list plus this one.
+wantedPaths:
+  - src/**
+
+settings:
+  # An explicit `null` clears the global default's contributorOpenPrCap for THIS repo only — e.g.
+  # for a small, high-trust repo where the instance-wide cap doesn't make sense. Omit this key
+  # entirely (rather than setting it to `null`) to just inherit the global cap instead.
+  contributorOpenPrCap: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,10 @@ services:
       PORT: "8787"
       DATABASE_PATH: /data/gittensory.sqlite
       # Container-private per-repo config (#1390): point at a mounted dir holding {owner}__{repo}/.gittensory.yml
-      # files (and an optional root .gittensory.yml global fallback). Keeps each repo's policy OUT of the public
-      # GitHub repo so contributors can't game the rules. Empty/unmounted ⇒ repos use the public file / defaults.
+      # files layered over an optional root .gittensory.yml global default (a per-repo file overrides only the
+      # keys it sets; anything it doesn't mention is inherited from the global default — see
+      # config/examples/README.md). Keeps each repo's policy OUT of the public GitHub repo so contributors can't
+      # game the rules. Empty/unmounted ⇒ repos use the public file / defaults.
       GITTENSORY_REPO_CONFIG_DIR: "${GITTENSORY_REPO_CONFIG_DIR:-/config}"
       # Claude Code usage telemetry → OTEL collector → Prometheus → Claude usage dashboard. OFF unless you set
       # CLAUDE_CODE_ENABLE_TELEMETRY=1 in .env (requires --profile observability so the otel-collector is up).
@@ -96,7 +98,9 @@ services:
     volumes:
       - gittensory-data:/data
       # Container-private per-repo config dir (read-only). Create ./gittensory-config/{owner}__{repo}/.gittensory.yml
-      # locally (gitignored — never commit real policy). Absent ⇒ Docker mounts an empty dir ⇒ defaults apply.
+      # locally, optionally alongside a ./gittensory-config/.gittensory.yml global default that every per-repo file
+      # is deep-merged over (gitignored — never commit real policy; see config/examples/ for generic templates).
+      # Absent ⇒ Docker mounts an empty dir ⇒ defaults apply.
       - ./gittensory-config:/config:ro
     depends_on:
       redis:

--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -5,18 +5,29 @@
 // into the Workers-safe loader via setLocalManifestReader at boot (server.ts), so this module's fs import never
 // reaches the Cloudflare bundle.
 //
-// Layout (CodeRabbit-style: per-repo override, then a global fallback). For a repo `JSONbored/gittensory` the
-// reader tries, in priority order:
+// Layout (CodeRabbit-style: per-repo override, layered over a global default). For a repo `JSONbored/gittensory`
+// the reader tries, in priority order:
 //   1. `jsonbored__gittensory/.gittensory.yml`  — owner-qualified folder (robust to repo-name collisions across owners)
 //   2. `gittensory/.gittensory.yml`             — bare repo-name folder (the clean, human-readable layout)
 //   3. `jsonbored__gittensory.yml`              — flat owner__repo file (the original #1390 layout; back-compat)
-//   4. `.gittensory.yml`                        — GLOBAL fallback at the dir root: defaults applied to every repo
-//      that has no per-repo file of its own.
-// `.yaml` / `.json` are accepted everywhere `.yml` is. The first existing candidate wins outright (a present
-// per-repo file fully REPLACES the global fallback — "fallback" means "used only when no per-repo file exists",
-// not a deep merge). The slug is lowercased (GitHub repo full-names are case-insensitive; #1390 already lowercased).
+//   4. `.gittensory.yml`                        — GLOBAL default at the dir root, shared by every repo.
+// `.yaml` / `.json` are accepted everywhere `.yml` is. With only ONE of {a per-repo candidate, the global default}
+// present, its raw text is returned unchanged — byte-identical to the original #1390 behavior. With BOTH present,
+// they are DEEP-MERGED (the per-repo file overlaid onto the global default): nested mappings (`gate`, `settings`,
+// `review`, `features`, `contentLane`, and their own nested blocks) merge key by key, arrays replace wholesale
+// (never concatenated), and an explicit YAML/JSON `null` at a key always overrides the global value there — which
+// clears a setting wherever the manifest parser already treats an explicit null as "off"/"clear" (e.g.
+// `settings.contributorOpenPrCap`, `settings.accountAgeThresholdDays`), and is otherwise equivalent to omitting the
+// key. A per-repo key that is simply absent leaves the corresponding global value untouched. If ONE file fails to
+// parse as a YAML/JSON mapping (or is oversized), the merge is skipped and the OTHER file's raw text is used alone
+// — a still-valid sibling's policy is never silently discarded just because its counterpart is broken. If BOTH
+// fail, the per-repo file's raw text is returned (matching the original single-candidate priority), so a doubly
+// broken pair degrades exactly like a single malformed manifest always has. The slug is lowercased (GitHub repo
+// full-names are case-insensitive; #1390 already lowercased).
 import { readFile, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
 import type {
   RepoReviewContext,
   RepoReviewSkill,
@@ -26,7 +37,7 @@ import type {
   RepoReviewContextReader,
 } from "../signals/focus-manifest-loader";
 
-/** The bare config filenames tried inside a per-repo folder and at the dir root (global fallback), in priority order. */
+/** The bare config filenames tried inside a per-repo folder and at the dir root (global default), in priority order. */
 const CONFIG_BASENAMES = [".gittensory.yml", ".gittensory.yaml", ".gittensory.json"] as const;
 const GITHUB_OWNER_SEGMENT = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
 const GITHUB_REPO_SEGMENT = /^[a-z0-9._-]+$/;
@@ -35,8 +46,8 @@ function isSafeRepoSegment(segment: string): boolean {
   return segment !== "." && segment !== ".." && GITHUB_REPO_SEGMENT.test(segment);
 }
 
-/** Global-fallback candidates (relative to GITTENSORY_REPO_CONFIG_DIR): the dir-root `.gittensory.{yml,yaml,json}`
- *  applied to any repo without its own per-repo file. */
+/** Global-default candidates (relative to GITTENSORY_REPO_CONFIG_DIR): the dir-root `.gittensory.{yml,yaml,json}`,
+ *  deep-merged under any per-repo file (or applied alone, when a repo has no per-repo file of its own). */
 export const GLOBAL_CONFIG_CANDIDATES: string[] = [...CONFIG_BASENAMES];
 
 /** Per-repo private-config candidate paths (relative to GITTENSORY_REPO_CONFIG_DIR), in priority order:
@@ -60,27 +71,89 @@ export function localConfigCandidates(repoFullName: string): string[] {
   ];
 }
 
+/** Read the first candidate that exists, trying each in order; null when none do. A read error (ENOENT or
+ *  otherwise unreadable) is swallowed so the next candidate is tried. */
+async function readFirstExisting(base: string, candidates: string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    try {
+      return await readFile(resolve(base, candidate), "utf8");
+    } catch {
+      // ENOENT / unreadable → try the next candidate
+    }
+  }
+  return null;
+}
+
+/** Tolerantly parse raw config text into a plain mapping for MERGE PURPOSES ONLY — same 2-line YAML/JSON detection
+ *  `parseFocusManifestContent` (focus-manifest.ts) uses, duplicated locally rather than exported from there so that
+ *  file's public surface stays unchanged for what is otherwise two lines of logic. Returns null — "not mergeable" —
+ *  for empty/oversized text, a parse error, or a parsed value that isn't a plain mapping (null/array/scalar); every
+ *  one of those cases makes the caller fall back to legacy single-candidate behavior instead of attempting a merge. */
+function parseConfigMapping(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > MAX_FOCUS_MANIFEST_BYTES) return null;
+  const looksLikeJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+  let parsed: unknown;
+  try {
+    parsed = looksLikeJson ? JSON.parse(trimmed) : parseYaml(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+/** Recursively overlay `override` onto `base`: a nested mapping merges key by key; an array or any other
+ *  non-mapping override value (including an explicit `null`) REPLACES the base value at that key wholesale — never
+ *  concatenated or blended. A key `override` never mentions leaves `base`'s value at that key completely untouched.
+ *  Exported for direct unit testing; deliberately ignorant of any manifest field name (`gate`, `settings`,
+ *  `wantedPaths`, etc.) so it composes correctly with the whole `.gittensory.yml` schema, present and future, with
+ *  zero repo- or field-specific code. */
+export function mergeConfigOverlay(base: unknown, override: unknown): unknown {
+  if (override === null) return null;
+  if (Array.isArray(override)) return override;
+  if (typeof override !== "object") return override;
+  if (base === null || typeof base !== "object" || Array.isArray(base)) return override;
+  const merged: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+  for (const key of Object.keys(override as Record<string, unknown>)) {
+    merged[key] = mergeConfigOverlay((base as Record<string, unknown>)[key], (override as Record<string, unknown>)[key]);
+  }
+  return merged;
+}
+
+/** Combine a global-default and a per-repo config's raw text, given that BOTH files exist. Both parse as mappings
+ *  → deep-merged (the per-repo file overlaid onto the global default via {@link mergeConfigOverlay}) into one JSON
+ *  document — a lossless round trip for the downstream `parseFocusManifestContent` (it starts with `{`, so that
+ *  parser `JSON.parse`s it) since both inputs are already JSON-safe values. Only one parses → that file's raw text
+ *  alone (best-effort: a broken sibling never discards a still-valid file's policy). Neither parses → the per-repo
+ *  text (matching the original single-candidate-wins priority, so it flows downstream to the same "malformed,
+ *  ignoring" warning a lone broken manifest always got). */
+function combineConfigText(globalText: string, repoText: string): string {
+  const globalRaw = parseConfigMapping(globalText);
+  const repoRaw = parseConfigMapping(repoText);
+  if (globalRaw && repoRaw) return JSON.stringify(mergeConfigOverlay(globalRaw, repoRaw));
+  if (repoRaw) return repoText;
+  if (globalRaw) return globalText;
+  return repoText;
+}
+
 /** Build the container-local manifest reader over GITTENSORY_REPO_CONFIG_DIR, or null when the dir is unset/blank
- *  (⇒ the loader keeps fetching the public `.gittensory.yml`). Each lookup returns the first existing per-repo
- *  candidate's text; failing that, the global-fallback `.gittensory.{yml,yaml,json}` at the dir root; null when
- *  neither exists (⇒ the loader falls through to the public file). An invalid repo full name yields no per-repo
- *  candidates and is NOT served the global fallback (it is never a real webhook repo). A read error on one
- *  candidate is swallowed so the next candidate is tried. */
+ *  (⇒ the loader keeps fetching the public `.gittensory.yml`). Looks up the first existing per-repo candidate and
+ *  the global-default candidate independently: with only one present, its raw text is returned unchanged; with
+ *  both present, they are deep-merged (see the module header) and returned as one JSON document; with neither
+ *  present, null (⇒ the loader falls through to the public file). An invalid repo full name yields no per-repo
+ *  candidates and is NOT served the global default (it is never a real webhook repo). */
 export function makeLocalManifestReader(dir: string | undefined): RepoFocusManifestFetcher | null {
   const trimmed = (dir ?? "").trim();
   if (!trimmed) return null;
   const base = resolve(trimmed);
   return async (repoFullName: string): Promise<string | null> => {
     const perRepo = localConfigCandidates(repoFullName);
-    if (perRepo.length === 0) return null; // invalid repo name → no per-repo file AND no global fallback
-    for (const candidate of [...perRepo, ...GLOBAL_CONFIG_CANDIDATES]) {
-      try {
-        return await readFile(resolve(base, candidate), "utf8");
-      } catch {
-        // ENOENT / unreadable → try the next candidate
-      }
-    }
-    return null;
+    if (perRepo.length === 0) return null; // invalid repo name → no per-repo file AND no global default
+    const [repoText, globalText] = await Promise.all([readFirstExisting(base, perRepo), readFirstExisting(base, GLOBAL_CONFIG_CANDIDATES)]);
+    if (repoText === null) return globalText;
+    if (globalText === null) return repoText;
+    return combineConfigText(globalText, repoText);
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -266,8 +266,9 @@ async function main(): Promise<void> {
   /* v8 ignore next -- importing this entrypoint starts the Node server; pure validation is covered in selfhost-preflight tests. */
   assertSelfHostPreflight(process.env);
   // Container-private per-repo config (self-host): register the GITTENSORY_REPO_CONFIG_DIR reader so the focus-
-  // manifest loader prefers a mounted `{owner}__{repo}.yml` over the public `.gittensory.yml` (review policy stays
-  // private). Unset dir ⇒ null reader ⇒ unchanged public-fetch behavior.
+  // manifest loader prefers a mounted `{owner}__{repo}.yml`, deep-merged over an optional root `.gittensory.yml`
+  // global default, over the public `.gittensory.yml` (review policy stays private; see
+  // config/examples/README.md). Unset dir ⇒ null reader ⇒ unchanged public-fetch behavior.
   setLocalManifestReader(
     makeLocalManifestReader(process.env.GITTENSORY_REPO_CONFIG_DIR),
   );

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -2,8 +2,9 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { GLOBAL_CONFIG_CANDIDATES, isReviewSkillEnabled, localConfigCandidates, makeLocalManifestReader, makeLocalReviewContextReader, parseReviewSkill } from "../../src/selfhost/private-config";
+import { GLOBAL_CONFIG_CANDIDATES, isReviewSkillEnabled, localConfigCandidates, makeLocalManifestReader, makeLocalReviewContextReader, mergeConfigOverlay, parseReviewSkill } from "../../src/selfhost/private-config";
 import { loadRepoReviewContext, setLocalReviewContextReader } from "../../src/signals/focus-manifest-loader";
+import { MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "../../src/signals/focus-manifest";
 
 describe("localConfigCandidates (container-private config paths)", () => {
   it("builds owner-folder → repo-folder → flat candidates (lowercased), each in .yml/.yaml/.json order", () => {
@@ -35,6 +36,39 @@ describe("localConfigCandidates (container-private config paths)", () => {
   });
   it("exposes the dir-root global-fallback candidates", () => {
     expect(GLOBAL_CONFIG_CANDIDATES).toEqual([".gittensory.yml", ".gittensory.yaml", ".gittensory.json"]);
+  });
+});
+
+describe("mergeConfigOverlay (generic recursive deep-merge, no manifest-field-specific code)", () => {
+  it("merges nested mappings key by key using generic, non-manifest field names", () => {
+    expect(mergeConfigOverlay({ a: 1, b: { c: 2 } }, { b: { d: 3 } })).toEqual({ a: 1, b: { c: 2, d: 3 } });
+  });
+  it("lets an override scalar replace a base scalar at the same key", () => {
+    expect(mergeConfigOverlay({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+  it("lets an override array replace a base array wholesale, never concatenated", () => {
+    expect(mergeConfigOverlay({ a: [1, 2] }, { a: [3] })).toEqual({ a: [3] });
+  });
+  it("lets an explicit override null win over any base value, including an object", () => {
+    expect(mergeConfigOverlay({ a: { nested: true } }, { a: null })).toEqual({ a: null });
+  });
+  it("takes the override value outright when the base value at that key isn't a mergeable mapping", () => {
+    expect(mergeConfigOverlay({ a: "scalar" }, { a: { nested: true } })).toEqual({ a: { nested: true } });
+    expect(mergeConfigOverlay({ a: [1, 2] }, { a: { nested: true } })).toEqual({ a: { nested: true } }); // base is an array, not mergeable
+    expect(mergeConfigOverlay({ a: null }, { a: { nested: true } })).toEqual({ a: { nested: true } });
+  });
+  it("takes the override value outright when the base has no value at that key at all", () => {
+    expect(mergeConfigOverlay({}, { a: { nested: true } })).toEqual({ a: { nested: true } });
+  });
+  it("returns the whole override object unchanged when the top-level base isn't a mergeable mapping", () => {
+    expect(mergeConfigOverlay("not-an-object", { a: 1 })).toEqual({ a: 1 });
+    expect(mergeConfigOverlay(null, { a: 1 })).toEqual({ a: 1 });
+    expect(mergeConfigOverlay([1, 2], { a: 1 })).toEqual({ a: 1 });
+  });
+  it("returns a non-mapping override value unchanged regardless of its type, ignoring base entirely", () => {
+    expect(mergeConfigOverlay({ a: 1 }, "scalar")).toBe("scalar");
+    expect(mergeConfigOverlay({ a: 1 }, 42)).toBe(42);
+    expect(mergeConfigOverlay({ a: 1 }, true)).toBe(true);
   });
 });
 
@@ -76,13 +110,82 @@ describe("makeLocalManifestReader (GITTENSORY_REPO_CONFIG_DIR)", () => {
     expect(await reader!("owner/unconfigured")).toBe("gate:\n  enabled: false\n");
   });
 
-  it("prefers a per-repo file over the global fallback when both exist", async () => {
+  it("deep-merges a per-repo file over the global default: per-repo wins on shared keys, global fills the rest", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
-    writeFileSync(join(dir, ".gittensory.yml"), "gate:\n  enabled: false\n"); // global
+    writeFileSync(join(dir, ".gittensory.yml"), "gate:\n  enabled: false\n  duplicates: block\n"); // global
     mkdirSync(join(dir, "repo"));
-    writeFileSync(join(dir, "repo", ".gittensory.yml"), "gate:\n  enabled: true\n"); // per-repo wins
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "gate:\n  enabled: true\n"); // per-repo overrides only `enabled`
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/repo"));
+    expect(manifest.gate.enabled).toBe(true); // per-repo wins on the shared key
+    expect(manifest.gate.duplicates).toBe("block"); // inherited from global, untouched
+  });
+
+  it("replaces an array wholesale instead of concatenating it with the global default's", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "wantedPaths:\n  - src/**\n  - test/**\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "wantedPaths:\n  - docs/**\n");
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/repo"));
+    expect(manifest.wantedPaths).toEqual(["docs/**"]);
+  });
+
+  it("lets an explicit per-repo null clear a global-configured contributorOpenPrCap", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "settings:\n  contributorOpenPrCap: 5\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "settings:\n  contributorOpenPrCap: null\n");
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/repo"));
+    expect(manifest.settings.contributorOpenPrCap).toBeNull(); // explicit null clears the global 5, not "unset"
+  });
+
+  it("lets an explicit per-repo null clear a global-configured accountAgeThresholdDays", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "settings:\n  accountAgeThresholdDays: 14\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "settings:\n  accountAgeThresholdDays: null\n");
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/repo"));
+    expect(manifest.settings.accountAgeThresholdDays).toBeNull();
+  });
+
+  it("treats a config file over the manifest size cap as unmergeable and falls back to the other file alone", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    const oversized = `# ${"x".repeat(MAX_FOCUS_MANIFEST_BYTES + 10)}\ngate:\n  enabled: false\n`;
+    writeFileSync(join(dir, ".gittensory.yml"), oversized); // global, too large to attempt a merge against
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "gate:\n  enabled: true\n");
+    const reader = makeLocalManifestReader(dir);
+    expect(await reader!("owner/repo")).toBe("gate:\n  enabled: true\n"); // oversized global dropped; per-repo raw text unchanged
+  });
+
+  it("falls back to the per-repo file alone when the global default fails to parse", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "{ not valid json"); // starts with `{` → JSON.parse throws
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "gate:\n  enabled: true\n");
     const reader = makeLocalManifestReader(dir);
     expect(await reader!("owner/repo")).toBe("gate:\n  enabled: true\n");
+  });
+
+  it("falls back to the global default alone when the per-repo file parses but isn't a mapping", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "gate:\n  enabled: false\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "[1, 2, 3]"); // valid JSON, but an array, not a mapping
+    const reader = makeLocalManifestReader(dir);
+    expect(await reader!("owner/repo")).toBe("gate:\n  enabled: false\n");
+  });
+
+  it("returns the per-repo raw text (today's legacy priority) when BOTH files fail to parse as mappings", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), "{ also broken");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "{ broken json");
+    const reader = makeLocalManifestReader(dir);
+    expect(await reader!("owner/repo")).toBe("{ broken json"); // flows downstream, which warns + ignores it, same as today
   });
 
   it("returns null when neither a per-repo file nor a global fallback exists (⇒ loader uses the public file)", async () => {

--- a/test/unit/selfhost-config-examples.test.ts
+++ b/test/unit/selfhost-config-examples.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeLocalManifestReader } from "../../src/selfhost/private-config";
+import { parseFocusManifestContent } from "../../src/signals/focus-manifest";
+
+// The shipped self-host private-config examples (config/examples/*.gittensory.yml, referenced by
+// config/examples/README.md) must stay valid, comment-tolerant YAML that the SAME parser the real
+// private-config reader uses accepts cleanly — a stale/broken example would silently mislead every
+// self-host operator who copies it. Pure structural checks only (no docker/CLI invocation, mirroring
+// the selfhost-compose-*.test.ts convention for other shipped self-host artifacts).
+
+function readExample(name: string): string {
+  return readFileSync(join("config/examples", name), "utf8");
+}
+
+describe("config/examples/global.gittensory.yml", () => {
+  it("parses cleanly with no warnings and sets the documented fields", () => {
+    const manifest = parseFocusManifestContent(readExample("global.gittensory.yml"));
+    expect(manifest.warnings).toEqual([]);
+    expect(manifest.present).toBe(true);
+    expect(manifest.gate.enabled).toBe(true);
+    expect(manifest.gate.duplicates).toBe("block");
+    expect(manifest.settings.contributorOpenPrCap).toBe(3);
+    expect(manifest.settings.autoCloseExemptLogins).toEqual(["your-admin-login"]);
+  });
+});
+
+describe("config/examples/repo-override.gittensory.yml", () => {
+  it("parses cleanly with no warnings and sets the documented fields", () => {
+    const manifest = parseFocusManifestContent(readExample("repo-override.gittensory.yml"));
+    expect(manifest.warnings).toEqual([]);
+    expect(manifest.present).toBe(true);
+    expect(manifest.gate.enabled).toBe(true);
+    expect(manifest.wantedPaths).toEqual(["src/**"]);
+    expect(manifest.settings.contributorOpenPrCap).toBeNull(); // documented null-clear example
+  });
+});
+
+describe("the two examples together demonstrate the documented overlay behavior", () => {
+  it("merges exactly as config/examples/README.md describes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-example-config-"));
+    writeFileSync(join(dir, ".gittensory.yml"), readExample("global.gittensory.yml"));
+    mkdirSync(join(dir, "owner__repo"));
+    writeFileSync(join(dir, "owner__repo", ".gittensory.yml"), readExample("repo-override.gittensory.yml"));
+    const reader = makeLocalManifestReader(dir)!;
+    const manifest = parseFocusManifestContent(await reader("owner/repo"));
+
+    expect(manifest.gate.enabled).toBe(true); // set the same way in both files
+    expect(manifest.gate.duplicates).toBe("block"); // inherited from global; repo-override never mentions it
+    expect(manifest.wantedPaths).toEqual(["src/**"]); // repo-override's array replaces global's (global sets none)
+    expect(manifest.settings.contributorOpenPrCap).toBeNull(); // repo-override's explicit null clears global's 3
+    expect(manifest.settings.autoCloseExemptLogins).toEqual(["your-admin-login"]); // inherited from global untouched
+  });
+});


### PR DESCRIPTION
## Summary

Self-host operators running many repos off one instance today have to fully duplicate a global
default into every per-repo private config file: `makeLocalManifestReader` picked the first
existing candidate outright, so a present per-repo file fully replaced an optional global
`.gittensory.yml` fallback rather than layering over it. This PR makes the two files deep-merge
when both exist (the per-repo file overlaid onto the global default), while staying
byte-identical to today's behavior when only one of them exists.

- Nested mappings (`gate`, `settings`, `review`, `features`, `contentLane`, and their own nested
  blocks) merge key by key — a per-repo file only needs to state what's different for that repo.
- Arrays (`wantedPaths`, `blockedPaths`, etc.) replace wholesale, never concatenated.
- An explicit `null` at a key in the per-repo file always overrides the global value there —
  clearing a setting wherever the manifest parser already treats `null` as "off" (e.g.
  `settings.contributorOpenPrCap`, `settings.accountAgeThresholdDays`), and a harmless no-op
  everywhere else.
- If either file fails to parse (or is oversized), the merge is skipped and the still-valid file
  is used alone, or the per-repo file's raw text is returned if both are broken — matching today's
  degradation for a single malformed manifest.

No new env var (reuses `GITTENSORY_REPO_CONFIG_DIR`) and no new config schema field (reuses the
entire existing `.gittensory.yml` parser/schema in `src/signals/focus-manifest.ts` unchanged) — the
change is fully contained to `src/selfhost/private-config.ts`. Also ships generic, safe example
templates under `config/examples/` (a global default + a per-repo override, both parse-validated
by tests), references them from the Docker image for convenience, and updates the
`docker-compose.yml`/`server.ts` comments describing the new precedence. No real repo names,
maintainer logins, or private policy appear anywhere in the diff.

No issue is linked: this is a self-contained self-host ergonomics improvement with no public
behavior change (public `.gittensory.yml` resolution is untouched) and no schema change, so a
tracking issue didn't seem necessary before implementing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `src/selfhost/private-config.ts` is 100% lines/branches/functions on the diff.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full `npm run test:ci` gate (all 358 test files, 6854 tests) plus `npm audit --audit-level=moderate` locally; both green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS/session code touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changed.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, backend/docs/Docker only, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `config/examples/README.md` added; `CHANGELOG.md` untouched.

## Notes

- `config/examples/global.gittensory.yml` and `config/examples/repo-override.gittensory.yml` are
  generic, inert placeholders (no real repo names/logins/thresholds) — validated by
  `test/unit/selfhost-config-examples.test.ts` to parse cleanly and to demonstrate the documented
  overlay behavior together.
- `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` is regenerated (`npm run
  selfhost:env-reference`) because a doc-comment edit in `src/server.ts` shifted the line number
  the generator records for several env vars — a pure line-number diff, no behavior change.