### PR TITLE
fix(selfhost): ignore embedding routing errors in AI circuit

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -694,6 +694,7 @@ export function resetAiProviderHealthForTest(): void {
 const AI_PROVIDER_FAILURE_THRESHOLD = 3;
 const AI_PROVIDER_COOLDOWN_MS = 60_000;
 const aiProviderCircuits = new Map<string, { failures: number; cooldownUntil: number }>();
+const EXPECTED_EMBEDDING_ROUTING_ERRORS = new Set(["claude_code_no_embed", "codex_no_embed"]);
 
 /** Test-only reset so circuit state from one test can't leak into the next (module-level map). */
 export function resetAiProviderCircuitBreakerForTest(): void {
@@ -770,6 +771,10 @@ function requestKind(options: AiRunOptions): "embedding" | "review" {
   return Array.isArray(options.text) ? "embedding" : "review";
 }
 
+function isExpectedEmbeddingRoutingError(options: AiRunOptions, error: unknown): boolean {
+  return requestKind(options) === "embedding" && EXPECTED_EMBEDDING_ROUTING_ERRORS.has(errorMessage(error));
+}
+
 async function runProviderWithOtel(
   provider: { name: string; ai: SelfHostAi },
   model: string,
@@ -791,6 +796,7 @@ async function runProviderWithOtel(
     aiProviderCircuits.delete(provider.name);
     return result;
   } catch (error) {
+    if (isExpectedEmbeddingRoutingError(options, error)) throw error;
     incr("gittensory_ai_provider_failures_total", { provider: provider.name });
     // Re-read the map here rather than reusing the `circuit` captured above: that read happened BEFORE the
     // `await` on the real provider call, so under concurrent same-provider calls it can be stale by the time

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -302,6 +302,30 @@ describe("per-provider circuit breaker (#2540 — skip fast during a sustained o
     await expect(route.run("codex", { prompt: "x" })).resolves.toEqual({ response: "ok" });
   });
 
+  it("REGRESSION: expected chat-only embedding fallbacks do not open a healthy review provider's circuit", async () => {
+    const chatOnlyCalls = vi.fn(async (_model: string, options: { text?: string[]; prompt?: string }) => {
+      if (options.text) throw new Error("claude_code_no_embed");
+      return { response: "review ok" };
+    });
+    const embedCalls = vi.fn(async () => ({ data: [[0.1, 0.2]] }));
+    const route = routeProviders([
+      { name: "claude-code", ai: { run: chatOnlyCalls } },
+      { name: "ollama", ai: { run: embedCalls } },
+    ]);
+
+    for (let i = 0; i < 3; i += 1) {
+      await expect(route.run("@cf/baai/bge-m3", { text: ["rag query"] })).resolves.toEqual({ data: [[0.1, 0.2]] });
+    }
+
+    expect(chatOnlyCalls).toHaveBeenCalledTimes(3);
+    expect(embedCalls).toHaveBeenCalledTimes(3);
+    await expect(route.run("claude-code", { prompt: "review this" })).resolves.toEqual({ response: "review ok" });
+    expect(chatOnlyCalls).toHaveBeenCalledTimes(4);
+    const metrics = await renderMetrics();
+    expect(metrics).not.toContain('gittensory_ai_provider_failures_total{provider="claude-code"}');
+    expect(metrics).not.toContain('gittensory_ai_provider_circuit_open_total{provider="claude-code"}');
+  });
+
   it("does not affect isAiProviderHealthy / aiConsecutiveFailures — independent whole-chain streak", async () => {
     const flaky = { name: "flaky-provider-3", ai: { run: async () => { throw new Error("down"); } } };
     for (let i = 0; i < 3; i += 1) {


### PR DESCRIPTION
### Motivation

- The per-provider circuit breaker treated every provider exception as a failure, which let expected chat-only embedding-routing errors (e.g. `claude_code_no_embed`, `codex_no_embed`) increment failure counts and open circuits for otherwise healthy chat reviewers.

### Description

- Add an allowlist `EXPECTED_EMBEDDING_ROUTING_ERRORS` for known embedding-routing signals and a helper `isExpectedEmbeddingRoutingError` to detect them.
- Short-circuit the circuit-breaker failure accounting in `runProviderWithOtel` when the caught error is an expected embedding-routing error so these fallbacks do not increment failure counters or open cooldown circuits.
- Add a regression unit test that exercises repeated embedding fallbacks (RAG embedding calls) through a fallback provider and asserts that the chat-only provider’s circuit is not tripped and no failure/circuit metrics are emitted.

### Testing

- Ran the targeted unit suite: `npx vitest run test/unit/selfhost-ai.test.ts`, and the file passed (95 tests passed).
- Attempted full gate: `npm run test:ci` was started but blocked during `actionlint` setup due to transient network name resolution (WASM fallback later reported runner-label mismatch); the full gate was not completed here.
- Ran `npm run typecheck`, which failed on unrelated existing test fixtures (`test/unit/queue.test.ts` missing a required `securityFocus` field), so typecheck was not fully green in this environment and is unrelated to the change.
- Scoped coverage runs were limited to the updated unit test file; targeted tests passed but running only a subset does not satisfy the repository-wide coverage thresholds enforced by CI (global coverage check reported failure when the whole project was not exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4749e7ddb4832cb555c7df99ef9689)