### PR TITLE
fix(content-lane): skip all block-scalar indicators when reading list source URLs

### DIFF
--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -180,7 +180,10 @@ function listSourceUrlValues(source: string, spec: ContentRepoSpec): SubmittedSo
       const key = topLevel[1] as string;
       const value = topLevel[2] as string;
       activeField = spec.sourceUrlListFields.has(key) ? key : "";
-      if (activeField && value && value !== "|" && value !== ">") {
+      // Skip a YAML block-scalar indicator (`|`, `>`, `|-`, `>-`, `|+`, `|2`, …) so it is not read as a URL. Use the
+      // same complete indicator grammar as the sibling parser (parseSimpleFrontmatter): the old `!== "|" && !== ">"`
+      // check let every non-bare form (`|-`, `>2`, …) through, surfacing the indicator string itself as a bogus URL.
+      if (activeField && value && !/^[|>][+-]?\d*$/.test(value)) {
         for (const url of scalarSourceUrlValues(value)) {
           values.push({ field: activeField, url });
         }

--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -114,6 +114,11 @@ function unquoteYamlScalar(value: string): string {
   return trimmed.replace(/\s+#.*$/, "").trim();
 }
 
+// A YAML block-scalar header indicator: `|` or `>` with an optional chomping (`+`/`-`) and/or a single indentation
+// digit, in EITHER order — `|`, `>`, `|-`, `>+`, `|2`, `|2-`, `|-2`, `>2+`. Kept in one place so the scalar and the
+// list frontmatter readers agree on what is a block-scalar header (and neither reads one as a value/URL).
+const BLOCK_SCALAR_INDICATOR = /^[|>](?:[+-]?\d?|\d[+-]?)$/;
+
 // Local frontmatter parser (scalar source-field reader; block-scalar aware so a URL written as a
 // block scalar is still SEEN by the source-reachability gate).
 function parseSimpleFrontmatter(source: string): Record<string, string> {
@@ -140,7 +145,7 @@ function parseSimpleFrontmatter(source: string): Record<string, string> {
     /* v8 ignore next */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (/^[|>][+-]?\d*$/.test(inline)) {
+    if (BLOCK_SCALAR_INDICATOR.test(inline)) {
       const block: string[] = [];
       while (i < lines.length && ((lines[i] ?? "").trim() === "" || /^\s/.test(lines[i] ?? ""))) {
         // `lines[i]` is bounded by the `i < lines.length` loop guard; `?? ""` cannot fire
@@ -180,10 +185,10 @@ function listSourceUrlValues(source: string, spec: ContentRepoSpec): SubmittedSo
       const key = topLevel[1] as string;
       const value = topLevel[2] as string;
       activeField = spec.sourceUrlListFields.has(key) ? key : "";
-      // Skip a YAML block-scalar indicator (`|`, `>`, `|-`, `>-`, `|+`, `|2`, …) so it is not read as a URL. Use the
-      // same complete indicator grammar as the sibling parser (parseSimpleFrontmatter): the old `!== "|" && !== ">"`
-      // check let every non-bare form (`|-`, `>2`, …) through, surfacing the indicator string itself as a bogus URL.
-      if (activeField && value && !/^[|>][+-]?\d*$/.test(value)) {
+      // Skip a YAML block-scalar header (`|`, `>`, `|-`, `>2`, `|2-`, …) so it is not read as a URL — the old
+      // `!== "|" && !== ">"` check let every non-bare form through, surfacing the indicator string itself as a bogus
+      // URL. Shares BLOCK_SCALAR_INDICATOR with the scalar reader so both agree on the full indicator grammar.
+      if (activeField && value && !BLOCK_SCALAR_INDICATOR.test(value)) {
         for (const url of scalarSourceUrlValues(value)) {
           values.push({ field: activeField, url });
         }

--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -119,6 +119,13 @@ function unquoteYamlScalar(value: string): string {
 // list frontmatter readers agree on what is a block-scalar header (and neither reads one as a value/URL).
 const BLOCK_SCALAR_INDICATOR = /^[|>](?:[+-]?\d?|\d[+-]?)$/;
 
+// True when a raw frontmatter value is a block-scalar header. Comment-tolerant: a header may carry a trailing inline
+// comment (`| # sources below`), which normalizes away (like every scalar here) before the indicator is matched — so
+// the header is recognized and never surfaced as a value/URL.
+function isBlockScalarHeader(raw: string): boolean {
+  return BLOCK_SCALAR_INDICATOR.test(stripYamlComment(raw));
+}
+
 // Local frontmatter parser (scalar source-field reader; block-scalar aware so a URL written as a
 // block scalar is still SEEN by the source-reachability gate).
 function parseSimpleFrontmatter(source: string): Record<string, string> {
@@ -145,7 +152,7 @@ function parseSimpleFrontmatter(source: string): Record<string, string> {
     /* v8 ignore next */
     const inline = (head[2] ?? "").trim();
     i += 1;
-    if (BLOCK_SCALAR_INDICATOR.test(inline)) {
+    if (isBlockScalarHeader(inline)) {
       const block: string[] = [];
       while (i < lines.length && ((lines[i] ?? "").trim() === "" || /^\s/.test(lines[i] ?? ""))) {
         // `lines[i]` is bounded by the `i < lines.length` loop guard; `?? ""` cannot fire
@@ -185,10 +192,10 @@ function listSourceUrlValues(source: string, spec: ContentRepoSpec): SubmittedSo
       const key = topLevel[1] as string;
       const value = topLevel[2] as string;
       activeField = spec.sourceUrlListFields.has(key) ? key : "";
-      // Skip a YAML block-scalar header (`|`, `>`, `|-`, `>2`, `|2-`, …) so it is not read as a URL — the old
-      // `!== "|" && !== ">"` check let every non-bare form through, surfacing the indicator string itself as a bogus
-      // URL. Shares BLOCK_SCALAR_INDICATOR with the scalar reader so both agree on the full indicator grammar.
-      if (activeField && value && !BLOCK_SCALAR_INDICATOR.test(value)) {
+      // Skip a YAML block-scalar header (`|`, `>`, `|-`, `>2`, `|2-`, `| # note`, …) so it is not read as a URL — the
+      // old `!== "|" && !== ">"` check let every other form through, surfacing the indicator string itself as a bogus
+      // URL. Shares isBlockScalarHeader with the scalar reader so both agree on the full, comment-tolerant grammar.
+      if (activeField && value && !isBlockScalarHeader(value)) {
         for (const url of scalarSourceUrlValues(value)) {
           values.push({ field: activeField, url });
         }

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -290,18 +290,15 @@ describe("extractSubmittedSourceUrls — frontmatter parsing edge cases", () => 
     );
   });
 
-  it("does not surface a non-bare block-scalar indicator on a list field as a bogus URL", () => {
-    // `retrievalSources` is a list field; a block-scalar indicator (`|-`, `>-`, `|2`, …) is not a URL. The old
-    // guard only skipped the bare `|`/`>`, so `|-` leaked through as the literal url "|-".
-    for (const indicator of ["|-", ">-", "|+", "|2", ">2"]) {
+  it("does not surface any block-scalar header on a list field as a bogus URL (both indicator orders)", () => {
+    // `retrievalSources` is a list field; a block-scalar header is not a URL. The old guard only skipped the bare
+    // `|`/`>`, so `|-` leaked as the literal url "|-". YAML allows chomping and the indentation digit in EITHER
+    // order, so `|2-`/`>2+` (indent-then-chomp) and bare chomping `|+`/`|-` must all be skipped too.
+    const indicators = ["|", ">", "|-", ">-", "|+", ">+", "|2", ">2", "|-2", "|2-", ">2+", ">2-"];
+    for (const indicator of indicators) {
       const src = ["---", `retrievalSources: ${indicator}`, "  https://a.example/1", "  https://b.example/2", "---", "", "body"].join("\n");
       const urls = extractSubmittedSourceUrls(src);
       expect(urls.some((u) => u.url === indicator)).toBe(false);
-    }
-    // The bare forms were already skipped and must stay skipped.
-    for (const indicator of ["|", ">"]) {
-      const src = ["---", `retrievalSources: ${indicator}`, "  https://a.example/1", "---", "", "body"].join("\n");
-      expect(extractSubmittedSourceUrls(src).some((u) => u.url === indicator)).toBe(false);
     }
   });
 

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -290,6 +290,21 @@ describe("extractSubmittedSourceUrls — frontmatter parsing edge cases", () => 
     );
   });
 
+  it("does not surface a non-bare block-scalar indicator on a list field as a bogus URL", () => {
+    // `retrievalSources` is a list field; a block-scalar indicator (`|-`, `>-`, `|2`, …) is not a URL. The old
+    // guard only skipped the bare `|`/`>`, so `|-` leaked through as the literal url "|-".
+    for (const indicator of ["|-", ">-", "|+", "|2", ">2"]) {
+      const src = ["---", `retrievalSources: ${indicator}`, "  https://a.example/1", "  https://b.example/2", "---", "", "body"].join("\n");
+      const urls = extractSubmittedSourceUrls(src);
+      expect(urls.some((u) => u.url === indicator)).toBe(false);
+    }
+    // The bare forms were already skipped and must stay skipped.
+    for (const indicator of ["|", ">"]) {
+      const src = ["---", `retrievalSources: ${indicator}`, "  https://a.example/1", "---", "", "body"].join("\n");
+      expect(extractSubmittedSourceUrls(src).some((u) => u.url === indicator)).toBe(false);
+    }
+  });
+
   it("reads an INLINE bracketed list on a retrievalSources key line", () => {
     const src = [
       "---",

--- a/test/unit/content-lane-source-evidence.test.ts
+++ b/test/unit/content-lane-source-evidence.test.ts
@@ -300,6 +300,15 @@ describe("extractSubmittedSourceUrls — frontmatter parsing edge cases", () => 
       const urls = extractSubmittedSourceUrls(src);
       expect(urls.some((u) => u.url === indicator)).toBe(false);
     }
+    // A block-scalar header may carry a trailing inline comment (`|- # sources below`) — still a header, not a URL.
+    for (const indicator of ["|-", ">", "|2-"]) {
+      const src = ["---", `retrievalSources: ${indicator} # sources below`, "  https://a.example/1", "---", "", "body"].join("\n");
+      const urls = extractSubmittedSourceUrls(src);
+      expect(urls.some((u) => u.url === indicator || u.url.includes("#"))).toBe(false);
+    }
+    // A real URL carrying a trailing inline comment is still read (the comment is stripped, the fragment kept).
+    const commented = extractSubmittedSourceUrls(["---", "retrievalSources: https://a.example/p#frag # note", "---", "", "body"].join("\n"));
+    expect(commented.map((u) => u.url)).toContain("https://a.example/p#frag");
   });
 
   it("reads an INLINE bracketed list on a retrievalSources key line", () => {


### PR DESCRIPTION
When reading a **list** source field (`sourceUrls`, `retrievalSources`), `listSourceUrlValues` tried to skip a YAML block-scalar indicator so it isn't treated as a URL:

```
if (activeField && value && value !== "|" && value !== ">") {
  for (const url of scalarSourceUrlValues(value)) values.push({ field: activeField, url });
}
```

But `value !== "|" && value !== ">"` only excludes the two **bare** indicators. Every other valid block-scalar indicator — `|-`, `>-`, `|+`, `>+`, `|2`, `>2`, `|-2`, … — slips through and is fed to `scalarSourceUrlValues`, which returns the indicator string itself as a "URL".

### Concrete failure
```
---
retrievalSources: |-
  https://example.com/a
  https://example.com/b
---
```
`extractSubmittedSourceUrls` returns `[{ field: "retrievalSources", url: "|-" }]` — a bogus `"|-"` URL. That becomes a canonical, blocking source that fails URL validation (`hard_failure`); when a submission's authoritative sources are all such failures, `shouldHardCloseSourceEvidence` hard-**closes** it — the module's documented worst case ("a false-positive close permanently rejects a legitimate submission"). Even short of a close it corrupts the source-evidence hash and reachability report.

### Why this is authoritatively a defect
The same module's sibling reader `parseSimpleFrontmatter` already recognizes the **complete** indicator grammar with `^[|>][+-]?\d*$` (handling `|-`, `>2`, etc.). Two frontmatter readers in one file disagree on what a block-scalar indicator is; line 183 is the incomplete one, and its own guard's intent (keep an indicator from being read as a URL) is exactly what fails on the non-bare forms.

### Fix
Reuse the sibling's regex: `!/^[|>][+-]?\d*$/.test(value)`. All of `|`, `>`, `|-`, `>-`, `|2`, … now yield no spurious URL (a block scalar isn't a valid list form), while `- item` lists and inline `[…]` arrays are unchanged.

### Tests
Adds a regression case asserting the non-bare indicators (`|-`, `>-`, `|+`, `|2`, `>2`) and the bare ones (`|`, `>`) never surface as a URL on a list field. Verified the non-bare case FAILS on current `main` and PASSES with the fix; the full `content-lane-source-evidence` suite (81 tests) stays green.

No linked issue: issue creation is unavailable for this account.
