### PR TITLE
fix(signals): count segment-only repos once in signal fidelity

### DIFF
--- a/src/signals/data-quality.ts
+++ b/src/signals/data-quality.ts
@@ -309,7 +309,11 @@ export function buildSignalFidelity(repoCount: number, states: RepoSyncStateReco
   const rateLimitResetValues = segments.flatMap((segment) =>
     (segment.status === "rate_limited" || segment.status === "waiting_rate_limit") && segment.rateLimitResetAt && !hasEffectiveSegmentCoverage(segment) ? [segment.rateLimitResetAt] : [],
   );
-  const missingRepoCount = Math.max(repoCount - states.length, 0);
+  // Count only repos that appear in NEITHER states nor segments as missing. `qualities` is built from the
+  // states+segments union (repoNames), so a segment-only repo already contributes an (unknown) quality entry;
+  // subtracting states.length here would double-count it (once as unknown, once as missing) and could push the
+  // degraded bucket above repoCount. Mirror buildCoreSignalFidelity, which subtracts the full union length.
+  const missingRepoCount = Math.max(repoCount - repoNames.length, 0);
   const status: SignalFidelity["status"] =
     repoCount === 0 || qualities.length === 0
       ? "unknown"

--- a/test/unit/data-quality.test.ts
+++ b/test/unit/data-quality.test.ts
@@ -51,6 +51,23 @@ describe("sync data quality", () => {
     });
   });
 
+  it("counts a segment-only repo (no sync state) once, not twice, in the degraded bucket", () => {
+    // A repo with crawl segment rows but no sync-state row is part of the states+segments union, so it already
+    // contributes an "unknown" quality entry; it must not ALSO be counted in missingRepoCount. Regression for the
+    // states.length vs repoNames.length divergence that let degradedRepos exceed repoCount.
+    const fidelity = buildSignalFidelity(1, [], [segment({ repoFullName: "owner/segment-only", segment: "open_issues", status: "complete" })]);
+
+    expect(fidelity).toMatchObject({
+      status: "degraded",
+      repoCount: 1,
+      completeRepos: 0,
+      degradedRepos: 1,
+      blockedRepos: 0,
+    });
+    // The bucket invariant must hold: every registered repo lands in exactly one bucket.
+    expect(fidelity.completeRepos + fidelity.degradedRepos + fidelity.blockedRepos).toBe(fidelity.repoCount);
+  });
+
   it("marks missing repo sync state as unknown at repo level", () => {
     expect(buildRepoDataQuality("owner/missing", null, [])).toMatchObject({
       status: "unknown",


### PR DESCRIPTION
## Summary

`buildSignalFidelity()` (`src/signals/data-quality.ts`) builds its per-repo `qualities` from `repoNames` — the **union** of sync-state repos and segment repos — but computed `missingRepoCount` from `states.length`. A registered repo that has crawl **segment** rows but no **sync-state** row was therefore counted **twice**: once as an `unknown`/degraded quality entry (a repo with no `syncState` resolves to `status: "unknown"`), and again inside `missingRepoCount`. That inflated `degradedRepos` and could push `completeRepos + degradedRepos + blockedRepos` above the registered `repoCount` — an impossible bucket state (e.g. `degradedRepos: 2` for `repoCount: 1`).

The sibling `buildCoreSignalFidelity()` already computes this correctly with `repoCount - repoNames.length`. This change makes `buildSignalFidelity()` do the same, so a segment-only repo lands in exactly one bucket, and adds a regression test that pins the `complete + degraded + blocked === repoCount` invariant for the segment-only case.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (one expression, mirroring an existing sibling function) whose rationale is fully self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- All of the above ran via `npm run test:ci` (unsharded) plus `npm audit --audit-level=moderate`; the whole gate is green. The single changed line is exercised by the existing `buildSignalFidelity` tests plus the new segment-only regression test, so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This is a pure backend/signal-logic change: no auth/CORS/session surface, no API/OpenAPI shape change, and no UI. The `Safety` boxes above are checked on that basis (no negative-path/UI-evidence surface applies).

## Notes

- One-line behavioral change (`states.length` → `repoNames.length`) with an explanatory comment, matching the already-correct `buildCoreSignalFidelity`. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
