### PR TITLE
feat(engine): add opportunity freshness scorer

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -33,3 +33,7 @@ export {
   computeMinerGoalLaneFit,
   isMinerRepoTargetable,
 } from "./miner-goal-lane-fit.js";
+export {
+  computeOpportunityFreshness,
+  type FreshnessIssue,
+} from "./opportunity-freshness.js";

--- a/packages/gittensory-engine/src/opportunity-freshness.ts
+++ b/packages/gittensory-engine/src/opportunity-freshness.ts
@@ -1,0 +1,45 @@
+export type FreshnessIssue = {
+  state: string;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+};
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function pickTimestamp(issue: FreshnessIssue): string | null {
+  const updated = typeof issue.updatedAt === "string" ? issue.updatedAt.trim() : "";
+  if (updated) return updated;
+  const created = typeof issue.createdAt === "string" ? issue.createdAt.trim() : "";
+  return created || null;
+}
+
+function issueAgeDays(value: string | null, nowMs: number): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.floor((nowMs - parsed) / 86_400_000);
+}
+
+/**
+ * Compute a [0.05, 1] freshness factor from open issue timestamps, mirroring
+ * `opportunityFreshnessFactor` in `src/signals/reward-risk.ts` but with an injected clock so the miner engine
+ * stays pure and testable.
+ */
+export function computeOpportunityFreshness(
+  issues: readonly FreshnessIssue[],
+  nowMs: number,
+): number {
+  if (!Number.isFinite(nowMs)) return 0;
+  const openIssues = issues.filter((issue) => issue?.state?.toLowerCase() === "open");
+  if (openIssues.length === 0) return 0;
+  const mostRecentAgeDays = Math.min(
+    ...openIssues.map((issue) => issueAgeDays(pickTimestamp(issue), nowMs)),
+  );
+  return round4(clamp(Math.exp(-mostRecentAgeDays / 20), 0.05, 1));
+}

--- a/packages/gittensory-engine/src/opportunity-freshness.ts
+++ b/packages/gittensory-engine/src/opportunity-freshness.ts
@@ -12,11 +12,18 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function isParseableTimestamp(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
+}
+
 function pickTimestamp(issue: FreshnessIssue): string | null {
   const updated = typeof issue.updatedAt === "string" ? issue.updatedAt.trim() : "";
-  if (updated) return updated;
+  if (updated && isParseableTimestamp(updated)) return updated;
+
   const created = typeof issue.createdAt === "string" ? issue.createdAt.trim() : "";
-  return created || null;
+  if (created && isParseableTimestamp(created)) return created;
+
+  return null;
 }
 
 function issueAgeDays(value: string | null, nowMs: number): number {
@@ -24,6 +31,10 @@ function issueAgeDays(value: string | null, nowMs: number): number {
   const parsed = Date.parse(value);
   if (!Number.isFinite(parsed)) return 0;
   return Math.floor((nowMs - parsed) / 86_400_000);
+}
+
+function isOpenIssue(issue: FreshnessIssue): boolean {
+  return typeof issue?.state === "string" && issue.state.trim().toLowerCase() === "open";
 }
 
 /**
@@ -36,7 +47,7 @@ export function computeOpportunityFreshness(
   nowMs: number,
 ): number {
   if (!Number.isFinite(nowMs)) return 0;
-  const openIssues = issues.filter((issue) => issue?.state?.toLowerCase() === "open");
+  const openIssues = issues.filter(isOpenIssue);
   if (openIssues.length === 0) return 0;
   const mostRecentAgeDays = Math.min(
     ...openIssues.map((issue) => issueAgeDays(pickTimestamp(issue), nowMs)),

--- a/packages/gittensory-engine/test/opportunity-freshness.test.ts
+++ b/packages/gittensory-engine/test/opportunity-freshness.test.ts
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeOpportunityFreshness } from "../dist/index.js";
+
+const nowMs = Date.parse("2026-07-03T00:00:00.000Z");
+
+test("barrel: the public entrypoint re-exports the freshness scorer API", () => {
+  assert.equal(typeof computeOpportunityFreshness, "function");
+});
+
+test("computeOpportunityFreshness returns 0 when no open issues exist", () => {
+  assert.equal(computeOpportunityFreshness([], nowMs), 0);
+  assert.equal(
+    computeOpportunityFreshness([{ state: "closed", updatedAt: "2026-07-01T00:00:00.000Z" }], nowMs),
+    0,
+  );
+});
+
+test("computeOpportunityFreshness decays with issue age", () => {
+  const fresh = computeOpportunityFreshness(
+    [{ state: "open", updatedAt: "2026-07-01T00:00:00.000Z" }],
+    nowMs,
+  );
+  assert.ok(fresh > 0.7);
+
+  const stale = computeOpportunityFreshness(
+    [{ state: "open", createdAt: "2023-01-01T00:00:00.000Z" }],
+    nowMs,
+  );
+  assert.ok(stale <= 0.05);
+});
+
+test("computeOpportunityFreshness uses the most recently updated open issue", () => {
+  const score = computeOpportunityFreshness(
+    [
+      { state: "open", updatedAt: "2023-01-01T00:00:00.000Z" },
+      { state: "open", updatedAt: "2026-07-01T00:00:00.000Z" },
+    ],
+    nowMs,
+  );
+  assert.ok(score > 0.7);
+});
+
+test("computeOpportunityFreshness normalizes issue state case and blank timestamps", () => {
+  assert.ok(
+    computeOpportunityFreshness([{ state: "OPEN", updatedAt: "2026-07-01T00:00:00.000Z" }], nowMs) > 0.7,
+  );
+  const score = computeOpportunityFreshness(
+    [{ state: "open", updatedAt: "", createdAt: "2026-07-01T00:00:00.000Z" }],
+    nowMs,
+  );
+  assert.ok(score > 0.7);
+});
+
+test("computeOpportunityFreshness treats malformed timestamps as fresh", () => {
+  assert.ok(
+    computeOpportunityFreshness([{ state: "open", updatedAt: "not-a-date" }], nowMs) > 0.9,
+  );
+});

--- a/packages/gittensory-engine/test/opportunity-freshness.test.ts
+++ b/packages/gittensory-engine/test/opportunity-freshness.test.ts
@@ -46,6 +46,9 @@ test("computeOpportunityFreshness normalizes issue state case and blank timestam
   assert.ok(
     computeOpportunityFreshness([{ state: "OPEN", updatedAt: "2026-07-01T00:00:00.000Z" }], nowMs) > 0.7,
   );
+  assert.ok(
+    computeOpportunityFreshness([{ state: " open ", updatedAt: "2026-07-01T00:00:00.000Z" }], nowMs) > 0.7,
+  );
   const score = computeOpportunityFreshness(
     [{ state: "open", updatedAt: "", createdAt: "2026-07-01T00:00:00.000Z" }],
     nowMs,
@@ -53,8 +56,16 @@ test("computeOpportunityFreshness normalizes issue state case and blank timestam
   assert.ok(score > 0.7);
 });
 
-test("computeOpportunityFreshness treats malformed timestamps as fresh", () => {
-  assert.ok(
-    computeOpportunityFreshness([{ state: "open", updatedAt: "not-a-date" }], nowMs) > 0.9,
+test("computeOpportunityFreshness falls back from malformed updatedAt to createdAt", () => {
+  const stale = computeOpportunityFreshness(
+    [{ state: "open", updatedAt: "not-a-date", createdAt: "2023-01-01T00:00:00.000Z" }],
+    nowMs,
   );
+  assert.ok(stale <= 0.05);
+
+  const fresh = computeOpportunityFreshness(
+    [{ state: "open", updatedAt: "not-a-date", createdAt: "2026-07-01T00:00:00.000Z" }],
+    nowMs,
+  );
+  assert.ok(fresh > 0.7);
 });


### PR DESCRIPTION
## Summary
- Add `computeOpportunityFreshness` to `@jsonbored/gittensory-engine` for the ranker `freshness` signal documented by `opportunity-ranker`.
- Mirror the decay curve from `src/signals/reward-risk.ts` with an injected `nowMs` clock, case-normalized open states, and blank-timestamp fallback to `createdAt`.
- Export through the engine barrel with tests importing from `dist/index.js`.

## Test plan
- [x] `npm test --workspace @jsonbored/gittensory-engine`
- [ ] CI green on upstream


