### PR TITLE
fix(queue): guard gate-only type labels

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6375,9 +6375,18 @@ async function maybePublishPrPublicSurface(
     }
     return undefined;
   }
+  // `typeLabelsEnabled` is optional only for RepositorySettings-fixture-construction backward compat (see
+  // its doc comment in types.ts); getRepositorySettings always resolves it to a concrete boolean, so the
+  // `?? true` fallback is unreachable on this webhook-integration path (unlike a pure function such as
+  // buildRepoSettingsPreview, which a unit test can call with a hand-built, genuinely-undefined settings object).
+  /* v8 ignore next -- see the comment above */
+  const typeLabelsEnabled = settings.typeLabelsEnabled ?? true;
+  const needsTypeLabelMinerCheck =
+    settings.publicAudienceMode === "gittensor_only" && typeLabelsEnabled;
   const prelimHasPublicOutput =
     !publicSurfaceSkipped &&
     (needsMinerCheckForDetectedComment ||
+      needsTypeLabelMinerCheck ||
       prelim.actions.some(
         (action) =>
           action === "comment" || action === "label" || action === "check_run",
@@ -6443,13 +6452,9 @@ async function maybePublishPrPublicSurface(
   // `publicAudienceMode: "gittensor_only"`'s stricter promise to stay entirely quiet for a
   // non-confirmed-miner author (`not_official_gittensor_miner` / `miner_detection_unavailable`) --
   // that mode's whole point is total silence for that audience, not merely suppressing the context
-  // label, so a type label would violate it same as a comment would.
-  // `typeLabelsEnabled` is optional only for RepositorySettings-fixture-construction backward compat (see
-  // its doc comment in types.ts); getRepositorySettings always resolves it to a concrete boolean, so the
-  // `?? true` fallback is unreachable on this webhook-integration path (unlike a pure function such as
-  // buildRepoSettingsPreview, which a unit test can call with a hand-built, genuinely-undefined settings object).
-  /* v8 ignore next -- see the comment above */
-  const typeLabelsEnabled = settings.typeLabelsEnabled ?? true;
+  // label, so a type label would violate it same as a comment would. `typeLabelsEnabled` itself is
+  // computed earlier (see its declaration above prelimHasPublicOutput) so gittensor_only's silence
+  // promise can gate the public-surface computation too, not just this label decision (#gate-only-type-labels).
   if (
     typeLabelsEnabled &&
     !settings.agentPaused &&

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -16552,6 +16552,67 @@ describe("queue processors", () => {
       expect(seen.removed.sort()).toEqual(["gittensor:feature", "gittensor:priority"]);
     });
 
+    it("keeps gate-only gittensor_only type labels silent until miner confirmation", async () => {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+      await upsertRepositorySettings(env, {
+        repoFullName: "JSONbored/gittensory",
+        commentMode: "off",
+        publicSurface: "off",
+        publicAudienceMode: "gittensor_only",
+        autoLabelEnabled: false,
+        createMissingLabel: false,
+        checkRunMode: "off",
+        gateCheckMode: "enabled",
+        linkedIssueGateMode: "off",
+        aiReviewMode: "off",
+      });
+      const seen = { posted: [] as string[], removed: [] as string[], checkRunCreated: false, minerList: 0 };
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url === "https://api.gittensor.io/miners") {
+          seen.minerList += 1;
+          return Response.json([]);
+        }
+        if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+        if (url.includes(`/commits/`) && url.includes("/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+        if (url.includes("/check-runs") && method === "POST") {
+          seen.checkRunCreated = true;
+          return Response.json({ id: 9002 }, { status: 201 });
+        }
+        if (url.includes("/check-runs/") && method === "PATCH") return Response.json({ id: 9002 });
+        if (url.includes(`/issues/218/labels`) && method === "GET") return Response.json([]);
+        if (url.includes(`/issues/218/labels`) && method === "POST") {
+          seen.posted.push(...((JSON.parse(String(init?.body ?? "{}")).labels ?? []) as string[]));
+          return Response.json([]);
+        }
+        if (url.includes(`/issues/218/labels/`) && method === "DELETE") {
+          seen.removed.push(decodeURIComponent(url.split(`/issues/218/labels/`)[1] ?? ""));
+          return new Response(null, { status: 204 });
+        }
+        if (url.endsWith("/labels") && method === "POST") return Response.json({ name: JSON.parse(String(init?.body ?? "{}")).name }, { status: 201 });
+        return new Response("not found", { status: 404 });
+      });
+
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "type-label-gittensor-only-gate-only-muted",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 218, title: "fix: gate-only silence", state: "open", user: { login: "contributor" }, author_association: "NONE", head: { sha: "sha218" }, labels: [], body: "Fixes #1" },
+        },
+      });
+
+      expect(seen.minerList).toBe(1);
+      expect(seen.checkRunCreated).toBe(true);
+      expect(seen.posted).toEqual([]);
+      expect(seen.removed).toEqual([]);
+    });
+
     it("still mutes the type label when gittensor_only mode's non-confirmed-miner silence applies, even with the gate enabled", async () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);


### PR DESCRIPTION
### Motivation
- Prevent a logic bug that allowed public per-PR type labels to be applied in gate-only repos with `publicAudienceMode: "gittensor_only"` before official miner detection ran, violating the total-silence promise for non-confirmed or detection-unavailable authors.
- Ensure the type-label publication path respects the same miner-confirmation requirement used by the public-surface decision so labels cannot leak in gate-only configurations.

### Description
- Require a miner-check when type labels are enabled by computing `needsTypeLabelMinerCheck` and including it in the `prelimHasPublicOutput` predicate so official miner detection runs for gate-only type-label scenarios.
- Reuse a single `typeLabelsEnabled` value and keep the existing `decision.skipReason` checks so type-label writes remain suppressed for `miner_detection_unavailable` and `not_official_gittensor_miner` outcomes.
- Move the `typeLabelsEnabled` evaluation earlier and align the miner-decision and label-write paths so the two decisions cannot diverge.
- Add a regression test `keeps gate-only gittensor_only type labels silent until miner confirmation` in `test/unit/queue.test.ts` that exercises a gate-only `gittensor_only` configuration and asserts no type labels are applied for an unconfirmed author.

### Testing
- Ran targeted unit tests: `npx vitest run test/unit/queue.test.ts -t "gate-only gittensor_only type labels"` and `npx vitest run test/unit/queue.test.ts -t "type label decoupling"`, and the new/regression tests passed.
- Ran `npm run typecheck` which completed successfully with no TypeScript errors.
- Attempted the full local gate `npm run test:ci` and coverage `npm run test:coverage`, but the environment blocked completion: `actionlint` download experienced DNS failures and fallback flagged a self-hosted runner label, several long-running queue sweep tests timed out in this environment, and `npm audit` returned `403` from the registry; these are environment/tooling issues rather than regressions in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47a4cb8aa4832ca90b1762e72cc6dc)