### PR TITLE
feat(engine): add contributor-fit classifier for the feasibility gate (#2312)

### DIFF
--- a/packages/gittensory-engine/src/contributor-fit.ts
+++ b/packages/gittensory-engine/src/contributor-fit.ts
@@ -1,0 +1,72 @@
+// Contributor fit sub-check (#2312): pure classifier over an already-computed contributor profile
+// that answers whether THIS contributor's own track record fits a target repo. No IO, no fetching.
+
+export type ContributorFit = "strong" | "neutral" | "weak";
+
+export type ContributorFitCheck = {
+  fit: ContributorFit;
+  reasons: string[];
+};
+
+export type ContributorFitProfile = {
+  login: string;
+  registeredRepoActivity: {
+    pullRequests: number;
+    mergedPullRequests: number;
+    reposTouched: readonly string[];
+  };
+  trustSignals: {
+    level: "new" | "emerging" | "established";
+    unlinkedOpenPullRequests: number;
+  };
+};
+
+/**
+ * A profile with no prior activity on the target repo is `neutral` (a first attempt is not evidence
+ * of poor fit). With prior activity, a personal burden signal (unlinked open PRs, or a `new` profile
+ * with a low merge ratio) reads `weak`; established trust with a clean queue and a high merge ratio
+ * reads `strong`; anything between reads `neutral`.
+ */
+export function classifyContributorFit(
+  profile: ContributorFitProfile,
+  targetRepoFullName: string,
+): ContributorFitCheck {
+  const { reposTouched, pullRequests, mergedPullRequests } = profile.registeredRepoActivity;
+  if (!reposTouched.includes(targetRepoFullName)) {
+    return {
+      fit: "neutral",
+      reasons: [`No prior activity on ${targetRepoFullName}; a first attempt is not evidence of poor fit.`],
+    };
+  }
+
+  const reasons: string[] = [];
+  const mergeRatio = pullRequests > 0 ? mergedPullRequests / pullRequests : 1;
+  const unlinked = profile.trustSignals.unlinkedOpenPullRequests;
+  const level = profile.trustSignals.level;
+
+  const hasUnlinkedBurden = unlinked > 0;
+  const hasNewProfileBurden = level === "new" && pullRequests > 0 && mergeRatio < 0.5;
+  if (hasUnlinkedBurden) reasons.push(`${unlinked} unlinked open pull request(s)`);
+  if (hasNewProfileBurden) {
+    reasons.push(`new profile with low merge ratio (${mergedPullRequests}/${pullRequests})`);
+  }
+
+  const cleanQueue = unlinked === 0;
+  const strongMerge = pullRequests > 0 && mergeRatio >= 0.8;
+  if (level === "established") reasons.push("trust level is 'established'");
+  if (cleanQueue) reasons.push("no unlinked open pull requests");
+  if (strongMerge) reasons.push(`strong merge ratio (${mergedPullRequests}/${pullRequests})`);
+
+  const burdened = hasUnlinkedBurden || hasNewProfileBurden;
+  const proven = level === "established" && cleanQueue && strongMerge;
+
+  let fit: ContributorFit;
+  if (burdened) {
+    fit = "weak";
+  } else if (proven) {
+    fit = "strong";
+  } else {
+    fit = "neutral";
+  }
+  return { fit, reasons };
+}

--- a/packages/gittensory-engine/src/contributor-fit.ts
+++ b/packages/gittensory-engine/src/contributor-fit.ts
@@ -32,7 +32,8 @@ export function classifyContributorFit(
   targetRepoFullName: string,
 ): ContributorFitCheck {
   const { reposTouched, pullRequests, mergedPullRequests } = profile.registeredRepoActivity;
-  if (!reposTouched.includes(targetRepoFullName)) {
+  const target = targetRepoFullName.toLowerCase();
+  if (!reposTouched.some((repo) => repo.toLowerCase() === target)) {
     return {
       fit: "neutral",
       reasons: [`No prior activity on ${targetRepoFullName}; a first attempt is not evidence of poor fit.`],

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -34,3 +34,9 @@ export {
   isMinerRepoTargetable,
 } from "./miner-goal-lane-fit.js";
 export { computeOpportunityCompetition } from "./opportunity-competition.js";
+export {
+  classifyContributorFit,
+  type ContributorFit,
+  type ContributorFitCheck,
+  type ContributorFitProfile,
+} from "./contributor-fit.js";

--- a/test/unit/contributor-fit.test.ts
+++ b/test/unit/contributor-fit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyContributorFit,
+  type ContributorFitProfile,
+} from "../../packages/gittensory-engine/src/index";
+
+function profile(overrides: Partial<ContributorFitProfile> = {}): ContributorFitProfile {
+  return {
+    login: "miner",
+    registeredRepoActivity: {
+      pullRequests: 10,
+      mergedPullRequests: 9,
+      reposTouched: ["JSONbored/gittensory"],
+    },
+    trustSignals: { level: "established", unlinkedOpenPullRequests: 0 },
+    ...overrides,
+  };
+}
+
+describe("classifyContributorFit", () => {
+  it("is neutral with no prior activity on the target repo (a first attempt is not poor fit)", () => {
+    const result = profile({
+      registeredRepoActivity: { pullRequests: 0, mergedPullRequests: 0, reposTouched: [] },
+      trustSignals: { level: "new", unlinkedOpenPullRequests: 5 },
+    });
+    expect(classifyContributorFit(result, "entrius/gittensor")).toEqual({
+      fit: "neutral",
+      reasons: ["No prior activity on entrius/gittensor; a first attempt is not evidence of poor fit."],
+    });
+  });
+
+  it("is weak when the contributor has unlinked open pull requests against the touched repo", () => {
+    const result = profile({
+      trustSignals: { level: "established", unlinkedOpenPullRequests: 3 },
+    });
+    const { fit, reasons } = classifyContributorFit(result, "JSONbored/gittensory");
+    expect(fit).toBe("weak");
+    expect(reasons).toContain("3 unlinked open pull request(s)");
+  });
+
+  it("is weak for a new profile whose few attempts mostly failed to merge", () => {
+    const result = profile({
+      registeredRepoActivity: { pullRequests: 10, mergedPullRequests: 2, reposTouched: ["JSONbored/gittensory"] },
+      trustSignals: { level: "new", unlinkedOpenPullRequests: 0 },
+    });
+    const { fit, reasons } = classifyContributorFit(result, "JSONbored/gittensory");
+    expect(fit).toBe("weak");
+    expect(reasons).toContain("new profile with low merge ratio (2/10)");
+  });
+
+  it("is strong for an established profile with a clean queue and a high merge ratio", () => {
+    const result = profile();
+    const { fit, reasons } = classifyContributorFit(result, "JSONbored/gittensory");
+    expect(fit).toBe("strong");
+    expect(reasons).toContain("trust level is 'established'");
+    expect(reasons).toContain("no unlinked open pull requests");
+    expect(reasons).toContain("strong merge ratio (9/10)");
+  });
+
+  it("is neutral when history exists but signals are mixed (emerging, clean queue, mid merge ratio)", () => {
+    const result = profile({
+      registeredRepoActivity: { pullRequests: 10, mergedPullRequests: 6, reposTouched: ["JSONbored/gittensory"] },
+      trustSignals: { level: "emerging", unlinkedOpenPullRequests: 0 },
+    });
+    const { fit, reasons } = classifyContributorFit(result, "JSONbored/gittensory");
+    expect(fit).toBe("neutral");
+    expect(reasons).toContain("no unlinked open pull requests");
+    expect(reasons.some((r) => r.startsWith("strong merge ratio"))).toBe(false);
+  });
+
+  it("is neutral for touched-repo history with no recorded pull-request count", () => {
+    const result = profile({
+      registeredRepoActivity: { pullRequests: 0, mergedPullRequests: 0, reposTouched: ["JSONbored/gittensory"] },
+      trustSignals: { level: "established", unlinkedOpenPullRequests: 0 },
+    });
+    const { fit, reasons } = classifyContributorFit(result, "JSONbored/gittensory");
+    expect(fit).toBe("neutral");
+    expect(reasons).toContain("trust level is 'established'");
+    expect(reasons).toContain("no unlinked open pull requests");
+  });
+
+  it("matches the exact verdicts across the strong/neutral/weak axis", () => {
+    const verdicts = [
+      profile(),
+      profile({ trustSignals: { level: "established", unlinkedOpenPullRequests: 0 } }),
+      profile({ trustSignals: { level: "established", unlinkedOpenPullRequests: 1 } }),
+    ].map((p) => classifyContributorFit(p, "JSONbored/gittensory").fit);
+    expect(verdicts).toEqual(["strong", "strong", "weak"]);
+  });
+});

--- a/test/unit/contributor-fit.test.ts
+++ b/test/unit/contributor-fit.test.ts
@@ -79,12 +79,27 @@ describe("classifyContributorFit", () => {
     expect(reasons).toContain("no unlinked open pull requests");
   });
 
+  it("matches the target repo case-insensitively (GitHub full names are case-insensitive)", () => {
+    const result = profile({
+      registeredRepoActivity: {
+        pullRequests: 10,
+        mergedPullRequests: 9,
+        reposTouched: ["JSONbored/gittensory"],
+      },
+      trustSignals: { level: "established", unlinkedOpenPullRequests: 0 },
+    });
+    expect(classifyContributorFit(result, "jsonbored/gittensory").fit).toBe("strong");
+    expect(classifyContributorFit(result, "JSONBORED/Gittensory").fit).toBe("strong");
+  });
+
   it("matches the exact verdicts across the strong/neutral/weak axis", () => {
-    const verdicts = [
-      profile(),
-      profile({ trustSignals: { level: "established", unlinkedOpenPullRequests: 0 } }),
-      profile({ trustSignals: { level: "established", unlinkedOpenPullRequests: 1 } }),
-    ].map((p) => classifyContributorFit(p, "JSONbored/gittensory").fit);
-    expect(verdicts).toEqual(["strong", "strong", "weak"]);
+    const strong = profile();
+    const weak = profile({ trustSignals: { level: "established", unlinkedOpenPullRequests: 1 } });
+    const neutral = profile({
+      registeredRepoActivity: { pullRequests: 10, mergedPullRequests: 6, reposTouched: ["JSONbored/gittensory"] },
+      trustSignals: { level: "emerging", unlinkedOpenPullRequests: 0 },
+    });
+    const verdicts = [strong, weak, neutral].map((p) => classifyContributorFit(p, "JSONbored/gittensory").fit);
+    expect(verdicts).toEqual(["strong", "weak", "neutral"]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a pure `classifyContributorFit` classifier to `@jsonbored/gittensory-engine`, the fourth signal for the miner-plan feasibility gate requested in #2312. It reads only fields already present on the `ContributorProfile` built by `src/signals/engine.ts:buildContributorProfile` and returns a `{ fit: "strong" | "neutral" | "weak"; reasons: string[] }` verdict for a target repo.
- The defining rule from the spec is honored: a profile with **no prior activity on the target repo is `neutral`**, never weak — a first attempt is not evidence of poor fit. With prior activity, a personal burden signal (unlinked open pull requests, or a `new` profile with a low merge ratio) reads `weak`; established trust with a clean queue and a high merge ratio reads `strong`; anything between reads `neutral`.
- Exposed from the package's public barrel (`packages/gittensory-engine/src/index.ts`) so the feasibility composer can import it once that lands. No IO, no fetching, no new data flow.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue — closes #2312.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — the new module and every other `gittensory-engine` test pass (`test/unit/contributor-fit.test.ts` plus the existing engine suites: 23 passed). This PR adds no lines under `src/**`, which is the only tree Codecov's patch gate measures (per `vitest.config.ts` coverage `include` and `codecov.yml` `ignore`), so there is no patch-coverage obligation; the new code is nonetheless exercised to 100% of its branches by the unit suite below.
- [ ] `npm run test:workers` — not run; the change is a pure module in `packages/gittensory-engine` with no Worker/runtime behavior.
- [x] `npm run build:miner` (builds `@jsonbored/gittensory-engine` then `-miner`) — green.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package change.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run; no UI or API-contract change.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries.

If any required check was skipped, explain why:

- The change is isolated to one new pure module + its barrel export + its unit tests in `packages/gittensory-engine`. The Worker, MCP-pack, and UI gates exercise code paths this PR does not touch, so they are unaffected. The local full `test:coverage` run on this Windows host showed only pre-existing environment-specific failures (`.sh`/docker/real-CLI-subprocess/npm-registry tests such as `backup-script`, `check-migrations-script`, `selfhost-*`, `mcp-cli-doctor`), none of which import or touch this change; those pass on the Linux CI runners.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS change.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A: no visible change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI, frontend, docs, or extension change; this is a pure engine module + tests.

## Notes

- Branch coverage of `classifyContributorFit` is complete: the `neutral` zero-history early return, the `weak` unlinked-burden arm, the `weak` new-profile-low-merge-ratio arm, the `strong` established-clean-high-merge arm, and the mid-signal `neutral` arm are each asserted, plus the defensive `pullRequests === 0` merge-ratio fallback.
- The input type `ContributorFitProfile` is a structural subset of `ContributorProfile` (`src/signals/engine.ts:144`) rather than a cross-package import, mirroring how `opportunity-ranker.ts` declares its own local `OpportunityRankInput` to keep this package decoupled from `src/`.
