### PR TITLE
fix(review): rank all test conventions below source in diff priority

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -6,18 +6,24 @@
 // which survived even with full-file grounding on). This builder orders source-first, reduces oversized
 // patches hunk-aware instead of dropping them, and always lists patch-less/over-budget files. (#accuracy-gap-1)
 
+import { isTestPath } from "../signals/test-evidence";
+
 /** Char budget of the diff fed to the review models. The 120B review models have ~128k-token context, so
  *  even a large PR fits in ONE coherent pass (accuracy over speed). Only a genuinely huge PR truncates —
  *  and then SOURCE survives via priority ordering. */
 export const DEFAULT_DIFF_BUDGET = 80_000;
 
 /** Review priority for diff ordering. When the budget is tight, SOURCE survives and
- *  lockfiles/generated/docs/tests are dropped first (least useful to a code reviewer). Lower = kept. */
+ *  lockfiles/generated/docs/tests are dropped first (least useful to a code reviewer). Lower = kept.
+ *  Test detection delegates to the canonical `isTestPath` so this matcher can't drift from it — the
+ *  previous inline regex missed real conventions (pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`,
+ *  Cypress/Playwright `.cy`/`.e2e`, a bare `spec/` dir), so those tests were ranked as SOURCE(0) and
+ *  could displace real source under a tight budget — the exact opposite of this function's job. */
 export function diffFilePriority(path: string): number {
   if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|rst|txt|adoc)$/i.test(path)) return 2;
-  if (/\.(test|spec)\.[a-z0-9]+$|(^|\/)(__tests__|tests?)\//i.test(path)) return 1;
+  if (isTestPath(path)) return 1;
   return 0; // source code
 }
 

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -15,6 +15,7 @@
 // params instead of reviewbot's RunContext/ReviewTarget/github helpers, so fetchFullFileContents is
 // self-contained and unit-testable. The host wires a real GitHub-backed FileFetcher at the call site.
 
+import { isTestPath } from "../signals/test-evidence";
 import { neutralizePromptInjection } from "./prompt-injection";
 
 // ── Inlined minimal types (ported from reviewbot src/core/types.ts) ──────────────────────────────
@@ -104,12 +105,15 @@ export function buildGrounding(f: GroundingFlags, checks?: CheckAggregate, fileC
 
 // ── Diff priority (ported from reviewbot src/core/diff.ts diffFilePriority) ───────────────────────
 /** Review priority for diff ordering. When the budget is tight, SOURCE survives and
- *  lockfiles/generated/docs/tests are dropped first (least useful to a code reviewer). Lower = kept. */
+ *  lockfiles/generated/docs/tests are dropped first (least useful to a code reviewer). Lower = kept.
+ *  Test detection delegates to the canonical `isTestPath` so this matcher can't drift from it (the inline
+ *  copy missed pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`, Cypress/Playwright `.cy`/`.e2e`, and a
+ *  bare `spec/` dir — so those tests ranked as SOURCE(0) and were inlined ahead of real source). */
 export function diffFilePriority(path: string): number {
   if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|rst|txt|adoc)$/i.test(path)) return 2;
-  if (/\.(test|spec)\.[a-z0-9]+$|(^|\/)(__tests__|tests?)\//i.test(path)) return 1;
+  if (isTestPath(path)) return 1;
   return 0; // source code
 }
 

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -10,6 +10,29 @@ describe("diffFilePriority — source survives, noise drops first", () => {
     expect(diffFilePriority("dist/bundle.js")).toBe(4);
     expect(diffFilePriority("app.min.css")).toBe(4);
   });
+
+  it("ranks every canonical test convention as tests(1), not source(0)", () => {
+    // These are all tests; before delegating to isTestPath the inline regex missed them and ranked
+    // them SOURCE(0), so on a tight budget they could displace real source (the opposite of the goal).
+    for (const path of [
+      "e2e/checkout.cy.ts", // Cypress
+      "e2e/flow.e2e.mjs", // Playwright/e2e, module extension
+      "pkg/server/handler_test.go", // Go suffix
+      "app/services/cleanup_test.py", // pytest suffix
+      "tests/test_utils.py", // pytest prefix (would be a test dir too, but bare test_*.py must also count)
+      "models/user_spec.rb", // RSpec suffix
+      "spec/models/account.rb", // bare spec/ directory
+      "src/test/fixtures.ts", // src/test convention
+      "components/__snapshots__/Card.tsx", // snapshot dir (non-.snap file)
+    ]) {
+      expect(diffFilePriority(path)).toBe(1);
+    }
+  });
+
+  it("still treats plain production sources as source(0)", () => {
+    expect(diffFilePriority("src/review/review-diff.ts")).toBe(0);
+    expect(diffFilePriority("packages/api/handler.py")).toBe(0);
+  });
 });
 
 describe("addedLineCount — counts +lines, ignores +++ header", () => {

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -101,6 +101,27 @@ describe("review-grounding: diffFilePriority (source survives the budget first)"
     expect(diffFilePriority("dist/bundle.js")).toBe(4);
     expect(diffFilePriority("src/a.ts")).toBeLessThan(diffFilePriority("README.md"));
   });
+
+  it("ranks every canonical test convention as tests(1) so real source is inlined first", () => {
+    for (const path of [
+      "e2e/checkout.cy.ts", // Cypress
+      "e2e/flow.e2e.mjs", // Playwright/e2e, module extension
+      "pkg/server/handler_test.go", // Go suffix
+      "app/services/cleanup_test.py", // pytest suffix
+      "tests/test_utils.py", // pytest prefix
+      "models/user_spec.rb", // RSpec suffix
+      "spec/models/account.rb", // bare spec/ directory
+      "src/test/fixtures.ts", // src/test convention
+      "components/__snapshots__/Card.tsx", // snapshot dir (non-.snap file)
+    ]) {
+      expect(diffFilePriority(path)).toBe(1);
+    }
+  });
+
+  it("still treats plain production sources as source(0)", () => {
+    expect(diffFilePriority("src/review/review-grounding.ts")).toBe(0);
+    expect(diffFilePriority("packages/api/handler.py")).toBe(0);
+  });
 });
 
 describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-safe + bounded)", () => {


### PR DESCRIPTION
## What
`diffFilePriority` (used to order files in the AI review diff and to pick which files get full-content grounding first) inlined a test-detection regex in **both** `src/review/review-diff.ts` and `src/review/review-grounding.ts`:

```
/\.(test|spec)\.[a-z0-9]+$|(^|\/)(__tests__|tests?)\//i
```

This had **drifted from the canonical `isTestPath`** (`src/signals/test-evidence.ts`). It failed to recognize several real test conventions:

- pytest `test_*.py` prefix
- Go `*_test.go`, Python `*_test.py`, Ruby `*_spec.rb` suffixes
- Cypress/Playwright `*.cy.*` / `*.e2e.*`
- a bare `spec/` directory (only `test/`, `tests/`, `__tests__/` were matched)

## Why it matters
The whole point of `diffFilePriority` is **source survives a tight budget; tests/docs/lockfiles drop first**. A misclassified test file gets priority `0` (source), so on a budget-constrained PR it competes with — and can displace — real source in the review diff, and is inlined ahead of source in the full-file grounding. That is the exact failure mode this function exists to prevent.

Concrete: `pkg/handler_test.go`, `tests/test_utils.py`, `e2e/checkout.cy.ts`, and `spec/models/user.rb` were all ranked as SOURCE before this change.

## Fix
Delegate the test check to the canonical `isTestPath` in both files, so this matcher **cannot drift from it again** — the same single-sourcing already applied to the signal-side test/code classifiers. `test-evidence.ts` is a dependency-free leaf module, so the import introduces no cycle.

## Tests
Added regression coverage in both `review-diff.test.ts` and `review-grounding.test.ts` asserting every previously-missed convention now ranks as tests(1), plus that plain production sources still rank source(0). Existing priority/ordering tests unchanged and green.