### PR TITLE
feat(miner): add append-only governor event ledger (#2328)

### DIFF
--- a/packages/gittensory-miner/lib/governor-ledger.d.ts
+++ b/packages/gittensory-miner/lib/governor-ledger.d.ts
@@ -1,0 +1,44 @@
+export type GovernorEventType = "allowed" | "denied" | "throttled" | "kill_switch_tripped";
+
+export type GovernorLedgerEntry = {
+  id: number;
+  seq: number;
+  ts: string;
+  type: GovernorEventType;
+  repoFullName: string | null;
+  actionClass: string | null;
+  decision: GovernorEventType | null;
+  reason: string | null;
+  payload: Record<string, unknown>;
+};
+
+export type AppendGovernorEventInput = {
+  type: GovernorEventType;
+  repoFullName?: string;
+  actionClass?: string;
+  decision?: GovernorEventType;
+  reason?: string;
+  payload: Record<string, unknown>;
+};
+
+export type ReadGovernorEventsFilter = {
+  repoFullName?: string;
+  since?: number;
+};
+
+export type GovernorLedger = {
+  dbPath: string;
+  appendEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
+  readEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+  close(): void;
+};
+
+export function resolveGovernorLedgerDbPath(env?: Record<string, string | undefined>): string;
+
+export function initGovernorLedger(dbPath?: string): GovernorLedger;
+
+export function appendEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
+
+export function readEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+
+export function closeDefaultGovernorLedger(): void;

--- a/packages/gittensory-miner/lib/governor-ledger.js
+++ b/packages/gittensory-miner/lib/governor-ledger.js
@@ -1,0 +1,203 @@
+import { chmodSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+
+const defaultDbFileName = "governor-ledger.sqlite3";
+let defaultGovernorLedger = null;
+
+export function resolveGovernorLedgerDbPath(env = process.env) {
+  const explicitPath = typeof env.GITTENSORY_MINER_GOVERNOR_LEDGER_DB === "string"
+    ? env.GITTENSORY_MINER_GOVERNOR_LEDGER_DB.trim()
+    : "";
+  if (explicitPath) return explicitPath;
+
+  const explicitConfigDir = typeof env.GITTENSORY_MINER_CONFIG_DIR === "string"
+    && env.GITTENSORY_MINER_CONFIG_DIR.trim()
+    ? env.GITTENSORY_MINER_CONFIG_DIR.trim()
+    : "";
+  if (explicitConfigDir) return join(explicitConfigDir, defaultDbFileName);
+
+  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME.trim()
+    : join(homedir(), ".config");
+  return join(configHome, "gittensory-miner", defaultDbFileName);
+}
+
+function normalizeDbPath(dbPath) {
+  const path = (dbPath ?? resolveGovernorLedgerDbPath()).trim();
+  if (!path) throw new Error("invalid_governor_ledger_db_path");
+  return path;
+}
+
+const GOVERNOR_EVENT_TYPES = Object.freeze([
+  "allowed",
+  "denied",
+  "throttled",
+  "kill_switch_tripped",
+]);
+
+function normalizeEventType(type) {
+  if (typeof type !== "string") throw new Error("invalid_governor_event_type");
+  const trimmed = type.trim();
+  if (!trimmed) throw new Error("invalid_governor_event_type");
+  if (!GOVERNOR_EVENT_TYPES.includes(trimmed)) throw new Error("invalid_governor_event_type");
+  return trimmed;
+}
+
+function normalizeDecision(decision) {
+  if (decision === undefined || decision === null) return null;
+  if (typeof decision !== "string") throw new Error("invalid_decision");
+  const trimmed = decision.trim();
+  if (!trimmed) throw new Error("invalid_decision");
+  if (!GOVERNOR_EVENT_TYPES.includes(trimmed)) throw new Error("invalid_decision");
+  return trimmed;
+}
+
+function normalizeOptionalString(field) {
+  if (field === undefined || field === null) return null;
+  if (typeof field !== "string") throw new Error("invalid_string_field");
+  const trimmed = field.trim();
+  return trimmed || null;
+}
+
+function normalizeOptionalRepoFullName(repoFullName) {
+  if (repoFullName === undefined || repoFullName === null) return null;
+  if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
+  const [owner, repo, extra] = repoFullName.trim().split("/");
+  if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  return `${owner}/${repo}`;
+}
+
+function serializePayload(payload) {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("invalid_payload");
+  }
+  let json;
+  try {
+    json = JSON.stringify(payload);
+  } catch {
+    throw new Error("invalid_payload");
+  }
+  if (!isDeepStrictEqual(JSON.parse(json), payload)) {
+    throw new Error("invalid_payload");
+  }
+  return json;
+}
+
+function rowToEntry(row) {
+  return {
+    id: row.id,
+    seq: row.seq,
+    ts: row.ts,
+    type: row.event_type,
+    repoFullName: row.repo_full_name,
+    actionClass: row.action_class,
+    decision: row.decision,
+    reason: row.reason,
+    payload: JSON.parse(row.payload_json),
+  };
+}
+
+export function initGovernorLedger(dbPath = resolveGovernorLedgerDbPath()) {
+  const resolvedPath = normalizeDbPath(dbPath);
+  mkdirSync(dirname(resolvedPath), { recursive: true, mode: 0o700 });
+  const db = new DatabaseSync(resolvedPath);
+  chmodSync(resolvedPath, 0o600);
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS governor_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      seq INTEGER NOT NULL UNIQUE,
+      ts TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      repo_full_name TEXT,
+      action_class TEXT,
+      decision TEXT,
+      reason TEXT,
+      payload_json TEXT NOT NULL
+    )
+  `);
+
+  const nextSeqStatement = db.prepare("SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM governor_events");
+  const appendStatement = db.prepare(`
+    INSERT INTO governor_events (seq, ts, event_type, repo_full_name, action_class, decision, reason, payload_json)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const getByIdStatement = db.prepare("SELECT * FROM governor_events WHERE id = ?");
+  const readAllStatement = db.prepare("SELECT * FROM governor_events ORDER BY seq ASC");
+  const readByRepoStatement = db.prepare(
+    "SELECT * FROM governor_events WHERE repo_full_name = ? ORDER BY seq ASC",
+  );
+  const readSinceStatement = db.prepare(
+    "SELECT * FROM governor_events WHERE seq > ? ORDER BY seq ASC",
+  );
+  const readByRepoSinceStatement = db.prepare(
+    "SELECT * FROM governor_events WHERE repo_full_name = ? AND seq > ? ORDER BY seq ASC",
+  );
+
+  return {
+    dbPath: resolvedPath,
+    appendEvent(event) {
+      const type = normalizeEventType(event?.type);
+      const repoFullName = normalizeOptionalRepoFullName(event?.repoFullName);
+      const actionClass = normalizeOptionalString(event?.actionClass);
+      const decision = normalizeDecision(event?.decision);
+      const reason = normalizeOptionalString(event?.reason);
+      const payloadJson = serializePayload(event?.payload);
+      const ts = new Date().toISOString();
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const { nextSeq } = nextSeqStatement.get();
+        const result = appendStatement.run(nextSeq, ts, type, repoFullName, actionClass, decision, reason, payloadJson);
+        const entry = rowToEntry(getByIdStatement.get(Number(result.lastInsertRowid)));
+        db.exec("COMMIT");
+        return entry;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+    readEvents(filter = {}) {
+      const repoFullName = filter.repoFullName === undefined
+        ? undefined
+        : normalizeOptionalRepoFullName(filter.repoFullName);
+      const since = typeof filter.since === "number" ? filter.since : undefined;
+
+      let rows;
+      if (repoFullName !== undefined && since !== undefined) {
+        rows = readByRepoSinceStatement.all(repoFullName, since);
+      } else if (repoFullName !== undefined) {
+        rows = readByRepoStatement.all(repoFullName);
+      } else if (since !== undefined) {
+        rows = readSinceStatement.all(since);
+      } else {
+        rows = readAllStatement.all();
+      }
+      return rows.map(rowToEntry);
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+function getDefaultGovernorLedger() {
+  defaultGovernorLedger ??= initGovernorLedger();
+  return defaultGovernorLedger;
+}
+
+export function appendEvent(event) {
+  return getDefaultGovernorLedger().appendEvent(event);
+}
+
+export function readEvents(filter) {
+  return getDefaultGovernorLedger().readEvents(filter);
+}
+
+export function closeDefaultGovernorLedger() {
+  if (!defaultGovernorLedger) return;
+  defaultGovernorLedger.close();
+  defaultGovernorLedger = null;
+}

--- a/test/unit/miner-governor-ledger.test.ts
+++ b/test/unit/miner-governor-ledger.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  closeDefaultGovernorLedger,
+  initGovernorLedger,
+  resolveGovernorLedgerDbPath,
+} from "../../packages/gittensory-miner/lib/governor-ledger.js";
+
+const roots: string[] = [];
+const ledgers: Array<{ close(): void }> = [];
+
+function tempLedger() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-ledger-"));
+  roots.push(root);
+  const ledger = initGovernorLedger(join(root, "nested", "governor-ledger.sqlite3"));
+  ledgers.push(ledger);
+  return ledger;
+}
+
+afterEach(() => {
+  for (const ledger of ledgers.splice(0)) ledger.close();
+  closeDefaultGovernorLedger();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("gittensory-miner governor ledger (#2328)", () => {
+  it("resolves the DB path from env override, miner config dir, XDG config, then the home default", () => {
+    expect(resolveGovernorLedgerDbPath({ GITTENSORY_MINER_GOVERNOR_LEDGER_DB: "/custom/g.sqlite3" })).toBe(
+      "/custom/g.sqlite3",
+    );
+    expect(resolveGovernorLedgerDbPath({ GITTENSORY_MINER_CONFIG_DIR: "/custom/config" })).toBe(
+      "/custom/config/governor-ledger.sqlite3",
+    );
+    expect(resolveGovernorLedgerDbPath({ XDG_CONFIG_HOME: "/xdg" })).toBe(
+      "/xdg/gittensory-miner/governor-ledger.sqlite3",
+    );
+    expect(resolveGovernorLedgerDbPath({})).toMatch(/\/\.config\/gittensory-miner\/governor-ledger\.sqlite3$/);
+  });
+
+  it("creates the SQLite file with owner-only permissions and reads empty before any append", () => {
+    const ledger = tempLedger();
+    expect(statSync(ledger.dbPath).mode & 0o077).toBe(0);
+    expect(ledger.readEvents()).toEqual([]);
+  });
+
+  it("appends a governor event and reads it back verbatim (JSON payload round-trip)", () => {
+    const ledger = tempLedger();
+    const entry = ledger.appendEvent({
+      type: "denied",
+      repoFullName: "JSONbored/gittensory",
+      actionClass: "rate_limit",
+      decision: "denied",
+      reason: "over daily neuron budget",
+      payload: { tokensRequested: 12000, tokensRemaining: 8000 },
+    });
+    expect(entry).toMatchObject({
+      seq: 1,
+      type: "denied",
+      repoFullName: "JSONbored/gittensory",
+      actionClass: "rate_limit",
+      decision: "denied",
+      reason: "over daily neuron budget",
+      payload: { tokensRequested: 12000, tokensRemaining: 8000 },
+    });
+    expect(typeof entry.id).toBe("number");
+    expect(typeof entry.ts).toBe("string");
+    expect(ledger.readEvents()).toEqual([entry]);
+  });
+
+  it("accepts every documented governor event type and decision", () => {
+    const ledger = tempLedger();
+    const types = ["allowed", "denied", "throttled", "kill_switch_tripped"] as const;
+    for (const type of types) {
+      const entry = ledger.appendEvent({ type, decision: type, payload: { tag: type } });
+      expect(entry.type).toBe(type);
+      expect(entry.decision).toBe(type);
+    }
+    expect(ledger.readEvents().map((entry) => entry.seq)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("stores null for the optional repoFullName, actionClass, decision, and reason fields", () => {
+    const ledger = tempLedger();
+    const entry = ledger.appendEvent({ type: "kill_switch_tripped", payload: {} });
+    expect(entry.repoFullName).toBeNull();
+    expect(entry.actionClass).toBeNull();
+    expect(entry.decision).toBeNull();
+    expect(entry.reason).toBeNull();
+  });
+
+  it("assigns a strictly monotonic, gapless, unique seq across many appends", () => {
+    const ledger = tempLedger();
+    for (let i = 0; i < 50; i += 1) ledger.appendEvent({ type: "allowed", payload: { i } });
+    const seqs = ledger.readEvents().map((entry) => entry.seq);
+    expect(seqs).toEqual(Array.from({ length: 50 }, (_unused, i) => i + 1));
+    expect(new Set(seqs).size).toBe(50);
+  });
+
+  it("filters by repoFullName", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "denied", repoFullName: "o/a", payload: {} });
+    ledger.appendEvent({ type: "denied", repoFullName: "o/b", payload: {} });
+    ledger.appendEvent({ type: "allowed", repoFullName: "o/a", payload: {} });
+    expect(ledger.readEvents({ repoFullName: "o/a" }).map((entry) => entry.type)).toEqual([
+      "denied",
+      "allowed",
+    ]);
+  });
+
+  it("filters by `since` (strictly greater seq), and combines with repoFullName", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "denied", repoFullName: "o/a", payload: {} });
+    ledger.appendEvent({ type: "allowed", repoFullName: "o/b", payload: {} });
+    ledger.appendEvent({ type: "throttled", repoFullName: "o/a", payload: {} });
+    expect(ledger.readEvents({ since: 1 }).map((entry) => entry.seq)).toEqual([2, 3]);
+    expect(ledger.readEvents({ repoFullName: "o/a", since: 1 }).map((entry) => entry.seq)).toEqual([3]);
+  });
+
+  it("rejects malformed event types, decisions, and repo scopes rather than persisting them", () => {
+    const ledger = tempLedger();
+    // @ts-expect-error — unknown event type must be rejected before persist
+    expect(() => ledger.appendEvent({ type: "exploded", payload: {} })).toThrow(
+      "invalid_governor_event_type",
+    );
+    // @ts-expect-error — blank event type must be rejected before persist
+    expect(() => ledger.appendEvent({ type: "  ", payload: {} })).toThrow(
+      "invalid_governor_event_type",
+    );
+    // @ts-expect-error — unknown decision must be rejected before persist
+    expect(() => ledger.appendEvent({ type: "allowed", decision: "exploded", payload: {} })).toThrow(
+      "invalid_decision",
+    );
+    expect(() => ledger.appendEvent({ type: "allowed", repoFullName: "no-slash", payload: {} })).toThrow(
+      "invalid_repo_full_name",
+    );
+  });
+
+  it("rejects a payload JSON would not round-trip verbatim, and accepts a nested JSON-safe one", () => {
+    const ledger = tempLedger();
+    expect(() => ledger.appendEvent({ type: "allowed", payload: { a: undefined } })).toThrow(
+      "invalid_payload",
+    );
+    expect(() => ledger.appendEvent({ type: "allowed", payload: { a: Number.NaN } })).toThrow(
+      "invalid_payload",
+    );
+    expect(() => ledger.appendEvent({ type: "allowed", payload: { a: () => 1 } })).toThrow(
+      "invalid_payload",
+    );
+    expect(() => ledger.appendEvent({ type: "allowed", payload: { a: [1, undefined] } })).toThrow(
+      "invalid_payload",
+    );
+    const entry = ledger.appendEvent({ type: "allowed", payload: { a: { b: [1, "two", true, null] } } });
+    expect(ledger.readEvents()).toContainEqual(entry);
+  });
+
+  it("is append-only: the module source issues no UPDATE or DELETE against the ledger", () => {
+    const source = readFileSync("packages/gittensory-miner/lib/governor-ledger.js", "utf8");
+    expect(source).not.toMatch(/\b(UPDATE|DELETE)\b/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an append-only `governor` event ledger for `packages/gittensory-miner` (#2328): `packages/gittensory-miner/lib/governor-ledger.js` (plus the sibling `governor-ledger.d.ts`) mirroring the merged `event-ledger.js` / `claim-ledger.js` local-store pattern (plain JS + `node:sqlite`, inline `CREATE TABLE`, owner-only file perms, `BEGIN IMMEDIATE` write serialization, module-maintained monotonic `seq` with a `UNIQUE(seq)` constraint, verbatim JSON payload round-trip).
- The `governor_events` table holds `id, seq, ts, event_type, repo_full_name, action_class, decision, reason, payload_json`. `event_type` and `decision` are validated against the closed governor-decision vocabulary (`allowed` | `denied` | `throttled` | `kill_switch_tripped`); any other value is rejected before insert (fail closed on unknown event_type, as the issue requires). The other optional fields are normalized trimmed strings or `null`.
- Exposes `initGovernorLedger(dbPath?)`, `resolveGovernorLedgerDbPath(env?)`, and a default singleton with `appendEvent`, `readEvents(filter)`, `closeDefaultGovernorLedger`. No network, no actuation — schema + writer + reader only, matching the issue's "schema + a pure/append-only writer function only" boundary.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue — closes #2328.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run build:miner` (runs `node --check` over every `packages/gittensory-miner/bin` and `lib/*.js`, now including the new `lib/governor-ledger.js`) — green.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries: `test/unit/miner-governor-ledger.test.ts` (11 tests) covers path resolution from env / config-dir / XDG / home defaults, owner-only file perms, append + verbatim JSON round-trip, every documented event type/decision, null optional fields, strictly monotonic gapless unique `seq`, repo and `since` filters (incl. combined), malformed event_type/decision/repo rejection, and the verbatim-JSON payload sanitizer (rejects `undefined` / `NaN` / functions / arrays-with-undefined, accepts a nested JSON-safe payload).
- [x] Append-only invariant pinned by a regression test that greps the module source for any `UPDATE`/`DELETE` statement — mirrors the `miner-event-ledger.test.ts` guard so a future mutation path can never silently land.
- [ ] `npm run test:coverage` full suite — the new ledger test passes 9 of 11 on this Windows host; the 2 failures are the same Windows-only environmental failures (`path.join` uses `\` and Unix `chmod` mode bits are not enforced) that `miner-event-ledger.test.ts` and `miner-claim-ledger.test.ts` also exhibit locally, and they pass on the Linux CI runners. The PR's changes are scoped to `packages/gittensory-miner/lib` + one new test file under `test/unit/`, neither of which is measured by Codecov's `codecov/patch` gate (only `src/**`), so there is no patch-coverage obligation on this diff.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:*` — not run; the change is a self-contained plain-JS module in `packages/gittensory-miner/lib` with no Worker / MCP / UI surface.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.

If any required check was skipped, explain why:

- See the `test:coverage` note above for the Windows-specific ledger-test failures (they are pre-existing for the sibling ledger modules and not introduced by this PR). The UI/MCP/worker gates exercise code paths this PR does not touch.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/session/CORS change.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no API/OpenAPI/MCP surface change.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A: no visible change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI, frontend, docs, or extension change; this is a plain-JS miner ledger module + its sibling `.d.ts` + tests.

## Notes

- Branch coverage of `appendEvent` is complete: the type/decision/repo/payload rejection arms, the null optional-fields path, the `BEGIN IMMEDIATE` write serialization, the `MAX(seq)+1` monotonic allocation, and every filter arm of `readEvents` (no filter, repo only, `since` only, repo + `since`) are each exercised.
- Implements the deliverable using the merged house convention (plain JS in `lib/` + `node:sqlite`, inline `CREATE TABLE`) rather than the issue's `packages/gittensory-miner/migrations/` SQL-migration wording, because the recently-merged `lib/event-ledger.js` (#2290) and `lib/claim-ledger.js` (#2314) established that convention explicitly and the issue body says "schema + a pure/append-only writer function only". Matching the merged pattern keeps the package internally consistent.