### PR TITLE
fix(mcp): re-sync isTestFile with the server isTestPath (pytest prefix + JVM/C#/Swift)

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -597,9 +597,14 @@ export function isTestFile(file) {
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
     /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
+    // JVM / C# / Swift `SomethingTest(s)`/`SomethingSpec` class-suffix convention (JUnit, Kotlin/ScalaTest,
+    // Spock, xUnit/NUnit, XCTest). Case-sensitive on the PascalCase suffix so it can't false-positive on words
+    // that merely end in "test"/"spec" (Latest.java, Contest.cs, manifest.scala).
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1762,6 +1762,18 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(true);
       expect(isCodeFile(file)).toBe(false);
     }
+    // #2666 + #2743 parity: the pytest `test_*.py` prefix and the JVM/C#/Swift `SomethingTest(s)`/`Spec`
+    // class-suffix conventions were added to the server isTestPath but not this MCP copy — so the local
+    // predictor wrongly counted Java/Kotlin/Scala/C#/Swift tests and pytest-prefixed files as SOURCE.
+    for (const file of ["tests/test_utils.py", "test_api.py", "app/FooTests.java", "src/BarSpec.kt", "core/BazTest.scala", "svc/QuuxTests.cs", "ios/CorgeSpec.swift", "build/GraultTest.groovy"]) {
+      expect(isTestFile(file)).toBe(true);
+      expect(isCodeFile(file)).toBe(false);
+    }
+    // Case-sensitive on the PascalCase suffix: a JVM source merely ENDING in "test"/"spec" stays source.
+    for (const file of ["src/Latest.java", "core/manifest.scala", "app/MyService.kt"]) {
+      expect(isTestFile(file)).toBe(false);
+      expect(isCodeFile(file)).toBe(true);
+    }
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {


### PR DESCRIPTION
## What
The MCP `local-branch` `isTestFile` (`packages/gittensory-mcp/lib/local-branch.js`) is a **standalone inlined copy** of the server's canonical `isTestPath` (`src/signals/test-evidence.ts`) — the MCP ships as a Node bin package and can't import from `src/`. Two test-convention rules added to `isTestPath` were **never mirrored** into this copy:

- the **pytest `test_*.py` prefix** (`#2666`)
- the **JVM / C# / Swift `SomethingTest(s)`/`Spec` class-suffix** (`#2743`): `\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)`

## Why it matters
`isTestFile` drives how the MCP's local pre-submit predictor classifies changed files (test vs source) when it builds the local score packet. Because these two rules were missing, the predictor counted **Java/Kotlin/Scala/C#/Swift test classes and pytest-prefixed files as SOURCE** — disagreeing with the server gate's own test-coverage classification. A contributor in those ecosystems using the MCP gets a wrong local prediction about their test coverage / readiness.

Concrete: `app/FooTests.java`, `src/BarSpec.kt`, `tests/test_utils.py` were all classified as non-test (and, for the `.java`/`.kt`/`.scala` ones, wrongly counted as code) by the MCP, while the server treats them as tests.

## Fix
Add both rules **verbatim** from `isTestPath` — same order, same **case-sensitive** JVM suffix so a source file merely ending in "test"/"spec" (`Latest.java`, `Contest.cs`, `manifest.scala`) stays source. This restores the copy's parity with the canonical matcher (the same single-sourcing discipline as `#2665`).

## Tests
Extends the existing MCP-copy classifier test (`test/unit/local-branch.test.ts`) with the pytest-prefix and JVM/C#/Swift test cases (now classified as tests) plus the case-sensitive negatives (still source). Fails on the pre-fix copy, passes with the fix.