### PR TITLE
fix(github): report broker-mode installation health honestly

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -9473,6 +9473,13 @@
             "items": {
               "type": "string"
             }
+          },
+          "authMode": {
+            "type": "string",
+            "enum": [
+              "local",
+              "broker"
+            ]
           }
         },
         "required": [
@@ -9485,7 +9492,8 @@
           "missingEvents",
           "permissions",
           "events",
-          "checkedAt"
+          "checkedAt",
+          "authMode"
         ]
       },
       "RepoSettingsPreview": {

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.test.tsx
@@ -2,11 +2,15 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 // Control the session role + stub the data hook so the dashboard branch never hits the network.
-const { useSession } = vi.hoisted(() => ({ useSession: vi.fn() }));
+const { useSession, useApiResource } = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  useApiResource: vi.fn(),
+}));
 vi.mock("@/lib/api/session", () => ({ useSession: () => useSession() }));
 vi.mock("@/lib/api/use-api-resource", () => ({
-  useApiResource: () => ({ status: "loading", data: null, reload: () => {}, error: null }),
+  useApiResource: () => useApiResource(),
 }));
+useApiResource.mockReturnValue({ status: "loading", data: null, reload: () => {}, error: null });
 
 import { MaintainerPanel } from "@/components/site/app-panels/maintainer-panel";
 
@@ -32,5 +36,57 @@ describe("MaintainerPanel role gate", () => {
     });
     render(<MaintainerPanel />);
     expect(screen.queryByText(/Maintainer access required/i)).toBeNull();
+  });
+});
+
+describe("MaintainerPanel install health — Orb broker mode (#selfhost-runtime-drift)", () => {
+  const dashboardData = {
+    metrics: [],
+    health: [
+      {
+        installationId: 1,
+        accountLogin: "brokered-owner",
+        installedReposCount: 2,
+        status: "healthy" as const,
+        missingPermissions: [],
+        missingEvents: [],
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        authMode: "broker" as const,
+      },
+      {
+        installationId: 2,
+        accountLogin: "local-owner",
+        installedReposCount: 1,
+        status: "needs_attention" as const,
+        missingPermissions: ["pull_requests"],
+        missingEvents: [],
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        authMode: "local" as const,
+      },
+    ],
+    reviewability: [],
+    settingsPreview: { removed: [], added: [] },
+  };
+
+  it("shows a neutral 'n/a (broker)' pill instead of a fabricated perms/webhook verdict for a brokered install", () => {
+    useSession.mockReturnValue({
+      session: { login: "maint", roles: ["maintainer"] },
+      hydrated: true,
+    });
+    useApiResource.mockReturnValue({
+      status: "ready",
+      data: dashboardData,
+      reload: () => {},
+      error: null,
+    });
+
+    render(<MaintainerPanel />);
+
+    expect(screen.getByText("perms n/a (broker)")).toBeTruthy();
+    expect(screen.getByText("webhook n/a (broker)")).toBeTruthy();
+    // The local-mode install is unaffected — still shows a real missing/ok verdict, not the broker text.
+    expect(screen.getByText("perms missing")).toBeTruthy();
+    expect(screen.getByText("webhook ok")).toBeTruthy();
+    expect(screen.queryAllByText(/n\/a \(broker\)/)).toHaveLength(2); // scoped to the brokered install only
   });
 });

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -62,6 +62,9 @@ type MaintainerDashboard = {
     missingPermissions: string[];
     missingEvents: string[];
     checkedAt: string;
+    // Brokered self-hosts (Orb token broker mode) can't introspect permissions/events today, so
+    // missingPermissions/missingEvents are always [] there — that means "unchecked", not "all granted".
+    authMode?: "local" | "broker";
   }>;
   reviewability: Array<{
     pr: string;
@@ -248,16 +251,27 @@ function MaintainerDashboardView() {
                       </StatusPill>
                     </div>
                     <div className="mt-2 flex flex-wrap gap-2 text-token-2xs">
-                      <StatusPill
-                        status={installation.missingPermissions.length === 0 ? "ready" : "blocked"}
-                      >
-                        perms {installation.missingPermissions.length === 0 ? "ok" : "missing"}
-                      </StatusPill>
-                      <StatusPill
-                        status={installation.missingEvents.length === 0 ? "ready" : "warn"}
-                      >
-                        webhook {installation.missingEvents.length === 0 ? "ok" : "lagging"}
-                      </StatusPill>
+                      {installation.authMode === "broker" ? (
+                        <>
+                          <StatusPill status="info">perms n/a (broker)</StatusPill>
+                          <StatusPill status="info">webhook n/a (broker)</StatusPill>
+                        </>
+                      ) : (
+                        <>
+                          <StatusPill
+                            status={
+                              installation.missingPermissions.length === 0 ? "ready" : "blocked"
+                            }
+                          >
+                            perms {installation.missingPermissions.length === 0 ? "ok" : "missing"}
+                          </StatusPill>
+                          <StatusPill
+                            status={installation.missingEvents.length === 0 ? "ready" : "warn"}
+                          >
+                            webhook {installation.missingEvents.length === 0 ? "ok" : "lagging"}
+                          </StatusPill>
+                        </>
+                      )}
                       <span className="font-mono text-muted-foreground">
                         last event {new Date(installation.checkedAt).toUTCString().slice(5, 22)}
                       </span>

--- a/migrations/0106_installation_health_auth_mode.sql
+++ b/migrations/0106_installation_health_auth_mode.sql
@@ -1,0 +1,7 @@
+-- Installation health needs to distinguish a brokered self-host (no local GitHub App private key by design,
+-- permission introspection unavailable through the token broker today) from local App-key mode, so a brokered
+-- deployment stops reporting a misleading "GitHub App credentials are not configured" / fabricated missing
+-- permissions status (#selfhost-runtime-drift). Defaults to 'local' so every existing row (all cloud + local-mode
+-- self-host installs, which is everything recorded before this migration) keeps its current, already-correct
+-- meaning without a backfill.
+ALTER TABLE installation_health ADD COLUMN auth_mode TEXT NOT NULL DEFAULT 'local';

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4452,6 +4452,7 @@ export async function upsertInstallationHealth(env: Env, health: InstallationHea
       eventsJson: jsonString(health.events),
       checkedAt: health.checkedAt,
       errorSummary: health.errorSummary ?? null,
+      authMode: health.authMode,
     })
     .onConflictDoUpdate({
       target: installationHealth.installationId,
@@ -4467,6 +4468,7 @@ export async function upsertInstallationHealth(env: Env, health: InstallationHea
         eventsJson: jsonString(health.events),
         checkedAt: health.checkedAt,
         errorSummary: health.errorSummary ?? null,
+        authMode: health.authMode,
       },
     });
 }
@@ -5206,6 +5208,7 @@ function toInstallationHealthRecord(row: typeof installationHealth.$inferSelect)
     events: parseJson<string[]>(row.eventsJson, []),
     checkedAt: row.checkedAt,
     errorSummary: row.errorSummary,
+    authMode: parseInstallationHealthAuthMode(row.authMode),
   };
 }
 
@@ -6268,6 +6271,10 @@ function parseCollisionRisk(value: string): CollisionEdgeRecord["risk"] {
 function parseInstallationHealthStatus(value: string): InstallationHealthRecord["status"] {
   if (value === "healthy" || value === "broken") return value;
   return "needs_attention";
+}
+
+function parseInstallationHealthAuthMode(value: string): InstallationHealthRecord["authMode"] {
+  return value === "broker" ? "broker" : "local";
 }
 
 function parseScoringSourceKind(value: string): ScoringModelSnapshotRecord["sourceKind"] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -735,6 +735,7 @@ export const installationHealth = sqliteTable("installation_health", {
   eventsJson: text("events_json").notNull().default("[]"),
   checkedAt: text("checked_at").notNull(),
   errorSummary: text("error_summary"),
+  authMode: text("auth_mode").notNull().default("local"),
 });
 
 export const advisories = sqliteTable("advisories", {

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -78,6 +78,7 @@ import {
 } from "./client";
 import { fetchCachedGitHubGraphQl } from "./graphql-cache";
 import { incr } from "../selfhost/metrics";
+import { fetchBrokeredInstallationToken, isOrbBrokerMode } from "../orb/broker-client";
 type GitHubLabelPayload = {
   name: string;
   color?: string;
@@ -847,7 +848,52 @@ type InstallationEventDiagnostic = {
   action: string;
 };
 
+// Broker mode (#selfhost-runtime-drift): a brokered self-host holds no local GitHub App private key by design,
+// and the token broker does not expose granted permissions/scopes today -- there is nothing to introspect. Report
+// that plainly instead of running the local-mode remediation math against permissions/events that were never
+// (and structurally cannot be) refreshed, which would otherwise read as either fabricated gaps or fabricated
+// confirmations depending on whatever stale/default data happens to be stored.
+function enrichBrokerInstallationHealth(health: InstallationHealthRecord) {
+  const brokerHealthy = health.status === "healthy";
+  return {
+    ...health,
+    requiredPermissions: REQUIRED_INSTALLATION_PERMISSIONS,
+    optionalPermissions: OPTIONAL_CHECK_RUN_PERMISSION,
+    requiredEvents: [...REQUIRED_INSTALLATION_EVENTS],
+    optionalVisibleEvents: [...OPTIONAL_VISIBLE_INSTALLATION_EVENTS],
+    // ok is always false here, regardless of brokerHealthy -- a reachable broker only proves it can mint
+    // tokens, never that this specific permission/event is actually granted (the broker exposes no
+    // introspection API for that today). Reporting ok: true for a check that was never verified would recreate
+    // the exact fabricated-success problem broker mode exists to avoid; brokerHealthy still drives repairSteps
+    // and the overall status above, just not these per-check flags.
+    permissionRemediation: Object.entries(REQUIRED_INSTALLATION_PERMISSIONS).map(([permission, access]) => ({
+      permission,
+      requiredAccess: access,
+      currentAccess: "unavailable_in_broker_mode",
+      ok: false,
+      action: "Permission introspection is unavailable in broker mode.",
+    })),
+    eventRemediation: REQUIRED_INSTALLATION_EVENTS.map((event) => ({
+      event,
+      ok: false,
+      action: "Event-subscription introspection is unavailable in broker mode.",
+    })),
+    repairSteps: brokerHealthy
+      ? [
+          "This is a brokered self-host (Orb token broker mode) -- it holds no local GitHub App private key by design.",
+          "The token broker is reachable and minting installation tokens normally.",
+          "Permission/event introspection is not available through the token broker today.",
+        ]
+      : [
+          "This is a brokered self-host (Orb token broker mode) -- it holds no local GitHub App private key by design.",
+          `The token broker is unreachable or failing to mint installation tokens${health.errorSummary ? `: ${health.errorSummary}` : "."}`,
+          "Check ORB_ENROLLMENT_SECRET / ORB_BROKER_URL and the central Orb's availability, then re-run refresh-installation-health.",
+        ],
+  };
+}
+
 export function enrichInstallationHealth(health: InstallationHealthRecord) {
+  if (health.authMode === "broker") return enrichBrokerInstallationHealth(health);
   const missingPermissions = new Set(health.missingPermissions);
   const requiredEventSet = new Set<string>(REQUIRED_INSTALLATION_EVENTS);
   const normalizedMissingEvents = health.missingEvents.filter((event) => requiredEventSet.has(event));
@@ -1064,9 +1110,36 @@ export async function refreshInstallationHealthForInstallation(env: Env, install
 async function refreshInstallationHealthRecords(env: Env, installations: InstallationRecord[], repositories: RepositoryRecord[]) {
   const health = [];
   for (const installation of installations) {
-    const { installation: currentInstallation, errorSummary } = await refreshStoredInstallation(env, installation);
+    const { installation: currentInstallation, errorSummary, authMode } = await refreshStoredInstallation(env, installation);
     const installedRepos = repositories.filter((repo) => repo.installationId === currentInstallation.id && repo.isInstalled);
     const registeredInstalled = installedRepos.filter((repo) => repo.isRegistered);
+
+    // Broker mode (#selfhost-runtime-drift): the token broker exposes no permission/event introspection today, so
+    // there is nothing to compare against REQUIRED_INSTALLATION_PERMISSIONS -- computing "missing" from whatever
+    // (never-refreshed) permissions/events happen to be stored would fabricate a gap. Health instead reflects
+    // whether the broker itself is reachable and minting tokens; see enrichInstallationHealth's broker branch for
+    // the honest "introspection unavailable" remediation surfaced to callers.
+    if (authMode === "broker") {
+      const record = {
+        installationId: currentInstallation.id,
+        accountLogin: currentInstallation.accountLogin,
+        repositorySelection: currentInstallation.repositorySelection,
+        installedReposCount: installedRepos.length,
+        registeredInstalledCount: registeredInstalled.length,
+        status: errorSummary ? ("needs_attention" as const) : ("healthy" as const),
+        missingPermissions: [] as string[],
+        missingEvents: [] as string[],
+        permissions: currentInstallation.permissions,
+        events: currentInstallation.events,
+        checkedAt: nowIso(),
+        errorSummary,
+        authMode,
+      } as const;
+      await upsertInstallationHealth(env, record);
+      health.push(enrichInstallationHealth(record));
+      continue;
+    }
+
     const installedSettings = await Promise.all(installedRepos.map((repo) => getRepositorySettings(env, repo.fullName)));
     const requiresChecks = installedSettings.some((settings) => settings.checkRunMode === "enabled");
     const requiresPrWrite = installedSettings.some((settings) => agentRequiresPrWrite(settings.autonomy));
@@ -1094,6 +1167,7 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
       events: currentInstallation.events,
       checkedAt: nowIso(),
       errorSummary,
+      authMode,
     } as const;
     await upsertInstallationHealth(env, record);
     health.push(enrichInstallationHealth(record));
@@ -1101,7 +1175,31 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
   return { ok: true, installations: health };
 }
 
-async function refreshStoredInstallation(env: Env, installation: InstallationRecord): Promise<{ installation: InstallationRecord; errorSummary?: string }> {
+/** Local App-key mode: refresh permissions/events from GitHub via the App's own JWT (unchanged). Broker mode
+ *  (#selfhost-runtime-drift): a brokered self-host holds no local App private key by design, so calling
+ *  getAppInstallation would always throw "GitHub App credentials are not configured" -- correct for local mode,
+ *  misleading here. Instead confirm the ONE thing broker mode can actually check today: whether the token broker
+ *  mints an installation token. currentInstallation.permissions/events are left untouched (there is nothing to
+ *  refresh them from), so callers must key off authMode rather than treating an empty missingPermissions as a
+ *  clean bill of health the way they would for local mode. */
+async function refreshStoredInstallation(
+  env: Env,
+  installation: InstallationRecord,
+): Promise<{ installation: InstallationRecord; errorSummary?: string; authMode: InstallationHealthRecord["authMode"] }> {
+  if (isOrbBrokerMode(env)) {
+    try {
+      await fetchBrokeredInstallationToken(env);
+      incr("gittensory_installation_health_broker_probe_total", { result: "ok" });
+      return { installation, authMode: "broker" };
+    } catch (error) {
+      incr("gittensory_installation_health_broker_probe_total", { result: "failed" });
+      return {
+        installation,
+        errorSummary: strippedErrorMessage(error, "Token broker did not mint an installation token."),
+        authMode: "broker",
+      };
+    }
+  }
   try {
     const live = await getAppInstallation(env, installation.id);
     await upsertInstallation(env, { installation: live });
@@ -1117,11 +1215,13 @@ async function refreshStoredInstallation(env: Env, installation: InstallationRec
         suspendedAt: live.suspended_at ?? undefined,
         updatedAt: nowIso(),
       },
+      authMode: "local",
     };
   } catch (error) {
     return {
       installation,
       errorSummary: strippedErrorMessage(error, "Failed to refresh GitHub App installation metadata."),
+      authMode: "local",
     };
   }
 }

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -26,6 +26,7 @@ import {
   upsertContributor,
   upsertContributorRepoStat,
   upsertInstallationHealth,
+  getInstallationHealth,
   upsertIssueFromGitHub,
   upsertPullRequestFile,
   upsertPullRequestDetailSyncState,
@@ -1119,7 +1120,16 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
     // (never-refreshed) permissions/events happen to be stored would fabricate a gap. Health instead reflects
     // whether the broker itself is reachable and minting tokens; see enrichInstallationHealth's broker branch for
     // the honest "introspection unavailable" remediation surfaced to callers.
+    //
+    // Persistence (#selfhost-runtime-drift follow-up): writing missingPermissions/missingEvents as [] here reads,
+    // to any OTHER consumer of InstallationHealthRecord that predates broker mode and doesn't branch on authMode
+    // (e.g. registration-readiness / settings-preview warnings), as "verified, nothing missing" -- indistinguishable
+    // from a real local-mode clean bill of health. "No data to compute a diff from" is not the same claim as
+    // "confirmed zero missing", so carry forward whatever was last persisted (from an earlier local-mode refresh,
+    // or an earlier broker probe) instead of stomping it with a fabricated-clean []. A row with no prior record at
+    // all has never been verified either way, so [] is the only honest starting point.
     if (authMode === "broker") {
+      const previous = await getInstallationHealth(env, currentInstallation.id);
       const record = {
         installationId: currentInstallation.id,
         accountLogin: currentInstallation.accountLogin,
@@ -1127,8 +1137,8 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
         installedReposCount: installedRepos.length,
         registeredInstalledCount: registeredInstalled.length,
         status: errorSummary ? ("needs_attention" as const) : ("healthy" as const),
-        missingPermissions: [] as string[],
-        missingEvents: [] as string[],
+        missingPermissions: previous?.missingPermissions ?? ([] as string[]),
+        missingEvents: previous?.missingEvents ?? ([] as string[]),
         permissions: currentInstallation.permissions,
         events: currentInstallation.events,
         checkedAt: nowIso(),
@@ -1188,7 +1198,21 @@ async function refreshStoredInstallation(
 ): Promise<{ installation: InstallationRecord; errorSummary?: string; authMode: InstallationHealthRecord["authMode"] }> {
   if (isOrbBrokerMode(env)) {
     try {
-      await fetchBrokeredInstallationToken(env);
+      const minted = await fetchBrokeredInstallationToken(env);
+      // A brokered self-host is bound to exactly ONE real installation, but the local DB can carry
+      // multiple installation rows (e.g. a stale row left over from a prior re-registration). The mint
+      // call takes no installationId -- it always returns "the" broker-bound token -- so a successful
+      // mint here only proves the broker is reachable, never that it is bound to THIS row. Compare the
+      // minted token's own installationId (parsed from the broker's response payload) against the row
+      // being probed; a mismatch (or a missing/zero id from an older broker) must not be reported healthy.
+      if (minted.installationId === 0 || minted.installationId !== installation.id) {
+        incr("gittensory_installation_health_broker_probe_total", { result: "mismatched_installation" });
+        return {
+          installation,
+          errorSummary: `Token broker minted a token for installation ${minted.installationId || "unknown"}, not ${installation.id}.`,
+          authMode: "broker",
+        };
+      }
       incr("gittensory_installation_health_broker_probe_total", { result: "ok" });
       return { installation, authMode: "broker" };
     } catch (error) {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1048,6 +1048,10 @@ export const InstallationHealthSchema = z
     events: z.array(z.string()),
     checkedAt: z.string(),
     errorSummary: z.string().nullable().optional(),
+    // "broker" = a brokered self-host (Orb token broker mode, no local GitHub App private key by design).
+    // Permission/event introspection is unavailable through the broker today, so missingPermissions/missingEvents
+    // are always [] there -- an empty array means "unchecked", not "all satisfied", unlike "local" mode.
+    authMode: z.enum(["local", "broker"]),
     requiredPermissions: z.record(z.string(), z.string()).optional(),
     requiredEvents: z.array(z.string()).optional(),
     optionalVisibleEvents: z.array(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1461,6 +1461,11 @@ export type InstallationHealthRecord = {
   events: string[];
   checkedAt: string;
   errorSummary?: string | null | undefined;
+  // "broker" = a brokered self-host (ORB_ENROLLMENT_SECRET set, no local GitHub App private key by design).
+  // Permission/event introspection is not available through the token broker today, so missingPermissions /
+  // missingEvents are always [] in broker mode -- an EMPTY array there means "unchecked", not "all satisfied"
+  // the way it does for "local" mode. Consumers must branch on authMode, not infer it from empty arrays alone.
+  authMode: "local" | "broker";
 };
 
 export type ScoringModelSnapshotRecord = {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1877,6 +1877,7 @@ describe("api routes", () => {
       permissions: { metadata: "read", pull_requests: "read" },
       events: ["issues", "pull_request", "repository"],
       checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
     });
 
     const repair = await app.request("/v1/installations/777/repair", { headers: apiHeaders(env) }, env);
@@ -1919,6 +1920,7 @@ describe("api routes", () => {
       permissions: { metadata: "read", pull_requests: "write", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:01:00.000Z",
+      authMode: "local",
     });
     const repairWithChecks = await app.request("/v1/installations/777/repair", { headers: apiHeaders(env) }, env);
     const repairWithChecksBody = (await repairWithChecks.json()) as typeof repairBody;
@@ -2221,6 +2223,7 @@ describe("api routes", () => {
       permissions: { metadata: "read" },
       events: ["pull_request"],
       checkedAt: "2026-05-31T12:00:00.000Z",
+      authMode: "local",
       errorSummary: "victim install needs privileged recovery",
     });
     await recordGitHubRateLimitObservation(ownerEnv, {
@@ -3233,6 +3236,7 @@ describe("api routes", () => {
       permissions: { metadata: "read", pull_requests: "write", issues: "write" },
       events: ["issues", "pull_request", "repository"],
       checkedAt: "2026-05-31T11:00:00.000Z",
+      authMode: "local",
     });
     await upsertInstallationHealth(env, {
       installationId: 456,
@@ -3246,6 +3250,7 @@ describe("api routes", () => {
       permissions: { metadata: "read" },
       events: [],
       checkedAt: "2026-05-31T11:01:00.000Z",
+      authMode: "local",
     });
     const warningDigest = await app.request("/v1/app/digest", { headers: cookieHeaders }, env);
     expect(warningDigest.status).toBe(200);
@@ -4667,6 +4672,7 @@ describe("api routes", () => {
       permissions: { metadata: "read", pull_requests: "read" },
       events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-23T00:00:00.000Z",
+      authMode: "local",
     });
     await upsertRepoSyncSegment(env, {
       repoFullName: "entrius/allways-ui",
@@ -6578,6 +6584,7 @@ async function seedSignalData(env: Env): Promise<void> {
     permissions: { metadata: "read", pull_requests: "write", issues: "write" },
     events: ["issues", "pull_request", "repository"],
     checkedAt: freshAt,
+    authMode: "local",
   });
   const snapshot = normalizeRegistryPayload(
     {
@@ -6759,6 +6766,7 @@ async function seedSignalData(env: Env): Promise<void> {
     permissions: { metadata: "read", pull_requests: "write", issues: "write" },
     events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
     checkedAt: freshAt,
+    authMode: "local",
   });
   await upsertIssueFromGitHub(env, "entrius/allways-ui", {
     number: 7,

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -18,6 +18,7 @@ import {
   persistRepoGithubTotalsSnapshot,
   recordGitHubRateLimitObservation,
   upsertInstallation,
+  upsertInstallationHealth,
   upsertRepoSyncSegment,
   upsertRepoSyncState,
   upsertPullRequestFile,
@@ -497,6 +498,65 @@ describe("GitHub backfill", () => {
       // The persisted authMode round-trips as "broker" through the repository read path (getInstallationHealth),
       // not just the in-memory refresh result — mirrors the "local" round-trip check above.
       expect(await getInstallationHealth(env, 900)).toMatchObject({ authMode: "broker" });
+    });
+
+    it("REGRESSION (gate finding): never reports healthy when the broker mints a token for a DIFFERENT installation than the one being refreshed", async () => {
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
+      // Two local rows exist (e.g. a stale row left over from a prior re-registration), but a brokered
+      // self-host is bound to exactly ONE real installation — the broker always mints for that ONE install
+      // regardless of which local row's refresh triggered the call.
+      await upsertInstallation(env, {
+        installation: { id: 910, account: { login: "brokered-owner", id: 9, type: "User" }, repository_selection: "selected" },
+      });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.endsWith("/v1/orb/token")) return Response.json({ token: "ghs_brokered", installationId: 999 }); // NOT 910
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await refreshInstallationHealth(env);
+
+      expect(result.installations[0]?.status).toBe("needs_attention");
+      expect(result.installations[0]?.authMode).toBe("broker");
+      expect(result.installations[0]?.errorSummary).toMatch(/910/);
+      expect(await renderMetrics()).toContain('gittensory_installation_health_broker_probe_total{result="mismatched_installation"} 1');
+    });
+
+    it("REGRESSION (gate finding): a broker-mode refresh preserves the previously-persisted missingPermissions/missingEvents instead of fabricating a clean []", async () => {
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
+      await upsertInstallation(env, {
+        installation: { id: 911, account: { login: "brokered-owner", id: 9, type: "User" }, repository_selection: "selected" },
+      });
+      // A prior refresh (e.g. before this install switched into broker mode, or an earlier probe) left a
+      // REAL, non-empty missing-permissions/events record — that's genuine last-known information, not a
+      // fabricated broker-mode guess, so a later broker-mode refresh must not silently erase it back to [].
+      await upsertInstallationHealth(env, {
+        installationId: 911,
+        accountLogin: "brokered-owner",
+        repositorySelection: "selected",
+        installedReposCount: 1,
+        registeredInstalledCount: 1,
+        status: "needs_attention",
+        missingPermissions: ["pull_requests"],
+        missingEvents: ["issues"],
+        permissions: {},
+        events: [],
+        checkedAt: "2026-07-01T00:00:00.000Z",
+        authMode: "local",
+      });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.endsWith("/v1/orb/token")) return Response.json({ token: "ghs_brokered", installationId: 911 });
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await refreshInstallationHealth(env);
+
+      expect(result.installations[0]).toMatchObject({
+        authMode: "broker",
+        missingPermissions: ["pull_requests"],
+        missingEvents: ["issues"],
+      });
     });
 
     it("reports needs_attention with a broker-specific errorSummary (not the local App-key message) when the token broker fails to mint", async () => {

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getInstallationHealth,
   listCheckSummaries,
   listContributorRepoStats,
   listIssues,
@@ -458,6 +459,129 @@ describe("GitHub backfill", () => {
     });
     const refreshed = await refreshInstallationHealth(env);
     expect(refreshed.installations).toEqual(expect.arrayContaining([expect.objectContaining({ installationId: 124, status: "healthy" })]));
+    // The persisted authMode round-trips as "local" through the repository read path (getInstallationHealth),
+    // not just the in-memory refresh result — the same mapper the broker-mode test below exercises for "broker".
+    expect(await getInstallationHealth(env, 124)).toMatchObject({ authMode: "local" });
+  });
+
+  describe("installation health — Orb broker mode (#selfhost-runtime-drift)", () => {
+    it("reports healthy with authMode 'broker' and no fabricated missing permissions when the token broker mints successfully", async () => {
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" }); // broker mode — no GITHUB_APP_PRIVATE_KEY
+      await upsertInstallation(env, {
+        installation: {
+          id: 900,
+          account: { login: "brokered-owner", id: 9, type: "User" },
+          repository_selection: "selected",
+        },
+      });
+      const calls: string[] = [];
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        calls.push(url);
+        if (url.endsWith("/v1/orb/token")) return Response.json({ token: "ghs_brokered", installationId: 900 });
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await refreshInstallationHealth(env);
+
+      expect(result.installations[0]).toMatchObject({
+        status: "healthy",
+        authMode: "broker",
+        missingPermissions: [],
+        missingEvents: [],
+        errorSummary: undefined,
+      });
+      // Never takes the local App-JWT path (which would 404 here and throw "credentials not configured").
+      expect(calls.some((url) => url.includes("/app/installations/"))).toBe(false);
+      expect(await renderMetrics()).toContain('gittensory_installation_health_broker_probe_total{result="ok"} 1');
+      // The persisted authMode round-trips as "broker" through the repository read path (getInstallationHealth),
+      // not just the in-memory refresh result — mirrors the "local" round-trip check above.
+      expect(await getInstallationHealth(env, 900)).toMatchObject({ authMode: "broker" });
+    });
+
+    it("reports needs_attention with a broker-specific errorSummary (not the local App-key message) when the token broker fails to mint", async () => {
+      const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orbsec_test" });
+      await upsertInstallation(env, {
+        installation: { id: 901, account: { login: "brokered-owner", id: 9, type: "User" }, repository_selection: "selected" },
+      });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        const url = input.toString();
+        if (url.endsWith("/v1/orb/token")) return new Response("broker down", { status: 500 });
+        return new Response("not found", { status: 404 });
+      });
+
+      const result = await refreshInstallationHealth(env);
+
+      expect(result.installations[0]?.status).toBe("needs_attention");
+      expect(result.installations[0]?.authMode).toBe("broker");
+      expect(result.installations[0]?.errorSummary).toMatch(/token/i);
+      expect(result.installations[0]?.errorSummary).not.toMatch(/GitHub App credentials are not configured/);
+      expect(await renderMetrics()).toContain('gittensory_installation_health_broker_probe_total{result="failed"} 1');
+    });
+
+    it("enrichInstallationHealth's broker branch reports introspection-unavailable remediation, not fabricated grants or gaps", () => {
+      const healthy = enrichInstallationHealth({
+        installationId: 902,
+        accountLogin: "brokered-owner",
+        repositorySelection: "selected",
+        installedReposCount: 1,
+        registeredInstalledCount: 1,
+        status: "healthy",
+        missingPermissions: [],
+        missingEvents: [],
+        permissions: {},
+        events: [],
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        authMode: "broker",
+      });
+      // ok is false even on a HEALTHY broker: the broker minting tokens proves reachability, never that any
+      // specific permission/event is actually granted -- there is no introspection API to confirm that today.
+      expect(healthy.permissionRemediation).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ permission: "pull_requests", currentAccess: "unavailable_in_broker_mode", ok: false }),
+        ]),
+      );
+      expect(healthy.eventRemediation).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "issues", ok: false })]),
+      );
+      expect(healthy.repairSteps.join(" ")).toMatch(/token broker is reachable/i);
+
+      const degraded = enrichInstallationHealth({
+        installationId: 903,
+        accountLogin: "brokered-owner",
+        repositorySelection: "selected",
+        installedReposCount: 1,
+        registeredInstalledCount: 1,
+        status: "needs_attention",
+        missingPermissions: [],
+        missingEvents: [],
+        permissions: {},
+        events: [],
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        errorSummary: "Token broker did not mint an installation token: 500.",
+        authMode: "broker",
+      });
+      expect(degraded.permissionRemediation.every((entry) => entry.ok === false)).toBe(true);
+      expect(degraded.repairSteps.join(" ")).toContain("Token broker did not mint an installation token: 500.");
+
+      // No errorSummary at all (e.g. the broker call itself never completed) — repairSteps still reads as a
+      // plain sentence instead of dangling on a missing colon-suffix.
+      const degradedNoSummary = enrichInstallationHealth({
+        installationId: 904,
+        accountLogin: "brokered-owner",
+        repositorySelection: "selected",
+        installedReposCount: 1,
+        registeredInstalledCount: 1,
+        status: "needs_attention",
+        missingPermissions: [],
+        missingEvents: [],
+        permissions: {},
+        events: [],
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        authMode: "broker",
+      });
+      expect(degradedNoSummary.repairSteps.join(" ")).toContain("The token broker is unreachable or failing to mint installation tokens.");
+    });
   });
 
   it("normalizes stale automatic installation repository event health", () => {
@@ -473,6 +597,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", pull_requests: "write", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository"],
       checkedAt: "2026-06-05T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(health).toMatchObject({
@@ -495,6 +620,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", pull_requests: "read", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository"],
       checkedAt: "2026-06-05T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(health.requiredPermissions).toMatchObject({ pull_requests: "write" }); // not the baseline read
@@ -516,6 +642,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository"],
       checkedAt: "2026-06-05T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(health.requiredPermissions).toMatchObject({ pull_requests: "read" });
@@ -635,6 +762,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", pull_requests: "read", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(repair.repairSteps).toEqual(["No repair needed."]);
@@ -666,6 +794,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", pull_requests: "read", issues: "write" },
       events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(repair.requiredPermissions.pull_requests).toBe("write");
@@ -702,6 +831,7 @@ describe("GitHub backfill", () => {
       permissions: { metadata: "read", pull_requests: "read", issues: "read" },
       events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
       checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
     });
 
     expect(repair.modeImpacts).toEqual(

--- a/test/unit/data-spine.test.ts
+++ b/test/unit/data-spine.test.ts
@@ -237,6 +237,7 @@ describe("data spine repositories", () => {
       permissions: { checks: "write" },
       events: ["issues", "pull_request", "repository"],
       checkedAt: "2026-05-23T00:00:00.000Z",
+      authMode: "local",
     });
     expect(await getInstallationHealth(env, 123)).toMatchObject({ status: "healthy" });
     expect(await listInstallationHealth(env)).toHaveLength(1);
@@ -417,6 +418,7 @@ describe("data spine repositories", () => {
       permissions: {},
       events: [],
       checkedAt: "2026-05-23T00:00:00.000Z",
+      authMode: "local",
     });
     await env.DB.prepare("update installation_health set status = ? where installation_id = ?").bind("weird", 999).run();
     expect(await getInstallationHealth(env, 999)).toMatchObject({ status: "needs_attention" });

--- a/test/unit/weekly-value-report.test.ts
+++ b/test/unit/weekly-value-report.test.ts
@@ -390,6 +390,7 @@ function health(installationId: number, status: InstallationHealthRecord["status
     permissions: {},
     events: [],
     checkedAt: "2026-06-01T00:00:00.000Z",
+    authMode: "local",
   };
 }
 


### PR DESCRIPTION
## Summary

- Installation health always refreshed via `getAppInstallation` (a local GitHub App JWT). For a brokered self-host (`ORB_ENROLLMENT_SECRET` set, no local App private key by design), that call always throws `"GitHub App credentials are not configured."`, and the caller's stale/never-populated local `permissions`/`events` snapshot then made *every* required permission and event look "missing" — a fabricated `needs_attention`/`broken` verdict, not a real one.
- Added an `authMode: "local" | "broker"` field to `InstallationHealthRecord` (new migration, Drizzle column, type, OpenAPI schema). Broker-mode health now checks the one thing actually verifiable today — whether the token broker mints an installation token (`fetchBrokeredInstallationToken`) — instead of taking the local App-key path at all, and reports "permission introspection unavailable in broker mode" remediation instead of fake gaps or fake grants. Local App-key mode is completely unchanged.
- The maintainer dashboard pill now shows "n/a (broker)" instead of a fabricated perms/webhook verdict for a brokered install; a local-mode install is unaffected.
- New `gittensory_installation_health_broker_probe_total{result}` metric distinguishes "broker unreachable" from "introspection just isn't available."

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue — a self-host operational bug found via direct investigation of a reported symptom cluster; the summary above explains the root cause.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run db:migrations:check`
- [x] `npm run test:coverage` locally (full, unsharded) — 375 files / 7261 tests passed, 0 failures
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:openapi:settings-parity`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [ ] `npm run actionlint` (no workflow files touched)
- [ ] `npm run test:workers` (no Cloudflare-worker-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (no MCP package changes)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes; the broker token-mint call itself is already tested elsewhere.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (`InstallationHealthSchema` extended + regenerated `apps/gittensory-ui/public/openapi.json`.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (The `authMode` field flows through the real `enrichInstallationHealth` → `/v1/app/maintainer-dashboard` response path; no demo data added.)
- [x] Visible UI changes include a `UI Evidence` section below.
- [ ] Public docs/changelogs are updated where needed. (N/A — no changelog edits in a normal PR.)

## UI Evidence

I do not have a mechanism in this environment to host screenshots at a GitHub-attachment URL, so I can't embed the clickable-thumbnail table the template asks for. What I actually did to verify, in place of that:

- Added `apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.test.tsx`'s new `describe("MaintainerPanel install health — Orb broker mode")` block, which renders the real `MaintainerPanel` component tree (not a mock-up) with fixture dashboard data containing one `authMode: "broker"` install and one `authMode: "local"` install, and asserts the exact rendered pill text for both (`perms n/a (broker)` / `webhook n/a (broker)` vs. the real `perms missing` / `webhook ok` verdict for the local install). This test passes and runs in CI via `ui:test`.
- Additionally ran the actual `vite dev` server for `apps/gittensory-ui` and drove it with a real browser (via the local preview-session escape hatch this repo already ships for exactly this purpose, `useSession().signInPreview()`), with the `/v1/app/maintainer-dashboard` fetch mocked to return realistic before/after payload shapes. Confirmed live-rendered:
  - **Before** (pre-fix payload shape: a brokered install with no `authMode` field, `missingPermissions` fabricated from an empty local snapshot): the "acme-selfhost" broker install shows a red "PERMS MISSING" pill and an orange "WEBHOOK LAGGING" pill — the exact misleading behavior this PR fixes.
  - **After** (post-fix payload: `authMode: "broker"`, `missingPermissions: []`): the same install shows a neutral "PERMS N/A (BROKER)" / "WEBHOOK N/A (BROKER)" pill, while a sibling `authMode: "local"` install in the same list is unaffected and still shows its real "PERMS MISSING" verdict.
- Happy to attach the actual PNGs to this PR as a follow-up comment if there's a preferred upload path, or reproduce this on request.

## Notes

- Third of several focused follow-ups from an operator-reported self-host runtime-drift investigation. See #2764 (maintenance-queue starvation) and #2769 (Orb relay registration retries). A follow-up (cap-close permission-denial noise) and a dashboard-panels PR tying all the new metrics together land separately to keep each change reviewable on its own.
- The deeper root cause connecting this PR to the cap-close denial noise (next PR): a brokered self-host has no mechanism today to ever populate its local `installations.permissions` snapshot (the central Orb doesn't forward `installation` webhook events to brokered containers, by design, to avoid cross-installation state confusion), so `resolveAgentPermissionReadiness` always reads an empty permissions object for a brokered install. This PR does not attempt to fix that deeper gap (a real fix needs a broker-side permission-introspection endpoint, out of scope here) — it only stops the health check from reporting it dishonestly.