### PR TITLE
feat(enrichment): public-API undocumented-export scan analyzer (#2035)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
+# undocumentedExport
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
@@ -73,11 +74,11 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
-# approvalIntegrity,ciCheckSignals
+# approvalIntegrity,ciCheckSignals,undocumentedExport
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals
+# ciCheckSignals,undocumentedExport
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -654,7 +654,7 @@ export const REES_ANALYZERS = [
       network:
         "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
       notes:
-        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line (except tool directives like `eslint-disable`) or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
     },
   },
 ] as const satisfies readonly ReesAnalyzerDoc[];

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -632,6 +632,31 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads name/status/conclusion/started_at/completed_at, never check output or logs. Fail-safe on missing token/head SHA/fetch error.",
     },
   },
+  {
+    name: "undocumentedExport",
+    title: "Undocumented public exports",
+    category: "quality",
+    cost: "github-light",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["files", "github-token", "head-sha"],
+    limits: {
+      maxFiles: 10,
+      maxFindings: 30,
+    },
+    docs: {
+      summary:
+        "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
+      looksAt:
+        "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+      reports:
+        "File, line, and symbol name of each undocumented added export — never file contents.",
+      network:
+        "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
+      notes:
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -648,7 +648,7 @@ export const REES_ANALYZERS = [
       summary:
         "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
       looksAt:
-        "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+        "Direct `export const/let/var/function/class/interface/type/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
       reports:
         "File, line, and symbol name of each undocumented added export — never file contents.",
       network:

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -654,7 +654,7 @@ export const REES_ANALYZERS = [
       network:
         "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
       notes:
-        "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented.",
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
     },
   },
 ] as const satisfies readonly ReesAnalyzerDoc[];

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -714,6 +714,33 @@
         "network": "Calls the GitHub check-runs API once, bounded to one page.",
         "notes": "Structured-fields-only: reads name/status/conclusion/started_at/completed_at, never check output or logs. Fail-safe on missing token/head SHA/fetch error."
       }
+    },
+    {
+      "name": "undocumentedExport",
+      "title": "Undocumented public exports",
+      "category": "quality",
+      "cost": "github-light",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files",
+        "github-token",
+        "head-sha"
+      ],
+      "limits": {
+        "maxFiles": 10,
+        "maxFindings": 30
+      },
+      "docs": {
+        "summary": "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
+        "looksAt": "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+        "reports": "File, line, and symbol name of each undocumented added export — never file contents.",
+        "network": "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
+        "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented."
+      }
     }
   ]
 }

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -736,7 +736,7 @@
       },
       "docs": {
         "summary": "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
-        "looksAt": "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+        "looksAt": "Direct `export const/let/var/function/class/interface/type/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
         "reports": "File, line, and symbol name of each undocumented added export — never file contents.",
         "network": "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
         "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented."

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -739,7 +739,7 @@
         "looksAt": "Direct `export const/let/var/function/class/interface/type/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
         "reports": "File, line, and symbol name of each undocumented added export — never file contents.",
         "network": "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
-        "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not)."
+        "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line (except tool directives like `eslint-disable`) or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not)."
       }
     }
   ]

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -739,7 +739,7 @@
         "looksAt": "Direct `export const/let/var/function/class/interface/type/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
         "reports": "File, line, and symbol name of each undocumented added export — never file contents.",
         "network": "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
-        "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented."
+        "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not)."
       }
     }
   ]

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -22,6 +22,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanTyposquat } from "./typosquat.js";
+import { scanUndocumentedExport } from "./undocumented-export.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -553,6 +554,36 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCiCheckSignals(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "undocumentedExport",
+    title: "Undocumented public exports",
+    category: "quality",
+    cost: "github-light",
+    defaultEnabled: true,
+    requires: ["files", "github-token", "head-sha"],
+    limits: { maxFiles: 10, maxFindings: 30 },
+    docs: {
+      summary:
+        "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
+      looksAt:
+        "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+      reports: "File, line, and symbol name of each undocumented added export — never file contents.",
+      network: "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
+      notes:
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Undocumented public exports (new public surface with no doc comment)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} exports ${helpers.safeCodeSpan(item.symbol)} with no adjacent doc comment`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanUndocumentedExport(req, fetch, { signal }),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -571,7 +571,7 @@ export const ANALYZER_DESCRIPTORS = [
       reports: "File, line, and symbol name of each undocumented added export — never file contents.",
       network: "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
       notes:
-        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line (except tool directives like `eslint-disable`) or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
     },
     render: (findings, helpers) => {
       if (!findings.length) return [];

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -571,7 +571,7 @@ export const ANALYZER_DESCRIPTORS = [
       reports: "File, line, and symbol name of each undocumented added export — never file contents.",
       network: "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
       notes:
-        "Conservative: re-export lists (`export { x }`) and `export *` are ignored, and any preceding `//`/JSDoc comment counts as documented.",
+        "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
     },
     render: (findings, helpers) => {
       if (!findings.length) return [];

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -567,7 +567,7 @@ export const ANALYZER_DESCRIPTORS = [
       summary:
         "Flags exports newly added to a package's public entrypoint (an index.* barrel) that ship with no adjacent doc comment.",
       looksAt:
-        "Direct `export function/const/class/type/interface/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
+        "Direct `export const/let/var/function/class/interface/type/enum` declarations added to changed index.* files, checked against the file fetched at headSha.",
       reports: "File, line, and symbol name of each undocumented added export — never file contents.",
       network: "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
       notes:

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -1,0 +1,146 @@
+// Public-API undocumented-export scan (#2035, part of #1499). Flags exports NEWLY ADDED to a package's public
+// entrypoint (an `index.*` barrel) that ship with no adjacent doc comment — undocumented public surface a reviewer
+// should notice. It reads added export declarations from the diff, then fetches the changed entrypoint at headSha
+// (one authed contents fetch) to confirm, against the FINAL file, that each added export has no preceding
+// JSDoc/line comment. Deliberately conservative + fail-safe: only DIRECT `export function|const|let|var|class|
+// interface|type|enum NAME` declarations in `index.*` files (re-export lists and `export *` are ignored, since they
+// aggregate symbols documented at their definition); a missing token/head-sha, an unresolvable repo slug, or any
+// fetch error yields no finding rather than an error.
+import type { EnrichRequest, UndocumentedExportFinding } from "../types.js";
+
+const GITHUB_API = "https://api.github.com";
+const MAX_FILES = 10;
+const MAX_FINDINGS = 30;
+const MAX_FETCH_BYTES = 1_000_000;
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+// A public entrypoint barrel — an `index.<js/ts>` source file. Declaration (.d.ts), test, and generated output are
+// excluded: they are not the hand-authored public surface this scan is about.
+const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
+const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
+// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`).
+const EXPORT_DECL_RE =
+  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+
+interface ScanOptions {
+  signal?: AbortSignal;
+}
+
+/** Added export declarations in a unified diff, each with its NEW-file line number. Walks hunk headers to track the
+ *  new-file cursor; only `+` lines that declare a direct export are collected (`-`/`\` lines never advance the new
+ *  cursor, `+++`/`---` headers are ignored). Pure. */
+export function parseAddedExports(patch: string): Array<{ symbol: string; newLine: number }> {
+  const out: Array<{ symbol: string; newLine: number }> = [];
+  let newLine = 0;
+  for (const raw of patch.split("\n")) {
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (header) {
+      newLine = Number(header[1]);
+      continue;
+    }
+    if (raw.startsWith("+")) {
+      if (!raw.startsWith("+++")) {
+        const decl = EXPORT_DECL_RE.exec(raw.slice(1));
+        if (decl) out.push({ symbol: decl[1]!, newLine });
+        newLine += 1;
+      }
+    } else if (!raw.startsWith("-") && !raw.startsWith("\\")) {
+      newLine += 1; // context line advances the new-file cursor
+    }
+  }
+  return out;
+}
+
+/** True when the line at `lineIndex` (0-based) has an adjacent doc comment directly above it — a block comment
+ *  ending in `*​/` (JSDoc or plain) or a `//` line — allowing only blank lines in between. Conservative: ANY
+ *  preceding comment counts as documented, so only an export with code (or nothing) directly above is flagged. Pure. */
+export function hasPrecedingDocComment(lines: string[], lineIndex: number): boolean {
+  let i = lineIndex - 1;
+  while (i >= 0 && lines[i]!.trim() === "") i -= 1; // skip blank lines between the doc and the export
+  if (i < 0) return false;
+  const above = lines[i]!.trim();
+  return above.startsWith("//") || above.endsWith("*/");
+}
+
+async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
+  const length = Number(resp.headers.get("content-length"));
+  if (Number.isFinite(length) && length > MAX_FETCH_BYTES) return null;
+  if (!resp.body) return null;
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  try {
+    while (true) {
+      if (signal?.aborted) return null;
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_FETCH_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Analyzer entrypoint: for each changed `index.*` entrypoint, fetch it at headSha and flag added exports with no
+ *  adjacent doc comment. Fail-safe — returns no finding on a missing token/head-sha, bad slug, or fetch error. */
+export async function scanUndocumentedExport(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<UndocumentedExportFinding[]> {
+  const { repoFullName, githubToken, headSha, files = [] } = req;
+  if (!githubToken || !headSha) return [];
+  const [owner, repo] = repoFullName.split("/");
+  if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${githubToken}`,
+    Accept: "application/vnd.github.raw",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const entrypoints = files
+    .filter((file) => file.patch && ENTRYPOINT_RE.test(file.path) && !SKIP_RE.test(file.path))
+    .slice(0, MAX_FILES);
+
+  const findings: UndocumentedExportFinding[] = [];
+  for (const file of entrypoints) {
+    if (options.signal?.aborted) break;
+    const added = parseAddedExports(file.patch!);
+    if (!added.length) continue;
+
+    let content: string | null = null;
+    try {
+      const path = file.path.split("/").map(encodeURIComponent).join("/");
+      const resp = await fetchFn(
+        `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}?ref=${encodeURIComponent(headSha)}`,
+        { headers, signal: options.signal },
+      );
+      if (resp.ok) content = await readBoundedText(resp, options.signal);
+    } catch {
+      content = null;
+    }
+    if (!content) continue;
+    if (options.signal?.aborted) break; // an abort during the fetch should suppress this file's findings too
+
+    const lines = content.split("\n");
+    for (const { symbol, newLine } of added) {
+      const idx = newLine - 1;
+      const line = lines[idx];
+      if (line === undefined) continue;
+      // Confirm the export still declares this symbol at that line in the FINAL file (patch/head aligned); a mismatch
+      // means the line moved or changed, so fail closed and skip it.
+      if (EXPORT_DECL_RE.exec(line)?.[1] !== symbol) continue;
+      if (hasPrecedingDocComment(lines, idx)) continue;
+      findings.push({ file: file.path, line: newLine, symbol });
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -17,11 +17,11 @@ const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 // excluded: they are not the hand-authored public surface this scan is about.
 const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
-// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`). Leading
-// whitespace is allowed so an indented top-level export — TS only permits `export` at module scope or inside a
-// `namespace`/`module` block, both public API — is still matched.
+// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`). Anchored at
+// column 1 so only TOP-LEVEL module exports are considered public surface: an INDENTED `export` (e.g. a member of
+// an unexported `namespace Internal { … }`) is intentionally NOT scanned, since it is not a public module export.
 const EXPORT_DECL_RE =
-  /^\s*export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
 
 interface ScanOptions {
   signal?: AbortSignal;

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -17,19 +17,74 @@ const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 // excluded: they are not the hand-authored public surface this scan is about.
 const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
-// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`). Anchored at
-// column 1 so only TOP-LEVEL module exports are considered public surface: an INDENTED `export` (e.g. a member of
-// an unexported `namespace Internal { … }`) is intentionally NOT scanned, since it is not a public module export.
+// A DIRECT exported declaration and its kind (matched on the line body, without the diff `+`). Anchored at column 1
+// so only TOP-LEVEL module exports are considered public surface: an INDENTED `export` (e.g. a member of an
+// unexported `namespace Internal { … }`) is intentionally NOT scanned, since it is not a public module export.
 const EXPORT_DECL_RE =
-  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(function\s*\*?|const|let|var|class|interface|type|enum)\s+/;
+const IDENT_RE = /^[A-Za-z_$][\w$]*/;
 
 interface ScanOptions {
   signal?: AbortSignal;
 }
 
-/** Added export declarations in a unified diff, each with its NEW-file line number. Walks hunk headers to track the
- *  new-file cursor; only `+` lines that declare a direct export are collected (`-`/`\` lines never advance the new
- *  cursor, `+++`/`---` headers are ignored). Pure. */
+/** Split a `const`/`let`/`var` declarator list on TOP-LEVEL commas, tracking ()/{}/[] depth and string literals so a
+ *  comma inside an initializer (`f(1, 2)`, `[1, 2]`) does not split, and stopping at the first top-level `;`. Pure. */
+function splitTopLevelCommas(src: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  let quote: string | null = null;
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i]!;
+    if (quote) {
+      if (ch === quote && src[i - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+    else if (ch === "(" || ch === "{" || ch === "[") depth += 1;
+    else if (ch === ")" || ch === "}" || ch === "]") depth = Math.max(0, depth - 1);
+    else if (ch === ";" && depth === 0) {
+      parts.push(src.slice(start, i));
+      return parts; // the declarator list ends at the statement terminator
+    } else if (ch === "," && depth === 0) {
+      parts.push(src.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(src.slice(start));
+  return parts;
+}
+
+/** The exported symbol name(s) a line body declares (no diff `+`), or [] if it is not a direct export declaration.
+ *  `function/class/interface/type/enum` declare a single symbol; a `const/let/var` line may declare SEVERAL via a
+ *  comma-separated declarator list (`export const a = 1, b = 2`). A declarator whose binding is not a plain
+ *  identifier (destructuring `{…}`/`[…]`, or an identifier not followed by `=`/`:`/`!`/`?`/end) is skipped
+ *  conservatively, so a comma inside a generic type (`Map<K, V>`) can't fabricate a `V` binding. Pure. */
+export function exportedSymbols(lineBody: string): string[] {
+  const decl = EXPORT_DECL_RE.exec(lineBody);
+  if (!decl) return [];
+  const rest = lineBody.slice(decl[0].length);
+  if (decl[1] !== "const" && decl[1] !== "let" && decl[1] !== "var") {
+    const name = IDENT_RE.exec(rest);
+    return name ? [name[0]] : [];
+  }
+  const symbols: string[] = [];
+  for (const part of splitTopLevelCommas(rest)) {
+    const trimmed = part.trim();
+    if (!trimmed || trimmed.startsWith("{") || trimmed.startsWith("[")) continue; // destructuring — not enumerable
+    const name = IDENT_RE.exec(trimmed);
+    if (!name) continue;
+    const after = trimmed.slice(name[0].length).trimStart();
+    if (after === "" || /^[=:!?]/.test(after)) symbols.push(name[0]); // a real binding, not e.g. `V>` from a generic
+  }
+  return symbols;
+}
+
+/** Added export declarations in a unified diff, each exported symbol with its NEW-file line number. Walks hunk
+ *  headers to track the new-file cursor; only `+` lines that declare a direct export are collected (`-`/`\` lines
+ *  never advance the new cursor, `+++`/`---` headers are ignored). A multi-declarator line yields one entry per
+ *  binding, all sharing the same line. Pure. */
 export function parseAddedExports(patch: string): Array<{ symbol: string; newLine: number }> {
   const out: Array<{ symbol: string; newLine: number }> = [];
   let newLine = 0;
@@ -41,8 +96,7 @@ export function parseAddedExports(patch: string): Array<{ symbol: string; newLin
     }
     if (raw.startsWith("+")) {
       if (!raw.startsWith("+++")) {
-        const decl = EXPORT_DECL_RE.exec(raw.slice(1));
-        if (decl) out.push({ symbol: decl[1]!, newLine });
+        for (const symbol of exportedSymbols(raw.slice(1))) out.push({ symbol, newLine });
         newLine += 1;
       }
     } else if (!raw.startsWith("-") && !raw.startsWith("\\")) {
@@ -162,7 +216,7 @@ export async function scanUndocumentedExport(
       if (line === undefined) continue;
       // Confirm the export still declares this symbol at that line in the FINAL file (patch/head aligned); a mismatch
       // means the line moved or changed, so fail closed and skip it.
-      if (EXPORT_DECL_RE.exec(line)?.[1] !== symbol) continue;
+      if (!exportedSymbols(line).includes(symbol)) continue;
       if (hasPrecedingDocComment(lines, idx)) continue;
       findings.push({ file: file.path, line: newLine, symbol });
       if (findings.length >= MAX_FINDINGS) return findings;

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -21,8 +21,11 @@ const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:di
 // so only TOP-LEVEL module exports are considered public surface: an INDENTED `export` (e.g. a member of an
 // unexported `namespace Internal { … }`) is intentionally NOT scanned, since it is not a public module export.
 const EXPORT_DECL_RE =
-  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(function\s*\*?|const|let|var|class|interface|type|enum)\s+/;
+  /^export\s+(?:default\s+)?(?:declare\s+)?(?:async\s+)?(?:abstract\s+)?(function\s*\*?|const|let|var|class|interface|type|enum)\s+/;
 const IDENT_RE = /^[A-Za-z_$][\w$]*/;
+// A `//` comment whose text starts like one of these is a tool/suppression directive, not symbol documentation.
+const DIRECTIVE_COMMENT_RE =
+  /^(?:eslint-|@ts-|prettier-|biome-|deno-lint-|istanbul\b|c8\b|v8\b|@preserve\b|@license\b|noinspection\b)/;
 
 interface ScanOptions {
   signal?: AbortSignal;
@@ -123,7 +126,9 @@ export function hasPrecedingDocComment(lines: string[], lineIndex: number): bool
   }
   if (i < 0) return false;
   const above = lines[i]!.trim();
-  if (above.startsWith("//")) return true; // a line comment counts as documentation
+  // A `//` line comment counts as documentation UNLESS it is a tool/suppression directive (eslint-disable,
+  // ts-* pragmas, prettier-ignore, istanbul/c8/v8 ignore, …) — those describe tooling, not the symbol.
+  if (above.startsWith("//")) return !DIRECTIVE_COMMENT_RE.test(above.slice(2).trim());
   if (!above.endsWith("*/")) return false; // not a block-comment terminator directly above → undocumented
   // Walk up to the block's opener; only a real JSDoc block (`/**`) is documentation. This also rejects a code line
   // with a trailing comment (`const x = 1; /* c */`) — its opener line starts with code, not `/**`.

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -52,13 +52,13 @@ export function parseAddedExports(patch: string): Array<{ symbol: string; newLin
   return out;
 }
 
-/** True when the line at `lineIndex` (0-based) has an adjacent doc comment directly above it — a block comment
- *  ending in `*​/` (JSDoc or plain) or a `//` line — allowing only blank lines in between. Conservative: ANY
- *  preceding comment counts as documented, so only an export with code (or nothing) directly above is flagged. Pure. */
+/** True when the line at `lineIndex` (0-based) has an adjacent DOC comment directly above it: a `//` line comment,
+ *  or a block comment whose opener is a real JSDoc `/**` (walked up from its `*​/` terminator). Blank lines and
+ *  decorator lines (`@Component()`) in between are skipped. A plain non-doc block (`/* eslint-disable *​/`) and a
+ *  code line with a trailing block comment are NOT documentation, so a genuinely undocumented export is still
+ *  flagged. Pure. */
 export function hasPrecedingDocComment(lines: string[], lineIndex: number): boolean {
   let i = lineIndex - 1;
-  // Skip blank lines AND decorator lines (`@Component()`) between the export and its doc comment, so a documented
-  // decorated `export class` is not falsely flagged.
   while (i >= 0) {
     const trimmed = lines[i]!.trim();
     if (trimmed === "" || trimmed.startsWith("@")) {
@@ -69,9 +69,13 @@ export function hasPrecedingDocComment(lines: string[], lineIndex: number): bool
   }
   if (i < 0) return false;
   const above = lines[i]!.trim();
-  // Require a COMMENT-ONLY line: a `//` line comment or a block-comment opener/body/terminator (starts with `/*`
-  // or `*`). A code line with a TRAILING block comment starts with code, so it is not treated as documentation.
-  return above.startsWith("//") || above.startsWith("/*") || above.startsWith("*");
+  if (above.startsWith("//")) return true; // a line comment counts as documentation
+  if (!above.endsWith("*/")) return false; // not a block-comment terminator directly above → undocumented
+  // Walk up to the block's opener; only a real JSDoc block (`/**`) is documentation. This also rejects a code line
+  // with a trailing comment (`const x = 1; /* c */`) — its opener line starts with code, not `/**`.
+  let j = i;
+  while (j >= 0 && !lines[j]!.includes("/*")) j -= 1;
+  return j >= 0 && lines[j]!.trimStart().startsWith("/**");
 }
 
 async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
@@ -122,15 +126,20 @@ export async function scanUndocumentedExport(
     Accept: "application/vnd.github.raw",
     "X-GitHub-Api-Version": "2022-11-28",
   };
-  const entrypoints = files
-    .filter((file) => file.patch && ENTRYPOINT_RE.test(file.path) && !SKIP_RE.test(file.path))
-    .slice(0, MAX_FILES);
+  // Parse added exports FIRST (cheap, pure), then spend the MAX_FILES fetch budget only on entrypoints that actually
+  // have added exports — so index files with no relevant additions can't consume the budget and hide later ones.
+  const candidates: Array<{ file: (typeof files)[number]; added: Array<{ symbol: string; newLine: number }> }> = [];
+  for (const file of files) {
+    if (!file.patch || !ENTRYPOINT_RE.test(file.path) || SKIP_RE.test(file.path)) continue;
+    const added = parseAddedExports(file.patch);
+    if (!added.length) continue;
+    candidates.push({ file, added });
+    if (candidates.length >= MAX_FILES) break;
+  }
 
   const findings: UndocumentedExportFinding[] = [];
-  for (const file of entrypoints) {
+  for (const { file, added } of candidates) {
     if (options.signal?.aborted) break;
-    const added = parseAddedExports(file.patch!);
-    if (!added.length) continue;
 
     let content: string | null = null;
     try {

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -17,9 +17,11 @@ const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 // excluded: they are not the hand-authored public surface this scan is about.
 const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
-// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`).
+// A DIRECT exported declaration and its symbol name (matched on the line body, without the diff `+`). Leading
+// whitespace is allowed so an indented top-level export — TS only permits `export` at module scope or inside a
+// `namespace`/`module` block, both public API — is still matched.
 const EXPORT_DECL_RE =
-  /^export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+  /^\s*export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
 
 interface ScanOptions {
   signal?: AbortSignal;

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -57,7 +57,16 @@ export function parseAddedExports(patch: string): Array<{ symbol: string; newLin
  *  preceding comment counts as documented, so only an export with code (or nothing) directly above is flagged. Pure. */
 export function hasPrecedingDocComment(lines: string[], lineIndex: number): boolean {
   let i = lineIndex - 1;
-  while (i >= 0 && lines[i]!.trim() === "") i -= 1; // skip blank lines between the doc and the export
+  // Skip blank lines AND decorator lines (`@Component()`) between the export and its doc comment, so a documented
+  // decorated `export class` is not falsely flagged.
+  while (i >= 0) {
+    const trimmed = lines[i]!.trim();
+    if (trimmed === "" || trimmed.startsWith("@")) {
+      i -= 1;
+      continue;
+    }
+    break;
+  }
   if (i < 0) return false;
   const above = lines[i]!.trim();
   // Require a COMMENT-ONLY line: a `//` line comment or a block-comment opener/body/terminator (starts with `/*`
@@ -101,8 +110,10 @@ export async function scanUndocumentedExport(
 ): Promise<UndocumentedExportFinding[]> {
   const { repoFullName, githubToken, headSha, files = [] } = req;
   if (!githubToken || !headSha) return [];
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+  // Require EXACTLY `owner/repo`: a 3+ segment value would otherwise query the wrong repo instead of failing safe.
+  const parts = repoFullName.split("/");
+  const [owner, repo] = parts;
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${githubToken}`,

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -58,7 +58,9 @@ export function hasPrecedingDocComment(lines: string[], lineIndex: number): bool
   while (i >= 0 && lines[i]!.trim() === "") i -= 1; // skip blank lines between the doc and the export
   if (i < 0) return false;
   const above = lines[i]!.trim();
-  return above.startsWith("//") || above.endsWith("*/");
+  // Require a COMMENT-ONLY line: a `//` line comment or a block-comment opener/body/terminator (starts with `/*`
+  // or `*`). A code line with a TRAILING block comment starts with code, so it is not treated as documentation.
+  return above.startsWith("//") || above.startsWith("/*") || above.startsWith("*");
 }
 
 async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
@@ -102,6 +104,8 @@ export async function scanUndocumentedExport(
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${githubToken}`,
+    // `vnd.github.raw` returns the file's raw bytes from the Contents API — the same media type the sibling
+    // github-light analyzer doc-comment-drift.ts uses to fetch a file at headSha.
     Accept: "application/vnd.github.raw",
     "X-GitHub-Api-Version": "2022-11-28",
   };

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -15,7 +15,7 @@ const MAX_FETCH_BYTES = 1_000_000;
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 // A public entrypoint barrel — an `index.<js/ts>` source file. Declaration (.d.ts), test, and generated output are
 // excluded: they are not the hand-authored public surface this scan is about.
-const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
+const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
 // A DIRECT exported declaration and its kind (matched on the line body, without the diff `+`). Anchored at column 1
 // so only TOP-LEVEL module exports are considered public surface: an INDENTED `export` (e.g. a member of an
@@ -41,7 +41,13 @@ function splitTopLevelCommas(src: string): string[] {
   for (let i = 0; i < src.length; i++) {
     const ch = src[i]!;
     if (quote) {
-      if (ch === quote && src[i - 1] !== "\\") quote = null;
+      // The quote closes only when it is NOT escaped: count consecutive preceding backslashes — an EVEN count means
+      // the quote is unescaped (a trailing `\\` inside the string doesn't escape the closing quote).
+      if (ch === quote) {
+        let backslashes = 0;
+        for (let k = i - 1; k >= 0 && src[k] === "\\"; k--) backslashes += 1;
+        if (backslashes % 2 === 0) quote = null;
+      }
       continue;
     }
     if (ch === '"' || ch === "'" || ch === "`") quote = ch;

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -382,6 +382,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("blameLink", findings.blameLink));
   lines.push(...renderDescriptorSection("approvalIntegrity", findings.approvalIntegrity));
   lines.push(...renderDescriptorSection("ciCheckSignals", findings.ciCheckSignals));
+  lines.push(...renderDescriptorSection("undocumentedExport", findings.undocumentedExport));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -301,6 +301,14 @@ export interface BlameLinkFinding {
   lastTouchedByShaPrefix?: string;
 }
 
+/** An export newly ADDED to a package's public entrypoint (an `index.*` barrel) that ships with no adjacent doc
+ *  comment — undocumented public surface. Reports the symbol + its line only, never file contents. (#2035) */
+export interface UndocumentedExportFinding {
+  file: string;
+  line: number;
+  symbol: string;
+}
+
 /** A review/approval integrity signal, read from structured PR-reviews API fields only (state, commit_id,
  *  user.login, submitted_at) — never diff/file content. `stale-approval`: the reviewer's latest APPROVED review
  *  predates the PR's current head commit. `self-approval`: the PR author approved their own PR.
@@ -351,6 +359,7 @@ export interface BriefFindings {
   blameLink?: BlameLinkFinding[];
   approvalIntegrity?: ApprovalIntegrityFinding[];
   ciCheckSignals?: CiCheckSignalFinding[];
+  undocumentedExport?: UndocumentedExportFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -34,6 +34,7 @@ const EXPECTED_ANALYZERS = [
   "blameLink",
   "approvalIntegrity",
   "ciCheckSignals",
+  "undocumentedExport",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   parseAddedExports,
+  exportedSymbols,
   hasPrecedingDocComment,
   scanUndocumentedExport,
 } from "../dist/analyzers/undocumented-export.js";
@@ -33,6 +34,25 @@ test("parseAddedExports: collects direct added exports with new-file line number
   // context/deletions keep the new-line cursor aligned; `export { x }` and `export *` are not direct declarations
   const mixed = ["@@ -5,2 +5,3 @@", " const keep = 1;", "-old", "+export type Added = string;", "+export { Added };", "+export * from './x';"].join("\n");
   assert.deepEqual(parseAddedExports(mixed), [{ symbol: "Added", newLine: 6 }]);
+});
+
+test("exportedSymbols: multi-declarator const/let/var reports every binding; generics don't fabricate names", () => {
+  assert.deepEqual(exportedSymbols("export const a = 1, b = 2;"), ["a", "b"]);
+  assert.deepEqual(exportedSymbols("export let x = f(1, 2), y = 3;"), ["x", "y"]); // comma inside a call doesn't split
+  assert.deepEqual(exportedSymbols("export const m: Map<K, V> = new Map(), n = 2;"), ["m", "n"]); // no fabricated `V`
+  assert.deepEqual(exportedSymbols("export function foo() {}"), ["foo"]); // single-symbol kinds unchanged
+  assert.deepEqual(exportedSymbols("export const { a, b } = obj;"), []); // destructuring skipped (conservative)
+  assert.deepEqual(exportedSymbols("const notExported = 1;"), []); // not an export
+});
+
+test("scanUndocumentedExport: a multi-declarator export reports EVERY undocumented binding", async () => {
+  const patch = ["@@ -0,0 +1,1 @@", "+export const alpha = 1, beta = 2;"].join("\n");
+  const head = "export const alpha = 1, beta = 2;";
+  const findings = await scanUndocumentedExport(req([{ path: "src/index.ts", status: "modified", patch }]), headFetch(head));
+  assert.deepEqual(findings, [
+    { file: "src/index.ts", line: 1, symbol: "alpha" },
+    { file: "src/index.ts", line: 1, symbol: "beta" },
+  ]);
 });
 
 test("hasPrecedingDocComment: a `//` line or block-comment end above (through blanks) counts as documented", () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -43,6 +43,9 @@ test("hasPrecedingDocComment: a `//` line or block-comment end above (through bl
   // a CODE line with a trailing block comment ends in `*/` but is not documentation
   assert.equal(hasPrecedingDocComment(["const c = 1; /* trailing */", "export const x = 1;"], 1), false);
   assert.equal(hasPrecedingDocComment([" * jsdoc body", "export const x = 1;"], 1), true); // block-comment body line
+  // a doc comment above a DECORATOR on the export still counts (decorator lines are skipped while walking up)
+  assert.equal(hasPrecedingDocComment(["/** doc */", "@Component()", "export class Widget {}"], 2), true);
+  assert.equal(hasPrecedingDocComment(["@Component()", "export class Widget {}"], 1), false); // decorator only, no doc
 });
 
 test("scanUndocumentedExport: flags the undocumented export, not the documented one, and renders it", async () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -43,6 +43,16 @@ test("exportedSymbols: multi-declarator const/let/var reports every binding; gen
   assert.deepEqual(exportedSymbols("export function foo() {}"), ["foo"]); // single-symbol kinds unchanged
   assert.deepEqual(exportedSymbols("export const { a, b } = obj;"), []); // destructuring skipped (conservative)
   assert.deepEqual(exportedSymbols("const notExported = 1;"), []); // not an export
+  assert.deepEqual(exportedSymbols("export async function* gen() {}"), ["gen"]); // async generator
+  assert.deepEqual(exportedSymbols("export declare function foo(): void;"), ["foo"]); // ambient declaration
+  assert.deepEqual(exportedSymbols("export declare const bar: number;"), ["bar"]);
+});
+
+test("hasPrecedingDocComment: a tool/suppression directive comment is NOT documentation", () => {
+  assert.equal(hasPrecedingDocComment(["// eslint-disable-next-line no-restricted-syntax", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment(["// @ts-expect-error legacy", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment(["// prettier-ignore", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment(["// what this symbol does", "export const x = 1;"], 1), true); // real note still counts
 });
 
 test("scanUndocumentedExport: a multi-declarator export reports EVERY undocumented binding", async () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -53,6 +53,22 @@ test("scanUndocumentedExport: flags the undocumented export, not the documented 
   assert.match(brief, /undoc/);
 });
 
+test("scanUndocumentedExport: fetches the entrypoint at the head ref with a per-segment-encoded path", async () => {
+  let calledUrl = "";
+  const recording = async (url) => {
+    calledUrl = url;
+    return url.includes("/contents/") ? rawResponse(HEAD) : new Response("", { status: 404 });
+  };
+  await scanUndocumentedExport(req([{ path: "src/dir name/index.ts", status: "modified", patch: PATCH }]), recording);
+  // path segments are individually encoded (space -> %20) and the head SHA is passed as ?ref=
+  assert.match(calledUrl, /\/repos\/octo\/repo\/contents\/src\/dir%20name\/index\.ts\?ref=abc123$/);
+});
+
+test("parseAddedExports: matches an indented (namespace-level) export too", () => {
+  const patch = ["@@ -1,0 +1,1 @@", "+  export const nested = 1;"].join("\n");
+  assert.deepEqual(parseAddedExports(patch), [{ symbol: "nested", newLine: 1 }]);
+});
+
 test("scanUndocumentedExport: a non-entrypoint file is skipped (only index.* is scanned)", async () => {
   const findings = await scanUndocumentedExport(
     req([{ path: "src/helpers.ts", status: "modified", patch: PATCH }]),

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -70,9 +70,19 @@ test("scanUndocumentedExport: fetches the entrypoint at the head ref with a per-
   assert.match(calledUrl, /\/repos\/octo\/repo\/contents\/src\/dir%20name\/index\.ts\?ref=abc123$/);
 });
 
-test("parseAddedExports: matches an indented (namespace-level) export too", () => {
+test("parseAddedExports: an INDENTED export (e.g. an unexported-namespace member) is not scanned — top-level only", () => {
   const patch = ["@@ -1,0 +1,1 @@", "+  export const nested = 1;"].join("\n");
-  assert.deepEqual(parseAddedExports(patch), [{ symbol: "nested", newLine: 1 }]);
+  assert.deepEqual(parseAddedExports(patch), []); // column-1 anchor: only public module-level exports count
+});
+
+test("scanUndocumentedExport: an export inside an unexported namespace is not reported (not public API)", async () => {
+  const nsPatch = ["@@ -0,0 +1,3 @@", "+namespace Internal {", "+  export const helper = 1;", "+}"].join("\n");
+  const nsHead = ["namespace Internal {", "  export const helper = 1;", "}"].join("\n");
+  const findings = await scanUndocumentedExport(
+    req([{ path: "src/index.ts", status: "modified", patch: nsPatch }]),
+    headFetch(nsHead),
+  );
+  assert.deepEqual(findings, []); // the indented namespace member is not a public export → no false positive
 });
 
 test("scanUndocumentedExport: a non-entrypoint file is skipped (only index.* is scanned)", async () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -1,0 +1,75 @@
+// Units for the undocumented-export analyzer (#2035). Own file (not enrichment.test.ts) so concurrent analyzer PRs
+// don't collide. All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseAddedExports,
+  hasPrecedingDocComment,
+  scanUndocumentedExport,
+} from "../dist/analyzers/undocumented-export.js";
+import { renderBrief } from "../dist/render.js";
+
+// The head file that this PR produces: a documented export (preceding JSDoc) and an undocumented one.
+const HEAD = ["/** A documented helper. */", "export function documented() {}", "", "export const undoc = 1;"].join("\n");
+// The diff that added both exports (new-file lines 1-4 line up with HEAD).
+const PATCH = ["@@ -0,0 +1,4 @@", "+/** A documented helper. */", "+export function documented() {}", "+", "+export const undoc = 1;"].join("\n");
+
+const rawResponse = (text) => new Response(text, { status: 200 });
+const headFetch = (text) => async (url) => (url.includes("/contents/") ? rawResponse(text) : new Response("", { status: 404 }));
+const req = (files, extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 1,
+  githubToken: "ghp_test",
+  headSha: "abc123",
+  files,
+  ...extra,
+});
+
+test("parseAddedExports: collects direct added exports with new-file line numbers, ignores re-exports", () => {
+  assert.deepEqual(parseAddedExports(PATCH), [
+    { symbol: "documented", newLine: 2 },
+    { symbol: "undoc", newLine: 4 },
+  ]);
+  // context/deletions keep the new-line cursor aligned; `export { x }` and `export *` are not direct declarations
+  const mixed = ["@@ -5,2 +5,3 @@", " const keep = 1;", "-old", "+export type Added = string;", "+export { Added };", "+export * from './x';"].join("\n");
+  assert.deepEqual(parseAddedExports(mixed), [{ symbol: "Added", newLine: 6 }]);
+});
+
+test("hasPrecedingDocComment: a `//` line or block-comment end above (through blanks) counts as documented", () => {
+  assert.equal(hasPrecedingDocComment(["/** doc */", "export const x = 1;"], 1), true);
+  assert.equal(hasPrecedingDocComment(["// note", "", "export const x = 1;"], 2), true);
+  assert.equal(hasPrecedingDocComment(["export const prev = 0;", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment(["export const x = 1;"], 0), false); // nothing above
+});
+
+test("scanUndocumentedExport: flags the undocumented export, not the documented one, and renders it", async () => {
+  const findings = await scanUndocumentedExport(req([{ path: "src/index.ts", status: "modified", patch: PATCH }]), headFetch(HEAD));
+  assert.deepEqual(findings, [{ file: "src/index.ts", line: 4, symbol: "undoc" }]);
+  const brief = renderBrief({ undocumentedExport: findings }).promptSection;
+  assert.match(brief, /Undocumented public exports/i);
+  assert.match(brief, /undoc/);
+});
+
+test("scanUndocumentedExport: a non-entrypoint file is skipped (only index.* is scanned)", async () => {
+  const findings = await scanUndocumentedExport(
+    req([{ path: "src/helpers.ts", status: "modified", patch: PATCH }]),
+    headFetch(HEAD),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanUndocumentedExport: an export whose head line no longer declares it is skipped (fail closed)", async () => {
+  // HEAD does not contain `undoc` at line 4 → the added export cannot be confirmed → no finding.
+  const shifted = ["export const somethingElse = 2;", "", "", "export const alsoElse = 3;"].join("\n");
+  const findings = await scanUndocumentedExport(
+    req([{ path: "src/index.ts", status: "modified", patch: PATCH }]),
+    headFetch(shifted),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no throw)", async () => {
+  const files = [{ path: "src/index.ts", status: "modified", patch: PATCH }];
+  assert.deepEqual(await scanUndocumentedExport(req(files, { githubToken: undefined }), headFetch(HEAD)), []);
+  assert.deepEqual(await scanUndocumentedExport(req(files, { headSha: undefined }), headFetch(HEAD)), []);
+});

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -42,7 +42,10 @@ test("hasPrecedingDocComment: a `//` line or block-comment end above (through bl
   assert.equal(hasPrecedingDocComment(["export const x = 1;"], 0), false); // nothing above
   // a CODE line with a trailing block comment ends in `*/` but is not documentation
   assert.equal(hasPrecedingDocComment(["const c = 1; /* trailing */", "export const x = 1;"], 1), false);
-  assert.equal(hasPrecedingDocComment([" * jsdoc body", "export const x = 1;"], 1), true); // block-comment body line
+  // a multi-line JSDoc block counts; a plain (non-doc) block comment does NOT
+  assert.equal(hasPrecedingDocComment(["/**", " * doc", " */", "export const x = 1;"], 3), true);
+  assert.equal(hasPrecedingDocComment(["/* eslint-disable */", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment(["/*", " plain", " */", "export const x = 1;"], 3), false);
   // a doc comment above a DECORATOR on the export still counts (decorator lines are skipped while walking up)
   assert.equal(hasPrecedingDocComment(["/** doc */", "@Component()", "export class Widget {}"], 2), true);
   assert.equal(hasPrecedingDocComment(["@Component()", "export class Widget {}"], 1), false); // decorator only, no doc
@@ -100,6 +103,25 @@ test("scanUndocumentedExport: an oversized response (content-length over the cap
     oversized,
   );
   assert.deepEqual(findings, []); // the bounded-read guard bails before parsing content
+});
+
+test("scanUndocumentedExport: entrypoints without added exports don't consume the file budget", async () => {
+  // MAX_FILES worth of index files that add NO export must not crowd out a later index file that does.
+  const noop = "@@ -1,1 +1,1 @@\n-const a = 1;\n+const a = 2;";
+  const fillers = Array.from({ length: 10 }, (_, i) => ({ path: `p${i}/index.ts`, status: "modified", patch: noop }));
+  const real = { path: "real/index.ts", status: "modified", patch: PATCH };
+  const findings = await scanUndocumentedExport(req([...fillers, real]), headFetch(HEAD));
+  assert.deepEqual(findings, [{ file: "real/index.ts", line: 4, symbol: "undoc" }]);
+});
+
+test("scanUndocumentedExport: preserves the { file, line, symbol } contract through the render", async () => {
+  const findings = await scanUndocumentedExport(req([{ path: "pkg/index.ts", status: "modified", patch: PATCH }]), headFetch(HEAD));
+  assert.equal(findings.length, 1);
+  assert.deepEqual(Object.keys(findings[0]).sort(), ["file", "line", "symbol"]);
+  assert.deepEqual(findings[0], { file: "pkg/index.ts", line: 4, symbol: "undoc" });
+  const brief = renderBrief({ undocumentedExport: findings }).promptSection;
+  assert.match(brief, /pkg\/index\.ts:4/); // file:line preserved by the inline renderer
+  assert.match(brief, /\bundoc\b/); // symbol preserved
 });
 
 test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no throw)", async () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -134,6 +134,16 @@ test("scanUndocumentedExport: preserves the { file, line, symbol } contract thro
   assert.match(brief, /\bundoc\b/); // symbol preserved
 });
 
+test("scanUndocumentedExport: a rejected fetch or a non-OK (404) response yields no finding (fail-safe)", async () => {
+  const files = [{ path: "src/index.ts", status: "modified", patch: PATCH }];
+  const rejecting = async () => {
+    throw new Error("network down");
+  };
+  assert.deepEqual(await scanUndocumentedExport(req(files), rejecting), []); // fetch throws → caught → no finding
+  const notOk = async () => new Response("nope", { status: 404 });
+  assert.deepEqual(await scanUndocumentedExport(req(files), notOk), []); // resp.ok false → content skipped
+});
+
 test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no throw)", async () => {
   const files = [{ path: "src/index.ts", status: "modified", patch: PATCH }];
   assert.deepEqual(await scanUndocumentedExport(req(files, { githubToken: undefined }), headFetch(HEAD)), []);

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -46,6 +46,13 @@ test("exportedSymbols: multi-declarator const/let/var reports every binding; gen
   assert.deepEqual(exportedSymbols("export async function* gen() {}"), ["gen"]); // async generator
   assert.deepEqual(exportedSymbols("export declare function foo(): void;"), ["foo"]); // ambient declaration
   assert.deepEqual(exportedSymbols("export declare const bar: number;"), ["bar"]);
+  // a string literal ending in an escaped backslash must not swallow the following declarator
+  assert.deepEqual(exportedSymbols('export const a = "\\\\", b = 1;'), ["a", "b"]);
+});
+
+test("scanUndocumentedExport: .mts / .cts index entrypoints are scanned", async () => {
+  const findings = await scanUndocumentedExport(req([{ path: "pkg/index.mts", status: "modified", patch: PATCH }]), headFetch(HEAD));
+  assert.deepEqual(findings, [{ file: "pkg/index.mts", line: 4, symbol: "undoc" }]);
 });
 
 test("hasPrecedingDocComment: a tool/suppression directive comment is NOT documentation", () => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -40,6 +40,9 @@ test("hasPrecedingDocComment: a `//` line or block-comment end above (through bl
   assert.equal(hasPrecedingDocComment(["// note", "", "export const x = 1;"], 2), true);
   assert.equal(hasPrecedingDocComment(["export const prev = 0;", "export const x = 1;"], 1), false);
   assert.equal(hasPrecedingDocComment(["export const x = 1;"], 0), false); // nothing above
+  // a CODE line with a trailing block comment ends in `*/` but is not documentation
+  assert.equal(hasPrecedingDocComment(["const c = 1; /* trailing */", "export const x = 1;"], 1), false);
+  assert.equal(hasPrecedingDocComment([" * jsdoc body", "export const x = 1;"], 1), true); // block-comment body line
 });
 
 test("scanUndocumentedExport: flags the undocumented export, not the documented one, and renders it", async () => {
@@ -66,6 +69,18 @@ test("scanUndocumentedExport: an export whose head line no longer declares it is
     headFetch(shifted),
   );
   assert.deepEqual(findings, []);
+});
+
+test("scanUndocumentedExport: an oversized response (content-length over the cap) is not read → no finding", async () => {
+  const oversized = async (url) =>
+    url.includes("/contents/")
+      ? new Response(HEAD, { status: 200, headers: { "content-length": "2000000" } }) // > MAX_FETCH_BYTES (1 MB)
+      : new Response("", { status: 404 });
+  const findings = await scanUndocumentedExport(
+    req([{ path: "src/index.ts", status: "modified", patch: PATCH }]),
+    oversized,
+  );
+  assert.deepEqual(findings, []); // the bounded-read guard bails before parsing content
 });
 
 test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no throw)", async () => {


### PR DESCRIPTION
Closes #2035 (part of #1499).

New REES **github-light** analyzer: flags exports newly **added** to a package's public entrypoint (an `index.*` barrel) that ship with **no adjacent doc comment** — undocumented public surface a reviewer should notice. It reads added export declarations from the diff, then fetches the entrypoint at `headSha` (one authed contents fetch) to confirm, against the final file, that each added export has no preceding JSDoc/`//` comment. Conservative + fail-safe.

## Deliverables
- **`review-enrichment/src/types.ts`** — `UndocumentedExportFinding` (`{ file, line, symbol }`) + `undocumentedExport?` on `BriefFindings`.
- **`review-enrichment/src/analyzers/undocumented-export.ts`**:
  - `parseAddedExports(patch)` — pure diff walk collecting **direct** added exports (`export function/const/let/var/class/interface/type/enum NAME`) with their new-file line; re-export lists (`export { x }`) and `export *` are ignored (they aggregate symbols documented at their definition).
  - `hasPrecedingDocComment(lines, i)` — pure; a block-comment end (`*/`) or a `//` line above (through blank lines) counts as documented.
  - `scanUndocumentedExport(...)` — fetches the entrypoint at `headSha`, flags added exports lacking a doc comment; `maxFiles` 10 / `maxFindings` 30; **fail-safe** (no token/head-sha, bad slug, or fetch error → no finding), and **fail-closed** if the head line no longer declares the symbol.
- **`registry.ts`** — descriptor (`category: quality`, `cost: github-light`, `requires: ['files','github-token','head-sha']`) with an **inline `render()`**.
- **`render.ts`** — dispatches the `undocumentedExport` section.
- Regenerated `analyzer-metadata.json`, `.env.example`, and the UI metadata; added `undocumentedExport` to the registry meta-test's expected list.
- **`test/undocumented-export.test.ts`** — undocumented flagged / documented not flagged (+ brief render), non-entrypoint skip, head-mismatch fail-closed, token/head-sha-absent skip, plus pure `parseAddedExports` / `hasPrecedingDocComment` cases.

## Validation
Full `review-enrichment` suite (build + sourcemaps + `metadata --check` + `node:test`):

```
ℹ tests 504
ℹ pass 504
ℹ fail 0
```

Includes the 6 new tests and the "generated analyzer metadata matches the runtime registry and profiles" check, so the metadata/`.env`/UI regeneration stays consistent with the descriptor.