### PR TITLE
fix(signals): flag missing_tests only when a PR touches real source

### DIFF
--- a/src/signals/contributor-open-pr-monitor.ts
+++ b/src/signals/contributor-open-pr-monitor.ts
@@ -11,7 +11,7 @@ import {
 import type { CheckSummaryRecord, PullRequestFileRecord, PullRequestRecord, PullRequestReviewRecord } from "../types";
 import { nowIso } from "../utils/json";
 import { buildRoleContext } from "./engine";
-import { isFailingCheckSummary } from "./local-branch";
+import { isCodeFile, isFailingCheckSummary } from "./local-branch";
 import { isTestPath } from "./test-evidence";
 
 export type OpenPrWorkClassification =
@@ -260,7 +260,10 @@ function normalizeTitle(title: string): string {
 
 function missingTestsFromFiles(files: PullRequestFileRecord[]): boolean {
   if (files.length === 0) return false;
-  const codeFiles = files.filter((file) => file.path && !isTestPath(file.path));
+  // "Code" is genuine source (isCodeFile), not merely "anything that isn't a test": a docs-, lockfile-, or
+  // config-only PR has no code to cover and must not be flagged missing_tests. Mirrors the isCodeFile code-side
+  // used by slop.ts's buildMissingTestEvidenceFinding and the local-branch/local-scorer source predicates.
+  const codeFiles = files.filter((file) => file.path && isCodeFile(file.path));
   const testFiles = files.filter((file) => file.path && isTestPath(file.path));
   return codeFiles.length > 0 && testFiles.length === 0;
 }

--- a/test/unit/contributor-open-pr-monitor.test.ts
+++ b/test/unit/contributor-open-pr-monitor.test.ts
@@ -353,6 +353,15 @@ describe("contributor open PR monitor", () => {
     expect(missingTestsFromFiles([{ path: "service.py" } as never, { path: "service_test.py" } as never])).toBe(false);
     expect(missingTestsFromFiles([{ path: "lib/widget.rb" } as never, { path: "models/widget_test.rb" } as never])).toBe(false);
     expect(missingTestsFromFiles([{ path: "lib/widget.rb" } as never, { path: "widget_spec.rb" } as never])).toBe(false);
+
+    // A PR touching only non-source artifacts (docs, lockfile, CI/config) has no code to cover, so it is NOT
+    // missing_tests. Regression: the code side used `!isTestPath`, which counted every non-test file as code.
+    expect(missingTestsFromFiles([{ path: "README.md" } as never])).toBe(false);
+    expect(missingTestsFromFiles([{ path: "pnpm-lock.yaml" } as never])).toBe(false);
+    expect(missingTestsFromFiles([{ path: "docs/guide.md" } as never])).toBe(false);
+    expect(missingTestsFromFiles([{ path: "package.json" } as never])).toBe(false);
+    // Genuine source alongside docs, with no test, is still missing_tests.
+    expect(missingTestsFromFiles([{ path: "src/a.ts" } as never, { path: "README.md" } as never])).toBe(true);
   });
 
   it("returns an empty monitor when the contributor has no cached open PRs", async () => {


### PR DESCRIPTION
The open-PR monitor defined the "code" side of its missing-tests check as `!isTestPath`:

```
const codeFiles = files.filter((file) => file.path && !isTestPath(file.path));
```

So **any** non-test file — `README.md`, `pnpm-lock.yaml`, `package.json`, a docs `.md` — counted as code that "needs tests." A docs-only or lockfile-bump PR (which has no source to cover) was therefore classified `missing_tests`, feeding `mapPendingClassToWorkClassification` → `cleanupFirst` triage and `priorityRank` with a false signal.

## Why `isCodeFile` is the correct predicate (not a convention call)
The rest of the codebase already agrees that "code" means genuine source, not "anything that is not a test":
- `slop.ts` `buildMissingTestEvidenceFinding` uses `changedPaths.filter(isCodeFile)` for its code side, and `slop.ts` counts code files with `isCodeFile`.
- `local-branch.ts` / `local-scorer.ts` use `isCodeFile` as the source predicate.
- This function`s own existing tests only ever use real source (`foo.go`, `service.py`, `widget.rb`) as the "code" side.

`isCodeFile` is a source-extension allowlist that already excludes tests, so it is the right, established predicate.

## Fix
Import `isCodeFile` (already exported from `./local-branch`, which this file already imports from) and use it for the code side. Fully backward-compatible: genuine-source cases are unchanged; only non-source-only PRs stop being flagged.

## Tests
Adds regression cases: docs/lockfile/`package.json`-only PRs → not `missing_tests`; source-plus-docs with no test → still `missing_tests`. Verified the new cases FAIL on current `main` and PASS with the fix; `contributor-open-pr-monitor`, `slop`, and `local-branch-file-classifiers` suites stay green.

No linked issue: issue creation is unavailable for this account.