### PR TITLE
feat(enrichment): detect GitLab and npm tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -31,6 +31,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // GitLab personal/project/group access token: `glpat-` + 20 base64url chars.
+    kind: "gitlab_token",
+    re: /\bglpat-[0-9A-Za-z_-]{20}\b/,
+    confidence: "high",
+  },
+  {
+    // npm automation/publish token: `npm_` + 36 base62 chars.
+    kind: "npm_token",
+    re: /\bnpm_[A-Za-z0-9]{36}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -15,6 +15,8 @@ const awsKeyFragmentA = "AKIA" + "IOSFODNN7"; // 13 chars — too short alone to
 const awsKeyFragmentB = "EXAMPLE"; // matches no RULES pattern alone
 const fakeAwsKey = awsKeyFragmentA + awsKeyFragmentB;
 const fakeStripeKey = ["sk_live_", "abcdefghijklmnop1234567890"].join("");
+const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
+const fakeNpmToken = "npm_" + "a".repeat(36);
 
 test("scanPatch flags a single-line AWS access key with high confidence", () => {
   const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeAwsKey}";`]));
@@ -29,6 +31,20 @@ test("scanPatch flags a private key header", () => {
   const findings = scanPatch("id_rsa", hunk(["-----BEGIN RSA PRIVATE KEY-----"]));
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "private_key");
+});
+
+test("scanPatch flags a GitLab access token with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const gl = "${fakeGitlabToken}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "gitlab_token");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags an npm token with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const registryAuth = "${fakeNpmToken}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "npm_token");
+  assert.equal(findings[0].confidence, "high");
 });
 
 test("scanPatch flags a generic secret assignment", () => {

--- a/src/review/content-lane/security-scan.ts
+++ b/src/review/content-lane/security-scan.ts
@@ -20,6 +20,8 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "aws_access_key", re: /\bAKIA[0-9A-Z]{16}\b/ },
   { name: "slack_token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
   { name: "google_api_key", re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: "gitlab_token", re: /\bglpat-[0-9A-Za-z_-]{20}\b/ },
+  { name: "npm_token", re: /\bnpm_[A-Za-z0-9]{36}\b/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },
@@ -115,6 +117,8 @@ const HARD_SECRET_KINDS = new Set([
   "aws_access_key",
   "slack_token",
   "google_api_key",
+  "gitlab_token",
+  "npm_token",
   "jwt",
   "generic_secret_assignment",
 ]);

--- a/src/review/safety.ts
+++ b/src/review/safety.ts
@@ -29,6 +29,8 @@ const HARD_SECRET_KINDS = new Set([
   "aws_access_key",
   "slack_token",
   "google_api_key",
+  "gitlab_token",
+  "npm_token",
   "jwt",
   "generic_secret_assignment",
 ]);

--- a/src/review/secrets-scan.ts
+++ b/src/review/secrets-scan.ts
@@ -20,6 +20,8 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "aws_access_key", re: /\bAKIA[0-9A-Z]{16}\b/ },
   { name: "slack_token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
   { name: "google_api_key", re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: "gitlab_token", re: /\bglpat-[0-9A-Za-z_-]{20}\b/ },
+  { name: "npm_token", re: /\bnpm_[A-Za-z0-9]{36}\b/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },

--- a/test/unit/content-lane-security-scan.test.ts
+++ b/test/unit/content-lane-security-scan.test.ts
@@ -34,6 +34,11 @@ describe("scanForSecrets", () => {
     expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");
   });
 
+  it("flags a GitLab and an npm token (parity with the PR-diff gate)", () => {
+    expect(scanForSecrets("glpat-" + "aBcDeFgHiJkLmNoPqRsT").kinds).toContain("gitlab_token");
+    expect(scanForSecrets("npm_" + "a".repeat(36)).kinds).toContain("npm_token");
+  });
+
   it("flags a generic secret/password/token assignment with a high-entropy value", () => {
     expect(scanForSecrets(`secret = "${GENERIC_VALUE}"`).kinds).toContain("generic_secret_assignment");
     expect(scanForSecrets(`api_key: '${GENERIC_VALUE}'`).kinds).toContain("generic_secret_assignment");

--- a/test/unit/secrets-scan.test.ts
+++ b/test/unit/secrets-scan.test.ts
@@ -55,6 +55,16 @@ describe("scanForSecrets — deterministic secret-pattern scanner", () => {
     expect(scanForSecrets(fakeKey).kinds).toContain("google_api_key");
   });
 
+  it("flags a GitLab access token", () => {
+    const fakeToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT";
+    expect(scanForSecrets(fakeToken).kinds).toContain("gitlab_token");
+  });
+
+  it("flags an npm token", () => {
+    const fakeToken = "npm_" + "a".repeat(36);
+    expect(scanForSecrets(fakeToken).kinds).toContain("npm_token");
+  });
+
   it("flags a JWT", () => {
     const fakeJwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");


### PR DESCRIPTION
## Summary
The secret-scan analyzer flagged AWS, GitHub, Slack, and Google keys but not two other common, unambiguously-shaped credentials: **GitLab access tokens** (`glpat-` + 20 base64url chars) and **npm automation tokens** (`npm_` + 36 base62 chars). Both leak frequently in configs, CI env, and `.npmrc` snippets.

Adds high-confidence rules for both, ordered before the medium-confidence generic-assignment rule so they report their specific kind. Test fixtures are assembled at runtime so the source never commits a token-shaped literal.

## Validation
- `npm --prefix review-enrichment test` (rees gate: build + sourcemaps + metadata check + node:test) — **500/500 pass**, incl. the two new high-confidence cases