### PR TITLE
fix(signals): count C#/Swift/Groovy source as code files

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -600,12 +600,13 @@ export function isTestFile(file) {
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -13,7 +13,7 @@ function isTestFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|js|jsx|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) && !isTestFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -8,7 +8,10 @@ function isTestFile(file) {
     /(^|\/)src\/test\//i.test(file) ||
     /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
-    /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file)
+    /\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file) ||
+    // JVM/.NET/Swift PascalCase test-class suffix (case-sensitive, matching the
+    // signal classifiers) so C#/Swift/Groovy tests aren't counted as source.
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file)
   );
 }
 

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -152,7 +152,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif path.endswith((".ts", ".tsx", ".js", ".jsx", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql")):
+        elif path.endswith((".ts", ".tsx", ".js", ".jsx", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy")):
             source += lines
         else:
             non_code += lines

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -8,8 +8,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
+
+# JVM/.NET/Swift PascalCase test-class suffix (case-sensitive, on the original
+# path) so C#/Swift/Groovy tests aren't counted as source once their extensions
+# are recognized as code. Matches the signal classifiers' isTestPath rule.
+_JVM_TEST_SUFFIX_RE = re.compile(r"(?:Tests?|Spec)\.(?:java|kt|kts|scala|cs|swift|groovy)$")
 
 
 def is_test_file(path: str) -> bool:
@@ -40,6 +46,8 @@ def is_test_file(path: str) -> bool:
         ".spec.rb",
         ".spec.rs",
     )
+    if _JVM_TEST_SUFFIX_RE.search(path):
+        return True
     return any(token in lowered for token in patterns) or any(basename.endswith(suffix) for suffix in ("_test.go", "_test.py", "_test.rb"))
 
 

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5515,7 +5515,13 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 }
 
 function isCodeFile(file: string): boolean {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy added
+  // so C#/Swift/Groovy source counts as code, matching the test conventions
+  // isTestPath already recognizes).
+  return (
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
+    !isTestFile(file)
+  );
 }
 
 function isTestFile(file: string): boolean {

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1267,7 +1267,14 @@ export function isTestFile(file: string): boolean {
 }
 
 export function isCodeFile(file: string): boolean {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql)$/i.test(file) && !isTestFile(file);
+  // cs/swift/groovy round out the JVM/.NET/Swift set: isTestPath already
+  // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
+  // count as code too — otherwise a C#/Swift/Groovy source file is neither test
+  // nor code in the local scorer.
+  return (
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
+    !isTestFile(file)
+  );
 }
 
 function sameRepo(left: string, right: string): boolean {

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -117,6 +117,11 @@ describe("isCodeFile", () => {
       "src/config.mts",
       "src/setup.cts",
       "helper_test.ts",
+      // C#/Swift/Groovy source — their test files are already recognized by
+      // isTestPath, so their source must count as code too.
+      "Api/Controllers/UserController.cs",
+      "Sources/App/Router.swift",
+      "src/main/groovy/Pipeline.groovy",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }
@@ -133,6 +138,9 @@ describe("isCodeFile", () => {
       // module-extension e2e tests must not count as code
       "e2e/checkout.cy.mts",
       "e2e/flow.e2e.mjs",
+      // C#/Swift test files carry a code extension but are tests, not code.
+      "Services/AccountTests.cs",
+      "AppTests/LoginTests.swift",
     ]) {
       expect(isCodeFile(path)).toBe(false);
     }


### PR DESCRIPTION
## Summary
`isCodeFile` recognized the JVM trio (`kt`/`scala`/`java`) plus go/rust/python, but not `cs`/`swift`/`groovy` — even though `isTestPath` already recognizes their `SomethingTest(s)`/`Spec` test files. So a C#/Swift/Groovy source file was classified as neither test nor code by the local scorer, understating real source effort while its test counterpart still counted as a test.

Adds `cs`/`swift`/`groovy` to both `isCodeFile` copies (`local-branch.ts` + `engine.ts`, kept in sync).

## Validation
- `npx vitest run test/unit/local-branch-file-classifiers.test.ts test/unit/local-branch.test.ts` — green (source-as-code + test-still-excluded)
- `npm run typecheck` — clean