### PR TITLE
fix(rees): classify bower_components and jspm_packages as vendored in provenance

### DIFF
--- a/review-enrichment/src/analyzers/provenance.ts
+++ b/review-enrichment/src/analyzers/provenance.ts
@@ -20,9 +20,11 @@ const MAX_FINDINGS = 30; // keep the brief bounded
 // Compiled/non-source binary artifact extensions.
 const BINARY_EXT_RE =
   /\.(exe|dll|so|dylib|bin|pyc|pyo|class|jar|war|ear|wasm|o|a)$/i;
-// Vendored / embedded third-party source trees.
+// Vendored / embedded third-party source trees. bower_components (Bower) and jspm_packages (JSPM) are
+// installed-dependency directories — the same vendored case as node_modules — so a committed tree under either
+// is a vendored artifact, not contributor source (mirrors src/signals/path-matchers.ts's vendored classifier).
 const VENDORED_PATH_RE =
-  /(?:^|\/)(?:vendor|node_modules|third[_-]party|vendors)\//;
+  /(?:^|\/)(?:vendor|vendors|node_modules|bower_components|jspm_packages|third[_-]party)\//;
 // Minified files carry no reviewable source in the diff (effectively vendored).
 const MINIFIED_RE = /\.min\.[cm]?[jt]s$|\.min\.css$/i;
 

--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyAddedFile } from "../dist/analyzers/provenance.js";
+
+test("classifyAddedFile treats bower_components and jspm_packages as vendored, like node_modules (#2777 parity)", () => {
+  // Installed-dependency directories are vendored artifacts, not contributor source. Before this, a committed
+  // bower/jspm tree fell through to null (ordinary source) while node_modules/vendor were already caught.
+  for (const path of [
+    "bower_components/jquery/dist/jquery.js",
+    "web/bower_components/angular/angular.js",
+    "jspm_packages/npm/lodash@4.17.21/lodash.js",
+    "frontend/jspm_packages/github/x.js",
+  ]) {
+    assert.equal(classifyAddedFile(path), "vendored", path);
+  }
+  // Existing vendored directories still classify (control).
+  for (const path of ["node_modules/x/index.js", "vendor/foo.rb", "third_party/lib.c", "third-party/lib.c", "vendors/a.js"]) {
+    assert.equal(classifyAddedFile(path), "vendored", path);
+  }
+  // Directory-segment anchored: a source file merely NAMED like the dir is not vendored; plain source is null.
+  assert.equal(classifyAddedFile("src/bower_components.ts"), null);
+  assert.equal(classifyAddedFile("src/app.ts"), null);
+});


### PR DESCRIPTION
## What
The rees provenance analyzer classifies a newly-added file as `binary` / `vendored` / source via `classifyAddedFile`. Its `VENDORED_PATH_RE`:

```ts
/(?:^|\/)(?:vendor|node_modules|third[_-]party|vendors)\//
```

recognizes `vendor`/`node_modules`/`third_party` but **not `bower_components` (Bower) or `jspm_packages` (JSPM)** — installed-dependency directories that are the same vendored case as `node_modules`.

## Why it matters
`#2777` (`fix(signals): classify bower_components and jspm_packages as vendored`) added exactly these to the **server-side** path classifier (`src/signals/path-matchers.ts`), with the rationale *"the same vendored case as node_modules."* But `review-enrichment` ships as a **standalone package** with its own inlined `VENDORED_PATH_RE`, so #2777's `src/` change never reached it.

Consequence: a PR that commits a `bower_components/` or `jspm_packages/` tree has those files fall through to `null` (ordinary source) instead of `"vendored"`, so the provenance analyzer treats committed third-party dependency code as reviewable contributor source — the exact misclassification #2777 fixed on the server side.

## Fix
Add `bower_components` and `jspm_packages` to `VENDORED_PATH_RE`, mirroring the path-matchers vendored classifier. The pattern stays directory-segment anchored (`(?:^|\/)…\//`), so a source file merely *named* like the directory (`src/bower_components.ts`) is unaffected.

## Tests
Adds `review-enrichment/test/provenance.test.ts`: bower/jspm trees now classify as `vendored`, the existing dirs still do (control), and directory-name lookalikes / plain source stay `null`. Fails on the pre-fix regex, passes with the fix.