### PR TITLE
fix(signals): drop the stale v8-ignore on buildCollisionReport's pairwise loop

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -842,7 +842,6 @@ export function buildCollisionReport(
   const items = [...pairwiseIssues.map(issueItem), ...pairwisePullRequests.map(prItem), ...pairwiseRecentMergedPullRequests.map(recentMergedItem)];
   const itemTerms = new Map<string, CollisionTerms>();
   for (const item of items) itemTerms.set(itemKey(item), collisionTerms(item));
-  /* v8 ignore start -- Pairwise collision guards protect sparse cached rows; public collision behavior is covered by report tests. */
   for (let leftIndex = 0; leftIndex < items.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < items.length; rightIndex += 1) {
       const left = items[leftIndex];
@@ -891,7 +890,6 @@ export function buildCollisionReport(
       });
     }
   }
-  /* v8 ignore stop */
 
   const clusterList = [...clusters.values()].sort((left, right) => riskRank(right.risk) - riskRank(left.risk));
   const report = {


### PR DESCRIPTION
## Summary

- Follow-up to #2696 (merged before I could push this): codecov/patch flagged the path-overlap guard at 66.66% because the whole pairwise loop in `buildCollisionReport` was wrapped in a `/* v8 ignore start/stop */` comment that predates real per-branch test coverage for it.
- Confirmed via the full unsharded suite that removing the ignore reveals **zero new gaps** — `engine.ts` stays at 99.25% stmts / 97.94% branch, with the exact same 3 pre-existing, unrelated uncovered lines (just shifted by the 2 deleted comment lines). The loop is fully exercised by the existing + #2696's new collision tests; the ignore was simply stale.
- No behavior change — comment-only deletion.

## Scope

- [x] Conventional Commit title.
- [x] Focused, single change (2 lines removed).
- [x] Follows CONTRIBUTING.md.
- [x] No fresh issue needed — direct follow-up to #2696's codecov/patch finding.

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, unsharded — full suite green, engine.ts 99.25%/97.94% branch, no new uncovered lines
- [x] Targeted re-run of `test/unit/signals-v2.test.ts`, `signals-coverage.test.ts`, `signals.test.ts` — all pass

## Safety

- [x] No secrets/private data exposed.
- [x] N/A — no auth/UI/API/docs surface touched.

## Notes

- Comment-only change; this is purely fixing coverage *reporting* accuracy for the diff, not adding new tested behavior.