### PR TITLE
test(content-lane): cover missing-status scope-close in classifyContentFiles

### DIFF
--- a/test/unit/content-lane-scope.test.ts
+++ b/test/unit/content-lane-scope.test.ts
@@ -110,6 +110,20 @@ describe("classifyContentFiles", () => {
     expect(r.kind).toBe("close");
   });
 
+  it("closes a single supported entry whose status is missing or empty (scope-status guard)", () => {
+    // A content file that arrives with no `status` (or an empty one) is not a trustworthy add/edit: the
+    // `String(entry.file.status || "")` falsy path normalizes it to "" so it fails the added/modified check
+    // and routes to a scope-status close, never a silent review.
+    const missingStatus = classifyContentFiles([{ filename: "content/skills/foo.mdx" }]);
+    expect(missingStatus.kind).toBe("close");
+    if (missingStatus.kind === "close") {
+      expect(missingStatus.category).toBe("skills");
+      expect(missingStatus.reason).toContain("Direct content submissions can only add a new content file");
+    }
+    // An explicitly empty status string takes the same falsy branch.
+    expect(classifyContentFiles([{ filename: "content/skills/foo.mdx", status: "" }]).kind).toBe("close");
+  });
+
   it("exposes the supported categories set", () => {
     expect(SUPPORTED_CONTENT_CATEGORIES.has("skills")).toBe(true);
     expect(SUPPORTED_CONTENT_CATEGORIES.has("not-a-category")).toBe(false);


### PR DESCRIPTION
## Summary

Adds a focused unit test for a previously-uncovered branch in the content-lane scope
primitive. `classifyContentFiles` (`src/review/content-lane/scope.ts`) normalizes a content
file's status with `String(entry.file.status || "")`; every existing test that reaches that
line supplies a truthy status (`added` / `modified` / `removed` / `renamed`), so the **falsy
arm** — a single supported-category entry whose `status` is missing or empty — was never
exercised. That path routes the PR to a `scope-status` close (SCOPE_STATUS) rather than a
silent review, so it is a real behavior worth pinning with a regression test.

Test-only change; touches exactly one file (`test/unit/content-lane-scope.test.ts`). Branch
coverage of `scope.ts` rises from 93.2% → 95.45% with this case covered (the two remaining
uncovered lines are unreachable defensive guards). No production code changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed — self-contained coverage add for an existing pure function; no issue needed (mirrors the recently-merged test-only coverage add #2748).

## Validation

- [x] `git diff --check` — clean
- [x] `npm run actionlint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm run test:coverage` — the new/changed file passes; `scope.ts` line 124 now covered. `codecov/patch` obligation for this diff is zero (the only change is in `test/**`, which is codecov-ignored).
- [x] New behavior has a unit test for the previously-uncovered fallback branch

If any required check was skipped, explain why:

- This is a single additive unit test in `test/**`, with no `src/`, schema, binding, migration, MCP, or UI change — so `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:*`, `cf-typegen`, and OpenAPI/migration regen are unaffected by this diff and were not separately re-run.
- Running the full suite locally surfaced two artifacts that are **independent of this change** (both reproduce on a pristine checkout with the diff stashed): (1) `selfhost:env-reference:check` reports `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` stale — a generated UI file this PR does not touch; (2) three CPU-heavy tests in the unrelated `test/unit/routes-remediation-plan.test.ts` hit the 30s per-test timeout under full-suite parallel load but pass when the file is run in isolation (CI shards the suite, so they are not starved there).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence exposed.
- [x] Public text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/GitHub-App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI changes.
- [x] No changelog edit (not a release-prep PR).

## Notes

- Test asserts both the missing-`status` case and the explicit empty-string `status` case take the same falsy branch and produce a `close` with the `SCOPE_STATUS` guidance.
