### PR TITLE
fix(gate): bypass commit cache for fresh rebase check

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2800,7 +2800,7 @@ export async function fetchLiveBaseBranchAdvancedAt(
     repoFullName,
     `/commits/${encodeURIComponent(baseRef)}`,
     token,
-    githubRateLimitOptions(admissionKey),
+    { ...githubRateLimitOptions(admissionKey), bypassResponseCache: true },
   ).catch(() => undefined);
   return result?.data.commit?.committer?.date ?? undefined;
 }
@@ -3646,6 +3646,7 @@ async function githubJson<T>(
 type GitHubJsonRequestOptions = {
   validators?: GitHubConditionalValidators;
   rateLimitAdmissionKey?: GitHubRateLimitAdmissionKey;
+  bypassResponseCache?: boolean;
 };
 type GitHubJsonStandardOptions = GitHubJsonRequestOptions & { allowNotModified?: false };
 type GitHubJsonConditionalOptions = GitHubJsonRequestOptions & { allowNotModified: true };
@@ -3682,8 +3683,12 @@ async function githubJsonWithHeaders<T>(
   let response = await timeoutFetch(url, {
     headers: githubRestHeaders(token, options?.validators),
     ...(options?.rateLimitAdmissionKey ? { githubRateLimitAdmission: true, githubRateLimitAdmissionKey: options.rateLimitAdmissionKey } : {}),
+    ...(options?.bypassResponseCache ? { githubBypassResponseCache: true } : {}),
   });
-  if (!isGitHubResponseCacheReplay(response)) {
+  // A bypass request is a live-freshness read (e.g. the fresh-rebase gate's base-tip check): it must neither
+  // replay nor be recorded into the persistent response/rate-limit-observation state, mirroring the
+  // isGitHubResponseCacheReplay guard immediately below for the same reason.
+  if (!isGitHubResponseCacheReplay(response) && !options?.bypassResponseCache) {
     await recordGitHubResponse(env, repoFullName, path, response, "rest", options?.rateLimitAdmissionKey);
   }
   if (response.status === 304 && options?.allowNotModified) return notModifiedResponse(response);

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -69,6 +69,8 @@ export type GitHubTimeoutFetchInit = RequestInit & {
    *  can fall back without spending a REST request. Lets a budget-gate suppress fresh reads while still serving
    *  free cache hits under pressure. */
   githubSkipNetworkWhen?: () => boolean | Promise<boolean>;
+  /** Force this request to hit GitHub instead of the persistent response cache; use for freshness/security reads. */
+  githubBypassResponseCache?: boolean;
 };
 export type GitHubRateLimitAdmissionKey = string;
 export type LocalGitHubRestRateLimitObservation = {
@@ -499,7 +501,7 @@ export async function timeoutFetch(input: RequestInfo | URL, init?: GitHubTimeou
   const url = requestUrl(input);
   const headers = requestHeaders(input, init);
   const conditional = hasConditionalRequestHeader(headers);
-  const cls = method === "GET" && !conditional ? githubCacheClassForUrl(url) : null;
+  const cls = method === "GET" && !conditional && !init?.githubBypassResponseCache ? githubCacheClassForUrl(url) : null;
   if (method === "GET" && !conditional && cls === null && isVolatileSingleFlightEligibleGithubUrl(url, headers)) {
     return fetchWithVolatileSingleFlight(input, init, volatileSingleFlightScope(url, headers));
   }

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -35,6 +35,7 @@ import {
   enrichInstallationHealth,
   fetchAndStorePullRequestFilesForReview,
   fetchLinkedIssueFacts,
+  fetchLiveBaseBranchAdvancedAt,
   fetchLiveCiAggregate,
   fetchLiveReviewThreadBlockers,
   fetchNamedCheckRunConclusion,
@@ -62,6 +63,34 @@ describe("GitHub backfill", () => {
     vi.useRealTimers();
     clearGitHubResponseCacheForTest();
     vi.unstubAllGlobals();
+  });
+
+  it("fetches the fresh base branch tip timestamp without replaying the commit response cache", async () => {
+    const env = createTestEnv();
+    const cacheGet = vi.fn(async () => ({
+      status: 200,
+      body: JSON.stringify({ commit: { committer: { date: "2024-01-01T00:00:00Z" } } }),
+      contentType: "application/json",
+    }));
+    const cacheSet = vi.fn(async () => undefined);
+    setGitHubResponseCache({ get: cacheGet, set: cacheSet });
+    let getFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      getFetches += 1;
+      expect(String(input)).toBe("https://api.github.com/repos/JSONbored/gittensory/commits/main");
+      return Response.json({ commit: { committer: { date: "2026-07-02T23:32:36.181Z" } } });
+    });
+
+    await expect(
+      fetchLiveBaseBranchAdvancedAt(env, "JSONbored/gittensory", "main", "tok", githubRateLimitAdmissionKeyForInstallation(123)),
+    ).resolves.toBe("2026-07-02T23:32:36.181Z");
+
+    expect(getFetches).toBe(1);
+    expect(cacheGet).not.toHaveBeenCalled();
+    expect(cacheSet).not.toHaveBeenCalled();
+    // The bypass contract is neither READ nor WRITE: a live-freshness read must not land in the
+    // persistent rate-limit-observation state either (#2762 gate finding).
+    expect(await listLatestGitHubRateLimitObservations(env)).toEqual([]);
   });
 
   it("stores bounded repo metadata, labels, issues, PR details, recent merges, and contributor stats", async () => {


### PR DESCRIPTION
### Motivation

- The fresh-rebase gate read the base branch via a bare `/commits/{ref}` REST GET which is classified as a short-TTL cached commit lookup, allowing stale cached commit metadata to defeat the intended live-freshness check and let an autonomous merge proceed without a required rebase/CI recheck.

### Description

- Add an explicit `githubBypassResponseCache` option to `GitHubTimeoutFetchInit` and thread it through `githubJsonWithHeaders` so callers can force a live network read that bypasses the persistent GitHub response cache (`src/github/client.ts`).
- Wire the new `bypassResponseCache` option into `fetchLiveBaseBranchAdvancedAt(...)` so the base-branch timestamp freshness read always performs a live fetch for the fresh-rebase gate (`src/github/backfill.ts`).
- Add a unit regression test confirming a stale cached `/commits/{ref}` entry is ignored and the freshness helper performs a live fetch and returns the updated timestamp (`test/unit/backfill.test.ts`).

### Testing

- Ran the focused unit test: `npx vitest run test/unit/backfill.test.ts -t "fresh base branch"`, which passed.
- Ran the related client + backfill unit suites: `npx vitest run test/unit/github-client.test.ts test/unit/backfill.test.ts`, both suites passed for the exercised tests.
- Performed type checking with `npm run typecheck`, which surfaced unrelated existing test fixtures errors in `test/unit/queue.test.ts` (missing `securityFocus` in `AiReviewCacheInput`); this PR does not modify those fixtures and the typecheck failure is pre-existing and unrelated to the changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4749e8f54c832c8e2b631a82c6defc)