### PR TITLE
feat(engine): add discover plan template for miner lifecycle

### DIFF
--- a/packages/gittensory-engine/src/plan-templates.ts
+++ b/packages/gittensory-engine/src/plan-templates.ts
@@ -17,7 +17,7 @@ export type RawPlanStep = {
 };
 
 // The lifecycle-stage transitions this library provides a template for.
-export type PlanTemplateStage = "analyze" | "prepare";
+export type PlanTemplateStage = "discover" | "analyze" | "prepare";
 
 // Context woven into a template's step titles so a plan reads against the opportunity it targets.
 export type PlanTemplateContext = {
@@ -42,6 +42,16 @@ function normalizeSubject(subject: string | undefined): string {
 function titleFor(prefix: string, subject: string): string {
   const full = subject ? `${prefix}: ${subject}` : prefix;
   return full.slice(0, MAX_TITLE_CHARS);
+}
+
+// discover: rank candidate opportunities, validate lane fit, then run a pre-start check before analyze.
+export function discoverPlanTemplate(context: PlanTemplateContext = {}): RawPlanStep[] {
+  const subject = normalizeSubject(context.subject);
+  return [
+    { id: "opportunity-rank", title: titleFor("Rank candidate opportunities", subject), actionClass: "discover", dependsOn: [], maxAttempts: 2 },
+    { id: "lane-fit-check", title: titleFor("Validate miner goal lane fit", subject), actionClass: "analyze", dependsOn: ["opportunity-rank"], maxAttempts: 1 },
+    { id: "pre-start-check", title: titleFor("Run pre-start check", subject), actionClass: "analyze", dependsOn: ["lane-fit-check"], maxAttempts: 2 },
+  ];
 }
 
 // analyze: feasibility check and repository RAG retrieval run independently, then the prompt-packet build consumes
@@ -70,6 +80,7 @@ export function preparePlanTemplate(context: PlanTemplateContext = {}): RawPlanS
 // Frozen so a consumer cannot mutate the shared registry and change dispatch behavior process-wide.
 export const PLAN_TEMPLATE_BUILDERS: Readonly<Record<PlanTemplateStage, (context?: PlanTemplateContext) => RawPlanStep[]>> =
   Object.freeze({
+    discover: discoverPlanTemplate,
     analyze: analyzePlanTemplate,
     prepare: preparePlanTemplate,
   });

--- a/test/unit/plan-templates.test.ts
+++ b/test/unit/plan-templates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   analyzePlanTemplate,
   buildPlanTemplate,
+  discoverPlanTemplate,
   preparePlanTemplate,
   PLAN_TEMPLATE_BUILDERS,
   type PlanTemplateStage,
@@ -17,7 +18,7 @@ function idsOf(steps: RawPlanStep[]): string[] {
 
 describe("plan-templates", () => {
   it("exposes a builder for every declared stage", () => {
-    expect(STAGES.sort()).toEqual(["analyze", "prepare"]);
+    expect(STAGES.sort()).toEqual(["analyze", "discover", "prepare"]);
   });
 
   it.each(STAGES)("'%s' template round-trips through the real rawPlanStepSchema", (stage) => {
@@ -47,6 +48,7 @@ describe("plan-templates", () => {
   });
 
   it("is deterministic: same context yields identical output", () => {
+    expect(discoverPlanTemplate({ subject: "x" })).toEqual(discoverPlanTemplate({ subject: "x" }));
     expect(analyzePlanTemplate({ subject: "x" })).toEqual(analyzePlanTemplate({ subject: "x" }));
     expect(preparePlanTemplate()).toEqual(preparePlanTemplate());
   });
@@ -70,6 +72,13 @@ describe("plan-templates", () => {
       expect(() => rawPlanStepSchema.parse(step)).not.toThrow();
       expect(step.title.length).toBeLessThanOrEqual(300);
     }
+  });
+
+  it("encodes the real discover ordering: lane-fit and pre-start depend on prior discovery steps", () => {
+    const steps = discoverPlanTemplate();
+    expect(steps.map((s) => s.id)).toEqual(["opportunity-rank", "lane-fit-check", "pre-start-check"]);
+    expect(steps.find((s) => s.id === "lane-fit-check")?.dependsOn).toEqual(["opportunity-rank"]);
+    expect(steps.find((s) => s.id === "pre-start-check")?.dependsOn).toEqual(["lane-fit-check"]);
   });
 
   it("encodes the real analyze ordering: prompt-packet depends on both feasibility and retrieval", () => {


### PR DESCRIPTION
## Summary

- Add a `discover` stage to the shared miner plan-template library
- Emit a deterministic DAG: rank opportunities → lane-fit check → pre-start check
- Register the builder in `PLAN_TEMPLATE_BUILDERS` so `buildPlanTemplate("discover")` works

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `npx vitest run test/unit/plan-templates.test.ts`
- [ ] Full `npm run test:ci` (running in CI)

## Safety

- [x] Pure engine templates only; no actuation, IO, or secrets.

## UI Evidence

N/A — engine library only.

## Notes

- Complements merged analyze/prepare templates without touching MCP CLI code.
- Disjoint from `feat/mcp-issue-slop-cli` — no overlapping files, so either can merge first.

