### PR TITLE
fix(codeowners): match trailing-slash directory rules at any depth

### DIFF
--- a/review-enrichment/src/analyzers/codeowners.ts
+++ b/review-enrichment/src/analyzers/codeowners.ts
@@ -54,14 +54,17 @@ function normalizePattern(pattern: string): {
   const leadingSlash = p.startsWith("/");
   if (leadingSlash) p = p.slice(1);
 
+  // Anchored when explicitly rooted, or when a path separator appears outside a leading `**/`.
+  // Decided from the ORIGINAL pattern (a purely trailing `/` is a directory marker, not an
+  // anchoring separator) and BEFORE the `/**` expansion below — otherwise expanding a bare
+  // directory pattern like `apps/` to `apps/**` would inject a mid-pattern slash and wrongly
+  // anchor it to the repo root, missing nested files a trailing-slash rule should own.
+  const anchored = leadingSlash || (p.replace(/\/$/, "").includes("/") && !p.startsWith("**/"));
+
   // Trailing `/` means "all files under this directory" — expand to `<dir>/**`.
   if (p.endsWith("/")) p += "**";
 
-  // Anchored when explicitly rooted, or when a path separator appears outside a leading `**/`.
-  return {
-    pattern: p,
-    anchored: leadingSlash || (p.includes("/") && !p.startsWith("**/")),
-  };
+  return { pattern: p, anchored };
 }
 
 function compilePattern(pattern: string): { tokens: GlobToken[]; anchored: boolean } {

--- a/review-enrichment/test/codeowners.test.ts
+++ b/review-enrichment/test/codeowners.test.ts
@@ -54,3 +54,14 @@ test("scanCodeowners: reports files where the author is not listed as an owner",
   );
   assert.deepEqual(out, [{ file: "src/a.ts", owners: ["@bob"] }]);
 });
+
+test("scanCodeowners: a trailing-slash directory rule owns files at any depth", async () => {
+  // `config/` has only a trailing slash, so per gitignore/CODEOWNERS semantics it must match at
+  // any depth — not just repo-root `config/…`. Regression for the anchoring being computed after
+  // the `config/` → `config/**` expansion, which wrongly treated the rule as root-anchored.
+  const out = await scanCodeowners(
+    req({ author: "alice", files: [{ path: "services/api/config/settings.yaml" }] }),
+    async () => new Response("config/ @bob\n", { status: 200 }),
+  );
+  assert.deepEqual(out, [{ file: "services/api/config/settings.yaml", owners: ["@bob"] }]);
+});


### PR DESCRIPTION
## Summary
- `normalizePattern` computes a rule's `anchored` flag **after** expanding a trailing-slash directory pattern (`config/` → `config/**`). That expansion injects a mid-pattern `/`, so `p.includes("/")` becomes true and a bare directory rule is wrongly treated as **root-anchored**.
- Per gitignore/CODEOWNERS semantics a trailing-slash-only rule matches at **any** depth, so ownership of nested files (e.g. `services/api/config/settings.yaml` under `config/ @team`) was silently missed — a fail-open that under-reports CODEOWNERS violations. The same helper feeds the exported `patternToRegex`, so both matchers are corrected.
- Fix computes `anchored` from the original pattern (treating a purely trailing `/` as a directory marker, not an anchoring separator) **before** the `/**` expansion. `/config/` (leading slash) and `docs/api/` (mid slash) stay anchored; `**/logs` and `*.js` stay unanchored.

## Test plan
- [x] Added a regression test in `review-enrichment/test/codeowners.test.ts`: a `config/ @bob` rule now owns `services/api/config/settings.yaml`.
- [x] `node --test test/codeowners.test.ts` — 5 passed.
- [x] `generate-analyzer-metadata.mjs --check` — clean.

Made with [Cursor](https://cursor.com)