### PR TITLE
feat(mcp): add issue-slop CLI for issue-quality self-checks

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -59,6 +59,7 @@ gittensory-mcp analyze-branch --login jsonbored --json
 gittensory-mcp preflight --login jsonbored --json
 gittensory-mcp lint-pr-text --commit "feat(mcp): add doctor grouping" --body "Fixes #160. Validated with npm test." --linked-issue 160 --json
 gittensory-mcp slop-risk --changed-file src/widget.ts:80:2 --description "Adds retry handling." --test-file test/unit/widget.test.ts --json
+gittensory-mcp issue-slop --title "Add retry handling" --body "Widget reconnects fail without bounded retries." --json
 gittensory-mcp agent plan --login jsonbored --json
 gittensory-mcp agent packet --login jsonbored --json
 gittensory-mcp agent status <run-id> --json

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -41,6 +41,7 @@ const CLI_COMMAND_SPEC = {
   preflight: [],
   "lint-pr-text": [],
   "slop-risk": [],
+  "issue-slop": [],
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear"],
   agent: ["plan", "status", "explain", "packet"],
@@ -1444,6 +1445,7 @@ async function runCli(args) {
   if (command === "init-client") return initClient(options);
   if (command === "lint-pr-text") return lintPrTextCli(args.slice(1));
   if (command === "slop-risk") return slopRiskCli(args.slice(1));
+  if (command === "issue-slop") return issueSlopCli(args.slice(1));
   if (command === "decision-pack") return decisionPackCli(options);
   if (command === "repo-decision") return repoDecisionCli(options);
   if (command !== "analyze-branch" && command !== "preflight") {
@@ -1577,6 +1579,40 @@ async function slopRiskCli(args) {
     return;
   }
   process.stdout.write(`Slop risk: ${payload.slopRisk} (${payload.band})\n`);
+  for (const finding of payload.findings ?? []) process.stdout.write(`- ${finding.title}: ${finding.detail}\n`);
+}
+
+function printIssueSlopHelp() {
+  process.stdout.write(
+    [
+      "Usage: gittensory-mcp issue-slop [--title <text>] [--body <text>] [--body-file <path>] [--json]",
+      "",
+      "Assess deterministic issue slop risk from an issue title and body alone.",
+      "Mirrors the gittensory_check_issue_slop MCP tool and POST /v1/lint/issue-slop. Advisory only; no source upload.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
+async function issueSlopCli(args) {
+  if (!args.length || args[0] === "--help" || args[0] === "help") return printIssueSlopHelp();
+  const options = parseOptions(args);
+  let body = normalizeOptionalStringOption(options.body);
+  if (options.bodyFile) {
+    if (!existsSync(options.bodyFile)) throw new Error(`Body file not found: ${options.bodyFile}`);
+    body = readFileSync(options.bodyFile, "utf8");
+  }
+  const title = normalizeOptionalStringOption(options.title);
+  const payload = await apiPost("/v1/lint/issue-slop", {
+    ...(title !== undefined ? { title } : {}),
+    ...(body !== undefined ? { body } : {}),
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`Issue slop risk: ${payload.slopRisk} (${payload.band})\n`);
   for (const finding of payload.findings ?? []) process.stdout.write(`- ${finding.title}: ${finding.detail}\n`);
 }
 
@@ -1968,6 +2004,7 @@ function printHelp() {
   gittensory-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--json]
   gittensory-mcp lint-pr-text [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
   gittensory-mcp slop-risk [--description <text>] [--description-file <path>] [--changed-file <path[:additions:deletions]>]... [--test <command>]... [--test-file <path>]... [--json]
+  gittensory-mcp issue-slop [--title <text>] [--body <text>] [--body-file <path>] [--json]
   gittensory-mcp agent plan --login <github-login> [--repo owner/repo] [--json]
   gittensory-mcp agent status <run-id> [--json]
   gittensory-mcp agent explain <run-id> [--json]
@@ -2812,6 +2849,13 @@ function parsePositiveIntegerOption(value, flagName) {
   const parsed = optionalInteger(value);
   if (parsed === undefined || parsed <= 0) throw new Error(`Pass ${flagName} as a positive integer.`);
   return parsed;
+}
+
+function normalizeOptionalStringOption(value) {
+  if (value === undefined) return undefined;
+  if (value === true) return "";
+  if (typeof value === "string") return value;
+  throw new Error("Expected a string flag value.");
 }
 
 function optionalNumber(value) {

--- a/test/unit/mcp-cli-issue-slop.test.ts
+++ b/test/unit/mcp-cli-issue-slop.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, run, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+
+describe("gittensory-mcp CLI — issue-slop", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    await closeFixtureServer();
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  async function env() {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const url = await startFixtureServer();
+    return { GITTENSORY_API_URL: url, GITTENSORY_TOKEN: "session-token", GITTENSORY_CONFIG_DIR: tempDir, GITTENSORY_API_TIMEOUT_MS: "1000" };
+  }
+
+  it("assesses issue slop via the API and prints plain or json output", async () => {
+    const e = await env();
+    const plain = await runAsync(
+      [
+        "issue-slop",
+        "--title",
+        "Add retry handling for widget reconnects",
+        "--body",
+        "The widget client drops transient failures without retrying. Add bounded retries with jitter and cover the reconnect path in unit tests.",
+      ],
+      e,
+    );
+    expect(plain).toMatch(/Issue slop risk: 0 \(clean\)/);
+
+    const json = JSON.parse(
+      await runAsync(
+        [
+          "issue-slop",
+          "--title",
+          "Add retry handling for widget reconnects",
+          "--body",
+          "The widget client drops transient failures without retrying.",
+          "--json",
+        ],
+        e,
+      ),
+    ) as { slopRisk: number; band: string; findings: unknown[]; rubric: string };
+    expect(json).toMatchObject({ slopRisk: 0, band: "clean", findings: [], rubric: expect.any(String) });
+    expect(JSON.stringify(json)).not.toMatch(/wallet|hotkey|reward|trust score/i);
+  });
+
+  it("reads issue bodies from --body-file", async () => {
+    const e = await env();
+    const bodyPath = join(tempDir!, "issue-body.md");
+    writeFileSync(bodyPath, "Retry widget reconnects with bounded backoff and add unit coverage.", "utf8");
+    const json = JSON.parse(await runAsync(["issue-slop", "--title", "Improve widget reconnects", "--body-file", bodyPath, "--json"], e)) as {
+      band: string;
+    };
+    expect(json.band).toBe("clean");
+  });
+
+  it("surfaces elevated issue slop findings in plain output", async () => {
+    const e = await env();
+    const json = JSON.parse(await runAsync(["issue-slop", "--title", "Add retries", "--body", "", "--json"], e)) as {
+      slopRisk: number;
+      band: string;
+      findings: Array<{ title: string }>;
+    };
+    expect(json).toMatchObject({ slopRisk: 30, band: "elevated" });
+    const plain = await runAsync(["issue-slop", "--title", "Add retries", "--body", ""], e);
+    expect(plain).toMatch(/Issue slop risk: 30 \(elevated\)/);
+    expect(plain).toMatch(/Issue has no description/);
+  });
+
+  it("validates inputs and prints help", async () => {
+    const e = await env();
+    await expect(runAsync(["issue-slop", "--body-file", "/tmp/missing-gittensory-issue-body.md"], e)).rejects.toThrow(/Body file not found/);
+    const help = run(["issue-slop", "--help"]);
+    expect(help).toMatch(/Usage: gittensory-mcp issue-slop/);
+    expect(help).toMatch(/gittensory_check_issue_slop/);
+    expect(help).toMatch(/--body-file/);
+  });
+
+  it("suggests issue-slop for close typos", () => {
+    expect(() => run(["issue-slopx"])).toThrow(/Did you mean `issue-slop`\?/);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -244,6 +244,11 @@ export async function startFixtureServer(
       response.end(JSON.stringify(slopRiskFixture(body)));
       return;
     }
+    if (request.url === "/v1/lint/issue-slop" && request.method === "POST") {
+      const body = (await readJsonRequest(request)) as { title?: string; body?: string };
+      response.end(JSON.stringify(issueSlopFixture(body)));
+      return;
+    }
     if (request.url === "/v1/opportunities/find" && request.method === "POST") {
       const body = (await readJsonRequest(request)) as {
         targets?: Array<{ owner: string; repo: string }>;
@@ -493,5 +498,26 @@ export function slopRiskFixture(input: {
     band: slopRisk <= 0 ? "clean" : slopRisk < 25 ? "low" : slopRisk < 60 ? "elevated" : "high",
     findings,
     rubric: "Fixture slop rubric.",
+  };
+}
+
+export function issueSlopFixture(input: { title?: string; body?: string } = {}) {
+  const bodyText = typeof input.body === "string" ? input.body : "";
+  const emptyBody = !bodyText.trim();
+  const unfilledTemplate = !emptyBody && /##\s*summary/i.test(bodyText) && /-\s*\[?\s*\]?\s*$/m.test(bodyText);
+  const titleOnly = !emptyBody && !unfilledTemplate && input.title && bodyText.trim().toLowerCase() === input.title.trim().toLowerCase();
+  const slopRisk = emptyBody ? 30 : unfilledTemplate ? 40 : titleOnly ? 25 : 0;
+  const findings = emptyBody
+    ? [{ code: "empty_issue_body", title: "Issue has no description", severity: "warning", detail: "This issue was opened with an empty body." }]
+    : unfilledTemplate
+      ? [{ code: "unfilled_issue_template", title: "Issue template left unfilled", severity: "warning", detail: "Fill in the issue template sections with concrete detail." }]
+      : titleOnly
+        ? [{ code: "title_restatement", title: "Issue body only restates the title", severity: "warning", detail: "Add specific detail beyond the title." }]
+        : [];
+  return {
+    slopRisk,
+    band: slopRisk <= 0 ? "clean" : slopRisk < 25 ? "low" : slopRisk < 60 ? "elevated" : "high",
+    findings,
+    rubric: "Fixture issue slop rubric.",
   };
 }


### PR DESCRIPTION
## Summary

- Add `gittensory-mcp issue-slop` as a stdio CLI mirror of `gittensory_check_issue_slop` and `POST /v1/lint/issue-slop`
- Support `--title`, `--body`, `--body-file`, and `--json` for agent self-checks before opening issues
- Handle empty `--body ""` via `normalizeOptionalStringOption` so falsy empty strings are not dropped by `parseOptions`

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `npx vitest run test/unit/mcp-cli-issue-slop.test.ts`
- [ ] Full `npm run test:ci` (running in CI)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Advisory lint only; no source upload.

## UI Evidence

N/A — MCP CLI only.

## Notes

- Disjoint from `feat/engine-discover-plan-template` — no overlapping files.

