### PR TITLE
feat(miner): add CoC-compliant rejection message templates

### DIFF
--- a/packages/gittensory-miner/lib/rejection-templates.d.ts
+++ b/packages/gittensory-miner/lib/rejection-templates.d.ts
@@ -1,0 +1,12 @@
+export type RejectionReason = "gate_close" | "maintainer_close_no_reason" | "superseded_by_duplicate";
+
+export type RejectionContext = {
+  repoFullName: string;
+  prNumber: number;
+};
+
+export const REJECTION_REASONS: readonly RejectionReason[];
+
+export function containsPrivateLanguage(text: string): boolean;
+
+export function renderRejectionMessage(reason: RejectionReason, context: RejectionContext): string;

--- a/packages/gittensory-miner/lib/rejection-templates.js
+++ b/packages/gittensory-miner/lib/rejection-templates.js
@@ -1,0 +1,71 @@
+// CoC-compliant rejection message templates (#2324). When one of the miner's PRs is closed/rejected, it may leave
+// a single, final, human-readable local note (e.g. in a run summary or CLI output — posting anywhere is a separate
+// write action, out of scope here). The note must be courteous, non-defensive, and never re-litigate the
+// maintainer's decision. This module is pure content/formatting: static template strings + a deterministic
+// renderer — no GitHub calls, no LLM, no network. Same inputs always render the same message.
+
+// Templates keyed by rejection-reason bucket. Every placeholder is `{name}`; the renderer resolves the structured
+// context (a PR number + a repo) and never interpolates free-form/private text.
+const REASON_TEMPLATES = {
+  gate_close:
+    "The automated review gate closed PR #{prNumber} on {repoFullName}. Thanks for the review — I'll address the flagged points and open a fresh PR if the change still fits.",
+  maintainer_close_no_reason:
+    "PR #{prNumber} on {repoFullName} was closed by the maintainer. Thanks for taking the time to look — I'll leave it here unless you'd like me to revisit it.",
+  superseded_by_duplicate:
+    "PR #{prNumber} on {repoFullName} looks superseded by other work on the same issue, so I'm closing it on my side to avoid duplication. Thanks to whoever is carrying it forward.",
+};
+
+/** The supported rejection-reason buckets, in declaration order. */
+export const REJECTION_REASONS = Object.freeze(Object.keys(REASON_TEMPLATES));
+
+// Private-language tokens that must never surface in a public-facing courtesy note (mirrors the redaction set in
+// `sanitizePublicComment`, src/github/commands.ts). Templates are authored clean and this is asserted in tests;
+// the structured context (a PR number + a validated `owner/repo`) carries no private scoring/reward/wallet data,
+// so — deliberately — no value-level redaction is applied that could mangle a legitimate repo name.
+const PRIVATE_LANGUAGE =
+  /\b(?:raw trust scores?|trust scores?|wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?|payouts?|rewards?)\b/i;
+
+/** True when the given text contains any banned private-language token. */
+export function containsPrivateLanguage(text) {
+  return PRIVATE_LANGUAGE.test(text);
+}
+
+// A GitHub `owner/repo`: owner is 1-39 chars of alphanumerics/hyphens starting alphanumeric; repo is
+// alphanumerics/`.`/`_`/`-`. Anchored + character-class-restricted so control characters, whitespace, markup, or an
+// extra `/` (e.g. `owner/repo\nextra`, `owner/<repo>`) are rejected — the note interpolates this text directly, so a
+// malformed value must throw rather than leak caller-controlled display text.
+const GITHUB_FULL_NAME = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+
+function normalizeRepoFullName(repoFullName) {
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const trimmed = repoFullName.trim();
+  if (!GITHUB_FULL_NAME.test(trimmed)) throw new Error("invalid_repo_full_name");
+  return trimmed;
+}
+
+function normalizePrNumber(prNumber) {
+  if (!Number.isInteger(prNumber) || prNumber < 1) throw new Error("invalid_pr_number");
+  return prNumber;
+}
+
+/**
+ * Render the courtesy note for a closed/rejected PR. `reason` must be one of {@link REJECTION_REASONS}; `context`
+ * supplies `repoFullName` (`owner/repo`) and `prNumber` (a positive integer). Throws on an unknown reason, a
+ * malformed context, or (defensively) any placeholder a template leaves unresolved — so a caller can never emit a
+ * half-rendered note. Pure and deterministic.
+ */
+export function renderRejectionMessage(reason, context = {}) {
+  const template = REASON_TEMPLATES[reason];
+  if (template === undefined) throw new Error("invalid_rejection_reason");
+  const values = {
+    repoFullName: normalizeRepoFullName(context.repoFullName),
+    prNumber: normalizePrNumber(context.prNumber),
+  };
+  const rendered = template.replace(/\{(\w+)\}/g, (_match, key) => {
+    const value = values[key];
+    if (value === undefined) throw new Error(`missing_placeholder:${key}`);
+    return String(value);
+  });
+  if (/\{[^}]+\}/.test(rendered)) throw new Error("unresolved_placeholder");
+  return rendered;
+}

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/claim-ledger.js && node --check lib/portfolio-queue.js && node --check lib/opportunity-ranker.js && node --check lib/plan-store.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/claim-ledger.js && node --check lib/portfolio-queue.js && node --check lib/opportunity-ranker.js && node --check lib/plan-store.js && node --check lib/rejection-templates.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-rejection-templates.test.ts
+++ b/test/unit/miner-rejection-templates.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  REJECTION_REASONS,
+  containsPrivateLanguage,
+  renderRejectionMessage,
+} from "../../packages/gittensory-miner/lib/rejection-templates.js";
+
+const CONTEXT = { repoFullName: "JSONbored/gittensory", prNumber: 2751 } as const;
+
+describe("gittensory-miner rejection templates (#2324)", () => {
+  it("exposes the frozen reason vocabulary", () => {
+    expect(REJECTION_REASONS).toEqual(["gate_close", "maintainer_close_no_reason", "superseded_by_duplicate"]);
+    expect(Object.isFrozen(REJECTION_REASONS)).toBe(true);
+  });
+
+  it("renders every reason bucket with no unresolved placeholders and the resolved context", () => {
+    for (const reason of REJECTION_REASONS) {
+      const message = renderRejectionMessage(reason, CONTEXT);
+      expect(message).not.toMatch(/\{[^}]+\}/); // no unresolved {placeholder}
+      expect(message).toContain("JSONbored/gittensory");
+      expect(message).toContain("#2751");
+    }
+  });
+
+  it("keeps every rendered note courteous and free of private-language tokens", () => {
+    for (const reason of REJECTION_REASONS) {
+      const message = renderRejectionMessage(reason, CONTEXT);
+      expect(containsPrivateLanguage(message)).toBe(false);
+      // Non-defensive: no blaming / decision re-litigation language.
+      expect(message.toLowerCase()).not.toMatch(/\b(wrong|unfair|mistake|should have|disagree)\b/);
+    }
+  });
+
+  it("detects private-language tokens (the public-safe guard)", () => {
+    expect(containsPrivateLanguage("thanks for the review")).toBe(false);
+    expect(containsPrivateLanguage("do not expose the hotkey")).toBe(true);
+    expect(containsPrivateLanguage("no trust score here")).toBe(true);
+  });
+
+  it("throws on an unknown reason bucket", () => {
+    // @ts-expect-error — reason must be a known bucket
+    expect(() => renderRejectionMessage("unknown_reason", CONTEXT)).toThrow("invalid_rejection_reason");
+  });
+
+  it("throws on a malformed context rather than emitting a half-rendered note", () => {
+    expect(() => renderRejectionMessage("gate_close", { repoFullName: "no-slash", prNumber: 1 })).toThrow(
+      "invalid_repo_full_name",
+    );
+    expect(() => renderRejectionMessage("gate_close", { repoFullName: "o/a", prNumber: 0 })).toThrow(
+      "invalid_pr_number",
+    );
+    // @ts-expect-error — prNumber is required
+    expect(() => renderRejectionMessage("gate_close", { repoFullName: "o/a" })).toThrow("invalid_pr_number");
+  });
+
+  it("rejects a repoFullName carrying control characters, markup, or an extra slash (no display-text leakage)", () => {
+    for (const bad of ["owner/repo\nextra", "owner/repo extra", "owner/<repo>", "owner/repo/extra", "-owner/repo", "owner/re*po"]) {
+      expect(() => renderRejectionMessage("gate_close", { repoFullName: bad, prNumber: 1 })).toThrow(
+        "invalid_repo_full_name",
+      );
+    }
+    // A well-formed owner/repo with the allowed punctuation still renders.
+    expect(renderRejectionMessage("gate_close", { repoFullName: "JSONbored/gittensory.io_test-1", prNumber: 9 })).toContain(
+      "JSONbored/gittensory.io_test-1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds **CoC-compliant rejection message templates** to `@jsonbored/gittensory-miner`: when one of the miner's PRs is closed/rejected, it can render a single, final, human-readable courtesy note (for a local run summary or CLI output — posting anywhere is a separate write action, out of scope here). Pure content/formatting: static template strings + a deterministic renderer, **no GitHub calls, no LLM, no network**.

- `renderRejectionMessage(reason, context)` renders the note for one of the reason buckets in `REJECTION_REASONS` — `gate_close`, `maintainer_close_no_reason`, `superseded_by_duplicate` — from a structured `context` (`repoFullName` = `owner/repo`, `prNumber` = positive integer). It throws on an unknown reason, a malformed context, or (defensively) any unresolved placeholder, so a caller can never emit a half-rendered note. Same inputs always render the same message.
- Every template is **courteous and non-defensive** — it thanks the reviewer and never re-litigates the maintainer's decision.
- `containsPrivateLanguage(text)` mirrors the redaction set in `sanitizePublicComment` (`src/github/commands.ts`); the templates are authored clean and this is asserted in tests. The structured context (a PR number + a validated `owner/repo`) carries no private scoring/reward/wallet data, so — deliberately — no value-level redaction is applied that would mangle a legitimate repo name.

Closes #2324.

**Location note:** the issue sketched `src/manage/rejection-templates.ts`, but this package is authored as plain-JS `lib/*.js` + hand-written `.d.ts` (no TS build — its `build` is `node --check`), like every other module beside it (`deny-hooks`, `run-state`, `event-ledger`, `claim-ledger`, …). I followed that established, merged convention rather than introducing a TS toolchain to the package.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#2324).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new `test/unit/miner-rejection-templates.test.ts` passes (whole miner suite green). This change lives entirely in `packages/**`, which Codecov does not measure, so it carries no `codecov/patch` obligation; the logic is nonetheless exercised across every reason bucket rendering cleanly, the courteous/no-private-language assertions, the private-language guard, unknown-reason, and malformed-context rejection.
- [x] `node --check lib/rejection-templates.js` via `npm run --workspace @jsonbored/gittensory-miner build`
- [ ] `npm audit --audit-level=moderate` — this PR adds **no dependencies**, so dependency-review has nothing new to evaluate.
- [x] New behavior has unit tests for new branches and the public-safe invariant.

If any required check was skipped, explain why:

- UI/OpenAPI/migration/workers checks are not applicable: this change is one pure content/formatting module in `packages/gittensory-miner/lib` plus its test — no `src/**`, UI, API schema, DB, or Cloudflare-binding surface is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. Templates are public-safe by construction and asserted free of private-language tokens.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. The notes are courteous and never re-litigate a maintainer decision.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — n/a: pure string formatting, no auth/session/network surface.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — n/a: no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real states. — n/a: no UI change.
- [ ] Visible UI changes include a `UI Evidence` section. — n/a: no visible UI, frontend, docs, or extension change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

Additive: two new files (`lib/rejection-templates.js` + its `lib/rejection-templates.d.ts`), one line added to the package `build` (`node --check`) gate, and one new test file. No existing code is modified.
