### PR TITLE
fix(selfhost): ignore YAML inline comments on review-skill name and when

### DIFF
--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -174,11 +174,14 @@ export function parseReviewSkill(filename: string, text: string): RepoReviewSkil
   const fm = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/.exec(text);
   const head = fm?.[1] ?? "";
   const body = (fm?.[2] ?? text).trim();
-  // Strip surrounding quotes on `name` too, symmetric with `when` below — a quoted scalar
-  // (`name: "SQL Rubric"`) is ordinary YAML frontmatter, so the quotes must not survive into the label.
-  const nameRaw = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1]?.trim();
+  // Drop an unquoted YAML inline comment (` # …`) before stripping surrounding quotes — symmetric with
+  // isReviewSkillEnabled. A trailing comment (`when: "**/*.sql"  # only sql`) is not part of the scalar; left in
+  // place it corrupts the label and, for `when`, produces a glob that never matches so the skill silently never
+  // fires. Also strip surrounding quotes on `name`, symmetric with `when` — a quoted scalar (`name: "SQL Rubric"`)
+  // is ordinary frontmatter, so neither the quotes nor the comment must survive into the label/glob.
+  const nameRaw = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1]?.replace(/\s+#.*$/, "").trim();
   const name = (nameRaw ?? "").replace(/^["']|["']$/g, "") || filename.replace(/\.md$/i, "");
-  const whenRaw = /(?:^|\n)when:\s*(.+)/.exec(head)?.[1]?.trim();
+  const whenRaw = /(?:^|\n)when:\s*(.+)/.exec(head)?.[1]?.replace(/\s+#.*$/, "").trim();
   const when = (whenRaw ?? "always").replace(/^["']|["']$/g, "") || "always";
   return { name, when, body };
 }

--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -168,24 +168,26 @@ function reviewContextFolders(repoFullName: string): string[] {
   return [join(`${owner}__${repo}`, "review"), join(repo, "review")];
 }
 
-/** Extract a YAML frontmatter scalar's value, quote-aware. A double/single-quoted scalar returns its quoted body
- *  verbatim (an inline comment or stray text after the closing quote is dropped, and a `#` INSIDE the quotes — e.g.
- *  `"SQL #1 Rubric"` — is preserved as part of the value). An unquoted scalar drops a trailing ` # …` inline comment
- *  (whitespace-before-hash; `a#b` keeps its `#`) and any stray surrounding quote. */
-function reviewSkillScalar(raw: string): string {
-  const s = raw.trim();
-  const quote = s[0];
-  if (quote === '"' || quote === "'") {
-    const close = s.indexOf(quote, 1);
-    if (close !== -1) return s.slice(1, close); // well-formed quoted scalar; a `#` within it is not a comment
+/** Read a `name:` / `when:` frontmatter value robustly. The value text (everything after the key on its line) is
+ *  parsed as a standalone YAML scalar, so the real parser handles quoting, escaped `\"` / doubled `''` quotes, and a
+ *  trailing inline comment — `"SQL #1 Rubric"` keeps its internal `#`, `SQL Rubric  # note` drops the comment. A
+ *  value the YAML parser rejects standalone — notably an unquoted glob that begins with a `*` wildcard — falls back
+ *  to a lenient strip (drop an inline comment and any surrounding quote) so those globs keep working. */
+function reviewSkillScalar(rawValue: string): string {
+  try {
+    const parsed = parseYaml(rawValue);
+    if (typeof parsed === "string") return parsed.trim();
+  } catch {
+    // not a standalone-parseable scalar (e.g. an unquoted *-leading glob) — fall through to the lenient strip
   }
-  return s.replace(/\s+#.*$/, "").replace(/^["']|["']$/g, "").trim();
+  return rawValue.replace(/\s+#.*$/, "").replace(/^["']|["']$/g, "").trim();
 }
 
 /** Parse a skill markdown file into {name, when, body}. YAML frontmatter (`---\nname:\nwhen:\n---`) is optional; name
- *  defaults to the filename and `when` to "always". `name`/`when` are read as quote-aware scalars so a quoted value
- *  keeps its contents (incl. an internal `#`) while a trailing inline comment is dropped — an unstripped comment
- *  corrupts the label and turns `when` into a glob that never matches, silently disabling the rubric. */
+ *  defaults to the filename and `when` to "always". `name`/`when` are decoded through the YAML parser (see
+ *  reviewSkillScalar) so a quoted value keeps its contents (incl. an internal `#`) while a trailing inline comment is
+ *  dropped — an unstripped comment corrupts the label and turns `when` into a glob that never matches, silently
+ *  disabling the rubric. */
 export function parseReviewSkill(filename: string, text: string): RepoReviewSkill {
   const fm = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/.exec(text);
   const head = fm?.[1] ?? "";

--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -168,21 +168,32 @@ function reviewContextFolders(repoFullName: string): string[] {
   return [join(`${owner}__${repo}`, "review"), join(repo, "review")];
 }
 
+/** Extract a YAML frontmatter scalar's value, quote-aware. A double/single-quoted scalar returns its quoted body
+ *  verbatim (an inline comment or stray text after the closing quote is dropped, and a `#` INSIDE the quotes — e.g.
+ *  `"SQL #1 Rubric"` — is preserved as part of the value). An unquoted scalar drops a trailing ` # …` inline comment
+ *  (whitespace-before-hash; `a#b` keeps its `#`) and any stray surrounding quote. */
+function reviewSkillScalar(raw: string): string {
+  const s = raw.trim();
+  const quote = s[0];
+  if (quote === '"' || quote === "'") {
+    const close = s.indexOf(quote, 1);
+    if (close !== -1) return s.slice(1, close); // well-formed quoted scalar; a `#` within it is not a comment
+  }
+  return s.replace(/\s+#.*$/, "").replace(/^["']|["']$/g, "").trim();
+}
+
 /** Parse a skill markdown file into {name, when, body}. YAML frontmatter (`---\nname:\nwhen:\n---`) is optional; name
- *  defaults to the filename and `when` to "always". */
+ *  defaults to the filename and `when` to "always". `name`/`when` are read as quote-aware scalars so a quoted value
+ *  keeps its contents (incl. an internal `#`) while a trailing inline comment is dropped — an unstripped comment
+ *  corrupts the label and turns `when` into a glob that never matches, silently disabling the rubric. */
 export function parseReviewSkill(filename: string, text: string): RepoReviewSkill {
   const fm = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/.exec(text);
   const head = fm?.[1] ?? "";
   const body = (fm?.[2] ?? text).trim();
-  // Drop an unquoted YAML inline comment (` # …`) before stripping surrounding quotes — symmetric with
-  // isReviewSkillEnabled. A trailing comment (`when: "**/*.sql"  # only sql`) is not part of the scalar; left in
-  // place it corrupts the label and, for `when`, produces a glob that never matches so the skill silently never
-  // fires. Also strip surrounding quotes on `name`, symmetric with `when` — a quoted scalar (`name: "SQL Rubric"`)
-  // is ordinary frontmatter, so neither the quotes nor the comment must survive into the label/glob.
-  const nameRaw = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1]?.replace(/\s+#.*$/, "").trim();
-  const name = (nameRaw ?? "").replace(/^["']|["']$/g, "") || filename.replace(/\.md$/i, "");
-  const whenRaw = /(?:^|\n)when:\s*(.+)/.exec(head)?.[1]?.replace(/\s+#.*$/, "").trim();
-  const when = (whenRaw ?? "always").replace(/^["']|["']$/g, "") || "always";
+  const nameRaw = /(?:^|\n)name:\s*(.+)/.exec(head)?.[1];
+  const name = (nameRaw !== undefined ? reviewSkillScalar(nameRaw) : "") || filename.replace(/\.md$/i, "");
+  const whenRaw = /(?:^|\n)when:\s*(.+)/.exec(head)?.[1];
+  const when = (whenRaw !== undefined ? reviewSkillScalar(whenRaw) : "always") || "always";
   return { name, when, body };
 }
 

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -226,6 +226,14 @@ describe("parseReviewSkill (#review-skills)", () => {
     expect(parseReviewSkill("y.md", "---\nname: 'Voice Guide'\n---\nb").name).toBe("Voice Guide");
     expect(parseReviewSkill("fallback.md", '---\nname: ""\n---\nb').name).toBe("fallback");
   });
+  it("ignores a YAML inline comment on name and when, symmetric with enabled", () => {
+    // A trailing ` # …` is a YAML comment, not part of the scalar: left in, it corrupts the label and turns
+    // `when` into a glob that never matches, silently disabling the rubric.
+    expect(parseReviewSkill("sql.md", '---\nname: SQL Rubric  # the sql one\nwhen: "**/*.sql"  # only sql\n---\nBody.\n')).toEqual({ name: "SQL Rubric", when: "**/*.sql", body: "Body." });
+    // A `#` with no preceding whitespace is part of the value (real YAML), not a comment — must be preserved.
+    expect(parseReviewSkill("cs.md", '---\nname: "C# Rubric"\n---\nb').name).toBe("C# Rubric");
+    expect(parseReviewSkill("z.md", "---\nname: a#b\n---\nb").name).toBe("a#b");
+  });
 });
 
 describe("isReviewSkillEnabled (#review-skills)", () => {

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -226,13 +226,17 @@ describe("parseReviewSkill (#review-skills)", () => {
     expect(parseReviewSkill("y.md", "---\nname: 'Voice Guide'\n---\nb").name).toBe("Voice Guide");
     expect(parseReviewSkill("fallback.md", '---\nname: ""\n---\nb').name).toBe("fallback");
   });
-  it("ignores a YAML inline comment on name and when, symmetric with enabled", () => {
+  it("ignores a trailing YAML inline comment on name and when, quote-aware", () => {
     // A trailing ` # …` is a YAML comment, not part of the scalar: left in, it corrupts the label and turns
     // `when` into a glob that never matches, silently disabling the rubric.
     expect(parseReviewSkill("sql.md", '---\nname: SQL Rubric  # the sql one\nwhen: "**/*.sql"  # only sql\n---\nBody.\n')).toEqual({ name: "SQL Rubric", when: "**/*.sql", body: "Body." });
     // A `#` with no preceding whitespace is part of the value (real YAML), not a comment — must be preserved.
     expect(parseReviewSkill("cs.md", '---\nname: "C# Rubric"\n---\nb').name).toBe("C# Rubric");
     expect(parseReviewSkill("z.md", "---\nname: a#b\n---\nb").name).toBe("a#b");
+    // A `#` INSIDE a quoted scalar — even with preceding whitespace — is part of the value, not a comment.
+    expect(parseReviewSkill("h.md", '---\nname: "SQL #1 Rubric"\nwhen: "src/#hot/**"  # trailing note\n---\nb')).toEqual({ name: "SQL #1 Rubric", when: "src/#hot/**", body: "b" });
+    // A malformed unterminated quote degrades to stripping the stray leading quote (back-compat, not a crash).
+    expect(parseReviewSkill("u.md", '---\nname: "unterminated\n---\nb').name).toBe("unterminated");
   });
 });
 

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -235,6 +235,13 @@ describe("parseReviewSkill (#review-skills)", () => {
     expect(parseReviewSkill("z.md", "---\nname: a#b\n---\nb").name).toBe("a#b");
     // A `#` INSIDE a quoted scalar — even with preceding whitespace — is part of the value, not a comment.
     expect(parseReviewSkill("h.md", '---\nname: "SQL #1 Rubric"\nwhen: "src/#hot/**"  # trailing note\n---\nb')).toEqual({ name: "SQL #1 Rubric", when: "src/#hot/**", body: "b" });
+    // YAML-escaped double quotes and doubled single quotes are decoded, not treated as the terminator.
+    expect(parseReviewSkill("e.md", '---\nname: "SQL \\"Index\\" Rubric"\n---\nb').name).toBe('SQL "Index" Rubric');
+    expect(parseReviewSkill("o.md", "---\nname: 'Owner''s Rubric'\n---\nb").name).toBe("Owner's Rubric");
+    // An unquoted *-leading glob is not valid standalone YAML; it must still survive as the literal when-glob.
+    expect(parseReviewSkill("g.md", "---\nwhen: **/*.ts\n---\nb").when).toBe("**/*.ts");
+    // A non-string YAML scalar (e.g. a bare number) falls through to the literal text rather than a typed value.
+    expect(parseReviewSkill("n.md", "---\nname: 42\n---\nb").name).toBe("42");
     // A malformed unterminated quote degrades to stripping the stray leading quote (back-compat, not a crash).
     expect(parseReviewSkill("u.md", '---\nname: "unterminated\n---\nb').name).toBe("unterminated");
   });


### PR DESCRIPTION
A self-host operator annotating their private review rubrics inline — the most common way to document YAML — silently breaks them today:

```
---
name: SQL Rubric   # our sql-index rubric
when: "**/*.sql"   # only sql files
---
```

`parseReviewSkill` captured the whole value tail and stripped only surrounding quotes, not a trailing comment:
- `name` became `"SQL Rubric   # our sql-index rubric"` — the comment leaked into the label rendered in the reviewer prompt (`## skill: …`).
- `when` became `'**/*.sql"  # only sql files'` — a stray quote + comment. `reviewSkillApplies` glob-matches that against changed paths, so it **never matches** and the rubric **silently never fires**, with no error (a container-private file with no CI lint over it).

## Fix
Decode `name`/`when` through the **YAML parser** (`yaml`, already imported in this module) instead of hand-rolling scalar parsing. Each value is parsed as a standalone YAML scalar, so quoting, escaped `\"` / doubled `''` quotes, and trailing inline comments are all handled correctly:
- `name: "SQL #1 Rubric"` → `SQL #1 Rubric` (internal `#` preserved)
- `name: "SQL \"Index\" Rubric"` → `SQL "Index" Rubric`; `name: 'Owner''s Rubric'` → `Owner's Rubric`
- `name: SQL Rubric  # note` → `SQL Rubric` (comment dropped); `name: a#b` → `a#b`

A value the parser rejects standalone — notably an unquoted `*`-leading glob (`when: **/…`, which is invalid standalone YAML) — falls back to a lenient inline-comment/quote strip so those globs keep working exactly as before. Each field is parsed independently, so a malformed value in one never affects the other.

## Tests
Adds regression cases for inline comments, internal `#`, escaped/doubled quotes, an unquoted glob (no regression), a non-string scalar, and a malformed unterminated quote. Verified the pre-fix behavior FAILS these and the fix PASSES; the full `private-config` + `focus-manifest` suites stay green.

No linked issue: issue creation is unavailable for this account.
