### PR TITLE
fix(agent-queue): re-gate a staged close/merge on the admin (#2133) close exemption

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -5,6 +5,7 @@ import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/
 import { executeAgentMaintenanceActions, pendingActionToPlanned } from "./agent-action-executor";
 import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, type PlannedAgentAction } from "../settings/agent-actions";
 import { findBlacklistEntry } from "../settings/contributor-blacklist";
+import { parseGitHubLoginList } from "../auth/security";
 import { isCloseHoldOnly, isHoldOnly } from "../review/outcomes-wire";
 import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestReviewDecision } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
@@ -127,8 +128,13 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     const repoOwner = pending.repoFullName.includes("/") ? pending.repoFullName.slice(0, pending.repoFullName.indexOf("/")) : "";
     const authorLogin = pr.authorLogin ?? "";
     const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
+    // Fleet-operator identity (#2133): an ADMIN_GITHUB_LOGINS login gets the same never-auto-closed exemption
+    // as the owner, so it must be re-gated on closeOwnerAuthors here too — matching the live planner
+    // (queue/processors.ts) and staging (settings/agent-actions.ts closeEligible). Without this, an admin PR
+    // staged for close while the toggle was on would still close after the operator turns it off.
+    const authorIsAdmin = authorLogin.length > 0 && parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS).has(authorLogin.toLowerCase());
     const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
-    const closeEligible = (!authorIsOwner && !authorIsAutomationBot) || (authorIsOwner && settings.closeOwnerAuthors === true);
+    const closeEligible = (!authorIsOwner && !authorIsAdmin && !authorIsAutomationBot) || ((authorIsOwner || authorIsAdmin) && settings.closeOwnerAuthors === true);
     let stillJustified = closeEligible;
     if (closeEligible) {
       const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, pending.repoFullName);
@@ -245,8 +251,11 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     const repoOwner = pending.repoFullName.includes("/") ? pending.repoFullName.slice(0, pending.repoFullName.indexOf("/")) : "";
     const authorLogin = pr.authorLogin ?? "";
     const authorIsOwner = authorLogin.length > 0 && authorLogin.toLowerCase() === repoOwner.toLowerCase();
+    // Fleet-operator identity (#2133): mirror the primary close-eligibility exemption for an admin login, so a
+    // now-close-eligible admin PR supersedes its staged merge on the same terms an owner's does.
+    const authorIsAdmin = authorLogin.length > 0 && parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS).has(authorLogin.toLowerCase());
     const authorIsAutomationBot = isProtectedAutomationAuthor(pr.authorLogin);
-    const closeEligible = (!authorIsOwner && !authorIsAutomationBot) || (authorIsOwner && settings.closeOwnerAuthors === true);
+    const closeEligible = (!authorIsOwner && !authorIsAdmin && !authorIsAutomationBot) || ((authorIsOwner || authorIsAdmin) && settings.closeOwnerAuthors === true);
     if (closeEligible) {
       const linkedIssueRulesConfig = await loadLinkedIssueHardRules(env, pending.repoFullName);
       // Best-effort mint, same as the #2126 CI/mergeable/review re-check above: a failed mint here does NOT

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -407,6 +407,60 @@ describe("agent approval queue (#779)", () => {
     expect(closeStillEligible).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
   });
 
+  it("REGRESSION: accept supersedes a staged close for a fleet-ADMIN author when closeOwnerAuthors is turned off before accept (#2133 admin exemption)", async () => {
+    // #2133 gives an ADMIN_GITHUB_LOGINS login the same never-auto-closed exemption as the owner, so the
+    // accept-time re-check must re-gate an admin on closeOwnerAuthors exactly like an owner. The old re-check
+    // omitted authorIsAdmin, treating a non-owner admin as an ordinary contributor (always close-eligible), so
+    // an admin PR staged while the toggle was on would still close after the operator turned it off.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x", ADMIN_GITHUB_LOGINS: "fleetadmin" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, closeOwnerAuthors: false });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "fleetadmin" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    // Intentionally no resolveLinkedIssueHardRule mock: an ineligible admin must be superseded WITHOUT the rule
+    // being consulted (asserted below), so queuing an unconsumed `...Once` here would leak to later tests.
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("no_longer_close_eligible");
+    expect(resolveLinkedIssueHardRule).not.toHaveBeenCalled();
+    const { closePullRequest: closeAdminNoLonger } = await import("../../src/github/pr-actions");
+    expect(closeAdminNoLonger).not.toHaveBeenCalled();
+  });
+
+  it("accept still executes a staged close for a fleet-ADMIN author when closeOwnerAuthors is (still) true at accept time", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x", ADMIN_GITHUB_LOGINS: "fleetadmin" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" }, closeOwnerAuthors: true });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "fleetadmin" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "still ineligible" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "ineligible", closeKind: "linked-issue-hard-rule", expectedHeadSha: "h7" }, reason: "linked issue ineligible" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest: closeAdminStill } = await import("../../src/github/pr-actions");
+    expect(closeAdminStill).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
+  it("supersedes a staged MERGE for a fleet-ADMIN author when the linked-issue rule is now violated and admin-close is enabled (#2133 merge-side exemption)", async () => {
+    // Merge-re-check side of the same #2133 fix: an admin is close-eligible (closeOwnerAuthors true), so a
+    // linked-issue rule that BECAME violated must supersede the admin's staged merge — exactly as it would an
+    // owner's. Before the fix, the merge re-check ignored authorIsAdmin and (for an owner-repo admin) still
+    // treated them as an ordinary contributor; here it exercises the admin arm of closeEligible.
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x", ADMIN_GITHUB_LOGINS: "fleetadmin" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" }, closeOwnerAuthors: true });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "fleetadmin" }, head: { sha: "h7" }, labels: [], body: "Closes #9" });
+    vi.mocked(resolveLinkedIssueHardRule).mockResolvedValueOnce({ violated: true, reason: "admin's linked issue is ineligible" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash", expectedHeadSha: "h7" }, reason: "clean" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("linked_issue_hard_rule");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+
   it("accept tolerates a slash-less repoFullName for a staged linked-issue hard-rule close (defensive fallback)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "solorepo", autonomy: { close: "auto_with_approval" } });


### PR DESCRIPTION
## What
The accept-time re-checks in `agent-approval-queue.ts` re-derive `closeEligible` against the **current** settings so a staged close/merge doesn't act on a stale `closeOwnerAuthors` toggle (the head-SHA pin can't catch a settings flip). But **both** copies (the close re-check and the merge re-check) computed:

```ts
const closeEligible = (!authorIsOwner && !authorIsAutomationBot) || (authorIsOwner && settings.closeOwnerAuthors === true);
```

— omitting `authorIsAdmin` entirely.

## Why it matters
`#2133` folds the fleet-operator allowlist (`ADMIN_GITHUB_LOGINS`) into the **same never-auto-closed exemption** as the repo owner — see `settings/agent-actions.ts` (`isContributor = !owner && !admin && !bot`; `closeEligible = isContributor || ((owner || admin) && closeOwnerAuthors)`) and `queue/processors.ts`. The approval-queue re-checks never mirrored it, so a **non-owner admin** fell into the first clause and was treated as an ordinary contributor — *always* close-eligible.

**Observable consequence:** an admin PR staged for a `linked-issue-hard-rule` close while `closeOwnerAuthors` was **on** would still auto-close after the operator turned it **off** — the owner is correctly superseded by the re-check, but the admin was not (the re-check's whole purpose is to catch exactly that toggle flip). Same gap on the merge-re-check's `closeEligible`.

## Fix
Mirror the primary derivation in both re-checks:
```ts
const authorIsAdmin = authorLogin.length > 0 && parseGitHubLoginList(env.ADMIN_GITHUB_LOGINS).has(authorLogin.toLowerCase());
const closeEligible = (!authorIsOwner && !authorIsAdmin && !authorIsAutomationBot) || ((authorIsOwner || authorIsAdmin) && settings.closeOwnerAuthors === true);
```

## Tests
Adds admin regressions mirroring the existing owner ones: (1) accept **supersedes** a staged close for a fleet-admin when `closeOwnerAuthors` is turned off before accept (fails on the old code); (2) accept **still executes** the close when it's still on; (3) the merge-re-check **supersedes** an admin's staged merge when the linked-issue rule is now violated and admin-close is enabled. All branches on the changed lines covered; full approval-queue suite green (59 tests).