### PR TITLE
fix(github): avoid caching failed PR file syncs

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2041,7 +2041,6 @@ async function fetchAndStorePullRequestDetails(
   // >=): millisecond-resolution ISO timestamps can tie when a sync and a racing invalidation land in the same
   // millisecond, and sub-millisecond ordering is unknowable from the stored strings — a tie must fail toward
   // "still needs a refetch," never toward silently trusting a possibly-stale cache.
-  const reviewsSyncedAtBefore = existingState?.reviewsSyncedAt;
   const reviewsUpToDate = isReviewsCacheUpToDate(existingState);
   const fileFetchStartedAt = nowIso();
   // Gate review finding (TOCTOU race): `existingState` above is a snapshot read at the TOP of this call. If a
@@ -2060,17 +2059,26 @@ async function fetchAndStorePullRequestDetails(
   ]);
   const fileSyncFailed = warnings.slice(warningStart).some((warning) => warning.startsWith(`File sync failed for #${pr.number}:`));
   // A filesSyncedAt/headSha pair means "the stored pull_request_files rows are a confirmed snapshot for
-  // this exact head." On a failed refetch we preserve old file rows, so we must also preserve the old marker
-  // instead of stamping the new head; otherwise the next run would cache-hit stale rows for the new diff.
-  const headShaResult = filesUpToDate || fileSyncFailed ? existingState?.headSha : pr.headSha;
-  const filesSyncedAtResult = filesUpToDate || fileSyncFailed ? existingState?.filesSyncedAt : fileFetchStartedAt;
+  // this exact head." On a cache-hit skip or a failed refetch we did not advance the stored files, so we must
+  // not advance the marker either -- BUT we must also not *replay* the snapshot we read at the top of this
+  // call. `existingState` is a TOCTOU read: if a DIFFERENT concurrent call for the same PR successfully syncs
+  // to an even newer head between that read and this call's own persist, re-writing our stale snapshot here
+  // would regress the durable marker backward and clobber the newer, correct value the concurrent call just
+  // wrote (gate review finding). `upsertPullRequestDetailSyncState` treats an `undefined` field as "leave this
+  // column unchanged" (see its PARTIAL-UPDATE CONTRACT comment) -- so returning `undefined` instead of the
+  // snapshot tells every caller's upsert to skip the column entirely, which is safe whether the row is still
+  // exactly what we read or has since moved on: either way we simply don't touch it.
+  const headShaResult = filesUpToDate || fileSyncFailed ? undefined : pr.headSha;
+  const filesSyncedAtResult = filesUpToDate || fileSyncFailed ? undefined : fileFetchStartedAt;
   // reviewsSyncedAt only ever ADVANCES on a genuine success in THIS call -- never on a cache-hit skip, and
   // never on a failed fetch attempt. This is what makes a stored reviewsSyncedAt a trustworthy "last confirmed
   // successful sync" marker on its own (no separate errorSummary string-matching needed: a failed or skipped
-  // pass simply preserves whatever was already known, which -- being unchanged -- correctly keeps comparing as
-  // stale against reviewsInvalidatedAt on the next pass until a real fetch actually succeeds).
+  // pass simply leaves whatever was already known untouched, which -- being unchanged -- correctly keeps
+  // comparing as stale against reviewsInvalidatedAt on the next pass until a real fetch actually succeeds).
+  // Same TOCTOU hazard as headSha/filesSyncedAt above: `undefined` (not the pre-fetch `existingState`
+  // snapshot) so a skipped/failed pass never regresses a marker a concurrent call has since advanced.
   const reviewSyncFailedThisCall = !reviewsUpToDate && warnings.slice(warningStart).some((warning) => warning.startsWith(`Review sync failed for #${pr.number}:`));
-  const reviewsSyncedAtResult = !reviewsUpToDate && !reviewSyncFailedThisCall ? reviewFetchStartedAt : reviewsSyncedAtBefore;
+  const reviewsSyncedAtResult = !reviewsUpToDate && !reviewSyncFailedThisCall ? reviewFetchStartedAt : undefined;
 
   if (!filesUpToDate && !fileSyncFailed) {
     await deletePullRequestFiles(env, repoFullName, pr.number);

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -625,15 +625,15 @@ export async function backfillOpenPullRequestDetails(
   await mapWithConcurrency(batch, 2, async (pr) => {
     await upsertPullRequestDetailSyncState(env, { repoFullName: repo.fullName, pullNumber: pr.number, status: "running" });
     const before = warnings.length;
-    const { reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
+    const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
     const syncedAt = nowIso();
     const newWarnings = warnings.slice(before);
     await upsertPullRequestDetailSyncState(env, {
       repoFullName: repo.fullName,
       pullNumber: pr.number,
       status: newWarnings.length > 0 ? "partial" : "complete",
-      headSha: pr.headSha,
-      filesSyncedAt: syncedAt,
+      headSha,
+      filesSyncedAt,
       reviewsSyncedAt,
       checksSyncedAt: syncedAt,
       lastSyncedAt: syncedAt,
@@ -701,15 +701,15 @@ export async function refreshPullRequestDetails(
   const admissionKey = repoAdmissionKeyForToken(env, repo, token);
   const warnings: string[] = [];
   await upsertPullRequestDetailSyncState(env, { repoFullName, pullNumber, status: "running" });
-  const { reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repoFullName, pr, token, warnings, admissionKey, "live_review", { forceFiles: options.force });
+  const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repoFullName, pr, token, warnings, admissionKey, "live_review", { forceFiles: options.force });
   const syncedAt = nowIso();
   const status: PullRequestDetailSyncStateRecord["status"] = warnings.length > 0 ? "partial" : "complete";
   await upsertPullRequestDetailSyncState(env, {
     repoFullName,
     pullNumber,
     status,
-    headSha: pr.headSha,
-    filesSyncedAt: syncedAt,
+    headSha,
+    filesSyncedAt,
     reviewsSyncedAt,
     checksSyncedAt: syncedAt,
     lastSyncedAt: syncedAt,
@@ -1819,7 +1819,7 @@ async function backfillRepository(env: Env, repo: RepositoryRecord, limits: Back
     const detailWarningStart = warnings.length;
     await mapWithConcurrency(detailTargets, limits.detailConcurrency, async (pr) => {
       const before = warnings.length;
-      const { reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
+      const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
       // Persist the repo+PR+headSha snapshot marker (#audit-rate-headroom) so a later call through ANY
       // cache-aware path (open-PR convergence, live review) can skip refetching this PR's files while its
       // head is unchanged — without this write, fetchAndStorePullRequestDetails's cache check always misses
@@ -1830,8 +1830,8 @@ async function backfillRepository(env: Env, repo: RepositoryRecord, limits: Back
         repoFullName: repo.fullName,
         pullNumber: pr.number,
         status: newWarnings.length > 0 ? "partial" : "complete",
-        headSha: pr.headSha,
-        filesSyncedAt: syncedAt,
+        headSha,
+        filesSyncedAt,
         reviewsSyncedAt,
         checksSyncedAt: syncedAt,
         lastSyncedAt: syncedAt,
@@ -2019,7 +2019,7 @@ async function fetchAndStorePullRequestDetails(
   admissionKey: GitHubRateLimitAdmissionKey | undefined,
   caller: PullRequestFilesFetchCaller,
   options: { forceFiles?: boolean | undefined } = {},
-): Promise<{ reviewsSyncedAt: string | null | undefined }> {
+): Promise<{ headSha: string | null | undefined; filesSyncedAt: string | null | undefined; reviewsSyncedAt: string | null | undefined }> {
   // Durable repo+PR+headSha file snapshot (#audit-rate-headroom): a bare URL cache is insufficient because
   // `/pulls/{n}/files` has the SAME url across different heads. Reuse the stored `pull_request_files` rows
   // instead of refetching when the last successful files sync already covered the PR's CURRENT head SHA —
@@ -2043,6 +2043,7 @@ async function fetchAndStorePullRequestDetails(
   // "still needs a refetch," never toward silently trusting a possibly-stale cache.
   const reviewsSyncedAtBefore = existingState?.reviewsSyncedAt;
   const reviewsUpToDate = isReviewsCacheUpToDate(existingState);
+  const fileFetchStartedAt = nowIso();
   // Gate review finding (TOCTOU race): `existingState` above is a snapshot read at the TOP of this call. If a
   // `pull_request_review` webhook races in AFTER that read but BEFORE this function returns, an unconditional
   // "stamp reviewsSyncedAt to now" on the CALLER's side (the old design) would advance the timestamp PAST that
@@ -2058,6 +2059,11 @@ async function fetchAndStorePullRequestDetails(
     fetchPullRequestChecks(env, repoFullName, pr, token, warnings, admissionKey),
   ]);
   const fileSyncFailed = warnings.slice(warningStart).some((warning) => warning.startsWith(`File sync failed for #${pr.number}:`));
+  // A filesSyncedAt/headSha pair means "the stored pull_request_files rows are a confirmed snapshot for
+  // this exact head." On a failed refetch we preserve old file rows, so we must also preserve the old marker
+  // instead of stamping the new head; otherwise the next run would cache-hit stale rows for the new diff.
+  const headShaResult = filesUpToDate || fileSyncFailed ? existingState?.headSha : pr.headSha;
+  const filesSyncedAtResult = filesUpToDate || fileSyncFailed ? existingState?.filesSyncedAt : fileFetchStartedAt;
   // reviewsSyncedAt only ever ADVANCES on a genuine success in THIS call -- never on a cache-hit skip, and
   // never on a failed fetch attempt. This is what makes a stored reviewsSyncedAt a trustworthy "last confirmed
   // successful sync" marker on its own (no separate errorSummary string-matching needed: a failed or skipped
@@ -2109,7 +2115,7 @@ async function fetchAndStorePullRequestDetails(
       payload: check as unknown as Record<string, JsonValue>,
     });
   }
-  return { reviewsSyncedAt: reviewsSyncedAtResult };
+  return { headSha: headShaResult, filesSyncedAt: filesSyncedAtResult, reviewsSyncedAt: reviewsSyncedAtResult };
 }
 
 // GitHub caps list endpoints at 100 items/page, so a single `per_page=100` fetch silently truncates a

--- a/test/unit/backfill-file-hydration-scoping.test.ts
+++ b/test/unit/backfill-file-hydration-scoping.test.ts
@@ -270,6 +270,56 @@ describe("GitHub PR file hydration scoping (#audit-rate-headroom)", () => {
     expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 33)).toMatchObject({ headSha: "head-2" });
   });
 
+  it("a failed file sync never regresses a marker a concurrent successful sync already advanced past it (gate review finding)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 34,
+      title: "Open PR, racing concurrent refresh",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "head-2" },
+      labels: [],
+      body: "",
+    });
+    // This call's own initial state read (TOCTOU snapshot): stale head-1.
+    await upsertPullRequestDetailSyncState(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 34,
+      status: "complete",
+      headSha: "head-1",
+      filesSyncedAt: "2026-05-20T00:00:00.000Z",
+    });
+    stubFetchTracking((url) => {
+      if (url.includes("/pulls/34/files")) {
+        // Simulate a DIFFERENT concurrent call successfully syncing to an even newer head and persisting
+        // its own (correct, newer) marker BETWEEN this call's initial state read and this call's own
+        // failed-fetch persist below -- the exact interleaving the gate review flagged.
+        void upsertPullRequestDetailSyncState(env, {
+          repoFullName: "JSONbored/gittensory",
+          pullNumber: 34,
+          status: "complete",
+          headSha: "head-3",
+          filesSyncedAt: "2026-05-25T00:00:00.000Z",
+        });
+        return new Response("transient REST failure", { status: 503 });
+      }
+      if (url.includes("/graphql")) return new Response("transient GraphQL failure", { status: 503 });
+      return Response.json([]);
+    });
+
+    const failed = await refreshPullRequestDetails(env, "JSONbored/gittensory", 34);
+
+    expect(failed).toMatchObject({ status: "partial", warnings: [expect.stringContaining("File sync failed for #34")] });
+    // The failed call must not stomp the concurrently-written newer marker back to its own stale head-1
+    // snapshot -- it must leave the column untouched (undefined-omit), so the concurrent success's head-3
+    // marker survives.
+    expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 34)).toMatchObject({
+      headSha: "head-3",
+      filesSyncedAt: "2026-05-25T00:00:00.000Z",
+    });
+  });
+
   it("defers historical merged-PR file hydration when the REST budget is below the historical-backfill floor, while cheap metadata still syncs", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);

--- a/test/unit/backfill-file-hydration-scoping.test.ts
+++ b/test/unit/backfill-file-hydration-scoping.test.ts
@@ -213,6 +213,63 @@ describe("GitHub PR file hydration scoping (#audit-rate-headroom)", () => {
     expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 32)).toMatchObject({ headSha: "head-2" });
   });
 
+  it("does not stamp a new head-SHA file snapshot when the changed-head file fetch fails", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 33,
+      title: "Open PR, new push with transient file failure",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "head-2" },
+      labels: [],
+      body: "",
+    });
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 33,
+      path: "src/old.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: { filename: "src/old.ts" },
+    });
+    await upsertPullRequestDetailSyncState(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 33,
+      status: "complete",
+      headSha: "head-1",
+      filesSyncedAt: "2026-05-20T00:00:00.000Z",
+    });
+    let failFiles = true;
+    const urls = stubFetchTracking((url) => {
+      if (url.includes("/pulls/33/files")) {
+        return failFiles ? new Response("transient REST failure", { status: 503 }) : Response.json([{ filename: "src/new.ts", status: "added", additions: 5, deletions: 0, changes: 5 }]);
+      }
+      if (url.includes("/graphql")) return new Response("transient GraphQL failure", { status: 503 });
+      return Response.json([]);
+    });
+
+    const failed = await refreshPullRequestDetails(env, "JSONbored/gittensory", 33);
+
+    expect(failed).toMatchObject({ status: "partial", warnings: [expect.stringContaining("File sync failed for #33")] });
+    expect(await listPullRequestFiles(env, "JSONbored/gittensory", 33)).toEqual([expect.objectContaining({ path: "src/old.ts" })]);
+    expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 33)).toMatchObject({
+      headSha: "head-1",
+      filesSyncedAt: "2026-05-20T00:00:00.000Z",
+    });
+
+    failFiles = false;
+    urls.length = 0;
+    const retried = await refreshPullRequestDetails(env, "JSONbored/gittensory", 33);
+
+    expect(retried).toMatchObject({ status: "complete", warnings: [] });
+    expect(urls.some((url) => url.includes("/pulls/33/files"))).toBe(true);
+    expect(await listPullRequestFiles(env, "JSONbored/gittensory", 33)).toEqual([expect.objectContaining({ path: "src/new.ts" })]);
+    expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 33)).toMatchObject({ headSha: "head-2" });
+  });
+
   it("defers historical merged-PR file hydration when the REST budget is below the historical-backfill floor, while cheap metadata still syncs", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
### Motivation

- Prevent stale stored pull_request_files rows from being treated as a current-head snapshot when a files fetch transiently fails, which can cause review/gate logic to evaluate the wrong diff and produce security-relevant integrity loss. 
- Ensure the durable repo+PR+headSha marker reflects a confirmed successful files sync, not merely an attempted refresh.

### Description

- Change `fetchAndStorePullRequestDetails` to return `headSha` and `filesSyncedAt` alongside `reviewsSyncedAt`, and compute marker values that preserve the previous marker when a files fetch fails. 
- Update callers (`refreshPullRequestDetails`, open-PR backfill, and monolithic backfill paths) to persist the `headSha`/`filesSyncedAt` values returned by the helper instead of unconditionally stamping the current `pr.headSha` and a new timestamp. 
- Add logic so a failed `/pulls/:n/files` attempt does not advance the durable marker, preventing a later cache hit from skipping a now-available file refetch. 
- Add a regression unit test that reproduces a changed-head transient files-fetch failure, asserts the old marker and stored files are preserved, then confirms a later successful retry fetches and stores the new-head files.

### Testing

- Ran the impacted unit suite: `npx vitest run test/unit/backfill-file-hydration-scoping.test.ts --reporter=verbose`, and all tests in that file passed (14 tests). 
- Ran `git diff --check` which returned clean. 
- `npm run typecheck` failed with unrelated pre-existing TypeScript errors in `test/unit/queue.test.ts` (missing `securityFocus` on `AiReviewCacheInput`), and did not report errors for the modified files. 
- `npm audit --audit-level=moderate` could not complete due to an npm registry audit endpoint `403 Forbidden` response; the audit step was not successfully executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474ad6d614832cb8344af8baba4ca2)