### PR TITLE
fix(agent): live-verify install-wide contributor cap siblings, report mixed item kind

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3150,19 +3150,56 @@ async function listRepoFullNamesForInstallation(env: Env, installationId: number
  * never gated them on -- the exact cross-tenant leak install-scoped helpers elsewhere in this codebase (e.g.
  * markRepositoriesRemovedFromInstallation) exist to avoid.
  */
-export async function countOpenItemsForAuthorAcrossRepos(env: Env, installationId: number, authorLogin: string): Promise<number> {
+export type OpenItemAcrossInstallRow = { repoFullName: string; number: number; kind: "pull_request" | "issue" };
+
+const AUTHOR_OPEN_ITEM_LIST_LIMIT = 20_000;
+
+/**
+ * Install-wide open-item ROWS for one author (#2562 gate-review follow-up), across every repo THIS
+ * INSTALLATION tracks. Returns the actual rows (not just a count) so the caller can LIVE-VERIFY each one
+ * before trusting the aggregate toward an irreversible close -- the stored DB cache can lag GitHub for a repo
+ * OTHER than the one the current webhook is for, and an inflated stale count must never itself trigger a
+ * close (mirrors the existing per-repo issue-cap's own sibling live-verification, #2479). Same-database
+ * aggregate only -- no cross-instance networking, mirroring the install-scoped singleton shape of
+ * global_contributor_blacklist. Case-insensitive login match (mirrors loginMatches/findBlacklistEntry
+ * elsewhere in this file).
+ */
+export async function listOpenItemsForAuthorAcrossInstall(env: Env, installationId: number, authorLogin: string): Promise<OpenItemAcrossInstallRow[]> {
   const repoNames = await listRepoFullNamesForInstallation(env, installationId);
-  if (repoNames.length === 0) return 0;
+  if (repoNames.length === 0) return [];
   const db = getDb(env.DB);
-  const [[prRow], [issueRow]] = await Promise.all([
-    db.select({ count: sql<number>`count(*)` }).from(pullRequests).where(and(eq(pullRequests.state, "open"), loginMatches(pullRequests.authorLogin, authorLogin), inArray(pullRequests.repoFullName, repoNames))),
-    db.select({ count: sql<number>`count(*)` }).from(issues).where(and(eq(issues.state, "open"), loginMatches(issues.authorLogin, authorLogin), inArray(issues.repoFullName, repoNames))),
-  ]);
-  /* v8 ignore next -- SQL aggregate count always returns one row; fallback protects D1 driver anomalies. */
-  const prCount = Number(prRow?.count ?? 0);
-  /* v8 ignore next -- SQL aggregate count always returns one row; fallback protects D1 driver anomalies. */
-  const issueCount = Number(issueRow?.count ?? 0);
-  return prCount + issueCount;
+  const prRows = await db
+    .select({ repoFullName: pullRequests.repoFullName, number: pullRequests.number })
+    .from(pullRequests)
+    .where(and(eq(pullRequests.state, "open"), loginMatches(pullRequests.authorLogin, authorLogin), inArray(pullRequests.repoFullName, repoNames)))
+    .limit(AUTHOR_OPEN_ITEM_LIST_LIMIT);
+  if (prRows.length === AUTHOR_OPEN_ITEM_LIST_LIMIT) {
+    await recordAuditEvent(env, {
+      eventType: "agent.global_open_item_cap.author_items_truncated",
+      actor: "gittensory",
+      targetKey: `${authorLogin}@installation:${installationId}`,
+      outcome: "error",
+      detail: `author has >= ${AUTHOR_OPEN_ITEM_LIST_LIMIT} open pull requests across the install; the global contributor-cap check may undercount`,
+    }).catch(() => undefined);
+  }
+  const issueRows = await db
+    .select({ repoFullName: issues.repoFullName, number: issues.number })
+    .from(issues)
+    .where(and(eq(issues.state, "open"), loginMatches(issues.authorLogin, authorLogin), inArray(issues.repoFullName, repoNames)))
+    .limit(AUTHOR_OPEN_ITEM_LIST_LIMIT);
+  if (issueRows.length === AUTHOR_OPEN_ITEM_LIST_LIMIT) {
+    await recordAuditEvent(env, {
+      eventType: "agent.global_open_item_cap.author_items_truncated",
+      actor: "gittensory",
+      targetKey: `${authorLogin}@installation:${installationId}`,
+      outcome: "error",
+      detail: `author has >= ${AUTHOR_OPEN_ITEM_LIST_LIMIT} open issues across the install; the global contributor-cap check may undercount`,
+    }).catch(() => undefined);
+  }
+  return [
+    ...prRows.map((row) => ({ repoFullName: row.repoFullName, number: row.number, kind: "pull_request" as const })),
+    ...issueRows.map((row) => ({ repoFullName: row.repoFullName, number: row.number, kind: "issue" as const })),
+  ];
 }
 
 // Anti-farming (#anti-gaming-flood): how many PRs this author has SUBMITTED to this repo since `sinceIso` (ANY

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1,7 +1,8 @@
 import {
   countOpenIssues,
-  countOpenItemsForAuthorAcrossRepos,
   countOpenPullRequests,
+  listOpenItemsForAuthorAcrossInstall,
+  type OpenItemAcrossInstallRow,
   getAgentCommandAnswer,
   getInstallation,
   getLatestRepoGithubTotalsSnapshot,
@@ -2036,7 +2037,7 @@ async function runAgentMaintenancePlanAndExecute(
   // default) ⇒ this block is a no-op. A below-account-age-threshold author (#2561) gets a TIGHTER effective
   // cap (half, rounded up, minimum 1) — visibility/friction, still never a close on account age by itself
   // (the close, if any, is still tagged/reasoned as the ordinary contributor-cap close).
-  let contributorCapMatch: { matched: boolean; authorLogin: string; openCount: number; cap: number; itemKind: "pull requests" | "issues"; scope?: "repository" | "install" | undefined } | undefined;
+  let contributorCapMatch: { matched: boolean; authorLogin: string; openCount: number; cap: number; itemKind: "pull requests" | "issues" | "pull requests and issues"; scope?: "repository" | "install" | undefined } | undefined;
   const contributorOpenPrCap =
     isNewAccount && typeof settings.contributorOpenPrCap === "number"
       ? Math.max(1, Math.ceil(settings.contributorOpenPrCap / 2))
@@ -2074,9 +2075,15 @@ async function runAgentMaintenancePlanAndExecute(
   if (contributorCapMatch === undefined && pr.authorLogin && !isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) {
     const globalCap = resolveGlobalContributorOpenItemCap(env);
     if (globalCap !== null) {
-      const installOpenCount = await countOpenItemsForAuthorAcrossRepos(env, installationId, pr.authorLogin);
-      if (installOpenCount > globalCap) {
-        contributorCapMatch = { matched: true, authorLogin: pr.authorLogin, openCount: installOpenCount, cap: globalCap, itemKind: "pull requests", scope: "install" };
+      const globalOpenCount = await verifiedGlobalOpenItemCount(env, installationId, pr.authorLogin, {
+        repoFullName,
+        number: pr.number,
+        kind: "pull_request",
+      });
+      if (globalOpenCount > globalCap) {
+        // verifiedGlobalOpenItemCount sums BOTH open PRs and open issues -- reporting this as "pull requests"
+        // when the author's over-cap total may include issues would be a factually wrong close message.
+        contributorCapMatch = { matched: true, authorLogin: pr.authorLogin, openCount: globalOpenCount, cap: globalCap, itemKind: "pull requests and issues", scope: "install" };
       }
     }
   }
@@ -3935,6 +3942,75 @@ async function loadOpenQueueCounts(
 }
 
 /**
+ * True when one row from listOpenItemsForAuthorAcrossInstall is CONFIRMED still open on GitHub right now
+ * (#2562 gate-review follow-up): the stored DB cache can lag GitHub for a repo OTHER than the one this
+ * webhook is for (closed manually, by another automation, or by a webhook this instance hasn't processed
+ * yet) -- an inflated stale count must never itself trigger an irreversible close. Fail SAFE, not fail-open:
+ * an item this call cannot POSITIVELY confirm is still open is excluded from the count (mirrors the existing
+ * per-repo issue-cap's own sibling live-verification, #2479).
+ */
+async function isOpenItemRowStillLiveOpen(
+  env: Env,
+  row: OpenItemAcrossInstallRow,
+  liveToken: string | undefined,
+  admissionKey: GitHubRateLimitAdmissionKey | undefined,
+): Promise<boolean> {
+  if (row.kind === "issue") {
+    const liveState = await fetchLiveIssueState(env, row.repoFullName, row.number, liveToken, admissionKey).catch(() => undefined);
+    return liveState === "open";
+  }
+  const livePr = await fetchLivePullRequest(env, row.repoFullName, row.number, liveToken, admissionKey).catch(() => undefined);
+  return livePr?.state === "open";
+}
+
+// A contributor can have thousands of open rows across a large install -- an unbounded Promise.all over every
+// one of them would fire that many concurrent GitHub API calls from a single webhook, exhausting the
+// installation's rate limit for every OTHER repo it gates. Bounded worker-pool fan-out, mirroring the same
+// fixed-concurrency shape already used elsewhere in this codebase for GitHub fan-out.
+const GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY = 10;
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, items.length || 1));
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(items[index] as T);
+      }
+    }),
+  );
+  return results;
+}
+
+/**
+ * Install-wide contributor open-item count, LIVE-VERIFIED (#2562 gate-review follow-up): every OTHER counted
+ * item is confirmed still-open via a live GET before counting toward the cap (mirrors the existing per-repo
+ * issue-cap's own sibling live-verification, #2479); `currentItem` (the one THIS webhook just delivered) is
+ * trusted unverified, same as every other cap check in this file.
+ */
+async function verifiedGlobalOpenItemCount(
+  env: Env,
+  installationId: number,
+  authorLogin: string,
+  currentItem: { repoFullName: string; number: number; kind: "pull_request" | "issue" },
+): Promise<number> {
+  const rows = await listOpenItemsForAuthorAcrossInstall(env, installationId, authorLogin);
+  const otherRows = rows.filter(
+    (row) => !(row.repoFullName === currentItem.repoFullName && row.number === currentItem.number && row.kind === currentItem.kind),
+  );
+  const token = await createInstallationToken(env, installationId).catch(() => undefined);
+  const liveToken = token ?? env.GITHUB_PUBLIC_TOKEN;
+  const admissionKey = githubAdmissionKeyForToken(env, installationId, liveToken);
+  const confirmedOpen = await mapWithConcurrency(otherRows, GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY, (row) =>
+    isOpenItemRowStillLiveOpen(env, row, liveToken, admissionKey),
+  );
+  return confirmedOpen.filter(Boolean).length + 1;
+}
+
+/**
  * Per-contributor open-ISSUE cap (#2270, anti-abuse): the first `eventName === "issues"` actuation branch —
  * issues have no other auto-close path today. Mirrors the PR-path cap in runAgentMaintenancePlanAndExecute:
  * counts the author's currently-open issues on this repo (including this one), ranked by issue NUMBER
@@ -3980,12 +4056,16 @@ async function maybeCloseIssueOverContributorCap(
   const authorIsAutomationBot = isProtectedAutomationAuthor(authorLogin);
   if (authorIsOwner || authorIsAdmin || authorIsAutomationBot) return;
 
-  // Install-wide check first (#2562): reuses the shared autoCloseExemptLogins list, same as the PR path. A
-  // match here closes THIS issue directly (unlike the per-repo cap below, there is no cross-repo sibling set to
-  // union/live-verify -- the aggregate count already covers every repo, so a single over-cap read is enough).
+  // Install-wide check first (#2562): reuses the shared autoCloseExemptLogins list, same as the PR path.
+  // verifiedGlobalOpenItemCount live-verifies every OTHER counted item before trusting it toward an
+  // irreversible close (#2562 gate-review follow-up), mirroring the per-repo cap's own sibling live-verify.
   if (globalCap !== null && !isAutoCloseExempt(authorLogin, settings.autoCloseExemptLogins)) {
-    const installOpenCount = await countOpenItemsForAuthorAcrossRepos(env, installationId, authorLogin);
-    if (installOpenCount > globalCap) {
+    const globalOpenCount = await verifiedGlobalOpenItemCount(env, installationId, authorLogin, {
+      repoFullName,
+      number: issue.number,
+      kind: "issue",
+    });
+    if (globalOpenCount > globalCap) {
       const planned = planAgentMaintenanceActions({
         conclusion: "skipped",
         blockerTitles: [],
@@ -3996,7 +4076,9 @@ async function maybeCloseIssueOverContributorCap(
         authorIsAdmin,
         authorIsAutomationBot,
         ciState: "unverified",
-        contributorCapMatch: { matched: true, authorLogin, openCount: installOpenCount, cap: globalCap, itemKind: "issues", scope: "install" },
+        // verifiedGlobalOpenItemCount sums BOTH open PRs and open issues; "pull requests and issues" is
+        // accurate regardless of the actual split, unlike a hardcoded single kind.
+        contributorCapMatch: { matched: true, authorLogin, openCount: globalOpenCount, cap: globalCap, itemKind: "pull requests and issues", scope: "install" },
         contributorCapLabel: settings.contributorCapLabel,
         pr: { labels: [] },
       });

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -169,11 +169,13 @@ export type AgentActionPlanInput = {
   // so — unlike the blacklist's private-reason close — they ARE interpolated into the public close comment.
   // `itemKind` selects the close-comment noun ("pull requests" for the PR-path caller, "issues" for the
   // issue-path caller, #2270) — REQUIRED (not defaulted) so a caller can't silently mislabel the other kind.
+  // "pull requests and issues" (#2562) is for the install-wide globalContributorOpenItemCap, whose count sums
+  // BOTH kinds across the install — a single-kind label there would misstate a mixed-kind contributor's count.
   // `scope` (#2562) selects the close-comment's cap description: "repository" (default when absent, back-compat
   // for every existing per-repo caller) says "this repository's configured limit"; "install" says "across every
   // repository this install gates, combined" for the install-wide globalContributorOpenItemCap. Same closeKind
   // ("contributor_cap") and label either way — this is a description-only distinction, not a new disposition.
-  contributorCapMatch?: { matched: boolean; authorLogin: string; openCount: number; cap: number; itemKind: "pull requests" | "issues"; scope?: "repository" | "install" | undefined } | undefined;
+  contributorCapMatch?: { matched: boolean; authorLogin: string; openCount: number; cap: number; itemKind: "pull requests" | "issues" | "pull requests and issues"; scope?: "repository" | "install" | undefined } | undefined;
   // The repo-configured label applied to an over-cap author's PR/issue (#2270), resolved from `.gittensory.yml`.
   // Absent ⇒ the default (`DEFAULT_CONTRIBUTOR_CAP_LABEL` = "over-contributor-limit").
   contributorCapLabel?: string | undefined;
@@ -315,7 +317,7 @@ function blacklistCloseMessage(): string {
 // (#2562) picks the cap description: "repository" (default, back-compat for every existing per-repo caller) vs.
 // "install" for the install-wide globalContributorOpenItemCap — same message shape, closeKind, and label either
 // way, just an accurate noun phrase for where the count was aggregated.
-function contributorCapCloseMessage(authorLogin: string, openCount: number, cap: number, itemNoun: "pull requests" | "issues", scope?: "repository" | "install" | undefined): string {
+function contributorCapCloseMessage(authorLogin: string, openCount: number, cap: number, itemNoun: "pull requests" | "issues" | "pull requests and issues", scope?: "repository" | "install" | undefined): string {
   const scopeDescription = scope === "install" ? "this install's configured limit (across every repository it gates, combined)" : "this repository's configured limit";
   return `Gittensory closed this because @${authorLogin} has ${openCount} open ${itemNoun}, above ${scopeDescription} of ${cap}. Close or merge an existing one to open a new one. This is an automated maintenance action.`;
 }

--- a/test/unit/global-contributor-cap.test.ts
+++ b/test/unit/global-contributor-cap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { resolveGlobalContributorOpenItemCap } from "../../src/settings/global-contributor-cap";
-import { countOpenItemsForAuthorAcrossRepos, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { listOpenItemsForAuthorAcrossInstall, upsertIssueFromGitHub, upsertPullRequestFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 describe("resolveGlobalContributorOpenItemCap (#2562)", () => {
@@ -24,8 +24,8 @@ describe("resolveGlobalContributorOpenItemCap (#2562)", () => {
   });
 });
 
-describe("countOpenItemsForAuthorAcrossRepos (#2562)", () => {
-  it("sums open PRs + open issues for one author across EVERY repo THIS INSTALLATION tracks, not just one", async () => {
+describe("listOpenItemsForAuthorAcrossInstall (#2562)", () => {
+  it("lists open PRs + open issues for one author across EVERY repo THIS INSTALLATION tracks, not just one", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "repo-a", full_name: "org/repo-a", owner: { login: "org" } }, 123);
     await upsertRepositoryFromGitHub(env, { name: "repo-b", full_name: "org/repo-b", owner: { login: "org" } }, 123);
@@ -37,25 +37,33 @@ describe("countOpenItemsForAuthorAcrossRepos (#2562)", () => {
     await upsertPullRequestFromGitHub(env, "org/repo-a", { number: 4, title: "a2 (closed)", state: "closed", user: { login: "farmer99" } });
     await upsertPullRequestFromGitHub(env, "org/repo-a", { number: 5, title: "a3 (other author)", state: "open", user: { login: "someone-else" } });
 
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "farmer99")).toBe(3);
+    const rows = await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99");
+    expect(rows).toHaveLength(3);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { repoFullName: "org/repo-a", number: 1, kind: "pull_request" },
+        { repoFullName: "org/repo-b", number: 2, kind: "pull_request" },
+        { repoFullName: "org/repo-c", number: 3, kind: "issue" },
+      ]),
+    );
   });
 
   it("is case-insensitive on the author login (mirrors loginMatches/findBlacklistEntry elsewhere)", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "repo-a", full_name: "org/repo-a", owner: { login: "org" } }, 123);
     await upsertPullRequestFromGitHub(env, "org/repo-a", { number: 1, title: "a1", state: "open", user: { login: "Farmer99" } });
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "farmer99")).toBe(1);
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "FARMER99")).toBe(1);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99")).toHaveLength(1);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "FARMER99")).toHaveLength(1);
   });
 
-  it("returns 0 for an author with no open items anywhere", async () => {
+  it("returns [] for an author with no open items anywhere", async () => {
     const env = createTestEnv();
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "nobody")).toBe(0);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "nobody")).toEqual([]);
   });
 
-  it("returns 0 for an installation that tracks no repos yet (regression fix, gate finding: no repoNames means no rows to scope against, not an unscoped fetch-everything)", async () => {
+  it("returns [] for an installation that tracks no repos yet (gate finding: no repoNames means no rows to scope against, not an unscoped fetch-everything)", async () => {
     const env = createTestEnv();
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 999, "farmer99")).toBe(0);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 999, "farmer99")).toEqual([]);
   });
 
   it("REGRESSION (cross-tenant leak fix): an author's open items on a DIFFERENT installation do not count toward this installation's cap, even though both installations share the same D1 database", async () => {
@@ -67,8 +75,8 @@ describe("countOpenItemsForAuthorAcrossRepos (#2562)", () => {
     await upsertPullRequestFromGitHub(env, "org-b/repo-b", { number: 2, title: "b1", state: "open", user: { login: "farmer99" } });
     await upsertIssueFromGitHub(env, "org-b/repo-b", { number: 3, title: "b2", state: "open", user: { login: "farmer99" } });
 
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "farmer99")).toBe(1);
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 456, "farmer99")).toBe(2);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99")).toHaveLength(1);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 456, "farmer99")).toHaveLength(2);
   });
 
   it("audits (never silently drops) when an installation's own repo set hits the list limit (gate finding)", async () => {
@@ -79,7 +87,7 @@ describe("countOpenItemsForAuthorAcrossRepos (#2562)", () => {
     await env.DB.prepare(`INSERT INTO repositories (full_name, owner, name, installation_id, created_at, updated_at) VALUES ${values}`).run();
     await upsertPullRequestFromGitHub(env, "org/repo-0", { number: 1, title: "a1", state: "open", user: { login: "farmer99" } });
 
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "farmer99")).toBe(1);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99")).toHaveLength(1);
 
     const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
       .bind("agent.global_open_item_cap.repo_list_truncated", "installation:123")
@@ -91,9 +99,28 @@ describe("countOpenItemsForAuthorAcrossRepos (#2562)", () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "repo-a", full_name: "org/repo-a", owner: { login: "org" } }, 123);
 
-    expect(await countOpenItemsForAuthorAcrossRepos(env, 123, "farmer99")).toBe(0);
+    expect(await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99")).toEqual([]);
 
     const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.global_open_item_cap.repo_list_truncated'").first<{ n: number }>();
     expect(audit?.n ?? 0).toBe(0);
+  });
+
+  // #2562 gate-review follow-up: an author's open items across the install hit the AUTHOR_OPEN_ITEM_LIST_LIMIT
+  // truncation guard (distinct from the repo-list limit above).
+  it("audits (never silently drops) when an author's open items across the install hit the list limit", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo-a", full_name: "org/repo-a", owner: { login: "org" } }, 123);
+    const LIMIT = 20_000;
+    const now = new Date().toISOString();
+    const prValues = Array.from({ length: LIMIT }, (_, i) => `('pr-${i}', 'org/repo-a', ${i + 1}, 'PR ${i}', 'open', 'farmer99', '[]', '${now}', '${now}')`).join(",");
+    await env.DB.prepare(`INSERT INTO pull_requests (id, repo_full_name, number, title, state, author_login, labels_json, created_at, updated_at) VALUES ${prValues}`).run();
+
+    const rows = await listOpenItemsForAuthorAcrossInstall(env, 123, "farmer99");
+    expect(rows).toHaveLength(LIMIT);
+
+    const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+      .bind("agent.global_open_item_cap.author_items_truncated", "farmer99@installation:123")
+      .first<{ n: number }>();
+    expect(audit?.n).toBe(1);
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7793,12 +7793,16 @@ describe("queue processors", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
+      // Install-wide live-verify (#2562 gate-review follow-up) re-fetches every OTHER counted sibling before
+      // trusting it toward the cap -- both of farmer99's other open items must resolve as confirmed-open here.
+      if (url.endsWith("/repos/JSONbored/repo-a/pulls/20")) return Response.json({ number: 20, state: "open" });
+      if (url.endsWith("/repos/JSONbored/repo-b/pulls/10")) return Response.json({ number: 10, state: "open" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/f55/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/55/labels") && method === "GET") return Response.json([]);
@@ -7822,7 +7826,9 @@ describe("queue processors", () => {
 
     expect(seen.closed).toBe(true);
     expect(seen.labels).toContain("over-contributor-limit");
-    expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open pull requests") && c.includes("across every repository it gates"))).toBe(true);
+    // Install-wide cap counts BOTH open PRs and open issues together (#2562 gate-review follow-up), so the
+    // close message reports the mixed noun rather than a stale "pull requests"-only phrasing.
+    expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open pull requests and issues") && c.includes("across every repository it gates"))).toBe(true);
     const closeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.close'").first<{ n: number }>();
     expect(closeAudit?.n).toBeGreaterThanOrEqual(1);
   });
@@ -8840,11 +8846,15 @@ describe("queue processors", () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       const method = init?.method ?? "GET";
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
       if (url.endsWith("/issues/62") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ state: "closed" }); }
       if (url.includes("/issues/62/labels") && method === "GET") return Response.json([]);
       if (url.includes("/issues/62/labels") && method === "POST") { seen.labels.push(...((JSON.parse(String(init?.body ?? "{}")).labels ?? []) as string[])); return Response.json([]); }
       if (url.includes("/issues/62/comments") && method === "POST") { seen.comments.push(String(JSON.parse(String(init?.body ?? "{}")).body ?? "")); return Response.json({ id: 1 }, { status: 201 }); }
+      // Install-wide live-verify (#2562 gate-review follow-up) re-fetches every OTHER counted sibling before
+      // trusting it toward the cap -- both of farmer99's other open items must resolve as confirmed-open here.
+      if (url.endsWith("/repos/JSONbored/repo-a/issues/20")) return Response.json({ number: 20, state: "open" });
+      if (url.endsWith("/repos/JSONbored/repo-b/issues/10")) return Response.json({ number: 10, state: "open" });
       return Response.json({});
     });
 
@@ -8862,7 +8872,9 @@ describe("queue processors", () => {
 
     expect(seen.closed).toBe(true);
     expect(seen.labels).toContain("over-contributor-limit");
-    expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open issues") && c.includes("across every repository it gates"))).toBe(true);
+    // Install-wide cap counts BOTH open PRs and open issues together (#2562 gate-review follow-up), so the
+    // close message reports the mixed noun rather than a stale "issues"-only phrasing from the old count-only path.
+    expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open pull requests and issues") && c.includes("across every repository it gates"))).toBe(true);
   });
 
   it("install-wide contributor open-item cap (#2562): off by default (env var unset) — an issue author spread across repos is never closed", async () => {


### PR DESCRIPTION
## Summary
- Live-verifies every OTHER counted sibling PR/issue against GitHub before trusting it toward the install-wide contributor open-item cap, instead of trusting a DB cache that can lag reality (mirrors the existing per-repo issue-cap's own sibling live-verification, #2479).
- Reports the close reason as "pull requests and issues" (not just one or the other) since the install-wide cap sums both kinds across every repo the installation gates.
- Bounded-concurrency (10) fan-out for the live-verify reads so a large contributor's item list can't exhaust the installation's rate limit.

Advances #2562

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/global-contributor-cap.test.ts test/unit/queue.test.ts test/unit/agent-actions.test.ts` (545 passed)