### PR TITLE
chore(selfhost): regenerate stale env reference

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -7,23 +7,23 @@ export type SelfHostEnvReferenceRow = {
 export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   {
     name: "AI_COMBINE",
-    firstReference: "src/selfhost/ai.ts:848",
+    firstReference: "src/selfhost/ai.ts:888",
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:419",
+    firstReference: "src/server.ts:420",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:416",
+    firstReference: "src/server.ts:417",
   },
   {
     name: "AI_EMBED_MODEL",
-    firstReference: "src/selfhost/ai.ts:744",
+    firstReference: "src/selfhost/ai.ts:784",
   },
   {
     name: "AI_ON_MERGE",
-    firstReference: "src/selfhost/ai.ts:850",
+    firstReference: "src/selfhost/ai.ts:890",
   },
   {
     name: "AI_PROVIDER",
@@ -31,7 +31,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:748",
+    firstReference: "src/selfhost/ai.ts:788",
   },
   {
     name: "ANTHROPIC_AI_MODEL",
@@ -39,11 +39,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_API_KEY",
-    firstReference: "src/selfhost/ai.ts:747",
+    firstReference: "src/selfhost/ai.ts:787",
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:358",
+    firstReference: "src/server.ts:359",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -75,11 +75,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:839",
+    firstReference: "src/server.ts:845",
   },
   {
     name: "DATABASE_PATH",
-    firstReference: "src/server.ts:241",
+    firstReference: "src/server.ts:242",
   },
   {
     name: "DATABASE_URL",
@@ -103,11 +103,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:487",
+    firstReference: "src/server.ts:488",
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:275",
+    firstReference: "src/server.ts:276",
   },
   {
     name: "GITTENSORY_VERSION",
@@ -119,7 +119,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:371",
+    firstReference: "src/server.ts:372",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -131,11 +131,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OLLAMA_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:741",
+    firstReference: "src/selfhost/ai.ts:781",
   },
   {
     name: "OLLAMA_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:737",
+    firstReference: "src/selfhost/ai.ts:777",
   },
   {
     name: "OLLAMA_AI_MODEL",
@@ -143,7 +143,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:739",
+    firstReference: "src/selfhost/ai.ts:779",
   },
   {
     name: "OPENAI_AI_MODEL",
@@ -151,15 +151,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:741",
+    firstReference: "src/selfhost/ai.ts:781",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:741",
+    firstReference: "src/selfhost/ai.ts:781",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:740",
+    firstReference: "src/selfhost/ai.ts:780",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_MODEL",
@@ -179,7 +179,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:883",
+    firstReference: "src/server.ts:889",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -195,7 +195,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:885",
+    firstReference: "src/server.ts:891",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -227,11 +227,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGVECTOR_ENABLED",
-    firstReference: "src/server.ts:221",
+    firstReference: "src/server.ts:222",
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:643",
+    firstReference: "src/server.ts:644",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -247,7 +247,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:506",
+    firstReference: "src/server.ts:507",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
@@ -259,7 +259,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:551",
+    firstReference: "src/server.ts:552",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -295,23 +295,23 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:760",
+    firstReference: "src/server.ts:761",
   },
 ];
 
 export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
-  "| `AI_COMBINE` | `src/selfhost/ai.ts:848` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:419` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:416` |",
-  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:744` |",
-  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:850` |",
+  "| `AI_COMBINE` | `src/selfhost/ai.ts:888` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:420` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:417` |",
+  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:784` |",
+  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:890` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
-  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:748` |",
+  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:788` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:57` |",
-  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:747` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:358` |",
+  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:787` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:359` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:108` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:49` |",
@@ -319,37 +319,37 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_EFFORT` | `src/selfhost/ai.ts:112` |",
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:53` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:112` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:839` |",
-  "| `DATABASE_PATH` | `src/server.ts:241` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:845` |",
+  "| `DATABASE_PATH` | `src/server.ts:242` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/selfhost/discord-notify.ts:31` |",
   "| `DISCORD_WEBHOOK_URL` | `src/selfhost/discord-notify.ts:40` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:487` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:275` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:488` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:276` |",
   "| `GITTENSORY_VERSION` | `src/selfhost/health.ts:29` |",
   "| `MAINTENANCE_ADMISSION_ENABLED` | `src/selfhost/maintenance-admission.ts:83` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:371` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:372` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
-  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:741` |",
-  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:737` |",
+  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:781` |",
+  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:777` |",
   "| `OLLAMA_AI_MODEL` | `src/selfhost/ai.ts:61` |",
-  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:739` |",
+  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:779` |",
   "| `OPENAI_AI_MODEL` | `src/selfhost/ai.ts:62` |",
-  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:741` |",
-  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:741` |",
-  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:740` |",
+  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:781` |",
+  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:781` |",
+  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:780` |",
   "| `OPENAI_COMPATIBLE_AI_MODEL` | `src/selfhost/ai.ts:63` |",
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:883` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:889` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:885` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:891` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -357,15 +357,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_EXPORTER` | `src/selfhost/otel.ts:40` |",
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
-  "| `PGVECTOR_ENABLED` | `src/server.ts:221` |",
-  "| `PORT` | `src/server.ts:643` |",
+  "| `PGVECTOR_ENABLED` | `src/server.ts:222` |",
+  "| `PORT` | `src/server.ts:644` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:506` |",
+  "| `QDRANT_URL` | `src/server.ts:507` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:102` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:551` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:552` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
@@ -374,5 +374,5 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
   "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:373` |",
   "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:161` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:760` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:761` |",
 ].join("\n");


### PR DESCRIPTION
## Summary

`apps/gittensory-ui/src/lib/selfhost-env-reference.ts` is a generated file mapping self-host env
vars to their first source reference (file:line). Commit aa9a7199 (#2715, adding the
`ciCheckSignals` REES analyzer) shifted line numbers in `src/selfhost/ai.ts`/`src/server.ts`
without regenerating this derived file, so `npm run selfhost:env-reference:check` has been failing
on `main`. This PR regenerates it — purely mechanical `firstReference` line-number updates, no
functional/logic changes.

No linked issue: small, self-evident generated-artifact regeneration.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `npm run typecheck`
- [x] `npm run selfhost:env-reference:check` passes after regeneration

If any required check was skipped, explain why:

- Relying on CI to run the full `test:ci` gate for this single-generated-file change rather than
  duplicating it locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/schema change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI behavior change (docs-data file only).
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — `CHANGELOG.md` untouched.