### PR TITLE
feat(selfhost): add claim-time backlog-vs-fresh-intake fairness

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -130,10 +130,23 @@ import {
   type MaintenanceAdmissionConfig,
   type MaintenancePressureSignals,
 } from "./maintenance-admission";
+import {
+  backlogRepoCandidatesFromJobKeys,
+  foregroundLaneForJob,
+  nextForegroundLane,
+  pickBacklogRepo,
+  type ForegroundLane,
+} from "./queue-fairness";
 import type { JobMessage } from "../types";
 
 const TABLE = "_selfhost_jobs";
 const STATS_TABLE = "_selfhost_job_stats";
+// Claim-time backlog-vs-fresh-intake fairness state (#selfhost-backlog-convergence, see queue-fairness.ts). A
+// SEPARATE singleton table -- NOT the app DB's `global_agent_controls` -- because this queue backend never
+// touches the app D1/Postgres database (it owns its own storage, same as _selfhost_jobs/_selfhost_job_stats
+// above); reusing global_agent_controls would require a cross-database dependency this queue deliberately has
+// never had.
+const FAIRNESS_TABLE = "_selfhost_queue_fairness";
 const DDL = `
 CREATE TABLE IF NOT EXISTS ${TABLE} (
   id BIGSERIAL PRIMARY KEY,
@@ -149,11 +162,18 @@ CREATE TABLE IF NOT EXISTS ${TABLE} (
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS job_key TEXT;
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS is_maintenance INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS foreground_lane TEXT;
 CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, run_after, priority);
 CREATE INDEX IF NOT EXISTS ${TABLE}_pending_job_key ON ${TABLE}(job_key, status);
+CREATE INDEX IF NOT EXISTS ${TABLE}_lane_claim ON ${TABLE}(status, foreground_lane, run_after);
 CREATE TABLE IF NOT EXISTS ${STATS_TABLE} (
   name TEXT PRIMARY KEY,
   value BIGINT NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS ${FAIRNESS_TABLE} (
+  id TEXT PRIMARY KEY,
+  claim_sequence BIGINT NOT NULL DEFAULT 0,
+  last_backlog_repo TEXT
 );`;
 
 export interface PgDurableQueue {
@@ -226,6 +246,9 @@ export function createPgQueue(
 
   async function init(): Promise<void> {
     await pool.query(DDL);
+    await pool.query(
+      `INSERT INTO ${FAIRNESS_TABLE} (id, claim_sequence) VALUES ('singleton', 0) ON CONFLICT (id) DO NOTHING`,
+    );
     const priorityBackfilled = await backfillJobPriorities();
     if (priorityBackfilled)
       console.log(
@@ -248,6 +271,14 @@ export function createPgQueue(
         JSON.stringify({
           event: "selfhost_queue_maintenance_flags_backfilled",
           count: maintenanceFlagsBackfilled,
+        }),
+      );
+    const lanesBackfilled = await backfillJobForegroundLanes();
+    if (lanesBackfilled)
+      console.log(
+        JSON.stringify({
+          event: "selfhost_queue_foreground_lanes_backfilled",
+          count: lanesBackfilled,
         }),
       );
     const recovered = await recoverProcessingJobs();
@@ -311,6 +342,21 @@ export function createPgQueue(
       const isMaintenance = isMaintenanceJobType(extractPayloadType(row.payload) ?? "") ? 1 : 0;
       if (Number(row.is_maintenance ?? 0) === isMaintenance) continue;
       await pool.query(`UPDATE ${TABLE} SET is_maintenance=$1 WHERE id=$2`, [isMaintenance, row.id]);
+      changed += 1;
+    }
+    return changed;
+  }
+
+  async function backfillJobForegroundLanes(): Promise<number> {
+    const res = await pool.query(
+      `SELECT id, payload, foreground_lane FROM ${TABLE} WHERE status IN ('pending', 'processing')`,
+    );
+    let changed = 0;
+    for (const row of res.rows as Array<{ id: string; payload: string; foreground_lane: string | null }>) {
+      const type = extractPayloadType(row.payload) ?? "";
+      const lane = foregroundLaneForJob(type, row.payload);
+      if ((row.foreground_lane ?? null) === lane) continue;
+      await pool.query(`UPDATE ${TABLE} SET foreground_lane=$1 WHERE id=$2`, [lane, row.id]);
       changed += 1;
     }
     return changed;
@@ -448,6 +494,7 @@ export function createPgQueue(
     const payload = JSON.stringify(message);
     const priority = jobPriority(payload);
     const key = jobCoalesceKey(payload);
+    const lane = foregroundLaneForJob(message.type, payload);
     const runAfter = now + delaySeconds * 1000;
     const absorbedByKey = jobCoalesceAbsorbedByKey(payload);
     if (absorbedByKey) {
@@ -481,9 +528,9 @@ export function createPgQueue(
         // (4h default) can keep re-arming the clock forever, and sustained pressure defers the job indefinitely.
         await pool.query(
           `UPDATE ${TABLE}
-             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), job_key=$4, last_error=NULL
-           WHERE id=$5`,
-          [payload, runAfter, priority, key, existing.id],
+             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), job_key=$4, foreground_lane=$5, last_error=NULL
+           WHERE id=$6`,
+          [payload, runAfter, priority, key, lane, existing.id],
         );
         await pool.query(
           `DELETE FROM ${TABLE}
@@ -507,9 +554,9 @@ export function createPgQueue(
         // maintenance trickle clock reflects genuine wait time, not the most recent re-request.
         await pool.query(
           `UPDATE ${TABLE}
-             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), last_error=NULL
-           WHERE id=$4`,
-          [payload, runAfter, priority, existing.id],
+             SET payload=$1, run_after=GREATEST(run_after, $2), priority=GREATEST(priority, $3), foreground_lane=$4, last_error=NULL
+           WHERE id=$5`,
+          [payload, runAfter, priority, lane, existing.id],
         );
         await recordQueueMetric("gittensory_jobs_coalesced_total");
         kickOne();
@@ -517,8 +564,8 @@ export function createPgQueue(
       }
     }
     await pool.query(
-      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance) VALUES ($1,'pending',0,$2,$3,$4,$5,$6)`,
-      [payload, runAfter, now, priority, key, isMaintenanceJobType(message.type) ? 1 : 0],
+      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance, foreground_lane) VALUES ($1,'pending',0,$2,$3,$4,$5,$6,$7)`,
+      [payload, runAfter, now, priority, key, isMaintenanceJobType(message.type) ? 1 : 0, lane],
     );
     await recordQueueMetric("gittensory_jobs_enqueued_total");
     kickOne();
@@ -526,7 +573,7 @@ export function createPgQueue(
 
   async function claimNext(): Promise<JobRow | null> {
     const now = Date.now();
-    const foreground = await claimNextWhere(now, "priority >= $2");
+    const foreground = (await claimNextForegroundLane(now)) ?? (await claimNextWhere(now, "priority >= $2"));
     if (foreground) return foreground;
     if (activeBackground >= backgroundConcurrency) return null;
     activeBackground++;
@@ -549,23 +596,64 @@ export function createPgQueue(
     return { ...background, backgroundSlotReserved: true };
   }
 
+  /** Claim-time backlog-vs-fresh-intake fairness (#selfhost-backlog-convergence, see queue-fairness.ts). Tries
+   *  ONE lane-scoped claim before falling back to the plain unscoped foreground claim (claimNext() falls back to
+   *  claimNextWhere(now, "priority >= $2") when this returns null) -- a null here just means "no work to prefer
+   *  this cycle," never "no foreground work at all." The fairness singleton's claim_sequence always advances
+   *  (best-effort, hit or miss) so the ratio cycle keeps progressing even through empty cycles. */
+  async function claimNextForegroundLane(now: number): Promise<JobRow | null> {
+    const fairnessRes = await pool.query(
+      `SELECT claim_sequence, last_backlog_repo FROM ${FAIRNESS_TABLE} WHERE id='singleton'`,
+    );
+    const fairness = fairnessRes.rows[0] as { claim_sequence: number | string; last_backlog_repo: string | null } | undefined;
+    const sequence = fairness ? Number(fairness.claim_sequence) : 0;
+    const lane: ForegroundLane = nextForegroundLane(sequence);
+    await pool.query(`UPDATE ${FAIRNESS_TABLE} SET claim_sequence=claim_sequence+1 WHERE id='singleton'`);
+    if (lane === "fresh") {
+      return claimNextWhere(now, "priority >= $2", { sql: "foreground_lane='fresh'", params: [] });
+    }
+    const backlogRes = await pool.query(
+      `SELECT job_key, created_at FROM ${TABLE} WHERE status='pending' AND run_after<=$1 AND foreground_lane='backlog'`,
+      [now],
+    );
+    const candidates = backlogRepoCandidatesFromJobKeys(
+      (backlogRes.rows as Array<{ job_key: string | null; created_at: number | string }>).map((row) => ({
+        jobKey: row.job_key,
+        createdAtMs: Number(row.created_at),
+      })),
+      now,
+    );
+    const repo = pickBacklogRepo(candidates, fairness?.last_backlog_repo ?? null);
+    if (!repo) return null;
+    const row = await claimNextWhere(now, "priority >= $2", {
+      sql: "foreground_lane='backlog' AND job_key LIKE $3",
+      params: [`agent-regate-pr:${repo}#%`],
+    });
+    if (row) {
+      await pool.query(`UPDATE ${FAIRNESS_TABLE} SET last_backlog_repo=$1 WHERE id='singleton'`, [repo]);
+    }
+    return row;
+  }
+
   async function claimNextWhere(
     now: number,
     priorityPredicate: string,
+    extra?: { sql: string; params: readonly unknown[] },
   ): Promise<JobRow | null> {
+    const extraSql = extra ? ` AND ${extra.sql}` : "";
     // Atomic, multi-instance-safe: lock + claim one due job, skipping rows another instance already locked.
     const res = await pool.query(
       `UPDATE ${TABLE} SET status='processing', run_after=$1
        WHERE id = (
          SELECT id
            FROM ${TABLE}
-          WHERE status='pending' AND run_after<=$1 AND ${priorityPredicate}
+          WHERE status='pending' AND run_after<=$1 AND ${priorityPredicate}${extraSql}
           ORDER BY priority DESC, run_after, id
           FOR UPDATE SKIP LOCKED
           LIMIT 1
        )
        RETURNING id, payload, attempts, job_key, priority, created_at`,
-      [now, FOREGROUND_QUEUE_PRIORITY_FLOOR],
+      [now, FOREGROUND_QUEUE_PRIORITY_FLOOR, ...(extra?.params ?? [])],
     );
     return (res.rows[0] as JobRow | undefined) ?? null;
   }

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -600,15 +600,18 @@ export function createPgQueue(
    *  ONE lane-scoped claim before falling back to the plain unscoped foreground claim (claimNext() falls back to
    *  claimNextWhere(now, "priority >= $2") when this returns null) -- a null here just means "no work to prefer
    *  this cycle," never "no foreground work at all." The fairness singleton's claim_sequence always advances
-   *  (best-effort, hit or miss) so the ratio cycle keeps progressing even through empty cycles. */
+   *  (best-effort, hit or miss) so the ratio cycle keeps progressing even through empty cycles. Sequence
+   *  allocation is a single atomic UPDATE ... RETURNING (not a separate SELECT-then-UPDATE): this backend is
+   *  the multi-instance one (multiple app instances can share one Postgres, see the file header), so two
+   *  concurrent callers reading the same pre-increment value would both compute the SAME lane and defeat the
+   *  bounded-ratio guarantee -- the row's own lock serializes concurrent allocations instead. */
   async function claimNextForegroundLane(now: number): Promise<JobRow | null> {
     const fairnessRes = await pool.query(
-      `SELECT claim_sequence, last_backlog_repo FROM ${FAIRNESS_TABLE} WHERE id='singleton'`,
+      `UPDATE ${FAIRNESS_TABLE} SET claim_sequence=claim_sequence+1 WHERE id='singleton' RETURNING claim_sequence, last_backlog_repo`,
     );
     const fairness = fairnessRes.rows[0] as { claim_sequence: number | string; last_backlog_repo: string | null } | undefined;
     const sequence = fairness ? Number(fairness.claim_sequence) : 0;
     const lane: ForegroundLane = nextForegroundLane(sequence);
-    await pool.query(`UPDATE ${FAIRNESS_TABLE} SET claim_sequence=claim_sequence+1 WHERE id='singleton'`);
     if (lane === "fresh") {
       return claimNextWhere(now, "priority >= $2", { sql: "foreground_lane='fresh'", params: [] });
     }

--- a/src/selfhost/queue-fairness.ts
+++ b/src/selfhost/queue-fairness.ts
@@ -1,0 +1,117 @@
+// Claim-time backlog-vs-fresh-intake fairness (#selfhost-backlog-convergence). Without this, every foreground
+// job (priority >= FOREGROUND_QUEUE_PRIORITY_FLOOR) is claimed in plain `priority DESC, run_after, id` order —
+// so a `github-webhook` PR-refresh row (priority 10) ALWAYS wins over an `agent-regate-pr` backlog-convergence
+// row (priority 9), no matter how old the backlog work is. A sustained burst of fresh webhook traffic can then
+// starve backlog-convergence work indefinitely, even though both are foreground-priority. These pure helpers
+// decide, at claim time, which of the two classified lanes to PREFER this cycle and (for the backlog lane)
+// which repo to serve next — the queue backends (sqlite-queue.ts / pg-queue.ts) consult them before falling
+// back to the existing unscoped foreground claim. Pure + deterministic; no wall-clock, no hidden state.
+
+export type ForegroundLane = "backlog" | "fresh" | null;
+
+const FRESH_PULL_REQUEST_ACTIONS = new Set(["opened", "reopened", "synchronize", "ready_for_review"]);
+
+// The prefix a backlog-convergence-sourced `agent-regate-pr` job's deliveryId carries (see
+// selfhost/backlog-convergence.ts) — distinct from sweep-originated (`regate-sweep:`) or manual
+// (`manual-regate:`) origins, which are intentionally left unclassified (lane `null`): their relative
+// ordering against everything else is unaffected by this fairness mechanism.
+const BACKLOG_CONVERGENCE_DELIVERY_PREFIX = "backlog-convergence:";
+
+/**
+ * Classify a job's foreground fairness lane from its type + raw payload — `"fresh"` for a webhook-driven PR
+ * open/reopen/synchronize/ready-for-review event, `"backlog"` for a backlog-convergence-sourced re-gate job,
+ * `null` for everything else (untouched by this mechanism; falls through to plain priority-ordered claiming).
+ * A malformed payload classifies as `null` rather than throwing — fail-closed, matching queue-common.ts's
+ * `jobPriority`/`jobCoalesceKey` style. Pure.
+ */
+export function foregroundLaneForJob(type: string, payload: string): ForegroundLane {
+  try {
+    if (type === "github-webhook") {
+      const message = JSON.parse(payload) as {
+        eventName?: unknown;
+        payload?: { action?: unknown } | null;
+      };
+      const eventName = typeof message.eventName === "string" ? message.eventName : "";
+      const action = typeof message.payload?.action === "string" ? message.payload.action : "";
+      return eventName === "pull_request" && FRESH_PULL_REQUEST_ACTIONS.has(action) ? "fresh" : null;
+    }
+    if (type === "agent-regate-pr") {
+      const message = JSON.parse(payload) as { deliveryId?: unknown };
+      const deliveryId = typeof message.deliveryId === "string" ? message.deliveryId : "";
+      return deliveryId.startsWith(BACKLOG_CONVERGENCE_DELIVERY_PREFIX) ? "backlog" : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export type ForegroundLaneRatio = { backlogPer: number; freshPer: number };
+
+// 3 backlog claims for every 1 fresh claim (suggested by the operator report, not a fixed law): heavily favors
+// draining old backlog while still guaranteeing fresh PR events a claim slot at least 1-in-4 cycles, never
+// fully starved.
+export const DEFAULT_FOREGROUND_LANE_RATIO: ForegroundLaneRatio = { backlogPer: 3, freshPer: 1 };
+
+/**
+ * Which lane a claim at this point in the sequence should prefer: a fixed repeating pattern indexed by
+ * `sequence % windowSize` — no wall-clock, so the SAME sequence value always yields the SAME lane. `sequence`
+ * is a monotonically-advancing counter the queue backend bumps on every foreground claim attempt (hit or miss),
+ * so the cycle always progresses even when the preferred lane happens to be empty this turn (the caller falls
+ * back to an unscoped claim on a miss — see sqlite-queue.ts / pg-queue.ts). Pure.
+ */
+export function nextForegroundLane(
+  sequence: number,
+  ratio: ForegroundLaneRatio = DEFAULT_FOREGROUND_LANE_RATIO,
+): "backlog" | "fresh" {
+  const windowSize = ratio.backlogPer + ratio.freshPer;
+  return sequence % windowSize < ratio.backlogPer ? "backlog" : "fresh";
+}
+
+export type BacklogRepoCandidate = { repo: string; oldestPendingAgeMs: number };
+
+/**
+ * Per-repo round-robin for the backlog lane: pick the repo whose oldest pending backlog job is stalest,
+ * EXCEPT when that repo was also the last one served — in that case, rotate to the next-stalest so a single
+ * repo with a deep backlog cannot monopolize every backlog-lane claim and starve every other repo's backlog.
+ * A `lastClaimedRepo` no longer present in `candidates` (its backlog fully drained since) falls back to the
+ * stalest overall, same as a first-ever pick. Pure.
+ */
+export function pickBacklogRepo(candidates: readonly BacklogRepoCandidate[], lastClaimedRepo: string | null): string | null {
+  if (candidates.length === 0) return null;
+  const sorted = [...candidates].sort((a, b) => b.oldestPendingAgeMs - a.oldestPendingAgeMs || a.repo.localeCompare(b.repo));
+  // sorted.length is provably >0 past the early return above, so every index below is in bounds.
+  const stalest = sorted[0] as BacklogRepoCandidate;
+  if (!lastClaimedRepo) return stalest.repo;
+  const lastIndex = sorted.findIndex((candidate) => candidate.repo === lastClaimedRepo);
+  if (lastIndex === -1) return stalest.repo;
+  return (sorted[(lastIndex + 1) % sorted.length] as BacklogRepoCandidate).repo;
+}
+
+const AGENT_REGATE_PR_JOB_KEY_PREFIX = "agent-regate-pr:";
+
+/**
+ * Derive per-repo backlog candidates from raw pending backlog-lane job rows (job_key + created_at), rather than
+ * a repo-extracting SQL expression — keeps the string parsing in one pure, unit-testable place instead of
+ * duplicated/diverging between the SQLite and Postgres claim queries. `job_key` for a backlog-convergence
+ * `agent-regate-pr` row is always `agent-regate-pr:{repo}#{pr}` (queue-common.ts's `jobCoalesceKey`); a row with
+ * no/malformed job_key is skipped (it cannot be attributed to a repo, so it cannot participate in the per-repo
+ * round-robin — the unscoped fallback claim still picks it up normally). Pure.
+ */
+export function backlogRepoCandidatesFromJobKeys(
+  rows: readonly { jobKey: string | null | undefined; createdAtMs: number }[],
+  nowMs: number,
+): BacklogRepoCandidate[] {
+  const oldestAgeByRepo = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.jobKey || !row.jobKey.startsWith(AGENT_REGATE_PR_JOB_KEY_PREFIX)) continue;
+    const rest = row.jobKey.slice(AGENT_REGATE_PR_JOB_KEY_PREFIX.length);
+    const hashIndex = rest.indexOf("#");
+    const repo = hashIndex === -1 ? rest : rest.slice(0, hashIndex);
+    if (!repo) continue;
+    const ageMs = Math.max(0, nowMs - row.createdAtMs);
+    const existingAge = oldestAgeByRepo.get(repo);
+    if (existingAge === undefined || ageMs > existingAge) oldestAgeByRepo.set(repo, ageMs);
+  }
+  return [...oldestAgeByRepo.entries()].map(([repo, oldestPendingAgeMs]) => ({ repo, oldestPendingAgeMs }));
+}

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -46,10 +46,23 @@ import {
   type MaintenanceAdmissionConfig,
   type MaintenancePressureSignals,
 } from "./maintenance-admission";
+import {
+  backlogRepoCandidatesFromJobKeys,
+  foregroundLaneForJob,
+  nextForegroundLane,
+  pickBacklogRepo,
+  type ForegroundLane,
+} from "./queue-fairness";
 import type { JobMessage } from "../types";
 
 const TABLE = "_selfhost_jobs";
 const STATS_TABLE = "_selfhost_job_stats";
+// Claim-time backlog-vs-fresh-intake fairness state (#selfhost-backlog-convergence, see queue-fairness.ts). A
+// SEPARATE singleton table -- NOT the app DB's `global_agent_controls` -- because this queue backend never
+// touches the app D1/Postgres database (it owns its own storage, same as _selfhost_jobs/_selfhost_job_stats
+// above); reusing global_agent_controls would require a cross-database dependency this queue deliberately has
+// never had.
+const FAIRNESS_TABLE = "_selfhost_queue_fairness";
 const DDL = `
 CREATE TABLE IF NOT EXISTS ${TABLE} (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -67,11 +80,19 @@ CREATE TABLE IF NOT EXISTS ${STATS_TABLE} (
   name TEXT PRIMARY KEY,
   value INTEGER NOT NULL DEFAULT 0
 );`;
+const FAIRNESS_DDL = `
+CREATE TABLE IF NOT EXISTS ${FAIRNESS_TABLE} (
+  id TEXT PRIMARY KEY,
+  claim_sequence INTEGER NOT NULL DEFAULT 0,
+  last_backlog_repo TEXT
+);`;
 const CLAIM_INDEX_DDL = `
 DROP INDEX IF EXISTS ${TABLE}_claim;
 CREATE INDEX ${TABLE}_claim ON ${TABLE}(status, run_after, priority);`;
 const JOB_KEY_INDEX_DDL = `
 CREATE INDEX IF NOT EXISTS ${TABLE}_pending_job_key ON ${TABLE}(job_key, status);`;
+const LANE_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS ${TABLE}_lane_claim ON ${TABLE}(status, foreground_lane, run_after);`;
 
 export interface DurableQueue {
   binding: Queue;
@@ -153,8 +174,16 @@ export function createSqliteQueue(
   } catch {
     /* column already present */
   }
+  try {
+    driver.exec(`ALTER TABLE ${TABLE} ADD COLUMN foreground_lane TEXT`);
+  } catch {
+    /* column already present */
+  }
   driver.exec(CLAIM_INDEX_DDL);
   driver.exec(JOB_KEY_INDEX_DDL);
+  driver.exec(LANE_INDEX_DDL);
+  driver.exec(FAIRNESS_DDL);
+  driver.exec(`INSERT OR IGNORE INTO ${FAIRNESS_TABLE} (id, claim_sequence) VALUES ('singleton', 0)`);
   const priorityBackfilled = backfillJobPriorities(driver);
   if (priorityBackfilled)
     console.log(
@@ -177,6 +206,14 @@ export function createSqliteQueue(
       JSON.stringify({
         event: "selfhost_queue_maintenance_flags_backfilled",
         count: maintenanceFlagsBackfilled,
+      }),
+    );
+  const lanesBackfilled = backfillJobForegroundLanes(driver);
+  if (lanesBackfilled)
+    console.log(
+      JSON.stringify({
+        event: "selfhost_queue_foreground_lanes_backfilled",
+        count: lanesBackfilled,
       }),
     );
   const maintenanceAdmissionConfig: MaintenanceAdmissionConfig = resolveMaintenanceAdmissionConfig();
@@ -240,6 +277,7 @@ export function createSqliteQueue(
     const payload = JSON.stringify(message);
     const priority = jobPriority(payload);
     const key = jobCoalesceKey(payload);
+    const lane = foregroundLaneForJob(message.type, payload);
     const runAfter = now + delaySeconds * 1000;
     const absorbedByKey = jobCoalesceAbsorbedByKey(payload);
     if (absorbedByKey) {
@@ -270,9 +308,9 @@ export function createSqliteQueue(
         // (4h default) can keep re-arming the clock forever, and sustained pressure defers the job indefinitely.
         driver.query(
           `UPDATE ${TABLE}
-             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), job_key=?, last_error=NULL
+             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), job_key=?, foreground_lane=?, last_error=NULL
            WHERE id=?`,
-          [payload, runAfter, priority, key, existing.id],
+          [payload, runAfter, priority, key, lane, existing.id],
         );
         driver.query(
           `DELETE FROM ${TABLE}
@@ -294,9 +332,9 @@ export function createSqliteQueue(
         // maintenance trickle clock reflects genuine wait time, not the most recent re-request.
         driver.query(
           `UPDATE ${TABLE}
-             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), last_error=NULL
+             SET payload=?, run_after=max(run_after, ?), priority=max(priority, ?), foreground_lane=?, last_error=NULL
            WHERE id=?`,
-          [payload, runAfter, priority, existing.id],
+          [payload, runAfter, priority, lane, existing.id],
         );
         recordQueueMetric(driver, "gittensory_jobs_coalesced_total");
         kickOne();
@@ -304,8 +342,8 @@ export function createSqliteQueue(
       }
     }
     driver.query(
-      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance) VALUES (?, 'pending', 0, ?, ?, ?, ?, ?)`,
-      [payload, runAfter, now, priority, key, isMaintenanceJobType(message.type) ? 1 : 0],
+      `INSERT INTO ${TABLE} (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance, foreground_lane) VALUES (?, 'pending', 0, ?, ?, ?, ?, ?, ?)`,
+      [payload, runAfter, now, priority, key, isMaintenanceJobType(message.type) ? 1 : 0, lane],
     );
     recordQueueMetric(driver, "gittensory_jobs_enqueued_total");
     kickOne();
@@ -313,7 +351,7 @@ export function createSqliteQueue(
 
   function claimNext(): JobRow | null {
     const now = Date.now();
-    const foreground = claimNextWhere(now, "priority>=?");
+    const foreground = claimNextForegroundLane(now) ?? claimNextWhere(now, "priority>=?");
     if (foreground) return foreground;
     if (activeBackground >= backgroundConcurrency) return null;
     activeBackground++;
@@ -335,14 +373,58 @@ export function createSqliteQueue(
     return { ...background, backgroundSlotReserved: true };
   }
 
-  function claimNextWhere(now: number, priorityPredicate: string): JobRow | null {
+  /** Claim-time backlog-vs-fresh-intake fairness (#selfhost-backlog-convergence, see queue-fairness.ts). Tries
+   *  ONE lane-scoped claim before falling back to the plain unscoped foreground claim (claimNext() OR's this
+   *  return value with claimNextWhere(now, "priority>=?")) -- a null here just means "no work to prefer this
+   *  cycle," never "no foreground work at all." The fairness singleton's claim_sequence always advances (best-
+   *  effort, hit or miss) so the ratio cycle keeps progressing even through empty cycles. */
+  function claimNextForegroundLane(now: number): JobRow | null {
+    const fairness = driver.query(
+      `SELECT claim_sequence, last_backlog_repo FROM ${FAIRNESS_TABLE} WHERE id='singleton'`,
+      [],
+    ).rows[0] as { claim_sequence: number; last_backlog_repo: string | null } | undefined;
+    const sequence = fairness?.claim_sequence ?? 0;
+    const lane: ForegroundLane = nextForegroundLane(sequence);
+    driver.query(`UPDATE ${FAIRNESS_TABLE} SET claim_sequence=claim_sequence+1 WHERE id='singleton'`, []);
+    if (lane === "fresh") {
+      return claimNextWhere(now, "priority>=?", { sql: "foreground_lane='fresh'", params: [] });
+    }
+    const { rows: backlogRows } = driver.query(
+      `SELECT job_key, created_at FROM ${TABLE} WHERE status='pending' AND run_after<=? AND foreground_lane='backlog'`,
+      [now],
+    );
+    const candidates = backlogRepoCandidatesFromJobKeys(
+      (backlogRows as Array<{ job_key: string | null; created_at: number }>).map((row) => ({
+        jobKey: row.job_key,
+        createdAtMs: Number(row.created_at),
+      })),
+      now,
+    );
+    const repo = pickBacklogRepo(candidates, fairness?.last_backlog_repo ?? null);
+    if (!repo) return null;
+    const row = claimNextWhere(now, "priority>=?", {
+      sql: "foreground_lane='backlog' AND job_key LIKE ?",
+      params: [`agent-regate-pr:${repo}#%`],
+    });
+    if (row) {
+      driver.query(`UPDATE ${FAIRNESS_TABLE} SET last_backlog_repo=? WHERE id='singleton'`, [repo]);
+    }
+    return row;
+  }
+
+  function claimNextWhere(
+    now: number,
+    priorityPredicate: string,
+    extra?: { sql: string; params: readonly unknown[] },
+  ): JobRow | null {
+    const extraSql = extra ? ` AND ${extra.sql}` : "";
     const { rows } = driver.query(
       `SELECT id, payload, attempts, job_key, priority, created_at
          FROM ${TABLE}
-        WHERE status='pending' AND run_after<=? AND ${priorityPredicate}
+        WHERE status='pending' AND run_after<=? AND ${priorityPredicate}${extraSql}
         ORDER BY priority DESC, run_after, id
         LIMIT 1`,
-      [now, FOREGROUND_QUEUE_PRIORITY_FLOOR],
+      [now, FOREGROUND_QUEUE_PRIORITY_FLOOR, ...(extra?.params ?? [])],
     );
     const row = rows[0] as JobRow | undefined;
     if (!row) return null;
@@ -788,6 +870,22 @@ function backfillJobMaintenanceFlags(driver: SqliteDriver): number {
     const isMaintenance = isMaintenanceJobType(extractPayloadType(row.payload) ?? "") ? 1 : 0;
     if (Number(row.is_maintenance) === isMaintenance) continue;
     driver.query(`UPDATE ${TABLE} SET is_maintenance=? WHERE id=?`, [isMaintenance, row.id]);
+    changed += 1;
+  }
+  return changed;
+}
+
+function backfillJobForegroundLanes(driver: SqliteDriver): number {
+  const { rows } = driver.query(
+    `SELECT id, payload, foreground_lane FROM ${TABLE} WHERE status IN ('pending', 'processing')`,
+    [],
+  );
+  let changed = 0;
+  for (const row of rows as Array<{ id: number; payload: string; foreground_lane: string | null }>) {
+    const type = extractPayloadType(row.payload) ?? "";
+    const lane = foregroundLaneForJob(type, row.payload);
+    if ((row.foreground_lane ?? null) === lane) continue;
+    driver.query(`UPDATE ${TABLE} SET foreground_lane=? WHERE id=?`, [lane, row.id]);
     changed += 1;
   }
   return changed;

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -111,6 +111,17 @@ function makePool(): MockPool {
       const rowCount = reviveUpdateRowCounts.length > 0 ? (reviveUpdateRowCounts.shift() ?? 1) : 1;
       return { rows: [], rowCount };
     }
+    // The claim-time fairness sequence allocator (#selfhost-backlog-convergence) ALSO uses RETURNING (atomic
+    // UPDATE ... RETURNING, not a separate SELECT-then-UPDATE — see claimNextForegroundLane). It must be
+    // matched BEFORE the generic job-claim RETURNING check below, or it would wrongly pop a job row queued via
+    // enqueueJob/enqueueResult meant for the real claim query. A harmless fixed default (sequence 0 -> lane
+    // "backlog", no repo) lets every pre-existing test that doesn't care about fairness behave exactly as
+    // before: the backlog-scoped claim then finds nothing (no candidates SELECT is mocked here), so
+    // claimNextForegroundLane returns null and claimNext() falls through to the plain unscoped claim query,
+    // which IS the generic RETURNING branch below.
+    if (q.includes("_selfhost_queue_fairness") && q.includes("RETURNING")) {
+      return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
+    }
     // Claim queries use RETURNING — pop from queue; fall through to empty default otherwise.
     if (q.includes("RETURNING")) {
       const next = results.shift();
@@ -565,6 +576,9 @@ describe("createPgQueue (durable #977)", () => {
         }
         return { rows: [], rowCount: 1 };
       }
+      if (q.includes("_selfhost_queue_fairness") && q.includes("RETURNING")) {
+        return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
+      }
       if (q.includes("RETURNING")) {
         if (claimed) return { rows: [], rowCount: 0 };
         claimed = true;
@@ -590,6 +604,9 @@ describe("createPgQueue (durable #977)", () => {
         const err = new Error("connection terminated") as Error & { code: string };
         err.code = "ECONNRESET";
         throw err;
+      }
+      if (q.includes("_selfhost_queue_fairness") && q.includes("RETURNING")) {
+        return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
       }
       if (q.includes("RETURNING")) {
         if (claimed) return { rows: [], rowCount: 0 };
@@ -743,17 +760,17 @@ describe("createPgQueue (durable #977)", () => {
 
     it("prefers a pending backlog-lane candidate at sequence 0 (default ratio) and records it as the last-served repo", async () => {
       const claimSql: string[] = [];
-      let sequenceBumped = false;
+      let sequenceAllocations = 0;
       let repoRecorded: string | null = null;
       let claimed = false; // one-shot: the row is only claimable until the first successful claim
       const fn = vi.fn().mockImplementation(async (sql: unknown, params?: unknown[]) => {
         const q = String(sql);
-        if (q.includes("SELECT claim_sequence, last_backlog_repo")) {
+        // Atomic allocation (#selfhost-backlog-convergence review): a single UPDATE ... RETURNING, not a
+        // separate SELECT-then-UPDATE -- concurrent self-host instances sharing one Postgres must never be
+        // able to read the same pre-increment claim_sequence.
+        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1") && q.includes("RETURNING claim_sequence, last_backlog_repo")) {
+          sequenceAllocations += 1;
           return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
-        }
-        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1")) {
-          sequenceBumped = true;
-          return { rows: [], rowCount: 1 };
         }
         if (q.includes("UPDATE _selfhost_queue_fairness SET last_backlog_repo")) {
           repoRecorded = (params as [string])[0];
@@ -784,7 +801,7 @@ describe("createPgQueue (durable #977)", () => {
 
       expect(seen).toEqual(["agent-regate-pr"]);
       expect(claimSql[0]).toContain("foreground_lane='backlog'");
-      expect(sequenceBumped).toBe(true);
+      expect(sequenceAllocations).toBeGreaterThan(0);
       expect(repoRecorded).toBe("owner/repo");
     });
 
@@ -793,7 +810,7 @@ describe("createPgQueue (durable #977)", () => {
       let claimed = false; // one-shot: the row is only claimable until the first successful claim
       const fn = vi.fn().mockImplementation(async (sql: unknown) => {
         const q = String(sql);
-        if (q.includes("SELECT claim_sequence, last_backlog_repo")) {
+        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1") && q.includes("RETURNING claim_sequence, last_backlog_repo")) {
           return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
         }
         if (q.includes("UPDATE _selfhost_queue_fairness")) return { rows: [], rowCount: 1 };
@@ -823,6 +840,55 @@ describe("createPgQueue (durable #977)", () => {
       // query, which still finds the untagged foreground row rather than stalling.
       expect(seen).toEqual(["recapture-preview"]);
       expect(claimSql[0]).not.toContain("foreground_lane");
+    });
+
+    it("allocates the claim sequence atomically via UPDATE ... RETURNING, not a separate SELECT-then-UPDATE (#selfhost-backlog-convergence review)", async () => {
+      // A stateful counter mimics what Postgres's own row lock guarantees: each call to the fairness UPDATE
+      // sees the PRIOR call's committed increment, never a stale pre-increment value two callers could both
+      // observe. If the code ever regressed to a separate SELECT-then-UPDATE, this mock would not by itself
+      // catch a real race (it's still single-threaded JS) -- what it DOES prove is that the code reads its
+      // lane decision from the SAME query that performs the increment (the RETURNING clause), which is the
+      // actual fix: no separate read exists to go stale between two real concurrent Postgres connections.
+      let claimSequence = 0;
+      const claimedRepoJobs = new Set(["1", "2"]);
+      const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+        const q = String(sql);
+        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1") && q.includes("RETURNING claim_sequence, last_backlog_repo")) {
+          claimSequence += 1;
+          return { rows: [{ claim_sequence: claimSequence, last_backlog_repo: null }], rowCount: 1 };
+        }
+        if (q.includes("UPDATE _selfhost_queue_fairness")) return { rows: [], rowCount: 1 };
+        if (q.includes("SELECT job_key, created_at") && q.includes("foreground_lane='backlog'")) {
+          return {
+            rows: [...claimedRepoJobs].map((n) => ({ job_key: `agent-regate-pr:owner/repo#${n}`, created_at: 1000 })),
+            rowCount: claimedRepoJobs.size,
+          };
+        }
+        if (q.includes("UPDATE _selfhost_jobs SET status='processing'") && q.includes("foreground_lane='backlog'")) {
+          const next = [...claimedRepoJobs][0];
+          if (next === undefined) return { rows: [], rowCount: 0 };
+          claimedRepoJobs.delete(next);
+          return {
+            rows: [{ id: `backlog-${next}`, payload: JSON.stringify(backlogJob("owner/repo", Number(next))), attempts: 0, job_key: `agent-regate-pr:owner/repo#${next}`, priority: 9, created_at: 1000 }],
+            rowCount: 1,
+          };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      const seen: string[] = [];
+      const q = createPgQueue({ query: fn } as unknown as Pool, async (m) => void seen.push(typeOf(m)), { concurrency: 1 });
+
+      await q.init();
+      await q.drain();
+
+      // 2 backlog-tagged rows are pending; the fairness allocator's RETURNING values (1, then 2 -- both
+      // < the default ratio's backlogPer=3 window) both resolve to "backlog", so both rows are claimed via
+      // the backlog-scoped path in order, proving the lane decision tracks the atomically-allocated sequence
+      // rather than a stale value from a separate read. (drain() keeps polling after both are claimed until a
+      // claim genuinely comes up empty, so the allocator may advance past 2 -- that trailing empty cycle is
+      // not what this test is verifying.)
+      expect(seen).toEqual(["agent-regate-pr", "agent-regate-pr"]);
+      expect(claimSequence).toBeGreaterThanOrEqual(2);
     });
 
     it("backfills the foreground_lane column on startup for jobs enqueued by an older version", async () => {

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -182,6 +182,7 @@ describe("createPgQueue (durable #977)", () => {
   it("init() backfills event-aware priorities with the shared classifier", async () => {
     const m = makePool();
     m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // DDL
+    m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // fairness singleton INSERT
     m.fn.mockResolvedValueOnce({
       rows: [
         { id: "a", payload: JSON.stringify(msg("agent-regate-pr")), priority: 0 },
@@ -728,6 +729,122 @@ describe("createPgQueue (durable #977)", () => {
       expect.stringContaining("DELETE FROM _selfhost_jobs WHERE id=$1"),
       ["background"],
     );
+  });
+
+  describe("claim-time backlog-vs-fresh-intake fairness (#selfhost-backlog-convergence)", () => {
+    const backlogJob = (repo: string, prNumber: number): JobMessage =>
+      ({
+        type: "agent-regate-pr",
+        deliveryId: `backlog-convergence:${repo}#${prNumber}`,
+        repoFullName: repo,
+        prNumber,
+        installationId: 1,
+      }) as unknown as JobMessage;
+
+    it("prefers a pending backlog-lane candidate at sequence 0 (default ratio) and records it as the last-served repo", async () => {
+      const claimSql: string[] = [];
+      let sequenceBumped = false;
+      let repoRecorded: string | null = null;
+      let claimed = false; // one-shot: the row is only claimable until the first successful claim
+      const fn = vi.fn().mockImplementation(async (sql: unknown, params?: unknown[]) => {
+        const q = String(sql);
+        if (q.includes("SELECT claim_sequence, last_backlog_repo")) {
+          return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
+        }
+        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1")) {
+          sequenceBumped = true;
+          return { rows: [], rowCount: 1 };
+        }
+        if (q.includes("UPDATE _selfhost_queue_fairness SET last_backlog_repo")) {
+          repoRecorded = (params as [string])[0];
+          return { rows: [], rowCount: 1 };
+        }
+        if (q.includes("SELECT job_key, created_at") && q.includes("foreground_lane='backlog'")) {
+          return claimed ? { rows: [], rowCount: 0 } : { rows: [{ job_key: "agent-regate-pr:owner/repo#1", created_at: 1000 }], rowCount: 1 };
+        }
+        if (q.includes("UPDATE _selfhost_jobs SET status='processing'")) {
+          claimSql.push(q);
+          if (!claimed && q.includes("foreground_lane='backlog'")) {
+            expect((params as unknown[])[2]).toBe("agent-regate-pr:owner/repo#%");
+            claimed = true;
+            return {
+              rows: [{ id: "backlog-1", payload: JSON.stringify(backlogJob("owner/repo", 1)), attempts: 0, job_key: "agent-regate-pr:owner/repo#1", priority: 9, created_at: 1000 }],
+              rowCount: 1,
+            };
+          }
+          return { rows: [], rowCount: 0 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      const seen: string[] = [];
+      const q = createPgQueue({ query: fn } as unknown as Pool, async (m) => void seen.push(typeOf(m)));
+
+      await q.init();
+      await q.drain();
+
+      expect(seen).toEqual(["agent-regate-pr"]);
+      expect(claimSql[0]).toContain("foreground_lane='backlog'");
+      expect(sequenceBumped).toBe(true);
+      expect(repoRecorded).toBe("owner/repo");
+    });
+
+    it("falls through to the plain unscoped foreground claim when the backlog lane has no pending candidates", async () => {
+      const claimSql: string[] = [];
+      let claimed = false; // one-shot: the row is only claimable until the first successful claim
+      const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+        const q = String(sql);
+        if (q.includes("SELECT claim_sequence, last_backlog_repo")) {
+          return { rows: [{ claim_sequence: 0, last_backlog_repo: null }], rowCount: 1 };
+        }
+        if (q.includes("UPDATE _selfhost_queue_fairness")) return { rows: [], rowCount: 1 };
+        if (q.includes("SELECT job_key, created_at") && q.includes("foreground_lane='backlog'")) {
+          return { rows: [], rowCount: 0 }; // no backlog work pending
+        }
+        if (q.includes("UPDATE _selfhost_jobs SET status='processing'")) {
+          claimSql.push(q);
+          if (!claimed && !q.includes("foreground_lane")) {
+            claimed = true;
+            return {
+              rows: [{ id: "fresh-1", payload: JSON.stringify(msg("recapture-preview")), attempts: 0, job_key: "recapture-preview:owner/repo#1:0", priority: 9, created_at: 1000 }],
+              rowCount: 1,
+            };
+          }
+          return { rows: [], rowCount: 0 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      const seen: string[] = [];
+      const q = createPgQueue({ query: fn } as unknown as Pool, async (m) => void seen.push(typeOf(m)));
+
+      await q.init();
+      await q.drain();
+
+      // The backlog-scoped claim yields nothing (no candidates) -- falls through to the unscoped foreground
+      // query, which still finds the untagged foreground row rather than stalling.
+      expect(seen).toEqual(["recapture-preview"]);
+      expect(claimSql[0]).not.toContain("foreground_lane");
+    });
+
+    it("backfills the foreground_lane column on startup for jobs enqueued by an older version", async () => {
+      const m = makePool();
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // DDL
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // fairness singleton INSERT
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // priority backfill SELECT
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // job-key backfill SELECT
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // maintenance-flags backfill SELECT
+      m.fn.mockResolvedValueOnce({
+        rows: [{ id: "legacy", payload: JSON.stringify({ type: "agent-regate-pr", deliveryId: "backlog-convergence:owner/repo#1" }), foreground_lane: null }],
+        rowCount: 1,
+      }); // foreground-lane backfill SELECT
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // the backfill UPDATE for the legacy row
+      m.fn.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // recovery UPDATE
+      const q = createPgQueue(m.pool, async () => undefined);
+      await q.init();
+      expect(m.pool.query).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE _selfhost_jobs SET foreground_lane=$1"),
+        ["backlog", "legacy"],
+      );
+    });
   });
 
   it("REGRESSION: releases the reserved background slot when a background claim query rejects (#selfhost-bg-slot-leak)", async () => {

--- a/test/unit/selfhost-queue-fairness.test.ts
+++ b/test/unit/selfhost-queue-fairness.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FOREGROUND_LANE_RATIO,
+  backlogRepoCandidatesFromJobKeys,
+  foregroundLaneForJob,
+  nextForegroundLane,
+  pickBacklogRepo,
+} from "../../src/selfhost/queue-fairness";
+
+function webhookPayload(eventName: string, action?: string): string {
+  return JSON.stringify({ type: "github-webhook", eventName, payload: action === undefined ? {} : { action } });
+}
+
+function regatePrPayload(deliveryId?: string): string {
+  return JSON.stringify({ type: "agent-regate-pr", ...(deliveryId === undefined ? {} : { deliveryId }) });
+}
+
+describe("foregroundLaneForJob (#selfhost-backlog-convergence)", () => {
+  it("classifies a fresh PR intake event for each recognized action", () => {
+    for (const action of ["opened", "reopened", "synchronize", "ready_for_review"]) {
+      expect(foregroundLaneForJob("github-webhook", webhookPayload("pull_request", action))).toBe("fresh");
+    }
+  });
+
+  it("does not classify a pull_request action outside the fresh-intake set", () => {
+    expect(foregroundLaneForJob("github-webhook", webhookPayload("pull_request", "closed"))).toBeNull();
+    expect(foregroundLaneForJob("github-webhook", webhookPayload("pull_request", "edited"))).toBeNull();
+  });
+
+  it("does not classify a non-pull_request webhook event", () => {
+    expect(foregroundLaneForJob("github-webhook", webhookPayload("check_suite", "completed"))).toBeNull();
+  });
+
+  it("treats a missing/non-string action as unclassified rather than throwing", () => {
+    expect(foregroundLaneForJob("github-webhook", JSON.stringify({ type: "github-webhook", eventName: "pull_request", payload: null }))).toBeNull();
+    expect(foregroundLaneForJob("github-webhook", JSON.stringify({ type: "github-webhook", eventName: "pull_request" }))).toBeNull();
+  });
+
+  it("fails closed (null) on a malformed webhook payload", () => {
+    expect(foregroundLaneForJob("github-webhook", "not-json")).toBeNull();
+  });
+
+  it("treats a missing/non-string eventName as unclassified rather than throwing", () => {
+    expect(foregroundLaneForJob("github-webhook", JSON.stringify({ type: "github-webhook", payload: { action: "opened" } }))).toBeNull();
+  });
+
+  it("classifies a backlog-convergence-sourced agent-regate-pr job", () => {
+    expect(foregroundLaneForJob("agent-regate-pr", regatePrPayload("backlog-convergence:owner/repo#7"))).toBe("backlog");
+  });
+
+  it("does not classify a sweep- or manually-originated agent-regate-pr job", () => {
+    expect(foregroundLaneForJob("agent-regate-pr", regatePrPayload("regate-sweep:owner/repo#7"))).toBeNull();
+    expect(foregroundLaneForJob("agent-regate-pr", regatePrPayload("manual-regate:owner/repo#7:1"))).toBeNull();
+  });
+
+  it("treats a missing deliveryId as unclassified rather than throwing", () => {
+    expect(foregroundLaneForJob("agent-regate-pr", regatePrPayload())).toBeNull();
+  });
+
+  it("fails closed (null) on a malformed agent-regate-pr payload", () => {
+    expect(foregroundLaneForJob("agent-regate-pr", "not-json")).toBeNull();
+  });
+
+  it("does not classify any other job type", () => {
+    expect(foregroundLaneForJob("recapture-preview", JSON.stringify({ type: "recapture-preview" }))).toBeNull();
+    expect(foregroundLaneForJob("agent-regate-sweep", JSON.stringify({ type: "agent-regate-sweep" }))).toBeNull();
+  });
+});
+
+describe("nextForegroundLane (#selfhost-backlog-convergence)", () => {
+  it("prefers backlog for backlogPer of every windowSize cycle under the default 3:1 ratio", () => {
+    expect(nextForegroundLane(0)).toBe("backlog");
+    expect(nextForegroundLane(1)).toBe("backlog");
+    expect(nextForegroundLane(2)).toBe("backlog");
+    expect(nextForegroundLane(3)).toBe("fresh");
+  });
+
+  it("wraps the cycle deterministically (same sequence mod windowSize -> same lane)", () => {
+    expect(nextForegroundLane(4)).toBe("backlog"); // 4 % 4 === 0
+    expect(nextForegroundLane(7)).toBe("fresh"); // 7 % 4 === 3
+  });
+
+  it("honors a custom ratio", () => {
+    const ratio = { backlogPer: 1, freshPer: 1 };
+    expect(nextForegroundLane(0, ratio)).toBe("backlog");
+    expect(nextForegroundLane(1, ratio)).toBe("fresh");
+  });
+
+  it("the exported default ratio matches the documented 3:1 policy", () => {
+    expect(DEFAULT_FOREGROUND_LANE_RATIO).toEqual({ backlogPer: 3, freshPer: 1 });
+  });
+});
+
+describe("pickBacklogRepo (#selfhost-backlog-convergence)", () => {
+  it("returns null when there are no candidates", () => {
+    expect(pickBacklogRepo([], null)).toBeNull();
+  });
+
+  it("picks the stalest repo on a first-ever pick (no last-claimed repo)", () => {
+    const candidates = [
+      { repo: "owner/a", oldestPendingAgeMs: 1000 },
+      { repo: "owner/b", oldestPendingAgeMs: 5000 },
+    ];
+    expect(pickBacklogRepo(candidates, null)).toBe("owner/b");
+  });
+
+  it("rotates past the last-claimed repo to the next-stalest, not re-picking the same repo", () => {
+    const candidates = [
+      { repo: "owner/a", oldestPendingAgeMs: 1000 },
+      { repo: "owner/b", oldestPendingAgeMs: 5000 },
+      { repo: "owner/c", oldestPendingAgeMs: 3000 },
+    ];
+    // sorted stalest-first: b(5000), c(3000), a(1000) — last-claimed b -> rotate to c
+    expect(pickBacklogRepo(candidates, "owner/b")).toBe("owner/c");
+  });
+
+  it("wraps around to the stalest repo when the last-claimed repo was the least-stale", () => {
+    const candidates = [
+      { repo: "owner/a", oldestPendingAgeMs: 1000 },
+      { repo: "owner/b", oldestPendingAgeMs: 5000 },
+    ];
+    expect(pickBacklogRepo(candidates, "owner/a")).toBe("owner/b");
+  });
+
+  it("falls back to the stalest repo when the last-claimed repo has since drained (no longer a candidate)", () => {
+    const candidates = [{ repo: "owner/b", oldestPendingAgeMs: 5000 }];
+    expect(pickBacklogRepo(candidates, "owner/a")).toBe("owner/b");
+  });
+
+  it("breaks a tie in oldestPendingAgeMs by repo name for determinism", () => {
+    const candidates = [
+      { repo: "owner/z", oldestPendingAgeMs: 1000 },
+      { repo: "owner/a", oldestPendingAgeMs: 1000 },
+    ];
+    expect(pickBacklogRepo(candidates, null)).toBe("owner/a");
+  });
+});
+
+describe("backlogRepoCandidatesFromJobKeys (#selfhost-backlog-convergence)", () => {
+  it("extracts the repo and oldest pending age from backlog-lane job keys", () => {
+    const candidates = backlogRepoCandidatesFromJobKeys(
+      [{ jobKey: "agent-regate-pr:owner/repo#7", createdAtMs: 1000 }],
+      6000,
+    );
+    expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 5000 }]);
+  });
+
+  it("skips a row with a missing job_key", () => {
+    expect(backlogRepoCandidatesFromJobKeys([{ jobKey: null, createdAtMs: 1000 }], 2000)).toEqual([]);
+    expect(backlogRepoCandidatesFromJobKeys([{ jobKey: undefined, createdAtMs: 1000 }], 2000)).toEqual([]);
+  });
+
+  it("skips a row whose job_key is not an agent-regate-pr key", () => {
+    expect(backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-sweep:owner/repo", createdAtMs: 1000 }], 2000)).toEqual([]);
+  });
+
+  it("treats a job_key with no '#' as the repo being everything after the prefix", () => {
+    const candidates = backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-pr:owner/repo", createdAtMs: 1000 }], 2000);
+    expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 1000 }]);
+  });
+
+  it("skips a row whose extracted repo is empty", () => {
+    expect(backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-pr:#7", createdAtMs: 1000 }], 2000)).toEqual([]);
+  });
+
+  it("keeps the OLDEST (largest age) pending row per repo when multiple rows share a repo", () => {
+    const candidates = backlogRepoCandidatesFromJobKeys(
+      [
+        { jobKey: "agent-regate-pr:owner/repo#1", createdAtMs: 5000 },
+        { jobKey: "agent-regate-pr:owner/repo#2", createdAtMs: 1000 },
+      ],
+      6000,
+    );
+    expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 5000 }]);
+  });
+
+  it("does NOT overwrite an already-older pending row for the same repo with a newer (smaller-age) one", () => {
+    const candidates = backlogRepoCandidatesFromJobKeys(
+      [
+        { jobKey: "agent-regate-pr:owner/repo#1", createdAtMs: 1000 }, // age 5000, seen first
+        { jobKey: "agent-regate-pr:owner/repo#2", createdAtMs: 5000 }, // age 1000, seen second — must NOT win
+      ],
+      6000,
+    );
+    expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 5000 }]);
+  });
+
+  it("clamps a negative age (createdAt in the future) to zero", () => {
+    const candidates = backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-pr:owner/repo#1", createdAtMs: 9000 }], 1000);
+    expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 0 }]);
+  });
+});

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1249,6 +1249,145 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(seen).toEqual(["github-webhook", "agent-regate-pr", "agent-regate-sweep", "rag-index-repo", "github-webhook"]);
   });
 
+  describe("claim-time backlog-vs-fresh-intake fairness (#selfhost-backlog-convergence)", () => {
+    const backlogJob = (repo: string, prNumber: number): JobMessage =>
+      ({
+        type: "agent-regate-pr",
+        deliveryId: `backlog-convergence:${repo}#${prNumber}`,
+        repoFullName: repo,
+        prNumber,
+        installationId: 1,
+      }) as unknown as JobMessage;
+
+    it("prefers 3 backlog-lane claims for every 1 fresh-intake claim (default ratio), deterministically", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId: string }).deliveryId), { concurrency: 1 });
+      await q.binding.send(backlogJob("owner/repo", 1));
+      await q.binding.send(backlogJob("owner/repo", 2));
+      await q.binding.send(backlogJob("owner/repo", 3));
+      await q.binding.send(prWebhook("fresh-1"));
+      await q.drain();
+      expect(seen).toEqual([
+        "backlog-convergence:owner/repo#1",
+        "backlog-convergence:owner/repo#2",
+        "backlog-convergence:owner/repo#3",
+        "fresh-1",
+      ]);
+    });
+
+    it("repeats the ratio cycle across a longer run (6 backlog : 2 fresh -> B,B,B,F,B,B,B,F)", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId: string }).deliveryId), { concurrency: 1 });
+      for (let i = 1; i <= 6; i++) await q.binding.send(backlogJob("owner/repo", i));
+      // Distinct head SHAs -- prWebhook's coalesce key is repo#pr@headSha, so two same-PR events with the
+      // SAME default sha would coalesce into one row instead of two.
+      await q.binding.send(prWebhook("fresh-1", "synchronize", "a".repeat(40)));
+      await q.binding.send(prWebhook("fresh-2", "synchronize", "b".repeat(40)));
+      await q.drain();
+      expect(seen).toEqual([
+        "backlog-convergence:owner/repo#1",
+        "backlog-convergence:owner/repo#2",
+        "backlog-convergence:owner/repo#3",
+        "fresh-1",
+        "backlog-convergence:owner/repo#4",
+        "backlog-convergence:owner/repo#5",
+        "backlog-convergence:owner/repo#6",
+        "fresh-2",
+      ]);
+    });
+
+    it("falls through to the plain unscoped foreground claim when the preferred lane has nothing pending", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId?: string; type: string }).deliveryId ?? typeOf(m)), { concurrency: 1 });
+      // Sequence 0 prefers "backlog", but only a "fresh" row is pending — must not stall behind an empty lane.
+      await q.binding.send(prWebhook("fresh-only"));
+      await q.drain();
+      expect(seen).toEqual(["fresh-only"]);
+    });
+
+    it("rotates the backlog lane across repos so one repo's deep backlog cannot starve another's (per-repo fairness)", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId?: string; type: string }).deliveryId ?? typeOf(m)), { concurrency: 1 });
+      // owner/a has 3 pending backlog rows, all older than owner/b's 1 row -- owner/a would win on pure
+      // staleness EVERY time if rotation didn't exclude the just-served repo.
+      const rows: Array<{ repo: string; prNumber: number; createdAt: number }> = [
+        { repo: "owner/a", prNumber: 1, createdAt: 1000 },
+        { repo: "owner/a", prNumber: 2, createdAt: 1500 },
+        { repo: "owner/a", prNumber: 3, createdAt: 2000 },
+        { repo: "owner/b", prNumber: 1, createdAt: 5000 },
+      ];
+      for (const { repo, prNumber, createdAt } of rows) {
+        driver.query(
+          "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, 'pending', 0, 0, ?, 9, ?, 'backlog')",
+          [JSON.stringify(backlogJob(repo, prNumber)), createdAt, `agent-regate-pr:${repo}#${prNumber}`],
+        );
+      }
+      await q.drain();
+      // owner/a (stalest) claimed first; rotation then forces owner/b even though owner/a is STILL stalest;
+      // owner/b then has nothing left, so the round-robin falls back to owner/a (the only remaining candidate).
+      expect(seen).toEqual([
+        "backlog-convergence:owner/a#1",
+        "backlog-convergence:owner/b#1",
+        "backlog-convergence:owner/a#2",
+        "backlog-convergence:owner/a#3",
+      ]);
+    });
+
+    it("defaults the claim sequence to 0 when the fairness singleton row is missing (defensive, never crashes)", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId: string }).deliveryId), { concurrency: 1 });
+      driver.query("DELETE FROM _selfhost_queue_fairness WHERE id='singleton'", []);
+      await q.binding.send(backlogJob("owner/repo", 1));
+      await q.drain();
+      expect(seen).toEqual(["backlog-convergence:owner/repo#1"]);
+    });
+
+    it("falls through gracefully when the picked repo's candidate row can't actually be claimed (defensive)", async () => {
+      const driver = makeDriver();
+      const seen: string[] = [];
+      const q = createSqliteQueue(driver, async (m) => void seen.push((m as unknown as { deliveryId: string }).deliveryId), { concurrency: 1 });
+      // A malformed/legacy row: tagged foreground_lane='backlog' (so it shows up as a fairness candidate) but
+      // its priority sits BELOW the foreground floor -- the fairness-scoped claim's priority filter excludes
+      // it, so pickBacklogRepo's chosen repo yields no row. Falls through to the background lane instead of
+      // stalling foreground claims.
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, 'pending', 0, 0, 1000, 0, ?, 'backlog')",
+        [JSON.stringify(backlogJob("owner/repo", 1)), "agent-regate-pr:owner/repo#1"],
+      );
+      await q.drain();
+      expect(seen).toEqual(["backlog-convergence:owner/repo#1"]);
+    });
+
+    it("backfills the foreground_lane column on startup for jobs enqueued by an older version", async () => {
+      const driver = nodeSqliteDriver(new DatabaseSync(":memory:") as never);
+      driver.exec(`
+        CREATE TABLE _selfhost_jobs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          payload TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          attempts INTEGER NOT NULL DEFAULT 0,
+          run_after INTEGER NOT NULL DEFAULT 0,
+          created_at INTEGER NOT NULL,
+          last_error TEXT,
+          priority INTEGER NOT NULL DEFAULT 0,
+          job_key TEXT
+        );
+      `);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority) VALUES (?, 'pending', 0, 0, 0, 10)",
+        [JSON.stringify(prWebhook("legacy-fresh"))],
+      );
+      createSqliteQueue(driver, async () => undefined);
+      const row = driver.query("SELECT foreground_lane FROM _selfhost_jobs", []).rows[0] as { foreground_lane: string | null };
+      expect(row.foreground_lane).toBe("fresh");
+    });
+  });
+
   it("retries then dead-letters after maxRetries", async () => {
     const driver = makeDriver();
     let calls = 0;


### PR DESCRIPTION
## Summary
- Every foreground job (`priority >= FOREGROUND_QUEUE_PRIORITY_FLOOR`) is claimed in plain `priority DESC, run_after, id` order today, so a fresh `github-webhook` PR-refresh row (priority 10) always wins over a `agent-regate-pr` backlog-convergence row (priority 9), no matter how old the backlog work is. A sustained burst of fresh webhook traffic can starve backlog convergence indefinitely even though both are foreground-priority, and there is no per-repo fairness at all — one repo's deep backlog can dominate every other repo's.
- Adds a pure classifier (`src/selfhost/queue-fairness.ts`) that tags each foreground claim attempt `"backlog"` or `"fresh"`, and a claim-time preference that favors backlog in a bounded 3:1 ratio (tunable) while still guaranteeing fresh intake a claim slot at least 1-in-4 cycles — never fully starved.
- Per-repo round-robin within the backlog lane (oldest-pending-first, rotating past the just-served repo) stops one repo's deep backlog from starving another repo's backlog work.
- The fairness state (a claim sequence counter + last-served repo) lives in the queue's own storage — a new singleton table (`_selfhost_queue_fairness`), same self-bootstrapping pattern as the existing `_selfhost_jobs`/`_selfhost_job_stats` tables — since this backend never touches the app D1/Postgres database (deliberately not reusing `global_agent_controls`, which lives there).
- A lane-scoped claim that finds nothing (empty lane, or a stale/raced repo candidate) falls through to the existing unscoped foreground query unchanged, so no work ever sits unclaimed just because its preferred lane happened to be empty this cycle.
- Wired into both the SQLite and Postgres self-host queue backends in lockstep. No app-database migration needed (this table is bootstrapped by the queue backend itself, same as its siblings).

Companion/precondition PR: #2830 (backlog-convergence sweeper) tags its output `agent-regate-pr` jobs with a `backlog-convergence:` deliveryId prefix that this PR's classifier recognizes — but this PR is self-contained and fully tested against literal payloads either way; it does not depend on that PR merging first.

## Scope
- [x] `src/selfhost/queue-fairness.ts` (new, pure), `src/selfhost/sqlite-queue.ts`, `src/selfhost/pg-queue.ts` (claim-time wiring, both backends), tests.
- [x] In `wantedPaths`, narrow, single concern (claim-time ordering only — does not touch gate/action decision logic).
- [x] No secrets, wallet/hotkey/trust/reward terms anywhere.
- [x] No new migration needed — the fairness table is self-bootstrapped by the queue backend, same pattern as its existing sibling tables.

## Validation
- `npm run typecheck`
- `npm run db:migrations:check`
- `npm run test:coverage` (full, unsharded) — 393 files / 7604 tests passing, 0 failures
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check` (clean)
- 100% branch coverage on `queue-fairness.ts` (pure module) and `sqlite-queue.ts`'s new lines; `pg-queue.ts` is Codecov-ignored per repo convention but has dedicated correctness tests for the same wiring.

## Safety
- [x] No auth/CORS/session paths touched.
- [x] Existing rate-limit and maintenance-admission claim-path checks are untouched — fairness selection happens entirely upstream of them in `claimNextWhere`'s SQL; a deferred fairness-selected row requeues exactly like any row does today.
- [x] No secrets committed.