### PR TITLE
feat(engine): add miner goal lane-fit scorer

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -28,3 +28,7 @@ export {
   type MinerIssueDiscoveryPolicy,
   type ParsedMinerGoalSpec,
 } from "./miner-goal-spec.js";
+export {
+  computeMinerGoalLaneFit,
+  isMinerRepoTargetable,
+} from "./miner-goal-lane-fit.js";

--- a/packages/gittensory-engine/src/miner-goal-lane-fit.ts
+++ b/packages/gittensory-engine/src/miner-goal-lane-fit.ts
@@ -1,0 +1,50 @@
+import type { MinerGoalSpec } from "./miner-goal-spec.js";
+
+/** Whether a repo's miner goal spec permits autonomous targeting (explicit opt-out only). */
+export function isMinerRepoTargetable(spec: MinerGoalSpec): boolean {
+  return spec.minerEnabled;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function normalizeLabels(labels: readonly string[]): string[] {
+  return labels
+    .filter((label): label is string => typeof label === "string")
+    .map((label) => label.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Compute a [0, 1] lane-fit score from issue labels and a parsed {@link MinerGoalSpec}. Path-based fit is
+ * intentionally omitted — discovery metadata has labels only; path gating belongs in the analyze phase.
+ */
+export function computeMinerGoalLaneFit(
+  issue: { labels: readonly string[] },
+  spec: MinerGoalSpec,
+): number {
+  const issueLabels = normalizeLabels(issue.labels);
+  const preferred = normalizeLabels(spec.preferredLabels);
+
+  let score: number;
+  if (preferred.length === 0) {
+    score = 1;
+  } else {
+    const preferredMatch = preferred.some((want) => issueLabels.includes(want));
+    if (preferredMatch) {
+      score = 1;
+    } else if (spec.issueDiscoveryPolicy === "discouraged") {
+      score = 0.6;
+    } else {
+      score = 0.25;
+    }
+  }
+
+  if (spec.issueDiscoveryPolicy === "encouraged") {
+    score = Math.max(score, 0.85);
+  }
+
+  return clamp01(score);
+}

--- a/packages/gittensory-engine/test/miner-goal-lane-fit.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-lane-fit.test.ts
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_MINER_GOAL_SPEC } from "../dist/miner-goal-spec.js";
+import { computeMinerGoalLaneFit, isMinerRepoTargetable } from "../dist/miner-goal-lane-fit.js";
+
+test("isMinerRepoTargetable respects minerEnabled opt-out", () => {
+  assert.equal(isMinerRepoTargetable(DEFAULT_MINER_GOAL_SPEC), true);
+  assert.equal(isMinerRepoTargetable({ ...DEFAULT_MINER_GOAL_SPEC, minerEnabled: false }), false);
+});
+
+test("computeMinerGoalLaneFit returns 1 when no preferred labels are configured", () => {
+  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, DEFAULT_MINER_GOAL_SPEC), 1);
+});
+
+test("computeMinerGoalLaneFit matches preferred labels case-insensitively", () => {
+  const spec = { ...DEFAULT_MINER_GOAL_SPEC, preferredLabels: ["bug"] };
+  assert.equal(computeMinerGoalLaneFit({ labels: ["Bug"] }, spec), 1);
+  assert.equal(computeMinerGoalLaneFit({ labels: ["feature"] }, spec), 0.25);
+});
+
+test("computeMinerGoalLaneFit applies issueDiscoveryPolicy modifiers", () => {
+  const encouraged = {
+    ...DEFAULT_MINER_GOAL_SPEC,
+    preferredLabels: ["feature"],
+    issueDiscoveryPolicy: "encouraged" as const,
+  };
+  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, encouraged), 0.85);
+
+  const discouraged = {
+    ...DEFAULT_MINER_GOAL_SPEC,
+    preferredLabels: ["feature"],
+    issueDiscoveryPolicy: "discouraged" as const,
+  };
+  assert.equal(computeMinerGoalLaneFit({ labels: ["docs"] }, discouraged), 0.6);
+  assert.equal(computeMinerGoalLaneFit({ labels: ["feature"] }, discouraged), 1);
+});
+
+test("computeMinerGoalLaneFit ignores malformed label entries safely", () => {
+  assert.equal(
+    computeMinerGoalLaneFit({ labels: ["bug", "", 42 as unknown as string, "  "] }, {
+      ...DEFAULT_MINER_GOAL_SPEC,
+      preferredLabels: ["BUG"],
+    }),
+    1,
+  );
+});


### PR DESCRIPTION
## Summary
- Add `computeMinerGoalLaneFit` and `isMinerRepoTargetable` in `@jsonbored/gittensory-engine` so discovery can derive the `laneFit` signal documented by `opportunity-ranker`.
- Score preferred labels case-insensitively and apply `issueDiscoveryPolicy` modifiers (`encouraged` floor, `discouraged` soft cap when labels do not match).
- Export the helpers from the engine package barrel with unit coverage.

## Test plan
- [x] `npm test --workspace @jsonbored/gittensory-engine`
- [ ] CI green on upstream
