### PR TITLE
ci(selfhost): run observability validation for config PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       mcp: ${{ steps.filter.outputs.mcp }}
       mcpCliHarness: ${{ steps.filter.outputs.mcpCliHarness }}
       rees: ${{ steps.filter.outputs.rees }}
+      observability: ${{ steps.filter.outputs.observability }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -58,6 +59,9 @@ jobs:
               - '.github/workflows/**'
               - 'wrangler.jsonc'
               - 'worker-configuration.d.ts'
+            observability:
+              - 'grafana/dashboards/**'
+              - 'prometheus/rules/**'
             # The UI's own app/extension code -- triggers the FULL toolchain (lint/typecheck/test/build).
             # A dependency bump (package.json/package-lock.json) stays here too since it can break the UI
             # build or types in ways only that full toolchain would catch.
@@ -121,7 +125,7 @@ jobs:
   validate-code:
     name: validate-code
     needs: changes
-    if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rees == 'true' || needs.changes.outputs.ui == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rees == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.observability == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -199,6 +203,9 @@ jobs:
       - name: cf-typegen drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run cf-typegen:check
+      - name: Validate observability configs
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}
+        run: npm run selfhost:validate-observability
       - name: Typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run typecheck

--- a/test/unit/observability-ci.test.ts
+++ b/test/unit/observability-ci.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  return record(parse(readFileSync(path, "utf8")), path);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function recordArray(value: unknown, label: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value.map((entry, index) => record(entry, `${label}[${index}]`));
+}
+
+function nestedRecord(source: Record<string, unknown>, path: string[]): Record<string, unknown> {
+  return path.reduce((current, key) => record(current[key], path.join(".")), source);
+}
+
+describe("observability config CI guard", () => {
+  it("runs the observability validator for config-only PRs", () => {
+    const workflow = readYaml(".github/workflows/ci.yml");
+    const changesJob = nestedRecord(workflow, ["jobs", "changes"]);
+    const outputs = record(changesJob.outputs, "jobs.changes.outputs");
+    const steps = recordArray(changesJob.steps, "jobs.changes.steps");
+    const filterStep = steps.find((step) => step.id === "filter");
+    expect(filterStep).toBeDefined();
+
+    const validateCode = nestedRecord(workflow, ["jobs", "validate-code"]);
+    const validateSteps = recordArray(validateCode.steps, "jobs.validate-code.steps");
+    const validateStep = validateSteps.find((step) => step.name === "Validate observability configs");
+
+    expect(outputs.observability).toBe("${{ steps.filter.outputs.observability }}");
+    expect(String(validateCode.if)).toContain("needs.changes.outputs.observability == 'true'");
+    const filters = String(record(filterStep!.with, "filter.with").filters);
+    expect(filters).toContain("observability:");
+    expect(filters).toContain("grafana/dashboards/**");
+    expect(filters).toContain("prometheus/rules/**");
+    expect(validateStep).toBeDefined();
+    expect(String(validateStep!.if)).toBe(
+      "${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}",
+    );
+    expect(validateStep!.run).toBe("npm run selfhost:validate-observability");
+  });
+});


### PR DESCRIPTION
### Motivation

- The new observability validator (`scripts/validate-observability-configs.mjs`) was added to `package.json` but CI path filters did not include Grafana or Prometheus config paths, so config-only PRs could bypass pre-merge validation.
- This change closes that CI blind spot so dashboard and alert-rule edits trigger the same validation guard as backend changes.

### Description

- Add an `observability` paths filter to the `changes` job that includes `grafana/dashboards/**` and `prometheus/rules/**` in `.github/workflows/ci.yml`.
- Make the `validate-code` job condition include `needs.changes.outputs.observability == 'true'` so config-only PRs run the validation flow.
- Insert a `Validate observability configs` step that runs `npm run selfhost:validate-observability` when push/backend/observability paths change, and add a unit test `test/unit/observability-ci.test.ts` that pins the filter output, `validate-code` condition, and validator step.

### Testing

- Ran `npx vitest run test/unit/observability-ci.test.ts test/unit/validate-observability-configs-script.test.ts` and both test files passed.
- Executed the validator directly with `npm run selfhost:validate-observability` and it reported the observability configs as valid in this tree.
- Ran `git diff --check` which passed, and attempted `npm run actionlint` but the environment could not reach GitHub (network/setup) and actionlint reported failures from the offline fallback; this is an environment/network limitation, not a regression in the CI wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4748e9ddd8832c83e83b616cfd5e8a)