### PR TITLE
fix(orb-broker): validate App credentials only after enrollment is proven valid

### DIFF
--- a/src/orb/broker.ts
+++ b/src/orb/broker.ts
@@ -54,12 +54,6 @@ export type BrokerResult = { token: string; installationId: number; expiresAt: s
  *  install. installation_id is read from the enrollment row, never the caller; the install must still be
  *  registered=1 and neither suspended nor removed at mint time (the gate is re-checked, not trusted from issue). */
 export async function brokerOrbToken(env: Env, secret: string): Promise<BrokerResult> {
-  // Validate Orb App credentials up front so a misconfiguration returns a structured error (503) rather than an
-  // unhandled exception that manifests as a generic 500 to the self-hosted engine.
-  if (!env.ORB_GITHUB_APP_ID || !env.ORB_GITHUB_APP_PRIVATE_KEY) {
-    console.error(JSON.stringify({ level: "error", event: "orb_broker_misconfigured", message: "ORB_GITHUB_APP_ID or ORB_GITHUB_APP_PRIVATE_KEY is not set; broker cannot mint tokens." }));
-    return { error: "broker_misconfigured" };
-  }
   // Warn when TOKEN_ENCRYPTION_SECRET is absent — without it, the broker cache is bypassed and every exchange hits
   // GitHub's token endpoint, dramatically increasing exposure to throttle-induced failures.
   if (!env.TOKEN_ENCRYPTION_SECRET) {
@@ -83,6 +77,14 @@ export async function brokerOrbToken(env: Env, secret: string): Promise<BrokerRe
   if (cached) {
     await touchLastToken(env, row.enroll_id);
     return { token: cached.token, installationId: row.installation_id, expiresAt: cached.expiresAt };
+  }
+  // Validate Orb App credentials only now that the caller is proven to hold a valid, eligible enrollment — NOT
+  // up front. Checking credentials before the enrollment lookup would let an unauthenticated caller (any bad
+  // secret) distinguish "broker misconfigured" from "invalid secret" via the response code alone, leaking the
+  // server's deployment-config state to callers who never proved they hold a real enrollment (#2710).
+  if (!env.ORB_GITHUB_APP_ID || !env.ORB_GITHUB_APP_PRIVATE_KEY) {
+    console.error(JSON.stringify({ level: "error", event: "orb_broker_misconfigured", message: "ORB_GITHUB_APP_ID or ORB_GITHUB_APP_PRIVATE_KEY is not set; broker cannot mint tokens." }));
+    return { error: "broker_misconfigured" };
   }
   const minted = await createOrbInstallationToken(env, row.installation_id);
   await cacheOrbToken(env, row.enroll_id, minted);

--- a/test/integration/orb-broker.test.ts
+++ b/test/integration/orb-broker.test.ts
@@ -16,6 +16,14 @@ const seedInstall = (e: Env, id: number, cols: Record<string, string | number | 
 };
 const brokerEnv = async (over: Partial<Env> = {}): Promise<Env> =>
   createTestEnv({ ORB_BROKER_ENABLED: "true", ORB_GITHUB_APP_ID: "4139483", ORB_GITHUB_APP_PRIVATE_KEY: await pkcs8Pem(), INTERNAL_JOB_TOKEN: "dev-internal-token", ...over });
+// `exactOptionalPropertyTypes` forbids `KEY: undefined` overrides, so a truly-ABSENT App credential means simply
+// never setting the key (not spreading `undefined` over it) — hence a dedicated builder rather than `brokerEnv({...})`.
+const brokerEnvMissingAppCreds = async (missing: "id" | "key" | "both", over: Partial<Env> = {}): Promise<Env> => {
+  const base: Partial<Env> = { ORB_BROKER_ENABLED: "true", INTERNAL_JOB_TOKEN: "dev-internal-token", ...over };
+  if (missing !== "id") base.ORB_GITHUB_APP_ID = "4139483";
+  if (missing !== "key") base.ORB_GITHUB_APP_PRIVATE_KEY = await pkcs8Pem();
+  return createTestEnv(base);
+};
 const tokenFetch = (token = "ghs_broker", expires = "2026-06-25T08:00:00Z") => vi.stubGlobal("fetch", async () => Response.json({ token, expires_at: expires }));
 const countingTokenFetch = (expires = "2026-06-25T08:00:00Z") => {
   let calls = 0;
@@ -153,6 +161,48 @@ describe("brokerOrbToken", () => {
     const { secret } = (await issueOrbEnrollment(e, 302)) as { secret: string };
     await db(e).prepare("UPDATE orb_github_installations SET suspended_at=CURRENT_TIMESTAMP WHERE installation_id=302").run();
     expect(await brokerOrbToken(e, secret)).toEqual({ error: "installation_not_eligible" });
+  });
+
+  it("#2710 regression: an invalid secret NEVER reveals broker misconfiguration — invalid_enrollment wins even with no App credentials at all", async () => {
+    // Before the fix, the ORB_GITHUB_APP_ID/PRIVATE_KEY check ran BEFORE the enrollment lookup, so ANY caller
+    // (no valid secret required) could learn the server's deployment-config state via the response code. The
+    // credential check must only ever run once the caller is already proven to hold a valid, eligible enrollment.
+    const e = await brokerEnvMissingAppCreds("both");
+    expect(await brokerOrbToken(e, "orbsec_totally_bogus")).toEqual({ error: "invalid_enrollment" });
+  });
+
+  it("returns broker_misconfigured only once the enrollment is valid+eligible and a real mint is required", async () => {
+    const missingAppId = await brokerEnvMissingAppCreds("id");
+    await seedInstall(missingAppId, 310, { registered: 1 });
+    const { secret: secretA } = (await issueOrbEnrollment(missingAppId, 310)) as { secret: string };
+    expect(await brokerOrbToken(missingAppId, secretA)).toEqual({ error: "broker_misconfigured" });
+
+    const missingPrivateKey = await brokerEnvMissingAppCreds("key");
+    await seedInstall(missingPrivateKey, 311, { registered: 1 });
+    const { secret: secretB } = (await issueOrbEnrollment(missingPrivateKey, 311)) as { secret: string };
+    expect(await brokerOrbToken(missingPrivateKey, secretB)).toEqual({ error: "broker_misconfigured" });
+  });
+
+  it("still eligible-checks BEFORE reporting broker_misconfigured (an ineligible install never leaks config state either)", async () => {
+    const e = await brokerEnvMissingAppCreds("both");
+    await seedInstall(e, 312, { registered: 1 });
+    const { secret } = (await issueOrbEnrollment(e, 312)) as { secret: string };
+    await db(e).prepare("UPDATE orb_github_installations SET removed_at=CURRENT_TIMESTAMP WHERE installation_id=312").run();
+    expect(await brokerOrbToken(e, secret)).toEqual({ error: "installation_not_eligible" });
+  });
+
+  it("serves a still-fresh cached token even with no Orb App credentials at all (mint is never reached)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T07:00:00Z"));
+    const e = await brokerEnv({ TOKEN_ENCRYPTION_SECRET: "orb-cache-test-secret" });
+    await seedInstall(e, 313, { registered: 1 });
+    const { secret } = (await issueOrbEnrollment(e, 313)) as { secret: string };
+    tokenFetch("ghs_minted", "2026-06-25T08:00:00Z");
+    expect(await brokerOrbToken(e, secret)).toEqual({ token: "ghs_minted", installationId: 313, expiresAt: "2026-06-25T08:00:00Z" });
+
+    // Drop the App credentials AFTER the initial mint+cache — a still-fresh cache hit must not need them.
+    const eNoCreds = await brokerEnvMissingAppCreds("both", { TOKEN_ENCRYPTION_SECRET: "orb-cache-test-secret", DB: e.DB });
+    expect(await brokerOrbToken(eNoCreds, secret)).toEqual({ token: "ghs_minted", installationId: 313, expiresAt: "2026-06-25T08:00:00Z" });
   });
 });
 


### PR DESCRIPTION
## Summary

- `brokerOrbToken` checked `ORB_GITHUB_APP_ID`/`ORB_GITHUB_APP_PRIVATE_KEY` before looking up the enrollment secret, so an unauthenticated caller with any bad/unknown secret could distinguish "broker misconfigured" (503) from "invalid secret" (401) via the response code alone — leaking the server's deployment-config state without ever proving a valid enrollment. Moves the credential check to immediately before the mint call (the only place it's actually needed — a cache hit never needs it), so an invalid/unknown secret always yields `invalid_enrollment` regardless of server configuration.
- Follow-up to #2710, which merged before this ordering issue (flagged during that PR's own review) was addressed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No pre-existing issue; a single-function ordering fix with full test coverage, discovered via the review gate on #2710.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (scoped to `src/orb/broker.ts` — 100% patch coverage on the changed lines/branches)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (Regression test asserts an invalid secret always returns `invalid_enrollment`, even with zero App credentials configured.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No public API contract change — same result shapes/status codes, only the internal check order changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — internal broker ordering fix, no public-facing doc change.)

## UI Evidence

N/A — backend-only change, no UI.

## Notes

- The eligibility check (`installation_not_eligible`) still runs before the credential check, so a revoked/suspended install never leaks config state either.
- A still-fresh cached token is served without ever touching the credential check, since `readCachedOrbToken` only depends on `TOKEN_ENCRYPTION_SECRET`.