### PR TITLE
fix(content-lane): normalize RFC 3986 percent-encoding in the duplicate gate

### DIFF
--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -176,6 +176,20 @@ function normalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/^www\./, "");
 }
 
+// RFC 3986 §2.3 unreserved set: a percent-encoding of one of these characters is equivalent to the bare character.
+const UNRESERVED_CHARACTER = /^[A-Za-z0-9\-._~]$/;
+
+// Canonicalize percent-encoding so two URLs that differ only in how a character is encoded collapse to one form
+// (RFC 3986 §2.1/§2.3): decode a triplet that encodes an unreserved character (`%7E`→`~`, `%41`→`A`), and
+// uppercase the hex digits of every other triplet (`%2f`→`%2F`). Reserved/other encodings are preserved and only
+// case-normalized, so `%2F` never collapses into a literal `/` — a genuinely different path is never conflated.
+function normalizePercentEncoding(segment: string): string {
+  return segment.replace(/%[0-9A-Fa-f]{2}/g, (triplet) => {
+    const char = String.fromCharCode(parseInt(triplet.slice(1), 16));
+    return UNRESERVED_CHARACTER.test(char) ? char : triplet.toUpperCase();
+  });
+}
+
 function normalizeUrl(value: unknown, spec: ContentRepoSpec): string {
   const raw = String(value || "").trim();
   if (!raw) return "";
@@ -208,7 +222,9 @@ function normalizeUrl(value: unknown, spec: ContentRepoSpec): string {
       }
     }
 
-    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    // RFC 3986 §2.1/§2.3 percent-encoding normalization so a path that differs only in how a character is encoded
+    // (`/%7Euser` ≡ `/~user`, `/a%2fb` ≡ `/a%2Fb`) collapses to one canonical form for duplicate detection.
+    parsed.pathname = normalizePercentEncoding(parsed.pathname).replace(/\/+$/, "") || "/";
     return parsed.toString().replace(/\/$/, "");
   } catch {
     return "";

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -149,6 +149,43 @@ describe("extractContentDuplicateSignals + strict match", () => {
   });
 });
 
+describe("normalizeUrl — RFC 3986 percent-encoding canonicalization for duplicate detection", () => {
+  const urlOf = (websiteUrl: string) =>
+    extractContentDuplicateSignals({ filePath: "content/skills/x.mdx", content: mdx({ title: "X", slug: "x", websiteUrl }) }).urls[0];
+
+  it("decodes percent-encoded unreserved characters (RFC 3986 §2.3)", () => {
+    expect(urlOf("https://acme.example/%7Euser")).toBe(urlOf("https://acme.example/~user"));
+    expect(urlOf("https://acme.example/%41BC")).toBe(urlOf("https://acme.example/ABC"));
+    expect(urlOf("https://acme.example/~user")).toBe("https://acme.example/~user");
+  });
+
+  it("uppercases the hex of a reserved percent-triplet without decoding it (RFC 3986 §2.1)", () => {
+    expect(urlOf("https://acme.example/a%2fb")).toBe(urlOf("https://acme.example/a%2Fb"));
+    // …but an encoded reserved char is NOT the literal char — a genuinely different path must not be conflated.
+    expect(urlOf("https://acme.example/a%2Fb")).not.toBe(urlOf("https://acme.example/a/b"));
+  });
+
+  it("leaves the query untouched and does not over-match a genuinely different URL", () => {
+    // Percent-encoding normalization must not disturb the query or conflate distinct paths.
+    expect(urlOf("https://acme.example/p?utm_source=z&a=1")).toBe(urlOf("https://acme.example/p?a=1")); // tracking strip unchanged
+    expect(urlOf("https://acme.example/p")).not.toBe(urlOf("https://acme.example/q"));
+    expect(urlOf("https://acme.example/p?b=2&a=1")).not.toBe(urlOf("https://acme.example/p?a=1&b=2")); // query order preserved
+  });
+
+  it("collapses two submissions that differ only by path percent-encoding into a STRICT duplicate", () => {
+    const a = extractContentDuplicateSignals({
+      filePath: "content/skills/a.mdx",
+      content: mdx({ title: "A", slug: "a", description: "Identical purpose text", websiteUrl: "https://acme.example/docs/%7Eguide" }),
+    });
+    const b = extractContentDuplicateSignals({
+      filePath: "content/skills/b.mdx",
+      content: mdx({ title: "B", slug: "b", description: "Identical purpose text", websiteUrl: "https://acme.example/docs/~guide" }),
+    });
+    const m = findStrictContentDuplicateMatch(a, [b]);
+    expect(m?.reasons.some((r) => r.includes("same canonical source URL"))).toBe(true);
+  });
+});
+
 describe("buildContentDuplicateReview", () => {
   it("returns legacy / strict / related buckets", () => {
     const sig = extractContentDuplicateSignals({


### PR DESCRIPTION
`normalizeUrl` is the single canonicalizer every duplicate-signal URL flows through (`extractContentDuplicateSignals` → `urls`/`domains` → `findStrictContentDuplicateMatch`). It already forces https, lowercases the host, strips `www.`, drops the hash, and strips tracking params — but it treats percent-encoding variants of the **same path** as *distinct*, so a duplicate submission that only re-encodes a path character produces a different normalized string on each side and slips past the STRICT duplicate gate (the "same canonical source URL" rule the gate closes on), admitting a duplicate entry.

Confirmed misses:

| Two URLs for the same resource | Before |
|---|---|
| `…/%7Euser` vs `…/~user` (percent-encoded unreserved char, RFC 3986 §2.3) | not matched |
| `…/%41BC` vs `…/ABC` | not matched |
| `…/a%2fb` vs `…/a%2Fb` (percent-triplet case, §2.1) | not matched |

## Change
Normalize percent-encoding to its RFC 3986 canonical form on the path (one small pure helper):
- decode a triplet that encodes an **unreserved** character (`%7E`→`~`, `%41`→`A`; §2.3);
- **uppercase** the hex of every other triplet (`%2f`→`%2F`; §2.1).

Reserved/other encodings are preserved and only case-normalized, so **`%2F` never collapses into a literal `/`** — a genuinely different path is never conflated.

## Scope / safety
Deliberately minimal and **standards-only**: this applies the two unambiguous RFC 3986 percent-encoding equivalences and nothing else. The **query is left untouched** (parameter order is preserved, so order-sensitive endpoints are never conflated), and the `github.com` repo-root branch returns before this code and is unchanged. It only ever conflates paths the RFC declares equivalent and never *splits* a currently-matching pair — a tightening purely in the safe direction, with no risk of a false-positive duplicate close.

## Tests
Focused cases via the public `extractContentDuplicateSignals` + `findStrictContentDuplicateMatch`: unreserved decoding (§2.3), reserved-triplet case-only normalization with a `%2F` ≠ `/` over-match guard (§2.1), a query-untouched + no-over-match guard (distinct paths and preserved query order stay distinct), and an end-to-end STRICT-duplicate collapse on a path-encoding difference. Verified the equivalence/strict cases FAIL on current `main` and PASS with the change; the full `content-lane-duplicates` suite stays green.

No linked issue: issue creation is unavailable for this account.
