### PR TITLE
fix(signals): classify Package.swift and Podfile as dependency manifests

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -134,6 +134,11 @@ const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([
   "pubspec.yaml",
   "mix.exs",
   "go.work",
+  // Swift Package Manager + CocoaPods manifests. Their lockfiles
+  // (package.resolved, podfile.lock) are already recognized above, so the
+  // manifests they resolve belong in the same dependency-manifest category.
+  "package.swift",
+  "podfile",
 ]);
 
 const DOCS_EXTENSIONS: ReadonlySet<string> = new Set(["md", "mdx", "markdown", "rst", "adoc", "asciidoc"]);

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -314,6 +314,8 @@ describe("classifyChangedFile", () => {
       ["pubspec.yaml", "dependency_manifest"],
       ["mix.exs", "dependency_manifest"],
       ["go.work", "dependency_manifest"],
+      ["MyApp/Package.swift", "dependency_manifest"], // Swift PM manifest (package.resolved lockfile already recognized)
+      ["ios/Podfile", "dependency_manifest"], // CocoaPods manifest (Podfile.lock already recognized)
       ["tsconfig.json", "config"],
       ["vitest.config.ts", "config"],
       ["wrangler.jsonc", "config"],


### PR DESCRIPTION
## Summary
`classifyChangedFile` already recognizes the Swift PM and CocoaPods **lockfiles** (`package.resolved`, `podfile.lock`) as `lockfile`, but the manifests they resolve (`Package.swift`, `Podfile`) fell through to `source`/`other`. A change to those files is a dependency-manifest edit, not source effort.

Adds both to `DEPENDENCY_MANIFEST_NAMES` so they classify consistently with the lockfiles already handled and the other ecosystems' manifests.

## Validation
- `npx vitest run test/unit/path-matchers.test.ts` — green
- `npm run typecheck` — clean