### PR TITLE
fix(selfhost): retry Orb relay registration with backoff and safer diagnostics

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -75,6 +75,25 @@ export async function fetchBrokeredInstallationToken(
   return { token: payload.token, installationId: payload.installationId ?? 0, expiresAtMs };
 }
 
+// Diagnosing a broker register failure (#selfhost-runtime-drift) needs more than a bare status code, but the
+// response body is attacker/operator-adjacent (the broker, or anything on-path to it) and must never be logged
+// verbatim. Only a short, structured hint is ever surfaced: a JSON body's own `error`/`message` string field,
+// bounded in length -- never raw bytes/headers, so there is nothing here for a secret to hide inside.
+const ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES = 2_000;
+const ORB_RELAY_REGISTER_ERROR_HINT_MAX_CHARS = 200;
+
+async function safeOrbRelayRegisterErrorHint(res: Response): Promise<string | undefined> {
+  try {
+    const text = await res.text();
+    if (!text) return undefined;
+    const parsed = JSON.parse(text.slice(0, ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES)) as { error?: unknown; message?: unknown };
+    const hint = typeof parsed.error === "string" ? parsed.error : typeof parsed.message === "string" ? parsed.message : undefined;
+    return hint ? hint.slice(0, ORB_RELAY_REGISTER_ERROR_HINT_MAX_CHARS) : undefined;
+  } catch {
+    return undefined; // non-JSON / unreadable body — the status code alone still carries the failure
+  }
+}
+
 /** Self-register this container's PUBLIC relay URL with the central Orb on boot, so the Orb forwards this install's
  *  events to us (the event half of brokered review). BEST-EFFORT: skipped unless broker mode + a public origin are
  *  configured, and any failure (Orb down, install not registered yet, non-public origin rejected) just means no
@@ -99,16 +118,59 @@ export async function registerOrbRelayTarget(
       body: JSON.stringify({ relayUrl, mode }),
       signal: AbortSignal.timeout(10_000),
     });
-    // Carry WHY it failed (HTTP status) so the caller's log — and Sentry — show a real reason, not "(no message)".
-    return res.ok
-      ? { status: "registered" }
-      : { status: "failed", reason: `http_${res.status}` };
+    if (res.ok) return { status: "registered" };
+    // Carry WHY it failed (HTTP status + an optional sanitized hint) so the caller's log — and Sentry — show a
+    // real reason, not "(no message)".
+    const hint = await safeOrbRelayRegisterErrorHint(res);
+    return { status: "failed", reason: hint ? `http_${res.status}: ${hint}` : `http_${res.status}` };
   } catch (error) {
     return {
       status: "failed",
       reason: error instanceof Error ? error.message : "fetch_threw",
     };
   }
+}
+
+export type OrbRelayRegistrationState = { registered: boolean; lastAttemptAtMs: number | null; attempts: number };
+
+export function createOrbRelayRegistrationState(): OrbRelayRegistrationState {
+  return { registered: false, lastAttemptAtMs: null, attempts: 0 };
+}
+
+// Mirrors RELAY_RETRY_BACKOFF_MINUTES (src/orb/relay.ts) for the same reason: a sustained broker outage must not
+// re-attempt registration on every ~1min tick -- fleet-wide, that is a synchronized retry storm against a
+// central Orb that is already degraded.
+export const ORB_RELAY_REGISTER_RETRY_BACKOFF_MS = 5 * 60_000;
+
+/** Stateful retry wrapper around {@link registerOrbRelayTarget} (#selfhost-runtime-drift): a one-shot boot-time
+ *  registration that never retries leaves a container permanently deaf to its relay after a single transient
+ *  broker 500 -- the ONLY way it recovers is a process restart. Call this on a recurring timer (e.g. every
+ *  minute) instead: it no-ops once registered, and otherwise re-attempts at most once per
+ *  {@link ORB_RELAY_REGISTER_RETRY_BACKOFF_MS} so a persistent outage degrades to a bounded, sane retry rate
+ *  rather than spamming the broker. `state` is mutated in place so the caller can hold one instance for the
+ *  process lifetime. */
+export async function registerOrbRelayTargetWithRetry(
+  env: { ORB_ENROLLMENT_SECRET?: string | undefined; ORB_BROKER_URL?: string | undefined; PUBLIC_API_ORIGIN?: string | undefined; ORB_RELAY_MODE?: string | undefined },
+  state: OrbRelayRegistrationState,
+  nowMs: number = Date.now(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ status: "registered" | "already_registered" | "skipped" | "backoff" | "failed"; reason?: string }> {
+  if (!isOrbBrokerMode(env)) return { status: "skipped" };
+  if (state.registered) return { status: "already_registered" };
+  if (state.lastAttemptAtMs !== null && nowMs - state.lastAttemptAtMs < ORB_RELAY_REGISTER_RETRY_BACKOFF_MS) {
+    return { status: "backoff" };
+  }
+  state.lastAttemptAtMs = nowMs;
+  state.attempts += 1;
+  const result = await registerOrbRelayTarget(env, fetchImpl);
+  if (result.status === "skipped") return { status: "skipped" };
+  if (result.status === "registered") {
+    state.registered = true;
+    return { status: "registered" };
+  }
+  /* v8 ignore next -- registerOrbRelayTarget's own "failed" returns always set a string reason (http_NNN or an
+   * error message); the undefined arm only satisfies exactOptionalPropertyTypes for the shared result shape. */
+  return result.reason !== undefined ? { status: "failed", reason: result.reason } : { status: "failed" };
 }
 
 /** Pull-mode drain (#secure-relay): fetch this install's queued events from the Orb, acking the previous batch's

--- a/src/selfhost/monitored-work.ts
+++ b/src/selfhost/monitored-work.ts
@@ -1,4 +1,5 @@
 import type { EnqueueWebhookResult } from "../github/webhook";
+import type { OrbRelayRegistrationState } from "../orb/broker-client";
 import { incr } from "./metrics";
 import { withSentryMonitor } from "./sentry";
 
@@ -93,4 +94,56 @@ export async function drainOrbRelayWithMonitor(args: {
         );
     },
   );
+}
+
+type OrbRelayRegisterEnv = {
+  ORB_ENROLLMENT_SECRET?: string | undefined;
+  ORB_BROKER_URL?: string | undefined;
+  PUBLIC_API_ORIGIN?: string | undefined;
+  ORB_RELAY_MODE?: string | undefined;
+};
+type OrbRelayRegisterResult = { status: "registered" | "already_registered" | "skipped" | "backoff" | "failed"; reason?: string };
+
+/** Recurring wrapper around the retryable relay-registration attempt (#selfhost-runtime-drift): a bare
+ *  one-shot boot-time call never recovers from a transient broker outage without a process restart. Called on
+ *  a timer (state persists across calls), it observes + logs only the calls that actually attempted the
+ *  network request (`registered` / `failed`) — `already_registered` / `backoff` / `skipped` are silent no-ops
+ *  so a healthy or intentionally-idle container does not spam logs/Sentry every tick. */
+export async function registerOrbRelayWithMonitor(args: {
+  env: OrbRelayRegisterEnv;
+  state: OrbRelayRegistrationState;
+  register: (env: OrbRelayRegisterEnv, state: OrbRelayRegistrationState) => Promise<OrbRelayRegisterResult>;
+  log?: (line: string) => void;
+}): Promise<void> {
+  await withSentryMonitor("orb-relay-register", { jobType: "orb-relay-register" }, async () => {
+    const result = await args.register(args.env, args.state);
+    if (result.status === "skipped" || result.status === "already_registered" || result.status === "backoff") return;
+    const mode = args.env.ORB_RELAY_MODE === "pull" ? "pull" : "push";
+    const log = args.log ?? console.log;
+    if (result.status === "registered") {
+      incr("gittensory_orb_relay_register_total", { mode, result: "registered" });
+      // attempts === 1 means this succeeded on the very first try (parity with the original boot-only log);
+      // a higher count means it recovered after one or more prior failures -- a distinct, more alertable event.
+      if (args.state.attempts > 1) {
+        log(JSON.stringify({ event: "selfhost_orb_relay_register_recovered", mode, attempts: args.state.attempts }));
+      } else {
+        log(JSON.stringify({ event: "selfhost_orb_relay_register", mode, attempts: args.state.attempts }));
+      }
+      return;
+    }
+    incr("gittensory_orb_relay_register_total", { mode, result: "failed" });
+    // A failed registration is fatal for PUSH mode (the Orb can't reach our public relay URL → the container
+    // looks alive but reviews NOTHING → error). In PULL mode the outbound drain loop delivers events once a
+    // later attempt succeeds, so a failed announce is only degraded telemetry → warn (not paged as deaf).
+    const pull = mode === "pull";
+    (pull ? console.warn : console.error)(
+      JSON.stringify({
+        level: pull ? "warn" : "error",
+        event: "selfhost_orb_relay_register_failed",
+        mode,
+        error: result.reason ?? "unknown",
+        attempts: args.state.attempts,
+      }),
+    );
+  });
 }

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -17,7 +17,7 @@ import { hashedInstallationIdWith } from "./review-tracing";
 type SentryNs = typeof import("@sentry/node");
 type SentryClient = NonNullable<ReturnType<SentryNs["init"]>>;
 type SentryMonitorConfig = NonNullable<Parameters<SentryNs["captureCheckIn"]>[1]>;
-export type SentryMonitorName = "scheduled-loop" | "orb-export" | "orb-relay-drain";
+export type SentryMonitorName = "scheduled-loop" | "orb-export" | "orb-relay-drain" | "orb-relay-register";
 type SentryScope = {
   setContext(name: string, context: Record<string, unknown>): void;
   setTag(key: string, value: string): void;
@@ -97,6 +97,16 @@ const SENTRY_MONITORS: Record<SentryMonitorName, { slug: string; config: SentryM
   },
   "orb-relay-drain": {
     slug: "orb-relay-drain",
+    config: {
+      schedule: { type: "interval", value: 1, unit: "minute" },
+      checkinMargin: 2,
+      maxRuntime: 1,
+      failureIssueThreshold: 3,
+      recoveryThreshold: 1,
+    },
+  },
+  "orb-relay-register": {
+    slug: "orb-relay-register",
     config: {
       schedule: { type: "interval", value: 1, unit: "minute" },
       checkinMargin: 2,

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ import {
   setupTokenFormRejection,
   timingSafeStrEqual,
 } from "./selfhost/setup-wizard";
-import { isOrbBrokerMode, registerOrbRelayTarget } from "./orb/broker-client";
+import { createOrbRelayRegistrationState, isOrbBrokerMode, registerOrbRelayTargetWithRetry } from "./orb/broker-client";
 import { exportOrbBatch } from "./selfhost/orb-collector";
 import { createD1Adapter, nodeSqliteDriver } from "./selfhost/d1-adapter";
 import {
@@ -73,6 +73,7 @@ import {
 } from "./selfhost/sentry";
 import {
   drainOrbRelayWithMonitor,
+  registerOrbRelayWithMonitor,
   runOrbExportWithMonitor,
   runScheduledLoopWithMonitor,
 } from "./selfhost/monitored-work";
@@ -899,35 +900,30 @@ async function main(): Promise<void> {
   setInterval(runOrbExport, 3_600_000); // then hourly
   /* v8 ignore stop */
 
-  // Brokered self-host: register our relay target with the central Orb (best-effort, fire-and-forget). PUSH mode
-  // (default) registers a public relay URL the Orb POSTs to; PULL mode (ORB_RELAY_MODE=pull) registers no URL and
-  // the drain loop below pulls events outbound — the right fit behind NAT/tailnet (no inbound endpoint exposed).
-  void registerOrbRelayTarget({
+  // Brokered self-host: register our relay target with the central Orb (best-effort). PUSH mode (default)
+  // registers a public relay URL the Orb POSTs to; PULL mode (ORB_RELAY_MODE=pull) registers no URL and the
+  // drain loop below pulls events outbound — the right fit behind NAT/tailnet (no inbound endpoint exposed).
+  // A bare one-shot boot-time attempt never recovers from a transient broker outage without a restart
+  // (#selfhost-runtime-drift), so this now RETRIES on a timer: registerOrbRelayWithMonitor no-ops once
+  // registered and otherwise backs off to at most one attempt per ORB_RELAY_REGISTER_RETRY_BACKOFF_MS.
+  /* v8 ignore start -- self-host entrypoint timer; the retry/backoff logic itself is unit-tested in
+   * orb-broker-client.test.ts and selfhost-monitored-work.test.ts. */
+  const orbRelayEnv = {
     ORB_ENROLLMENT_SECRET: process.env.ORB_ENROLLMENT_SECRET,
     ORB_BROKER_URL: process.env.ORB_BROKER_URL,
     PUBLIC_API_ORIGIN: process.env.PUBLIC_API_ORIGIN,
     ORB_RELAY_MODE: process.env.ORB_RELAY_MODE,
-  })
-    .then((r) => {
-      if (r.status === "registered") {
-        console.log(JSON.stringify({ event: "selfhost_orb_relay_register", result: r.status }));
-      } else if (r.status === "failed") {
-        // A failed registration is fatal for PUSH mode (the Orb can't reach our public relay URL → the container
-        // looks alive but reviews NOTHING → error). In PULL mode the outbound drain loop below delivers events
-        // regardless, so a failed announce is only degraded telemetry → warn (not paged as a deaf container).
-        // Either way carry the reason (HTTP status / fetch error) in `error` so Sentry shows WHY, not "(no message)".
-        const pull = process.env.ORB_RELAY_MODE === "pull";
-        console.error(
-          JSON.stringify({
-            level: pull ? "warn" : "error",
-            event: "selfhost_orb_relay_register_failed",
-            mode: pull ? "pull" : "push",
-            error: r.reason ?? "unknown",
-          }),
-        );
-      }
-    })
-    .catch((error) => captureError(error, { kind: "orb_relay_register" }));
+  };
+  const orbRelayRegistrationState = createOrbRelayRegistrationState();
+  const attemptOrbRelayRegistration = (): Promise<void> =>
+    registerOrbRelayWithMonitor({
+      env: orbRelayEnv,
+      state: orbRelayRegistrationState,
+      register: registerOrbRelayTargetWithRetry,
+    }).catch((error) => captureError(error, { kind: "orb_relay_register" }));
+  void attemptOrbRelayRegistration();
+  setInterval(() => void attemptOrbRelayRegistration(), 60_000);
+  /* v8 ignore stop */
 
   // Pull-mode relay drain (#secure-relay): when ORB_RELAY_MODE=pull, the engine DRAINS its events from the Orb on a
   // timer instead of exposing an inbound endpoint — the right fit behind NAT/tailnet. Acks the previous batch so the

--- a/test/unit/docs-selfhost-release-checklist-event-names.test.ts
+++ b/test/unit/docs-selfhost-release-checklist-event-names.test.ts
@@ -12,7 +12,7 @@ const script = readFileSync(SCRIPT_PATH, "utf8");
 
 // The exact source files that emit every selfhost_* event referenced in the checklist/script, per an
 // audit against the real console.log/console.error({ event: "selfhost_..." }) call sites.
-const EVENT_SOURCE_FILES = ["src/server.ts", "src/selfhost/ai.ts"];
+const EVENT_SOURCE_FILES = ["src/server.ts", "src/selfhost/ai.ts", "src/selfhost/monitored-work.ts"];
 const eventSource = EVENT_SOURCE_FILES.map((path) => readFileSync(path, "utf8")).join("\n");
 
 describe("self-hosting-release-checklist doc + smoke script: event names match source (#1944)", () => {

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { drainOrbRelay, fetchBrokeredInstallationToken, isOrbBrokerMode, registerOrbRelayTarget } from "../../src/orb/broker-client";
+import {
+  createOrbRelayRegistrationState,
+  drainOrbRelay,
+  fetchBrokeredInstallationToken,
+  isOrbBrokerMode,
+  ORB_RELAY_REGISTER_RETRY_BACKOFF_MS,
+  registerOrbRelayTarget,
+  registerOrbRelayTargetWithRetry,
+} from "../../src/orb/broker-client";
 
 /** A fetch stub that records the URL + init and returns a fixed response. */
 function captureFetch(resp: Response): { fetchImpl: typeof fetch; calls: { url: string; init?: RequestInit | undefined }[] } {
@@ -134,6 +142,93 @@ describe("registerOrbRelayTarget", () => {
     // No PUBLIC_API_ORIGIN — push would skip, but pull doesn't need an inbound URL.
     expect(await registerOrbRelayTarget({ ORB_ENROLLMENT_SECRET: "s", ORB_RELAY_MODE: "pull" }, fetchImpl)).toEqual({ status: "registered" });
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ relayUrl: "", mode: "pull" });
+  });
+
+  it("surfaces a sanitized error/message hint from a JSON failure body without leaking raw bytes", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    const errBody = (async () => Response.json({ error: "database unavailable" }, { status: 500 })) as typeof fetch;
+    expect(await registerOrbRelayTarget(cfg, errBody)).toEqual({ status: "failed", reason: "http_500: database unavailable" });
+
+    const messageBody = (async () => Response.json({ message: "install not found" }, { status: 404 })) as typeof fetch;
+    expect(await registerOrbRelayTarget(cfg, messageBody)).toEqual({ status: "failed", reason: "http_404: install not found" });
+  });
+
+  it("falls back to the bare status when the failure body is not JSON or has no error/message string", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    expect(await registerOrbRelayTarget(cfg, (async () => new Response("", { status: 502 })) as typeof fetch)).toEqual({ status: "failed", reason: "http_502" });
+    expect(await registerOrbRelayTarget(cfg, (async () => new Response("<html>gateway error</html>", { status: 502 })) as typeof fetch)).toEqual({
+      status: "failed",
+      reason: "http_502",
+    });
+    expect(await registerOrbRelayTarget(cfg, (async () => Response.json({ code: "ETIMEDOUT" }, { status: 500 })) as typeof fetch)).toEqual({
+      status: "failed",
+      reason: "http_500",
+    });
+  });
+
+  it("truncates an overlong error hint instead of logging an unbounded body", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    const longMessage = "x".repeat(500);
+    const result = await registerOrbRelayTarget(cfg, (async () => Response.json({ error: longMessage }, { status: 500 })) as typeof fetch);
+    expect(result.reason).toBe(`http_500: ${"x".repeat(200)}`);
+  });
+});
+
+describe("registerOrbRelayTargetWithRetry", () => {
+  it("skips outside broker mode without touching state", async () => {
+    const state = createOrbRelayRegistrationState();
+    expect(await registerOrbRelayTargetWithRetry({}, state)).toEqual({ status: "skipped" });
+    expect(state).toEqual({ registered: false, lastAttemptAtMs: null, attempts: 0 });
+  });
+
+  it("attempts, marks registered on success, and never attempts again", async () => {
+    const state = createOrbRelayRegistrationState();
+    const { fetchImpl, calls } = captureFetch(new Response("ok"));
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+
+    const first = await registerOrbRelayTargetWithRetry(cfg, state, 1_000, fetchImpl);
+    expect(first).toEqual({ status: "registered" });
+    expect(state).toEqual({ registered: true, lastAttemptAtMs: 1_000, attempts: 1 });
+
+    const second = await registerOrbRelayTargetWithRetry(cfg, state, 2_000, fetchImpl);
+    expect(second).toEqual({ status: "already_registered" });
+    expect(calls).toHaveLength(1); // the second call never re-fetched
+  });
+
+  it("backs off after a failure and only retries once the backoff window elapses", async () => {
+    const state = createOrbRelayRegistrationState();
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    const failThenSucceed = (async () => new Response("no", { status: 500 })) as typeof fetch;
+
+    const first = await registerOrbRelayTargetWithRetry(cfg, state, 0, failThenSucceed);
+    expect(first).toEqual({ status: "failed", reason: "http_500" });
+    expect(state.attempts).toBe(1);
+
+    // Still inside the backoff window — must not re-attempt (no fetch call at all).
+    const stillBackingOff = await registerOrbRelayTargetWithRetry(
+      cfg,
+      state,
+      ORB_RELAY_REGISTER_RETRY_BACKOFF_MS - 1,
+      (async () => {
+        throw new Error("must not fetch during backoff");
+      }) as typeof fetch,
+    );
+    expect(stillBackingOff).toEqual({ status: "backoff" });
+    expect(state.attempts).toBe(1);
+
+    // Backoff elapsed — retries and can now recover.
+    const { fetchImpl: successFetch } = captureFetch(new Response("ok"));
+    const recovered = await registerOrbRelayTargetWithRetry(cfg, state, ORB_RELAY_REGISTER_RETRY_BACKOFF_MS, successFetch);
+    expect(recovered).toEqual({ status: "registered" });
+    expect(state).toEqual({ registered: true, lastAttemptAtMs: ORB_RELAY_REGISTER_RETRY_BACKOFF_MS, attempts: 2 });
+  });
+
+  it("passes through a skipped result from the underlying attempt (e.g. push mode with no public origin) without arming backoff", async () => {
+    const state = createOrbRelayRegistrationState();
+    const result = await registerOrbRelayTargetWithRetry({ ORB_ENROLLMENT_SECRET: "s" }, state, 500);
+    expect(result).toEqual({ status: "skipped" });
+    // skipped still counts as an attempt (it went through the backoff gate), but never registers.
+    expect(state.registered).toBe(false);
   });
 });
 

--- a/test/unit/selfhost-monitored-work.test.ts
+++ b/test/unit/selfhost-monitored-work.test.ts
@@ -13,10 +13,12 @@ vi.mock("../../src/selfhost/sentry", () => ({
 
 import {
   drainOrbRelayWithMonitor,
+  registerOrbRelayWithMonitor,
   runOrbExportWithMonitor,
   runScheduledLoopWithMonitor,
   type OrbRelayDrainState,
 } from "../../src/selfhost/monitored-work";
+import type { OrbRelayRegistrationState } from "../../src/orb/broker-client";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
 beforeEach(() => {
@@ -180,5 +182,110 @@ describe("self-host monitored recurring work", () => {
     ).rejects.toThrow("broker down");
 
     expect(state.pendingAck).toEqual(["previous-delivery"]);
+  });
+
+  describe("registerOrbRelayWithMonitor", () => {
+    const freshState = (): OrbRelayRegistrationState => ({ registered: false, lastAttemptAtMs: null, attempts: 0 });
+
+    it("logs and records the registered metric on the first successful attempt", async () => {
+      const log = vi.fn();
+      const state = freshState();
+      state.attempts = 1; // the injected register() already bumped attempts before returning
+      const register = vi.fn().mockResolvedValue({ status: "registered" });
+
+      await registerOrbRelayWithMonitor({ env: { ORB_RELAY_MODE: "push" }, state, register, log });
+
+      expect(mocks.withSentryMonitor).toHaveBeenCalledWith(
+        "orb-relay-register",
+        { jobType: "orb-relay-register" },
+        expect.any(Function),
+      );
+      expect(log).toHaveBeenCalledWith(
+        JSON.stringify({ event: "selfhost_orb_relay_register", mode: "push", attempts: 1 }),
+      );
+      expect(await renderMetrics()).toContain('gittensory_orb_relay_register_total{mode="push",result="registered"} 1');
+    });
+
+    it("logs a distinct recovered event when registration succeeds after prior failures", async () => {
+      const log = vi.fn();
+      const state = freshState();
+      state.attempts = 3; // two prior failed attempts before this one succeeded
+      const register = vi.fn().mockResolvedValue({ status: "registered" });
+
+      await registerOrbRelayWithMonitor({ env: { ORB_RELAY_MODE: "pull" }, state, register, log });
+
+      expect(log).toHaveBeenCalledWith(
+        JSON.stringify({ event: "selfhost_orb_relay_register_recovered", mode: "pull", attempts: 3 }),
+      );
+    });
+
+    it("warns (not errors) on a pull-mode failure, and records the failed metric", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        const state = freshState();
+        state.attempts = 1;
+        const register = vi.fn().mockResolvedValue({ status: "failed", reason: "http_500" });
+
+        await registerOrbRelayWithMonitor({ env: { ORB_RELAY_MODE: "pull" }, state, register });
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          JSON.stringify({ level: "warn", event: "selfhost_orb_relay_register_failed", mode: "pull", error: "http_500", attempts: 1 }),
+        );
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(await renderMetrics()).toContain('gittensory_orb_relay_register_total{mode="pull",result="failed"} 1');
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("errors (not warns) on a push-mode failure, defaulting the reason to 'unknown' when absent", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        const state = freshState();
+        state.attempts = 1;
+        const register = vi.fn().mockResolvedValue({ status: "failed" });
+
+        await registerOrbRelayWithMonitor({ env: {}, state, register });
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          JSON.stringify({ level: "error", event: "selfhost_orb_relay_register_failed", mode: "push", error: "unknown", attempts: 1 }),
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("stays silent (no log, no metric) for skipped / already-registered / backoff outcomes", async () => {
+      const log = vi.fn();
+      for (const status of ["skipped", "already_registered", "backoff"] as const) {
+        const register = vi.fn().mockResolvedValue({ status });
+        await registerOrbRelayWithMonitor({ env: {}, state: freshState(), register, log });
+      }
+      expect(log).not.toHaveBeenCalled();
+      expect(await renderMetrics()).not.toContain("gittensory_orb_relay_register_total");
+    });
+
+    it("uses console.log as the default logger", async () => {
+      const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      try {
+        const state = freshState();
+        state.attempts = 1;
+        await registerOrbRelayWithMonitor({
+          env: { ORB_RELAY_MODE: "push" },
+          state,
+          register: vi.fn().mockResolvedValue({ status: "registered" }),
+        });
+        expect(consoleLog).toHaveBeenCalledWith(
+          JSON.stringify({ event: "selfhost_orb_relay_register", mode: "push", attempts: 1 }),
+        );
+      } finally {
+        consoleLog.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- The brokered self-host relay-registration call (`registerOrbRelayTarget`) ran exactly once at boot with no retry. A single transient broker 500 (or any outage during that one attempt) left the container permanently unregistered — in push mode it's effectively deaf until an operator restarts the process; in pull mode events only start flowing once/if a later boot succeeds.
- Failure logs only carried the bare HTTP status (`http_500`), with no hint of *why* the broker rejected the request.
- Added `registerOrbRelayTargetWithRetry` (a stateful retry wrapper) called on a 1-minute timer instead of once: it no-ops once registered, and otherwise backs off to at most one real attempt per 5 minutes (mirrors the existing `RELAY_RETRY_BACKOFF_MINUTES` pattern already used for relay-forward retries) so a sustained outage never spams the broker.
- Added a bounded, sanitized error/message hint parsed from a JSON failure body (never raw bytes/headers — only a short `error`/`message` string field, capped at 200 chars) alongside the status code, so operators can actually diagnose *why* without risking a token/secret leak into logs.
- New `gittensory_orb_relay_register_total{mode,result}` metric, plus a distinct `selfhost_orb_relay_register_recovered` log event when registration succeeds after one or more prior failures (vs. the existing `selfhost_orb_relay_register` event for a clean first-try success).
- Incidentally fixed a pre-existing drift-guard test (`docs-selfhost-release-checklist-event-names.test.ts`) whose hardcoded event-emitting-source-file list needed `src/selfhost/monitored-work.ts` added now that these events moved there.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue — a self-host operational bug found via direct investigation of a reported symptom cluster; the summary above explains the root cause.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full, unsharded) — 375 files / 7271 tests passed, 0 failures
- [ ] `npm run actionlint` (no workflow files touched)
- [ ] `npm run test:workers` (no Cloudflare-worker-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- This PR only touches self-host Orb-relay/monitoring TypeScript (`src/orb/broker-client.ts`, `src/selfhost/monitored-work.ts`, `src/selfhost/sentry.ts`, `src/server.ts`) and its unit tests; the UI/MCP/workers/dependency/workflow checks above are inapplicable to this diff and were skipped for that reason.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The new error-hint parsing is explicitly designed to avoid leaking tokens/secrets — see the summary above.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session changes; the Bearer-secret request shape is unchanged.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no public API/OpenAPI/MCP surface touched.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A.)

## Notes

- Second of several focused follow-ups from an operator-reported self-host runtime-drift investigation (see #2764 for the first — maintenance-queue starvation). Others (broker-mode installation health, cap-close permission-denial noise, and a dashboard-panels PR tying all the new metrics together) follow separately to keep each change reviewable on its own.