### PR TITLE
fix(db): make the gate-block upsert head-SHA compare portable to Postgres

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4059,20 +4059,31 @@ export async function recordGateBlockOutcome(
     overridden: false,
     // blockedAt + updatedAt default to nowIso() via the schema `$defaultFn` on a fresh insert.
   };
+  // Null-safe, dialect-portable "head SHA unchanged" predicate. Preserve `overridden` ONLY when the head SHA
+  // is unchanged: a maintainer override applies to the exact commit it was granted on, so a NEW commit
+  // re-blocking must clear it — otherwise a one-time override would permanently disable the gate (and the
+  // draft-dodge auto-close) for every future push to the PR. (#audit-3.14)
+  //
+  // Build the predicate from the (build-time) value rather than SQLite's `head_sha IS <value>` operator:
+  // that operator is a hard parse error on the self-host Postgres backend (`head_sha IS $1`), and because the
+  // sole caller records this as best-effort telemetry (`.catch`), it silently threw away every gate_outcomes
+  // upsert there — killing the draft-dodge enforcement `getGateBlockOutcome` drives. Deriving the branch here
+  // also keeps the value out of an untyped `$n IS NULL` position (which Postgres rejects). Both dialects treat
+  // `col = ?` / `col IS NULL` identically, matching the original null-safe semantics on SQLite.
+  const headShaUnchanged =
+    values.headSha === null
+      ? sql`${gateOutcomes.headSha} IS NULL`
+      : sql`${gateOutcomes.headSha} = ${values.headSha}`;
   await getDb(env.DB)
     .insert(gateOutcomes)
     .values(values)
     .onConflictDoUpdate({
       target: [gateOutcomes.repoFullName, gateOutcomes.pullNumber],
-      // Refresh the codes/head/timestamp on a re-block. Preserve `overridden` ONLY when the head SHA is
-      // unchanged: a maintainer override applies to the exact commit it was granted on, so a NEW commit
-      // re-blocking must clear it — otherwise a one-time override would permanently disable the gate
-      // (and the draft-dodge auto-close) for every future push to the PR. (#audit-3.14)
       set: {
         headSha: values.headSha,
         blockerCodesJson: values.blockerCodesJson,
         updatedAt: nowIso(),
-        overridden: sql`CASE WHEN ${gateOutcomes.headSha} IS ${values.headSha} THEN ${gateOutcomes.overridden} ELSE 0 END`,
+        overridden: sql`CASE WHEN ${headShaUnchanged} THEN ${gateOutcomes.overridden} ELSE 0 END`,
       },
     });
 }

--- a/test/integration/selfhost-pg.test.ts
+++ b/test/integration/selfhost-pg.test.ts
@@ -8,6 +8,7 @@ import { runSelfHostMigrations } from "../../src/selfhost/migrate";
 import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "../../src/selfhost/pg-adapter";
 import { pruneExpiredRecords } from "../../src/db/retention";
 import { processJob } from "../../src/queue/processors";
+import { getGateBlockOutcome, markGateOutcomeOverridden, recordGateBlockOutcome } from "../../src/db/repositories";
 
 const URL = process.env.PG_TEST_URL;
 const suite = URL ? describe : describe.skip;
@@ -83,6 +84,32 @@ suite("Postgres backend (#977) — real Postgres", () => {
     await expect(processJob(env, { type: "prune-retention", requestedBy: "schedule" })).resolves.toBeUndefined();
     const audit = await db.prepare("SELECT outcome FROM audit_events WHERE event_type = ?").bind("retention.prune").first<{ outcome: string }>();
     expect(audit?.outcome).toBe("success");
+  });
+
+  it("recordGateBlockOutcome upserts on Postgres and preserves/clears `overridden` null-safely (regression: the SQLite-only `head_sha IS <value>` operator was a hard Postgres parse error, so the swallowed upsert silently dropped every gate_outcomes row and the draft-dodge enforcement it drives)", async () => {
+    const db = createPgAdapter(pool);
+    const env = { DB: db } as unknown as Env;
+
+    // (1) Core regression: the ON CONFLICT upsert must not throw on Postgres. Before the fix its `overridden`
+    // clause emitted `head_sha IS $1`, which Postgres rejects at parse time, so this INSERT threw and — via the
+    // caller's best-effort `.catch(() => undefined)` — no gate_outcomes row was ever persisted on this backend.
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 42, headSha: "sha-a", blockerCodes: ["slop_risk"] });
+    expect(await getGateBlockOutcome(env, "owner/repo", 42)).toMatchObject({ headSha: "sha-a", overridden: false, blockerCodes: ["slop_risk"] });
+
+    // (2) A re-block on the SAME head preserves a maintainer override (the `=` branch of the null-safe compare).
+    await markGateOutcomeOverridden(env, "owner/repo", 42);
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 42, headSha: "sha-a", blockerCodes: ["slop_risk", "missing_linked_issue"] });
+    expect(await getGateBlockOutcome(env, "owner/repo", 42)).toMatchObject({ overridden: true, blockerCodes: ["slop_risk", "missing_linked_issue"] });
+
+    // (3) A re-block on a NEW head clears the override — it binds to the exact commit it was granted on (#audit-3.14).
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 42, headSha: "sha-b", blockerCodes: ["slop_risk"] });
+    expect(await getGateBlockOutcome(env, "owner/repo", 42)).toMatchObject({ headSha: "sha-b", overridden: false });
+
+    // (4) Null-safe branch: two blocks that both record NO head SHA still match, preserving the override.
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 43, blockerCodes: ["x"] });
+    await markGateOutcomeOverridden(env, "owner/repo", 43);
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 43, blockerCodes: ["x", "y"] });
+    expect(await getGateBlockOutcome(env, "owner/repo", 43)).toMatchObject({ overridden: true });
   });
 
   it("tunes github_rate_limit_observations autovacuum below Postgres's default, idempotently (#2543)", async () => {


### PR DESCRIPTION
## Summary

On the self-host **Postgres** backend, `recordGateBlockOutcome` throws on every call, so **no `gate_outcomes` row is ever persisted** — silently disabling the `#554` gate false-positive telemetry **and** the draft-dodge anti-abuse auto-close that depends on it.

The upsert preserves a maintainer `overridden` flag across a re-block with SQLite's null-safe `IS` operator:

```ts
overridden: sql`CASE WHEN ${gateOutcomes.headSha} IS ${values.headSha} THEN ${gateOutcomes.overridden} ELSE 0 END`
```

`${values.headSha}` is a JS value, so drizzle emits it as a bound parameter → `head_sha IS ?`. The Postgres adapter (`createPgAdapter` → `translateSql`) rewrites `?` → `$1` but leaves the operator, producing `head_sha IS $1`. Postgres's `IS` predicate only accepts `NULL`/`TRUE`/`FALSE`/`UNKNOWN`/`DISTINCT FROM`, so the whole `INSERT … ON CONFLICT` fails at **parse** time:

```
error: syntax error at or near "$1"   (SQLSTATE 42601)
```

The sole caller records this as best-effort telemetry behind `.catch(() => undefined)` ([`processors.ts`](src/queue/processors.ts)), so the exception is swallowed with no log. Every later `getGateBlockOutcome(repo, pull)` then returns `undefined`, so `closeDraftDodgeAttemptIfBlocked` never fires — a contributor who converts a gate-rejected PR to draft is never re-closed on Postgres deployments.

## Root cause

A SQLite-specific null-safe operator (`x IS <value>`) in a query that must also run on the self-host Postgres backend. It is the **only** `IS <value>` usage in `src/`, and the `translateSql` dialect layer does not rewrite it.

## Why it matters

An entire supported backend silently loses a gate-precision telemetry signal and — more importantly — a security/anti-abuse enforcement control, with **no error surfaced** (the failure is swallowed). It is invisible until someone notices draft-dodge attempts are never closed.

## Fix

Build the "head SHA unchanged" predicate from the build-time value instead of the `IS` operator:

```ts
const headShaUnchanged =
  values.headSha === null
    ? sql`${gateOutcomes.headSha} IS NULL`
    : sql`${gateOutcomes.headSha} = ${values.headSha}`;
// … overridden: sql`CASE WHEN ${headShaUnchanged} THEN ${gateOutcomes.overridden} ELSE 0 END`
```

- **Null-safe** — identical to the original `IS` semantics (`IS NULL` matches a stored null; `= ?` matches an equal SHA; a mismatch or one-sided null clears the override).
- **Portable** — both SQLite and Postgres accept `col IS NULL` / `col = ?` identically.
- Deriving the branch from the value also avoids the secondary Postgres error `could not determine data type of parameter` that a naive `$n IS NULL` rewrite would hit (an untyped bound param in an `IS NULL` position).

Minimal and backward-compatible: the default SQLite backend behaves exactly as before.

## Why this approach

I considered adding an `IS <value>` rewrite to `pg-dialect.ts`, but a regex SQL translation risks mis-handling legitimate `IS NULL` / `IS DISTINCT FROM` and this is the only such call site — so fixing it at the source is smaller, clearer, and lower-risk.

## Testing

- **Real-Postgres regression test** added to `test/integration/selfhost-pg.test.ts` (runs against a live PG via `PG_TEST_URL`; skipped in CI without it). It asserts the upsert succeeds and covers preserve-on-same-head, clear-on-new-head, and the null-safe no-head path.
  - Verified against `postgres:16`: **before** the fix the test fails with `syntax error at or near "$11" (42601)`; **after**, it passes.
- Existing SQLite gate tests (`test/unit/gate-precision.test.ts`, 16 tests) — which already pin the same-head / null-safe / new-head override semantics — remain green, confirming SQLite behavior is unchanged. Both branches of the new build-time predicate are exercised by these CI tests.
- `npm run typecheck` passes.

## Risk / tradeoffs

Very low. One backend-agnostic SQL expression changed; SQLite output is semantically identical, Postgres now parses and persists correctly. No schema/API/migration change.
