### PR TITLE
fix(api): floor badge color at high on low contribution, never downgrade critical

### DIFF
--- a/src/api/badge.ts
+++ b/src/api/badge.ts
@@ -14,6 +14,9 @@ const QUEUE_COLORS: Record<QueueHealthLevel, string> = {
   critical: "#f85149",
 };
 
+// Severity order of the queue-health levels, ascending (low = least alarming … critical = most alarming).
+const QUEUE_SEVERITY: Record<QueueHealthLevel, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+
 const LOW_REAL_CONTRIBUTION_PCT = 50;
 const UNAVAILABLE_COLOR = "#9e9e9e";
 
@@ -33,11 +36,14 @@ export function buildBadgeMessage(quality: PublicRepoQuality): string {
 }
 
 export function buildBadgeColor(quality: PublicRepoQuality): string {
-  // Color tracks queue health, but a low real-contribution share dominates the signal.
+  const queueColor = QUEUE_COLORS[quality.queueHealthLevel];
+  // A low real-contribution share dominates the signal — it FLOORS the color at `high`, escalating a healthier
+  // queue up to orange. It must never DOWNGRADE a more-severe queue: a `critical` (red) queue with low contribution
+  // is doubly bad, so keep its color rather than replacing it with the less-alarming `high` orange.
   if (quality.realContributionPct !== null && quality.realContributionPct < LOW_REAL_CONTRIBUTION_PCT) {
-    return QUEUE_COLORS.high;
+    return QUEUE_SEVERITY[quality.queueHealthLevel] >= QUEUE_SEVERITY.high ? queueColor : QUEUE_COLORS.high;
   }
-  return QUEUE_COLORS[quality.queueHealthLevel];
+  return queueColor;
 }
 
 export function buildShieldsBadge(quality: PublicRepoQuality, cacheSeconds: number): ShieldsBadge {

--- a/test/unit/badge.test.ts
+++ b/test/unit/badge.test.ts
@@ -45,6 +45,15 @@ describe("buildBadgeColor", () => {
     expect(buildBadgeColor(quality({ queueHealthLevel: "low", realContributionPct: 40 }))).toBe("#db6d28");
   });
 
+  it("never renders a lower severity than the queue color when the real-contribution share is low", () => {
+    // A low real-contribution share floors the color at `high` (orange) but must not DOWNGRADE a more-severe
+    // queue: a critical queue (red) with low contribution is doubly bad and must stay red, not become orange.
+    expect(buildBadgeColor(quality({ queueHealthLevel: "critical", realContributionPct: 20 }))).toBe("#f85149");
+    // A `high` queue with low contribution stays high (no double-count), and medium still escalates to high.
+    expect(buildBadgeColor(quality({ queueHealthLevel: "high", realContributionPct: 20 }))).toBe("#db6d28");
+    expect(buildBadgeColor(quality({ queueHealthLevel: "medium", realContributionPct: 20 }))).toBe("#db6d28");
+  });
+
   it("uses queue color when the contribution share is unknown", () => {
     expect(buildBadgeColor(quality({ queueHealthLevel: "low", realContributionPct: null }))).toBe("#3fb950");
   });


### PR DESCRIPTION
The README status badge (`#541`) colors a repo by queue health, with a low real-contribution share as a dominant negative signal. But `buildBadgeColor` returned a **fixed** `high` (orange) whenever the share was low:

```
if (quality.realContributionPct !== null && quality.realContributionPct < LOW_REAL_CONTRIBUTION_PCT) {
  return QUEUE_COLORS.high;   // even when queueHealthLevel === "critical"
}
return QUEUE_COLORS[quality.queueHealthLevel];
```

Severity order is `low` (#3fb950) < `medium` (#d29922) < `high` (#db6d28) < `critical` (#f85149).

### Inversion
- `{ queueHealthLevel: "critical", realContributionPct: 20 }` → **#db6d28 (orange)**
- `{ queueHealthLevel: "critical", realContributionPct: 90 }` → **#f85149 (red)**

A repo with **both** a critical queue and a low real-contribution share (the worst combination) renders *less* alarming than the same critical queue with a healthy share. Adding the dominant negative signal makes the public badge look *better*.

### Why this is a defect, not a convention
- The function's own comment says a low real-contribution share **"dominates the signal"** — a dominant negative signal must make the color *more* severe, never less.
- The sibling test is titled *"downgrades the color when the real-contribution share is low"* (worsens the rating), but it only ever exercised a `low` queue — which is exactly why the `critical` inversion went unnoticed.

The low-share branch treats `high` as a **ceiling** when it should be a **floor**.

### Fix
Return the more severe of `high` and the actual queue color (floor at `high`, never downgrade):
```
return QUEUE_SEVERITY[quality.queueHealthLevel] >= QUEUE_SEVERITY.high ? queueColor : QUEUE_COLORS.high;
```
Edge cases preserved: unknown share (`null`) → queue color unchanged; `low`/`medium` queue + low share → still escalate to `#db6d28`; `high` queue + low share → `#db6d28` (no double-count); `critical` + low share → correctly stays `#f85149`.

### Tests
Adds a regression case: `critical` + low share stays red; `high`/`medium` + low share behave as before. Verified the `critical` assertion FAILS on current `main` and PASSES with the fix; the full `badge` suite stays green.

No linked issue: issue creation is unavailable for this account.
