### PR TITLE
fix(content-lane): restore secret-scan parity with the PR-diff gate

### DIFF
--- a/src/review/content-lane/security-scan.ts
+++ b/src/review/content-lane/security-scan.ts
@@ -19,9 +19,63 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "private_key_block", re: /-----BEGIN(?: RSA| EC| OPENSSH| PGP| DSA)? PRIVATE KEY-----/ },
   { name: "aws_access_key", re: /\bAKIA[0-9A-Z]{16}\b/ },
   { name: "slack_token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { name: "google_api_key", re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },
 ];
+
+// Deliberately NOT in SECRET_PATTERNS above: unlike the format-specific patterns (a real GitHub token/AWS key
+// ALWAYS matches its exact character format, so a bare .test() is precise enough), a keyword-plus-quoted-value
+// SHAPE also matches plenty of non-secrets -- a Zod schema field (`password: z.string()`), a TypeScript type
+// declaration, or a placeholder value ("xxx", "your-api-key-here", "<REDACTED>"). Captured so each match's
+// VALUE can be checked against isPlaceholderSecretValue before counting as a hit; the value itself is never
+// returned from this module (only the kind name), preserving the existing never-echo-the-secret guarantee.
+const GENERIC_SECRET_ASSIGNMENT_PATTERN =
+  /(?:api[_-]?key|secret|token|password|passwd|access[_-]?key|client[_-]?secret)["']?\s*[:=]\s*["']([A-Za-z0-9+/=_-]{16,})["']/gi;
+
+const PLACEHOLDER_VALUE_PATTERN = /placeholder|change[_-]?me|your[_-]|<[^>]*>|\bexample\b|redacted|dummy|\bsample\b|\btodo\b|\bfixme\b|\binsert\b|replace[_-]?me|\bfake\b/i;
+
+// A string with NO repeated characters (e.g. "abcdefghijklmnop123") has HIGH Shannon entropy by raw
+// character-frequency counting, but is obviously not a real secret -- entropy alone only measures frequency,
+// not ORDER, so a keyboard-sequential/alphabetical run slips past a pure distinct-character-count check. Detect
+// the longest run of consecutive ascending or descending character codes (e.g. "abcdefg" or "9876543") and
+// treat a long one as a human-constructed test value, not a randomly generated credential -- real API
+// keys/tokens essentially never contain a 6+ character monotonic run.
+const MIN_SEQUENTIAL_RUN_LENGTH = 6;
+function hasLongSequentialRun(value: string): boolean {
+  let ascendingRun = 1;
+  let descendingRun = 1;
+  for (let i = 1; i < value.length; i += 1) {
+    const diff = value.charCodeAt(i) - value.charCodeAt(i - 1);
+    ascendingRun = diff === 1 ? ascendingRun + 1 : 1;
+    descendingRun = diff === -1 ? descendingRun + 1 : 1;
+    if (ascendingRun >= MIN_SEQUENTIAL_RUN_LENGTH || descendingRun >= MIN_SEQUENTIAL_RUN_LENGTH) return true;
+  }
+  return false;
+}
+
+/** True for an obvious non-secret filler value: a known placeholder phrase, a string built from at most 2
+ *  distinct characters (e.g. "xxxxxxxxxxxxxxxx", "----------------"), or a long monotonic character-code run
+ *  (e.g. "abcdefghijklmnop123") — real high-entropy secrets never look like any of these. */
+function isPlaceholderSecretValue(value: string): boolean {
+  if (PLACEHOLDER_VALUE_PATTERN.test(value)) return true;
+  if (new Set(value.toLowerCase()).size <= 2) return true;
+  return hasLongSequentialRun(value);
+}
+
+function hasGenericSecretAssignment(text: string): boolean {
+  // No zero-length-match / lastIndex-stall guard needed: the pattern's captured value alone requires 16+
+  // characters, so every match is well over 16 characters long and lastIndex always advances past match.index.
+  GENERIC_SECRET_ASSIGNMENT_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = GENERIC_SECRET_ASSIGNMENT_PATTERN.exec(text)) !== null) {
+    // The pattern's sole capturing group is mandatory (not `?`/`*`-wrapped), so it is always present
+    // whenever the overall match succeeds -- non-null by construction, not a runtime branch.
+    if (!isPlaceholderSecretValue(match[1]!)) return true;
+  }
+  return false;
+}
 
 export interface SecretScanResult {
   found: boolean;
@@ -32,6 +86,7 @@ export interface SecretScanResult {
 export function scanForSecrets(text: string): SecretScanResult {
   if (!text) return { found: false, kinds: [] };
   const kinds = SECRET_PATTERNS.filter((pattern) => pattern.re.test(text)).map((pattern) => pattern.name);
+  if (hasGenericSecretAssignment(text)) kinds.push("generic_secret_assignment");
   return { found: kinds.length > 0, kinds };
 }
 
@@ -48,8 +103,21 @@ export interface SecurityFinding {
 export const EXECUTABLE_CATEGORIES = new Set(["skills", "agents", "commands", "hooks", "mcp", "statuslines"]);
 
 // Concrete credential formats only — NOT the weak heuristics (seed phrase / hot|coldkey) that would
-// false-positive on legitimate Bittensor content.
-const HARD_SECRET_KINDS = new Set(["github_token", "github_pat", "private_key_block", "aws_access_key", "slack_token"]);
+// false-positive on legitimate Bittensor content. #2553: google_api_key/jwt are as format-precise as the
+// original five (near-zero false-positive risk), and generic_secret_assignment already excludes
+// placeholder/type-declaration/schema-shaped matches (see isPlaceholderSecretValue) before the kind is ever
+// produced, so all three are safe unconditional hard blockers — keeping this gate in parity with the PR-diff
+// gate it mirrors (safety.ts's HARD_SECRET_KINDS / secrets-scan.ts).
+const HARD_SECRET_KINDS = new Set([
+  "github_token",
+  "github_pat",
+  "private_key_block",
+  "aws_access_key",
+  "slack_token",
+  "google_api_key",
+  "jwt",
+  "generic_secret_assignment",
+]);
 
 // A literal pipe-to-shell install. Common in legitimate installers (uv/rustup/deno/nvm), so this is a
 // MANUAL flag for a human, never an auto-close.
@@ -64,10 +132,25 @@ function firstLineMatching(text: string, re: RegExp): { n: number; text: string 
 }
 
 function firstSecretLine(text: string): { n: number; kinds: string[] } | null {
+  // Per-line scan first — O(n): catches every LINE-CONTAINED hard kind (github_token, jwt, …) and cites its
+  // exact line. lines[i] is defined for an in-range index (split never yields holes) — assert past
+  // noUncheckedIndexedAccess.
   const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    const hits = scanForSecrets(lines[i] ?? "").kinds.filter((k) => HARD_SECRET_KINDS.has(k));
+    const hits = scanForSecrets(lines[i]!).kinds.filter((k) => HARD_SECRET_KINDS.has(k));
     if (hits.length) return { n: i + 1, kinds: hits };
+  }
+  // The only HARD kind whose keyword-to-value span can WRAP across lines is generic_secret_assignment, so the
+  // per-line scan above can miss it (`client_secret =\n"…"`). Recover it with ONE whole-blob pass over just that
+  // detector — LINEAR, not the quadratic prefix-rescan — citing the line where the non-placeholder match
+  // COMPLETES, so scanSubmissionContent's auto-close stays in parity with the whole-blob PR-diff gate.
+  GENERIC_SECRET_ASSIGNMENT_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = GENERIC_SECRET_ASSIGNMENT_PATTERN.exec(text)) !== null) {
+    if (!isPlaceholderSecretValue(match[1]!)) {
+      const n = text.slice(0, match.index + match[0].length).split(/\r?\n/).length;
+      return { n, kinds: ["generic_secret_assignment"] };
+    }
   }
   return null;
 }

--- a/test/unit/content-lane-security-scan.test.ts
+++ b/test/unit/content-lane-security-scan.test.ts
@@ -5,6 +5,13 @@ import {
   scanLinkedBodiesForSecrets,
   scanSubmissionContent,
 } from "../../src/review/content-lane/security-scan";
+import { scanForSecrets as prDiffScanForSecrets } from "../../src/review/secrets-scan";
+
+// A high-entropy secret VALUE (mixed case + digits, no monotonic run, not a placeholder). Assembled from two
+// literals and only ever joined to a keyword at RUNTIME (interpolation), so the raw source of THIS test file
+// never contains a contiguous `keyword = "value"` secret literal that the repo's own gate would flag as a
+// leak on this very diff.
+const GENERIC_VALUE = "aK9xQ2mZw7Ln" + "4Rv8Pt3Bh6Tc";
 
 describe("scanForSecrets", () => {
   it("detects concrete credential formats", () => {
@@ -16,6 +23,38 @@ describe("scanForSecrets", () => {
   it("returns empty for benign text", () => {
     expect(scanForSecrets("just normal documentation prose")).toEqual({ found: false, kinds: [] });
     expect(scanForSecrets("")).toEqual({ found: false, kinds: [] });
+  });
+
+  // #2553 parity: this content-lane scanner must catch the same higher-recall kinds the PR-diff gate does
+  // (safety.ts / secrets-scan.ts), or a Google key / JWT / generic secret leaks through a content submission
+  // while the identical secret is blocked in a PR diff.
+  it("flags a Google API key and a JWT", () => {
+    expect(scanForSecrets("AIza" + "SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456").kinds).toContain("google_api_key");
+    const fakeJwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");
+  });
+
+  it("flags a generic secret/password/token assignment with a high-entropy value", () => {
+    expect(scanForSecrets(`secret = "${GENERIC_VALUE}"`).kinds).toContain("generic_secret_assignment");
+    expect(scanForSecrets(`api_key: '${GENERIC_VALUE}'`).kinds).toContain("generic_secret_assignment");
+  });
+
+  // The value is interpolated at runtime (never a contiguous `keyword = "value"` literal in this source),
+  // and each is a value the filter must reject: a monotonic run, ≤2-distinct filler, a placeholder phrase,
+  // or a value under the 16-char floor.
+  it.each([
+    ["ascending run", "abcdefghijklmnop123"],
+    ["descending run", "zyxwvutsrqponmlkj987"],
+    ["repeated-character filler (<=2 distinct)", "xxxxxxxxxxxxxxxxxxxx"],
+    ["placeholder phrase", "your-api-key-placeholder"],
+    ["angle-bracket placeholder", "<REDACTED-VALUE-HERE>"],
+    ["under the 16-char floor", "short12345"],
+  ])("does NOT flag a redacted/placeholder/low-entropy value: %s", (_name, value) => {
+    expect(scanForSecrets(`secret = "${value}"`).kinds).not.toContain("generic_secret_assignment");
+  });
+
+  it("does NOT flag a schema field declaration with no literal value", () => {
+    expect(scanForSecrets("password: z.string()").kinds).not.toContain("generic_secret_assignment");
   });
 });
 
@@ -93,6 +132,35 @@ describe("scanSubmissionContent", () => {
     expect(finding?.verdict).toBe("close");
     expect(finding?.reasonCode).toBe("embedded_secret");
   });
+
+  it("hard-closes on each #2553-parity kind (google_api_key, jwt, generic_secret_assignment)", () => {
+    // Each must be a HARD_SECRET_KIND so scanSubmissionContent auto-closes, matching the PR-diff gate.
+    const jwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    for (const line of ["config: AIza" + "SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456", `bearer ${jwt}`, `client_secret = "${GENERIC_VALUE}"`]) {
+      const finding = scanSubmissionContent({ content: `intro line\n${line}`, category: "skills" });
+      expect(finding?.verdict, line).toBe("close");
+      expect(finding?.reasonCode, line).toBe("embedded_secret");
+      expect(finding?.summary, line).toContain("line 2");
+    }
+  });
+
+  it("hard-closes on a MULTILINE generic secret assignment whose value wraps to the next line (auto-close parity)", () => {
+    // generic_secret_assignment is the one HARD kind whose keyword-to-value span can wrap. scanForSecrets over the
+    // whole blob catches it; scanSubmissionContent must too, or a wrapped secret bypasses the auto-close gate the
+    // PR-diff gate (whole-blob) would block. Built from separate literals so this file embeds no contiguous secret.
+    const content = `intro line\nclient_secret =\n"${GENERIC_VALUE}"`;
+    const finding = scanSubmissionContent({ content, category: "guides" });
+    expect(finding?.verdict).toBe("close");
+    expect(finding?.reasonCode).toBe("embedded_secret");
+    expect(finding?.summary).toContain("line 3"); // cited where the wrapped match completes (the value line)
+  });
+
+  it("does NOT hard-close on a MULTILINE generic assignment whose wrapped value is a placeholder", () => {
+    // The whole-blob multiline recovery must apply the SAME placeholder filter as the per-line path — a wrapped
+    // filler value (≤2 distinct chars) is not a real secret and must not auto-close a submission.
+    const content = "intro\nsecret =\n" + '"' + "x".repeat(20) + '"';
+    expect(scanSubmissionContent({ content, category: "guides" })).toBeNull();
+  });
 });
 
 describe("scanLinkedBodiesForSecrets", () => {
@@ -104,5 +172,24 @@ describe("scanLinkedBodiesForSecrets", () => {
 
   it("returns null when no linked body leaks", () => {
     expect(scanLinkedBodiesForSecrets(["clean", "also clean"])).toBeNull();
+  });
+});
+
+// Guards against the exact drift this change fixes: if the content-lane scanner and the PR-diff scanner
+// (secrets-scan.ts) ever detect different kinds for the same input, a secret is enforced on one surface but
+// not the other. All fixtures are assembled from separate literals so this file never embeds a contiguous
+// secret the repo's own gate would flag on this diff.
+describe("secret-scan parity with the PR-diff gate (secrets-scan.ts)", () => {
+  const jwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+  it.each([
+    ["github_token", "token ghp_" + "e".repeat(30)],
+    ["aws_access_key", "AKIA" + "ABCDEFGHIJKLMNOP"],
+    ["private_key_block", "-----BEGIN OPENSSH " + "PRIVATE KEY-----"],
+    ["google_api_key", "AIza" + "SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"],
+    ["jwt", jwt],
+    ["generic_secret_assignment", `secret = "${GENERIC_VALUE}"`],
+    ["benign prose", "just normal documentation prose"],
+  ])("detects the same kinds as the PR-diff gate for %s", (_name, input) => {
+    expect([...scanForSecrets(input).kinds].sort()).toEqual([...prDiffScanForSecrets(input).kinds].sort());
   });
 });


### PR DESCRIPTION
## What
`content-lane/security-scan.ts` (the content-**submission** secret gate) had drifted out of parity with the PR-**diff** secret gate. Both are documented to mirror each other:

- `security-scan.ts` header: *"byte-faithful to reviewbot's … + the shared core/secrets-scan.ts (inlined here)"*
- `safety.ts` header: *"This mirrors the same gate the content lane already uses (src/review/content-lane/security-scan.ts)"*

`#2553` widened the PR-diff side — `secrets-scan.ts`'s `SECRET_PATTERNS` and `safety.ts`'s `HARD_SECRET_KINDS` — with **`google_api_key`**, **`jwt`**, and **`generic_secret_assignment`**. The content-submission gate was never updated.

## Why it matters (security gap)
`scanSubmissionContent` auto-**closes** a submission on a `HARD_SECRET_KINDS` hit, and `scanLinkedBodiesForSecrets` flags **manual**. Because those three kinds were missing here, a **Google API key, JWT, or generic `secret = "…"` assignment embedded in a submitted skill/agent/command was neither detected nor auto-closed** — while the identical secret in a PR diff is hard-blocked. Same secret, inconsistent enforcement depending on the surface.

Concrete: a submission containing `AIzaSy…` (35 chars) or `eyJ….eyJ….sig` previously returned `{ found: false }` from this gate.

## Fix
Port the two missing patterns and the full generic-secret-assignment detector (placeholder-phrase, ≤2-distinct-char, and monotonic-run filtering — byte-faithful to `secrets-scan.ts`) and add all three kinds to this gate's `HARD_SECRET_KINDS`, restoring the documented parity. The conservative auto-close posture is preserved: `#2553`'s own rationale (quoted in `safety.ts`) already establishes these three as *"format-precise … near-zero false-positive"* / placeholder-filtered, hence safe unconditional hard blockers.

## Tests
Mirrors `secrets-scan.test.ts` coverage into `content-lane-security-scan.test.ts`: detection of `google_api_key`/`jwt`/`generic_secret_assignment`, the non-flagging branches (monotonic runs, ≤2-distinct filler, placeholder phrases, schema fields, sub-16-char values), and integration cases asserting `scanSubmissionContent` now hard-closes on each new kind (cited to the line). Full unit suite green except the pre-existing CRLF/Node/Sentry env failures unrelated to this change.