### PR TITLE
fix(docs): keep setup token out of urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,9 +154,9 @@ GITTENSORY_REVIEW_DRAFT=false
 #                                            #   redirect the App-creation callback, so it must be set explicitly.
 #                                            #   Not needed once the App credentials are configured.
 # SELFHOST_SETUP_TOKEN=change-this-long-random-value  # REQUIRED to unlock the first-run /setup wizard. Without it
-#                                            #   /setup returns 400; with it, /setup needs ?token=<value> (or an
-#                                            #   x-setup-token / Bearer header) so a freshly-booted, not-yet-configured
-#                                            #   instance can't be driven through App creation by a random visitor.
+#                                            #   /setup returns 400; with it, enter the token in the browser form
+#                                            #   or send an x-setup-token / Bearer header. Never put this token in
+#                                            #   the URL; query strings leak to logs, proxies, and browser history.
 # ADMIN_GITHUB_LOGINS=your-github-login      # REQUIRED for control-panel ("operator") access. A comma- or
 #                                            #   whitespace-separated allowlist of GitHub logins, case-insensitive.
 #                                            #   FAIL-CLOSED: unset/empty means NOBODY can sign into the dashboard,

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -70,10 +70,12 @@ function SelfHostingGithubApp() {
         code={`PUBLIC_API_ORIGIN=https://reviews.example.com  # exact public URL, embedded in the manifest
 SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a freshly-booted instance`}
       />
-      <CodeBlock
-        lang="bash"
-        code={`open "https://reviews.example.com/setup?token=<SELFHOST_SETUP_TOKEN>"`}
-      />
+      <CodeBlock lang="bash" code={`open "https://reviews.example.com/setup"`} />
+      <p>
+        Enter <code>SELFHOST_SETUP_TOKEN</code> in the browser form. For scripted setup checks, send
+        the token in an <code>x-setup-token</code> header or <code>Authorization: Bearer</code>
+        header instead; never place the setup token in the URL.
+      </p>
       <Callout variant="note">
         Manual App creation (below) is still fully supported — for an air-gapped instance, a
         stricter change-review process, or simply a preference for reviewing every permission by

--- a/test/unit/setup-wizard-docs-parity.test.ts
+++ b/test/unit/setup-wizard-docs-parity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildManifest } from "../../src/selfhost/setup-wizard";
 
 const DOCS_PATH = "apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx";
+const ENV_EXAMPLE_PATH = ".env.example";
 
 // docs.self-hosting-github-app.tsx claims its manual permission list "is generated from the identical
 // source the wizard's manifest uses, so the two can never drift apart again" (#2542). That claim is only
@@ -21,6 +22,19 @@ const PERMISSION_LABELS: Record<string, string> = {
 };
 
 describe("self-host GitHub App manifest <-> docs parity (#2542)", () => {
+  it("documents setup-token entry without putting the secret in the URL", () => {
+    const docsSource = readFileSync(DOCS_PATH, "utf8");
+    const envExample = readFileSync(ENV_EXAMPLE_PATH, "utf8");
+
+    expect(docsSource).toContain('open "https://reviews.example.com/setup"');
+    expect(docsSource).toContain("x-setup-token");
+    expect(docsSource).toContain("Authorization: Bearer");
+    expect(envExample).toContain("enter the token in the browser form");
+    expect(envExample).toContain("x-setup-token / Bearer header");
+    expect(envExample).toContain("Never put this token in");
+    expect(`${docsSource}\n${envExample}`).not.toMatch(/\/setup\?token|\?token=<|token=</);
+  });
+
   it("the docs page's manual permission list names every buildManifest permission at the correct access level", () => {
     const manifest = buildManifest("https://example.com", "state") as { default_permissions: Record<string, string> };
     const docsSource = readFileSync(DOCS_PATH, "utf8");


### PR DESCRIPTION
### Motivation
- The published self-host setup docs instructed operators to place `SELFHOST_SETUP_TOKEN` in the URL query string, which contradicts the server's intended security model and risks leaking a bootstrap secret to logs, proxies, and browser history.
- Prevent accidental reintroduction by aligning docs with runtime behavior (token via POST body or headers) and adding an automated guard.

### Description
- Replace the unsafe example `open "https://reviews.example.com/setup?token=<SELFHOST_SETUP_TOKEN>"` with `open "https://reviews.example.com/setup"` and add guidance to enter `SELFHOST_SETUP_TOKEN` in the browser form or send it in an `x-setup-token` / `Authorization: Bearer` header instead; file changed: `apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx`.
- Update `.env.example` to remove the `?token=<value>` instruction and explicitly warn that setup tokens must not be placed in URLs; file changed: `.env.example`.
- Add a regression unit test that asserts the docs and `.env.example` contain the safe guidance and do not include `/setup?token`-style examples; file changed: `test/unit/setup-wizard-docs-parity.test.ts`.
- Ran formatting for UI workspace as part of the update to keep artifacts consistent (`npm --workspace @jsonbored/gittensory-ui run format`).

### Testing
- Ran `npx vitest run test/unit/setup-wizard-docs-parity.test.ts --reporter=dot`, and the new test suite passed.
- Ran `npm --workspace @jsonbored/gittensory-ui run lint`, which completed (warnings present but no errors that block the change).
- Ran `git diff --check` which reported clean output for this change.
- Built the UI with `npm --workspace @jsonbored/gittensory-ui run build`, and the build completed successfully.
- Attempted full gate `npm run test:ci`, but it was blocked by network/tooling issues in this environment (actionlint fallback encountered GitHub lookup/network errors and the actionlint WASM fallback flagged a custom runner label), so the full CI gate could not be completed locally here.
- Attempted `npm audit --audit-level=moderate`, but the audit endpoint returned `403 Forbidden` in this environment so dependency-audit could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4749f4cbb8832c8efc3202491ef192)