### PR TITLE
fix(review-enrichment): scope analyzer circuit breakers

### DIFF
--- a/review-enrichment/src/analyzer-circuit-breaker.ts
+++ b/review-enrichment/src/analyzer-circuit-breaker.ts
@@ -20,11 +20,16 @@ import type { AnalyzerName } from "./analyzers/types.js";
 
 const ANALYZER_CIRCUIT_FAILURE_STREAK = 3;
 const ANALYZER_CIRCUIT_COOLDOWN_MS = 5 * 60_000;
+// A repo×analyzer entry with no new failure in this long is assumed dead (the repo stopped sending PRs, or
+// started succeeding via a path that never calls recordAnalyzerCircuitSuccess, e.g. a skip for an unrelated
+// reason). Comfortably longer than the cooldown so a still-cooling-down entry is never swept mid-cooldown.
+const ANALYZER_CIRCUIT_IDLE_EVICTION_MS = 6 * ANALYZER_CIRCUIT_COOLDOWN_MS;
 
 interface AnalyzerCircuitState {
   consecutiveFailures: number;
   cooldownUntilMs: number;
   probeClaimed: boolean;
+  lastFailureMs: number;
 }
 
 /** Scope the in-memory breaker to the repository whose request produced the failures. */
@@ -34,8 +39,24 @@ export interface AnalyzerCircuitScope {
 
 const analyzerCircuits = new Map<string, AnalyzerCircuitState>();
 
+// GitHub repository full names are case-insensitive, so "Org/Repo" and "org/repo" must key the same breaker
+// bucket -- otherwise casing drift across callers would silently split one repository's failure history
+// across multiple never-tripping entries, and each entry would also count separately against the eviction
+// sweep below.
 function analyzerCircuitKey(name: AnalyzerName, scope: AnalyzerCircuitScope): string {
-  return `${scope.repoFullName}\0${name}`;
+  return `${scope.repoFullName.trim().toLowerCase()}\0${name}`;
+}
+
+/** Bound the map's size by dropping entries that have not failed recently, regardless of whether they ever
+ *  tripped -- otherwise a long-lived worker retains one entry per repo×analyzer pair that has EVER failed
+ *  even once, forever. Runs on every recorded failure (the only path that grows the map) rather than on a
+ *  timer, so it stays correct in tests that fake `Date.now` and needs no background interval to manage. */
+function evictIdleAnalyzerCircuits(nowMs: number): void {
+  for (const [key, state] of analyzerCircuits) {
+    if (state.lastFailureMs + ANALYZER_CIRCUIT_IDLE_EVICTION_MS < nowMs) {
+      analyzerCircuits.delete(key);
+    }
+  }
 }
 
 /** True while `name`'s breaker should skip the caller: either still within the full cooldown window, or past
@@ -78,10 +99,12 @@ export function recordAnalyzerCircuitFailure(
   scope: AnalyzerCircuitScope,
   nowMs = Date.now(),
 ): void {
+  evictIdleAnalyzerCircuits(nowMs);
   const key = analyzerCircuitKey(name, scope);
-  const state = analyzerCircuits.get(key) ?? { consecutiveFailures: 0, cooldownUntilMs: 0, probeClaimed: false };
+  const state = analyzerCircuits.get(key) ?? { consecutiveFailures: 0, cooldownUntilMs: 0, probeClaimed: false, lastFailureMs: nowMs };
   state.consecutiveFailures += 1;
   state.probeClaimed = false;
+  state.lastFailureMs = nowMs;
   if (state.consecutiveFailures >= ANALYZER_CIRCUIT_FAILURE_STREAK) {
     state.cooldownUntilMs = nowMs + ANALYZER_CIRCUIT_COOLDOWN_MS;
   }

--- a/review-enrichment/src/analyzer-circuit-breaker.ts
+++ b/review-enrichment/src/analyzer-circuit-breaker.ts
@@ -4,8 +4,9 @@
 // identical call just timed out or errored. Trip a short, in-process cooldown after a run of CONSECUTIVE
 // thrown failures (a timeout counts -- runWithTimeout's rejection is a thrown failure) and skip that analyzer
 // entirely -- no network/CLI call at all -- for the cooldown window, falling through the SAME plan.skipped
-// path any other skip reason already uses. In-process only (no persistence layer): review-enrichment is a
-// single long-lived process (Railway), matching the main app's equivalent per-provider AI circuit breaker
+// path any other skip reason already uses. In-process only (no persistence layer), but scoped by repository
+// so one PR cannot suppress security analysis for unrelated repositories sharing the same long-lived process,
+// matching the main app's equivalent per-provider AI circuit breaker
 // (src/selfhost/ai.ts's createChainAi).
 //
 // Half-open probing: review-enrichment serves CONCURRENT requests (one per in-flight PR review), so once the
@@ -26,7 +27,16 @@ interface AnalyzerCircuitState {
   probeClaimed: boolean;
 }
 
-const analyzerCircuits = new Map<AnalyzerName, AnalyzerCircuitState>();
+/** Scope the in-memory breaker to the repository whose request produced the failures. */
+export interface AnalyzerCircuitScope {
+  repoFullName: string;
+}
+
+const analyzerCircuits = new Map<string, AnalyzerCircuitState>();
+
+function analyzerCircuitKey(name: AnalyzerName, scope: AnalyzerCircuitScope): string {
+  return `${scope.repoFullName}\0${name}`;
+}
 
 /** True while `name`'s breaker should skip the caller: either still within the full cooldown window, or past
  *  it but another caller already claimed this cycle's single half-open probe. The FIRST caller to observe an
@@ -38,8 +48,13 @@ const analyzerCircuits = new Map<AnalyzerName, AnalyzerCircuitState>();
  *  threshold, so this is a reliable "never opened" check. Without it, a caller after just 1-2 failures would
  *  claim the half-open probe slot too, spuriously skipping a concurrent second caller as circuit_open even
  *  though the breaker was never actually open. */
-export function isAnalyzerCircuitOpen(name: AnalyzerName, nowMs = Date.now()): boolean {
-  const state = analyzerCircuits.get(name);
+export function isAnalyzerCircuitOpen(
+  name: AnalyzerName,
+  scope: AnalyzerCircuitScope,
+  nowMs = Date.now(),
+): boolean {
+  const key = analyzerCircuitKey(name, scope);
+  const state = analyzerCircuits.get(key);
   if (state === undefined || state.cooldownUntilMs === 0) return false;
   if (state.cooldownUntilMs > nowMs) return true;
   if (state.probeClaimed) return true;
@@ -49,8 +64,8 @@ export function isAnalyzerCircuitOpen(name: AnalyzerName, nowMs = Date.now()): b
 
 /** A completed run (whether a clean "ok" or a non-throwing "degraded"/"capped" partial result) resets the
  *  streak -- the dependency responded, so it is not the failure mode this breaker guards against. */
-export function recordAnalyzerCircuitSuccess(name: AnalyzerName): void {
-  analyzerCircuits.delete(name);
+export function recordAnalyzerCircuitSuccess(name: AnalyzerName, scope: AnalyzerCircuitScope): void {
+  analyzerCircuits.delete(analyzerCircuitKey(name, scope));
 }
 
 /** A THROWN failure (including the analyzer_timeout rejection) is the signal this breaker tracks. Trips the
@@ -58,22 +73,27 @@ export function recordAnalyzerCircuitSuccess(name: AnalyzerName): void {
  *  the analyzer is simply skipped while open, so no additional failures accrue until it is tried again). A
  *  half-open probe's failure re-extends the cooldown via this same threshold check, since consecutiveFailures
  *  is already at/above it by the time a probe can be claimed -- no separate re-trip path needed. */
-export function recordAnalyzerCircuitFailure(name: AnalyzerName, nowMs = Date.now()): void {
-  const state = analyzerCircuits.get(name) ?? { consecutiveFailures: 0, cooldownUntilMs: 0, probeClaimed: false };
+export function recordAnalyzerCircuitFailure(
+  name: AnalyzerName,
+  scope: AnalyzerCircuitScope,
+  nowMs = Date.now(),
+): void {
+  const key = analyzerCircuitKey(name, scope);
+  const state = analyzerCircuits.get(key) ?? { consecutiveFailures: 0, cooldownUntilMs: 0, probeClaimed: false };
   state.consecutiveFailures += 1;
   state.probeClaimed = false;
   if (state.consecutiveFailures >= ANALYZER_CIRCUIT_FAILURE_STREAK) {
     state.cooldownUntilMs = nowMs + ANALYZER_CIRCUIT_COOLDOWN_MS;
   }
-  analyzerCircuits.set(name, state);
+  analyzerCircuits.set(key, state);
 }
 
 /** Frees a claimed half-open probe WITHOUT recording success or failure -- for when the probing attempt never
  *  actually reached the analyzer call (capped by budget/timeout in brief.ts first). Safe no-op when `name` has
  *  no circuit state or no claimed probe, so callers can call this unconditionally on every capped early-return
  *  without needing to know whether this particular call was the one that claimed the probe. */
-export function releaseAnalyzerCircuitProbe(name: AnalyzerName): void {
-  const state = analyzerCircuits.get(name);
+export function releaseAnalyzerCircuitProbe(name: AnalyzerName, scope: AnalyzerCircuitScope): void {
+  const state = analyzerCircuits.get(analyzerCircuitKey(name, scope));
   if (state !== undefined) state.probeClaimed = false;
 }
 

--- a/review-enrichment/src/brief.ts
+++ b/review-enrichment/src/brief.ts
@@ -266,7 +266,7 @@ export async function buildBrief(
       // #2541: budget exhaustion, not a dependency-health signal -- if this call had claimed the circuit
       // breaker's half-open probe (isAnalyzerCircuitOpen), free it so a later request can still probe rather
       // than leaving the slot claimed forever with no outcome ever recorded.
-      releaseAnalyzerCircuitProbe(name);
+      releaseAnalyzerCircuitProbe(name, req);
       return;
     }
     const timeoutMs = analyzerTimeoutMs(
@@ -289,7 +289,7 @@ export async function buildBrief(
       partial = true;
       analysis.metrics.recordCappedWork(`analyzer_${item.descriptor.cost}`, 1);
       // #2541: same as above -- release a claimed half-open probe without recording an outcome.
-      releaseAnalyzerCircuitProbe(name);
+      releaseAnalyzerCircuitProbe(name, req);
       return;
     }
     try {
@@ -311,7 +311,7 @@ export async function buildBrief(
       // result (its own internal cap, not a dependency failure) -- so the dependency responded. Reset the
       // circuit rather than only resetting on a clean "ok"; a benign internal partial must not itself count
       // toward tripping the breaker.
-      recordAnalyzerCircuitSuccess(name);
+      recordAnalyzerCircuitSuccess(name, req);
       if (resultIsPartial(result) || diagnostics.partialStatus === "partial") {
         const status = statusFromDiagnostics(diagnostics, "degraded");
         const partialReason = publicPartialReason(
@@ -361,7 +361,7 @@ export async function buildBrief(
       // #2541: a THROWN failure (including the analyzer_timeout rejection from runWithTimeout) is the signal
       // the circuit breaker tracks -- the dependency did not respond at all, unlike a non-throwing partial
       // result above.
-      recordAnalyzerCircuitFailure(name);
+      recordAnalyzerCircuitFailure(name, req);
       const status = timeoutStatus(error, diagnostics);
       const partialReason = publicPartialReason(diagnostics.partialReason, "analyzer_error");
       analyzerStatus[name] = status;

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -332,7 +332,7 @@ function skipReasonForAnalyzer(
   // missing head SHA, no dependency manifest, etc.), leaking the claim forever with no outcome ever recorded.
   // An EXPLICIT request (req.analyzers) does not bypass this -- the circuit is about the dependency being
   // down right now, which an explicit request can't fix.
-  if (isAnalyzerCircuitOpen(descriptor.name)) return "circuit_open";
+  if (isAnalyzerCircuitOpen(descriptor.name, req)) return "circuit_open";
 
   return null;
 }

--- a/review-enrichment/test/analyzer-circuit-breaker.test.ts
+++ b/review-enrichment/test/analyzer-circuit-breaker.test.ts
@@ -308,6 +308,44 @@ test("REGRESSION: a half-open probe claim is not leaked when the SAME planning p
   }
 });
 
+test("REGRESSION: repoFullName casing does not split one repository's failures across separate circuit entries", async () => {
+  let calls = 0;
+  const failing = { history: async () => { calls += 1; throw new Error("boom"); } };
+  const lowerReq = { ...baseReq, repoFullName: "jsonbored/gittensory" };
+  const upperReq = { ...baseReq, repoFullName: "JSONbored/Gittensory" };
+  await buildBrief(lowerReq, failing);
+  await buildBrief(upperReq, failing);
+  await buildBrief(lowerReq, failing);
+
+  assert.equal(calls, 3);
+  assert.equal(isAnalyzerCircuitOpen("history", lowerReq), true);
+  assert.equal(isAnalyzerCircuitOpen("history", upperReq), true);
+});
+
+test("REGRESSION: an idle circuit entry is evicted rather than retained forever, bounding the breaker map's size", async () => {
+  const realNow = Date.now();
+  let fakeNow = realNow;
+  const originalNow = Date.now;
+  try {
+    Date.now = () => fakeNow;
+    // Trips the circuit for one repo, then goes idle -- no further failures ever recorded for it.
+    const staleReq = { ...baseReq, repoFullName: "stale/abandoned-repo" };
+    recordAnalyzerCircuitFailure("history", staleReq, fakeNow);
+    recordAnalyzerCircuitFailure("history", staleReq, fakeNow);
+    recordAnalyzerCircuitFailure("history", staleReq, fakeNow);
+    assert.equal(isAnalyzerCircuitOpen("history", staleReq, fakeNow), true);
+
+    // Far past both the cooldown AND the idle-eviction window -- another repo's failure should sweep it.
+    fakeNow = realNow + 6 * 5 * 60_000 + 1;
+    recordAnalyzerCircuitFailure("history", baseReq, fakeNow);
+
+    // The stale entry is gone: isAnalyzerCircuitOpen sees no state at all, not a lingering (expired) cooldown.
+    assert.equal(isAnalyzerCircuitOpen("history", staleReq, fakeNow), false);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("REGRESSION: failures for one repository do not open the analyzer circuit for another repository", async () => {
   let attackerCalls = 0;
   const failing = { history: async () => { attackerCalls += 1; throw new Error("boom"); } };

--- a/review-enrichment/test/analyzer-circuit-breaker.test.ts
+++ b/review-enrichment/test/analyzer-circuit-breaker.test.ts
@@ -33,7 +33,7 @@ test("does not open the circuit before the failure streak threshold — every re
     assert.equal(brief.analyzerStatus.history, "degraded");
   }
   assert.equal(calls, 2);
-  assert.equal(isAnalyzerCircuitOpen("history"), false);
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), false);
 });
 
 test("opens the circuit after 3 consecutive failures and SKIPS the analyzer on the next request — zero calls to the broken dependency", async () => {
@@ -43,7 +43,7 @@ test("opens the circuit after 3 consecutive failures and SKIPS the analyzer on t
     await buildBrief(baseReq, failing);
   }
   assert.equal(calls, 3);
-  assert.equal(isAnalyzerCircuitOpen("history"), true);
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), true);
 
   const brief = await buildBrief(baseReq, failing);
 
@@ -61,7 +61,7 @@ test("a timeout counts as a circuit-breaker failure, same as a thrown error", as
     const brief = await buildBrief(timeoutReq, hanging);
     assert.equal(brief.analyzerStatus.history, "timeout");
   }
-  assert.equal(isAnalyzerCircuitOpen("history"), true);
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), true);
 });
 
 test("a non-throwing DEGRADED/partial result does NOT count as a circuit-breaker failure (the dependency responded)", async () => {
@@ -74,20 +74,20 @@ test("a non-throwing DEGRADED/partial result does NOT count as a circuit-breaker
     assert.equal(brief.analyzerStatus.secret, "degraded");
     assert.notEqual(brief.analyzerStatus.secret, "skipped");
   }
-  assert.equal(isAnalyzerCircuitOpen("secret"), false);
+  assert.equal(isAnalyzerCircuitOpen("secret", baseReq), false);
 });
 
 test("a success resets the streak so it does not carry over into a LATER, separate run of failures", async () => {
-  recordAnalyzerCircuitFailure("history");
-  recordAnalyzerCircuitFailure("history");
-  recordAnalyzerCircuitSuccess("history");
+  recordAnalyzerCircuitFailure("history", baseReq);
+  recordAnalyzerCircuitFailure("history", baseReq);
+  recordAnalyzerCircuitSuccess("history", baseReq);
   let calls = 0;
   const failing = { history: async () => { calls += 1; throw new Error("boom"); } };
   // Two MORE failures after the reset — still below the streak threshold on their own.
   await buildBrief(baseReq, failing);
   await buildBrief(baseReq, failing);
   assert.equal(calls, 2);
-  assert.equal(isAnalyzerCircuitOpen("history"), false);
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), false);
 });
 
 test("REGRESSION: a circuit-expired analyzer is tried again rather than staying open forever", async () => {
@@ -96,22 +96,22 @@ test("REGRESSION: a circuit-expired analyzer is tried again rather than staying 
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    assert.equal(isAnalyzerCircuitOpen("history"), true);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), true);
 
     fakeNow = realNow + 5 * 60_000 + 1; // past the cooldown window
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false);
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false);
   } finally {
     Date.now = originalNow;
   }
 });
 
 test("recordAnalyzerCircuitSuccess on an analyzer with no prior failures is a safe no-op", () => {
-  assert.doesNotThrow(() => recordAnalyzerCircuitSuccess("secret"));
-  assert.equal(isAnalyzerCircuitOpen("secret"), false);
+  assert.doesNotThrow(() => recordAnalyzerCircuitSuccess("secret", baseReq));
+  assert.equal(isAnalyzerCircuitOpen("secret", baseReq), false);
 });
 
 test("an EXPLICITLY requested analyzer (req.analyzers) is still skipped while its circuit is open — the explicit request can't fix a down dependency", async () => {
@@ -136,11 +136,11 @@ test("REGRESSION: below the failure-streak threshold, isAnalyzerCircuitOpen neve
   // Before the fix, isAnalyzerCircuitOpen claimed probeClaimed for ANY existing state (cooldownUntilMs <=
   // nowMs is true even at cooldownUntilMs === 0, i.e. never-tripped), so a circuit with only 1-2 recorded
   // failures would spuriously block a second concurrent caller — even though the breaker never actually opened.
-  recordAnalyzerCircuitFailure("history");
-  recordAnalyzerCircuitFailure("history"); // 2 failures — still below the 3-failure trip threshold
+  recordAnalyzerCircuitFailure("history", baseReq);
+  recordAnalyzerCircuitFailure("history", baseReq); // 2 failures — still below the 3-failure trip threshold
 
-  assert.equal(isAnalyzerCircuitOpen("history"), false); // first caller — not open
-  assert.equal(isAnalyzerCircuitOpen("history"), false); // second, concurrent caller — also not open
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // first caller — not open
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // second, concurrent caller — also not open
 
   let calls = 0;
   const failing = { history: async () => { calls += 1; throw new Error("boom"); } };
@@ -157,13 +157,13 @@ test("half-open: only the FIRST caller after cooldown expiry gets to probe — a
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1; // past the cooldown window
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // first caller claims the probe
-    assert.equal(isAnalyzerCircuitOpen("history"), true); // second caller, same instant — still blocked
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // first caller claims the probe
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), true); // second caller, same instant — still blocked
   } finally {
     Date.now = originalNow;
   }
@@ -175,15 +175,15 @@ test("half-open: a successful probe fully closes the circuit — a later caller 
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1;
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // claims the probe
-    recordAnalyzerCircuitSuccess("history");
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // claims the probe
+    recordAnalyzerCircuitSuccess("history", baseReq);
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // fully closed, not "another probe"
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // fully closed, not "another probe"
   } finally {
     Date.now = originalNow;
   }
@@ -195,15 +195,15 @@ test("half-open: a failed probe re-extends the cooldown and immediately blocks n
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1;
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // claims the probe
-    recordAnalyzerCircuitFailure("history", fakeNow);
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // claims the probe
+    recordAnalyzerCircuitFailure("history", baseReq, fakeNow);
 
-    assert.equal(isAnalyzerCircuitOpen("history"), true); // re-tripped, new cooldown active
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), true); // re-tripped, new cooldown active
   } finally {
     Date.now = originalNow;
   }
@@ -215,27 +215,27 @@ test("releaseAnalyzerCircuitProbe frees a claimed slot without recording an outc
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
-    recordAnalyzerCircuitFailure("history");
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
+    recordAnalyzerCircuitFailure("history", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1;
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // claims the probe
-    assert.equal(isAnalyzerCircuitOpen("history"), true); // second caller blocked
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // claims the probe
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), true); // second caller blocked
 
-    releaseAnalyzerCircuitProbe("history"); // e.g. the probing analyzer never ran (budget-capped)
+    releaseAnalyzerCircuitProbe("history", baseReq); // e.g. the probing analyzer never ran (budget-capped)
 
-    assert.equal(isAnalyzerCircuitOpen("history"), false); // released — a fresh probe can be claimed
+    assert.equal(isAnalyzerCircuitOpen("history", baseReq), false); // released — a fresh probe can be claimed
   } finally {
     Date.now = originalNow;
   }
 });
 
 test("releaseAnalyzerCircuitProbe on an analyzer with no circuit state, or no claimed probe, is a safe no-op", () => {
-  assert.doesNotThrow(() => releaseAnalyzerCircuitProbe("secret"));
-  recordAnalyzerCircuitFailure("secret");
-  assert.doesNotThrow(() => releaseAnalyzerCircuitProbe("secret")); // tripped but cooling down, no probe claimed
-  assert.equal(isAnalyzerCircuitOpen("secret"), false); // below the streak threshold — unaffected either way
+  assert.doesNotThrow(() => releaseAnalyzerCircuitProbe("secret", baseReq));
+  recordAnalyzerCircuitFailure("secret", baseReq);
+  assert.doesNotThrow(() => releaseAnalyzerCircuitProbe("secret", baseReq)); // tripped but cooling down, no probe claimed
+  assert.equal(isAnalyzerCircuitOpen("secret", baseReq), false); // below the streak threshold — unaffected either way
 });
 
 test("end-to-end: two concurrent buildBrief calls right after cooldown expiry — only the FIRST invokes the analyzer, the second is skipped as circuit_open", async () => {
@@ -244,9 +244,9 @@ test("end-to-end: two concurrent buildBrief calls right after cooldown expiry �
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("secret");
-    recordAnalyzerCircuitFailure("secret");
-    recordAnalyzerCircuitFailure("secret");
+    recordAnalyzerCircuitFailure("secret", baseReq);
+    recordAnalyzerCircuitFailure("secret", baseReq);
+    recordAnalyzerCircuitFailure("secret", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1;
 
     let calls = 0;
@@ -277,9 +277,9 @@ test("REGRESSION: a half-open probe claim is not leaked when the SAME planning p
   const originalNow = Date.now;
   try {
     Date.now = () => fakeNow;
-    recordAnalyzerCircuitFailure("secret");
-    recordAnalyzerCircuitFailure("secret");
-    recordAnalyzerCircuitFailure("secret");
+    recordAnalyzerCircuitFailure("secret", baseReq);
+    recordAnalyzerCircuitFailure("secret", baseReq);
+    recordAnalyzerCircuitFailure("secret", baseReq);
     fakeNow = realNow + 5 * 60_000 + 1; // past the cooldown window
 
     // A pure deletion (no `+` line) — "secret" requires added lines, so this is skipped as "no_added_lines",
@@ -306,4 +306,24 @@ test("REGRESSION: a half-open probe claim is not leaked when the SAME planning p
   } finally {
     Date.now = originalNow;
   }
+});
+
+test("REGRESSION: failures for one repository do not open the analyzer circuit for another repository", async () => {
+  let attackerCalls = 0;
+  const failing = { history: async () => { attackerCalls += 1; throw new Error("boom"); } };
+  const attackerReq = { ...baseReq, repoFullName: "attacker/failure-seed" };
+  for (let i = 0; i < 3; i += 1) {
+    await buildBrief(attackerReq, failing);
+  }
+  assert.equal(attackerCalls, 3);
+  assert.equal(isAnalyzerCircuitOpen("history", attackerReq), true);
+  assert.equal(isAnalyzerCircuitOpen("history", baseReq), false);
+
+  let victimCalls = 0;
+  const healthy = { history: async () => { victimCalls += 1; return []; } };
+  const victimReq = { ...baseReq, repoFullName: "victim/security-critical" };
+  const victimBrief = await buildBrief(victimReq, healthy);
+
+  assert.equal(victimCalls, 1);
+  assert.notEqual(victimBrief.analyzerStatus.history, "skipped");
 });


### PR DESCRIPTION
### Motivation
- Prevent a process-global analyzer circuit breaker from suppressing the same analyzer across unrelated repositories by scoping breaker state to the originating repository.

### Description
- Replace the module-level `Map<AnalyzerName, ...>` with a `Map<string, ...>` keyed by `repoFullName` + analyzer name and add `AnalyzerCircuitScope` and `analyzerCircuitKey` helper.
- Thread request scope through circuit APIs by changing `isAnalyzerCircuitOpen`, `recordAnalyzerCircuitSuccess`, `recordAnalyzerCircuitFailure`, and `releaseAnalyzerCircuitProbe` to accept a `scope` (the enrichment `req`) and update all call sites in `brief.ts` and `scheduler.ts` accordingly.
- Update and extend tests in `review-enrichment/test/analyzer-circuit-breaker.test.ts` to call the new scoped APIs and add a regression test proving failures from one repo do not open the breaker for another repo.
- Preserve existing half-open probe semantics and budget-capped release behavior while localizing state to the repo that produced failures.

### Testing
- Ran the review-enrichment unit suite with `npm --prefix review-enrichment test` and the build; all review-enrichment tests passed (existing suites plus the new regression test).
- Verified `tsc` build for `review-enrichment` succeeded and the updated tests in `review-enrichment/test/analyzer-circuit-breaker.test.ts` passed.
- Attempted full repo gate `npm run test:ci` and `npm audit --audit-level=moderate` locally but these were blocked by external network/setup issues (actionlint GitHub access and npm audit endpoint), so full-gate run was not completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746587154832cbe204916a73cd16e)