### PR TITLE
feat(selfhost): add a durable backlog-convergence sweeper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,13 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
     }
     jobs.push({ type: "repair-data-fidelity", requestedBy: "schedule" });
     jobs.push({ type: "refresh-installation-health", requestedBy: "schedule" });
+    // #selfhost-backlog-convergence: catches open PRs whose public review surface was never published for their
+    // current head — a blind spot the ~2-min re-gate sweep's dispatch-time `lastRegatedAt` stamping can miss (see
+    // selfhost/backlog-convergence.ts). Runs on the same conservative 30-min cadence as the other maintenance-band
+    // jobs above: it is a backstop for a rare stranding, not the primary convergence path, so it does not need the
+    // sweep's ~2-min cadence. Self-host only (mirrors "agent-regate-sweep") — the trigger job itself is maintenance-
+    // classified (MAINTENANCE_JOB_TYPES) so it defers under live-work pressure like every other periodic sweep here.
+    if (selfHostedReviews) jobs.push({ type: "backlog-convergence-sweep", requestedBy: "schedule" });
   }
   if (isHourly) {
     jobs.push({ type: "refresh-registry", requestedBy: "schedule" });

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -230,6 +230,7 @@ import {
   isRegateSweepDraining,
   selectRegateCandidates,
 } from "../settings/agent-sweep";
+import { selectBacklogConvergenceCandidates } from "../selfhost/backlog-convergence";
 import {
   MAINTENANCE_RESERVED_HEADROOM,
   delayUntil,
@@ -866,6 +867,13 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
         return;
       }
       await sweepRepoRegate(env, message.repoFullName, message.requestedBy);
+      return;
+    case "backlog-convergence-sweep":
+      if (!message.repoFullName && message.requestedBy !== "test") {
+        await fanOutBacklogConvergenceSweepJobs(env, message.requestedBy);
+        return;
+      }
+      await sweepRepoBacklogConvergence(env, message.repoFullName, message.requestedBy);
       return;
     case "agent-regate-pr":
       // One bounded re-gate unit fanned out by the sweep (#audit-sweep-fanout): re-review + stamp a single PR.
@@ -1521,6 +1529,122 @@ async function sweepRepoRegate(
       flagged: flaggedPulls.length,
       flaggedPulls,
       verdicts,
+    },
+  });
+}
+
+// #selfhost-backlog-convergence: the cron (index.ts) enqueues one fan-out trigger periodically; this enqueues a
+// per-repo sweep job for every repo eligible for convergence (the SAME repo selection as the re-gate sweep, so
+// a repo that opted the agent in — or is explicitly convergence-allowlisted — gets both). Deliberately has no
+// fan-out dedup CAS (contrast fanOutAgentRegateSweepJobs): unlike that sweep, this one stamps nothing
+// optimistically, so a second overlapping trigger just re-reads current state and re-enqueues, which coalesces
+// harmlessly into the same pending agent-regate-pr rows (queue-common.ts's job_key coalescing) rather than
+// duplicating work.
+async function fanOutBacklogConvergenceSweepJobs(
+  env: Env,
+  requestedBy: "schedule" | "api" | "test",
+): Promise<void> {
+  const repositoriesByKey = new Map((await listRepositories(env)).map((repo) => [repo.fullName.toLowerCase(), repo]));
+  const byKey = new Map<string, { fullName: string; installationId?: number }>();
+  for (const repo of repositoriesByKey.values())
+    byKey.set(repo.fullName.toLowerCase(), { fullName: repo.fullName, ...(typeof repo.installationId === "number" ? { installationId: repo.installationId } : {}) });
+  for (const fullName of listConvergenceRepos(env)) {
+    const repo = repositoriesByKey.get(fullName.toLowerCase());
+    byKey.set(fullName.toLowerCase(), {
+      fullName,
+      ...(typeof repo?.installationId === "number" ? { installationId: repo.installationId } : {}),
+    });
+  }
+  const configured: Array<{ fullName: string; installationId?: number }> = [];
+  for (const repo of byKey.values()) {
+    const settings = await resolveRepositorySettings(env, repo.fullName);
+    if (isConvergenceRepoAllowed(env, repo.fullName) || isAgentConfigured(settings.autonomy)) {
+      configured.push(repo);
+    }
+  }
+  await Promise.all(
+    configured.map((repo, index) => {
+      const message: JobMessage = {
+        type: "backlog-convergence-sweep",
+        requestedBy,
+        repoFullName: repo.fullName,
+        ...(typeof repo.installationId === "number" ? { installationId: repo.installationId } : {}),
+      };
+      const delaySeconds = Math.min(index * 10, 600);
+      return delaySeconds > 0
+        ? env.JOBS.send(message, { delaySeconds })
+        : env.JOBS.send(message);
+    }),
+  );
+  await recordAuditEvent(env, {
+    eventType: "agent.sweep.backlog_convergence.fanout",
+    outcome: "queued",
+    metadata: { repoCount: configured.length, requestedBy },
+  });
+}
+
+// #selfhost-backlog-convergence: sweep one repo's open PRs for a stale/missing public review surface at the
+// current head (see selfhost/backlog-convergence.ts for why this is a distinct signal from the re-gate sweep's
+// own staleness check) and fan out one `agent-regate-pr` job per candidate, tagged with a `backlog-convergence:`
+// deliveryId prefix so the claim-time fairness lane (queue-fairness.ts, PR2) can prioritize it as backlog-drain
+// work. No installation → nothing can be re-reviewed; skip quietly (mirrors sweepRepoRegate).
+async function sweepRepoBacklogConvergence(
+  env: Env,
+  repoFullName: string | undefined,
+  requestedBy: "schedule" | "api" | "test",
+): Promise<void> {
+  if (!repoFullName) return;
+  const settings = await resolveRepositorySettings(env, repoFullName);
+  if (!(isConvergenceRepoAllowed(env, repoFullName) || isAgentConfigured(settings.autonomy))) return;
+  const mode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: settings.agentPaused,
+    agentDryRun: settings.agentDryRun,
+  });
+  if (mode === "paused") {
+    await recordAuditEvent(env, {
+      eventType: "agent.sweep.backlog_convergence",
+      actor: "gittensory",
+      targetKey: repoFullName,
+      outcome: "denied",
+      detail: "agent actions paused — backlog-convergence sweep skipped",
+      metadata: { repoFullName, mode },
+    });
+    return;
+  }
+  const repo = await getRepository(env, repoFullName);
+  const sweepInstallationId = repo?.installationId ?? null;
+  if (sweepInstallationId == null) return;
+  const openPullRequests = await listOpenPullRequests(env, repoFullName);
+  const candidates = selectBacklogConvergenceCandidates({ pulls: openPullRequests });
+  if (candidates.length === 0) return;
+  await Promise.all(
+    candidates.map((pr, index) => {
+      const job: JobMessage = {
+        type: "agent-regate-pr",
+        deliveryId: `backlog-convergence:${repoFullName}#${pr.number}`,
+        repoFullName,
+        prNumber: pr.number,
+        installationId: sweepInstallationId,
+      };
+      const delaySeconds = Math.min(index * 10, 600);
+      return delaySeconds > 0
+        ? env.JOBS.send(job, { delaySeconds })
+        : env.JOBS.send(job);
+    }),
+  );
+  await recordAuditEvent(env, {
+    eventType: "agent.sweep.backlog_convergence",
+    actor: "gittensory",
+    targetKey: repoFullName,
+    outcome: "completed",
+    detail: `backlog-convergence sweep found ${candidates.length} open PR(s) with a stale/missing public surface`,
+    metadata: {
+      repoFullName,
+      mode,
+      openCount: openPullRequests.length,
+      examined: candidates.length,
+      candidatePulls: candidates.map((pr) => pr.number),
     },
   });
 }

--- a/src/selfhost/backlog-convergence.ts
+++ b/src/selfhost/backlog-convergence.ts
@@ -1,0 +1,56 @@
+import type { PullRequestRecord } from "../types";
+
+// Self-host backlog-convergence sweeper: a durable catch-all for open PRs whose public review surface (the
+// gate comment/check-run/label) was never published for their CURRENT head — the case the periodic re-gate
+// sweep (agent-sweep.ts) can silently miss. That sweep stamps `lastRegatedAt` for every candidate at FAN-OUT
+// time, before its downstream per-PR job actually runs (#audit-sweep-dispatch-stamp, deliberately, so the
+// in-flight guard engages immediately) — so a per-PR job that then fails, dead-letters, or never completes
+// leaves the PR looking "freshly regated" even though its surface was never actually published. Because
+// `selectRegateCandidates` sorts by `lastRegatedAt`, such a PR now looks FRESH and won't be re-picked by the
+// normal sweep again for a full cycle. This module's ONE signal — `lastPublishedSurfaceSha` mismatched (or
+// missing) against the live head — is immune to that blind spot: it is stamped only on a genuinely completed
+// publish (`markPullRequestSurfacePublished`), never optimistically. Pure helpers; the queue processor stays a
+// thin orchestration shell, mirroring agent-sweep.ts.
+
+// Bounded per repo per sweep, same REST-budget rationale as SWEEP_MAX_PRS (agent-sweep.ts): each fanned-out
+// `agent-regate-pr` job costs several GitHub REST calls, and this sweeper's own claim-time priority (see
+// queue-fairness.ts, PR2) means its output already competes ahead of fresh webhook work — a large cap here
+// would starve fresh PR intake, not just old backlog. Deliberately smaller than SWEEP_MAX_PRS's original
+// (pre-#audit-rate-headroom) ceiling: this sweep exists to repair a rarer stranding, not to be the primary
+// convergence path.
+export const BACKLOG_CONVERGENCE_SWEEP_MAX_PRS = 5;
+
+/**
+ * True when `pr`'s current head has never had its public review surface published — either no publish has
+ * ever completed (`lastPublishedSurfaceSha` unset) or the live head has moved past the last completed publish.
+ * A PR with no known `headSha` cannot be usefully evaluated (nothing to compare against) and is never flagged.
+ * Pure.
+ */
+export function needsSurfaceConvergence(pr: Pick<PullRequestRecord, "headSha" | "lastPublishedSurfaceSha">): boolean {
+  if (!pr.headSha) return false;
+  return pr.lastPublishedSurfaceSha !== pr.headSha;
+}
+
+/**
+ * Select the open PRs a single repo's backlog-convergence sweep should re-enqueue: drop drafts and anything
+ * whose surface is already published at the current head, then take the `max` PRs that have been open longest
+ * (oldest `createdAt` first, falling back to the epoch so a PR with no known creation time still sorts
+ * deterministically rather than being silently dropped) — this is the explicit "oldest open PRs first" fairness
+ * ordering the backlog-drain lane depends on (see queue-fairness.ts, PR2). Ties broken by PR number. Pure +
+ * deterministic: same inputs -> same ordered batch.
+ */
+export function selectBacklogConvergenceCandidates(input: {
+  pulls: PullRequestRecord[];
+  max?: number;
+}): PullRequestRecord[] {
+  const max = input.max ?? BACKLOG_CONVERGENCE_SWEEP_MAX_PRS;
+  const ageKey = (pr: PullRequestRecord): number => {
+    const created = pr.createdAt ? Date.parse(pr.createdAt) : Number.NaN;
+    return Number.isFinite(created) ? created : 0;
+  };
+  return input.pulls
+    .filter((pr) => pr.state === "open" && !pr.isDraft)
+    .filter((pr) => needsSurfaceConvergence(pr))
+    .sort((a, b) => ageKey(a) - ageKey(b) || a.number - b.number)
+    .slice(0, Math.max(0, max));
+}

--- a/src/selfhost/maintenance-admission.ts
+++ b/src/selfhost/maintenance-admission.ts
@@ -47,6 +47,7 @@ export const MAINTENANCE_JOB_TYPES: ReadonlySet<string> = new Set([
   "ops-alerts",
   "selftune",
   "rag-index-repo",
+  "backlog-convergence-sweep",
 ]);
 
 export function isMaintenanceJobType(type: string): boolean {

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -704,6 +704,10 @@ export function jobCoalesceKey(payload: string): string | null {
       const repo = normalizedRepo(message.repoFullName);
       return `agent-regate-sweep:${repo ?? "all"}`;
     }
+    if (type === "backlog-convergence-sweep") {
+      const repo = normalizedRepo(message.repoFullName);
+      return `backlog-convergence-sweep:${repo ?? "all"}`;
+    }
     if (type === "recapture-preview") {
       const repo = normalizedRepo(message.repoFullName);
       const pr = normalizedNumber(message.prNumber);

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,17 @@ export type JobMessage =
       // Enqueued by the cron every sweep cycle (≈2 min) ONLY when ORB_BROKER_ENABLED is set.
       type: "retry-orb-relay";
       requestedBy: "schedule" | "test";
+    }
+  | {
+      // Self-host backlog-convergence sweep (#selfhost-backlog-convergence): finds open PRs whose public review
+      // surface was never published for their current head (a blind spot the periodic re-gate sweep's dispatch-
+      // time stamping can miss — see selfhost/backlog-convergence.ts) and fans out one `agent-regate-pr` job per
+      // candidate. No `repoFullName` = fan-out: enqueue one per convergence-eligible repo, mirroring
+      // "agent-regate-sweep". With `repoFullName` = sweep that one repo's stale-surface open PRs.
+      type: "backlog-convergence-sweep";
+      requestedBy: "schedule" | "api" | "test";
+      repoFullName?: string;
+      installationId?: number;
     };
 
 export type GitHubWebhookPayload = {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -306,6 +306,7 @@ describe("worker entrypoint", () => {
       { type: "backfill-registered-repos", requestedBy: "schedule", mode: "light" },
       { type: "repair-data-fidelity", requestedBy: "schedule" },
       { type: "refresh-installation-health", requestedBy: "schedule" },
+      { type: "backlog-convergence-sweep", requestedBy: "schedule" },
     ]);
     expect(snapshotCalled).toBe(true);
   });
@@ -334,6 +335,7 @@ describe("worker entrypoint", () => {
       { type: "backfill-registered-repos", requestedBy: "schedule", mode: "light" },
       { type: "repair-data-fidelity", requestedBy: "schedule" },
       { type: "refresh-installation-health", requestedBy: "schedule" },
+      { type: "backlog-convergence-sweep", requestedBy: "schedule" },
     ]);
   });
 
@@ -465,6 +467,7 @@ describe("worker entrypoint", () => {
       { type: "backfill-registered-repos", requestedBy: "schedule", mode: "light" },
       { type: "repair-data-fidelity", requestedBy: "schedule" },
       { type: "refresh-installation-health", requestedBy: "schedule" },
+      { type: "backlog-convergence-sweep", requestedBy: "schedule" },
       { type: "refresh-registry", requestedBy: "schedule" },
       { type: "refresh-scoring-model", requestedBy: "schedule" },
       { type: "refresh-upstream-drift", requestedBy: "schedule" },
@@ -491,6 +494,7 @@ describe("worker entrypoint", () => {
       { type: "backfill-registered-repos", requestedBy: "schedule", mode: "full" },
       { type: "repair-data-fidelity", requestedBy: "schedule" },
       { type: "refresh-installation-health", requestedBy: "schedule" },
+      { type: "backlog-convergence-sweep", requestedBy: "schedule" },
       { type: "refresh-registry", requestedBy: "schedule" },
       { type: "refresh-scoring-model", requestedBy: "schedule" },
       { type: "refresh-upstream-drift", requestedBy: "schedule" },
@@ -534,6 +538,7 @@ describe("worker entrypoint", () => {
       "backfill-registered-repos",
       "repair-data-fidelity",
       "refresh-installation-health",
+      "backlog-convergence-sweep",
       "refresh-registry",
       "refresh-scoring-model",
       "refresh-upstream-drift",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -18612,3 +18612,141 @@ describe("enrichOpenPullRequestsWithChangedFiles (#2653)", () => {
     expect(result).toBe(input);
   });
 });
+
+describe("backlog-convergence sweep (#selfhost-backlog-convergence)", () => {
+  it("fans out to acting-autonomy repos, skipping a non-acting/non-allowlisted repo", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_REPOS: "",
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(env, { name: "plain-repo", full_name: "owner/plain-repo", private: false, owner: { login: "owner" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-a", autonomy: { merge: "auto" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/plain-repo", autonomy: { review: "observe" } });
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "schedule" });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: "backlog-convergence-sweep", repoFullName: "owner/agent-a" });
+    const fanout = await env.DB.prepare("select outcome, metadata_json from audit_events where event_type = ?")
+      .bind("agent.sweep.backlog_convergence.fanout")
+      .first<{ outcome: string; metadata_json: string }>();
+    expect(fanout?.outcome).toBe("queued");
+    expect(JSON.parse(fanout?.metadata_json ?? "{}")).toMatchObject({ repoCount: 1, requestedBy: "schedule" });
+  });
+
+  it("also fans out to an allowlisted repo regardless of autonomy mode (#sweep-all-modes parity)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ GITTENSORY_REVIEW_REPOS: "owner/advisory-repo", JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertRepositoryFromGitHub(env, { name: "advisory-repo", full_name: "owner/advisory-repo", private: false, owner: { login: "owner" } }, 9502);
+    await upsertRepositorySettings(env, { repoFullName: "owner/advisory-repo", autonomy: { merge: "observe" } });
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "schedule" });
+
+    expect(sent).toEqual([expect.objectContaining({ type: "backlog-convergence-sweep", repoFullName: "owner/advisory-repo", installationId: 9502 })]);
+  });
+
+  it("fans out to an allowlisted repo that was never registered locally (no installationId) and staggers a second repo's delay", async () => {
+    const sent: Array<{ message: import("../../src/types").JobMessage; delaySeconds?: number }> = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_REPOS: "owner/never-registered",
+      JOBS: { async send(m: import("../../src/types").JobMessage, options?: { delaySeconds?: number }) { sent.push({ message: m, ...(options?.delaySeconds === undefined ? {} : { delaySeconds: options.delaySeconds }) }); } } as unknown as Queue,
+    });
+    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } }, 9506);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-a", autonomy: { merge: "auto" } });
+    // owner/never-registered is allowlisted but has no local repository row at all -> no installationId to attach.
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "schedule" });
+
+    expect(sent).toHaveLength(2);
+    const neverRegistered = sent.find((s) => s.message.type === "backlog-convergence-sweep" && s.message.repoFullName === "owner/never-registered");
+    expect(neverRegistered?.message).not.toHaveProperty("installationId");
+    // Whichever entry landed second (index 1) carries a nonzero stagger delay.
+    expect(sent.some((s) => (s.delaySeconds ?? 0) > 0)).toBe(true);
+  });
+
+  it("no-ops safely on a missing repo arg or an un-configured repo", async () => {
+    const env = createTestEnv({});
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "test" });
+    await upsertRepositoryFromGitHub(env, { name: "plain-repo", full_name: "owner/plain-repo", private: false, owner: { login: "owner" } });
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "test", repoFullName: "owner/plain-repo" });
+
+    const count = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.sweep.backlog_convergence").first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+
+  it("respects the global pause kill-switch: a paused repo records a denial and enqueues nothing", async () => {
+    const env = createTestEnv({});
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9503);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, agentPaused: true });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale surface", state: "open", user: { login: "contributor" }, head: { sha: "abc" }, labels: [], body: "x" });
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    const audit = await env.DB.prepare("select outcome, detail, metadata_json from audit_events where event_type = ?")
+      .bind("agent.sweep.backlog_convergence")
+      .first<{ outcome: string; detail: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("denied");
+    expect(audit?.detail).toMatch(/paused/i);
+    expect(JSON.parse(audit?.metadata_json ?? "{}")).toMatchObject({ mode: "paused" });
+  });
+
+  it("stays quiet (no audit, no enqueue) with no installation to act with", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }); // no installationId
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Stale surface", state: "open", user: { login: "contributor" }, head: { sha: "abc" }, labels: [], body: "x" });
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    expect(sent).toEqual([]);
+    const count = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("agent.sweep.backlog_convergence").first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+
+  it("stays quiet when every open PR's surface is already published at its current head", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9504, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9504);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Converged", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "x" });
+    await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 7, "a7");
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "test", repoFullName: "owner/agent-repo" });
+
+    expect(sent).toEqual([]);
+  });
+
+  it("fans out one agent-regate-pr per stale-surface candidate, tagged with the backlog-convergence deliveryId prefix", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({ JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue });
+    await upsertInstallation(env, { action: "created", installation: { id: 9505, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9505);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" } });
+    // #7 never had its surface published; #8 was published at an OLDER head than its current one; #9 is fully converged.
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Never published", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "x" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 8, title: "Stale surface", state: "open", user: { login: "contributor" }, head: { sha: "b8" }, labels: [], body: "x" });
+    await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 8, "old-b8");
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 9, title: "Converged", state: "open", user: { login: "contributor" }, head: { sha: "a9" }, labels: [], body: "x" });
+    await repositoriesModule.markPullRequestSurfacePublished(env, "owner/agent-repo", 9, "a9");
+
+    await processJob(env, { type: "backlog-convergence-sweep", requestedBy: "schedule", repoFullName: "owner/agent-repo" });
+
+    const fanned = sent.filter((job): job is Extract<import("../../src/types").JobMessage, { type: "agent-regate-pr" }> => job.type === "agent-regate-pr");
+    expect(fanned.map((job) => job.prNumber).sort()).toEqual([7, 8]);
+    for (const job of fanned) {
+      expect(job.deliveryId).toBe(`backlog-convergence:owner/agent-repo#${job.prNumber}`);
+      expect(job.installationId).toBe(9505);
+    }
+    const audit = await env.DB.prepare("select outcome, detail, metadata_json from audit_events where event_type = ?")
+      .bind("agent.sweep.backlog_convergence")
+      .first<{ outcome: string; detail: string; metadata_json: string }>();
+    expect(audit?.outcome).toBe("completed");
+    const meta = JSON.parse(audit?.metadata_json ?? "{}");
+    expect(meta).toMatchObject({ repoFullName: "owner/agent-repo", openCount: 3, examined: 2 });
+    expect(meta.candidatePulls.sort()).toEqual([7, 8]);
+  });
+});

--- a/test/unit/selfhost-backlog-convergence.test.ts
+++ b/test/unit/selfhost-backlog-convergence.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  BACKLOG_CONVERGENCE_SWEEP_MAX_PRS,
+  needsSurfaceConvergence,
+  selectBacklogConvergenceCandidates,
+} from "../../src/selfhost/backlog-convergence";
+import type { PullRequestRecord } from "../../src/types";
+
+const NOW = "2026-06-17T12:00:00.000Z";
+const nowMs = Date.parse(NOW);
+const minutesAgo = (m: number): string => new Date(nowMs - m * 60 * 1000).toISOString();
+
+function pr(overrides: Partial<PullRequestRecord> & { number: number }): PullRequestRecord {
+  return {
+    repoFullName: "owner/repo",
+    title: `PR ${overrides.number}`,
+    state: "open",
+    labels: [],
+    linkedIssues: [],
+    ...overrides,
+  };
+}
+
+describe("needsSurfaceConvergence (#selfhost-backlog-convergence)", () => {
+  it("is false when the PR has no known headSha (nothing to compare against)", () => {
+    expect(needsSurfaceConvergence({ headSha: null, lastPublishedSurfaceSha: null })).toBe(false);
+    expect(needsSurfaceConvergence({ headSha: undefined, lastPublishedSurfaceSha: "abc" })).toBe(false);
+  });
+
+  it("is true when the surface has never been published at all", () => {
+    expect(needsSurfaceConvergence({ headSha: "abc123", lastPublishedSurfaceSha: null })).toBe(true);
+    expect(needsSurfaceConvergence({ headSha: "abc123", lastPublishedSurfaceSha: undefined })).toBe(true);
+  });
+
+  it("is true when the last published surface is for an OLDER head (stale)", () => {
+    expect(needsSurfaceConvergence({ headSha: "def456", lastPublishedSurfaceSha: "abc123" })).toBe(true);
+  });
+
+  it("is false when the last published surface matches the current head", () => {
+    expect(needsSurfaceConvergence({ headSha: "abc123", lastPublishedSurfaceSha: "abc123" })).toBe(false);
+  });
+});
+
+describe("selectBacklogConvergenceCandidates (#selfhost-backlog-convergence)", () => {
+  it("drops closed PRs and drafts", () => {
+    const pulls = [
+      pr({ number: 1, state: "closed", headSha: "a", lastPublishedSurfaceSha: null }),
+      pr({ number: 2, isDraft: true, headSha: "a", lastPublishedSurfaceSha: null }),
+      pr({ number: 3, headSha: "a", lastPublishedSurfaceSha: null }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    expect(picked.map((p) => p.number)).toEqual([3]);
+  });
+
+  it("drops PRs whose surface is already published at the current head", () => {
+    const pulls = [
+      pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: "a" }),
+      pr({ number: 2, headSha: "b", lastPublishedSurfaceSha: "stale" }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    expect(picked.map((p) => p.number)).toEqual([2]);
+  });
+
+  it("orders oldest createdAt first — the backlog-drain fairness ordering", () => {
+    const pulls = [
+      pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(10) }),
+      pr({ number: 2, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(1000) }),
+      pr({ number: 3, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(100) }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    expect(picked.map((p) => p.number)).toEqual([2, 3, 1]);
+  });
+
+  it("falls back to the epoch (sorts first) when createdAt is missing or unparseable", () => {
+    const pulls = [
+      pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(5) }),
+      pr({ number: 2, headSha: "a", lastPublishedSurfaceSha: null }),
+      pr({ number: 3, headSha: "a", lastPublishedSurfaceSha: null, createdAt: "not-a-date" }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    // #2 and #3 both fall back to epoch (0) — tie broken by PR number ascending — then #1's real timestamp last.
+    expect(picked.map((p) => p.number)).toEqual([2, 3, 1]);
+  });
+
+  it("breaks ties by PR number when createdAt is identical", () => {
+    const pulls = [
+      pr({ number: 5, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(10) }),
+      pr({ number: 2, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(10) }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    expect(picked.map((p) => p.number)).toEqual([2, 5]);
+  });
+
+  it("bounds the result to the default max", () => {
+    expect(BACKLOG_CONVERGENCE_SWEEP_MAX_PRS).toBeGreaterThan(0);
+    const pulls = Array.from({ length: BACKLOG_CONVERGENCE_SWEEP_MAX_PRS + 3 }, (_, i) =>
+      pr({ number: i + 1, headSha: "a", lastPublishedSurfaceSha: null, createdAt: minutesAgo(i) }),
+    );
+    const picked = selectBacklogConvergenceCandidates({ pulls });
+    expect(picked).toHaveLength(BACKLOG_CONVERGENCE_SWEEP_MAX_PRS);
+  });
+
+  it("respects a custom max", () => {
+    const pulls = [
+      pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: null }),
+      pr({ number: 2, headSha: "a", lastPublishedSurfaceSha: null }),
+    ];
+    const picked = selectBacklogConvergenceCandidates({ pulls, max: 1 });
+    expect(picked).toHaveLength(1);
+  });
+
+  it("clamps a negative max to zero rather than throwing or wrapping", () => {
+    const pulls = [pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: null })];
+    const picked = selectBacklogConvergenceCandidates({ pulls, max: -5 });
+    expect(picked).toEqual([]);
+  });
+
+  it("returns an empty array when nothing needs convergence", () => {
+    const pulls = [pr({ number: 1, headSha: "a", lastPublishedSurfaceSha: "a" })];
+    expect(selectBacklogConvergenceCandidates({ pulls })).toEqual([]);
+  });
+});

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -56,6 +56,7 @@ describe("self-host queue common helpers", () => {
     expect(jobPriority(payload({ type: "recapture-preview" }))).toBe(9);
     expect(jobPriority(payload({ type: "agent-regate-sweep" }))).toBe(8);
     expect(jobPriority(payload({ type: "rag-index-repo" }))).toBe(0);
+    expect(jobPriority(payload({ type: "backlog-convergence-sweep" }))).toBe(0);
     expect(jobPriority("{}")).toBe(0);
     expect(jobPriority("not-json")).toBe(0);
   });
@@ -597,6 +598,8 @@ describe("self-host queue common helpers", () => {
     expect(jobCoalesceKey(payload({ type: "agent-regate-pr", repoFullName: "JSONbored/Gittensory" }))).toBeNull();
     expect(jobCoalesceKey(payload({ type: "agent-regate-sweep", requestedBy: "schedule" }))).toBe("agent-regate-sweep:all");
     expect(jobCoalesceKey(payload({ type: "agent-regate-sweep", repoFullName: "JSONbored/Gittensory" }))).toBe("agent-regate-sweep:jsonbored/gittensory");
+    expect(jobCoalesceKey(payload({ type: "backlog-convergence-sweep", requestedBy: "schedule" }))).toBe("backlog-convergence-sweep:all");
+    expect(jobCoalesceKey(payload({ type: "backlog-convergence-sweep", repoFullName: "JSONbored/Gittensory" }))).toBe("backlog-convergence-sweep:jsonbored/gittensory");
     expect(jobCoalesceKey(payload({ type: "recapture-preview", repoFullName: "JSONbored/Gittensory", prNumber: 7, attempt: 2 }))).toBe("recapture-preview:jsonbored/gittensory#7:2");
     expect(jobCoalesceKey(payload({ type: "recapture-preview", repoFullName: "JSONbored/Gittensory", prNumber: 7 }))).toBeNull();
     expect(


### PR DESCRIPTION
## Summary
- The periodic re-gate sweep (`agent-regate-sweep` / `sweepRepoRegate`) stamps `last_regated_at` for every candidate at fan-out time, before its per-PR job actually runs (`#audit-sweep-dispatch-stamp`, deliberately, so its own in-flight guard engages immediately). A per-PR job that then fails, dead-letters, or never completes leaves that PR looking freshly regated even though its public review surface (the gate comment/check-run/label) was never actually published — and since the sweep sorts by `last_regated_at`, such a PR now looks *fresh* and won't be re-picked by the normal sweep for a full cycle. This is a real, narrow blind spot distinct from ordinary staleness.
- Adds a separate, low-cadence (30-min) periodic sweep (`backlog-convergence-sweep`) keyed on a signal that blind spot can't fool: `lastPublishedSurfaceSha` mismatched (or missing) against the PR's live head — stamped only on a genuinely completed publish (`markPullRequestSurfacePublished`), never optimistically.
- Fans out one `agent-regate-pr` job per stale-surface open PR (oldest-`createdAt`-first, bounded per repo per sweep), tagged with a `backlog-convergence:` deliveryId prefix so a companion claim-time fairness lane (see the sibling PR) can prioritize it as backlog-drain work over fresh webhook intake.
- Reuses the existing `agent-regate-pr` coalesce mechanism (dedup by repo+PR key) for idempotent enqueueing — no new job-dedup machinery needed.
- The sweep trigger itself is maintenance-classified (`MAINTENANCE_JOB_TYPES`), so it defers under live-work pressure like every other periodic sweep in this codebase; self-host only, mirrors the existing `agent-regate-sweep` fan-out/per-repo pattern exactly.

## Scope
- [x] `src/selfhost/backlog-convergence.ts` (new, pure selection logic), `src/queue/processors.ts` (dispatch + fan-out, mirrors `fanOutAgentRegateSweepJobs`/`sweepRepoRegate`), `src/index.ts` (schedule wiring), `src/types.ts` (new `JobMessage` variant), `src/selfhost/queue-common.ts` (coalesce key case), `src/selfhost/maintenance-admission.ts` (classification), tests.
- [x] In `wantedPaths`, narrow, single concern.
- [x] No secrets, wallet/hotkey/trust/reward terms anywhere.
- [x] No new migration needed.

## Validation
- `npm run typecheck`
- `npm run db:migrations:check`
- `npm run test:coverage` (full, unsharded) — 393 files / 7586 tests passing, 0 failures
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check` (clean)
- 100% branch coverage on `backlog-convergence.ts` (pure module) and every new line in `processors.ts`/`index.ts`/`queue-common.ts`.

## Safety
- [x] No auth/CORS/session paths touched.
- [x] Respects the existing global pause kill-switch, per-repo `agentPaused`, and the same convergence-repo eligibility check (`isConvergenceRepoAllowed` / `isAgentConfigured`) the existing re-gate sweep uses — no new bypass of any protection.
- [x] No GitHub API calls from the sweep itself (pure local-DB query + enqueue); only the downstream `agent-regate-pr` job it enqueues makes GitHub calls, exactly as it already does today for sweep-originated regates.
- [x] No secrets committed.