### PR TITLE
fix(queue): wake every linked issue PR

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3412,10 +3412,12 @@ async function maybeReReviewOnLinkedIssueChange(
   if (!repoFullName || !installationId || !issueNumber) return false;
   if (isConvergenceRepoAllowed(env, repoFullName)) {
     const openPullRequests = await listOpenPullRequests(env, repoFullName);
+    // Issue-side label/assignment changes can flip linked-issue hard-rule verdicts from mergeable to close.
+    // Queue every linked open PR (bounded only by listOpenPullRequests' repo-wide DB limit) so the tail cannot
+    // retain a stale passing gate until the scheduled sweep happens to reach it.
     const linkingPrNumbers = openPullRequests
       .filter((pr) => pr.linkedIssues.includes(issueNumber))
-      .map((pr) => pr.number)
-      .slice(0, SWEEP_MAX_PRS);
+      .map((pr) => pr.number);
     for (const [index, prNumber] of linkingPrNumbers.entries()) {
       if (await issueLinkedPrReReviewCoalesced(env, repoFullName, prNumber)) {
         await scheduleTrailingIssueLinkedReReview(

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1959,7 +1959,7 @@ describe("queue processors", () => {
     ]);
   });
 
-  it("REGRESSION: issue-side linked PR wake is capped and queued instead of re-reviewing every linked PR inline", async () => {
+  it("REGRESSION: issue-side linked PR wake queues every linked PR instead of dropping the capped tail", async () => {
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
@@ -1996,13 +1996,13 @@ describe("queue processors", () => {
     });
 
     expect(fetchCount).toBe(0);
-    expect(sent).toHaveLength(SWEEP_MAX_PRS);
+    expect(sent).toHaveLength(SWEEP_MAX_PRS + 2);
     expect(sent.map(({ message }) => message)).toEqual(
-      Array.from({ length: SWEEP_MAX_PRS }, (_, index) =>
+      Array.from({ length: SWEEP_MAX_PRS + 2 }, (_, index) =>
         expect.objectContaining({ type: "agent-regate-pr", repoFullName: "owner/agent-repo", prNumber: index + 1, installationId: 9001 }),
       ),
     );
-    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }]);
+    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }, { delaySeconds: 30 }, { delaySeconds: 40 }]);
   });
 
   it("REGRESSION (#2371): a coalesced issue-side signal schedules a trailing re-review so an add-then-remove sequence is never lost", async () => {


### PR DESCRIPTION
### Motivation
- Issue-side label/assignment changes must re-evaluate every open PR that links the issue because linked-issue hard-rule violations take precedence over merge/approve actions and dropping the tail can leave contributor PRs with stale passing gates.
- The previous change truncated the issue-side fanout with `SWEEP_MAX_PRS`, silently omitting linked PRs beyond the cap and creating a security-relevant race window.

### Description
- Removed the `.slice(0, SWEEP_MAX_PRS)` truncation so the issue-side wake enqueues every open PR that links the changed issue in `src/queue/processors.ts` (the per-job delays are still bounded by the existing staggers).
- Added/updated regression coverage in `test/unit/queue.test.ts` to seed more than `SWEEP_MAX_PRS` linked PRs and assert that all of them are queued with the expected bounded `delaySeconds` sequence.
- Preserves coalescing and trailing re-review behavior (`issueLinkedPrReReviewCoalesced` and `scheduleTrailingIssueLinkedReReview`) so frequency bounding and latest-state guarantee remain intact.

### Testing
- Ran the targeted unit test: `npx vitest run test/unit/queue.test.ts -t "issue-side linked PR wake queues every linked PR"` and it passed.
- Attempted `npm run test:ci` but the run was blocked early by environment/tooling issues (actionlint setup DNS failure and a WASM fallback label mismatch); CI did not complete in this environment.
- `npm run typecheck` surfaced unrelated, pre-existing fixture `AiReviewCacheInput.securityFocus` errors in `test/unit/queue.test.ts` outside this change; typecheck did not pass in this environment.
- `npm run test:coverage` was started but did not complete within the session timeout and was terminated.
- `npm audit --audit-level=moderate` failed due to the registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4749e6efd8832c8f24adb06d768c2f)