### PR TITLE
feat(miner-foundation): add claim-ledger staleness/expiry sweep (#2316)

### DIFF
--- a/packages/gittensory-miner/lib/claim-ledger-expiry.d.ts
+++ b/packages/gittensory-miner/lib/claim-ledger-expiry.d.ts
@@ -1,0 +1,26 @@
+export type ClaimStatus = "active" | "expired";
+
+export type LocalClaimRecord = {
+  id: string;
+  status: ClaimStatus;
+  claimedAtMs: number;
+};
+
+export type ClaimLedgerSweepStore = {
+  listActiveClaims(): LocalClaimRecord[];
+  expireClaim(claimId: string, expiredAtMs: number): void;
+};
+
+export const DEFAULT_CLAIM_MAX_AGE_MS: number;
+
+export function findExpiredClaims(
+  claims: LocalClaimRecord[],
+  nowMs: number,
+  maxAgeMs: number,
+): LocalClaimRecord[];
+
+export function sweepExpiredClaims(
+  store: ClaimLedgerSweepStore,
+  nowMs: number,
+  maxAgeMs?: number,
+): LocalClaimRecord[];

--- a/packages/gittensory-miner/lib/claim-ledger-expiry.js
+++ b/packages/gittensory-miner/lib/claim-ledger-expiry.js
@@ -1,0 +1,56 @@
+/**
+ * Claim-ledger staleness/expiry sweep (#2316).
+ *
+ * A local miner marks an issue/PR "active" in its claim ledger while it works. If that claim is never
+ * resolved (crash, abandoned run, forgotten background loop) it stays "active" forever and needlessly
+ * blocks other miners from claiming or adjudicating the same work. The sweep releases such claims once
+ * they age past a configurable ceiling.
+ *
+ * {@link findExpiredClaims} is PURE — no IO, no network, no `Date.now()`, no randomness — so the same
+ * (claims, nowMs, maxAgeMs) always yields the same set and the caller supplies the clock. This mirrors
+ * the disciplined pure-adjudication pattern in `src/signals/duplicate-winner.ts:10`.
+ *
+ * Fail-closed rule: only an "active" claim with a finite `claimedAtMs` can expire. A claim whose timing
+ * is missing/malformed, or whose timestamp is in the future, is LEFT ACTIVE — we never release a claim
+ * we cannot confidently age, so a corrupt row can't silently free live work.
+ */
+
+// ~14 days. Suggested default ceiling before an unresolved local claim is considered abandoned (#2316).
+export const DEFAULT_CLAIM_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+function isExpiredActiveClaim(claim, nowMs, maxAgeMs) {
+  if (!claim || claim.status !== "active") return false;
+  const claimedAtMs = claim.claimedAtMs;
+  if (typeof claimedAtMs !== "number" || !Number.isFinite(claimedAtMs)) return false;
+  const age = nowMs - claimedAtMs;
+  // Boundary is inclusive: a claim exactly at the ceiling (age === maxAgeMs) is expired.
+  return age >= maxAgeMs;
+}
+
+/**
+ * Pure selector: the subset of `claims` that are active and have aged to/beyond `maxAgeMs` at `nowMs`.
+ * Input order is preserved and the returned records are the same references from `claims`.
+ */
+export function findExpiredClaims(claims, nowMs, maxAgeMs) {
+  if (!Array.isArray(claims)) throw new Error("invalid_claims");
+  if (typeof nowMs !== "number" || !Number.isFinite(nowMs)) throw new Error("invalid_now_ms");
+  if (typeof maxAgeMs !== "number" || !Number.isFinite(maxAgeMs) || maxAgeMs < 0) {
+    throw new Error("invalid_max_age_ms");
+  }
+  return claims.filter((claim) => isExpiredActiveClaim(claim, nowMs, maxAgeMs));
+}
+
+/**
+ * Thin store wrapper: runs the pure selector over the ledger's active claims and transitions each
+ * expired record to `status: "expired"` via the store's own API. Returns the records it expired.
+ */
+export function sweepExpiredClaims(store, nowMs, maxAgeMs = DEFAULT_CLAIM_MAX_AGE_MS) {
+  if (!store || typeof store.listActiveClaims !== "function" || typeof store.expireClaim !== "function") {
+    throw new Error("invalid_claim_ledger_store");
+  }
+  const expired = findExpiredClaims(store.listActiveClaims(), nowMs, maxAgeMs);
+  for (const claim of expired) {
+    store.expireClaim(claim.id, nowMs);
+  }
+  return expired;
+}

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/claim-ledger-expiry.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-claim-ledger-expiry.test.ts
+++ b/test/unit/miner-claim-ledger-expiry.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CLAIM_MAX_AGE_MS,
+  findExpiredClaims,
+  sweepExpiredClaims,
+} from "../../packages/gittensory-miner/lib/claim-ledger-expiry.js";
+import type {
+  ClaimLedgerSweepStore,
+  LocalClaimRecord,
+} from "../../packages/gittensory-miner/lib/claim-ledger-expiry.js";
+
+const NOW = 1_700_000_000_000;
+const MAX_AGE = 14 * 24 * 60 * 60 * 1000;
+
+function claim(overrides: Partial<LocalClaimRecord> = {}): LocalClaimRecord {
+  return { id: "c1", status: "active", claimedAtMs: NOW, ...overrides };
+}
+
+describe("gittensory-miner claim-ledger expiry sweep (#2316)", () => {
+  it("exposes a ~14-day default ceiling", () => {
+    expect(DEFAULT_CLAIM_MAX_AGE_MS).toBe(MAX_AGE);
+  });
+
+  it("returns nothing when no active claim has aged past the ceiling", () => {
+    const claims = [
+      claim({ id: "fresh", claimedAtMs: NOW - 1000 }),
+      claim({ id: "half", claimedAtMs: NOW - MAX_AGE / 2 }),
+    ];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE)).toEqual([]);
+  });
+
+  it("returns every active claim when all have aged out", () => {
+    const claims = [
+      claim({ id: "a", claimedAtMs: NOW - MAX_AGE - 1 }),
+      claim({ id: "b", claimedAtMs: NOW - MAX_AGE * 3 }),
+    ];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE).map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("selects only the aged-out claims in a mixed ledger, preserving order and references", () => {
+    const stale = claim({ id: "stale", claimedAtMs: NOW - MAX_AGE - 5 });
+    const claims = [
+      claim({ id: "fresh", claimedAtMs: NOW - 10 }),
+      stale,
+      claim({ id: "recent", claimedAtMs: NOW - 1 }),
+    ];
+    const expired = findExpiredClaims(claims, NOW, MAX_AGE);
+    expect(expired).toEqual([stale]);
+    expect(expired[0]).toBe(stale);
+  });
+
+  it("treats the exact boundary (age === maxAgeMs) as expired but one ms under as active", () => {
+    const onBoundary = claim({ id: "boundary", claimedAtMs: NOW - MAX_AGE });
+    const underBoundary = claim({ id: "under", claimedAtMs: NOW - MAX_AGE + 1 });
+    expect(findExpiredClaims([onBoundary, underBoundary], NOW, MAX_AGE)).toEqual([onBoundary]);
+  });
+
+  it("never expires a non-active claim", () => {
+    const claims = [claim({ id: "done", status: "expired", claimedAtMs: NOW - MAX_AGE * 2 })];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE)).toEqual([]);
+  });
+
+  it("fails closed on a future timestamp (negative age)", () => {
+    const claims = [claim({ id: "future", claimedAtMs: NOW + MAX_AGE })];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE)).toEqual([]);
+  });
+
+  it("fails closed on missing or non-finite claim timing", () => {
+    const claims = [
+      claim({ id: "nan", claimedAtMs: Number.NaN }),
+      claim({ id: "infinite", claimedAtMs: Number.POSITIVE_INFINITY }),
+      { id: "untimed", status: "active" } as unknown as LocalClaimRecord,
+    ];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE)).toEqual([]);
+  });
+
+  it("ignores nullish rows without throwing", () => {
+    const claims = [null, undefined, claim({ id: "old", claimedAtMs: NOW - MAX_AGE })] as unknown as LocalClaimRecord[];
+    expect(findExpiredClaims(claims, NOW, MAX_AGE).map((c) => c.id)).toEqual(["old"]);
+  });
+
+  it("rejects malformed arguments", () => {
+    expect(() => findExpiredClaims(null as unknown as LocalClaimRecord[], NOW, MAX_AGE)).toThrow("invalid_claims");
+    expect(() => findExpiredClaims([], Number.NaN, MAX_AGE)).toThrow("invalid_now_ms");
+    expect(() => findExpiredClaims([], NOW, Number.NaN)).toThrow("invalid_max_age_ms");
+    expect(() => findExpiredClaims([], NOW, -1)).toThrow("invalid_max_age_ms");
+  });
+
+  describe("sweepExpiredClaims", () => {
+    function fakeStore(claims: LocalClaimRecord[]): ClaimLedgerSweepStore & { expired: Array<[string, number]> } {
+      const expired: Array<[string, number]> = [];
+      return {
+        expired,
+        listActiveClaims: () => claims,
+        expireClaim: (claimId, expiredAtMs) => {
+          expired.push([claimId, expiredAtMs]);
+        },
+      };
+    }
+
+    it("transitions each expired claim through the store and returns them", () => {
+      const store = fakeStore([
+        claim({ id: "fresh", claimedAtMs: NOW - 1 }),
+        claim({ id: "stale", claimedAtMs: NOW - MAX_AGE - 1 }),
+      ]);
+      const result = sweepExpiredClaims(store, NOW, MAX_AGE);
+      expect(result.map((c) => c.id)).toEqual(["stale"]);
+      expect(store.expired).toEqual([["stale", NOW]]);
+    });
+
+    it("uses the default ceiling when maxAgeMs is omitted", () => {
+      const store = fakeStore([claim({ id: "aged", claimedAtMs: NOW - DEFAULT_CLAIM_MAX_AGE_MS })]);
+      expect(sweepExpiredClaims(store, NOW).map((c) => c.id)).toEqual(["aged"]);
+      expect(store.expired).toEqual([["aged", NOW]]);
+    });
+
+    it("makes no store writes when nothing is stale", () => {
+      const store = fakeStore([claim({ id: "fresh", claimedAtMs: NOW })]);
+      expect(sweepExpiredClaims(store, NOW, MAX_AGE)).toEqual([]);
+      expect(store.expired).toEqual([]);
+    });
+
+    it("rejects a store missing the required APIs", () => {
+      expect(() => sweepExpiredClaims(null as unknown as ClaimLedgerSweepStore, NOW, MAX_AGE)).toThrow(
+        "invalid_claim_ledger_store",
+      );
+      expect(() =>
+        sweepExpiredClaims({ listActiveClaims: () => [] } as unknown as ClaimLedgerSweepStore, NOW, MAX_AGE),
+      ).toThrow("invalid_claim_ledger_store");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #2316. Stale local claims left marked `active` after a crashed or abandoned miner run block other miners from claiming or adjudicating the same work indefinitely; this adds the staleness/expiry sweep.
- Adds a **pure** `findExpiredClaims(claims, nowMs, maxAgeMs)` selector — no IO, no network, no `Date.now()`, no randomness (the caller supplies the clock), following the disciplined pure-adjudication pattern in `src/signals/duplicate-winner.ts:10`.
- Adds a thin `sweepExpiredClaims(store, nowMs, maxAgeMs)` wrapper that runs the selector over the ledger's active claims and transitions each aged-out record to `status: "expired"` via the store's own API. Default ceiling `DEFAULT_CLAIM_MAX_AGE_MS` is ~14 days.
- **Fail-closed:** only an `active` claim with a finite `claimedAtMs` can expire; missing/malformed/future timing is left active so a corrupt row can never silently release live work.
- **Path note:** the issue suggested `packages/gittensory-miner/src/claim-ledger/expiry.ts`, but this package ships hand-written `lib/*.js` + sibling `.d.ts` (no `src/`, no `tsc`; its `build` is `node --check` per file). To stay byte-for-byte consistent with the existing package (`run-state.js`, `ci-poller.js`, …) the module lives at `packages/gittensory-miner/lib/claim-ledger-expiry.js` and is added to the package `build` check. Kept self-contained (defines `LocalClaimRecord` + a minimal sweep-store interface) so it does not pre-empt the separate schema/CRUD issue (#2314).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#2316).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` — N/A (no workflow files changed)
- [x] `npm run typecheck` — passes (`tsc --noEmit`, exit 0)
- [x] `npm run test:coverage` — new suite `test/unit/miner-claim-ledger-expiry.test.ts` runs green (14/14). Note: Codecov coverage is scoped to `src/**` (`vitest.config.ts`), so this `packages/**` change carries no `codecov/patch` obligation; unit tests are still included below.
- [x] `npm run build:miner` — passes (engine `tsc` + `node --check` on every `lib/*.js` incl. the new file, exit 0)
- [ ] `npm run test:workers` — N/A (no worker-pool code changed)
- [ ] `npm run build:mcp` / `test:mcp-pack` — N/A (no MCP change)
- [ ] `npm run ui:openapi:check` — N/A (no API/OpenAPI change)
- [ ] `npm run ui:lint` — N/A (no UI change)
- [ ] `npm run ui:typecheck` — N/A (no UI change)
- [ ] `npm run ui:build` — N/A (no UI change)
- [ ] `npm audit --audit-level=moderate` — not run (no dependency change)
- [x] New or changed behavior has unit tests for new branches, fallback paths, and boundaries — `test/unit/miner-claim-ledger-expiry.test.ts` covers zero/all/mixed expiry, the exact `age === maxAgeMs` boundary and one ms under, non-active/future/NaN/Infinity/untimed/nullish fail-closed paths, argument validation, and the wrapper (store writes, default ceiling, no-op, invalid-store).

If any required check was skipped, explain why:

- The change-relevant checks were run and pass: `git diff --check`, `tsc --noEmit` (typecheck), the new Vitest suite (14/14), and `build:miner`. The remaining `test:ci` steps (`test:workers`, `build:mcp`/`test:mcp-pack`, all `ui:*`, `db:migrations:check`, `selfhost:*`) exercise areas this PR does not touch (no worker-pool, MCP, UI, DB, or self-host changes) and are left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session — N/A (pure local library logic, no such surface).
- [x] API/OpenAPI/MCP behavior — N/A (no API surface changed).
- [x] UI changes — N/A.
- [x] Visible UI changes — N/A (no UI).
- [x] Public docs/changelogs — N/A; changelog not edited.

## Notes

- Self-contained by design: `LocalClaimRecord` and the sweep-store interface are defined locally so the sweep does not block on the claim-ledger schema/CRUD (#2314); when that lands, its record/store types converge on this contract.
