### PR TITLE
fix(selfhost): release the reserved background slot when a queue claim throws

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -438,7 +438,18 @@ export function createPgQueue(
     if (foreground) return foreground;
     if (activeBackground >= backgroundConcurrency) return null;
     activeBackground++;
-    const background = await claimNextWhere(now, "priority < $2");
+    let background: JobRow | null;
+    try {
+      background = await claimNextWhere(now, "priority < $2");
+    } catch (error) {
+      // Release the reserved background slot if the claim query itself throws (a dropped connection / lock
+      // timeout — the exact raw pool failures pump() below is documented to catch). claimNext() runs OUTSIDE
+      // processOne's try/finally, so without this rollback the reserved slot leaks permanently; since
+      // backgroundConcurrency defaults to 1, a single such error would starve the entire background/maintenance
+      // lane with no recovery short of a restart. (#selfhost-bg-slot-leak)
+      activeBackground--;
+      throw error;
+    }
     if (!background) {
       activeBackground--;
       return null;

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -310,7 +310,17 @@ export function createSqliteQueue(
     if (foreground) return foreground;
     if (activeBackground >= backgroundConcurrency) return null;
     activeBackground++;
-    const background = claimNextWhere(now, "priority<?");
+    let background: JobRow | null;
+    try {
+      background = claimNextWhere(now, "priority<?");
+    } catch (error) {
+      // Release the reserved background slot if the claim query itself throws (a SQLite "database is locked" / I/O
+      // error). claimNext() runs OUTSIDE processOne's try/finally, so without this rollback the reserved slot leaks
+      // permanently; since backgroundConcurrency defaults to 1, a single such error would starve the entire
+      // background/maintenance lane with no recovery short of a restart. (#selfhost-bg-slot-leak)
+      activeBackground--;
+      throw error;
+    }
     if (!background) {
       activeBackground--;
       return null;

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -621,6 +621,44 @@ describe("createPgQueue (durable #977)", () => {
     );
   });
 
+  it("REGRESSION: releases the reserved background slot when a background claim query rejects (#selfhost-bg-slot-leak)", async () => {
+    // A raw pool failure during the BACKGROUND claim (a dropped connection / lock timeout — the exact failures
+    // pump() is documented to catch) rejects out of claimNext(), which runs OUTSIDE processOne's try/finally, so
+    // its reserved slot must be rolled back. Without the rollback the slot leaks; since backgroundConcurrency
+    // defaults to 1, a single such error would starve the entire background/maintenance lane until a restart.
+    // Assert the lane still drains a background job after one rejected claim.
+    const m = makePool();
+    let failNextBackgroundClaim = true;
+    const pool = {
+      query: async (sql: unknown, params?: unknown[]) => {
+        const q = String(sql);
+        if (failNextBackgroundClaim && q.includes("UPDATE _selfhost_jobs SET status='processing'") && q.includes("priority < $2")) {
+          failNextBackgroundClaim = false;
+          throw new Error("connection terminated unexpectedly");
+        }
+        return (m.pool as unknown as { query(sql: unknown, params?: unknown[]): Promise<unknown> }).query(q, params);
+      },
+    } as unknown as Pool;
+    const seen: string[] = [];
+    const q = createPgQueue(pool, async (j) => void seen.push(typeOf(j)), { backgroundConcurrency: 1 });
+    await q.init();
+
+    // First drain: foreground claim empty, background claim rejects (transient). pump() catches it; the reserved
+    // slot must be released so the lane is not permanently starved.
+    m.enqueueResult({ rows: [], rowCount: 0 }); // foreground claim → empty
+    await q.drain();
+    expect(seen).toEqual([]);
+
+    // Second drain: the lane must have recovered — foreground empty, background claim returns the job.
+    m.enqueueResult({ rows: [], rowCount: 0 }); // foreground claim → empty
+    m.enqueueResult({
+      rows: [{ id: "background", payload: JSON.stringify(msg("agent-regate-sweep")), attempts: 0, job_key: "agent-regate-sweep", priority: 0 }],
+      rowCount: 1,
+    }); // background claim → job
+    await q.drain();
+    expect(seen).toEqual(["agent-regate-sweep"]);
+  });
+
   it("pre-yields GitHub-budget background jobs when the persisted REST budget is reserved", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -89,6 +89,40 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(q.size()).toBe(0);
   });
 
+  it("REGRESSION: releases the reserved background slot when a background claim query throws (#selfhost-bg-slot-leak)", async () => {
+    // A raw driver failure during the BACKGROUND claim (a transient SQLite "database is locked" / I/O error) throws
+    // out of claimNext(), which runs OUTSIDE processOne's try/finally, so its reserved slot must be rolled back.
+    // Without the rollback the slot leaks; since backgroundConcurrency defaults to 1, a single such error would
+    // starve the entire background/maintenance lane until a restart. Assert the lane still drains a background job
+    // after one throwing claim.
+    let failNextBackgroundClaim = true;
+    const base = makeDriver();
+    const driver = {
+      exec: base.exec.bind(base),
+      query: vi.fn((sql: string, params: unknown[]) => {
+        if (failNextBackgroundClaim && sql.includes("status='pending'") && sql.includes("priority<?")) {
+          failNextBackgroundClaim = false;
+          throw new Error("database is locked");
+        }
+        return base.query(sql, params);
+      }),
+    } as ReturnType<typeof nodeSqliteDriver>;
+    const seen: string[] = [];
+    const q = createSqliteQueue(driver, async (m) => void seen.push(typeOf(m)));
+    // Seed a background job (priority 0 < 8) directly, avoiding send()'s fire-and-forget pump so the drain timing
+    // is deterministic.
+    driver.query(
+      "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 0)",
+      [JSON.stringify(msg("bg-probe"))],
+    );
+
+    await q.drain(); // background claim throws once; pump() catches it, the job stays pending
+    expect(seen).toEqual([]);
+
+    await q.drain(); // the reserved slot was released, so the recovered lane now drains the background job
+    expect(seen).toEqual(["bg-probe"]);
+  });
+
   it("copies carried webhook trace ids into job audit logs", async () => {
     const driver = makeDriver();
     const writes: string[] = [];


### PR DESCRIPTION
## Summary

The self-host durable queue can **permanently and silently disable its entire background/maintenance lane** after a single transient database error.

`claimNext()` reserves a background concurrency slot by incrementing `activeBackground` **before** running the background claim query:

```ts
if (activeBackground >= backgroundConcurrency) return null;
activeBackground++;                                  // slot reserved
const background = await claimNextWhere(now, "priority < $2");   // can throw
```

If that claim query throws — a dropped connection / lock timeout / pool exhaustion on Postgres, or a `SQLITE_BUSY` ("database is locked") / I/O error on SQLite — the reservation is never rolled back. The two release sites are both bypassed: the no-row `activeBackground--` is skipped by the exception, and `processOne`'s `finally` release never runs because `claimNext()` is called **outside** `processOne`'s `try` block. The throw only reaches `pump()`'s catch, which decrements `active`, not `activeBackground`.

Because `backgroundConcurrency` **defaults to 1**, a single such error pins `activeBackground` at the cap, so every subsequent `claimNext()` short-circuits at the `activeBackground >= backgroundConcurrency` guard and returns `null`. From then on **no** background/maintenance job (`backfill-registered-repos`, `build-contributor-evidence`, `rag-index-repo`, `refresh-*`, `prune-retention`, notification evaluate/deliver, the regate sweep, …) is ever claimed again until the process restarts. Foreground webhook/PR work keeps flowing on the untouched foreground path, so queue depth and latency look healthy while maintenance quietly dies — the outage is invisible until stale data or undelivered notifications surface later.

**Root cause:** a reserved counter is incremented before an `await`/call that can throw, with no rollback on the throw path.

**Fix:** roll back the reserved background slot if the claim query throws, then rethrow so `pump()`'s existing error handling and logging are unchanged. Applied identically to both backends (`pg-queue.ts`, `sqlite-queue.ts`), each with a regression test.

- Root cause / files: [`src/selfhost/pg-queue.ts`](src/selfhost/pg-queue.ts) `claimNext()` and [`src/selfhost/sqlite-queue.ts`](src/selfhost/sqlite-queue.ts) `claimNext()`.
- Impact: eliminates a permanent, silent, single-error self-DoS of all self-host background maintenance.
- Risk/tradeoffs: minimal and backward-compatible — behavior is identical on every non-throwing path; the only change is that a throwing claim now releases its reservation before propagating the same error to the same handler. No API/DB/UI/MCP surface is touched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. _(No issue: a self-contained, two-file backend correctness fix; the summary explains the root cause and impact.)_

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files changed.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — run scoped to the changed files; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed**. Every changed line and the new `catch` branch are covered (both backends); the only uncovered lines reported for these files are pre-existing and untouched by this diff.
- [ ] `npm run test:workers` — not run; change is not a Workers-runtime path.
- [ ] `npm run build:mcp` — not run; no MCP change.
- [ ] `npm run test:mcp-pack` — not run; no MCP change.
- [ ] `npm run ui:openapi:check` — not run; no API/OpenAPI change.
- [ ] `npm run ui:lint` — not run; no UI change.
- [ ] `npm run ui:typecheck` — not run; no UI change.
- [ ] `npm run ui:build` — not run; no UI change.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency change.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — a regression test per backend that reproduces the leak (claim throws once) and asserts the lane still drains a background job afterward. Both tests were confirmed to **fail without the fix** and pass with it.

If any required check was skipped, explain why:

- This is a backend-only, two-file fix in `src/selfhost/*-queue.ts` with no UI, API/OpenAPI, MCP, migration, workflow, or dependency surface, so those checks are not applicable. `git diff --check`, `typecheck`, and coverage of the changed files were run and are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. _(N/A — no auth/session/CORS surface changed.)_
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. _(N/A — no API/OpenAPI/MCP surface changed.)_
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. _(N/A — no UI change.)_
- [x] Visible UI changes include a `UI Evidence` section. _(N/A — no visible UI change.)_
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. _(N/A — no changelog edited.)_

## Notes

- The related upstream branch `seer/fix/selfhost-pg-queue-resilience` wraps the **UPDATE/DELETE/reschedule** queries in `processOne` with a retry helper; it does not touch `claimNext()`, the `activeBackground` counter, or the SQLite backend, so this fix is complementary and non-overlapping.
