### PR TITLE
fix(ci): repair the self-host release workflow's Sentry commits and release notes

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -211,12 +211,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
-          # Matches selfhost.yml's CI build (same Dockerfile, same default GHA cache scope), so a release
-          # can inherit layers selfhost.yml already built and cached for the identical commit -- without
-          # this, every release rebuilt runtime-base from scratch under QEMU emulation for arm64, the most
-          # expensive leg (#2502).
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Deliberately NO cache-from/cache-to here (#2502 tried type=gha, reverted): the GHA cache scope
+          # this would read from is the SAME one selfhost.yml's regular CI build writes to on every push/PR
+          # to this repo -- a publish/release path inheriting layers from that shared, more broadly-writable
+          # cache is a cache-poisoning vector into an officially published, public image. A cold build costs
+          # more time per release (infrequent, acceptable) in exchange for the release build never trusting
+          # any cache it didn't produce itself.
 
       - name: Finalize Sentry release
         if: steps.sentry.outputs.enabled == 'true'

--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -139,7 +139,20 @@ jobs:
           test -n "$SENTRY_PROJECT"
           if [ -z "${SENTRY_URL:-}" ]; then unset SENTRY_URL; fi
           npx -y "$SENTRY_CLI_PACKAGE" releases new "$SENTRY_RELEASE"
-          npx -y "$SENTRY_CLI_PACKAGE" releases set-commits "$SENTRY_RELEASE" --commit "$SENTRY_REPOSITORY@$SENTRY_COMMIT_SHA" --ignore-missing
+          # `sentry-cli releases set-commits --commit` (even without --ignore-missing) can silently leave
+          # the release with ZERO associated commits against a repo connected via the modern GitHub App
+          # integration -- confirmed empirically cutting the first orb-v0.1.0-beta.1 release: the CLI
+          # printed a success table but `GET .../releases/<v>/commits/` stayed `[]`. A direct PUT to the
+          # release resource with an inline `commits` array resolves the same repo/commit against the
+          # SAME integration correctly and immediately, so use that instead of relying on the CLI here --
+          # it's what the later "Validate Sentry release" step's `SENTRY_REQUIRE_COMMITS=true` actually
+          # depends on being correct.
+          curl -sf -X PUT \
+            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${SENTRY_URL:-https://sentry.io}/api/0/organizations/${SENTRY_ORG}/releases/$(node -e "process.stdout.write(encodeURIComponent(process.env.SENTRY_RELEASE))")/" \
+            -d "$(node -e "process.stdout.write(JSON.stringify({commits:[{repository: process.env.SENTRY_REPOSITORY, id: process.env.SENTRY_COMMIT_SHA}]}))")" \
+            >/dev/null
           npx -y "$SENTRY_CLI_PACKAGE" sourcemaps inject dist
           node scripts/validate-selfhost-sourcemap.mjs
           npx -y "$SENTRY_CLI_PACKAGE" sourcemaps upload --release="$SENTRY_RELEASE" --validate --wait --strict dist
@@ -244,11 +257,17 @@ jobs:
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
           set -euo pipefail
+          # GHCR (like every Docker registry) rejects a mixed-case repository path client-side --
+          # `docker pull ghcr.io/JSONbored/...` fails with "must be lowercase" before it even reaches the
+          # registry. `github.repository_owner` preserves the org's actual casing ("JSONbored"), so the
+          # notes must lowercase it themselves -- docker/metadata-action (used for the actual image tags
+          # above) does this automatically, but this hand-written notes block doesn't go through it.
+          REPOSITORY_OWNER_LOWER="${REPOSITORY_OWNER,,}"
           NOTES="$(cat <<EOF
           Gittensory Orb container image:
 
           \`\`\`bash
-          docker pull ghcr.io/${REPOSITORY_OWNER}/gittensory-selfhost:${RELEASE_TAG}
+          docker pull ghcr.io/${REPOSITORY_OWNER_LOWER}/gittensory-selfhost:${RELEASE_TAG}
           \`\`\`
 
           Multi-arch (linux/amd64 + linux/arm64). See https://gittensory.aethereal.dev/docs/maintainer-self-hosting for setup.
@@ -263,6 +282,12 @@ jobs:
           if [ "$PRERELEASE" = "true" ]; then
             PRERELEASE_ARGS=(--prerelease --latest=false)
           fi
+          # `--generate-notes` appends GitHub's auto-generated "what's changed" body (every commit/PR
+          # description since the last release) on top of `$NOTES` -- confirmed by hitting GitHub's
+          # 125000-char release-body limit cutting the very first release here, where a single
+          # squash-merged PR's body alone was large. `$NOTES` (the pull command + version metadata) is
+          # what operators actually need; drop `--generate-notes` so an unusually large commit/PR history
+          # can never fail release creation outright.
           if gh release view "$REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "$REF_NAME" --repo "$GITHUB_REPOSITORY" \
               --title "gittensory-orb ${RELEASE_TAG}" \
@@ -273,6 +298,5 @@ jobs:
               --verify-tag \
               --title "gittensory-orb ${RELEASE_TAG}" \
               "${PRERELEASE_ARGS[@]}" \
-              --notes "$NOTES" \
-              --generate-notes
+              --notes "$NOTES"
           fi

--- a/test/unit/release-selfhost-docker-cache.test.ts
+++ b/test/unit/release-selfhost-docker-cache.test.ts
@@ -3,22 +3,20 @@ import { describe, expect, it } from "vitest";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
-describe("release-selfhost.yml Docker layer caching (#2502)", () => {
-  it("caches the multi-arch build-push-action step via the GHA backend, matching selfhost.yml's CI build", () => {
+describe("release-selfhost.yml Docker layer caching (#2502, reverted for cache-poisoning)", () => {
+  it("does NOT share selfhost.yml's GHA cache scope in the release build-push-action step", () => {
     const releaseWorkflow = read(".github/workflows/release-selfhost.yml");
-    const selfhostWorkflow = read(".github/workflows/selfhost.yml");
 
     const buildStep = releaseWorkflow.slice(
       releaseWorkflow.indexOf("- name: Build + push (linux/amd64 + linux/arm64)"),
+      releaseWorkflow.indexOf("- name: Finalize Sentry release"),
     );
-    expect(buildStep).toContain("cache-from: type=gha");
-    expect(buildStep).toContain("cache-to: type=gha,mode=max");
-
-    // Neither workflow sets a custom `scope:`, so both land in the GHA cache backend's default scope --
-    // this is what lets the release build inherit layers selfhost.yml's own CI build already cached for
-    // the identical Dockerfile/commit, not just cache across its own releases.
-    expect(buildStep).not.toContain("scope=");
-    expect(selfhostWorkflow).toContain("--cache-from type=gha");
-    expect(selfhostWorkflow).toContain("--cache-to type=gha,mode=max");
+    // #2502 originally had this step share selfhost.yml's CI build's GHA cache scope for speed. A
+    // release/publish path inheriting layers from that shared, more broadly-writable cache (written to
+    // by every push/PR to this repo) is a cache-poisoning vector into an officially published, public
+    // image -- removed once that risk surfaced reviewing the first cut release. The release build must
+    // stay cold: no cache-from/cache-to at all.
+    expect(buildStep).not.toContain("cache-from: type=gha");
+    expect(buildStep).not.toContain("cache-to: type=gha,mode=max");
   });
 });

--- a/test/unit/selfhost-sentry-release.test.ts
+++ b/test/unit/selfhost-sentry-release.test.ts
@@ -10,8 +10,16 @@ describe("self-host Sentry release wiring", () => {
     expect(releaseWorkflow).toContain(
       'sourcemaps upload --release="$SENTRY_RELEASE" --validate --wait --strict dist',
     );
+    // `sentry-cli releases set-commits --commit` can silently leave a release with zero associated
+    // commits against a repo connected via the modern GitHub App integration -- a direct PUT to the
+    // release resource with an inline `commits` array is what actually satisfies the later
+    // SENTRY_REQUIRE_COMMITS=true validation (confirmed empirically cutting the first beta release).
+    expect(releaseWorkflow).not.toContain('"$SENTRY_CLI_PACKAGE" releases set-commits');
     expect(releaseWorkflow).toContain(
-      'releases set-commits "$SENTRY_RELEASE" --commit "$SENTRY_REPOSITORY@$SENTRY_COMMIT_SHA" --ignore-missing',
+      "/api/0/organizations/${SENTRY_ORG}/releases/",
+    );
+    expect(releaseWorkflow).toContain(
+      "commits:[{repository: process.env.SENTRY_REPOSITORY, id: process.env.SENTRY_COMMIT_SHA}]",
     );
     expect(releaseWorkflow).toContain('SENTRY_CLI_PACKAGE: "@sentry/cli@3.6.0"');
     expect(releaseWorkflow).toContain('npx -y "$SENTRY_CLI_PACKAGE"');
@@ -26,8 +34,13 @@ describe("self-host Sentry release wiring", () => {
     expect(releaseWorkflow).toContain("VERSION_TAG: ${{ steps.version.outputs.tag }}");
     expect(releaseWorkflow).toContain("type=raw,value=${VERSION_TAG}");
     expect(releaseWorkflow).toContain("tags: ${{ steps.tags.outputs.list }}");
+    // Docker rejects a mixed-case image reference client-side -- `github.repository_owner` preserves
+    // the org's actual casing ("JSONbored"), so the release-notes pull command must lowercase it itself
+    // (docker/metadata-action does this automatically for the real image tags, but this hand-written
+    // notes block doesn't go through it).
+    expect(releaseWorkflow).toContain('REPOSITORY_OWNER_LOWER="${REPOSITORY_OWNER,,}"');
     expect(releaseWorkflow).toContain(
-      "docker pull ghcr.io/${REPOSITORY_OWNER}/gittensory-selfhost:${RELEASE_TAG}",
+      "docker pull ghcr.io/${REPOSITORY_OWNER_LOWER}/gittensory-selfhost:${RELEASE_TAG}",
     );
     expect(releaseWorkflow).not.toContain('"selfhost-v*"');
     expect(releaseWorkflow).not.toContain('VERSION="${REF_NAME#selfhost-v}"');


### PR DESCRIPTION
## Summary

Three bugs surfaced cutting the first `orb-v0.1.0-beta.1` self-host release:

- `sentry-cli releases set-commits --commit` silently left the release with zero associated
  commits against this repo's GitHub App integration in Sentry, failing the later
  `SENTRY_REQUIRE_COMMITS=true` validation. A direct `PUT` to the release resource with an
  inline `commits` array resolves the same repo/commit correctly and immediately (verified
  empirically against the live release).
- The GitHub Release notes hand-built a `docker pull ...` command from `github.repository_owner`,
  which preserves the org's actual casing (`JSONbored`) — Docker's CLI rejects a mixed-case
  image reference client-side before it even reaches the registry
  (`invalid reference format: repository name ... must be lowercase`).
- `--generate-notes` alongside a custom `--notes` block can exceed GitHub's 125000-character
  release-body limit when a squash-merged PR's own body is large (confirmed: this happened on
  the very first release attempt), failing release creation outright with a 422.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] Not applicable: no `src/**` change, so no Codecov patch obligation.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, workflow-only change.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no changelog edit.

## Notes

Both fixes were validated directly against the live `orb-v0.1.0-beta.1` release before landing
this PR: the Sentry release's commit association was fixed with the same `PUT` call this diff
adds, and the GitHub Release for that tag was created manually with the corrected (lowercase)
pull command.