### PR TITLE
fix(enrichment): reject multi-segment repo slugs in doc-comment drift scan

### DIFF
--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -347,8 +347,10 @@ export async function scanDocCommentDrift(
 ): Promise<DocCommentDriftFinding[]> {
   const { repoFullName, githubToken, headSha, files = [] } = req;
   if (!githubToken || !headSha) return [];
-  const [owner, repo] = repoFullName.split("/");
-  if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${githubToken}`,

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -276,6 +276,19 @@ test("scanDocCommentDrift: requires a github token and a head sha", async () => 
   assert.deepEqual(await scanDocCommentDrift({ repoFullName: "o/r", prNumber: 1, githubToken: "t", files: [{ path: "src/a.ts", patch: DRIFT_PATCH }] }, fileWith(DRIFTED)), []);
 });
 
+test("scanDocCommentDrift: rejects multi-segment repo slugs without fetching", async () => {
+  let called = false;
+  const out = await scanDocCommentDrift(
+    { repoFullName: "o/r/extra", prNumber: 1, headSha: "abc123", githubToken: "ght", files: [{ path: "src/a.ts", patch: DRIFT_PATCH }] },
+    async () => {
+      called = true;
+      return fileWith(DRIFTED)();
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanDocCommentDrift: skips non-source and test files without fetching", async () => {
   let called = false;
   const out = await scanDocCommentDrift(


### PR DESCRIPTION
## Summary

- Require exactly `owner/repo` before the doc-comment drift analyzer fetches head content.
- Reject multi-segment repo slugs so malformed identifiers fail closed instead of querying the wrong repository.

## Test plan

- [x] `npm run rees:test -- test/doc-comment-drift.test.ts`