### PR TITLE
docs(selfhost): clarify checkRunMode duplicates the required gate check

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -267,6 +267,13 @@ settings:
   publicSignalLevel: standard
 
   # Publish a GitHub check-run. off | enabled. Default: off.
+  # Independent, legacy advisory surface (#2691) -- separate from, and not gated
+  # by, the required `Gittensory Orb Review Agent` gate check under `gate:`
+  # above. At the default `checkRunDetailLevel: minimal` below it posts no
+  # findings at all; at standard/deep it only re-renders findings already shown
+  # in the gate check and the PR comment. One-shot self-host installs should
+  # leave this at the default `off` unless you specifically want a second,
+  # low-detail check-run surface alongside the required gate check.
   checkRunMode: off
 
   # Check-run detail. minimal | standard | deep. Default: minimal.


### PR DESCRIPTION
## Summary

- Closes out the docs follow-up explicitly offered in issue #2691's investigation comment. That
  investigation confirmed `checkRunMode` already defaults to `off`, that the advisory `Gittensory
  Context` check and the required `Gittensory Orb Review Agent` gate check are fully independent
  with zero cross-gating, and that at the default `checkRunDetailLevel: minimal` the Context check
  never posts findings, while at `standard`/`deep` it only re-renders findings already shown in the
  gate check and PR comment. The only remaining action item from that comment was documentation:
  nothing in `.gittensory.yml.example` explained that enabling `checkRunMode` adds a second,
  mostly-redundant check surface once the gate is already on.
- Adds a doc comment directly above `checkRunMode: off` in `.gittensory.yml.example` explaining
  that it's an independent, legacy advisory surface, distinct from and duplicative of the required
  gate check and PR comment, and that one-shot self-host installs should leave it at the default
  `off` unless they specifically want a second, low-detail check-run surface.
- Checked `config/examples/README.md`: it is deliberately scoped to the private-config
  layering/merge mechanism (precedence chain, deep-merge semantics) and explicitly defers to
  `.gittensory.yml.example` as "the exhaustive, field-by-field reference (not duplicated here, so
  the two never drift out of sync)." Adding a per-setting cross-reference there would duplicate
  content the file intentionally avoids duplicating, so it is left untouched.
- No code or behavior change; docs only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (N/A — no workflow files changed; docs-only edit to `.gittensory.yml.example`)
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally (N/A — no `src/**` lines changed; ran the targeted example-config parse test instead: `npx vitest run test/unit/focus-manifest.test.ts -t "gittensory.yml.example"`, passing, confirming the added comment doesn't break YAML/comment parsing)
- [ ] `npm run test:workers` (N/A — no worker code changed)
- [ ] `npm run build:mcp` (N/A — no MCP code changed)
- [ ] `npm run test:mcp-pack` (N/A — no MCP code changed)
- [ ] `npm run ui:openapi:check` (N/A — no API/schema changes)
- [ ] `npm run ui:lint` (N/A — no UI files changed)
- [ ] `npm run ui:typecheck` (N/A — no UI files changed)
- [ ] `npm run ui:build` (N/A — no UI files changed)
- [ ] `npm audit --audit-level=moderate` (N/A — no dependency changes; ran during this session's `npm ci` with 0 vulnerabilities found)
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries (N/A — comment-only change, no new logic branches)

If any required check was skipped, explain why:

- This is a docs-only change (a single YAML comment block added to `.gittensory.yml.example`), so
  the code-oriented checks above (lint/build/coverage/audit/workers/mcp) don't apply. Per the task
  scope, the two checks that matter for this change — the example-config parse test and
  `npm run typecheck` — were both run locally and passed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such change)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP change)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots... (N/A — no visible UI change; this is a config-example comment)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (`.gittensory.yml.example` updated; `CHANGELOG.md` untouched)

## UI Evidence

N/A — no visible UI, frontend, or rendered-docs change; this PR only adds a comment block to `.gittensory.yml.example`.

## Notes

- Closes #2691
