### PR TITLE
fix(gate): bind CLA check-run detection to trusted GitHub App slug

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -168,9 +168,14 @@ gate:
     # review.pre_merge_checks' descriptionContains. String or null. Default: null (not configured).
     consentPhrase: "I have read and agree to the CLA"
     # Name of a separate CLA-bot check-run this repo also runs (e.g. a CLA Assistant GitHub Action). A
-    # success/neutral conclusion for a check-run with this exact name also satisfies consent. Either
-    # method configured is enough; both may be set. String or null. Default: null (not configured).
+    # success/neutral conclusion for a check-run with this exact name also satisfies consent only when the
+    # run was produced by checkRunAppSlug. Either method configured is enough; both may be set. String or
+    # null. Default: null (not configured).
     checkRunName: null
+    # Trusted GitHub App slug that must have produced checkRunName. Required for check-run detection so a
+    # contributor-controlled same-name check-run cannot satisfy a blocking CLA/legal gate. String or null.
+    # Default: null (not configured).
+    checkRunAppSlug: null
 
   # Composite merge-readiness gate (no min score).
   # off | advisory | block. Default: off.

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -9054,6 +9054,10 @@
               "mode",
               "mappings"
             ]
+          },
+          "claCheckRunAppSlug": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2372,12 +2372,15 @@ function recordBranchProtectionFetchFailure(error: unknown): void {
 
 /**
  * Best-effort fetch of ONE named check-run's conclusion on a head SHA (#2564, the CLA-bot check-run detection
- * mode of `gate.claMode`). Returns the conclusion string (lowercased; `"neutral"`/`"success"`/… or `""` when
+ * mode of `gate.claMode`). The name match is bound to the configured trusted GitHub App slug so
+ * contributor-controlled same-name check-runs cannot spoof a legal/compliance gate. Returns the conclusion string (lowercased; `"neutral"`/`"success"`/… or `""` when
  * concluded with no conclusion field, which should not normally happen) when a check-run with that exact name
- * (case-insensitive) is found; `null` when the head SHA has no such check-run (a resolved "not found," distinct
- * from "could not resolve"); `undefined` when the check-runs themselves could not be read at all (network/auth
- * error, or no headSha) — the caller must treat `undefined` as "not evaluated," never as "missing," so a
- * transient fetch failure can never manufacture a false CLA-missing blocker. Scans only the FIRST page (100
+ * (case-insensitive) from that app slug is found; `null` when the head SHA has no such trusted check-run — a
+ * resolved "not found," distinct from "could not resolve" — which ALSO covers a missing `checkRunAppSlug`
+ * (no slug to trust means no run can ever match, a deterministic configuration gap, not a transient one);
+ * `undefined` when the check-runs themselves could not be read at all (network/auth error, or no headSha) —
+ * the caller must treat `undefined` as "not evaluated," never as "missing," so a transient fetch failure can
+ * never manufacture a false CLA-missing blocker. Scans only the FIRST page (100
  * check-runs) — a CLA bot posts exactly one check-run, so a repo with >100 check-runs on a single commit (very
  * unusual) risks missing it only in that pathological case, and still degrades to `undefined` (not evaluated)
  * rather than a false negative.
@@ -2387,10 +2390,18 @@ export async function fetchNamedCheckRunConclusion(
   repoFullName: string,
   headSha: string | null | undefined,
   checkRunName: string,
+  checkRunAppSlug: string | null | undefined,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<string | null | undefined> {
   if (!headSha) return undefined;
+  const trustedAppSlugLc = checkRunAppSlug?.trim().toLowerCase();
+  // A missing trusted app slug is a deterministic CONFIGURATION gap, not a transient read failure -- without a
+  // slug to bind the match to, no check-run can ever be trusted, so this resolves the same as "no matching run
+  // found" (null), never `undefined` ("not evaluated"). Returning undefined here let a check-run-only blocking
+  // CLA config silently stop enforcing (a maintainer who set checkRunName but forgot checkRunAppSlug would have
+  // the gate fail OPEN forever, since the caller treats undefined as "retry later," not "missing") -- gate finding.
+  if (!trustedAppSlugLc) return null;
   const result = await githubJsonWithHeaders<{ check_runs?: GitHubCheckRunPayload[] }>(
     env,
     repoFullName,
@@ -2400,8 +2411,10 @@ export async function fetchNamedCheckRunConclusion(
   ).catch(() => undefined);
   if (!result) return undefined; // fetch failed → not evaluated, never a false "missing".
   const nameLc = checkRunName.trim().toLowerCase();
-  const run = (result.data.check_runs ?? []).find((candidate) => candidate.name.trim().toLowerCase() === nameLc);
-  if (!run) return null; // resolved: no check-run with this name exists on this commit.
+  const run = (result.data.check_runs ?? []).find(
+    (candidate) => candidate.name.trim().toLowerCase() === nameLc && candidate.app?.slug?.trim().toLowerCase() === trustedAppSlugLc,
+  );
+  if (!run) return null; // resolved: no trusted check-run with this name exists on this commit.
   // A matching check-run that has NOT finished yet (status !== "completed") has conclusion: null by GitHub's
   // own contract — that is "not yet resolved," not "resolved with an empty conclusion." Returning `undefined`
   // here (rather than coercing to "") keeps this indistinguishable from a fetch failure to the caller, so

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -601,6 +601,7 @@ export const RepositorySettingsSchema = z
     claGateMode: z.enum(["off", "advisory", "block"]).optional(),
     claConsentPhrase: z.string().nullable().optional(),
     claCheckRunName: z.string().nullable().optional(),
+    claCheckRunAppSlug: z.string().nullable().optional(),
     gateDryRun: z.boolean().optional(),
     premergeContentRecheck: z.boolean().optional(),
     requireFreshRebaseWindowMinutes: z.number().int().positive().nullable().optional(),

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6816,6 +6816,7 @@ async function maybePublishPrPublicSurface(
     // opted in makes no extra GitHub call and pushes no finding — byte-identical to today.
     if (settings.claGateMode && settings.claGateMode !== "off") {
       const claCheckRunName = settings.claCheckRunName ?? null;
+      const claCheckRunAppSlug = settings.claCheckRunAppSlug ?? null;
       // Only resolve a live check-run when the maintainer actually configured that detection method — a
       // phrase-only config must never spend an extra GitHub call.
       const claCheckRunConclusion = claCheckRunName
@@ -6824,6 +6825,7 @@ async function maybePublishPrPublicSurface(
             repoFullName,
             advisory.headSha,
             claCheckRunName,
+            claCheckRunAppSlug,
             await resolveReviewEnrichmentGithubToken(env, repoFullName),
           )
         : undefined;

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -94,6 +94,9 @@ export type FocusManifestGateConfig = {
   /** `gate.cla.checkRunName` (#2564): the CLA-bot check-run name to trust. null (unset) ⇒ check-run
    *  detection is not configured. */
   claCheckRunName: string | null;
+  /** `gate.cla.checkRunAppSlug`: the trusted GitHub App slug that must produce `checkRunName`. null (unset) ⇒
+   *  check-run detection remains unresolved rather than trusting a spoofable name-only match. */
+  claCheckRunAppSlug: string | null;
 };
 
 // The converged per-PR review features a self-host operator toggles PER-REPO under `features:` in the private
@@ -379,6 +382,7 @@ const EMPTY_GATE_CONFIG: FocusManifestGateConfig = {
   claMode: null,
   claConsentPhrase: null,
   claCheckRunName: null,
+  claCheckRunAppSlug: null,
 };
 
 const EMPTY_FEATURES_CONFIG: FocusManifestFeaturesConfig = {
@@ -657,6 +661,7 @@ function parseGateConfig(value: JsonValue | undefined, warnings: string[]): Focu
     claMode: normalizeOptionalGateMode(record.claMode, "gate.claMode", warnings),
     claConsentPhrase: parsePublicSafeText(claRecord?.consentPhrase, "gate.cla.consentPhrase", warnings),
     claCheckRunName: parsePublicSafeText(claRecord?.checkRunName, "gate.cla.checkRunName", warnings),
+    claCheckRunAppSlug: parsePublicSafeText(claRecord?.checkRunAppSlug, "gate.cla.checkRunAppSlug", warnings),
   };
   // #2266: the flag is parsed, clamped, and threaded end-to-end, but the gate evaluator never reads it — a
   // maintainer who sets it to true believing it softens a blocker for newcomers gets no such effect. Surface
@@ -695,7 +700,8 @@ function parseGateConfig(value: JsonValue | undefined, warnings: string[]): Focu
     gate.requireFreshRebaseWindowMinutes !== null ||
     gate.claMode !== null ||
     gate.claConsentPhrase !== null ||
-    gate.claCheckRunName !== null;
+    gate.claCheckRunName !== null ||
+    gate.claCheckRunAppSlug !== null;
   return gate;
 }
 
@@ -760,10 +766,11 @@ export function gateConfigToJson(gate: FocusManifestGateConfig): JsonValue {
   if (gate.premergeContentRecheck !== null) out.premergeContentRecheck = gate.premergeContentRecheck;
   if (gate.requireFreshRebaseWindowMinutes !== null) out.requireFreshRebaseWindow = gate.requireFreshRebaseWindowMinutes;
   if (gate.claMode !== null) out.claMode = gate.claMode;
-  if (gate.claConsentPhrase !== null || gate.claCheckRunName !== null) {
+  if (gate.claConsentPhrase !== null || gate.claCheckRunName !== null || gate.claCheckRunAppSlug !== null) {
     const cla: Record<string, JsonValue> = {};
     if (gate.claConsentPhrase !== null) cla.consentPhrase = gate.claConsentPhrase;
     if (gate.claCheckRunName !== null) cla.checkRunName = gate.claCheckRunName;
+    if (gate.claCheckRunAppSlug !== null) cla.checkRunAppSlug = gate.claCheckRunAppSlug;
     out.cla = cla;
   }
   return out;
@@ -1548,6 +1555,7 @@ export function resolveEffectiveSettings(
   if (gate.claMode !== null) effective.claGateMode = gate.claMode;
   if (gate.claConsentPhrase !== null) effective.claConsentPhrase = gate.claConsentPhrase;
   if (gate.claCheckRunName !== null) effective.claCheckRunName = gate.claCheckRunName;
+  if (gate.claCheckRunAppSlug !== null) effective.claCheckRunAppSlug = gate.claCheckRunAppSlug;
   // The dashboard "Require linked issue" toggle must not silently diverge from gate blocking: when the
   // boolean is on but linkedIssueGateMode is still off, treat it as a block requirement (#797).
   if (effective.requireLinkedIssue && effective.linkedIssueGateMode === "off") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -568,7 +568,7 @@ export type RepositorySettings = {
    *  only — no DB column or dashboard toggle; set via `.gittensory.yml gate.lockfileIntegrity`. */
   lockfileIntegrityGateMode?: GateRuleMode | undefined;
   /** CLA / license-compatibility gate (#2564). `off` (default/absent) = no CLA check at all; `advisory`/`block` =
-   *  evaluate the configured detection method(s) (`claConsentPhrase` and/or `claCheckRunName`) and raise a
+   *  evaluate the configured detection method(s) (`claConsentPhrase` and/or `claCheckRunName` + `claCheckRunAppSlug`) and raise a
    *  `cla_consent_missing` finding when neither confirms consent — `block` also hard-blocks the gate. Config-as-code
    *  only (no DB column, mirrors sizeGateMode) — set via `.gittensory.yml gate.claMode`. */
   claGateMode?: GateRuleMode | undefined;
@@ -577,10 +577,13 @@ export type RepositorySettings = {
    *  configured. Config-as-code only, alongside {@link claGateMode}. */
   claConsentPhrase?: string | null | undefined;
   /** `gate.cla.checkRunName`: the name of a separate CLA-bot check-run this repo also runs (e.g. "CLA Assistant
-   *  Lite"). A `success`/`neutral` conclusion for a check-run with this exact name (case-insensitive) also
-   *  satisfies consent. `null`/absent ⇒ check-run detection is not configured. Config-as-code only, alongside
-   *  {@link claGateMode}. */
+   *  Lite"). A `success`/`neutral` conclusion for a check-run with this exact name (case-insensitive), produced
+   *  by `claCheckRunAppSlug`, also satisfies consent. `null`/absent ⇒ check-run detection is not configured.
+   *  Config-as-code only, alongside {@link claGateMode}. */
   claCheckRunName?: string | null | undefined;
+  /** `gate.cla.checkRunAppSlug`: the trusted GitHub App slug that must have produced `claCheckRunName`. Required
+   *  for check-run detection so contributor-controlled same-name runs cannot satisfy a blocking CLA gate. */
+  claCheckRunAppSlug?: string | null | undefined;
   /** Dry-run disposition (#gate-dryrun). When true, the gate renders the would-be merge/close/manual verdict (every
    *  advisory sub-gate promoted to block) WITHOUT enforcing — the posted check stays non-blocking. Lets advisory mode
    *  preview exactly what it would do before the maintainer flips to real enforcement. Default off. */

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -5089,7 +5089,7 @@ describe("GitHub backfill", () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       const fetchSpy = vi.fn();
       vi.stubGlobal("fetch", fetchSpy);
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", null, "CLA Assistant Lite", "public-token")).toBeUndefined();
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", null, "CLA Assistant Lite", "cla-assistant", "public-token")).toBeUndefined();
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
@@ -5097,21 +5097,54 @@ describe("GitHub backfill", () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
         expect(input.toString()).toContain("/commits/sha1/check-runs");
-        return Response.json({ total_count: 1, check_runs: [{ id: 1, name: "cla assistant lite", status: "completed", conclusion: "SUCCESS" }] });
+        return Response.json({ total_count: 1, check_runs: [{ id: 1, name: "cla assistant lite", status: "completed", conclusion: "SUCCESS", app: { slug: "cla-assistant" } }] });
       });
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBe("success");
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBe("success");
+    });
+
+    it("REGRESSION (gate finding): returns null (deterministic missing), not undefined (transient), without fetching when no trusted app slug is configured — a check-run-only config with no slug must still BLOCK, not silently hold forever", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", null, "public-token")).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores a completed same-name check-run from an untrusted app slug", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async () =>
+        Response.json({
+          total_count: 1,
+          check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: "success", app: { slug: "github-actions" } }],
+        }),
+      );
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBeNull();
+    });
+
+    it("uses the trusted producer when spoofed and trusted same-name runs both exist", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+      vi.stubGlobal("fetch", async () =>
+        Response.json({
+          total_count: 2,
+          check_runs: [
+            { id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+            { id: 2, name: "CLA Assistant Lite", status: "completed", conclusion: "failure", app: { slug: "cla-assistant" } },
+          ],
+        }),
+      );
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBe("failure");
     });
 
     it("returns null (resolved: not found) when the head SHA has no check-run with that name", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "Some Other Check", status: "completed", conclusion: "success" }] }));
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBeNull();
+      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "Some Other Check", status: "completed", conclusion: "success", app: { slug: "cla-assistant" } }] }));
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBeNull();
     });
 
     it("returns null (resolved: not found) when the response omits check_runs entirely (nullish fallback)", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async () => Response.json({ total_count: 0 }));
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBeNull();
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBeNull();
     });
 
     // #2564 gate-review finding: a matching check-run that has NOT finished yet must resolve to undefined
@@ -5120,20 +5153,20 @@ describe("GitHub backfill", () => {
     // actually finished running.
     it("returns undefined (unresolved) for a matching but still-in-progress check-run (status !== completed, conclusion: null)", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "in_progress", conclusion: null }] }));
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBeUndefined();
+      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "in_progress", conclusion: null, app: { slug: "cla-assistant" } }] }));
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBeUndefined();
     });
 
     it("returns an empty string for a matching, COMPLETED check-run with an unexpected empty conclusion (genuine edge case, not the in-progress case)", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: null }] }));
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBe("");
+      vi.stubGlobal("fetch", async () => Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: null, app: { slug: "cla-assistant" } }] }));
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBe("");
     });
 
     it("returns undefined (not evaluated) when the fetch fails, never a false 'missing'", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       vi.stubGlobal("fetch", async () => new Response("forbidden", { status: 403 }));
-      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "public-token")).toBeUndefined();
+      expect(await fetchNamedCheckRunConclusion(env, "JSONbored/gittensory", "sha1", "CLA Assistant Lite", "cla-assistant", "public-token")).toBeUndefined();
     });
   });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -516,7 +516,7 @@ describe("compileFocusManifestPolicy", () => {
       issueDiscoveryPolicy: "neutral",
       maintainerNotes: [],
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
-      gate: { present: false, enabled: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null },
+      gate: { present: false, enabled: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null },
       settings: {},
       review: { present: false, footerText: null, note: null, fields: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
@@ -824,7 +824,7 @@ describe("parseFocusManifest gate config", () => {
     // the block→advisory deprecation-downgrade behavior itself is covered separately below.
     const m = parseFocusManifest({ gate: { linkedIssue: "block", duplicates: "advisory", readiness: { mode: "advisory", minScore: 70 } } });
     expect(m.present).toBe(true);
-    expect(m.gate).toEqual({ present: true, enabled: null, pack: null, linkedIssue: "block", duplicates: "advisory", readinessMode: "advisory", readinessMinScore: 70, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null });
+    expect(m.gate).toEqual({ present: true, enabled: null, pack: null, linkedIssue: "block", duplicates: "advisory", readinessMode: "advisory", readinessMinScore: 70, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null });
   });
 
   it("parses gate.mergeReadiness + gate.firstTimeContributorGrace, round-trips them, and warns on bad values (#822)", () => {
@@ -2364,10 +2364,11 @@ describe("gate.claMode / gate.cla CLA / license-compatibility gate config (#2564
   });
 
   it("parses the gate.cla block (consentPhrase + checkRunName), round-trips it, and warns on a non-mapping", () => {
-    const m = parseFocusManifest({ gate: { claMode: "block", cla: { consentPhrase: "I have read and agree to the CLA", checkRunName: "CLA Assistant Lite" } } });
+    const m = parseFocusManifest({ gate: { claMode: "block", cla: { consentPhrase: "I have read and agree to the CLA", checkRunName: "CLA Assistant Lite", checkRunAppSlug: "cla-assistant" } } });
     expect(m.gate.claConsentPhrase).toBe("I have read and agree to the CLA");
     expect(m.gate.claCheckRunName).toBe("CLA Assistant Lite");
-    expect(gateConfigToJson(m.gate)).toMatchObject({ cla: { consentPhrase: "I have read and agree to the CLA", checkRunName: "CLA Assistant Lite" } });
+    expect(m.gate.claCheckRunAppSlug).toBe("cla-assistant");
+    expect(gateConfigToJson(m.gate)).toMatchObject({ cla: { consentPhrase: "I have read and agree to the CLA", checkRunName: "CLA Assistant Lite", checkRunAppSlug: "cla-assistant" } });
 
     const bad = parseFocusManifest({ gate: { cla: "block" as never } });
     expect(bad.gate.claConsentPhrase).toBeNull();

--- a/test/unit/gate-check-policy.test.ts
+++ b/test/unit/gate-check-policy.test.ts
@@ -261,10 +261,11 @@ describe("CLA / license-compatibility gate (#2564)", () => {
   });
 
   it("resolveEffectiveSettings maps gate.claMode / gate.cla.{consentPhrase,checkRunName} onto the effective settings", () => {
-    const eff = resolveEffectiveSettings(settings({}), parseFocusManifest({ gate: { claMode: "block", cla: { consentPhrase: "I agree to the CLA", checkRunName: "CLA Assistant Lite" } } }));
+    const eff = resolveEffectiveSettings(settings({}), parseFocusManifest({ gate: { claMode: "block", cla: { consentPhrase: "I agree to the CLA", checkRunName: "CLA Assistant Lite", checkRunAppSlug: "cla-assistant" } } }));
     expect(eff.claGateMode).toBe("block");
     expect(eff.claConsentPhrase).toBe("I agree to the CLA");
     expect(eff.claCheckRunName).toBe("CLA Assistant Lite");
+    expect(eff.claCheckRunAppSlug).toBe("cla-assistant");
   });
 
   it("resolveEffectiveSettings leaves claGateMode unset when the manifest has no gate.claMode (byte-identical default)", () => {
@@ -272,6 +273,7 @@ describe("CLA / license-compatibility gate (#2564)", () => {
     expect(eff.claGateMode).toBeUndefined();
     expect(eff.claConsentPhrase).toBeUndefined();
     expect(eff.claCheckRunName).toBeUndefined();
+    expect(eff.claCheckRunAppSlug).toBeUndefined();
   });
 
   it("end-to-end: a manifest gate.claMode: block + consentPhrase blocks a PR missing CLA consent (acceptance criterion)", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6430,7 +6430,7 @@ describe("queue processors", () => {
     });
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
     // Check-run-only config: no consentPhrase, so ONLY the named check-run's conclusion is consulted.
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { claMode: "block", cla: { checkRunName: "CLA Assistant Lite" } } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { claMode: "block", cla: { checkRunName: "CLA Assistant Lite", checkRunAppSlug: "cla-assistant" } } });
     await upsertPullRequestFile(env, { repoFullName: "JSONbored/gittensory", pullNumber: 52, path: "src/feature.ts", status: "modified", additions: 5, deletions: 0, changes: 5, payload: {} });
 
     let gateConclusion: string | undefined;
@@ -6439,7 +6439,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
       if (url.includes("/commits/gate129/check-runs")) {
-        return Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: "success" }] });
+        return Response.json({ total_count: 1, check_runs: [{ id: 1, name: "CLA Assistant Lite", status: "completed", conclusion: "success", app: { slug: "cla-assistant" } }] });
       }
       if (url.includes("/commits/") && url.includes("/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/") && url.includes("/status")) return Response.json({ statuses: [] });
@@ -6505,7 +6505,7 @@ describe("queue processors", () => {
       agentDryRun: false,
     });
     await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
-    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { claMode: "block", cla: { checkRunName: "CLA Assistant Lite" } } });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { claMode: "block", cla: { checkRunName: "CLA Assistant Lite", checkRunAppSlug: "cla-assistant" } } });
     await upsertPullRequestFile(env, { repoFullName: "JSONbored/gittensory", pullNumber: 53, path: "src/feature.ts", status: "modified", additions: 5, deletions: 0, changes: 5, payload: {} });
 
     let gateConclusion: string | undefined;
@@ -6515,7 +6515,7 @@ describe("queue processors", () => {
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
       if (url.includes("/commits/gate130/check-runs")) {
-        return Response.json({ total_count: 1, check_runs: [{ id: 2, name: "CLA Assistant Lite", status: "completed", conclusion: "failure" }] });
+        return Response.json({ total_count: 1, check_runs: [{ id: 2, name: "CLA Assistant Lite", status: "completed", conclusion: "failure", app: { slug: "cla-assistant" } }] });
       }
       if (url.includes("/commits/") && url.includes("/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
       if (url.includes("/commits/") && url.includes("/status")) return Response.json({ statuses: [] });
@@ -6546,6 +6546,91 @@ describe("queue processors", () => {
           state: "open",
           user: { login: "contributor" },
           head: { sha: "gate130" },
+          labels: [],
+          body: "Closes #1",
+          mergeable_state: "clean",
+          reviewDecision: "APPROVED",
+        },
+      },
+    });
+    expect(gateConclusion).toBe("failure");
+    expect(gateText).toContain("CLA consent not confirmed");
+  });
+
+  it("REGRESSION (gate finding): CLA gate (#2564) — a check-run-only config missing checkRunAppSlug BLOCKS the auto-merge instead of silently holding forever", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload({ "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } }, { kind: "raw-github", url: "https://example.test" }, "2026-05-23T00:00:00.000Z"),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "enabled",
+      gateCheckMode: "enabled",
+      autonomy: { merge: "observe", request_changes: "observe" },
+      agentDryRun: false,
+    });
+    await upsertOfficialMinerDetection(env, "contributor", { status: "confirmed", snapshot: queueMinerSnapshot("contributor") }, 60_000);
+    // Misconfigured: checkRunName set, checkRunAppSlug forgotten -- no run can ever be trusted, so the gate
+    // must BLOCK (not hold), even though a same-name check-run with a passing conclusion exists on the commit.
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { gate: { claMode: "block", cla: { checkRunName: "CLA Assistant Lite" } } });
+    await upsertPullRequestFile(env, { repoFullName: "JSONbored/gittensory", pullNumber: 54, path: "src/feature.ts", status: "modified", additions: 5, deletions: 0, changes: 5, payload: {} });
+
+    let gateConclusion: string | undefined;
+    let gateText = "";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+      // Even though a same-name check-run with a passing conclusion exists on the commit, the missing
+      // checkRunAppSlug means fetchNamedCheckRunConclusion never gets far enough to see it (returns null
+      // before any check-runs fetch) -- the gate must still see it as blocking, not "not evaluated".
+      if (url.includes("/commits/gate131/check-runs")) {
+        return Response.json({ total_count: 1, check_runs: [{ id: 3, name: "CLA Assistant Lite", status: "completed", conclusion: "success", app: { slug: "cla-assistant" } }] });
+      }
+      if (url.includes("/commits/") && url.includes("/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/") && url.includes("/status")) return Response.json({ statuses: [] });
+      if (url.includes("/check-runs")) {
+        if (init?.body) {
+          const body = JSON.parse(init.body.toString()) as { name?: string; conclusion?: string; output?: { title?: string; summary?: string } };
+          if ((body.name ?? "").includes("Gittensory Orb Review Agent") && body.conclusion) {
+            gateConclusion = body.conclusion;
+            gateText = `${body.output?.title ?? ""} ${body.output?.summary ?? ""}`;
+          }
+        }
+        return Response.json({ id: 906 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "cla-gate-checkrun-missing-slug",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 54,
+          title: "feat: add a feature",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "gate131" },
           labels: [],
           body: "Closes #1",
           mergeable_state: "clean",


### PR DESCRIPTION
### Motivation

- Prevent a spoofing vulnerability where any completed check-run with a matching name could satisfy the CLA gate regardless of producer identity.  
- Gate-driven auto-merges must only accept a named check-run when it was produced by a trusted producer to avoid bypassing maintainers' CLA/license enforcement.  

### Description

- Add a new `gate.cla.checkRunAppSlug` setting and wire it through types, manifest parsing, effective settings, OpenAPI, UI OpenAPI, and example config.  
- Require a configured trusted GitHub App slug when resolving a named CLA check-run and update `fetchNamedCheckRunConclusion` to match both `name` and `app.slug` before trusting a conclusion.  
- Thread `claCheckRunAppSlug` through the live evaluator (`src/queue/processors.ts`) so the queue passes both name and trusted producer into the lookup.  
- Add unit tests covering the missing-slug fail-fast behavior, ignoring same-name runs from untrusted apps, and choosing the trusted producer when both spoofed and trusted runs exist; update existing fixtures and regenerate `apps/gittensory-ui/public/openapi.json`.  

### Testing

- Ran targeted unit suites: `npx vitest run test/unit/backfill.test.ts test/unit/focus-manifest.test.ts test/unit/gate-check-policy.test.ts test/unit/cla-check.test.ts` and `npx vitest run test/unit/queue.test.ts -t "CLA"`; the CLA-related tests passed.  
- Ran `npm run typecheck`, `npm run ui:openapi`, `npm run ui:openapi:check`, and `npm run ui:openapi:settings-parity`; these succeeded and updated the generated OpenAPI artifact.  
- Attempted full `npm run test:ci` and `npm run test:coverage` but the environment hit external-network limitations (actionlint DNS failures / custom runner label in `actionlint`) and an `npm audit` 403, and the full coverage run timed out on long-running queue sweep tests under instrumentation; these environment issues prevented a complete `test:ci` coverage pass here, but the focused CLA regression tests succeed locally in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47dc9a8874832c818214222f966d87)