### PR TITLE
fix(services): suppress repeated cap-close permission denials

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -34,6 +34,7 @@ import {
   resolveModerationGateEnabled,
   type ModerationRuleType,
 } from "../settings/moderation-rules";
+import { incr } from "../selfhost/metrics";
 
 // The agent actor name on every audit record — the App acts on the maintainer's behalf per their configured
 // autonomy (the config IS the authorization; there is no human commenter to authorize, unlike #824).
@@ -55,6 +56,42 @@ function shouldRefreshInstallationHealthAfterPrWriteFailure(installationId: numb
   if (lastAttemptMs !== undefined && nowMs - lastAttemptMs < INSTALLATION_HEALTH_REFRESH_COOLDOWN_MS) return false;
   installationHealthRefreshAttempts.set(installationId, nowMs);
   return true;
+}
+
+// A known-denied PR-write action (missing pull_requests:write) must not re-run the freshness + live-CI GitHub
+// calls and re-write an identical audit record on every sweep (#selfhost-runtime-drift) -- that burns queue/API
+// cycles on an outcome that cannot change until the maintainer re-consents (which itself only refreshes on the
+// INSTALLATION_HEALTH_REFRESH_COOLDOWN_MS cadence above, or the periodic refresh-installation-health job). A
+// bounded per-installation/repo/action-class cooldown suppresses the redundant audit write/log while still
+// counting every suppressed attempt, so the denial remains visible in metrics without flooding the audit table.
+const PR_WRITE_DENIAL_COOLDOWN_MS = 15 * 60 * 1000;
+const writePermissionDenialCooldown = new Map<string, number>();
+
+function writePermissionDenialKey(installationId: number, repoFullName: string, actionClass: AgentActionClass): string {
+  return `${installationId}:${repoFullName}:${actionClass}`;
+}
+
+/** True when this exact installation/repo/action-class was already denied for a missing write permission within
+ *  the cooldown window -- the caller should suppress the redundant audit + log, count it, and move on. A pure
+ *  read: the caller must call markWritePermissionDenialAudited AFTER the loud audit write actually succeeds, not
+ *  here -- arming the cooldown before that write lands would mean a transient audit DB failure on the first
+ *  denial permanently swallows it (the retry within the window would see the cooldown already armed and never
+ *  attempt the audit again). */
+function shouldSuppressWritePermissionDenial(key: string, nowMs: number): boolean {
+  const lastDeniedMs = writePermissionDenialCooldown.get(key);
+  return lastDeniedMs !== undefined && nowMs - lastDeniedMs < PR_WRITE_DENIAL_COOLDOWN_MS;
+}
+
+/** Arms (or refreshes) the write-permission-denial cooldown -- call ONLY after the loud audit write for this
+ *  exact denial has actually succeeded, so a failed audit write is retried on the very next pass instead of
+ *  being silently suppressed for the whole cooldown window. */
+function markWritePermissionDenialAudited(key: string, nowMs: number): void {
+  writePermissionDenialCooldown.set(key, nowMs);
+}
+
+/** Test-only: clear the module-level write-permission denial cooldown so each test starts fresh. */
+export function clearWritePermissionDenialCooldownForTest(): void {
+  writePermissionDenialCooldown.clear();
 }
 
 export type AgentActionExecutionContext = {
@@ -116,10 +153,14 @@ function coupledCloseOutcome(planned: PlannedAgentAction[], outcomes: AgentActio
 
 /**
  * Execute (or dry-run, or stage for approval) a planned auto-maintain action set on one PR. Each action runs
- * through the SAME deny-toward-safety gate stack before any GitHub call:
- *   pause (#776 kill-switch) → current autonomy → approval (auto_with_approval → #779 queue) → write-permission (#775) → mode.
+ * through the SAME deny-toward-safety gate stack:
+ *   pause (#776 kill-switch) → current autonomy → dry_run → approval (auto_with_approval → #779 queue) →
+ *   write-permission (#775, checked BEFORE any GitHub call so a known-denied write never spends freshness/live-CI
+ *   API budget) → label/close correlation → freshness → live-CI re-verification → the real mutation.
  * Only `live` mode performs a real mutation; `dry_run` records what it WOULD do. Every path writes one
- * `agent.action.<class>` audit record (#776). A failed mutation is recorded as `error`, never swallowed.
+ * `agent.action.<class>` audit record (#776) EXCEPT a write-permission denial repeated within
+ * PR_WRITE_DENIAL_COOLDOWN_MS of the last one for the same installation/repo/action-class, which is counted but
+ * not re-audited (#selfhost-runtime-drift). A failed mutation is recorded as `error`, never swallowed.
  */
 export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionExecutionContext, planned: PlannedAgentAction[]): Promise<AgentActionOutcome[]> {
   const outcomes: AgentActionOutcome[] = [];
@@ -168,12 +209,34 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("queued", `awaiting maintainer approval — ${action.reason}`);
       continue;
     }
-    // 5) #label-close-split-brain: a `label` coupled to a same-batch anti-abuse close (closeKind set) must not
-    //    post if that close already denied/errored THIS pass — `label` mutates via the Issues API and is exempt
-    //    from the write-permission gate below (step 8) that `close` is not, so without this correlation a
-    //    transient `pull_requests: write` denial could leave a PR mislabeled "closed for X" while still open.
-    //    A coupled close that is still "queued" (awaiting the SAME approval) or "completed" lets the label through
-    //    unchanged; a close with no `closeKind` match (e.g. a plain review_state_label) is unaffected.
+    // 5) Write-permission readiness: a PR-write action needs `pull_requests: write` granted. Checked here --
+    //    before the freshness/live-CI GitHub calls below -- so a known-denied action never spends that API
+    //    budget on an outcome that cannot change until the maintainer re-consents (#selfhost-runtime-drift).
+    //    `label` mutates via the Issues API (`issues: write`, always held), so it is exempt from this gate.
+    if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
+      incr("gittensory_agent_action_permission_denied_total", { actionClass: action.actionClass });
+      const cooldownKey = writePermissionDenialKey(ctx.installationId, ctx.repoFullName, action.actionClass);
+      if (shouldSuppressWritePermissionDenial(cooldownKey, Date.now())) {
+        // Already denied + audited for this exact installation/repo/action-class within the cooldown window --
+        // count it (the denial stays visible in metrics) without re-writing an identical audit record every pass.
+        incr("gittensory_agent_action_permission_denied_suppressed_total", { actionClass: action.actionClass });
+        outcomes.push({
+          actionClass: action.actionClass,
+          outcome: "denied",
+          detail: "pull_requests: write not granted — maintainer must re-consent (suppressed repeat)",
+        });
+        continue;
+      }
+      await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
+      markWritePermissionDenialAudited(cooldownKey, Date.now());
+      continue;
+    }
+    // 6) #label-close-split-brain: a `label` coupled to a same-batch anti-abuse close (closeKind set) must not
+    //    post if that close already denied/errored THIS pass — `label` is exempt from the write-permission gate
+    //    above that `close` is not, so without this correlation a transient `pull_requests: write` denial could
+    //    leave a PR mislabeled "closed for X" while still open. A coupled close that is still "queued" (awaiting
+    //    the SAME approval) or "completed" lets the label through unchanged; a close with no `closeKind` match
+    //    (e.g. a plain review_state_label) is unaffected.
     if (action.actionClass === "label" && action.closeKind) {
       const closeOutcome = coupledCloseOutcome(planned, outcomes, action.closeKind);
       if (closeOutcome === "denied" || closeOutcome === "error") {
@@ -181,7 +244,7 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
         continue;
       }
     }
-    // 6) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
+    // 7) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
     //    target the reviewed, open head. This protects approval-queue replays and slow webhook jobs from
     //    force-pushes or manual closes that happen after the review was planned.
     const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
@@ -199,7 +262,7 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
       await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
       continue;
     }
-    // 7) Live CI re-verification for a merge or a CI-driven heuristic close (#2128): the CI aggregate that drove
+    // 8) Live CI re-verification for a merge or a CI-driven heuristic close (#2128): the CI aggregate that drove
     //    either decision was read seconds-to-tens-of-seconds earlier, in the planning pass, and the freshness
     //    guard above only re-checks head SHA/state, not CI. GitHub's own merge endpoint enforces
     //    branch-protection REQUIRED checks server-side, but only as a backstop when a repo actually configures
@@ -237,11 +300,6 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
         await audit("denied", `${staleReason} — action not executed`);
         continue;
       }
-    }
-    // 8) Write-permission readiness: a PR-write action needs `pull_requests: write` granted.
-    if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
-      await audit("denied", "pull_requests: write not granted — maintainer must re-consent");
-      continue;
     }
     // 9) live — perform the real mutation, recording success or the error.
     try {

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -62,13 +62,16 @@ function shouldRefreshInstallationHealthAfterPrWriteFailure(installationId: numb
 // calls and re-write an identical audit record on every sweep (#selfhost-runtime-drift) -- that burns queue/API
 // cycles on an outcome that cannot change until the maintainer re-consents (which itself only refreshes on the
 // INSTALLATION_HEALTH_REFRESH_COOLDOWN_MS cadence above, or the periodic refresh-installation-health job). A
-// bounded per-installation/repo/action-class cooldown suppresses the redundant audit write/log while still
+// bounded per-installation/repo/PR/action-class cooldown suppresses the redundant audit write/log while still
 // counting every suppressed attempt, so the denial remains visible in metrics without flooding the audit table.
+// The key is scoped to the PR too -- the permission denial is installation-wide, but a denial already audited
+// for one PR must never silently suppress the FIRST denial audit for a different PR in the same repo/window,
+// or that PR's maintainer never sees why it was denied.
 const PR_WRITE_DENIAL_COOLDOWN_MS = 15 * 60 * 1000;
 const writePermissionDenialCooldown = new Map<string, number>();
 
-function writePermissionDenialKey(installationId: number, repoFullName: string, actionClass: AgentActionClass): string {
-  return `${installationId}:${repoFullName}:${actionClass}`;
+function writePermissionDenialKey(installationId: number, repoFullName: string, pullNumber: number, actionClass: AgentActionClass): string {
+  return `${installationId}:${repoFullName}:${pullNumber}:${actionClass}`;
 }
 
 /** True when this exact installation/repo/action-class was already denied for a missing write permission within
@@ -215,7 +218,7 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     //    `label` mutates via the Issues API (`issues: write`, always held), so it is exempt from this gate.
     if (PR_WRITE_CLASSES.has(action.actionClass) && resolveAgentPermissionReadiness({ autonomy: ctx.autonomy, installationPermissions: ctx.installationPermissions }) !== "ready") {
       incr("gittensory_agent_action_permission_denied_total", { actionClass: action.actionClass });
-      const cooldownKey = writePermissionDenialKey(ctx.installationId, ctx.repoFullName, action.actionClass);
+      const cooldownKey = writePermissionDenialKey(ctx.installationId, ctx.repoFullName, ctx.pullNumber, action.actionClass);
       if (shouldSuppressWritePermissionDenial(cooldownKey, Date.now())) {
         // Already denied + audited for this exact installation/repo/action-class within the cooldown window --
         // count it (the denial stays visible in metrics) without re-writing an identical audit record every pass.

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -540,6 +540,20 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
       expect(retry[0]?.detail).toBe("pull_requests: write not granted — maintainer must re-consent");
       expect(await auditCount(env, "merge")).toBe(1);
     });
+
+    it("REGRESSION (gate finding): scopes the cooldown per PR — a denial on a DIFFERENT PR in the same installation/repo/action-class is not suppressed", async () => {
+      const env = createTestEnv({});
+      const perms = { pull_requests: "read" as const, issues: "write" as const };
+
+      const prA = await executeAgentMaintenanceActions(env, ctx({ installationId: 205, pullNumber: 501, installationPermissions: perms }), [merge]);
+      const prB = await executeAgentMaintenanceActions(env, ctx({ installationId: 205, pullNumber: 502, installationPermissions: perms }), [merge]);
+
+      // Both denials are loud — PR B's cooldown key differs from PR A's, so it must never be silently
+      // suppressed by PR A's already-armed cooldown within the same 15m window.
+      expect(prA[0]).toMatchObject({ outcome: "denied", detail: "pull_requests: write not granted — maintainer must re-consent" });
+      expect(prB[0]).toMatchObject({ outcome: "denied", detail: "pull_requests: write not granted — maintainer must re-consent" });
+      expect(await auditCount(env, "merge")).toBe(2); // one audit row per PR, not one shared row
+    });
   });
 
   it("#label-close-split-brain: a coupled anti-abuse label+close pair (matching closeKind) BOTH complete when the close succeeds", async () => {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -43,6 +43,7 @@ import { createInstallationToken } from "../../src/github/app";
 import { fetchLiveCiAggregate, refreshInstallationHealthForInstallation } from "../../src/github/backfill";
 import {
   actionParams,
+  clearWritePermissionDenialCooldownForTest,
   executeAgentMaintenanceActions,
   executeIssueMaintenanceActions,
   pendingActionToPlanned,
@@ -54,6 +55,8 @@ import {
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import { getGlobalContributorBlacklist, isGlobalAgentFrozen, setGlobalAgentFrozen, upsertGlobalModerationConfig, upsertPullRequestFromGitHub } from "../../src/db/repositories";
+import * as repositoriesModule from "../../src/db/repositories";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createTestEnv } from "../helpers/d1";
 import { MODERATION_VIOLATION_EVENT_TYPE } from "../../src/settings/moderation-rules";
 
@@ -90,6 +93,8 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
       liveHeadSha: args.expectedHeadSha ?? null,
       liveState: "open",
     }));
+    clearWritePermissionDenialCooldownForTest();
+    resetMetrics();
   });
 
   it("actionParams threads expectedHeadSha for an update_branch action (and omits absent fields)", () => {
@@ -448,6 +453,93 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(mergePullRequest).not.toHaveBeenCalled();
     expect(updatePullRequestBranch).not.toHaveBeenCalled();
     expect((await auditFor(env, "merge"))?.outcome).toBe("denied");
+  });
+
+  describe("write-permission denial cooldown (#selfhost-runtime-drift)", () => {
+    async function auditCount(env: Env, actionClass: string): Promise<number> {
+      const row = await env.DB.prepare("select count(*) as c from audit_events where event_type = ?")
+        .bind(`agent.action.${actionClass}`)
+        .first<{ c: number }>();
+      return Number(row?.c ?? 0);
+    }
+
+    it("suppresses a repeated pull_requests:write denial within the cooldown window — still denied, but not re-audited", async () => {
+      const env = createTestEnv({});
+      const deniedCtx = ctx({ installationId: 200, installationPermissions: { pull_requests: "read", issues: "write" } });
+
+      const first = await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+      expect(first[0]).toMatchObject({ outcome: "denied", detail: "pull_requests: write not granted — maintainer must re-consent" });
+      expect(await auditCount(env, "merge")).toBe(1);
+
+      const second = await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+      expect(second[0]?.outcome).toBe("denied");
+      expect(second[0]?.detail).toContain("suppressed repeat");
+      expect(await auditCount(env, "merge")).toBe(1); // no new audit row for the suppressed repeat
+      expect(mergePullRequest).not.toHaveBeenCalled();
+
+      const metrics = await renderMetrics();
+      expect(metrics).toContain('gittensory_agent_action_permission_denied_total{actionClass="merge"} 2');
+      expect(metrics).toContain('gittensory_agent_action_permission_denied_suppressed_total{actionClass="merge"} 1');
+    });
+
+    it("resumes loud auditing once the cooldown window elapses", async () => {
+      const env = createTestEnv({});
+      const deniedCtx = ctx({ installationId: 201, installationPermissions: { pull_requests: "read", issues: "write" } });
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-03T00:00:00Z"));
+      try {
+        await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+        expect(await auditCount(env, "merge")).toBe(1);
+
+        vi.setSystemTime(new Date("2026-07-03T00:14:00Z")); // still inside the 15m cooldown
+        await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+        expect(await auditCount(env, "merge")).toBe(1);
+
+        vi.setSystemTime(new Date("2026-07-03T00:15:01Z")); // cooldown elapsed
+        const afterCooldown = await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+        expect(afterCooldown[0]?.detail).toBe("pull_requests: write not granted — maintainer must re-consent");
+        expect(await auditCount(env, "merge")).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("scopes the cooldown per installation/repo/action-class — a different action class is not suppressed by another's denial", async () => {
+      const env = createTestEnv({});
+      const deniedCtx = ctx({ installationId: 202, installationPermissions: { pull_requests: "read", issues: "write" } });
+
+      await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+      const closeOutcome = await executeAgentMaintenanceActions(env, deniedCtx, [close]);
+
+      expect(closeOutcome[0]?.detail).toBe("pull_requests: write not granted — maintainer must re-consent"); // loud, not suppressed
+      expect(await auditCount(env, "close")).toBe(1);
+    });
+
+    it("scopes the cooldown per repo — the SAME installation denied on a different repo is not suppressed", async () => {
+      const env = createTestEnv({});
+      const perms = { pull_requests: "read" as const, issues: "write" as const };
+      await executeAgentMaintenanceActions(env, ctx({ installationId: 203, repoFullName: "owner/repo-a", installationPermissions: perms }), [merge]);
+      const otherRepo = await executeAgentMaintenanceActions(env, ctx({ installationId: 203, repoFullName: "owner/repo-b", installationPermissions: perms }), [merge]);
+
+      expect(otherRepo[0]?.detail).toBe("pull_requests: write not granted — maintainer must re-consent");
+      expect(await auditCount(env, "merge")).toBe(2); // one audit row per repo
+    });
+
+    it("REGRESSION (gate finding): a transient audit-write failure on the FIRST denial does not arm the cooldown — the retry attempts the audit again instead of being silently suppressed", async () => {
+      const env = createTestEnv({});
+      const deniedCtx = ctx({ installationId: 204, installationPermissions: { pull_requests: "read", issues: "write" } });
+      const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 write error"));
+
+      await expect(executeAgentMaintenanceActions(env, deniedCtx, [merge])).rejects.toThrow("D1 write error");
+      expect(await auditCount(env, "merge")).toBe(0); // the failed write never landed
+
+      auditSpy.mockRestore();
+      const retry = await executeAgentMaintenanceActions(env, deniedCtx, [merge]);
+
+      // Loud, not suppressed — the cooldown was never armed by the failed first attempt.
+      expect(retry[0]?.detail).toBe("pull_requests: write not granted — maintainer must re-consent");
+      expect(await auditCount(env, "merge")).toBe(1);
+    });
   });
 
   it("#label-close-split-brain: a coupled anti-abuse label+close pair (matching closeKind) BOTH complete when the close succeeds", async () => {


### PR DESCRIPTION
## Summary

- A PR-write action (close/merge/approve/request_changes/update_branch) denied for missing `pull_requests: write` re-ran the freshness check and (for a merge or CI-driven close) the live-CI re-verification — both real GitHub API calls — and re-wrote an identical `agent.action.<class>` audit record on every sweep, even though the outcome cannot change until the maintainer re-consents. Reported symptom: repeated `pull_requests: write not granted — maintainer must re-consent` denials burning queue/API cycles indefinitely on the same doomed action.
- Moved the write-permission readiness check earlier in the gate stack — before the freshness/live-CI GitHub calls — so a known-denied action skips that API budget entirely instead of paying for it only to be denied afterward anyway. (`label` remains exempt, unaffected — it mutates via `issues: write`, always held.)
- Added a bounded cooldown (15 minutes) keyed by installation/repo/action-class: the first denial for a given key still writes the normal loud audit record; a repeat within the cooldown window is counted but not re-audited, so a chronically-denied action degrades to a bounded, low-noise signal instead of a DB write on every sweep.
- New `gittensory_agent_action_permission_denied_total{actionClass}` (every denial) and `gittensory_agent_action_permission_denied_suppressed_total{actionClass}` (cooldown-suppressed repeats) metrics keep the denial visible to operators without the log/audit-table churn.
- No behavior change to the underlying permission decision itself (`resolveAgentPermissionReadiness`) — only when/how often it's re-checked and re-recorded.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue — a self-host operational bug found via direct investigation of a reported symptom cluster; the summary above explains the root cause.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full, unsharded) — 375 files / 7262 tests passed, 0 failures
- [ ] `npm run actionlint` (no workflow files touched)
- [ ] `npm run test:workers` (no Cloudflare-worker-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (no UI changes)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)

If any required check was skipped, explain why:

- This PR only touches `src/services/agent-action-executor.ts` and its unit tests; the UI/MCP/workers/dependency/workflow checks above are inapplicable to this diff and were skipped for that reason.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes; the permission-readiness decision itself is unchanged, only its call frequency.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no public API/OpenAPI/MCP surface touched.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A.)

## Notes

- Fourth of several focused follow-ups from an operator-reported self-host runtime-drift investigation. See #2764 (maintenance-queue starvation), #2769 (Orb relay registration retries), and #2771 (broker-mode installation health honesty — the deeper root cause connecting to this PR: brokered self-hosts have no mechanism today to ever populate their local permissions snapshot, so this denial path fires unconditionally for every brokered install with an acting PR-write autonomy; that deeper gap needs a broker-side permission-introspection endpoint and is intentionally out of scope here). A dashboard-panels PR tying all four PRs' new metrics together lands last.