### PR TITLE
fix(review): stop mislabeling a PR when its paired anti-abuse close is denied

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -67,6 +67,18 @@ export function pendingClosureLabelApplied(plan: PlannedAgentAction[], outcomes:
   return plan.some((action, index) => action.actionClass === "label" && action.label === AGENT_LABEL_PENDING_CLOSURE && action.labelOp === "add" && outcomes[index]?.outcome === "completed");
 }
 
+// #label-close-split-brain: the outcome of the `close` action tagged with `closeKind`, among the actions ALREADY
+// processed in this batch (outcomes[i] is 1:1 with planned[i], same order — see pendingClosureLabelApplied above).
+// The planner emits a coupled anti-abuse label+close pair (blacklist/contributor_cap/review_nag) with close pushed
+// FIRST, so by the time the executor reaches the label, the close's real outcome is already recorded here.
+// Undefined when no such close exists in this batch (e.g. a plain review_state_label with no closeKind at all).
+function coupledCloseOutcome(planned: PlannedAgentAction[], outcomes: AgentActionOutcome[], closeKind: PlannedAgentAction["closeKind"]): AgentActionOutcome["outcome"] | undefined {
+  for (let i = 0; i < outcomes.length; i++) {
+    if (planned[i]?.actionClass === "close" && planned[i]?.closeKind === closeKind) return outcomes[i]?.outcome;
+  }
+  return undefined;
+}
+
 /**
  * Execute (or dry-run, or stage for approval) a planned auto-maintain action set on one PR. Each action runs
  * through the SAME deny-toward-safety gate stack before any GitHub call:
@@ -121,7 +133,20 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("queued", `awaiting maintainer approval — ${action.reason}`);
       continue;
     }
-    // 5) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
+    // 5) #label-close-split-brain: a `label` coupled to a same-batch anti-abuse close (closeKind set) must not
+    //    post if that close already denied/errored THIS pass — `label` mutates via the Issues API and is exempt
+    //    from the write-permission gate below (step 8) that `close` is not, so without this correlation a
+    //    transient `pull_requests: write` denial could leave a PR mislabeled "closed for X" while still open.
+    //    A coupled close that is still "queued" (awaiting the SAME approval) or "completed" lets the label through
+    //    unchanged; a close with no `closeKind` match (e.g. a plain review_state_label) is unaffected.
+    if (action.actionClass === "label" && action.closeKind) {
+      const closeOutcome = coupledCloseOutcome(planned, outcomes, action.closeKind);
+      if (closeOutcome === "denied" || closeOutcome === "error") {
+        await audit("denied", `paired ${action.closeKind} close did not complete (${closeOutcome}) — skipping the companion label so the PR isn't mislabeled while still open`);
+        continue;
+      }
+    }
+    // 6) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
     //    target the reviewed, open head. This protects approval-queue replays and slow webhook jobs from
     //    force-pushes or manual closes that happen after the review was planned.
     const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
@@ -139,7 +164,7 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
       continue;
     }
-    // 6) Live CI re-verification for a merge or a CI-driven heuristic close (#2128): the CI aggregate that drove
+    // 7) Live CI re-verification for a merge or a CI-driven heuristic close (#2128): the CI aggregate that drove
     //    either decision was read seconds-to-tens-of-seconds earlier, in the planning pass, and the freshness
     //    guard above only re-checks head SHA/state, not CI. GitHub's own merge endpoint enforces
     //    branch-protection REQUIRED checks server-side, but only as a backstop when a repo actually configures
@@ -178,12 +203,12 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
         continue;
       }
     }
-    // 7) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
+    // 8) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
       await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
       continue;
     }
-    // 8) live — perform the real mutation, recording success or the error.
+    // 9) live — perform the real mutation, recording success or the error.
     try {
       await performAction(env, ctx, action);
       await audit("completed", action.reason);

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -84,6 +84,12 @@ export type PlannedAgentAction = {
   // duplicate / slop / CI). The breaker downgrades ONLY "heuristic" closes; the deterministic close is EXEMPT
   // (silently holding a close whose comment already promised closure would be incoherent). Absent on non-close
   // actions; treated as a heuristic close only when explicitly tagged "heuristic".
+  // ALSO set on a `label` action that is inseparable metadata on a close of this SAME kind in the same planned
+  // batch (blacklist/contributor_cap/review_nag) — the executor correlates the two by this value so the label
+  // is only actually applied when its paired close didn't get denied/error (#label-close-split-brain: `label`
+  // mutates via the Issues API and is exempt from the PR-write-permission gate `close` must pass, so without
+  // this correlation a transient write-permission denial could leave a PR mislabeled "closed for X" while it
+  // is, in fact, still open).
   closeKind?: "linked-issue-hard-rule" | "blacklist" | "contributor_cap" | "review_nag" | "heuristic";
   // For a CI-driven heuristic close, the CI state that must still hold at actuation time. Other heuristic
   // closes (gate verdict, duplicate/slop, conflict) do not depend on red CI and must not be blocked by green CI.
@@ -374,7 +380,8 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     // NOT the generic `label` class — a repo can enable close without also opting into the broad label dial.
     // Explicit `null` (vs. absent/undefined) means "close without any label."
     const label = input.blacklistLabel === null ? null : (input.blacklistLabel ?? DEFAULT_BLACKLIST_LABEL);
-    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", requiresApproval: approval("close"), reason: "blacklisted contributor", label, labelOp: "add" });
+    // Close is pushed BEFORE its coupled label (#label-close-split-brain) so the executor's outcome-correlation
+    // guard always has the close's outcome already recorded by the time it evaluates the label.
     if (acting("close")) {
       actions.push({
         actionClass: "close",
@@ -388,6 +395,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
         ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
       });
     }
+    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", closeKind: "blacklist", requiresApproval: approval("close"), reason: "blacklisted contributor", label, labelOp: "add" });
     return actions;
   }
 
@@ -399,7 +407,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     const { authorLogin, openCount, cap, itemKind, scope } = input.contributorCapMatch;
     // #label-scoping: same close-autonomy-gated, null-clearable shape as the blacklist label above.
     const label = input.contributorCapLabel === null ? null : (input.contributorCapLabel ?? DEFAULT_CONTRIBUTOR_CAP_LABEL);
-    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", requiresApproval: approval("close"), reason: "over the per-contributor open-item cap", label, labelOp: "add" });
+    // Close is pushed BEFORE its coupled label (#label-close-split-brain) — see the closeKind doc comment above.
     if (acting("close")) {
       actions.push({
         actionClass: "close",
@@ -409,6 +417,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
         closeKind: "contributor_cap",
       });
     }
+    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", closeKind: "contributor_cap", requiresApproval: approval("close"), reason: "over the per-contributor open-item cap", label, labelOp: "add" });
     return actions;
   }
 
@@ -422,7 +431,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     const { authorLogin, pingCount, maxPings } = input.reviewNagMatch;
     // #label-scoping: same close-autonomy-gated, null-clearable shape as the blacklist label above.
     const label = input.reviewNagLabel === null ? null : (input.reviewNagLabel ?? DEFAULT_REVIEW_NAG_LABEL);
-    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", requiresApproval: approval("close"), reason: "review-nag cooldown", label, labelOp: "add" });
+    // Close is pushed BEFORE its coupled label (#label-close-split-brain) — see the closeKind doc comment above.
     if (acting("close")) {
       actions.push({
         actionClass: "close",
@@ -433,6 +442,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
         ...(input.pr.headSha ? { expectedHeadSha: input.pr.headSha } : {}),
       });
     }
+    if (acting("close") && label !== null) actions.push({ actionClass: "label", autonomyClass: "close", closeKind: "review_nag", requiresApproval: approval("close"), reason: "review-nag cooldown", label, labelOp: "add" });
     return actions;
   }
 

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -449,6 +449,64 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect((await auditFor(env, "merge"))?.outcome).toBe("denied");
   });
 
+  it("#label-close-split-brain: a coupled anti-abuse label+close pair (matching closeKind) BOTH complete when the close succeeds", async () => {
+    const env = createTestEnv({});
+    const coupledClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", closeComment: "closing", closeKind: "contributor_cap" };
+    const coupledLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [coupledClose, coupledLabel]);
+    expect(outcomes.map((o) => o.outcome)).toEqual(["completed", "completed"]);
+    expect(closePullRequest).toHaveBeenCalledTimes(1);
+    expect(ensurePullRequestLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it("#label-close-split-brain (confirmed root cause of PR-cap miscounting): a coupled anti-abuse label is SKIPPED, not posted, when its paired close is denied for lacking pull_requests:write — `label` mutates via the Issues API and is otherwise exempt from that gate, so without this correlation a PR could be mislabeled 'over-contributor-limit' while it stays open forever", async () => {
+    const env = createTestEnv({});
+    const coupledClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", closeComment: "closing", closeKind: "contributor_cap" };
+    const coupledLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ installationPermissions: { pull_requests: "read", issues: "write" } }), [coupledClose, coupledLabel]);
+    expect(outcomes[0]).toMatchObject({ actionClass: "close", outcome: "denied" });
+    expect(outcomes[1]).toMatchObject({ actionClass: "label", outcome: "denied" });
+    expect(outcomes[1]?.detail).toContain("paired contributor_cap close did not complete");
+    expect(closePullRequest).not.toHaveBeenCalled();
+    expect(ensurePullRequestLabel).not.toHaveBeenCalled(); // the bug: this used to be called anyway
+    expect((await auditFor(env, "label"))?.outcome).toBe("denied");
+  });
+
+  it("#label-close-split-brain: an UNRELATED plain label (no closeKind — e.g. a review_state_label disposition) is unaffected by a same-batch close's outcome", async () => {
+    const env = createTestEnv({});
+    const unrelatedClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "heuristic", closeComment: "closing", closeKind: "heuristic" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ installationPermissions: { pull_requests: "read", issues: "write" } }), [unrelatedClose, label]);
+    expect(outcomes[0]).toMatchObject({ actionClass: "close", outcome: "denied" });
+    expect(outcomes[1]).toMatchObject({ actionClass: "label", outcome: "completed" }); // no closeKind on `label` -> not correlated
+    expect(ensurePullRequestLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it("#label-close-split-brain: a label's closeKind with NO matching close anywhere in the batch is unaffected (coupledCloseOutcome finds nothing, so the correlation guard never blocks it)", async () => {
+    const env = createTestEnv({});
+    // A close of a DIFFERENT closeKind precedes the label — the label's own "contributor_cap" closeKind has no
+    // matching close in this batch at all, so the scan exhausts without a match.
+    const differentKindClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "blacklisted contributor", closeComment: "closing", closeKind: "blacklist" };
+    const mismatchedLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [differentKindClose, mismatchedLabel]);
+    expect(outcomes[0]).toMatchObject({ actionClass: "close", outcome: "completed" });
+    expect(outcomes[1]).toMatchObject({ actionClass: "label", outcome: "completed" });
+    expect(ensurePullRequestLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it("#label-close-split-brain: a coupled label still applies when the paired close is only QUEUED for approval (not denied/errored) — both actions share the SAME requiresApproval, so this is the normal staged-together path, not a split-brain", async () => {
+    const env = createTestEnv({});
+    const coupledClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", closeComment: "closing", closeKind: "contributor_cap" };
+    const coupledLabel: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
+    // Force the close's OWN autonomy to auto_with_approval (queued) while the label's stays auto (would complete
+    // on its own) -- an artificial divergence from the planner's normal "both share requiresApproval" shape, used
+    // here purely to prove the correlation reads the close's REAL recorded outcome ("queued"), not just falls
+    // through to "denied" for anything other than "completed".
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ autonomy: { label: "auto", close: "auto_with_approval" } }), [{ ...coupledClose, requiresApproval: true }, coupledLabel]);
+    expect(outcomes[0]).toMatchObject({ actionClass: "close", outcome: "queued" });
+    expect(outcomes[1]).toMatchObject({ actionClass: "label", outcome: "completed" });
+    expect(ensurePullRequestLabel).toHaveBeenCalledTimes(1);
+  });
+
   it("DRY-RUN: records the intent without any GitHub call, audited with mode=dry_run", async () => {
     const env = createTestEnv({});
     const outcomes = await executeAgentMaintenanceActions(env, ctx({ agentDryRun: true }), [label, merge]);

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -880,13 +880,15 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     // #label-scoping: the blacklist label rides on `close` autonomy, not `label` — no `label: "auto"` needed.
     input({ conclusion: "success", autonomy: { close: "auto", approve: "auto", merge: "auto" }, blacklistMatch: { matched: true, reason: "plagiarism" }, ...extra });
 
-  it("labels + closes a blacklisted contributor's PR, winning over a passing gate (no merit review / merge)", () => {
+  it("closes + labels a blacklisted contributor's PR, winning over a passing gate (no merit review / merge)", () => {
     const plan = planAgentMaintenanceActions(blacklisted());
-    expect(classes(plan)).toEqual(["label", "close"]); // short-circuit: no approve/merge despite a SUCCESS gate
-    expect(plan[0]).toMatchObject({ actionClass: "label", label: DEFAULT_BLACKLIST_LABEL, labelOp: "add" });
-    expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "blacklist" });
-    expect(plan[1]?.closeComment).not.toContain("plagiarism");
-    expect(plan[1]?.closeComment).toContain("blocked from contributing");
+    // close is pushed BEFORE its coupled label (#label-close-split-brain) so the executor's outcome-correlation
+    // guard always has the close's outcome already recorded by the time it evaluates the label.
+    expect(classes(plan)).toEqual(["close", "label"]); // short-circuit: no approve/merge despite a SUCCESS gate
+    expect(plan[0]).toMatchObject({ actionClass: "close", closeKind: "blacklist" });
+    expect(plan[1]).toMatchObject({ actionClass: "label", label: DEFAULT_BLACKLIST_LABEL, labelOp: "add", closeKind: "blacklist" });
+    expect(plan[0]?.closeComment).not.toContain("plagiarism");
+    expect(plan[0]?.closeComment).toContain("blocked from contributing");
   });
 
   it("pins the blacklist close to the reviewed head, mirroring merge/approve (#2452)", () => {
@@ -900,15 +902,15 @@ describe("contributor blacklist short-circuit (#1425)", () => {
   });
 
   it("uses the repo-configured blacklistLabel, defaulting to 'slop' when unset", () => {
-    expect(planAgentMaintenanceActions(blacklisted({ blacklistLabel: "abuse" }))[0]).toMatchObject({ label: "abuse" });
+    expect(planAgentMaintenanceActions(blacklisted({ blacklistLabel: "abuse" }))[1]).toMatchObject({ label: "abuse" });
     expect(DEFAULT_BLACKLIST_LABEL).toBe("slop");
-    expect(planAgentMaintenanceActions(blacklisted())[0]).toMatchObject({ label: "slop" });
+    expect(planAgentMaintenanceActions(blacklisted())[1]).toMatchObject({ label: "slop" });
   });
 
   it("#label-scoping: an explicit null blacklistLabel closes WITHOUT any label; the label action carries autonomyClass: close", () => {
     const withLabel = planAgentMaintenanceActions(blacklisted());
-    expect(classes(withLabel)).toEqual(["label", "close"]);
-    expect(withLabel[0]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
+    expect(classes(withLabel)).toEqual(["close", "label"]);
+    expect(withLabel[1]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
     const withoutLabel = planAgentMaintenanceActions(blacklisted({ blacklistLabel: null }));
     expect(classes(withoutLabel)).toEqual(["close"]);
   });
@@ -916,12 +918,12 @@ describe("contributor blacklist short-circuit (#1425)", () => {
   it("uses the same static public close comment when the entry has no reason", () => {
     const withReason = planAgentMaintenanceActions(blacklisted());
     const withoutReason = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: null } }));
-    expect(withoutReason[1]?.closeComment).toBe(withReason[1]?.closeComment);
-    expect(withoutReason[1]?.closeComment).toContain("blocked from contributing");
+    expect(withoutReason[0]?.closeComment).toBe(withReason[0]?.closeComment);
+    expect(withoutReason[0]?.closeComment).toContain("blocked from contributing");
   });
 
   it("fires AHEAD of CI — closes even while CI is still pending (not the pending early-return)", () => {
-    expect(classes(planAgentMaintenanceActions(blacklisted({ ciState: "pending" })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(blacklisted({ ciState: "pending" })))).toEqual(["close", "label"]);
   });
 
   it("NEVER fires for the owner, an admin login, or an automation bot (standing rule) — the PR falls through to normal disposition", () => {
@@ -941,14 +943,14 @@ describe("contributor blacklist short-circuit (#1425)", () => {
     // `label: auto` alone (no `close`) is no longer sufficient — the enforcement label is inseparable from its close.
     expect(planAgentMaintenanceActions(blacklisted({ autonomy: { label: "auto" } }))).toEqual([]);
     // `close: auto` alone (no `label`) is now sufficient for BOTH the close and its label.
-    expect(classes(planAgentMaintenanceActions(blacklisted({ autonomy: { close: "auto" } })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(blacklisted({ autonomy: { close: "auto" } })))).toEqual(["close", "label"]);
   });
 
   it("never publishes blacklist reason text in the public close comment", () => {
     const privateReason = "internal-case-7421-do-not-publish";
     const plan = planAgentMaintenanceActions(blacklisted({ blacklistMatch: { matched: true, reason: privateReason } }));
-    expect(plan[1]?.closeComment).not.toContain(privateReason);
-    expect(plan[1]?.closeComment).toContain("blocked from contributing");
+    expect(plan[0]?.closeComment).not.toContain(privateReason);
+    expect(plan[0]?.closeComment).toContain("blocked from contributing");
   });
 });
 
@@ -962,61 +964,62 @@ describe("per-contributor open-item cap short-circuit (#2270)", () => {
       ...extra,
     });
 
-  it("labels + closes an over-cap contributor's PR, winning over a passing gate (no merit review / merge)", () => {
+  it("closes + labels an over-cap contributor's PR, winning over a passing gate (no merit review / merge)", () => {
     const plan = planAgentMaintenanceActions(overCap());
-    expect(classes(plan)).toEqual(["label", "close"]); // short-circuit: no approve/merge despite a SUCCESS gate
-    expect(plan[0]).toMatchObject({ actionClass: "label", label: DEFAULT_CONTRIBUTOR_CAP_LABEL, labelOp: "add" });
-    expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "contributor_cap" });
+    // close is pushed BEFORE its coupled label (#label-close-split-brain) — see the blacklist section above.
+    expect(classes(plan)).toEqual(["close", "label"]); // short-circuit: no approve/merge despite a SUCCESS gate
+    expect(plan[0]).toMatchObject({ actionClass: "close", closeKind: "contributor_cap" });
+    expect(plan[1]).toMatchObject({ actionClass: "label", label: DEFAULT_CONTRIBUTOR_CAP_LABEL, labelOp: "add", closeKind: "contributor_cap" });
   });
 
   it("interpolates the (public) login/count/cap into the close comment — unlike blacklist's static-only comment", () => {
     const plan = planAgentMaintenanceActions(overCap());
-    expect(plan[1]?.closeComment).toContain("@farmer99");
-    expect(plan[1]?.closeComment).toContain("3 open pull requests");
-    expect(plan[1]?.closeComment).toContain("limit of 2");
+    expect(plan[0]?.closeComment).toContain("@farmer99");
+    expect(plan[0]?.closeComment).toContain("3 open pull requests");
+    expect(plan[0]?.closeComment).toContain("limit of 2");
   });
 
   it("itemKind selects the close-comment noun — 'issues' for the issue-path caller, not hardcoded to PRs (regression, gate finding on #2467/#2479)", () => {
     const plan = planAgentMaintenanceActions(
       overCap({ contributorCapMatch: { matched: true, authorLogin: "farmer99", openCount: 3, cap: 2, itemKind: "issues" } }),
     );
-    expect(plan[1]?.closeComment).toContain("3 open issues");
-    expect(plan[1]?.closeComment).not.toContain("pull requests");
+    expect(plan[0]?.closeComment).toContain("3 open issues");
+    expect(plan[0]?.closeComment).not.toContain("pull requests");
   });
 
   it("scope 'install' (#2562) describes the cap as install-wide, not this-repository's — same closeKind/label shape", () => {
     const plan = planAgentMaintenanceActions(
       overCap({ contributorCapMatch: { matched: true, authorLogin: "farmer99", openCount: 5, cap: 4, itemKind: "pull requests", scope: "install" } }),
     );
-    expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "contributor_cap" });
-    expect(plan[1]?.closeComment).toContain("@farmer99");
-    expect(plan[1]?.closeComment).toContain("5 open pull requests");
-    expect(plan[1]?.closeComment).toContain("across every repository it gates, combined) of 4");
-    expect(plan[1]?.closeComment).not.toContain("this repository's configured limit");
+    expect(plan[0]).toMatchObject({ actionClass: "close", closeKind: "contributor_cap" });
+    expect(plan[0]?.closeComment).toContain("@farmer99");
+    expect(plan[0]?.closeComment).toContain("5 open pull requests");
+    expect(plan[0]?.closeComment).toContain("across every repository it gates, combined) of 4");
+    expect(plan[0]?.closeComment).not.toContain("this repository's configured limit");
   });
 
   it("scope 'repository' (default, absent) keeps the original this-repository close-comment wording — back-compat", () => {
     const plan = planAgentMaintenanceActions(overCap()); // overCap's base contributorCapMatch omits `scope`
-    expect(plan[1]?.closeComment).toContain("this repository's configured limit");
-    expect(plan[1]?.closeComment).not.toContain("across every repository it gates");
+    expect(plan[0]?.closeComment).toContain("this repository's configured limit");
+    expect(plan[0]?.closeComment).not.toContain("across every repository it gates");
   });
 
   it("uses the repo-configured contributorCapLabel, defaulting to 'over-contributor-limit' when unset", () => {
-    expect(planAgentMaintenanceActions(overCap({ contributorCapLabel: "spam-cap" }))[0]).toMatchObject({ label: "spam-cap" });
+    expect(planAgentMaintenanceActions(overCap({ contributorCapLabel: "spam-cap" }))[1]).toMatchObject({ label: "spam-cap" });
     expect(DEFAULT_CONTRIBUTOR_CAP_LABEL).toBe("over-contributor-limit");
-    expect(planAgentMaintenanceActions(overCap())[0]).toMatchObject({ label: "over-contributor-limit" });
+    expect(planAgentMaintenanceActions(overCap())[1]).toMatchObject({ label: "over-contributor-limit" });
   });
 
   it("#label-scoping: an explicit null contributorCapLabel closes WITHOUT any label; the label action carries autonomyClass: close", () => {
     const withLabel = planAgentMaintenanceActions(overCap());
-    expect(classes(withLabel)).toEqual(["label", "close"]);
-    expect(withLabel[0]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
+    expect(classes(withLabel)).toEqual(["close", "label"]);
+    expect(withLabel[1]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
     const withoutLabel = planAgentMaintenanceActions(overCap({ contributorCapLabel: null }));
     expect(classes(withoutLabel)).toEqual(["close"]);
   });
 
   it("fires AHEAD of CI — closes even while CI is still pending (not the pending early-return)", () => {
-    expect(classes(planAgentMaintenanceActions(overCap({ ciState: "pending" })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(overCap({ ciState: "pending" })))).toEqual(["close", "label"]);
   });
 
   it("NEVER fires for the owner, an admin login, or an automation bot (standing rule) — the PR falls through to normal disposition", () => {
@@ -1032,7 +1035,7 @@ describe("per-contributor open-item cap short-circuit (#2270)", () => {
   it("#label-scoping: the label rides on `close` autonomy, not `label` — `label` alone plans nothing, `close` alone plans both", () => {
     expect(planAgentMaintenanceActions(overCap({ autonomy: {} }))).toEqual([]);
     expect(planAgentMaintenanceActions(overCap({ autonomy: { label: "auto" } }))).toEqual([]);
-    expect(classes(planAgentMaintenanceActions(overCap({ autonomy: { close: "auto" } })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(overCap({ autonomy: { close: "auto" } })))).toEqual(["close", "label"]);
   });
 
   it("is independent of the blacklist short-circuit — a matched blacklist entry still wins when both are present", () => {
@@ -1041,7 +1044,7 @@ describe("per-contributor open-item cap short-circuit (#2270)", () => {
     const plan = planAgentMaintenanceActions(
       overCap({ blacklistMatch: { matched: true, reason: "plagiarism" } }),
     );
-    expect(plan[1]).toMatchObject({ closeKind: "blacklist" });
+    expect(plan[0]).toMatchObject({ closeKind: "blacklist" });
   });
 });
 
@@ -1055,14 +1058,15 @@ describe("review-nag cooldown short-circuit (#2463)", () => {
       ...extra,
     });
 
-  it("labels + closes a nagging contributor's PR, winning over a passing gate (no merit review / merge)", () => {
+  it("closes + labels a nagging contributor's PR, winning over a passing gate (no merit review / merge)", () => {
     const plan = planAgentMaintenanceActions(nagged());
-    expect(classes(plan)).toEqual(["label", "close"]); // short-circuit: no approve/merge despite a SUCCESS gate
-    expect(plan[0]).toMatchObject({ actionClass: "label", label: DEFAULT_REVIEW_NAG_LABEL, labelOp: "add" });
-    expect(plan[1]).toMatchObject({ actionClass: "close", closeKind: "review_nag" });
-    expect(plan[1]?.closeComment).toContain("chatty-contributor");
-    expect(plan[1]?.closeComment).toContain("4");
-    expect(plan[1]?.closeComment).toContain("3");
+    // close is pushed BEFORE its coupled label (#label-close-split-brain) — see the blacklist section above.
+    expect(classes(plan)).toEqual(["close", "label"]); // short-circuit: no approve/merge despite a SUCCESS gate
+    expect(plan[0]).toMatchObject({ actionClass: "close", closeKind: "review_nag" });
+    expect(plan[1]).toMatchObject({ actionClass: "label", label: DEFAULT_REVIEW_NAG_LABEL, labelOp: "add", closeKind: "review_nag" });
+    expect(plan[0]?.closeComment).toContain("chatty-contributor");
+    expect(plan[0]?.closeComment).toContain("4");
+    expect(plan[0]?.closeComment).toContain("3");
   });
 
   it("pins the review-nag close to the reviewed head, mirroring blacklist/merge/approve", () => {
@@ -1076,21 +1080,21 @@ describe("review-nag cooldown short-circuit (#2463)", () => {
   });
 
   it("uses the repo-configured reviewNagLabel, defaulting to 'review-nag-cooldown' when unset", () => {
-    expect(planAgentMaintenanceActions(nagged({ reviewNagLabel: "cooldown-hit" }))[0]).toMatchObject({ label: "cooldown-hit" });
+    expect(planAgentMaintenanceActions(nagged({ reviewNagLabel: "cooldown-hit" }))[1]).toMatchObject({ label: "cooldown-hit" });
     expect(DEFAULT_REVIEW_NAG_LABEL).toBe("review-nag-cooldown");
-    expect(planAgentMaintenanceActions(nagged())[0]).toMatchObject({ label: "review-nag-cooldown" });
+    expect(planAgentMaintenanceActions(nagged())[1]).toMatchObject({ label: "review-nag-cooldown" });
   });
 
   it("#label-scoping: an explicit null reviewNagLabel closes WITHOUT any label; the label action carries autonomyClass: close", () => {
     const withLabel = planAgentMaintenanceActions(nagged());
-    expect(classes(withLabel)).toEqual(["label", "close"]);
-    expect(withLabel[0]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
+    expect(classes(withLabel)).toEqual(["close", "label"]);
+    expect(withLabel[1]).toMatchObject({ actionClass: "label", autonomyClass: "close" });
     const withoutLabel = planAgentMaintenanceActions(nagged({ reviewNagLabel: null }));
     expect(classes(withoutLabel)).toEqual(["close"]);
   });
 
   it("fires AHEAD of CI — closes even while CI is still pending (not the pending early-return)", () => {
-    expect(classes(planAgentMaintenanceActions(nagged({ ciState: "pending" })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(nagged({ ciState: "pending" })))).toEqual(["close", "label"]);
   });
 
   it("NEVER fires for the owner, an admin login, or an automation bot (standing rule) — the PR falls through to normal disposition", () => {
@@ -1106,6 +1110,6 @@ describe("review-nag cooldown short-circuit (#2463)", () => {
   it("#label-scoping: the label rides on `close` autonomy, not `label` — `label` alone plans nothing, `close` alone plans both", () => {
     expect(planAgentMaintenanceActions(nagged({ autonomy: {} }))).toEqual([]);
     expect(planAgentMaintenanceActions(nagged({ autonomy: { label: "auto" } }))).toEqual([]);
-    expect(classes(planAgentMaintenanceActions(nagged({ autonomy: { close: "auto" } })))).toEqual(["label", "close"]);
+    expect(classes(planAgentMaintenanceActions(nagged({ autonomy: { close: "auto" } })))).toEqual(["close", "label"]);
   });
 });


### PR DESCRIPTION
## Summary

- The contributor-cap/blacklist/review-nag disposition planner emits a `label` and a `close` as two independent actions sharing the same close autonomy. `label` mutates via the Issues API (`issues: write`, always held) and is exempt from the write-permission readiness gate `close` must pass. When that gate denies the close, the label still posted -- leaving a PR mislabeled (e.g. "over-contributor-limit") while it stayed open indefinitely, since nothing else re-applies the close.
- Fix: push `close` before its coupled `label`, and correlate them by `closeKind` in the executor so the label only applies when its paired close actually completed (or is still queued for the same approval), not when denied/errored.
- Generic fix in the shared disposition planner/executor -- applies uniformly to all three anti-abuse mechanisms (blacklist, contributor cap, review-nag), not hardcoded to any one repo.

## Scope

- [x] Conventional Commit title.
- [x] Focused, backend-only change.
- [x] Follows `CONTRIBUTING.md`.
- [x] Small enough that no linked issue is needed -- a scoped correctness fix discovered via direct investigation of a live PR-cap flagging report.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` -- 100% line/branch coverage on every changed line in `src/settings/agent-actions.ts` and `src/services/agent-action-executor.ts`
- [x] Full `npm run test:ci`-equivalent gate (actionlint, migrations, workers, mcp, REES, UI lint/typecheck/test/build) run earlier this session against the combined working tree; unaffected by this commit's scope
- [x] `npm audit --audit-level=moderate`
- [x] New branches (label/close correlation, queued-vs-denied-vs-errored) covered by new regression tests

## Safety

- [x] No secrets/wallet/hotkey/trust-score/reward content anywhere.
- [x] Public close/label text unchanged.
- [x] N/A: no auth/CORS/session change, no API surface change, no UI change.

## Notes

- Backend-only; no UI Evidence needed.