### PR TITLE
fix(signals): detect sibling generated-file forms in isGeneratedFile

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -50,10 +50,17 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
   return (
     /(^|\/)(__generated__|generated)\//.test(norm) ||
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
-    /\.pb\.(go|ts|js)$/.test(norm) ||
-    /_pb2\.pyi?$/.test(norm) ||
+    // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, and the reference C++ plugin
+    // emits `.pb.cc` / `.pb.h` (the `.pb` infix keeps a hand-written `.h`/`.cc` from matching).
+    /\.pb\.(go|ts|js|cc|h)$/.test(norm) ||
+    // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
+    // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
+    /_pb2(_grpc)?\.pyi?$/.test(norm) ||
     /\.g\.dart$/.test(norm) ||
-    /\.(js|jsx|ts|tsx|css)\.map$/.test(norm) ||
+    // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
+    // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
+    // maps are generated output too — the same as `.js.map`.
+    /\.(js|jsx|mjs|cjs|ts|tsx|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -37,6 +37,30 @@ describe("isGeneratedFile", () => {
       expect(isGeneratedFile(path)).toBe(false);
     }
   });
+
+  it("matches source maps for every first-class JS/TS bundle extension", () => {
+    // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
+    // maps are generated output too — the same as `.js.map` / `.tsx.map`.
+    for (const path of ["dist/bundle.mjs.map", "dist/bundle.cjs.map", "lib/index.jsx.map"]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+  });
+
+  it("matches C++ protobuf output alongside the Go/TS/JS plugins", () => {
+    for (const path of ["proto/service.pb.cc", "proto/service.pb.h", "gen/messages.pb.cc"]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+    // The `.pb` infix keeps hand-written headers/sources from matching.
+    for (const path of ["src/service.h", "include/foo.h", "src/service.cc"]) {
+      expect(isGeneratedFile(path)).toBe(false);
+    }
+  });
+
+  it("matches Python gRPC protobuf stubs alongside the message stubs", () => {
+    for (const path of ["gen/service_pb2_grpc.py", "gen/service_pb2_grpc.pyi"]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+  });
 });
 
 describe("isVendoredFile", () => {


### PR DESCRIPTION
`isGeneratedFileFrom` in `src/signals/path-matchers.ts` is the single classifier for machine-generated output (`classifyChangedFile` → the slop/padding gate in `slop.ts`). Three of its extension allow-lists each omit valid **sibling** members of their own category — files the rest of the repo already treats as first-class — so a generated file that slips past is miscounted as substantive hand-authored effort by the padding signal.

### 1. Source maps drop `.mjs.map` / `.cjs.map`
`/\.(js|jsx|ts|tsx|css)\.map$/` misses `.mjs.map` / `.cjs.map`. But `.mjs`/`.cjs` are already first-class code extensions here (`isCodeFile` in `local-branch.ts` matches `mjs|cjs`), and esbuild/Rollup/Webpack/Vite emit `.mjs.map`/`.cjs.map` for ESM/CJS bundles exactly as they emit `.js.map` (which **is** matched). `dist/bundle.mjs.map` → today `false`, expected `true`.

### 2. Protobuf drops the reference C++ output `.pb.cc` / `.pb.h`
`/\.pb\.(go|ts|js)$/` misses `protoc`'s C++ plugin output `name.pb.cc` / `name.pb.h`. The `.pb` infix is what marks it generated — identical safety to the matched `.pb.go`, and it keeps a hand-written `src/service.h` / `include/foo.h` from matching. `proto/service.pb.cc` → today `false`, expected `true`.

### 3. Python protobuf drops gRPC stubs `_pb2_grpc.py[i]`
`/_pb2\.pyi?$/` misses `protoc`'s Python gRPC plugin output `*_pb2_grpc.py`, emitted alongside the `*_pb2.py` message stubs (which **are** matched) by the same generator. `gen/service_pb2_grpc.py` → today `false`, expected `true`.

## Common root cause
Each allow-list enumerated some members of a codegen/source-map family but omitted equally-standard siblings.

## Fix
```
/\.pb\.(go|ts|js|cc|h)$/            // + C++
/_pb2(_grpc)?\.pyi?$/               // + gRPC stubs
/\.(js|jsx|mjs|cjs|ts|tsx|css)\.map$/   // + mjs/cjs maps
```

## Tests
Adds regression cases for each new sibling form, plus controls that must stay non-generated: hand-written `service.h` / `include/foo.h`, `.mjs`/`.cjs` **sources** (not maps), and `a.scss.map` (Sass emits `.css.map`, not `.scss.map`). Verified the new inputs FAIL on current `main` and PASS with the fix; the `path-matchers` and downstream `slop` suites stay green.

No linked issue: issue creation is unavailable for this account.
