### PR TITLE
fix(selfhost): restrict smoke app exposure

### DIFF
--- a/scripts/smoke-selfhost.sh
+++ b/scripts/smoke-selfhost.sh
@@ -42,6 +42,13 @@ require_cmd() {
 
 require_cmd docker
 require_cmd curl
+require_cmd od
+
+if [ -n "${SELFHOST_SMOKE_SETUP_TOKEN:-}" ]; then
+  SETUP_TOKEN="$SELFHOST_SMOKE_SETUP_TOKEN"
+else
+  SETUP_TOKEN="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+fi
 
 cleanup() {
   docker rm -f "$APP_NAME" "$REDIS_NAME" >/dev/null 2>&1 || true
@@ -95,9 +102,9 @@ if [ -n "${SELFHOST_SMOKE_EXTRA_VOLUMES:-}" ]; then
   done <<<"$SELFHOST_SMOKE_EXTRA_VOLUMES"
 fi
 
-docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" -p "${PORT}:8787" \
+docker run -d --name "$APP_NAME" --network "$NETWORK_NAME" -p "127.0.0.1:${PORT}:8787" \
   -e "REDIS_URL=redis://${REDIS_NAME}:6379" \
-  -e "SELFHOST_SETUP_TOKEN=${SELFHOST_SMOKE_SETUP_TOKEN:-selfhost-smoke-setup-token}" \
+  -e "SELFHOST_SETUP_TOKEN=${SETUP_TOKEN}" \
   -e "PUBLIC_API_ORIGIN=${SELFHOST_SMOKE_PUBLIC_API_ORIGIN:-https://selfhost-smoke.example}" \
   "${EXTRA_ENV_ARGS[@]}" \
   "${EXTRA_VOLUME_ARGS[@]}" \

--- a/test/unit/smoke-selfhost-script.test.ts
+++ b/test/unit/smoke-selfhost-script.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/smoke-selfhost.sh";
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents, { mode: 0o755 });
+}
+
+function runSmoke(extraEnv: Record<string, string> = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "smoke-selfhost-test-"));
+  const calls = join(dir, "calls.log");
+  writeExecutable(
+    join(dir, "docker"),
+    `#!/usr/bin/env bash
+printf 'docker' >> "${calls}"
+for arg in "$@"; do printf '\\t%s' "$arg" >> "${calls}"; done
+printf '\\n' >> "${calls}"
+if [ "$1" = "exec" ]; then echo PONG; fi
+if [ "$1" = "logs" ]; then echo '{"event":"selfhost_migrations_applied"}'; fi
+`,
+  );
+  writeExecutable(
+    join(dir, "curl"),
+    `#!/usr/bin/env bash
+printf 'curl' >> "${calls}"
+for arg in "$@"; do printf '\\t%s' "$arg" >> "${calls}"; done
+printf '\\n' >> "${calls}"
+case "$*" in
+  *'/health'*) echo '{"status":"ok"}' ;;
+  *'/ready'*) echo '{"ok":true}' ;;
+  *'/metrics'*) echo 'gittensory_uptime_seconds 1' ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [SCRIPT_PATH, "gittensory:rc-candidate"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH ?? ""}`,
+      SELFHOST_SMOKE_PORT: "18787",
+      ...extraEnv,
+    },
+    encoding: "utf8",
+  });
+  const output = readFileSync(calls, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+  return { result, output };
+}
+
+describe("smoke-selfhost.sh", () => {
+  it("binds the app port to loopback and generates an unpredictable setup token by default", () => {
+    const { result, output } = runSmoke();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(output).toContain("\t-p\t127.0.0.1:18787:8787");
+    expect(output).not.toContain("\t-p\t18787:8787");
+    expect(output).not.toContain("SELFHOST_SETUP_TOKEN=selfhost-smoke-setup-token");
+    expect(output).toMatch(/SELFHOST_SETUP_TOKEN=[0-9a-f]{32}/);
+    expect(output).toContain("curl\t-sf\thttp://127.0.0.1:18787/health");
+  });
+
+  it("uses the caller-supplied setup token when explicitly provided", () => {
+    const { result, output } = runSmoke({ SELFHOST_SMOKE_SETUP_TOKEN: "caller-token" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(output).toContain("SELFHOST_SETUP_TOKEN=caller-token");
+  });
+});


### PR DESCRIPTION
### Motivation

- The smoke helper unnecessarily exposed the test app to all host interfaces via Docker port publish and supplied a predictable default setup token, creating adjacent-network exposure during release validation.
- The smoke checks themselves use `127.0.0.1`, so the script can preserve its functionality while reducing attack surface by limiting bind and hardening the default token.

### Description

- Bind the app container to loopback by changing the Docker publish to `-p "127.0.0.1:${PORT}:8787"` in `scripts/smoke-selfhost.sh`.
- Replace the predictable default `SELFHOST_SETUP_TOKEN` with a per-run random hex token generated via `od` when the caller does not supply `SELFHOST_SMOKE_SETUP_TOKEN`, while keeping caller-supplied tokens honored.
- Add `require_cmd od` and wire the `SETUP_TOKEN` variable into the container environment as `SELFHOST_SETUP_TOKEN` in `scripts/smoke-selfhost.sh`.
- Add a focused unit test `test/unit/smoke-selfhost-script.test.ts` that runs the script with fake `docker`/`curl` shims and verifies loopback binding, random-default token behavior, caller-supplied token handling, and localhost probes.

### Testing

- Ran the targeted unit test with `npx vitest run test/unit/smoke-selfhost-script.test.ts`, which passed.
- Attempted the full local gate via `npm run test:ci`, but the run stopped at `actionlint` due to inability to reach `github.com` in this environment, so the aggregate CI did not complete here.
- Attempted `npm audit --audit-level=moderate`, which failed with a `403 Forbidden` from the npm audit endpoint in this environment and did not complete.
- A `npm run test:coverage -- --runInBand` invocation failed because Vitest does not accept the `--runInBand` option, but the focused unit test above covers the script changes for regression verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47abfccf14832cb326078e6b9813d7)