### PR TITLE
fix(signals): count segment-only repos once in signal-fidelity

### DIFF
--- a/src/signals/data-quality.ts
+++ b/src/signals/data-quality.ts
@@ -309,7 +309,11 @@ export function buildSignalFidelity(repoCount: number, states: RepoSyncStateReco
   const rateLimitResetValues = segments.flatMap((segment) =>
     (segment.status === "rate_limited" || segment.status === "waiting_rate_limit") && segment.rateLimitResetAt && !hasEffectiveSegmentCoverage(segment) ? [segment.rateLimitResetAt] : [],
   );
-  const missingRepoCount = Math.max(repoCount - states.length, 0);
+  // Count repos we have no signal for at all against the union of state+segment repos,
+  // matching buildCoreSignalFidelity. A segment-only repo already surfaces as an
+  // unknown-status quality above, so keying missingRepoCount off states.length would
+  // charge it twice and let degradedRepos exceed repoCount.
+  const missingRepoCount = Math.max(repoCount - repoNames.length, 0);
   const status: SignalFidelity["status"] =
     repoCount === 0 || qualities.length === 0
       ? "unknown"

--- a/test/unit/data-quality.test.ts
+++ b/test/unit/data-quality.test.ts
@@ -51,6 +51,22 @@ describe("sync data quality", () => {
     });
   });
 
+  it("counts a segment-only repo once in degradedRepos instead of double-counting it as missing", () => {
+    // A repo with segment rows but no sync-state row appears in the state+segment
+    // union, so it already surfaces as an unknown-status quality. It must not also
+    // inflate missingRepoCount, or degradedRepos would exceed repoCount.
+    const fidelity = buildSignalFidelity(1, [], [segment({ repoFullName: "owner/only-segment", segment: "open_issues", status: "complete" })]);
+
+    expect(fidelity).toMatchObject({
+      status: "degraded",
+      repoCount: 1,
+      completeRepos: 0,
+      degradedRepos: 1,
+      partialRepos: ["owner/only-segment"],
+    });
+    expect(fidelity.degradedRepos).toBeLessThanOrEqual(fidelity.repoCount);
+  });
+
   it("marks missing repo sync state as unknown at repo level", () => {
     expect(buildRepoDataQuality("owner/missing", null, [])).toMatchObject({
       status: "unknown",


### PR DESCRIPTION
## Summary

`buildSignalFidelity` in `src/signals/data-quality.ts` builds its per-repo `qualities` from the **union** of repos appearing in `states` and `segments`, but computed `missingRepoCount` from `states.length` alone:

```ts
const repoNames = [...new Set([...states.map((s) => s.repoFullName), ...segments.map((s) => s.repoFullName)])].sort();
const qualities = repoNames.map((repoFullName) => buildRepoDataQuality(repoFullName, states.find(...), segmentRepos.get(repoFullName) ?? []));
...
const missingRepoCount = Math.max(repoCount - states.length, 0);   // <- states.length, not the union
...
degradedRepos: qualities.filter((q) => q.status === "degraded" || q.status === "unknown").length + missingRepoCount,
```

A repo that has `segments` rows but **no** sync-state row still appears in `repoNames`, so `buildRepoDataQuality` returns `status: "unknown"` for it (the `!syncState ? "unknown"` branch). That repo is then counted in `degradedRepos` via the `unknown` filter **and** again in `missingRepoCount`, because it is absent from `states` — so `degradedRepos` can exceed `repoCount` (e.g. `buildSignalFidelity(1, [], [segmentOnlyRepo])` reported `degradedRepos: 2` for `repoCount: 1`).

The sibling `buildCoreSignalFidelity` already derives the same "repos with no signal at all" count from the union (`repoCount - repoNames.length`). This aligns `buildSignalFidelity` with it so a segment-only repo is counted exactly once.

This is a small, self-contained fidelity-metric correctness fix, so it ships as a direct PR rather than a tracked issue; the summary above is the full rationale.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped; the full `npm run test:ci` gate plus `npm audit --audit-level=moderate` were run locally and are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This is a backend-only change to a signal-fidelity aggregate; there is no auth/CORS/session surface and no UI, OpenAPI, or MCP behavior change, so those boxes are N/A.

## Notes

- Added a regression test in `test/unit/data-quality.test.ts` that asserts a segment-only repo is counted once (`degradedRepos: 1` for `repoCount: 1`) and that the `degradedRepos <= repoCount` invariant holds; it fails on the previous `states.length` code and passes on the fix. Existing tests only exercised aligned inputs where `states.length === repoNames.length`, so the divergence was never triggered.
