### PR TITLE
fix(signals): align extension component band with the readiness partial cutoff

### DIFF
--- a/src/signals/extension-contributor-context.ts
+++ b/src/signals/extension-contributor-context.ts
@@ -105,7 +105,10 @@ function componentBand(score: number, max: number): ExtensionReadinessComponentB
   if (max <= 0) return "unmet";
   const ratio = score / max;
   if (ratio >= 0.85) return "met";
-  if (ratio >= 0.5) return "partial";
+  // Mirror the readiness rubric's ⚠️ cutoff (scoreResultIcon in engine.ts: ratio >= 0.45). A stricter 0.5 here
+  // showed a component scored in [0.45, 0.5) as fully "unmet" in the extension overlay while the maintainer-facing
+  // readiness table rendered the same component as ⚠️ (partial) — the two surfaces must agree on the same score.
+  if (ratio >= 0.45) return "partial";
   return "unmet";
 }
 

--- a/test/unit/extension-contributor-context.test.ts
+++ b/test/unit/extension-contributor-context.test.ts
@@ -120,4 +120,20 @@ describe("buildExtensionPrStatus", () => {
     });
     expect(status.components[0]!.band).toBe("unmet");
   });
+
+  it("bands a component at the readiness rubric's partial cutoff (ratio >= 0.45) as partial, not unmet", () => {
+    // scoreResultIcon in the readiness table treats ratio >= 0.45 as ⚠️ (partial); the extension band must agree,
+    // otherwise a component scored in [0.45, 0.5) is shown as fully unmet in the overlay while the table shows partial.
+    const status = buildExtensionPrStatus({
+      repoFullName: "octo/demo",
+      pullNumber: 1,
+      readiness: readiness(55, {
+        components: [
+          { key: "validation", label: "Validation", score: 9, max: 20, evidence: "Some tests.", action: "Add tests." }, // ratio 0.45 (boundary)
+          { key: "change_scope", label: "Change scope", score: 49, max: 100, evidence: "Large diff.", action: "Split it." }, // ratio 0.49
+        ],
+      }),
+    });
+    expect(status.components.map((component) => component.band)).toEqual(["partial", "partial"]);
+  });
 });


### PR DESCRIPTION
## Summary

`componentBand()` in `src/signals/extension-contributor-context.ts` maps a readiness component's `score/max` ratio to a `met`/`partial`/`unmet` band for the contributor extension overlay. It used a `0.5` "partial" cutoff, but the readiness table's own rubric — `scoreResultIcon()` in `src/signals/engine.ts`, operating on the **same** `PublicReadinessScore["components"][number]` shape — treats `ratio >= 0.45` as ⚠️ (partial). The `met` cutoff already agrees between the two (`0.85`); only the middle threshold had drifted.

The effect: a component scored in `[0.45, 0.5)` (e.g. Validation at 45%) was rendered as fully **`unmet`** in the extension overlay while the maintainer-facing readiness table showed the identical score as **partial** — the two surfaces disagreed about the same underlying component. This aligns `componentBand()` to the canonical `0.45` cutoff so both surfaces agree.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (a single threshold constant, brought into parity with the existing readiness rubric) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- All of the above ran via `npm run test:ci` (unsharded) plus `npm audit --audit-level=moderate`; the whole gate is green. The changed line's `>= 0.45` branch is exercised on both sides (a component at ratio 0.45/0.49 → partial in the new test; an existing 0.3 case → unmet), so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This is a pure backend/signal-logic change to a public-safe payload builder (it emits bands, never raw scores — that boundary is untouched and still covered by the existing `not.toMatch(/"score"|"total"|"max"/)` and forbidden-terms assertions). No auth/CORS/session surface, no API/OpenAPI shape change, and no UI rendering; the `Safety` boxes are checked on that basis.

## Notes

- One-line behavioral change (`0.5` → `0.45`) plus an explanatory comment pointing at the canonical `scoreResultIcon` rubric it mirrors. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
