### PR TITLE
fix(queue): bound global cap live verification

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2088,7 +2088,7 @@ async function runAgentMaintenancePlanAndExecute(
         repoFullName,
         number: pr.number,
         kind: "pull_request",
-      });
+      }, globalCap);
       if (globalOpenCount > globalCap) {
         // verifiedGlobalOpenItemCount sums BOTH open PRs and open issues -- reporting this as "pull requests"
         // when the author's over-cap total may include issues would be a factually wrong close message.
@@ -3972,26 +3972,24 @@ async function isOpenItemRowStillLiveOpen(
   return livePr?.state === "open";
 }
 
-// A contributor can have thousands of open rows across a large install -- an unbounded Promise.all over every
-// one of them would fire that many concurrent GitHub API calls from a single webhook, exhausting the
-// installation's rate limit for every OTHER repo it gates. Bounded worker-pool fan-out, mirroring the same
-// fixed-concurrency shape already used elsewhere in this codebase for GitHub fan-out.
+// A contributor can have thousands of open rows across a large install. Verify in fixed-size batches and stop
+// once the caller has enough confirmed-open siblings to prove the cap is exceeded, preserving stale-row safety
+// without letting one webhook drain the installation rate-limit bucket.
 const GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY = 10;
 
-async function mapWithConcurrency<T, R>(items: T[], concurrency: number, mapper: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workerCount = Math.max(1, Math.min(concurrency, items.length || 1));
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
-        const index = nextIndex;
-        nextIndex += 1;
-        results[index] = await mapper(items[index] as T);
-      }
-    }),
-  );
-  return results;
+async function countLiveOpenWithConcurrencyUntil(
+  rows: OpenItemAcrossInstallRow[],
+  concurrency: number,
+  stopAfterConfirmedOpen: number,
+  mapper: (row: OpenItemAcrossInstallRow) => Promise<boolean>,
+): Promise<number> {
+  let confirmedOpenCount = 0;
+  for (let start = 0; start < rows.length && confirmedOpenCount <= stopAfterConfirmedOpen; start += concurrency) {
+    const batch = rows.slice(start, start + concurrency);
+    const results = await Promise.all(batch.map(mapper));
+    confirmedOpenCount += results.filter(Boolean).length;
+  }
+  return confirmedOpenCount;
 }
 
 /**
@@ -4005,6 +4003,7 @@ async function verifiedGlobalOpenItemCount(
   installationId: number,
   authorLogin: string,
   currentItem: { repoFullName: string; number: number; kind: "pull_request" | "issue" },
+  globalCap: number,
 ): Promise<number> {
   const rows = await listOpenItemsForAuthorAcrossInstall(env, installationId, authorLogin);
   const otherRows = rows.filter(
@@ -4013,10 +4012,13 @@ async function verifiedGlobalOpenItemCount(
   const token = await createInstallationToken(env, installationId).catch(() => undefined);
   const liveToken = token ?? env.GITHUB_PUBLIC_TOKEN;
   const admissionKey = githubAdmissionKeyForToken(env, installationId, liveToken);
-  const confirmedOpen = await mapWithConcurrency(otherRows, GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY, (row) =>
-    isOpenItemRowStillLiveOpen(env, row, liveToken, admissionKey),
+  const confirmedOpenCount = await countLiveOpenWithConcurrencyUntil(
+    otherRows,
+    GLOBAL_OPEN_ITEM_LIVE_CHECK_CONCURRENCY,
+    globalCap - 1,
+    (row) => isOpenItemRowStillLiveOpen(env, row, liveToken, admissionKey),
   );
-  return confirmedOpen.filter(Boolean).length + 1;
+  return confirmedOpenCount + 1;
 }
 
 /**
@@ -4073,7 +4075,7 @@ async function maybeCloseIssueOverContributorCap(
       repoFullName,
       number: issue.number,
       kind: "issue",
-    });
+    }, globalCap);
     if (globalOpenCount > globalCap) {
       const planned = planAgentMaintenanceActions({
         conclusion: "skipped",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -8282,6 +8282,63 @@ describe("queue processors", () => {
     expect(closeAudit?.n).toBeGreaterThanOrEqual(1);
   });
 
+  it("install-wide contributor open-item cap (#2562): stops live verification after the cap is exceeded", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "1" });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "repo-a", full_name: "JSONbored/repo-a", private: false, owner: { login: "JSONbored" } }],
+    });
+    for (let number = 1; number <= 30; number += 1) {
+      await upsertPullRequestFromGitHub(env, "JSONbored/repo-a", { number, title: `Farmer PR ${number}`, state: "open", user: { login: "farmer99" }, head: { sha: `fa${number}` }, labels: [], body: "x" });
+    }
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/repo-a",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      aiReviewMode: "advisory",
+      autonomy: { close: "auto", label: "auto" },
+    });
+    const seen = { closed: false, livePullReads: [] as number[] };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      const siblingPull = url.match(/\/repos\/JSONbored\/repo-a\/pulls\/(\d+)$/);
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+      if (siblingPull && siblingPull[1] !== "55") { seen.livePullReads.push(Number(siblingPull[1])); return Response.json({ number: Number(siblingPull[1]), state: "open" }); }
+      if (url.includes("/pulls/55/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+const ok = true;" }]);
+      if (url.includes("/pulls/55/reviews")) return Response.json([]);
+      if (url.includes("/pulls/55/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/55") && method === "PATCH") { seen.closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ number: 55, state: "closed" }); }
+      if (url.endsWith("/pulls/55")) return Response.json({ number: 55, state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, mergeable_state: "clean" });
+      if (url.includes("/commits/f55/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/f55/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/55/labels") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/55/labels") && method === "POST") return Response.json([]);
+      if (url.includes("/issues/55/comments") && method === "POST") return Response.json({ id: 1 }, { status: 201 });
+      if (url.includes("/issues/55/comments")) return Response.json([]);
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "global-contributor-cap-short-circuit",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "repo-a", full_name: "JSONbored/repo-a", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 55, title: "Farmer's 31st PR install-wide", state: "open", user: { login: "farmer99" }, head: { sha: "f55" }, labels: [], body: "x", mergeable_state: "clean", reviewDecision: "APPROVED" },
+      },
+    });
+
+    expect(seen.closed).toBe(true);
+    expect(seen.livePullReads).toHaveLength(10);
+    expect(seen.livePullReads).not.toContain(11);
+  });
+
   it("install-wide contributor open-item cap (#2562): off by default (env var unset) — a spread-across-repos actor is never closed", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() }); // no GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP
     await upsertInstallation(env, {


### PR DESCRIPTION
### Motivation
- The install-wide contributor open-item cap previously live-verified every cached sibling row and could issue tens of thousands of GitHub reads for a single webhook, allowing an abusive actor to exhaust the installation rate-limit and worker capacity.

### Description
- Replace the unbounded per-row live-verifier with a batching short-circuit helper `countLiveOpenWithConcurrencyUntil` that performs fixed-size batches and stops once enough confirmed-open siblings prove the configured cap is exceeded, preserving stale-row safety while bounding outbound reads (`src/queue/processors.ts`).
- Pass the resolved `globalCap` into `verifiedGlobalOpenItemCount` from both the PR and issue webhook paths so the verifier can short-circuit without scanning a full author history (`src/queue/processors.ts`).
- Keep the existing live-confirmation semantics (only count items that can be positively confirmed open) while preventing full-history fan-out to GitHub.
- Add a regression unit test that seeds many cached sibling PR rows and asserts live verification short-circuits once the cap is exceeded (`test/unit/queue.test.ts`).

### Testing
- Ran `npx vitest run test/unit/queue.test.ts -t "install-wide contributor open-item cap" --reporter=verbose` and the focused suite passed.
- Ran `npm run typecheck` with no type errors reported.
- Ran `git diff --check` to ensure no whitespace/conflict markers and it produced no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47b0b38308832c83660dd2c8bc2a70)