### PR TITLE
fix: block shared MCP token from reading other contributors' private data over HTTP

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -21,6 +21,7 @@ import {
   extractBrowserSessionToken,
   extractCookieValue,
   isAuthorizedGitHubSessionLogin,
+  isMcpReadUnscoped,
   revokeSession,
   timingSafeEqual,
   type AuthIdentity,
@@ -4979,6 +4980,14 @@ async function requireContributorAccess(c: ProtectedRouteContext, login: string)
   /* v8 ignore next -- Protected middleware rejects unauthenticated private routes before contributor-scoped route guards. */
   if (!identity) return c.json({ error: "unauthorized" }, 401);
   if (identity.kind === "session" && identity.actor.toLowerCase() !== login.toLowerCase()) return c.json({ error: "forbidden_contributor" }, 403);
+  // The shared, end-user-obtainable GITTENSORY_MCP_TOKEN (static `mcp` identity) must NOT read an ARBITRARY
+  // contributor's private decision pack / profile / notifications over HTTP either — this mirrors the MCP tool
+  // surface's guard for the identical data (GittensoryMcp.requireContributorAccess, #2455). Without this, the
+  // HTTP surface silently grants what the MCP surface explicitly denies for the very same token. Only the full
+  // MCP_READ_REPO_ALLOWLIST wildcard opt-in unlocks it; operator-only `api`/`internal` tokens stay trusted by design.
+  if (identity.kind === "static" && identity.actor === "mcp" && !isMcpReadUnscoped(c.env.MCP_READ_REPO_ALLOWLIST)) {
+    return c.json({ error: "forbidden_contributor" }, 403);
+  }
   return null;
 }
 

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -285,6 +285,38 @@ describe("api route guards and error branches", () => {
     await expect(victimRun.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
   });
 
+  it("blocks the shared MCP token from reading another contributor's private data unless the read allowlist is unscoped (#2455 HTTP parity)", async () => {
+    const app = createApp();
+
+    // Scoped (non-wildcard) read allowlist: GITTENSORY_MCP_TOKEN is a shared, end-user-obtainable CLI credential,
+    // so it must NOT read an arbitrary contributor's private decision pack over HTTP — mirroring the MCP tool
+    // surface's guard for the identical data (GittensoryMcp.requireContributorAccess, #2455).
+    const scopedEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "owner/private-repo" });
+    await seedVictimDecisionPack(scopedEnv);
+    const mcpHeaders = { authorization: `Bearer ${scopedEnv.GITTENSORY_MCP_TOKEN}`, "content-type": "application/json" };
+
+    const scopedDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: mcpHeaders }, scopedEnv);
+    expect(scopedDecisionPack.status).toBe(403);
+    await expect(scopedDecisionPack.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
+
+    const scopedProfile = await app.request("/v1/contributors/victim/profile", { headers: mcpHeaders }, scopedEnv);
+    expect(scopedProfile.status).toBe(403);
+    await expect(scopedProfile.json()).resolves.toMatchObject({ error: "forbidden_contributor" });
+
+    // The operator-only API token stays trusted for cross-contributor reads by design.
+    const operatorDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: apiHeaders(scopedEnv) }, scopedEnv);
+    expect(operatorDecisionPack.status).toBe(200);
+    await expect(operatorDecisionPack.json()).resolves.toMatchObject({ login: "victim", summary: "private advisory summary" });
+
+    // Explicit MCP_READ_REPO_ALLOWLIST=* opt-in unlocks the shared token (the same escape hatch as the MCP surface).
+    const wildcardEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "*" });
+    await seedVictimDecisionPack(wildcardEnv);
+    const wildcardHeaders = { authorization: `Bearer ${wildcardEnv.GITTENSORY_MCP_TOKEN}`, "content-type": "application/json" };
+    const wildcardDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: wildcardHeaders }, wildcardEnv);
+    expect(wildcardDecisionPack.status).toBe(200);
+    await expect(wildcardDecisionPack.json()).resolves.toMatchObject({ login: "victim", summary: "private advisory summary" });
+  });
+
   it("keeps OAuth setup, CORS, and rate limits explicit", async () => {
     const app = createApp();
     const env = createTestEnv();
@@ -1036,6 +1068,38 @@ async function seedRegisteredInstalledRepo(env: Env, installationId: number, own
   await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
     .bind(`${owner}/${name}`)
     .run();
+}
+
+async function seedVictimDecisionPack(env: Env): Promise<void> {
+  await persistSignalSnapshot(env, {
+    id: "victim-decision-pack",
+    signalType: "contributor-decision-pack",
+    targetKey: "victim",
+    payload: {
+      status: "ready",
+      source: "computed",
+      login: "victim",
+      generatedAt: "2026-05-29T00:00:00.000Z",
+      stale: false,
+      freshness: "fresh",
+      rebuildEnqueued: false,
+      scoringModelSnapshotId: "scoring-1",
+      profile: {},
+      outcomeHistory: {},
+      roleContexts: [],
+      repoDecisions: [{ repoFullName: "owner/private-repo", recommendation: "avoid", scoreBlockers: ["private score blocker"] }],
+      topActions: [{ actionKind: "open_new_direct_pr", repoFullName: "owner/private-repo", priorityScore: 50, rationale: "private next action" }],
+      cleanupFirst: [],
+      pursueRepos: [],
+      avoidRepos: [{ repoFullName: "owner/private-repo", recommendation: "avoid" }],
+      maintainerLaneRepos: [],
+      scoreBlockers: ["private score blocker"],
+      dataQuality: { signalFidelity: { status: "ready" } },
+      summary: "private advisory summary",
+      nextActions: ["sensitive next action"],
+    } as never,
+    generatedAt: "2026-05-29T00:00:00.000Z",
+  });
 }
 
 function apiHeaders(env: Env): Record<string, string> {


### PR DESCRIPTION
## Summary

The HTTP `requireContributorAccess` guard in `src/api/routes.ts` only enforced self-only access for `session` identities and treated **every** static identity — including the shared `mcp` token — as fully trusted. The MCP tool surface already blocks the static `mcp` identity from reading an arbitrary contributor's private data unless `MCP_READ_REPO_ALLOWLIST` is the wildcard (`GittensoryMcp.requireContributorAccess`, #2455), but the HTTP API exposing the **identical** data never applied the same guard.

## Root cause

`authenticatePrivateToken` mints a `{ kind: "static", actor: "mcp" }` identity from `GITTENSORY_MCP_TOKEN`. The protected middleware only applies the `canSessionAccessPath` allowlist to `session` identities, so a bearer `mcp` token flows straight to the route handler. `requireContributorAccess` then returned `null` (allow) for any static identity, so the `mcp` token could read any contributor's `/v1/contributors/:login/decision-pack`, `/profile`, `/open-pr-monitor`, `/v1/scoring/preview`, `/v1/agent/*`, `/v1/local/*`, etc.

`GITTENSORY_MCP_TOKEN` is documented (in `src/auth/security.ts`) as a **shared, end-user-obtainable CLI credential** that must not be trusted for arbitrary contributor data. This is a cross-contributor IDOR that violates the project's stated privacy boundary.

## Fix approach

Mirror the shipped MCP #2455 guard in the HTTP `requireContributorAccess`: deny the static `mcp` identity unless `isMcpReadUnscoped(MCP_READ_REPO_ALLOWLIST)` (the explicit `*`/`all` operator opt-in). Operator-only `api`/`internal` tokens remain trusted by design, and `session` self-only behavior is unchanged.

## Impact

- Closes the cross-contributor private-data read over HTTP for the shared MCP token, bringing the HTTP surface into parity with the MCP tool surface.
- Preserves the existing operator escape hatch (`MCP_READ_REPO_ALLOWLIST=*`).

## Risk / tradeoffs

- Minimal, single-guard change. No behavior change for operator `api`/`internal` tokens or for browser/session identities.
- Existing HTTP tests that use the `mcp` token on contributor routes run with the default wildcard allowlist, so they are unaffected. Added a regression test (`test/integration/routes-errors.test.ts`) covering deny-when-scoped, operator-still-allowed, and allow-when-wildcard.

> Note: local `npm`/`tsc`/`vitest` could not be executed in the authoring environment (no Node package toolchain installed); IDE TypeScript diagnostics are clean. CI will run the full suite.