### PR TITLE
feat(engine): add plan/create/manage templates and competition parity

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -58,6 +58,18 @@ rankOpportunities(candidates); // sorted by descending score, each annotated wit
 `rankOpportunities` is a stable sort with an explicit index tie-break: candidates with an equal score keep their
 input order.
 
+## Plan templates
+
+`plan-templates.ts` exports one builder per miner lifecycle stage (`analyze`, `plan`, `prepare`, `create`, `manage`).
+Each builder returns `RawPlanStep[]` in the shape accepted by `gittensory_build_plan`. Templates are pure data — they
+describe step ordering via `dependsOn` but never actuate anything.
+
+## Opportunity competition
+
+`computeOpportunityCompetition(highRiskDuplicateClusters, openPullRequests)` mirrors the hosted
+`opportunityCompetitionFactor` in `src/signals/reward-risk.ts`, producing a `[0, 1]` signal suitable for the ranker's
+`dupRisk` input.
+
 ## AI Policy Map
 
 `scanAiPolicyText` and `resolveAiPolicyVerdict` provide the deterministic policy gate used by miner discovery.

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -33,3 +33,4 @@ export {
   computeMinerGoalLaneFit,
   isMinerRepoTargetable,
 } from "./miner-goal-lane-fit.js";
+export { computeOpportunityCompetition } from "./opportunity-competition.js";

--- a/packages/gittensory-engine/src/opportunity-competition.ts
+++ b/packages/gittensory-engine/src/opportunity-competition.ts
@@ -1,0 +1,26 @@
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function finiteNonNegative(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+/**
+ * Compute a [0, 1] competition factor from duplicate-cluster pressure and open PR volume, mirroring
+ * `opportunityCompetitionFactor` in `src/signals/reward-risk.ts` so the miner engine can derive `dupRisk`
+ * inputs without importing hosted signal code.
+ */
+export function computeOpportunityCompetition(
+  highRiskDuplicateClusters: number,
+  openPullRequests: number,
+): number {
+  const clusters = finiteNonNegative(highRiskDuplicateClusters);
+  const openPrs = finiteNonNegative(openPullRequests);
+  return round4(clamp(clusters / Math.max(1, openPrs), 0, 1));
+}

--- a/packages/gittensory-engine/src/plan-templates.ts
+++ b/packages/gittensory-engine/src/plan-templates.ts
@@ -17,7 +17,7 @@ export type RawPlanStep = {
 };
 
 // The lifecycle-stage transitions this library provides a template for.
-export type PlanTemplateStage = "analyze" | "prepare";
+export type PlanTemplateStage = "analyze" | "create" | "manage" | "plan" | "prepare";
 
 // Context woven into a template's step titles so a plan reads against the opportunity it targets.
 export type PlanTemplateContext = {
@@ -55,6 +55,16 @@ export function analyzePlanTemplate(context: PlanTemplateContext = {}): RawPlanS
   ];
 }
 
+// plan: validate the analyze prompt packet, build the execution DAG, then run a readiness check before prepare.
+export function planPlanTemplate(context: PlanTemplateContext = {}): RawPlanStep[] {
+  const subject = normalizeSubject(context.subject);
+  return [
+    { id: "packet-validate", title: titleFor("Validate prompt packet", subject), actionClass: "analyze", dependsOn: [], maxAttempts: 1 },
+    { id: "plan-dag-build", title: titleFor("Build execution plan DAG", subject), actionClass: "compose", dependsOn: ["packet-validate"], maxAttempts: 2 },
+    { id: "readiness-check", title: titleFor("Run plan readiness check", subject), actionClass: "analyze", dependsOn: ["plan-dag-build"], maxAttempts: 1 },
+  ];
+}
+
 // prepare: a strict chain — create the branch, invoke the coding agent (placeholder step; no actuation here), then
 // run the local tests. Mirrors the PREPARE-phase ordering described in the plan-template issue.
 export function preparePlanTemplate(context: PlanTemplateContext = {}): RawPlanStep[] {
@@ -66,11 +76,34 @@ export function preparePlanTemplate(context: PlanTemplateContext = {}): RawPlanS
   ];
 }
 
+// create: commit the working tree, push the branch, then open the pull request with the public-safe packet.
+export function createPlanTemplate(context: PlanTemplateContext = {}): RawPlanStep[] {
+  const subject = normalizeSubject(context.subject);
+  return [
+    { id: "commit-changes", title: titleFor("Commit working tree changes", subject), actionClass: "vcs", dependsOn: [], maxAttempts: 2 },
+    { id: "push-branch", title: titleFor("Push feature branch", subject), actionClass: "vcs", dependsOn: ["commit-changes"], maxAttempts: 3 },
+    { id: "open-pull-request", title: titleFor("Open pull request", subject), actionClass: "github", dependsOn: ["push-branch"], maxAttempts: 2 },
+  ];
+}
+
+// manage: wait for CI, read the gate verdict, then sync the fork default branch for the next cycle.
+export function managePlanTemplate(context: PlanTemplateContext = {}): RawPlanStep[] {
+  const subject = normalizeSubject(context.subject);
+  return [
+    { id: "wait-ci", title: titleFor("Wait for CI completion", subject), actionClass: "test", dependsOn: [], maxAttempts: 5 },
+    { id: "read-gate-result", title: titleFor("Read gate verdict", subject), actionClass: "analyze", dependsOn: ["wait-ci"], maxAttempts: 2 },
+    { id: "sync-fork", title: titleFor("Sync fork default branch", subject), actionClass: "vcs", dependsOn: ["read-gate-result"], maxAttempts: 3 },
+  ];
+}
+
 // Registry of every stage transition to its template builder, so callers can enumerate or dispatch by stage.
 // Frozen so a consumer cannot mutate the shared registry and change dispatch behavior process-wide.
 export const PLAN_TEMPLATE_BUILDERS: Readonly<Record<PlanTemplateStage, (context?: PlanTemplateContext) => RawPlanStep[]>> =
   Object.freeze({
     analyze: analyzePlanTemplate,
+    create: createPlanTemplate,
+    manage: managePlanTemplate,
+    plan: planPlanTemplate,
     prepare: preparePlanTemplate,
   });
 

--- a/packages/gittensory-engine/test/opportunity-competition.test.ts
+++ b/packages/gittensory-engine/test/opportunity-competition.test.ts
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeOpportunityCompetition } from "../dist/index.js";
+
+test("barrel: the public entrypoint re-exports the competition scorer API", () => {
+  assert.equal(typeof computeOpportunityCompetition, "function");
+});
+
+test("computeOpportunityCompetition: zero clusters or zero open PRs yields 0", () => {
+  assert.equal(computeOpportunityCompetition(0, 0), 0);
+  assert.equal(computeOpportunityCompetition(0, 5), 0);
+});
+
+test("computeOpportunityCompetition: zero open PR volume still caps at 1 when clusters are present", () => {
+  assert.equal(computeOpportunityCompetition(3, 0), 1);
+});
+
+test("computeOpportunityCompetition: scales high-risk clusters against open PR volume", () => {
+  assert.equal(computeOpportunityCompetition(2, 4), 0.5);
+  assert.equal(computeOpportunityCompetition(4, 4), 1);
+  assert.equal(computeOpportunityCompetition(10, 4), 1);
+});
+
+test("computeOpportunityCompetition: non-finite and negative inputs degrade safely", () => {
+  assert.equal(computeOpportunityCompetition(Number.NaN, 4), 0);
+  assert.equal(computeOpportunityCompetition(2, Number.POSITIVE_INFINITY), 1);
+  assert.equal(computeOpportunityCompetition(-3, 4), 0);
+  assert.equal(computeOpportunityCompetition(2, -1), 1);
+});

--- a/test/unit/opportunity-competition.test.ts
+++ b/test/unit/opportunity-competition.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { computeOpportunityCompetition } from "../../packages/gittensory-engine/src/opportunity-competition";
+
+describe("computeOpportunityCompetition", () => {
+  it("mirrors hosted reward-risk competitionFactor for representative inputs", () => {
+    expect(computeOpportunityCompetition(0, 12)).toBe(0);
+    expect(computeOpportunityCompetition(3, 6)).toBe(0.5);
+    expect(computeOpportunityCompetition(9, 3)).toBe(1);
+  });
+
+  it("treats a broken cluster count as zero contention", () => {
+    expect(computeOpportunityCompetition(Number.NaN, 3)).toBe(0);
+    expect(computeOpportunityCompetition(Number.NEGATIVE_INFINITY, 3)).toBe(0);
+  });
+
+  it("never divides by zero when open PR volume is missing", () => {
+    expect(computeOpportunityCompetition(2, 0)).toBe(1);
+    expect(computeOpportunityCompetition(2, Number.NaN)).toBe(1);
+    expect(computeOpportunityCompetition(0, Number.NaN)).toBe(0);
+  });
+});

--- a/test/unit/plan-templates.test.ts
+++ b/test/unit/plan-templates.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   analyzePlanTemplate,
   buildPlanTemplate,
+  createPlanTemplate,
+  managePlanTemplate,
+  planPlanTemplate,
   preparePlanTemplate,
   PLAN_TEMPLATE_BUILDERS,
   type PlanTemplateStage,
@@ -17,7 +20,7 @@ function idsOf(steps: RawPlanStep[]): string[] {
 
 describe("plan-templates", () => {
   it("exposes a builder for every declared stage", () => {
-    expect(STAGES.sort()).toEqual(["analyze", "prepare"]);
+    expect(STAGES.sort()).toEqual(["analyze", "create", "manage", "plan", "prepare"]);
   });
 
   it.each(STAGES)("'%s' template round-trips through the real rawPlanStepSchema", (stage) => {
@@ -48,7 +51,10 @@ describe("plan-templates", () => {
 
   it("is deterministic: same context yields identical output", () => {
     expect(analyzePlanTemplate({ subject: "x" })).toEqual(analyzePlanTemplate({ subject: "x" }));
+    expect(planPlanTemplate({ subject: "x" })).toEqual(planPlanTemplate({ subject: "x" }));
     expect(preparePlanTemplate()).toEqual(preparePlanTemplate());
+    expect(createPlanTemplate({ subject: "x" })).toEqual(createPlanTemplate({ subject: "x" }));
+    expect(managePlanTemplate()).toEqual(managePlanTemplate());
   });
 
   it("weaves the subject into every title as a single clean line", () => {
@@ -83,6 +89,27 @@ describe("plan-templates", () => {
     expect(steps.map((s) => s.id)).toEqual(["branch-create", "coding-agent", "local-test"]);
     expect(steps.find((s) => s.id === "coding-agent")?.dependsOn).toEqual(["branch-create"]);
     expect(steps.find((s) => s.id === "local-test")?.dependsOn).toEqual(["coding-agent"]);
+  });
+
+  it("encodes the real plan ordering: readiness depends on the built DAG", () => {
+    const steps = planPlanTemplate();
+    expect(steps.map((s) => s.id)).toEqual(["packet-validate", "plan-dag-build", "readiness-check"]);
+    expect(steps.find((s) => s.id === "plan-dag-build")?.dependsOn).toEqual(["packet-validate"]);
+    expect(steps.find((s) => s.id === "readiness-check")?.dependsOn).toEqual(["plan-dag-build"]);
+  });
+
+  it("encodes the real create ordering: open PR depends on a pushed branch", () => {
+    const steps = createPlanTemplate();
+    expect(steps.map((s) => s.id)).toEqual(["commit-changes", "push-branch", "open-pull-request"]);
+    expect(steps.find((s) => s.id === "push-branch")?.dependsOn).toEqual(["commit-changes"]);
+    expect(steps.find((s) => s.id === "open-pull-request")?.dependsOn).toEqual(["push-branch"]);
+  });
+
+  it("encodes the real manage ordering: fork sync follows the gate verdict", () => {
+    const steps = managePlanTemplate();
+    expect(steps.map((s) => s.id)).toEqual(["wait-ci", "read-gate-result", "sync-fork"]);
+    expect(steps.find((s) => s.id === "read-gate-result")?.dependsOn).toEqual(["wait-ci"]);
+    expect(steps.find((s) => s.id === "sync-fork")?.dependsOn).toEqual(["read-gate-result"]);
   });
 
   it("rejects an unknown stage with a clear error instead of a generic TypeError", () => {


### PR DESCRIPTION
## Summary

- Add `planPlanTemplate`, `createPlanTemplate`, and `managePlanTemplate` to the shared engine plan-template library so miners can describe the remaining miner lifecycle stages in the exact `gittensory_build_plan` raw-step shape.
- Export `computeOpportunityCompetition` for engine parity with hosted `opportunityCompetitionFactor`, giving local rankers a pure `dupRisk` input without importing `src/signals/reward-risk.ts`.
- Cover every new branch with unit tests and document the new surfaces in the engine README.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Local `npm run test:ci` is pending in this environment because Node.js is not installed on the contributor machine; CI will run the full gate on push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend engine-only change.

## Notes

- Plan/create/manage templates follow the same ordering contracts as the existing analyze/prepare builders and round-trip through `rawPlanStepSchema`.
- `computeOpportunityCompetition` mirrors the hosted formula `clamp(highRisk / max(1, openPrs), 0, 1)` with safe handling for non-finite inputs.
