### PR TITLE
fix(signals): classify bower_components and jspm_packages as vendored

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -59,7 +59,11 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
 }
 
 function isVendoredFileFrom(parts: NormalizedPath): boolean {
-  return /(^|\/)(vendor|vendored|third_party|third-party|node_modules)\//.test(parts.norm);
+  // bower_components (Bower) and jspm_packages (JSPM) are installed-dependency
+  // directories — the same vendored case as node_modules, not contributor source.
+  return /(^|\/)(vendor|vendored|third_party|third-party|node_modules|bower_components|jspm_packages)\//.test(
+    parts.norm,
+  );
 }
 
 function isLockfileFrom(parts: NormalizedPath): boolean {

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -41,7 +41,15 @@ describe("isGeneratedFile", () => {
 
 describe("isVendoredFile", () => {
   it("matches vendored / third-party directories", () => {
-    for (const path of ["vendor/lib.go", "vendored/x.js", "third_party/y.py", "third-party/z.ts", "node_modules/pkg/index.js"]) {
+    for (const path of [
+      "vendor/lib.go",
+      "vendored/x.js",
+      "third_party/y.py",
+      "third-party/z.ts",
+      "node_modules/pkg/index.js",
+      "bower_components/jquery/dist/jquery.js", // Bower
+      "jspm_packages/npm/lodash/index.js", // JSPM
+    ]) {
       expect(isVendoredFile(path)).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary
`isVendoredFileFrom` recognized `node_modules` and vendor/third_party dirs, but not `bower_components` (Bower) or `jspm_packages` (JSPM) — installed-dependency directories in the same vendored category, not contributor source. Changes under them were miscounted as substantive source effort.

Adds both to the vendored-directory matcher.

## Validation
- `npx vitest run test/unit/path-matchers.test.ts` — green
- `npm run typecheck` — clean