### PR TITLE
fix(signals): classify PHP class-suffix test files as tests

### DIFF
--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -7,11 +7,11 @@ export function isTestPath(file: string): boolean {
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
-    // JVM / C# / Swift `SomethingTest(s)`/`SomethingSpec` class-suffix convention
-    // (JUnit, Kotlin/ScalaTest, Spock, xUnit/NUnit, XCTest). Case-sensitive on the
+    // JVM / C# / Swift / PHP `SomethingTest(s)`/`SomethingSpec` class-suffix convention
+    // (JUnit, Kotlin/ScalaTest, Spock, xUnit/NUnit, XCTest, PHPUnit/PHPSpec). Case-sensitive on the
     // PascalCase suffix so it can't false-positive on words that merely end in
-    // "test"/"spec" (Latest.java, Contest.cs, manifest.scala).
-    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file) ||
+    // "test"/"spec" (Latest.java, Contest.cs, manifest.scala, Latest.php).
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy|php)$/.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -42,10 +42,13 @@ describe("test evidence helpers", () => {
     expect(isTestPath("Services/OrderTests.cs")).toBe(true); // xUnit/NUnit
     expect(isTestPath("Sources/App/LoginTests.swift")).toBe(true); // XCTest
     expect(isTestPath("gradle/CartSpec.groovy")).toBe(true); // Spock
+    expect(isTestPath("src/Service/UserTest.php")).toBe(true); // PHPUnit
+    expect(isTestPath("app/Domain/PricingSpec.php")).toBe(true); // PHPSpec
     // Case-sensitive suffix: words merely ending in test/spec are not tests.
     expect(isTestPath("app/src/main/java/Latest.java")).toBe(false);
     expect(isTestPath("Services/Contest.cs")).toBe(false);
     expect(isTestPath("modules/manifest.scala")).toBe(false);
+    expect(isTestPath("app/Latest.php")).toBe(false);
     // A non-JVM extension with the same class name is unaffected by this rule.
     expect(isTestPath("lib/WidgetTest.rb")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- `isTestPath` recognizes JVM/C#/Swift `*Test`/`*Spec` class-suffix files but omits PHP, so PHPUnit `*Test.php` and PHPSpec `*Spec.php` files sitting next to source (not under a `test/`/`spec/` directory) are classified as **source** rather than tests.
- This skews `diffFilePriority` diff-budget ordering (a PHP test can displace real source) and undercounts test coverage in `classifyTestCoverage` / `hasLocalTestEvidence` for PHP PRs.
- Fix adds `php` to the class-suffix extension alternation. The rule stays case-sensitive, so `Latest.php`/`Contest.php` are still correctly treated as source.

## Test plan
- [x] Extended `test/unit/test-evidence.test.ts` with `src/Service/UserTest.php` and `app/Domain/PricingSpec.php` (true) plus `app/Latest.php` (false).
- [x] `npx vitest run test/unit/test-evidence.test.ts` — 10 passed.

Made with [Cursor](https://cursor.com)