### PR TITLE
fix(advisory): flag Missing test evidence only for genuine source, not docs/config

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import type { CollisionCluster, CollisionReport } from "../signals/engine";
 import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
+import { isCodeFile } from "../signals/local-branch";
 import { isTestPath } from "../signals/test-evidence";
 import { nowIso } from "../utils/json";
 import { GITTENSORY_GATE_CHECK_NAME } from "../review/check-names";
@@ -354,7 +355,12 @@ export function buildCheckRunAnnotations(
   };
 
   const annotatableFiles = annotatablePullRequestFiles(annotationContext.files);
-  const codeFiles = annotatableFiles.filter((file) => !isTestPath(file.path));
+  // "Code" for the missing-test signal is GENUINE source (isCodeFile), not merely "anything that isn't a test":
+  // annotatableFiles is gated by isCodePath, which admits docs/config/data (.md/.yaml/.yml/.json/.toml), so a
+  // docs-, config-, or manifest-only PR would otherwise be flagged "Missing test evidence" for changing files
+  // that have nothing to cover. Mirrors the isCodeFile source predicate #2722 aligned the missing_tests check to
+  // (contributor-open-pr-monitor.ts) and slop.ts's buildMissingTestEvidenceFinding.
+  const codeFiles = annotatableFiles.filter((file) => isCodeFile(file.path));
   const testFiles = annotatableFiles.filter((file) => isTestPath(file.path));
   if (codeFiles.length > 0 && testFiles.length === 0) {
     for (const file of codeFiles) {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -745,6 +745,47 @@ describe("advisory rules", () => {
     expect(annotations.some((entry) => entry.title === "Missing test evidence")).toBe(false);
   });
 
+  it("does not flag Missing test evidence for a docs-/config-/manifest-only PR (#2722 class)", () => {
+    // annotatableFiles is gated by isCodePath, which admits docs/config/data (.md/.yaml/.yml/.json/.toml). Using
+    // `!isTestPath` as "code" wrongly flagged those files "Missing test evidence"; isCodeFile counts only genuine
+    // source, so a README/CI-config/manifest-only PR (nothing to cover) is no longer annotated.
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 21, title: "Update docs and CI config", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const files: PullRequestFileRecord[] = [
+      { repoFullName: repo.fullName, pullNumber: 21, path: "README.md", additions: 12, deletions: 0, changes: 12, payload: {} },
+      { repoFullName: repo.fullName, pullNumber: 21, path: ".github/workflows/ci.yml", additions: 8, deletions: 0, changes: 8, payload: {} },
+      { repoFullName: repo.fullName, pullNumber: 21, path: "package.json", additions: 3, deletions: 0, changes: 3, payload: {} },
+    ];
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 21 }, "standard");
+
+    expect(annotations.some((entry) => entry.title === "Missing test evidence")).toBe(false);
+  });
+
+  it("still flags Missing test evidence for a genuine source change shipped without a test (control)", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 22, title: "Add a util without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const files: PullRequestFileRecord[] = [
+      { repoFullName: repo.fullName, pullNumber: 22, path: "src/util/math.ts", additions: 15, deletions: 0, changes: 15, payload: {} },
+    ];
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 22 }, "standard");
+
+    expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === "src/util/math.ts")).toBe(true);
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),


### PR DESCRIPTION
## What
`buildCheckRunAnnotations` (src/rules/advisory.ts) builds the "Missing test evidence" check-run annotations. It classified "code files" as:

```ts
const codeFiles = annotatableFiles.filter((file) => !isTestPath(file.path)); // "anything not a test"
```

But `annotatableFiles` is gated by `isCodePath`, whose extension set **admits docs/config/data**:

```ts
/\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|c|h|swift|kt|m|sql|yaml|yml|json|toml|md)$/i
```

## Why it matters
Because `.md`/`.yaml`/`.yml`/`.json`/`.toml` pass `isCodePath` and are not tests, a **docs-only, CI-config-only, or manifest-only PR** landed with `codeFiles = [those files]` and `testFiles = []`, so `codeFiles.length > 0 && testFiles.length === 0` fired and every changed file got a **"Missing test evidence"** annotation — flagging changes that have nothing to cover.

Concrete: a PR touching only `README.md` (or `.github/workflows/ci.yml`, or `package.json`) currently gets a "Missing test evidence" annotation on each file (at `checkRunDetailLevel: standard`/`deep`).

## Fix
Use the `isCodeFile` source predicate instead of `!isTestPath` — exactly the alignment `#2722` applied to the `contributor-open-pr-monitor` `missing_tests` check, and what `slop.ts`'s `buildMissingTestEvidenceFinding` already does. This annotation path was the remaining sibling still on the `!isTestPath` heuristic (it wasn't in #2722's list). A genuine source change shipped without a test is still flagged.

## Tests
Adds a docs-/config-/manifest-only regression (no annotation — **fails on the pre-fix code**, passes with the fix) and a control asserting a real source change without a test is still flagged. Existing annotation tests unchanged and green.