### PR TITLE
feat(miner): add deny-hooks check CLI command

### DIFF
--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from "node:module";
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
+import { runDenyCheck } from "../lib/deny-check.js";
 import {
   awaitOpportunisticUpdateCheck,
   resolveUpgradeCommand,
@@ -39,6 +40,12 @@ if (
   printVersion({ packageName, packageVersion });
   await awaitOpportunisticUpdateCheck(updateCheck);
   process.exit(0);
+}
+
+if (cliArgs[0] === "hooks" && cliArgs[1] === "check") {
+  const exitCode = runDenyCheck(cliArgs.slice(2));
+  await awaitOpportunisticUpdateCheck(updateCheck);
+  process.exit(exitCode);
 }
 
 const exitCode = runCli(cliArgs, { packageName });

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -14,6 +14,7 @@ export function printHelp(input) {
       "  gittensory-miner --version",
       "  gittensory-miner help",
       "  gittensory-miner version",
+      "  gittensory-miner hooks check --tool <name> --input <json> [--json]",
       "",
       "Options:",
       "  --no-update-check  Skip the npm registry version nudge (also GITTENSORY_MINER_NO_UPDATE_CHECK=1)",

--- a/packages/gittensory-miner/lib/deny-check.d.ts
+++ b/packages/gittensory-miner/lib/deny-check.d.ts
@@ -1,0 +1,11 @@
+export type ParsedDenyCheckArgs =
+  | {
+      tool: string;
+      input: Record<string, unknown>;
+      json: boolean;
+    }
+  | { error: string };
+
+export function parseDenyCheckArgs(args: string[]): ParsedDenyCheckArgs;
+
+export function runDenyCheck(args: string[]): number;

--- a/packages/gittensory-miner/lib/deny-check.js
+++ b/packages/gittensory-miner/lib/deny-check.js
@@ -1,0 +1,76 @@
+import { evaluateDenyHooks } from "./deny-hooks.js";
+
+const DENY_CHECK_USAGE =
+  "Usage: gittensory-miner hooks check --tool <name> --input <json> [--json]";
+
+function parseToolInput(raw) {
+  if (raw === undefined) {
+    return { error: "Missing value for --input." };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { error: "Tool input must be a JSON object." };
+    }
+    return { value: parsed };
+  } catch {
+    return { error: "Tool input must be valid JSON." };
+  }
+}
+
+export function parseDenyCheckArgs(args) {
+  const options = {
+    json: false,
+    tool: undefined,
+    input: undefined,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--tool" || token === "--name") {
+      const tool = args[++index];
+      if (!tool) return { error: "Missing value for --tool." };
+      options.tool = tool;
+      continue;
+    }
+    if (token === "--input") {
+      const parsed = parseToolInput(args[++index]);
+      if ("error" in parsed) return { error: parsed.error };
+      options.input = parsed.value;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    return { error: DENY_CHECK_USAGE };
+  }
+
+  if (!options.tool || !options.input) {
+    return { error: DENY_CHECK_USAGE };
+  }
+
+  return options;
+}
+
+export function runDenyCheck(args) {
+  const parsed = parseDenyCheckArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    return 2;
+  }
+
+  const verdict = evaluateDenyHooks({ name: parsed.tool, input: parsed.input });
+  if (parsed.json) {
+    console.log(JSON.stringify(verdict));
+  } else if (!verdict.allowed) {
+    console.error(verdict.blockedBy?.reason ?? "Blocked by deny hook.");
+  } else {
+    console.log("allowed");
+  }
+
+  return verdict.allowed ? 0 : 1;
+}

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-cli-deny-check.test.ts
+++ b/test/unit/miner-cli-deny-check.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseDenyCheckArgs, runDenyCheck } from "../../packages/gittensory-miner/lib/deny-check.js";
+
+describe("gittensory-miner hooks check command", () => {
+  it("parseDenyCheckArgs requires tool and JSON input", () => {
+    expect(parseDenyCheckArgs([])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner hooks check"),
+    });
+    expect(parseDenyCheckArgs(["--tool", "Write"])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner hooks check"),
+    });
+    expect(parseDenyCheckArgs(["--tool", "Write", "--input", "[]"])).toEqual({
+      error: "Tool input must be a JSON object.",
+    });
+    expect(
+      parseDenyCheckArgs([
+        "--tool",
+        "Write",
+        "--input",
+        '{"file_path":"src/a.ts"}',
+        "--json",
+      ]),
+    ).toEqual({
+      tool: "Write",
+      input: { file_path: "src/a.ts" },
+      json: true,
+    });
+  });
+
+  it("runDenyCheck exits 1 when a built-in rule blocks the call", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runDenyCheck([
+        "--tool",
+        "Write",
+        "--input",
+        '{"file_path":".github/workflows/ci.yml"}',
+      ]),
+    ).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("CI workflows"));
+  });
+
+  it("runDenyCheck exits 0 for allowed calls and prints JSON when requested", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(
+      runDenyCheck([
+        "--tool",
+        "Write",
+        "--input",
+        '{"file_path":"src/a.ts"}',
+        "--json",
+      ]),
+    ).toBe(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"allowed":true'));
+  });
+
+  it("runDenyCheck returns exit code 2 for malformed flags", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runDenyCheck(["--tool", "Write", "--input", "{bad json"])).toBe(2);
+    expect(error).toHaveBeenCalledWith("Tool input must be valid JSON.");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `gittensory-miner hooks check --tool <name> --input <json>` to evaluate proposed tool calls against the built-in `DEFAULT_DENY_RULES`.
- Support `--json` output for scripting and document the command in `--help`.
- Unit tests cover arg parsing, allow/block exit codes, and malformed JSON handling.

## Test plan
- [x] `npm test -- test/unit/miner-cli-deny-check.test.ts`
- [ ] CI green on upstream
