### PR TITLE
fix(queue): use complete contributor PR cap set

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3433,6 +3433,16 @@ export async function listOtherOpenPullRequests(env: Env, fullName: string, numb
   return rows.map(toPullRequestRecordFromRow);
 }
 
+export async function listOtherOpenPullRequestsForAuthor(env: Env, fullName: string, number: number, authorLogin: string): Promise<PullRequestRecord[]> {
+  const db = getDb(env.DB);
+  const rows = await db
+    .select()
+    .from(pullRequests)
+    .where(and(eq(pullRequests.repoFullName, fullName), eq(pullRequests.state, "open"), not(eq(pullRequests.number, number)), sql`lower(${pullRequests.authorLogin}) = lower(${authorLogin})`))
+    .orderBy(asc(pullRequests.number));
+  return rows.map(toPullRequestRecordFromRow);
+}
+
 export async function getRepoAuthorPullRequestHistory(env: Env, fullName: string, login: string, excludeNumber?: number): Promise<{ mergedPrCount: number; closedUnmergedPrCount: number }> {
   const db = getDb(env.DB);
   const [row] = await db

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2194,12 +2194,17 @@ async function runAgentMaintenancePlanAndExecute(
     // (already resolved above for the live-CI recheck) rather than minting a second one.
     const otherAuthorOpenPullRequests = await listOtherOpenPullRequestsForAuthor(env, repoFullName, pr.number, pr.authorLogin);
     const confirmedOpen = new Set<number>();
-    await Promise.all(
-      otherAuthorOpenPullRequests.map(async (other) => {
-        const liveState = await fetchLivePullRequestState(env, repoFullName, other.number, token, admissionKey).catch(() => undefined);
-        if (liveState === "open") confirmedOpen.add(other.number);
-      }),
-    );
+    // Bounded concurrency (security review finding): an unbounded Promise.all here scales with the author's
+    // OWN open-PR count, not a fixed small number -- an author with dozens of open PRs would fire that many
+    // concurrent GitHub calls from a single webhook, and the delivery-order-guard wake below re-triggers this
+    // same block for every over-cap sibling, compounding into near-quadratic API growth that can exhaust the
+    // installation's rate-limit budget. Every entry must still be verified (the exact over-cap PR numbers
+    // below depend on the complete confirmed-open set, not just "is the count over cap"), so this bounds
+    // concurrency rather than stopping early, mirroring mapWithConcurrency's other callers in this file.
+    await mapWithConcurrency(otherAuthorOpenPullRequests, CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY, async (other) => {
+      const liveState = await fetchLivePullRequestState(env, repoFullName, other.number, token, admissionKey).catch(() => undefined);
+      if (liveState === "open") confirmedOpen.add(other.number);
+    });
     const authorOpenPrNumbers = otherAuthorOpenPullRequests
       .filter((other) => confirmedOpen.has(other.number))
       .map((other) => other.number)
@@ -4152,6 +4157,15 @@ async function countLiveOpenWithConcurrencyUntil(
 // backgroundConcurrency cap (which defaults to 1) entirely from inside one job's execution. Bounded worker-pool
 // fan-out, same shape as GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY above.
 const NOTIFY_EVALUATE_EVENT_CONCURRENCY = 5;
+
+// The per-repo contributor-cap live-verification (#2270 busy-repo bypass fix) walks the author's COMPLETE
+// open-PR set on this repo, not a fixed small number -- an author with dozens of open PRs would otherwise fire
+// that many concurrent fetchLivePullRequestState calls from a single webhook, and the delivery-order-guard
+// wake below re-triggers this same check for every over-cap sibling, compounding into near-quadratic API
+// growth across one busy author's siblings (security review finding). Every entry must still be verified (the
+// exact over-cap PR numbers depend on the complete confirmed-open set, not just whether the count is over
+// cap), so this bounds concurrency via mapWithConcurrency rather than stopping early.
+const CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY = 10;
 
 async function mapWithConcurrency<T, R>(items: T[], concurrency: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
   const results: R[] = new Array(items.length);

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -29,6 +29,7 @@ import {
   listSignalSnapshots,
   listRepoGithubTotalsSnapshotHistory,
   listOtherOpenPullRequests,
+  listOtherOpenPullRequestsForAuthor,
   listOpenIssues,
   listOpenPullRequests,
   listPullRequests,
@@ -2185,44 +2186,35 @@ async function runAgentMaintenancePlanAndExecute(
   // way to opt out of the PER-REPO cap specifically, even though `.gittensory.yml`'s own doc comment already
   // promised this reuse (auto-close-exempt.ts).
   if (typeof contributorOpenPrCap === "number" && pr.authorLogin && !isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) {
-    const authorLoginLower = pr.authorLogin.toLowerCase();
-    let otherAuthorOpenPrNumbers = otherOpenPullRequests
-      .filter((other) => (other.authorLogin ?? "").toLowerCase() === authorLoginLower)
-      .map((other) => other.number);
-    if (isNewAccount) {
-      const token = await createInstallationToken(env, installationId).catch(() => undefined);
-      // isNewAccount is only ever true after getGithubUserCreatedAt's OWN createInstallationToken call already
-      // succeeded for this exact installationId (it fails open to null/false otherwise) -- and that mint is
-      // cached (see app.ts's installationTokenCache), so THIS call almost always serves the cached token rather
-      // than re-hitting a failure. The `?? env.GITHUB_PUBLIC_TOKEN` fallback arm is exercised only in the rare
-      // window where the cached token expires between those two calls; not practically reachable from a unit
-      // test without reaching into that unrelated cache's internals. The fallback pattern itself is proven
-      // correct by the analogous, reachable contributor-issue-cap test ("falls back to GITHUB_PUBLIC_TOKEN for
-      // the sibling live-check when the installation token mint fails").
-      /* v8 ignore next -- see the comment above */
-      const liveToken = token ?? env.GITHUB_PUBLIC_TOKEN;
-      const admissionKey = githubAdmissionKeyForToken(env, installationId, liveToken);
-      const confirmedOpen = new Set<number>();
-      await Promise.all(
-        otherAuthorOpenPrNumbers.map(async (number) => {
-          const liveState = await fetchLivePullRequestState(env, repoFullName, number, liveToken, admissionKey).catch(() => undefined);
-          if (liveState === "open") confirmedOpen.add(number);
-        }),
-      );
-      otherAuthorOpenPrNumbers = otherAuthorOpenPrNumbers.filter((number) => confirmedOpen.has(number));
-    }
-    const authorOpenPrNumbers = otherAuthorOpenPrNumbers.concat(pr.number).sort((a, b) => a - b);
+    // Complete author-scoped set (not the duplicate-analysis 100-row sample), with every counted sibling
+    // positively LIVE-confirmed still open before it counts toward an irreversible close decision (#2270
+    // busy-repo bypass fix). Runs unconditionally now -- not just for isNewAccount -- since a stale-DB-row
+    // false positive is exactly as wrong for an established contributor as for a new one; this supersedes the
+    // narrower new-account-only live-verify this block used to have. Reuses the function-scoped token/admissionKey
+    // (already resolved above for the live-CI recheck) rather than minting a second one.
+    const otherAuthorOpenPullRequests = await listOtherOpenPullRequestsForAuthor(env, repoFullName, pr.number, pr.authorLogin);
+    const confirmedOpen = new Set<number>();
+    await Promise.all(
+      otherAuthorOpenPullRequests.map(async (other) => {
+        const liveState = await fetchLivePullRequestState(env, repoFullName, other.number, token, admissionKey).catch(() => undefined);
+        if (liveState === "open") confirmedOpen.add(other.number);
+      }),
+    );
+    const authorOpenPrNumbers = otherAuthorOpenPullRequests
+      .filter((other) => confirmedOpen.has(other.number))
+      .map((other) => other.number)
+      .concat(pr.number)
+      .sort((a, b) => a - b);
     const overCapNumbers = new Set(authorOpenPrNumbers.slice(contributorOpenPrCap));
     if (overCapNumbers.has(pr.number)) {
       contributorCapMatch = { matched: true, authorLogin: pr.authorLogin, openCount: authorOpenPrNumbers.length, cap: contributorOpenPrCap, itemKind: "pull requests" };
     }
     // Webhook-delivery-order guard (#2479 gate finding): delivery order is not guaranteed to match PR creation
     // order, so a sibling PR's own webhook can process before THIS PR exists in the DB and wrongly conclude the
-    // author is within the cap — nothing else would ever re-evaluate it, permanently bypassing the cap for that
-    // sibling. Now that THIS delivery has the complete picture, wake any OTHER still-open sibling that's also
-    // in the over-cap set so its own next pass re-evaluates against the complete set and self-corrects.
-    const otherOverCapSiblingNumbers = otherOpenPullRequests
-      .filter((other) => (other.authorLogin ?? "").toLowerCase() === authorLoginLower && overCapNumbers.has(other.number))
+    // author is within the cap. Use the complete author-scoped set (not the duplicate-analysis 100-row sample)
+    // and only siblings positively confirmed open, matching the issue-cap fail-safe close contract.
+    const otherOverCapSiblingNumbers = otherAuthorOpenPullRequests
+      .filter((other) => confirmedOpen.has(other.number) && overCapNumbers.has(other.number))
       .map((other) => other.number);
     if (otherOverCapSiblingNumbers.length > 0) {
       await wakeOverCapSiblingPullRequests(env, deliveryId, installationId, repoFullName, otherOverCapSiblingNumbers);

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -8243,6 +8243,71 @@ describe("queue processors", () => {
     expect(seen.comments.some((c) => c.includes("@spammer") && c.includes("2 open pull requests") && c.includes("limit of 1"))).toBe(true);
   });
 
+  it("REGRESSION (security review finding): the per-repo cap's sibling live-check bounds concurrency instead of firing one request per open PR at once", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    // 30 OTHER open PRs from the SAME author — well beyond CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY (10), so an
+    // unbounded Promise.all would fire all 30 live-state GETs at once.
+    const SIBLING_COUNT = 30;
+    for (let number = 1; number <= SIBLING_COUNT; number += 1) {
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number, title: `Prolific PR ${number}`, state: "open", user: { login: "prolific" }, head: { sha: `p${number}` }, labels: [], body: "x" });
+    }
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      autonomy: { close: "auto", label: "auto" },
+      contributorOpenPrCap: 100, // above SIBLING_COUNT + 1 — this test only cares about concurrency, not closing.
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const siblingCheckPattern = new RegExp(`/pulls/(?:${Array.from({ length: SIBLING_COUNT }, (_, i) => i + 1).join("|")})$`);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (siblingCheckPattern.test(url) && method === "GET") {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // A tiny real delay forces genuine overlap between concurrently-dispatched sibling checks — without
+        // it, each mock resolves synchronously and never actually overlaps another in-flight call.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return Response.json({ state: "open" });
+      }
+      if (url.includes(`/pulls/${SIBLING_COUNT + 1}/files`)) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes(`/pulls/${SIBLING_COUNT + 1}/reviews`)) return Response.json([]);
+      if (url.includes(`/pulls/${SIBLING_COUNT + 1}/commits`)) return Response.json([]);
+      if (url.endsWith(`/pulls/${SIBLING_COUNT + 1}`)) return Response.json({ number: SIBLING_COUNT + 1, state: "open", user: { login: "prolific" }, head: { sha: `p${SIBLING_COUNT + 1}` }, mergeable_state: "clean" });
+      if (url.includes(`/commits/p${SIBLING_COUNT + 1}/check-runs`)) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes(`/commits/p${SIBLING_COUNT + 1}/status`)) return Response.json({ state: "success", statuses: [] });
+      if (url.includes(`/issues/${SIBLING_COUNT + 1}/labels`)) return Response.json([]);
+      if (url.includes(`/issues/${SIBLING_COUNT + 1}/comments`)) return Response.json([]);
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "contributor-cap-bounded-concurrency",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: SIBLING_COUNT + 1, title: "Prolific author's newest PR", state: "open", user: { login: "prolific" }, head: { sha: `p${SIBLING_COUNT + 1}` }, labels: [], body: "x", mergeable_state: "clean" },
+      },
+    });
+
+    expect(maxInFlight).toBeGreaterThan(1); // proves the check is genuinely concurrent, not accidentally serial
+    expect(maxInFlight).toBeLessThanOrEqual(10); // CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY
+  });
+
   it("contributor open-PR cap (#2270): disabled (no cap configured, the default) never closes an over-threshold contributor", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7001,6 +7001,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "baduser" }, head: { sha: "bl55" }, mergeable_state: "clean" });
       if (url.includes("/commits/bl55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -7721,6 +7722,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -7828,6 +7830,9 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/commits")) return Response.json([]);
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
+      // The other-siblings live-state recheck (#2270 complete-set fix) confirms every counted sibling PR is
+      // still open before trusting it toward the cap — farmer99's two pre-existing PRs (53, 54) must report open.
+      if (url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) return Response.json({ number: 53, state: "open" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/f55/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/55/labels")) return Response.json([]);
@@ -8182,6 +8187,62 @@ describe("queue processors", () => {
     expect(seen.cancelledIds).toEqual([]);
   });
 
+  it("contributor open-PR cap (#2270): uses a complete author-scoped set beyond the duplicate-analysis 100-row sample (regression)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    for (let number = 1; number <= 100; number += 1) {
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number, title: `Busy repo PR ${number}`, state: "open", user: { login: `other-${number}` }, head: { sha: `o${number}` }, labels: [], body: "x" });
+    }
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 101, title: "Spammer PR one", state: "open", user: { login: "spammer" }, head: { sha: "s101" }, labels: [], body: "x" });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      aiReviewMode: "advisory",
+      autonomy: { close: "auto", label: "auto" },
+      contributorOpenPrCap: 1,
+    });
+    const seen = { closed: false, comments: [] as string[] };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/pulls/101") && method === "GET") return Response.json({ number: 101, state: "open" });
+      if (url.includes("/pulls/102/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes("/pulls/102/reviews")) return Response.json([]);
+      if (url.includes("/pulls/102/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/102") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 102, state: "closed" }); }
+      if (url.endsWith("/pulls/102")) return Response.json({ number: 102, state: "open", user: { login: "spammer" }, head: { sha: "s102" }, mergeable_state: "clean" });
+      if (url.includes("/commits/s102/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/s102/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/102/labels")) return Response.json([]);
+      if (url.includes("/issues/102/comments") && method === "POST") { seen.comments.push(String(JSON.parse(String(init?.body ?? "{}")).body ?? "")); return Response.json({ id: 1 }, { status: 201 }); }
+      if (url.includes("/issues/102/comments")) return Response.json([]);
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "contributor-cap-busy-repo",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 102, title: "Spammer PR two", state: "open", user: { login: "spammer" }, head: { sha: "s102" }, labels: [], body: "x", mergeable_state: "clean", reviewDecision: "APPROVED" },
+      },
+    });
+
+    expect(seen.closed).toBe(true);
+    expect(seen.comments.some((c) => c.includes("@spammer") && c.includes("2 open pull requests") && c.includes("limit of 1"))).toBe(true);
+  });
+
   it("contributor open-PR cap (#2270): disabled (no cap configured, the default) never closes an over-threshold contributor", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, {
@@ -8209,6 +8270,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8264,6 +8326,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8331,6 +8394,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       // Install-wide live-verify (#2562 gate-review follow-up) re-fetches every OTHER counted sibling before
@@ -8453,6 +8517,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8511,6 +8576,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8570,6 +8636,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8681,6 +8748,7 @@ describe("queue processors", () => {
       if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
       if (url.includes("/pulls/55/reviews")) return Response.json([]);
       if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if ((url.endsWith("/pulls/53") || url.endsWith("/pulls/54")) && method === "GET") return Response.json({ state: "open" });
       if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
       if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
       if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
@@ -8720,6 +8788,9 @@ describe("queue processors", () => {
       if (url.includes(`/pulls/${prNumber}/commits`)) return Response.json([]);
       if (url.endsWith(`/pulls/${prNumber}`) && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: prNumber, state: "closed" }); }
       if (url.endsWith(`/pulls/${prNumber}`)) return Response.json({ number: prNumber, state: "open", user: { login: "newbie" }, head: { sha: `s${prNumber}` }, mergeable_state: "clean" });
+      // The other-siblings live-state recheck (#2270 complete-set fix) confirms every counted sibling PR is
+      // still open before trusting it toward the cap — a generic catch-all covers any of newbie's other
+      // pre-existing PR numbers without hard-coding specific ones.
       if (/\/pulls\/\d+$/.test(url)) return Response.json({ state: "open" });
       if (url.includes(`/commits/s${prNumber}/check-runs`)) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes(`/commits/s${prNumber}/status`)) return Response.json({ state: "success", statuses: [] });
@@ -9061,7 +9132,7 @@ describe("queue processors", () => {
       const method = init?.method ?? "GET";
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      for (const [n, sha] of [[55, "f55"], [56, "f56"]] as const) {
+      for (const [n, sha] of [[54, "f54"], [55, "f55"], [56, "f56"]] as const) {
         if (url.includes(`/pulls/${n}/files`)) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
         if (url.includes(`/pulls/${n}/reviews`)) return Response.json([]);
         if (url.includes(`/pulls/${n}/commits`)) return Response.json([]);


### PR DESCRIPTION
### Motivation

- The per-contributor open-PR cap used a repository-scoped 100-row sample helper and then filtered by author, which can omit an author's higher-numbered open PRs on busy repos and let the cap be bypassed.

### Description

- Add a new DB helper `listOtherOpenPullRequestsForAuthor` that returns the full author-scoped set of open PRs (ordered by PR number) without the repository-wide `LIMIT 100` (file: `src/db/repositories.ts`).
- Change the webhook/agent path to use the author-scoped set and `fetchLivePullRequestState` to positively confirm each counted sibling is still open before trusting it for an irreversible close decision (file: `src/queue/processors.ts`).
- Wake any other over-cap siblings discovered from the complete, live-confirmed set so out-of-order webhook deliveries self-correct (preserves the existing delivery-order guard semantics).
- Add a regression unit test that reproduces the busy-repo bypass (100 lower-numbered PRs from other users + a spammer's prior PR) and verifies the cap now closes the incoming PR (file: `test/unit/queue.test.ts`).

### Testing

- Ran the focused unit tests for the contributor-cap scenarios with `npx vitest run test/unit/queue.test.ts -t "contributor open-PR cap"`, which passed for the modified cases.
- Ran `git diff --check` to validate whitespace/conflict hygiene and found no failures.
- Attempted `npm run test:coverage`; a long-running coverage run was started during validation and was interrupted before a final, repo-wide coverage report was produced in this session.
- Ran `npm run typecheck`; this produced existing, unrelated `AiReviewCacheInput.securityFocus` type errors originating in `test/unit/queue.test.ts` (pre-existing test typing issues) and not caused by the logic changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4748e8a508832c87aa2cd5a914b275)