### PR TITLE
fix(api): accept selfAuthoredLinkedIssueGateMode in the settings write path

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -664,6 +664,7 @@ const maintainerSettingsSchema = z
     qualityGateMinScore: z.number().int().min(0).max(100).nullable(),
     mergeReadinessGateMode: z.enum(["off", "advisory", "block"]),
     manifestPolicyGateMode: z.enum(["off", "advisory", "block"]),
+    selfAuthoredLinkedIssueGateMode: z.enum(["off", "advisory", "block"]),
     firstTimeContributorGrace: z.boolean(),
     slopGateMode: z.enum(["off", "advisory", "block"]),
     slopGateMinScore: z.number().int().min(0).max(100).nullable(),

--- a/test/integration/maintainer-activation.test.ts
+++ b/test/integration/maintainer-activation.test.ts
@@ -150,6 +150,28 @@ describe("maintainer activation routes", () => {
     expect(await response.json()).toMatchObject({ autonomy: { merge: "auto_with_approval" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" } });
   });
 
+  it("persists selfAuthoredLinkedIssueGateMode from the settings PUT (API/OpenAPI parity)", async () => {
+    // The dashboard save path (maintainerSettingsSchema) omitted this DB-backed gate mode, so a maintainer
+    // setting it to `block` via the API had it silently stripped by the validator — while its OpenAPI schema
+    // and config-as-code path both accept it, and the gate genuinely enforces `block`. Prove the round-trip.
+    const app = createApp();
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRepo(env, "owner", "repo", 202);
+    stubMinerFetch();
+    mockedPermission.mockResolvedValue("write");
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 202 });
+    const response = await app.request(`${PATH_ACTIVATE.replace("/activation", "/settings")}`, {
+      method: "PUT",
+      headers: { cookie: `gittensory_session=${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ selfAuthoredLinkedIssueGateMode: "block" }),
+    }, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ selfAuthoredLinkedIssueGateMode: "block" });
+    const persisted = await getRepositorySettings(env, FULL_NAME);
+    expect(persisted.selfAuthoredLinkedIssueGateMode).toBe("block");
+  });
+
   it("forbids a non-maintainer session from the activation preview", async () => {
     const app = createApp();
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator-admin" });


### PR DESCRIPTION
## What
`selfAuthoredLinkedIssueGateMode` — a **DB-backed, required** gate mode (`types.ts`; `db/schema.ts .notNull().default("advisory")`) whose **`block` mode is genuinely enforced** (`rules/advisory.ts:895` closes a self-authored-linked-issue PR when set) — is settable via **config-as-code** (`.gittensory.yml gate.selfAuthoredLinkedIssue`) and is advertised as settable in the **OpenAPI schemas** (`src/openapi/schemas.ts:609,697`). But it was **missing from the maintainer dashboard write path** `maintainerSettingsSchema` (`src/api/routes.ts`), which the `PUT /v1/repos/:owner/:repo/settings` handler uses.

Its DB-backed peers `mergeReadinessGateMode` and `manifestPolicyGateMode` **are** in that schema — this one field was left out.

## Why it matters
The PUT handler spreads the zod-parsed body onto current settings. Because the field wasn't in the schema, a maintainer setting `selfAuthoredLinkedIssueGateMode: "block"` via the dashboard/API had it **silently stripped** — the change was lost and the gate stayed `advisory`, so a self-authored-linked-issue PR that the maintainer intended to hard-block would not be. The **OpenAPI contract and the config-as-code path both accept the field**, but the API write path silently disagreed.

Concrete: `PUT /settings` with `{"selfAuthoredLinkedIssueGateMode":"block"}` returned/persisted `"advisory"` before this change.

## Fix
Add `selfAuthoredLinkedIssueGateMode: z.enum(["off","advisory","block"])` to `maintainerSettingsSchema`, restoring parity with the OpenAPI schema and its DB-backed peers. No downgrade is applied (unlike `qualityGateMode`, whose block is downgraded because it can't enforce — this gate's `block` is real).

## Tests
Adds an integration regression: a `PUT /settings` with `selfAuthoredLinkedIssueGateMode: "block"` now round-trips to the response and persisted settings. The test **fails on the pre-fix code** (returns `"advisory"`), passes with the fix.