### PR TITLE
fix(selfhost): wire autoCloseExemptLogins into the per-repo contributor cap

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2045,7 +2045,13 @@ async function runAgentMaintenancePlanAndExecute(
     isNewAccount && typeof settings.contributorOpenPrCap === "number"
       ? Math.max(1, Math.ceil(settings.contributorOpenPrCap / 2))
       : settings.contributorOpenPrCap;
-  if (typeof contributorOpenPrCap === "number" && pr.authorLogin) {
+  // #2270/#2463-parity: the per-repo cap now honors the SAME shared `autoCloseExemptLogins` allowlist the
+  // install-wide cap (below) and review-nag cooldown already do -- previously only the owner/admin/automation-bot
+  // exemption (applied later, inside planAgentMaintenanceActions) protected an author here, so a maintainer-named
+  // trusted-but-not-a-recognized-bot login (e.g. a third-party automation App like Sentry's Seer fix bot) had no
+  // way to opt out of the PER-REPO cap specifically, even though `.gittensory.yml`'s own doc comment already
+  // promised this reuse (auto-close-exempt.ts).
+  if (typeof contributorOpenPrCap === "number" && pr.authorLogin && !isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) {
     const authorLoginLower = pr.authorLogin.toLowerCase();
     const authorOpenPrNumbers = otherOpenPullRequests
       .filter((other) => (other.authorLogin ?? "").toLowerCase() === authorLoginLower)
@@ -4096,7 +4102,9 @@ async function maybeCloseIssueOverContributorCap(
     }
   }
 
-  if (typeof cap !== "number") return;
+  // #2270/#2463-parity: same shared `autoCloseExemptLogins` allowlist the install-wide cap above and review-nag
+  // cooldown already honor -- see the matching comment on the PR-side per-repo cap in the PR maintenance path.
+  if (typeof cap !== "number" || isAutoCloseExempt(authorLogin, settings.autoCloseExemptLogins)) return;
 
   const otherOpenIssues = await listOpenIssues(env, repoFullName);
   const authorLoginLower = authorLogin.toLowerCase();

--- a/src/settings/auto-close-exempt.ts
+++ b/src/settings/auto-close-exempt.ts
@@ -6,7 +6,12 @@
 // settings (`.gittensory.yml` > DB), never hard-coded for any repo. Mirrors contributor-blacklist.ts's shape
 // (normalize → validated list + warnings), minus the reason/evidence metadata a ban carries that an exemption
 // doesn't need.
-const GITHUB_LOGIN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+// A trailing `[bot]` is a real, common GitHub App-actor login shape (e.g. `dependabot[bot]`, `sentry[bot]`) --
+// this is exactly the kind of third-party automation identity a maintainer needs to exempt (a repo-specific bot
+// integration the hardcoded, install-wide well-known-bot set in agent-actions.ts has no way to know about), so
+// the base GitHub-login pattern (1-39 chars, alphanumeric/single-hyphens) is extended with an optional literal
+// `[bot]` suffix rather than rejecting every bot-shaped login outright.
+const GITHUB_LOGIN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}(?:\[bot\])?$/;
 const MAX_ENTRIES = 500;
 
 /** Normalize a raw exempt-logins value (DB JSON or `.gittensory.yml`) into a validated, de-duplicated list of

--- a/test/unit/auto-close-exempt.test.ts
+++ b/test/unit/auto-close-exempt.test.ts
@@ -15,10 +15,16 @@ describe("normalizeAutoCloseExemptLogins (#2463)", () => {
     expect(logins).toEqual(["a-b", "user123", "a".repeat(39)]);
   });
 
+  it("accepts a `[bot]`-suffixed App-actor login (e.g. a third-party automation integration like sentry[bot]) — a maintainer must be able to exempt a repo-specific bot the hardcoded well-known-bot set doesn't know about", () => {
+    const { logins, warnings } = normalizeAutoCloseExemptLogins(["sentry[bot]", "dependabot[bot]", "github-actions[bot]"]);
+    expect(logins).toEqual(["sentry[bot]", "dependabot[bot]", "github-actions[bot]"]);
+    expect(warnings).toEqual([]);
+  });
+
   it("drops non-string and invalid-login entries with a warning", () => {
-    const { logins, warnings } = normalizeAutoCloseExemptLogins([42, "-bad", "bad-", "a--b", "has space", "a".repeat(40)]);
+    const { logins, warnings } = normalizeAutoCloseExemptLogins([42, "-bad", "bad-", "a--b", "has space", "a".repeat(40), "sentry[Bot]", "[bot]", "weird[bot][bot]"]);
     expect(logins).toEqual([]);
-    expect(warnings.length).toBeGreaterThanOrEqual(5);
+    expect(warnings.length).toBeGreaterThanOrEqual(8);
   });
 
   it("trims whitespace around a login", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7672,6 +7672,66 @@ describe("queue processors", () => {
     expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open pull requests") && c.includes("limit of 2"))).toBe(true);
   });
 
+  it("contributor open-PR cap (#2270): a maintainer-named autoCloseExemptLogins entry is exempt from the PER-REPO cap too (not just the install-wide cap)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    // Two PRE-EXISTING open PRs from an exempt bot author (e.g. a third-party automation App like Sentry's Seer
+    // fix bot) — same over-cap shape as the "3rd PR" test above, but this login is on autoCloseExemptLogins.
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 53, title: "Sentry fix one", state: "open", user: { login: "sentry[bot]" }, head: { sha: "f53" }, labels: [], body: "x" });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 54, title: "Sentry fix two", state: "open", user: { login: "sentry[bot]" }, head: { sha: "f54" }, labels: [], body: "y" });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      aiReviewMode: "advisory",
+      autonomy: { close: "auto", label: "auto" },
+      contributorOpenPrCap: 2,
+      autoCloseExemptLogins: ["sentry[bot]"],
+    });
+    const seen = { closed: false, labels: [] as string[], comments: [] as string[] };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes("/pulls/55/reviews")) return Response.json([]);
+      if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
+      if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "sentry[bot]" }, head: { sha: "f55" }, mergeable_state: "clean" });
+      if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/f55/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/55/labels") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/55/labels") && method === "POST") { seen.labels.push(...((JSON.parse(String(init?.body ?? "{}")).labels ?? []) as string[])); return Response.json([]); }
+      if (url.includes("/issues/55/comments") && method === "POST") { seen.comments.push(String(JSON.parse(String(init?.body ?? "{}")).body ?? "")); return Response.json({ id: 1 }, { status: 201 }); }
+      if (url.includes("/issues/55/comments")) return Response.json([]);
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "contributor-cap-exempt-login",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 55, title: "Sentry's 3rd PR", state: "open", user: { login: "sentry[bot]" }, head: { sha: "f55" }, labels: [], body: "x", mergeable_state: "clean", reviewDecision: "APPROVED" },
+      },
+    });
+
+    // Exempt: the 3rd PR is NOT closed or labeled for the cap, despite being (numerically) over it.
+    expect(seen.closed).toBe(false);
+    expect(seen.labels).not.toContain("over-contributor-limit");
+    const closeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.close'").first<{ n: number }>();
+    expect(closeAudit?.n).toBe(0);
+  });
+
   function stubContributorCapCiCancelFetch(seen: { closed: boolean; cancelledIds: number[]; listedStatuses: string[] }, runListResponses: { in_progress?: number[]; queued?: number[] } = {}, cancelResponse: () => Response = () => new Response(null, { status: 202 })) {
     return async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -9016,6 +9076,48 @@ describe("queue processors", () => {
     expect(seen.comments.some((c) => c.includes("@farmer99") && c.includes("3 open issues") && c.includes("limit of 2"))).toBe(true);
     const closeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.close'").first<{ n: number }>();
     expect(closeAudit?.n).toBeGreaterThanOrEqual(1);
+  });
+
+  it("contributor open-ISSUE cap (#2270): a maintainer-named autoCloseExemptLogins entry is exempt from the PER-REPO issue cap too (not just the install-wide cap)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", issues: "write" }, events: ["issues"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 60, title: "Sentry issue one", state: "open", user: { login: "sentry[bot]" }, labels: [], body: "x" });
+    await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number: 61, title: "Sentry issue two", state: "open", user: { login: "sentry[bot]" }, labels: [], body: "y" });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autonomy: { close: "auto", label: "auto" },
+      contributorOpenIssueCap: 2,
+      autoCloseExemptLogins: ["sentry[bot]"],
+    });
+    const seen = { closed: false };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if ((url.endsWith("/issues/60") || url.endsWith("/issues/61")) && method === "GET") return Response.json({ state: "open" });
+      if (url.endsWith("/issues/62") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ state: "closed" }); }
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "contributor-issue-cap-exempt-login",
+      eventName: "issues",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 62, title: "Sentry's 3rd issue", state: "open", user: { login: "sentry[bot]" }, labels: [], body: "x" },
+      },
+    });
+
+    // Exempt: the 3rd issue is NOT closed for the cap, despite being (numerically) over it.
+    expect(seen.closed).toBe(false);
+    const closeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.close'").first<{ n: number }>();
+    expect(closeAudit?.n).toBe(0);
   });
 
   it("REGRESSION (#2479 gate finding): a stale-open DB row for an already-closed sibling does NOT inflate the count and wrongly close a newly opened issue within the real cap", async () => {


### PR DESCRIPTION
## Summary

- The per-repo `contributorOpenPrCap`/`contributorOpenIssueCap` check never consulted the shared `autoCloseExemptLogins` allowlist -- only the install-wide cap and the review-nag cooldown did, even though `autoCloseExemptLogins`'s own doc comment already promised this reuse. A maintainer-configured exempt login (e.g. a third-party automation App like a Sentry fix bot) had no way to opt out of the per-repo cap specifically.
- Also fixes the exempt-login validator itself, which rejected any `[bot]`-suffixed login outright -- exactly the login shape GitHub Apps use -- so a maintainer could not even configure the exemption that was needed in the first place.
- Both fixes are fully generic: no repo-specific behavior is hardcoded into the engine. A self-hoster sets their own trusted logins via `autoCloseExemptLogins` in `.gittensory.yml`/repo settings.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] This is small enough that the summary explains why an issue is not needed (a scoped correctness fix to an existing anti-abuse mechanism, discovered via direct investigation of a live flagging report).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- 100% line/branch coverage on every changed line in `src/queue/processors.ts` and `src/settings/auto-close-exempt.ts`
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API surface change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- no UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Backend-only change; no UI Evidence section needed.