### PR TITLE
fix(ai-slop): parse reasoning-model verdict with brace-aware JSON extractor

### DIFF
--- a/src/services/ai-slop.ts
+++ b/src/services/ai-slop.ts
@@ -28,6 +28,7 @@ import {
   clampNumber,
   coerceAiText,
   estimateNeurons,
+  extractLastJsonObject,
   isEnabled,
   toPublicSafe,
   utcDayStartIso,
@@ -91,13 +92,15 @@ type AiRunner = { run?: (model: string, options: Record<string, unknown>, extra?
 
 /** Parse a model's JSON slop opinion into a normalized {@link SlopOpinion}, or null when unusable. */
 export function parseSlopOpinion(text: string): SlopOpinion | null {
-  const match = text
-    .replace(/^```(?:json)?\s*/i, "")
-    .replace(/```$/i, "")
-    .match(/\{[\s\S]*\}/);
-  if (!match) return null;
+  // Use the brace-depth-aware, string-safe extractor (shared with the AI review path). The Workers-AI slop
+  // slots are the SAME gpt-oss/nemotron reasoning models that emit a `<think>` scratchpad object BEFORE the
+  // real verdict; a greedy first-`{`-to-last-`}` match spans both objects and corrupts the parse, silently
+  // dropping the advisory. extractLastJsonObject returns the LAST complete top-level object (the verdict),
+  // matching parseModelReview. (#accuracy-gap-3)
+  const jsonText = extractLastJsonObject(text);
+  if (!jsonText) return null;
   try {
-    const obj = JSON.parse(match[0]) as Record<string, unknown>;
+    const obj = JSON.parse(jsonText) as Record<string, unknown>;
     if (!isSlopBand(obj.band)) return null;
     const rationale = typeof obj.rationale === "string" ? obj.rationale.trim().slice(0, 400) : "";
     const signals = Array.isArray(obj.signals)

--- a/test/unit/ai-slop.test.ts
+++ b/test/unit/ai-slop.test.ts
@@ -75,6 +75,15 @@ describe("parseSlopOpinion", () => {
     const parsed = parseSlopOpinion(JSON.stringify({ band: "low", rationale: "ok", signals: ["real", 5, null, "two"] }));
     expect(parsed?.signals).toEqual(["real", "two"]);
   });
+
+  it("parses the verdict when a reasoning model prepends a <think> scratchpad JSON object (#accuracy-gap-3)", () => {
+    // gpt-oss/nemotron (the Workers-AI slop slots) emit a scratchpad object BEFORE the real verdict. A greedy
+    // first-`{`-to-last-`}` match spans both and JSON.parse throws → advisory silently dropped. The brace-aware
+    // extractor must return the LAST top-level object (the verdict).
+    const reasoning = `<think>\n{"scratch":"weighing intent vs diff {nested braces} here"}\n</think>\n${slopJson({ band: "high", rationale: "boilerplate not matching intent" })}`;
+    const parsed = parseSlopOpinion(reasoning);
+    expect(parsed).toMatchObject({ band: "high", rationale: "boilerplate not matching intent" });
+  });
 });
 
 describe("slopFindingFromOpinion", () => {


### PR DESCRIPTION
## Problem

The AI slop advisory (`parseSlopOpinion`) used a greedy first-`{`-to-last-`}` regex to extract JSON from model output. The Workers-AI slop path runs on the same reasoning models as the AI reviewer (`@cf/openai/gpt-oss-120b`, `@cf/nvidia/nemotron-3-120b-a12b`). Those models emit a `<think>` scratchpad JSON object **before** the real verdict object.

A greedy match spans both objects, so `JSON.parse` throws and the advisory is silently dropped — maintainers lose a second-opinion signal the feature is designed to provide.

## Root cause

`parseSlopOpinion` in `src/services/ai-slop.ts` used `/\{[\s\S]*\}/`, while the AI review path already fixed this exact class of bug by porting `extractLastJsonObject` (#accuracy-gap-3), which returns the **last** complete top-level JSON object (the verdict), brace-depth-aware and string-safe.

## Fix

Reuse the shared `extractLastJsonObject` helper from `ai-review.ts` in `parseSlopOpinion`, bringing the slop parser into parity with `parseModelReview`. This also subsumes the previous code-fence stripping, since the extractor scans for balanced braces regardless of surrounding prose/fences.

## Why this solution

- **Minimal**: 2 files, reuses an existing tested helper — no new dependencies or abstractions.
- **Established pattern**: Same fix already merged for the review path (#accuracy-gap-3); maintainers have accepted this approach.
- **Low regression risk**: All existing `parseSlopOpinion` tests remain valid; added one regression test for the reasoning-model scratchpad case.

## Testing

- Added regression test: `<think>{scratchpad}</think>{verdict}` → parses verdict correctly.
- Existing `parseSlopOpinion` tests (well-formed JSON, code fences, invalid bands, non-JSON text, etc.) unchanged and expected to pass.
- IDE TypeScript diagnostics clean on both edited files.

## Risks

None identified. Advisory-only feature (`ai_slop_advisory` never blocks the gate); fix only improves parse reliability.