### PR TITLE
fix(github): reject malformed repo slugs in label helpers

### DIFF
--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -6,6 +6,17 @@ type GitHubLabel = {
   name?: string | null;
 };
 
+function parseRepoFullName(repoFullName: string): { owner: string; repo: string } {
+  if (repoFullName !== repoFullName.trim()) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  const parts = repoFullName.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
 export async function ensurePullRequestLabel(
   env: Env,
   installationId: number,
@@ -14,8 +25,7 @@ export async function ensurePullRequestLabel(
   labelName: string,
   options: { createMissingLabel: boolean; mode?: AgentActionMode },
 ): Promise<{ applied: boolean; created: boolean }> {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) throw new Error(`Invalid repository full name: ${repoFullName}`);
+  const { owner, repo } = parseRepoFullName(repoFullName);
 
   const token = await createInstallationToken(env, installationId);
   // Non-live mode suppresses the label create + apply writes; the GET dedup probe below still runs.
@@ -61,8 +71,13 @@ export async function ensurePullRequestLabel(
 /** Remove a single label from a PR if present. Best-effort — a 404 (label not on the PR) is ignored. Used to
  *  keep the mutually-exclusive managed TYPE labels (gittensor:bug/feature/priority) down to exactly one. */
 export async function removePullRequestLabel(env: Env, installationId: number, repoFullName: string, pullNumber: number, labelName: string, mode: AgentActionMode = "live"): Promise<void> {
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo) return;
+  let owner: string;
+  let repo: string;
+  try {
+    ({ owner, repo } = parseRepoFullName(repoFullName));
+  } catch {
+    return;
+  }
   const token = await createInstallationToken(env, installationId);
   const octokit = makeInstallationOctokit(env, token, mode, githubRateLimitAdmissionKeyForInstallation(installationId));
   await octokit

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -7,14 +7,15 @@ type GitHubLabel = {
 };
 
 function parseRepoFullName(repoFullName: string): { owner: string; repo: string } {
-  if (repoFullName !== repoFullName.trim()) {
-    throw new Error(`Invalid repository full name: ${repoFullName}`);
-  }
   const parts = repoFullName.split("/");
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+  const owner = parts[0];
+  const repo = parts[1];
+  // Reject any whitespace (leading, trailing, or per-segment like `owner/ repo`) so a padded slug can never
+  // reach a GitHub call — a valid owner/repo name never contains spaces.
+  if (parts.length !== 2 || !owner || !repo || /\s/.test(repoFullName)) {
     throw new Error(`Invalid repository full name: ${repoFullName}`);
   }
-  return { owner: parts[0], repo: parts[1] };
+  return { owner, repo };
 }
 
 export async function ensurePullRequestLabel(

--- a/test/unit/github-labels.test.ts
+++ b/test/unit/github-labels.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { ensurePullRequestLabel } from "../../src/github/labels";
+import { ensurePullRequestLabel, removePullRequestLabel } from "../../src/github/labels";
 import { createTestEnv } from "../helpers/d1";
 
 describe("GitHub PR labels", () => {
@@ -10,6 +10,48 @@ describe("GitHub PR labels", () => {
 
   it("rejects invalid repository names before making GitHub calls", async () => {
     await expect(ensurePullRequestLabel(createTestEnv(), 123, "invalid", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(/Invalid repository full name/);
+    await expect(ensurePullRequestLabel(createTestEnv(), 123, "owner/repo/extra", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    await expect(ensurePullRequestLabel(createTestEnv(), 123, " owner/repo ", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
+      /Invalid repository full name/,
+    );
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return Response.json({ token: "t" });
+    });
+    await expect(
+      ensurePullRequestLabel(
+        createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),
+        123,
+        "owner/repo/extra",
+        4,
+        "gittensor",
+        { createMissingLabel: true },
+      ),
+    ).rejects.toThrow(/Invalid repository full name/);
+    expect(called).toBe(false);
+  });
+
+  it("removePullRequestLabel: skips malformed repository names without calling GitHub", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return Response.json({ token: "t" });
+    });
+    for (const repoFullName of ["invalid", "owner/repo/extra", " owner/repo "]) {
+      await expect(
+        removePullRequestLabel(
+          createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),
+          123,
+          repoFullName,
+          4,
+          "gittensor",
+        ),
+      ).resolves.toBeUndefined();
+    }
+    expect(called).toBe(false);
   });
 
   it("does nothing when the label is already applied", async () => {

--- a/test/unit/github-labels.test.ts
+++ b/test/unit/github-labels.test.ts
@@ -13,24 +13,28 @@ describe("GitHub PR labels", () => {
     await expect(ensurePullRequestLabel(createTestEnv(), 123, "owner/repo/extra", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
       /Invalid repository full name/,
     );
-    await expect(ensurePullRequestLabel(createTestEnv(), 123, " owner/repo ", 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
-      /Invalid repository full name/,
-    );
+    for (const padded of [" owner/repo ", "owner/ repo", "owner /repo", "own er/repo"]) {
+      await expect(ensurePullRequestLabel(createTestEnv(), 123, padded, 4, "gittensor", { createMissingLabel: true })).rejects.toThrow(
+        /Invalid repository full name/,
+      );
+    }
     let called = false;
     vi.stubGlobal("fetch", async () => {
       called = true;
       return Response.json({ token: "t" });
     });
-    await expect(
-      ensurePullRequestLabel(
-        createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),
-        123,
-        "owner/repo/extra",
-        4,
-        "gittensor",
-        { createMissingLabel: true },
-      ),
-    ).rejects.toThrow(/Invalid repository full name/);
+    for (const malformed of ["owner/repo/extra", "owner/ repo", "owner /repo"]) {
+      await expect(
+        ensurePullRequestLabel(
+          createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),
+          123,
+          malformed,
+          4,
+          "gittensor",
+          { createMissingLabel: true },
+        ),
+      ).rejects.toThrow(/Invalid repository full name/);
+    }
     expect(called).toBe(false);
   });
 
@@ -40,7 +44,7 @@ describe("GitHub PR labels", () => {
       called = true;
       return Response.json({ token: "t" });
     });
-    for (const repoFullName of ["invalid", "owner/repo/extra", " owner/repo "]) {
+    for (const repoFullName of ["invalid", "owner/repo/extra", " owner/repo ", "owner/ repo", "owner /repo"]) {
       await expect(
         removePullRequestLabel(
           createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }),


### PR DESCRIPTION
## Summary

- Require exactly `owner/repo` in label mutation helpers, matching the merged `pr-actions` fail-closed contract.
- Reject multi-segment and padded slugs before any GitHub label create/apply/delete call.

## Test plan

- [x] `npx vitest run test/unit/github-labels.test.ts`