### PR TITLE
fix(selfhost): stop maintenance jobs from starving under sustained load

### DIFF
--- a/src/selfhost/maintenance-admission.ts
+++ b/src/selfhost/maintenance-admission.ts
@@ -137,9 +137,12 @@ export interface MaintenanceAdmissionDecision {
 
 /** PURE policy decision: admit this maintenance job now, or defer it? Checked in priority order -- the
  *  trickle (age) escape hatch first, so a starved job is never re-denied by a later check, then each pressure
- *  signal in turn. `pendingSinceMs` is the job's ORIGINAL enqueue time (its row's created_at), not the time of
- *  its most recent deferral, so the trickle clock only resets on a genuine fresh request (a coalesced
- *  re-enqueue), never on a repeated denial of the same wait. */
+ *  signal in turn. `pendingSinceMs` is the job's ORIGINAL enqueue time (its row's created_at), which the queue
+ *  backends (sqlite-queue.ts / pg-queue.ts) preserve across BOTH an admission-deferral requeue AND a coalesced
+ *  re-enqueue (a periodic scheduler re-requesting the same still-pending maintenance need) -- only a truly
+ *  fresh need, enqueued after the prior row was fully processed and deleted, starts a new clock. Otherwise a
+ *  re-enqueue cadence shorter than `maxDeferAgeMs` would keep re-arming the clock and defeat the trickle
+ *  entirely under sustained pressure. */
 export function evaluateMaintenanceAdmission(
   signals: MaintenancePressureSignals,
   config: MaintenanceAdmissionConfig,

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -474,11 +474,16 @@ export function createPgQueue(
         )
       ).rows[0] as { id: string } | undefined;
       if (existing) {
+        // created_at is deliberately NOT overwritten here (#selfhost-runtime-drift): it anchors the maintenance
+        // trickle's age clock (see maintenance-admission.ts). A periodic scheduler re-enqueuing the SAME still-
+        // pending maintenance need must coalesce into the existing row without resetting how long that need has
+        // genuinely been outstanding -- otherwise a re-enqueue cadence shorter than the trickle's maxDeferAgeMs
+        // (4h default) can keep re-arming the clock forever, and sustained pressure defers the job indefinitely.
         await pool.query(
           `UPDATE ${TABLE}
-             SET payload=$1, run_after=GREATEST(run_after, $2), created_at=$3, priority=GREATEST(priority, $4), job_key=$5, last_error=NULL
-           WHERE id=$6`,
-          [payload, runAfter, now, priority, key, existing.id],
+             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), job_key=$4, last_error=NULL
+           WHERE id=$5`,
+          [payload, runAfter, priority, key, existing.id],
         );
         await pool.query(
           `DELETE FROM ${TABLE}
@@ -498,11 +503,13 @@ export function createPgQueue(
         )
       ).rows[0] as { id: string } | undefined;
       if (existing) {
+        // See the supersededKeyPrefix branch above: created_at is preserved across a coalesced re-enqueue so the
+        // maintenance trickle clock reflects genuine wait time, not the most recent re-request.
         await pool.query(
           `UPDATE ${TABLE}
-             SET payload=$1, run_after=GREATEST(run_after, $2), created_at=$3, priority=GREATEST(priority, $4), last_error=NULL
-           WHERE id=$5`,
-          [payload, runAfter, now, priority, existing.id],
+             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), last_error=NULL
+           WHERE id=$4`,
+          [payload, runAfter, priority, existing.id],
         );
         await recordQueueMetric("gittensory_jobs_coalesced_total");
         kickOne();
@@ -702,6 +709,23 @@ export function createPgQueue(
             { parentTraceParent: jobTraceParent },
           );
           return true;
+        }
+        // Force-admitted despite pressure (#selfhost-runtime-drift): a distinct signal from a normal clear-
+        // pressure admission -- it means the box has been under SUSTAINED load for the job's entire
+        // maxDeferAgeMs wait, not just a brief blip. A dashboard trending this alongside the deferred-by-reason
+        // counters distinguishes "load-shed maintenance is working as designed" from "maintenance is chronically
+        // starved and only ever runs via the trickle floor" (the "truly stuck" signal operators need).
+        if (decision.reason === "trickle_max_defer_age") {
+          await recordQueueMetric("gittensory_jobs_maintenance_trickle_admitted_total");
+          incr("gittensory_jobs_maintenance_trickle_admitted_by_type_total", { job_type: message.type });
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              event: "selfhost_queue_maintenance_trickle_admitted",
+              jobType: message.type,
+              pending_ms: Date.now() - Number(job.created_at),
+            }),
+          );
         }
       }
       try {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -263,11 +263,16 @@ export function createSqliteQueue(
         [prefixLength, supersededKeyPrefix],
       ).rows[0] as { id: number } | undefined;
       if (existing) {
+        // created_at is deliberately NOT overwritten here (#selfhost-runtime-drift): it anchors the maintenance
+        // trickle's age clock (see maintenance-admission.ts). A periodic scheduler re-enqueuing the SAME still-
+        // pending maintenance need must coalesce into the existing row without resetting how long that need has
+        // genuinely been outstanding -- otherwise a re-enqueue cadence shorter than the trickle's maxDeferAgeMs
+        // (4h default) can keep re-arming the clock forever, and sustained pressure defers the job indefinitely.
         driver.query(
           `UPDATE ${TABLE}
-             SET payload=?, run_after=max(run_after, ?), created_at=?, priority=max(priority, ?), job_key=?, last_error=NULL
+             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), job_key=?, last_error=NULL
            WHERE id=?`,
-          [payload, runAfter, now, priority, key, existing.id],
+          [payload, runAfter, priority, key, existing.id],
         );
         driver.query(
           `DELETE FROM ${TABLE}
@@ -285,11 +290,13 @@ export function createSqliteQueue(
         [key],
       ).rows[0] as { id: number } | undefined;
       if (existing) {
+        // See the supersededKeyPrefix branch above: created_at is preserved across a coalesced re-enqueue so the
+        // maintenance trickle clock reflects genuine wait time, not the most recent re-request.
         driver.query(
           `UPDATE ${TABLE}
-             SET payload=?, run_after=max(run_after, ?), created_at=?, priority=max(priority, ?), last_error=NULL
+             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), last_error=NULL
            WHERE id=?`,
-          [payload, runAfter, now, priority, existing.id],
+          [payload, runAfter, priority, existing.id],
         );
         recordQueueMetric(driver, "gittensory_jobs_coalesced_total");
         kickOne();
@@ -480,6 +487,23 @@ export function createSqliteQueue(
             { parentTraceParent: jobTraceParent },
           );
           return true;
+        }
+        // Force-admitted despite pressure (#selfhost-runtime-drift): a distinct signal from a normal clear-
+        // pressure admission -- it means the box has been under SUSTAINED load for the job's entire
+        // maxDeferAgeMs wait, not just a brief blip. A dashboard trending this alongside the deferred-by-reason
+        // counters distinguishes "load-shed maintenance is working as designed" from "maintenance is chronically
+        // starved and only ever runs via the trickle floor" (the "truly stuck" signal operators need).
+        if (decision.reason === "trickle_max_defer_age") {
+          recordQueueMetric(driver, "gittensory_jobs_maintenance_trickle_admitted_total");
+          incr("gittensory_jobs_maintenance_trickle_admitted_by_type_total", { job_type: message.type });
+          console.warn(
+            JSON.stringify({
+              level: "warn",
+              event: "selfhost_queue_maintenance_trickle_admitted",
+              jobType: message.type,
+              pending_ms: Date.now() - job.created_at,
+            }),
+          );
         }
       }
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -607,6 +607,7 @@ async function main(): Promise<void> {
     "gittensory_jobs_coalesced_total",
     "gittensory_jobs_recovered_total",
     "gittensory_jobs_maintenance_admission_deferred_total",
+    "gittensory_jobs_maintenance_trickle_admitted_total",
   ]) {
     gauge(name.replace("_total", "_persisted_total"), () =>
       durableJobMetric(name),

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -363,12 +363,29 @@ describe("createPgQueue (durable #977)", () => {
     );
     expect(m.pool.query).toHaveBeenCalledWith(
       expect.stringContaining("SET payload=$1, run_after=GREATEST"),
-      expect.arrayContaining([expect.stringContaining('"deliveryId":"ci-2"'), expect.any(Number), expect.any(Number), 10, "existing"]),
+      expect.arrayContaining([expect.stringContaining('"deliveryId":"ci-2"'), expect.any(Number), 10, "existing"]),
     );
     expect(m.pool.query).not.toHaveBeenCalledWith(
       expect.stringContaining("INSERT INTO _selfhost_jobs (payload"),
       expect.arrayContaining([expect.stringContaining('"deliveryId":"ci-2"')]),
     );
+  });
+
+  it("does not reset created_at when coalescing a re-enqueue into an existing pending row (regression for #selfhost-runtime-drift)", async () => {
+    // created_at anchors the maintenance trickle's age clock (maintenance-admission.ts). If a coalesced
+    // re-enqueue reset it, a periodic scheduler re-requesting the same still-pending maintenance job faster
+    // than the trickle's maxDeferAgeMs would re-arm the clock forever and defeat the anti-starvation escape.
+    const m = makePool();
+    const q = createPgQueue(m.pool, async () => undefined);
+    await q.init();
+    m.fn.mockResolvedValueOnce({ rows: [{ id: "existing" }], rowCount: 1 });
+
+    await q.binding.send(msg("refresh-registry"));
+
+    const calls = (m.fn as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const coalesceCall = calls.find((c: unknown[]) => String(c[0]).includes("SET payload=$1, run_after=GREATEST"));
+    expect(coalesceCall?.[0]).toBeDefined();
+    expect(String(coalesceCall?.[0])).not.toContain("created_at");
   });
 
   it("lets a pending full RAG index absorb a later repo incremental", async () => {
@@ -414,7 +431,6 @@ describe("createPgQueue (durable #977)", () => {
       expect.stringContaining("SET payload=$1, run_after=GREATEST"),
       expect.arrayContaining([
         expect.stringContaining('"requestedBy":"schedule"'),
-        expect.any(Number),
         expect.any(Number),
         0,
         "rag-index-repo:jsonbored/gittensory:full",
@@ -487,7 +503,6 @@ describe("createPgQueue (durable #977)", () => {
       expect.arrayContaining([
         expect.stringContaining('"type":"backfill-registered-repos"'),
         expect.any(Number),
-        expect.any(Number),
         0,
         "existing-backfill",
       ]),
@@ -496,7 +511,6 @@ describe("createPgQueue (durable #977)", () => {
       expect.stringContaining("SET payload=$1, run_after=GREATEST"),
       expect.arrayContaining([
         expect.stringContaining('"type":"generate-weekly-value-report"'),
-        expect.any(Number),
         expect.any(Number),
         0,
         "existing-report",
@@ -1873,6 +1887,9 @@ describe("createPgQueue (durable #977)", () => {
         const q = createPgQueue(m.pool, async (j) => void started.push(typeOf(j)));
         await q.drain();
         expect(started).toEqual(["build-contributor-evidence"]);
+        expect(await renderMetrics()).toContain(
+          'gittensory_jobs_maintenance_trickle_admitted_by_type_total{job_type="build-contributor-evidence"} 1',
+        );
       } finally {
         if (oldEnv === undefined) delete process.env.MAINTENANCE_ADMISSION_MAX_DEFER_AGE_MS;
         else process.env.MAINTENANCE_ADMISSION_MAX_DEFER_AGE_MS = oldEnv;

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1062,6 +1062,42 @@ describe("createSqliteQueue (durable #980)", () => {
     });
   });
 
+  it("preserves the original created_at across a coalesced re-enqueue of a recurring maintenance job (regression for #selfhost-runtime-drift)", async () => {
+    // A periodic scheduler (e.g. the hourly refresh-registry trigger) re-enqueues the SAME still-pending
+    // maintenance job while it is deferred under sustained pressure. created_at anchors the maintenance
+    // trickle's age clock (maintenance-admission.ts) -- if the coalesced re-enqueue reset it to "now" every
+    // time, a re-enqueue cadence shorter than maxDeferAgeMs would re-arm the clock forever and the job would
+    // never force-admit, no matter how long the underlying need had genuinely been outstanding.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-24T12:00:00.000Z"));
+    try {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+
+      await q.binding.send(msg("refresh-registry"), { delaySeconds: 60 });
+      const first = driver.query(
+        "SELECT id, created_at, run_after FROM _selfhost_jobs WHERE payload LIKE '%refresh-registry%'",
+        [],
+      ).rows[0] as { id: number; created_at: number; run_after: number };
+
+      vi.setSystemTime(new Date("2026-06-24T12:30:00.000Z")); // 30m later: next periodic tick, still pending
+      await q.binding.send(msg("refresh-registry"), { delaySeconds: 60 });
+
+      const rows = driver.query("SELECT id, created_at, run_after FROM _selfhost_jobs", []).rows as Array<{
+        id: number;
+        created_at: number;
+        run_after: number;
+      }>;
+      expect(rows).toHaveLength(1); // coalesced into the same row, not a second insert
+      expect(rows[0]?.id).toBe(first.id);
+      expect(rows[0]?.created_at).toBe(first.created_at); // NOT reset to the re-enqueue time
+      expect(rows[0]?.run_after).toBeGreaterThan(first.run_after); // still advances with the new request
+      expect(q.stats()).toMatchObject({ gittensory_jobs_coalesced_total: 1 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not coalesce terminal pull_request events that carry distinct lifecycle side effects", async () => {
     const driver = makeDriver();
     const q = createSqliteQueue(driver, async () => undefined);
@@ -2236,6 +2272,21 @@ describe("createSqliteQueue (durable #980)", () => {
       );
       await q.drain();
       expect(started).toEqual(["build-contributor-evidence"]);
+      expect(q.stats()).toMatchObject({ gittensory_jobs_maintenance_trickle_admitted_total: 1 });
+      expect(await renderMetrics()).toContain(
+        'gittensory_jobs_maintenance_trickle_admitted_by_type_total{job_type="build-contributor-evidence"} 1',
+      );
+    });
+
+    it("does not record a trickle-admitted metric on a normal clear-pressure admission", async () => {
+      const driver = makeDriver();
+      const started: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void started.push(typeOf(m)));
+      await q.binding.send(msg("build-contributor-evidence"));
+      await q.drain();
+      expect(started).toEqual(["build-contributor-evidence"]);
+      expect(q.stats()).not.toHaveProperty("gittensory_jobs_maintenance_trickle_admitted_total");
+      expect(await renderMetrics()).not.toContain("gittensory_jobs_maintenance_trickle_admitted");
     });
 
     it("pressureSignals() reports live/maintenance pending counts and oldest ages", async () => {


### PR DESCRIPTION
## Summary

- A coalesced re-enqueue of a still-pending maintenance job reset its `created_at` to the re-enqueue time in both queue backends (SQLite and Postgres). Since `created_at` anchors the maintenance-trickle anti-starvation clock (`maintenance-admission.ts`), a periodic scheduler re-requesting the same still-pending maintenance work (e.g. an hourly `refresh-registry` trigger) kept re-arming the clock every time it fired — under sustained live-traffic pressure, this let a maintenance job be deferred indefinitely, never reaching the trickle's max-defer-age floor.
- Fix: the coalesce path no longer touches `created_at` on either backend, only `run_after`/`priority`/`payload`. Added regression tests for both backends proving the original enqueue time survives a coalesced re-enqueue, and that the trickle-admitted metric now fires correctly.
- Added a new `gittensory_jobs_maintenance_trickle_admitted_total` metric (+ by-type breakdown) so operators can distinguish "maintenance cleared pressure normally" from "maintenance is chronically starved and only runs via the anti-starvation floor" — the "truly stuck" signal called for in the runtime-drift investigation.
- No behavior change to the admission-deferral requeue path itself (already correctly preserved `created_at`); only the enqueue-time coalesce path was affected.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue — a self-host operational bug found via direct investigation of a reported symptom cluster; the summary above explains the root cause.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full, unsharded) — 375 files / 7261 tests passed, 0 failures
- [ ] `npm run actionlint` (no workflow files touched)
- [ ] `npm run test:workers` (no Cloudflare-worker-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- This PR only touches self-host queue/backend TypeScript (`src/selfhost/**`, `src/server.ts`) and its unit tests; the UI/MCP/workers/dependency/workflow checks above are inapplicable to this diff and were skipped for that reason, not omitted carelessly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session changes.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A.)

## Notes

- This is the first of several focused follow-ups from an operator-reported self-host runtime-drift investigation (queue starvation, Orb relay registration retries, broker-mode installation health, and cap-close permission-denial noise); the others are separate PRs to keep each change reviewable on its own.