### PR TITLE
fix(signals): derive direct-PR lane preference from public-safe test expectations

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1935,10 +1935,15 @@ function buildPolicyContributionLanes(manifest: FocusManifest): FocusManifestPol
   const lanes: FocusManifestPolicyContributionLane[] = [];
   const safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe);
   const safeBlockedPaths = manifest.blockedPaths.filter(isFocusManifestPublicSafe);
+  const safeTestExpectations = manifest.testExpectations.filter(isFocusManifestPublicSafe);
 
+  // Derive the public preference only from public-safe signals: use the SAME filtered list that surfaces in
+  // validationExpectations below, not the raw testExpectations. Otherwise a manifest whose only test expectation is
+  // public-unsafe (e.g. a wallet/seed phrase) is redacted from the lane yet still flips the public preference to
+  // "preferred" ("…with required validation evidence"), a self-contradictory verdict with no visible basis.
   const directPrPreference: "preferred" | "neutral" | "discouraged" =
     manifest.issueDiscoveryPolicy === "encouraged" ? "discouraged"
-    : safeWantedPaths.length > 0 || manifest.testExpectations.length > 0 ? "preferred"
+    : safeWantedPaths.length > 0 || safeTestExpectations.length > 0 ? "preferred"
     : "neutral";
 
   lanes.push({
@@ -1953,7 +1958,7 @@ function buildPolicyContributionLanes(manifest: FocusManifest): FocusManifestPol
           : "Direct pull requests are accepted when they stay inside maintainer-wanted scope.",
     preferredPaths: safeWantedPaths,
     discouragedPaths: safeBlockedPaths,
-    validationExpectations: manifest.testExpectations.filter(isFocusManifestPublicSafe),
+    validationExpectations: safeTestExpectations,
     publicNotes: manifest.publicNotes.filter(isFocusManifestPublicSafe),
   });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -386,6 +386,26 @@ describe("compileFocusManifestPolicy", () => {
     expect(policy.authenticated.privateNoteCount).toBe(0);
   });
 
+  it("does not mark the direct-PR lane 'preferred' from a redacted (public-unsafe) test expectation", () => {
+    // The only test expectation is public-unsafe (wallet/seed) and there are no wanted paths, so nothing
+    // public-safe signals that direct PRs are preferred. The lane preference must derive from the same
+    // public-safe-filtered list it displays, not the raw testExpectations count.
+    const manifest = parseFocusManifest({ testExpectations: ["Submit your wallet seed phrase"] });
+    const policy = compileFocusManifestPolicy(REPO, manifest, opts);
+    const directPr = policy.publicSafe.contributionLanes.find((lane) => lane.id === "direct-pr");
+    expect(directPr).toBeDefined();
+    expect(directPr!.validationExpectations).toEqual([]); // the unsafe expectation is redacted from the lane
+    expect(directPr!.preferredPaths).toEqual([]);
+    expect(directPr!.preference).toBe("neutral"); // was wrongly "preferred", driven by the raw (unfiltered) count
+    expect(directPr!.summary).not.toMatch(/required validation evidence/i);
+
+    // A PUBLIC-SAFE test expectation (no wanted paths) still drives the lane to "preferred" — the signal is real.
+    const safeManifest = parseFocusManifest({ testExpectations: ["unit tests for new branches"] });
+    const safeDirectPr = compileFocusManifestPolicy(REPO, safeManifest, opts).publicSafe.contributionLanes.find((lane) => lane.id === "direct-pr");
+    expect(safeDirectPr!.preference).toBe("preferred");
+    expect(safeDirectPr!.validationExpectations).toEqual(["unit tests for new branches"]);
+  });
+
   it("forwards parse warnings into authenticated.parseWarnings for a malformed manifest", () => {
     const policy = compileFocusManifestPolicy(REPO, parseFocusManifestContent("{ broken json"), opts);
     expect(policy.present).toBe(false);


### PR DESCRIPTION
`buildPolicyContributionLanes` builds the **publicSafe** `contributionLanes`, but the direct-PR lane preference mixed a public-safe-filtered operand with a raw one:

```
const safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe);
...
const directPrPreference =
  manifest.issueDiscoveryPolicy === "encouraged" ? "discouraged"
  : safeWantedPaths.length > 0 || manifest.testExpectations.length > 0 ? "preferred"  // ← raw testExpectations
  : "neutral";
```

`safeWantedPaths` is public-safe-filtered, but `manifest.testExpectations` is the **raw** list — even though the very same block filters that field before surfacing it (`validationExpectations: manifest.testExpectations.filter(isFocusManifestPublicSafe)`).

## Impact
For a manifest whose only test expectation is public-unsafe (e.g. `["Submit your wallet seed phrase"]`) and which has no wanted paths:
- `validationExpectations` → `[]` (redacted), `preferredPaths` → `[]`
- but `directPrPreference` → `"preferred"`, summary → *"Contribute changes in maintainer-wanted areas with required validation evidence."*

The public lane asserts a "preferred, with required validation evidence" verdict whose entire basis is redacted and never shown — a self-contradictory public output, and a weak leak that *some* private expectation exists.

## Why this is a defect, not a convention
The function's contract is public-safe derivation: every other operand and output here is `isFocusManifestPublicSafe`-filtered (`safeWantedPaths` on the same line; `validationExpectations` 15 lines later; `publicNotes`). Mixing a raw operand into that single decision contradicts the module's own discipline — the same shape as the recently-merged #2722 (a predicate inconsistent with its sibling).

## Fix
Filter `testExpectations` once (`safeTestExpectations`) and use it both in the preference decision and as the displayed `validationExpectations`. A **public-safe** test expectation still drives `"preferred"` (the signal is real); only redacted-only manifests fall back to `"neutral"`.

## Tests
Adds a regression case: a redacted-only test expectation yields a `neutral` direct-PR lane with no "required validation evidence" summary and empty `validationExpectations`; a public-safe test expectation still yields `preferred`. Verified the redacted case FAILS on current `main` and PASSES with the fix; `focus-manifest`, `repo-policy-compiler`, and `onboarding-pack` suites stay green.

No linked issue: issue creation is unavailable for this account.
