### PR TITLE
fix(selfhost): harden codex readiness probe

### DIFF
--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -135,18 +135,37 @@ export function codexAuthReadinessProbe(
   parentEnv: Record<string, string | undefined>,
   runCodexVersion: (env: Record<string, string | undefined>) => Promise<{ code: number | null }>,
   checkAuthFile: (env: Record<string, string | undefined>) => Promise<boolean> = defaultCodexAuthFileCheck,
+  cacheMs = 30_000,
 ): ReadinessProbe | null {
   if (parentEnv.GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER !== "1") return null;
+  let cached: boolean | undefined;
+  let cachedUntil = 0;
+  let inFlight: Promise<boolean> | undefined;
+  const evaluate = async (): Promise<boolean> => {
+    const [versionOk, authFileOk] = await Promise.all([
+      runCodexVersion(parentEnv)
+        .then(({ code }) => code === 0)
+        .catch(() => false),
+      checkAuthFile(parentEnv).catch(() => false),
+    ]);
+    return versionOk && authFileOk;
+  };
   return {
     name: "codex_auth",
-    check: async () => {
-      const [versionOk, authFileOk] = await Promise.all([
-        runCodexVersion(parentEnv)
-          .then(({ code }) => code === 0)
-          .catch(() => false),
-        checkAuthFile(parentEnv).catch(() => false),
-      ]);
-      return versionOk && authFileOk;
+    check: () => {
+      const now = Date.now();
+      if (cached !== undefined && now < cachedUntil) return Promise.resolve(cached);
+      if (inFlight) return inFlight;
+      inFlight = evaluate()
+        .then((ok) => {
+          cached = ok;
+          cachedUntil = Date.now() + cacheMs;
+          return ok;
+        })
+        .finally(() => {
+          inFlight = undefined;
+        });
+      return inFlight;
     },
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import {
   resolveRequiredCliProviders,
   resolveSubscriptionCliPath,
   shouldMarkAiProviderUnhealthyAtBoot,
+  subscriptionCliEnv,
 } from "./selfhost/ai";
 import {
   cookieValue,
@@ -580,11 +581,17 @@ async function main(): Promise<void> {
   // unauthenticated auth volume surfaces in /ready instead of silently inside a spawned subprocess mid-review.
   const codexProbe = codexAuthReadinessProbe(process.env, async (env) => {
     const { spawn } = await import("node:child_process");
-    return new Promise((resolve) => {
-      const child = spawn("codex", ["--version"], { env: env as NodeJS.ProcessEnv, stdio: "ignore" });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1500);
+    return new Promise<{ code: number | null }>((resolve) => {
+      const child = spawn("codex", ["--version"], {
+        env: subscriptionCliEnv(env) as NodeJS.ProcessEnv,
+        signal: controller.signal,
+        stdio: "ignore",
+      });
       child.on("close", (code) => resolve({ code }));
       child.on("error", () => resolve({ code: 1 }));
-    });
+    }).finally(() => clearTimeout(timeout));
   });
   if (codexProbe) {
     readinessProbes.push({

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -133,6 +133,51 @@ describe("codexAuthReadinessProbe (#GITTENSORY-C)", () => {
     await expect(probe!.check()).resolves.toBe(true);
   });
 
+  it("regression: coalesces concurrent checks and reuses the cached result", async () => {
+    let versionCalls = 0;
+    let resolveVersion: ((value: { code: number }) => void) | undefined;
+    let markStarted: (() => void) | undefined;
+    const versionStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const probe = codexAuthReadinessProbe(
+      { GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },
+      async () => {
+        versionCalls += 1;
+        markStarted!();
+        return new Promise<{ code: number }>((done) => {
+          resolveVersion = done;
+        });
+      },
+      async () => true,
+    );
+
+    const first = probe!.check();
+    const second = probe!.check();
+    await versionStarted;
+    resolveVersion!({ code: 0 });
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    await expect(probe!.check()).resolves.toBe(true);
+    expect(versionCalls).toBe(1);
+  });
+
+  it("rechecks after the codex readiness cache expires", async () => {
+    let versionCalls = 0;
+    const probe = codexAuthReadinessProbe(
+      { GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },
+      async () => {
+        versionCalls += 1;
+        return { code: 0 };
+      },
+      async () => true,
+      0,
+    );
+
+    await expect(probe!.check()).resolves.toBe(true);
+    await expect(probe!.check()).resolves.toBe(true);
+    expect(versionCalls).toBe(2);
+  });
+
   it("reports unhealthy when codex --version exits non-zero (missing/unauthenticated auth volume)", async () => {
     const probe = codexAuthReadinessProbe(
       { GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1" },


### PR DESCRIPTION
### Motivation
- Remediate an unauthenticated resource-amplification path where `/ready` readiness probes could spawn `codex --version` processes with the full server environment and no cancellation, risking process accumulation and exposure of runtime secrets.
- Ensure the codex readiness check fails closed on missing/empty auth credentials while preventing per-request CLI spawning under burst load.

### Description
- Restrict the subprocess environment for the codex probe to the allowlisted CLI env by using `subscriptionCliEnv(...)` instead of passing the full `process.env` to the child process.
- Add an `AbortController` deadline and pass `signal` to the spawned `codex` process, and clear the timeout when the child exits so hung processes are aborted when the readiness deadline elapses.
- Coalesce concurrent `codex_auth` checks and add a short-lived cache (`cacheMs`) in `codexAuthReadinessProbe` so overlapping or bursty `/ready` requests reuse an in-flight result instead of spawning multiple CLI processes.
- Add unit test coverage for coalescing, cached reuse, and cache expiry in `test/unit/selfhost-health.test.ts` and wire the changes in `src/server.ts` and `src/selfhost/health.ts`.

### Testing
- Ran the targeted unit tests with `npx vitest run test/unit/selfhost-health.test.ts test/unit/selfhost-ai.test.ts --coverage=false` and they passed.
- Ran static typechecking with `npm run typecheck` and it passed (`tsc --noEmit`).
- Attempted the full local gate (`npm run test:ci`) but it was blocked by `actionlint` setup/network issues; `npm audit --audit-level=moderate` returned a `403` from the registry so the audit step could not complete; a full unsharded `npm run test:coverage` was attempted but the broader test suite run was interrupted/long-running and not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a479e5f7550832c951594382ab669ae)