### PR TITLE
fix(review): break public-stats byProject ties deterministically

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -271,7 +271,10 @@ export async function getPublicStats(
       };
     })
     .filter((r) => r.reviewed > 0)
-    .sort((a, b) => b.reviewed - a.reviewed);
+    // Tie-break on project so repos with an equal reviewed count keep a stable,
+    // deterministic published order instead of following arbitrary SQL row order,
+    // matching the localeCompare tie-breaks used by the parity/auto-tune reports.
+    .sort((a, b) => b.reviewed - a.reviewed || a.project.localeCompare(b.project));
 
   // Global counter: fold in every REGISTERED Orb install's outcomes on top of the own-ledger totals above, so the
   // homepage reflects the whole fleet. No excludeAccount here (see the file header) -- reversals/weekly stay

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -117,6 +117,23 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(out.updatedAt).toBe(out.generatedAt);
   });
 
+  it("breaks byProject ties on project name so equal-reviewed repos keep a deterministic order", async () => {
+    // Two repos share reviewed=10, fed in reverse-alphabetical input order; the busier repo
+    // still leads and the tied pair must come out alphabetically, not in arbitrary SQL order.
+    const tied = (sql: string): Row[] => {
+      if (isDispositions(sql)) {
+        return [
+          { project: "JSONbored/zed", reviewed: 10, merged: 5, closed: 3, inReview: 2 },
+          { project: "JSONbored/alpha", reviewed: 10, merged: 5, closed: 3, inReview: 2 },
+          { project: "JSONbored/beta", reviewed: 50, merged: 30, closed: 10, inReview: 10 },
+        ];
+      }
+      return [];
+    };
+    const out = await getPublicStats(stubEnv(tied), NOW);
+    expect(out.byProject.map((p) => p.project)).toEqual(["JSONbored/beta", "JSONbored/alpha", "JSONbored/zed"]);
+  });
+
   it("folds Orb installs into the global totals on top of the own-ledger totals", async () => {
     const withOrb = (sql: string): Row[] =>
       sql.includes("orb_pr_outcomes") ? [{ merged: 50, closed: 30, total: 80 }] : ledger(sql);


### PR DESCRIPTION
## Summary

The public per-repo split in `getPublicStats` (`src/review/public-stats.ts`) is sorted "busiest first" by `reviewed` count only, with no secondary key:

```ts
.filter((r) => r.reviewed > 0)
.sort((a, b) => b.reviewed - a.reviewed);
```

When two repos have an equal `reviewed` count, their relative order follows whatever order the SQL `GROUP BY ev.repo` read happens to return (there is no `ORDER BY` on that query), so the published `byProject` list is non-deterministic across runs for tied repos. Every sibling report in this codebase adds a `localeCompare` tie-break for exactly this reason (e.g. `src/review/parity.ts` sorts `rows` by `a.project.localeCompare(b.project)`, and `src/review/auto-tune.ts` breaks ties with `|| a.project.localeCompare(b.project)`); `byProject` was the outlier.

This adds the same deterministic project tie-break so equal-`reviewed` repos keep a stable published order:

```ts
.sort((a, b) => b.reviewed - a.reviewed || a.project.localeCompare(b.project));
```

Values are unchanged — only the ordering of ties becomes stable. This is a small, self-contained determinism fix, so it ships as a direct PR rather than a tracked issue; the summary above is the full rationale.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped; the full `npm run test:ci` gate plus `npm audit --audit-level=moderate` were run locally and are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This is a backend-only ordering fix to an existing public-stats aggregate; the response schema and values are unchanged, so there is no OpenAPI/MCP behavior change and no auth/CORS/session or UI surface touched.

## Notes

- Added a regression test in `test/unit/public-stats.test.ts` that feeds two repos with an equal `reviewed` count in reverse-alphabetical input order and asserts the tied pair comes out alphabetically (with the busier repo still leading). It fails on the previous tie-break-less sort and passes on the fix. Existing `byProject` assertions used only distinct `reviewed` values, so the tie path was never exercised.
