### PR TITLE
feat(miner): add run-state CLI commands

### DIFF
--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -49,7 +49,7 @@ if (cliArgs[0] === "hooks" && cliArgs[1] === "check") {
   process.exit(exitCode);
 }
 
-if (cliArgs[0] === "state" && (cliArgs[1] === "get" || cliArgs[1] === "set")) {
+if (cliArgs[0] === "state") {
   const exitCode = runStateCli(cliArgs[1], cliArgs.slice(2));
   await awaitOpportunisticUpdateCheck(updateCheck);
   process.exit(exitCode);

--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
 import { runDenyCheck } from "../lib/deny-check.js";
+import { runStateCli } from "../lib/run-state-cli.js";
 import {
   awaitOpportunisticUpdateCheck,
   resolveUpgradeCommand,
@@ -44,6 +45,12 @@ if (
 
 if (cliArgs[0] === "hooks" && cliArgs[1] === "check") {
   const exitCode = runDenyCheck(cliArgs.slice(2));
+  await awaitOpportunisticUpdateCheck(updateCheck);
+  process.exit(exitCode);
+}
+
+if (cliArgs[0] === "state" && (cliArgs[1] === "get" || cliArgs[1] === "set")) {
+  const exitCode = runStateCli(cliArgs[1], cliArgs.slice(2));
   await awaitOpportunisticUpdateCheck(updateCheck);
   process.exit(exitCode);
 }

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -15,6 +15,8 @@ export function printHelp(input) {
       "  gittensory-miner help",
       "  gittensory-miner version",
       "  gittensory-miner hooks check --tool <name> --input <json> [--json]",
+      "  gittensory-miner state get <owner/repo> [--json]",
+      "  gittensory-miner state set <owner/repo> <idle|discovering|planning|preparing> [--json]",
       "",
       "Options:",
       "  --no-update-check  Skip the npm registry version nudge (also GITTENSORY_MINER_NO_UPDATE_CHECK=1)",

--- a/packages/gittensory-miner/lib/run-state-cli.d.ts
+++ b/packages/gittensory-miner/lib/run-state-cli.d.ts
@@ -1,0 +1,24 @@
+export type ParsedStateGetArgs =
+  | {
+      repoFullName: string;
+      json: boolean;
+    }
+  | { error: string };
+
+export type ParsedStateSetArgs =
+  | {
+      repoFullName: string;
+      state: "idle" | "discovering" | "planning" | "preparing";
+      json: boolean;
+    }
+  | { error: string };
+
+export function parseStateGetArgs(args: string[]): ParsedStateGetArgs;
+
+export function parseStateSetArgs(args: string[]): ParsedStateSetArgs;
+
+export function runStateGet(args: string[]): number;
+
+export function runStateSet(args: string[]): number;
+
+export function runStateCli(subcommand: string | undefined, args: string[]): number;

--- a/packages/gittensory-miner/lib/run-state-cli.js
+++ b/packages/gittensory-miner/lib/run-state-cli.js
@@ -80,13 +80,18 @@ export function runStateGet(args) {
     return 2;
   }
 
-  const state = getRunState(parsed.repoFullName);
-  if (parsed.json) {
-    console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
-  } else {
-    console.log(state ?? "none");
+  try {
+    const state = getRunState(parsed.repoFullName);
+    if (parsed.json) {
+      console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+    } else {
+      console.log(state ?? "none");
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
   }
-  return 0;
 }
 
 export function runStateSet(args) {

--- a/packages/gittensory-miner/lib/run-state-cli.js
+++ b/packages/gittensory-miner/lib/run-state-cli.js
@@ -1,0 +1,118 @@
+import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
+
+const STATE_GET_USAGE = "Usage: gittensory-miner state get <owner/repo> [--json]";
+const STATE_SET_USAGE =
+  "Usage: gittensory-miner state set <owner/repo> <idle|discovering|planning|preparing> [--json]";
+
+const allowedRunStates = new Set(RUN_STATES);
+
+function parseRepoArg(value, usage) {
+  if (!value) return { error: usage };
+  const trimmed = value.trim();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) {
+    return { error: "Repository must be in owner/repo form." };
+  }
+  return { repoFullName: `${owner}/${repo}` };
+}
+
+export function parseStateGetArgs(args) {
+  const options = { json: false };
+  const positional = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 1) {
+    return { error: STATE_GET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_GET_USAGE);
+  if ("error" in repo) return repo;
+
+  return { repoFullName: repo.repoFullName, ...options };
+}
+
+export function parseStateSetArgs(args) {
+  const options = { json: false };
+  const positional = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+
+  if (positional.length !== 2) {
+    return { error: STATE_SET_USAGE };
+  }
+
+  const repo = parseRepoArg(positional[0], STATE_SET_USAGE);
+  if ("error" in repo) return repo;
+
+  const state = positional[1];
+  if (!allowedRunStates.has(state)) {
+    return { error: `Invalid state: ${state}. Expected one of ${RUN_STATES.join(", ")}.` };
+  }
+
+  return { repoFullName: repo.repoFullName, state, ...options };
+}
+
+export function runStateGet(args) {
+  const parsed = parseStateGetArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    return 2;
+  }
+
+  const state = getRunState(parsed.repoFullName);
+  if (parsed.json) {
+    console.log(JSON.stringify({ repoFullName: parsed.repoFullName, state }));
+  } else {
+    console.log(state ?? "none");
+  }
+  return 0;
+}
+
+export function runStateSet(args) {
+  const parsed = parseStateSetArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    return 2;
+  }
+
+  try {
+    const write = setRunState(parsed.repoFullName, parsed.state);
+    if (parsed.json) {
+      console.log(JSON.stringify(write));
+    } else {
+      console.log(write.state);
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+}
+
+export function runStateCli(subcommand, args) {
+  if (subcommand === "get") return runStateGet(args);
+  if (subcommand === "set") return runStateSet(args);
+  console.error(`Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
+  return 2;
+}

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/run-state-cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-cli-run-state.test.ts
+++ b/test/unit/miner-cli-run-state.test.ts
@@ -17,6 +17,7 @@ const {
 } = await import("../../packages/gittensory-miner/lib/run-state-cli.js");
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -67,5 +68,14 @@ describe("gittensory-miner state CLI", () => {
     expect(runStateSet(["not-a-repo", "idle"])).toBe(2);
     expect(error).toHaveBeenCalledWith("Repository must be in owner/repo form.");
     expect(setRunState).not.toHaveBeenCalled();
+  });
+
+  it("runStateGet returns exit code 2 when the store read fails", () => {
+    getRunState.mockImplementation(() => {
+      throw new Error("invalid_repo_full_name");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateGet(["acme/widgets"])).toBe(2);
+    expect(error).toHaveBeenCalledWith("invalid_repo_full_name");
   });
 });

--- a/test/unit/miner-cli-run-state.test.ts
+++ b/test/unit/miner-cli-run-state.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getRunState = vi.fn();
+const setRunState = vi.fn();
+
+vi.mock("../../packages/gittensory-miner/lib/run-state.js", () => ({
+  RUN_STATES: ["idle", "discovering", "planning", "preparing"],
+  getRunState,
+  setRunState,
+}));
+
+const {
+  parseStateGetArgs,
+  parseStateSetArgs,
+  runStateGet,
+  runStateSet,
+} = await import("../../packages/gittensory-miner/lib/run-state-cli.js");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("gittensory-miner state CLI", () => {
+  it("parseStateGetArgs and parseStateSetArgs validate argv", () => {
+    expect(parseStateGetArgs([])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner state get"),
+    });
+    expect(parseStateGetArgs(["acme/widgets", "--json"])).toEqual({
+      repoFullName: "acme/widgets",
+      json: true,
+    });
+    expect(parseStateSetArgs(["acme/widgets", "planning"])).toEqual({
+      repoFullName: "acme/widgets",
+      state: "planning",
+      json: false,
+    });
+    expect(parseStateSetArgs(["acme/widgets", "bogus"])).toEqual({
+      error: expect.stringMatching(/Invalid state/),
+    });
+  });
+
+  it("runStateGet prints none before any write", () => {
+    getRunState.mockReturnValue(null);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runStateGet(["acme/widgets"])).toBe(0);
+    expect(getRunState).toHaveBeenCalledWith("acme/widgets");
+    expect(log).toHaveBeenCalledWith("none");
+  });
+
+  it("runStateSet persists state and runStateGet returns JSON output", () => {
+    setRunState.mockReturnValue({
+      repoFullName: "acme/widgets",
+      state: "discovering",
+      updatedAt: "2026-07-03T00:00:00.000Z",
+    });
+    getRunState.mockReturnValue("discovering");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runStateSet(["acme/widgets", "discovering", "--json"])).toBe(0);
+    expect(runStateGet(["acme/widgets", "--json"])).toBe(0);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('"state":"discovering"'),
+    );
+  });
+
+  it("runStateSet returns exit code 2 for malformed repositories", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runStateSet(["not-a-repo", "idle"])).toBe(2);
+    expect(error).toHaveBeenCalledWith("Repository must be in owner/repo form.");
+    expect(setRunState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `gittensory-miner state get|set` for the local SQLite run-state store (#2289).
- Support `--json` output for scripting and document the commands in `--help`.
- Unit tests cover arg parsing, allow paths, and malformed repository handling via mocked store calls.

## Test plan
- [x] `npm test -- test/unit/miner-cli-run-state.test.ts`
- [ ] CI green on upstream


