### PR TITLE
feat(backup): emit restore manifest

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -11,11 +11,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:421",
+    firstReference: "src/server.ts:422",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:418",
+    firstReference: "src/server.ts:419",
   },
   {
     name: "AI_EMBED_MODEL",
@@ -43,7 +43,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:360",
+    firstReference: "src/server.ts:361",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -79,11 +79,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:863",
+    firstReference: "src/server.ts:864",
   },
   {
     name: "DATABASE_PATH",
-    firstReference: "src/server.ts:243",
+    firstReference: "src/server.ts:244",
   },
   {
     name: "DATABASE_URL",
@@ -107,11 +107,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:489",
+    firstReference: "src/server.ts:490",
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:277",
+    firstReference: "src/server.ts:278",
   },
   {
     name: "GITTENSORY_VERSION",
@@ -127,7 +127,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:373",
+    firstReference: "src/server.ts:374",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -187,7 +187,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:907",
+    firstReference: "src/server.ts:913",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -203,7 +203,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:909",
+    firstReference: "src/server.ts:915",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -235,11 +235,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGVECTOR_ENABLED",
-    firstReference: "src/server.ts:223",
+    firstReference: "src/server.ts:224",
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:662",
+    firstReference: "src/server.ts:663",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -255,7 +255,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:508",
+    firstReference: "src/server.ts:509",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
@@ -267,7 +267,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:553",
+    firstReference: "src/server.ts:554",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -283,7 +283,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SENTRY_DSN",
-    firstReference: "src/selfhost/sentry.ts:355",
+    firstReference: "src/selfhost/sentry.ts:365",
   },
   {
     name: "SENTRY_ENVIRONMENT",
@@ -295,15 +295,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SENTRY_SERVER_NAME",
-    firstReference: "src/selfhost/sentry.ts:373",
+    firstReference: "src/selfhost/sentry.ts:383",
   },
   {
     name: "SENTRY_TRACES_SAMPLE_RATE",
-    firstReference: "src/selfhost/sentry.ts:161",
+    firstReference: "src/selfhost/sentry.ts:171",
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:779",
+    firstReference: "src/server.ts:780",
   },
 ];
 
@@ -311,15 +311,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
   "| `AI_COMBINE` | `src/selfhost/ai.ts:930` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:421` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:418` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:422` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:419` |",
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:826` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts:932` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:830` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:57` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:829` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:360` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:361` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:108` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:49` |",
@@ -328,19 +328,19 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:53` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:112` |",
   "| `CODEX_HOME` | `src/selfhost/ai.ts:274` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:863` |",
-  "| `DATABASE_PATH` | `src/server.ts:243` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:864` |",
+  "| `DATABASE_PATH` | `src/server.ts:244` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/selfhost/discord-notify.ts:31` |",
   "| `DISCORD_WEBHOOK_URL` | `src/selfhost/discord-notify.ts:40` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:489` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:277` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:490` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:278` |",
   "| `GITTENSORY_VERSION` | `src/selfhost/health.ts:29` |",
   "| `HOME` | `src/selfhost/ai.ts:274` |",
   "| `MAINTENANCE_ADMISSION_ENABLED` | `src/selfhost/maintenance-admission.ts:83` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:373` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:374` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
   "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:823` |",
@@ -355,11 +355,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:907` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:913` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:909` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:915` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -367,22 +367,22 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_EXPORTER` | `src/selfhost/otel.ts:40` |",
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
-  "| `PGVECTOR_ENABLED` | `src/server.ts:223` |",
-  "| `PORT` | `src/server.ts:662` |",
+  "| `PGVECTOR_ENABLED` | `src/server.ts:224` |",
+  "| `PORT` | `src/server.ts:663` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:508` |",
+  "| `QDRANT_URL` | `src/server.ts:509` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:102` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:553` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:554` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
-  "| `SENTRY_DSN` | `src/selfhost/sentry.ts:355` |",
+  "| `SENTRY_DSN` | `src/selfhost/sentry.ts:365` |",
   "| `SENTRY_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
-  "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:373` |",
-  "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:161` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:779` |",
+  "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:383` |",
+  "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:171` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:780` |",
 ].join("\n");

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -14,6 +14,8 @@ PGPASSFILE_CREATED=""
 MANIFEST_TMP=""
 SQLITE_MANIFEST_FILE=""
 SQLITE_MANIFEST_BYTES=""
+POSTGRES_MANIFEST_FILE=""
+POSTGRES_MANIFEST_BYTES=""
 QDRANT_MANIFEST_FILE=""
 cleanup() {
   if [ -n "$PGPASSFILE_CREATED" ]; then
@@ -72,10 +74,14 @@ json_file_entry() {
 
 write_manifest() {
   sqlite_json=null
+  postgres_json=null
   qdrant_file_json=null
 
   if [ -n "$SQLITE_MANIFEST_FILE" ]; then
     sqlite_json=$(json_file_entry "$SQLITE_MANIFEST_FILE" "$SQLITE_MANIFEST_BYTES")
+  fi
+  if [ -n "$POSTGRES_MANIFEST_FILE" ]; then
+    postgres_json=$(json_file_entry "$POSTGRES_MANIFEST_FILE" "$POSTGRES_MANIFEST_BYTES")
   fi
   if [ -n "$QDRANT_MANIFEST_FILE" ]; then
     qdrant_file_json="\"$(json_escape "$QDRANT_MANIFEST_FILE")\""
@@ -85,6 +91,7 @@ write_manifest() {
   {
     printf '{\n'
     printf '  "ts": "%s",\n' "$(json_escape "$TS")"
+    printf '  "postgres": %s,\n' "$postgres_json"
     printf '  "sqlite": %s,\n' "$sqlite_json"
     printf '  "qdrant": {"file": %s},\n' "$qdrant_file_json"
     printf '  "retain": %s\n' "$RETAIN"
@@ -237,6 +244,8 @@ case "$PG_DB" in
     prepare_pg_env
     POSTGRES_OUT="$OUT/postgres/gittensory-$TS.dump"
     pg_dump -Fc -f "$POSTGRES_OUT" "$PG_SANITIZED_URL"
+    POSTGRES_MANIFEST_FILE="postgres/$(basename "$POSTGRES_OUT")"
+    POSTGRES_MANIFEST_BYTES=$(file_bytes "$POSTGRES_OUT")
     echo "[backup] postgres -> $POSTGRES_OUT"
     ;;
   *)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -81,7 +81,7 @@ write_manifest() {
     qdrant_file_json="\"$(json_escape "$QDRANT_MANIFEST_FILE")\""
   fi
 
-  MANIFEST_TMP="$OUT/.manifest.$$.tmp"
+  MANIFEST_TMP=$(mktemp "$OUT/.manifest.XXXXXX")
   {
     printf '{\n'
     printf '  "ts": "%s",\n' "$(json_escape "$TS")"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -11,9 +11,16 @@ DB=${DATABASE_PATH:-/data/gittensory.sqlite}
 PG_DB="${GITTENSORY_BACKUP_SOURCE_DATABASE_URL:-${DATABASE_URL:-}}"
 OUT=${BACKUP_OUT_DIR:-/backups}
 PGPASSFILE_CREATED=""
+MANIFEST_TMP=""
+SQLITE_MANIFEST_FILE=""
+SQLITE_MANIFEST_BYTES=""
+QDRANT_MANIFEST_FILE=""
 cleanup() {
   if [ -n "$PGPASSFILE_CREATED" ]; then
     rm -f "$PGPASSFILE_CREATED"
+  fi
+  if [ -n "$MANIFEST_TMP" ]; then
+    rm -f "$MANIFEST_TMP"
   fi
 }
 trap cleanup EXIT HUP INT TERM
@@ -47,6 +54,44 @@ url_decode() {
 
 pgpass_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/:/\\:/g'
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+file_bytes() {
+  wc -c < "$1" | tr -d '[:space:]'
+}
+
+json_file_entry() {
+  rel_file=$1
+  bytes=$2
+  printf '{"file":"%s","bytes":%s}' "$(json_escape "$rel_file")" "$bytes"
+}
+
+write_manifest() {
+  sqlite_json=null
+  qdrant_file_json=null
+
+  if [ -n "$SQLITE_MANIFEST_FILE" ]; then
+    sqlite_json=$(json_file_entry "$SQLITE_MANIFEST_FILE" "$SQLITE_MANIFEST_BYTES")
+  fi
+  if [ -n "$QDRANT_MANIFEST_FILE" ]; then
+    qdrant_file_json="\"$(json_escape "$QDRANT_MANIFEST_FILE")\""
+  fi
+
+  MANIFEST_TMP="$OUT/.manifest.$$.tmp"
+  {
+    printf '{\n'
+    printf '  "ts": "%s",\n' "$(json_escape "$TS")"
+    printf '  "sqlite": %s,\n' "$sqlite_json"
+    printf '  "qdrant": {"file": %s},\n' "$qdrant_file_json"
+    printf '  "retain": %s\n' "$RETAIN"
+    printf '}\n'
+  } > "$MANIFEST_TMP"
+  mv "$MANIFEST_TMP" "$OUT/manifest.json"
+  MANIFEST_TMP=""
 }
 
 # Strips the password from a postgres(ql):// URI -- from EITHER the userinfo (user:password@host) or a
@@ -190,8 +235,9 @@ case "$PG_DB" in
       exit 1
     fi
     prepare_pg_env
-    pg_dump -Fc -f "$OUT/postgres/gittensory-$TS.dump" "$PG_SANITIZED_URL"
-    echo "[backup] postgres -> $OUT/postgres/gittensory-$TS.dump"
+    POSTGRES_OUT="$OUT/postgres/gittensory-$TS.dump"
+    pg_dump -Fc -f "$POSTGRES_OUT" "$PG_SANITIZED_URL"
+    echo "[backup] postgres -> $POSTGRES_OUT"
     ;;
   *)
     if [ -f "$DB" ]; then
@@ -203,6 +249,8 @@ case "$PG_DB" in
         && [ -s "$SQLITE_OUT" ] \
         && [ "$(sqlite3 "$SQLITE_OUT" 'PRAGMA integrity_check;' 2>/dev/null)" = "ok" ]; then
         gzip -f "$SQLITE_OUT"
+        SQLITE_MANIFEST_FILE="sqlite/$(basename "$SQLITE_OUT").gz"
+        SQLITE_MANIFEST_BYTES=$(file_bytes "$SQLITE_OUT.gz")
         echo "[backup] sqlite -> $SQLITE_OUT.gz"
       else
         rm -f "$SQLITE_OUT"
@@ -221,6 +269,7 @@ if [ -n "${QDRANT_URL:-}" ]; then
   NAME=$(curl -sf -X POST "$QDRANT_URL/snapshots" 2>/dev/null | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
   if [ -n "$NAME" ]; then
     if curl -sf "$QDRANT_URL/snapshots/$NAME" -o "$OUT/qdrant/$NAME" 2>/dev/null; then
+      QDRANT_MANIFEST_FILE="qdrant/$NAME"
       echo "[backup] qdrant -> $OUT/qdrant/$NAME"
     fi
     curl -sf -X DELETE "$QDRANT_URL/snapshots/$NAME" >/dev/null 2>&1 || true
@@ -249,4 +298,5 @@ if [ "$SQLITE_BACKUP_FAILED" = 1 ]; then
   exit 1
 fi
 
+write_manifest
 echo "[backup] complete ($TS); retaining newest $RETAIN per target"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -5,8 +5,30 @@
 # Backups land in the `gittensory-backups` volume at /backups/{postgres,sqlite,qdrant}.
 set -eu
 
+normalize_backup_retain() {
+  retain_value=$1
+  case "$retain_value" in
+    ''|*[!0-9]*)
+      echo "[backup] invalid BACKUP_RETAIN=$retain_value; using 7" >&2
+      printf '%s\n' 7
+      return
+      ;;
+  esac
+
+  while [ "${retain_value#0}" != "$retain_value" ]; do
+    retain_value=${retain_value#0}
+  done
+  if [ -z "$retain_value" ] || [ "$retain_value" = 0 ]; then
+    echo "[backup] BACKUP_RETAIN=0 would remove the current backup; using 1" >&2
+    printf '%s\n' 1
+    return
+  fi
+
+  printf '%s\n' "$retain_value"
+}
+
 TS=$(date -u +%Y%m%dT%H%M%SZ)
-RETAIN=${BACKUP_RETAIN:-7}
+RETAIN=$(normalize_backup_retain "${BACKUP_RETAIN:-7}")
 DB=${DATABASE_PATH:-/data/gittensory.sqlite}
 PG_DB="${GITTENSORY_BACKUP_SOURCE_DATABASE_URL:-${DATABASE_URL:-}}"
 OUT=${BACKUP_OUT_DIR:-/backups}

--- a/test/unit/backup-script.test.ts
+++ b/test/unit/backup-script.test.ts
@@ -63,6 +63,22 @@ fi
 exit 0
 `;
 
+const STUB_PG_DUMP = `#!/bin/sh
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-f" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+if [ -z "$out" ]; then
+  exit 2
+fi
+printf %s "stub-postgres-dump-bytes" > "$out"
+exit 0
+`;
+
 function createHarness() {
   const dir = mkdtempSync(join(tmpdir(), "gittensory-backup-"));
   const binDir = join(dir, "bin");
@@ -76,13 +92,16 @@ function createHarness() {
   const curlStub = join(binDir, "curl");
   writeFileSync(curlStub, STUB_CURL);
   chmodSync(curlStub, 0o755);
+  const pgDumpStub = join(binDir, "pg_dump");
+  writeFileSync(pgDumpStub, STUB_PG_DUMP);
+  chmodSync(pgDumpStub, 0o755);
   return { dir, binDir, outDir, dbPath };
 }
 
 function runBackup(
   h: ReturnType<typeof createHarness>,
   mode: "ok" | "corrupt",
-  options: { qdrant?: boolean } = {},
+  options: { databaseUrl?: string; qdrant?: boolean } = {},
 ) {
   // Absolute /bin/sh so the command itself never depends on PATH; the script's own
   // sqlite3/gzip/date lookups use the PATH we inject (stub bin first, real tools after).
@@ -95,8 +114,8 @@ function runBackup(
       DATABASE_PATH: h.dbPath,
       BACKUP_RETAIN: "1",
       STUB_SQLITE_MODE: mode,
-      // Force the SQLite branch + skip Qdrant regardless of the ambient test env.
-      DATABASE_URL: "",
+      // Keep ambient test env from selecting a different backup branch or Qdrant target.
+      DATABASE_URL: options.databaseUrl ?? "",
       GITTENSORY_BACKUP_SOURCE_DATABASE_URL: "",
       QDRANT_URL: options.qdrant ? "http://qdrant.test" : "",
     },
@@ -106,6 +125,7 @@ function runBackup(
 function readManifest(h: ReturnType<typeof createHarness>) {
   return JSON.parse(readFileSync(join(h.outDir, "manifest.json"), "utf8")) as {
     ts: string;
+    postgres: { file: string; bytes: number } | null;
     sqlite: { file: string; bytes: number } | null;
     qdrant: { file: string | null };
     retain: number;
@@ -141,7 +161,14 @@ describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
     const manifest = readManifest(harness);
     expect(manifest.ts).toMatch(/^\d{8}T\d{6}Z$/);
     expect(manifest.retain).toBe(1);
-    expect(Object.keys(manifest).sort()).toEqual(["qdrant", "retain", "sqlite", "ts"]);
+    expect(Object.keys(manifest).sort()).toEqual([
+      "postgres",
+      "qdrant",
+      "retain",
+      "sqlite",
+      "ts",
+    ]);
+    expect(manifest.postgres).toBeNull();
     expect(manifest.sqlite?.file).toMatch(/^sqlite\/gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
     expect(manifest.sqlite?.bytes).toBe(
       statSync(join(harness.outDir, manifest.sqlite!.file)).size,
@@ -155,6 +182,7 @@ describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
     expect(res.status).toBe(0);
     const manifest = readManifest(harness);
     expect(manifest.sqlite?.file).toMatch(/^sqlite\/gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
+    expect(manifest.postgres).toBeNull();
     expect(manifest.qdrant.file).toBe("qdrant/qdrant-snapshot-123.snap");
     expect(readFileSync(join(harness.outDir, manifest.qdrant.file!), "utf8")).toBe(
       "stub-qdrant-snapshot-bytes",
@@ -169,10 +197,30 @@ describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("sqlite db not found");
     const manifest = readManifest(harness);
+    expect(manifest.postgres).toBeNull();
     expect(manifest.sqlite).toBeNull();
     expect(manifest.qdrant.file).toBeNull();
     expect(existsSync(join(harness.outDir, "sqlite"))).toBe(true);
     expect(readdirSync(join(harness.outDir, "sqlite"))).toHaveLength(0);
+  });
+
+  it("records a postgres dump artifact when postgres backup succeeds", () => {
+    const res = runBackup(harness, "ok", {
+      databaseUrl: "postgresql://backup@example.invalid/gittensory",
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("[backup] postgres ->");
+    const manifest = readManifest(harness);
+    expect(manifest.postgres?.file).toMatch(/^postgres\/gittensory-\d{8}T\d{6}Z\.dump$/);
+    expect(manifest.postgres?.bytes).toBe(
+      statSync(join(harness.outDir, manifest.postgres!.file)).size,
+    );
+    expect(manifest.sqlite).toBeNull();
+    expect(manifest.qdrant.file).toBeNull();
+    expect(readFileSync(join(harness.outDir, manifest.postgres!.file), "utf8")).toBe(
+      "stub-postgres-dump-bytes",
+    );
   });
 
   it("fails loudly, removes the bad file, and skips retention when the backup is corrupt", () => {

--- a/test/unit/backup-script.test.ts
+++ b/test/unit/backup-script.test.ts
@@ -1,9 +1,12 @@
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -36,6 +39,30 @@ esac
 exit 0
 `;
 
+const STUB_CURL = `#!/bin/sh
+case "$*" in
+  *"-X POST"*)
+    printf '%s\\n' '{"name":"qdrant-snapshot-123.snap"}'
+    exit 0
+    ;;
+  *"-X DELETE"*)
+    exit 0
+    ;;
+esac
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+if [ -n "$out" ]; then
+  printf %s "stub-qdrant-snapshot-bytes" > "$out"
+fi
+exit 0
+`;
+
 function createHarness() {
   const dir = mkdtempSync(join(tmpdir(), "gittensory-backup-"));
   const binDir = join(dir, "bin");
@@ -46,10 +73,17 @@ function createHarness() {
   const stub = join(binDir, "sqlite3");
   writeFileSync(stub, STUB_SQLITE);
   chmodSync(stub, 0o755);
+  const curlStub = join(binDir, "curl");
+  writeFileSync(curlStub, STUB_CURL);
+  chmodSync(curlStub, 0o755);
   return { dir, binDir, outDir, dbPath };
 }
 
-function runBackup(h: ReturnType<typeof createHarness>, mode: "ok" | "corrupt") {
+function runBackup(
+  h: ReturnType<typeof createHarness>,
+  mode: "ok" | "corrupt",
+  options: { qdrant?: boolean } = {},
+) {
   // Absolute /bin/sh so the command itself never depends on PATH; the script's own
   // sqlite3/gzip/date lookups use the PATH we inject (stub bin first, real tools after).
   return spawnSync("/bin/sh", [scriptPath], {
@@ -64,9 +98,18 @@ function runBackup(h: ReturnType<typeof createHarness>, mode: "ok" | "corrupt") 
       // Force the SQLite branch + skip Qdrant regardless of the ambient test env.
       DATABASE_URL: "",
       GITTENSORY_BACKUP_SOURCE_DATABASE_URL: "",
-      QDRANT_URL: "",
+      QDRANT_URL: options.qdrant ? "http://qdrant.test" : "",
     },
   });
+}
+
+function readManifest(h: ReturnType<typeof createHarness>) {
+  return JSON.parse(readFileSync(join(h.outDir, "manifest.json"), "utf8")) as {
+    ts: string;
+    sqlite: { file: string; bytes: number } | null;
+    qdrant: { file: string | null };
+    retain: number;
+  };
 }
 
 describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
@@ -89,6 +132,47 @@ describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
     expect(files.filter((f) => f.endsWith(".sqlite.gz")).length).toBe(1);
     // no uncompressed leftover
     expect(files.filter((f) => f.endsWith(".sqlite")).length).toBe(0);
+  });
+
+  it("writes a manifest for a verified sqlite backup without qdrant", () => {
+    const res = runBackup(harness, "ok");
+
+    expect(res.status).toBe(0);
+    const manifest = readManifest(harness);
+    expect(manifest.ts).toMatch(/^\d{8}T\d{6}Z$/);
+    expect(manifest.retain).toBe(1);
+    expect(Object.keys(manifest).sort()).toEqual(["qdrant", "retain", "sqlite", "ts"]);
+    expect(manifest.sqlite?.file).toMatch(/^sqlite\/gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
+    expect(manifest.sqlite?.bytes).toBe(
+      statSync(join(harness.outDir, manifest.sqlite!.file)).size,
+    );
+    expect(manifest.qdrant.file).toBeNull();
+  });
+
+  it("records both sqlite and qdrant artifacts when both succeed", () => {
+    const res = runBackup(harness, "ok", { qdrant: true });
+
+    expect(res.status).toBe(0);
+    const manifest = readManifest(harness);
+    expect(manifest.sqlite?.file).toMatch(/^sqlite\/gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
+    expect(manifest.qdrant.file).toBe("qdrant/qdrant-snapshot-123.snap");
+    expect(readFileSync(join(harness.outDir, manifest.qdrant.file!), "utf8")).toBe(
+      "stub-qdrant-snapshot-bytes",
+    );
+  });
+
+  it("writes no sqlite artifact entry when the database is missing", () => {
+    rmSync(harness.dbPath);
+
+    const res = runBackup(harness, "ok");
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("sqlite db not found");
+    const manifest = readManifest(harness);
+    expect(manifest.sqlite).toBeNull();
+    expect(manifest.qdrant.file).toBeNull();
+    expect(existsSync(join(harness.outDir, "sqlite"))).toBe(true);
+    expect(readdirSync(join(harness.outDir, "sqlite"))).toHaveLength(0);
   });
 
   it("fails loudly, removes the bad file, and skips retention when the backup is corrupt", () => {

--- a/test/unit/backup-script.test.ts
+++ b/test/unit/backup-script.test.ts
@@ -101,7 +101,7 @@ function createHarness() {
 function runBackup(
   h: ReturnType<typeof createHarness>,
   mode: "ok" | "corrupt",
-  options: { databaseUrl?: string; qdrant?: boolean } = {},
+  options: { databaseUrl?: string; qdrant?: boolean; retain?: string } = {},
 ) {
   // Absolute /bin/sh so the command itself never depends on PATH; the script's own
   // sqlite3/gzip/date lookups use the PATH we inject (stub bin first, real tools after).
@@ -112,7 +112,7 @@ function runBackup(
       PATH: `${h.binDir}:${process.env.PATH ?? ""}`,
       BACKUP_OUT_DIR: h.outDir,
       DATABASE_PATH: h.dbPath,
-      BACKUP_RETAIN: "1",
+      BACKUP_RETAIN: options.retain ?? "1",
       STUB_SQLITE_MODE: mode,
       // Keep ambient test env from selecting a different backup branch or Qdrant target.
       DATABASE_URL: options.databaseUrl ?? "",
@@ -187,6 +187,18 @@ describe("scripts/backup.sh sqlite online-backup verification (#2084)", () => {
     expect(readFileSync(join(harness.outDir, manifest.qdrant.file!), "utf8")).toBe(
       "stub-qdrant-snapshot-bytes",
     );
+  });
+
+  it("keeps the current artifact when BACKUP_RETAIN is zero", () => {
+    const res = runBackup(harness, "ok", { retain: "0" });
+
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("BACKUP_RETAIN=0");
+    const manifest = readManifest(harness);
+    expect(manifest.retain).toBe(1);
+    expect(manifest.sqlite?.file).toMatch(/^sqlite\/gittensory-\d{8}T\d{6}Z\.sqlite\.gz$/);
+    expect(existsSync(join(harness.outDir, manifest.sqlite!.file))).toBe(true);
+    expect(readdirSync(join(harness.outDir, "sqlite"))).toHaveLength(1);
   });
 
   it("writes no sqlite artifact entry when the database is missing", () => {


### PR DESCRIPTION
## Summary
- Adds an atomic backup manifest for restore tooling.
- Records Postgres dump details, verified SQLite artifact details, successful Qdrant snapshot file, timestamp, and retention count.
- Regenerates the self-host env reference required by the gate.

## What changed
- Writes the manifest through a temp file and `mv` to avoid partial JSON on interruption.
- Records Postgres file and bytes after `pg_dump` succeeds.
- Records SQLite file and bytes only after backup verification and gzip succeed.
- Records Qdrant file only after snapshot download succeeds.
- Covers Postgres, sqlite-only, sqlite+Qdrant, and missing database branches.

## Why
Restore and rollback tooling needs a machine-readable latest-good backup pointer without parsing directory listings.

## Validation
- `npx vitest run test/unit/backup-script.test.ts`
- `npm run selfhost:env-reference:check`
- `npm run test:ci`
- `npm audit --audit-level=moderate`

Closes #2085