### PR TITLE
fix(github): invalidate file snapshot on cached head advance

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2855,22 +2855,28 @@ function isPrStateCacheFresh(fetchedAt: string | null | undefined): boolean {
  *  the row's own `status` (defaulting to "never_synced" only when no row exists yet) — this write must NEVER force
  *  `status: "complete"`, since `status` is shared with the FILES-cache staleness machinery
  *  (backfillOpenPullRequestDetails / refreshPullRequestDetails treat `status !== "complete"` as "needs a files
- *  resync"); a PR-state-only write claiming `complete` would falsely mark a files sync that never happened. A
- *  write failure is swallowed (#2537 fail-open: the cache is an optimization, never a correctness dependency —
- *  every caller already tolerates a live-fetch fallback). */
+ *  resync"); a PR-state-only write claiming `complete` would falsely mark a files sync that never happened.
+ *  When that PR-state-only read advances `headSha`, clear `filesSyncedAt` in the same upsert so the shared
+ *  headSha/filesSyncedAt file-cache invariant never claims old files were fetched for the new head. A write
+ *  failure is swallowed (#2537 fail-open: the cache is an optimization, never a correctness dependency — every
+ *  caller already tolerates a live-fetch fallback). */
 async function writeThroughPrStateCache(
   env: Env,
   repoFullName: string,
   prNumber: number,
-  previousStatus: PullRequestDetailSyncStateRecord["status"] | undefined,
+  previousState: Pick<PullRequestDetailSyncStateRecord, "status" | "headSha" | "filesSyncedAt"> | null | undefined,
   fields: { prMergeableState?: string | null; prState?: string | null; headSha?: string | null },
 ): Promise<void> {
   incr(PR_STATE_CACHE_METRIC, { field: "write", result: "set" });
+  const fileSnapshotBecameStale = Boolean(
+    fields.headSha && previousState?.headSha && previousState.headSha !== fields.headSha && previousState.filesSyncedAt,
+  );
   await upsertPullRequestDetailSyncState(env, {
     repoFullName,
     pullNumber: prNumber,
-    status: previousStatus ?? "never_synced",
+    status: previousState?.status ?? "never_synced",
     prStateFetchedAt: nowIso(),
+    ...(fileSnapshotBecameStale ? { filesSyncedAt: null } : {}),
     ...fields,
   }).catch(() => undefined);
 }
@@ -2895,12 +2901,12 @@ async function fetchAndCachePrStateFields(
   prNumber: number,
   token: string | undefined,
   admissionKey: GitHubRateLimitAdmissionKey | undefined,
-  previousStatus: PullRequestDetailSyncStateRecord["status"] | undefined,
+  previousState: Pick<PullRequestDetailSyncStateRecord, "status" | "headSha" | "filesSyncedAt"> | null | undefined,
 ): Promise<GitHubPullRequestPayload | undefined> {
   const live = await fetchLivePullRequest(env, repoFullName, prNumber, token, admissionKey);
   if (!live) return undefined;
   const liveHeadSha = live.head?.sha;
-  await writeThroughPrStateCache(env, repoFullName, prNumber, previousStatus, {
+  await writeThroughPrStateCache(env, repoFullName, prNumber, previousState, {
     prMergeableState: live.mergeable_state ?? null,
     prState: live.state ?? null,
     // Omit (not null) when the live payload carries no head SHA -- mirrors primeDurablePrStateCache's own
@@ -2924,7 +2930,7 @@ export async function primeDurablePrStateCache(
   if (!live) return;
   const existing = await getPullRequestDetailSyncState(env, repoFullName, prNumber).catch(() => null);
   const liveHeadSha = live.head?.sha;
-  await writeThroughPrStateCache(env, repoFullName, prNumber, existing?.status, {
+  await writeThroughPrStateCache(env, repoFullName, prNumber, existing, {
     prMergeableState: live.mergeable_state ?? null,
     prState: live.state ?? null,
     // Omit (not null) when the live payload carries no head SHA — a PR-state-only write must never CLEAR the
@@ -2951,7 +2957,7 @@ export async function cachedFetchLivePullRequestMergeState(
     return cached.prMergeableState ?? undefined;
   }
   incr(PR_STATE_CACHE_METRIC, { field: "mergeable_state", result: "miss" });
-  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached?.status);
+  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached);
   return live?.mergeable_state ?? undefined;
 }
 
@@ -2970,7 +2976,7 @@ export async function cachedFetchLivePullRequestState(
     return cached.prState ?? undefined;
   }
   incr(PR_STATE_CACHE_METRIC, { field: "state", result: "miss" });
-  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached?.status);
+  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached);
   return live?.state ?? undefined;
 }
 
@@ -2993,7 +2999,7 @@ export async function cachedFetchLivePullRequestHeadSha(
     return cached.headSha;
   }
   incr(PR_STATE_CACHE_METRIC, { field: "head_sha", result: "miss" });
-  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached?.status);
+  const live = await fetchAndCachePrStateFields(env, repoFullName, prNumber, token, admissionKey, cached);
   return live?.head?.sha ?? undefined;
 }
 

--- a/test/unit/pr-detail-durable-cache.test.ts
+++ b/test/unit/pr-detail-durable-cache.test.ts
@@ -340,6 +340,44 @@ describe("durable PR-state cache (#2537)", () => {
       });
     });
 
+    it("REGRESSION: clears filesSyncedAt when a PR-state-only write advances headSha", async () => {
+      const env = createTestEnv();
+      await upsertPullRequestDetailSyncState(env, {
+        repoFullName: "owner/repo",
+        pullNumber: 65,
+        status: "complete",
+        headSha: "old-benign-head",
+        filesSyncedAt: "2026-05-20T00:00:00.000Z",
+      });
+
+      await primeDurablePrStateCache(env, "owner/repo", 65, { mergeable_state: "clean", state: "open", head: { sha: "new-unreviewed-head" } });
+
+      expect(await getPullRequestDetailSyncState(env, "owner/repo", 65)).toMatchObject({
+        prMergeableState: "clean",
+        prState: "open",
+        headSha: "new-unreviewed-head",
+        filesSyncedAt: null,
+      });
+    });
+
+    it("keeps filesSyncedAt when a PR-state-only write repeats the files-cache headSha", async () => {
+      const env = createTestEnv();
+      await upsertPullRequestDetailSyncState(env, {
+        repoFullName: "owner/repo",
+        pullNumber: 66,
+        status: "complete",
+        headSha: "already-synced-head",
+        filesSyncedAt: "2026-05-20T00:00:00.000Z",
+      });
+
+      await primeDurablePrStateCache(env, "owner/repo", 66, { mergeable_state: "clean", state: "open", head: { sha: "already-synced-head" } });
+
+      expect(await getPullRequestDetailSyncState(env, "owner/repo", 66)).toMatchObject({
+        headSha: "already-synced-head",
+        filesSyncedAt: "2026-05-20T00:00:00.000Z",
+      });
+    });
+
     it("primes the cache so a subsequent cachedFetchLivePullRequestMergeState reads the primed value without a network call", async () => {
       const env = createTestEnv();
       let fetchCount = 0;


### PR DESCRIPTION
### Motivation
- A durable PR-state cache write was recording `headSha` into the shared detail-sync row without clearing `filesSyncedAt`, breaking the invariant that a populated `filesSyncedAt` only applies to files fetched for that head.
- If a sweep/resync primes the PR-state cache before `refreshPullRequestDetails` runs, an advanced `headSha` could make `refreshPullRequestDetails` skip fetching `/pulls/{n}/files`, causing reviewers or automated gates to act on stale file contents.

### Description
- Change `writeThroughPrStateCache` to accept the prior detail-sync state and detect when a PR-state-only write advances `headSha`, and clear `filesSyncedAt` in the same upsert when that happens.
- Propagate the existing detail-sync row into `fetchAndCachePrStateFields`, `primeDurablePrStateCache`, and the cached readers so the write helper can compare previous `headSha`/`filesSyncedAt` before updating.
- Preserve the previous `status` behavior while adding a guarded `filesSyncedAt: null` update only when the head actually changed and an old file snapshot exists.
- Add regression tests covering the poisoned-cache case (clears `filesSyncedAt` when head advances) and the unchanged-head preservation case (keeps `filesSyncedAt` when head is identical).

### Testing
- Ran `git diff --check` and `npm run typecheck`, both succeeded locally.
- Ran the focused unit suite with `npx vitest run test/unit/pr-detail-durable-cache.test.ts --reporter=verbose`; all tests in that file passed (27/27).
- Ran coverage for that test file (`npm run test:coverage -- --run test/unit/pr-detail-durable-cache.test.ts`); the test file passed but global coverage thresholds failed when evaluated against the repo-wide limits (the scoped run does not satisfy the repo global thresholds).
- Attempted to run the full local gate (`npm run test:ci`) and `npm audit --audit-level=moderate`, but those were blocked in this environment due to external network/setup issues (actionlint setup and npm audit endpoint errors) and could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47658f1e4c832c93ce682b98820a27)