### PR TITLE
feat(github): extend webhook coalescing to label churn and review bursts

### DIFF
--- a/src/github/webhook-coalesce.ts
+++ b/src/github/webhook-coalesce.ts
@@ -11,6 +11,28 @@ const COALESCABLE_PULL_REQUEST_ACTIONS = new Set([
   "ready_for_review",
 ]);
 
+// #selfhost-backlog-convergence: label churn on a PR (repeated add/remove) does NOT trigger the public-surface
+// re-review pipeline at all -- shouldProcessPullRequestPublicSurface (processors.ts) only reacts to
+// PR_PUBLIC_SURFACE_ACTIONS, which excludes "labeled"/"unlabeled" -- the handler just re-syncs the PR row
+// (upsertPullRequestFromGitHub), identical work regardless of which specific label changed. A burst of label
+// events for the same PR is pure duplicate overhead; safe to coalesce to one job (unlike issue-side
+// labeled/unlabeled on a linked ISSUE, which has its OWN dedicated trailing-re-review coalescer in
+// processors.ts specifically because an add-then-remove sequence there carries a genuinely different state).
+const COALESCABLE_PULL_REQUEST_LABEL_ACTIONS = new Set(["labeled", "unlabeled"]);
+
+// #selfhost-backlog-convergence: mirrors shouldProcessPullRequestPublicSurface's (processors.ts) own action
+// allowlist per event -- these three event types are the ones that trigger a full re-review pipeline run for a
+// PR (readiness/review/publish), so a burst of review activity on the same head (e.g. several reviewers
+// submitting close together, or one reviewer leaving many inline comments) fans out one FULL re-review per
+// delivery today. The re-review pipeline always re-fetches live review/comment state from GitHub rather than
+// acting on the specific webhook payload's content, so collapsing a burst into one job loses nothing -- exactly
+// the same safety property the existing pull_request coalescing above already relies on.
+const REVIEW_SURFACE_ACTIONS_BY_EVENT: Record<string, ReadonlySet<string>> = {
+  pull_request_review: new Set(["submitted", "edited", "dismissed"]),
+  pull_request_review_comment: new Set(["created", "edited", "deleted"]),
+  pull_request_review_thread: new Set(["resolved", "unresolved"]),
+};
+
 export function githubWebhookCoalesceKey(
   eventName: string,
   payload: GitHubWebhookPayload,
@@ -43,6 +65,20 @@ export function githubWebhookCoalesceKey(
     const headSha = normalizedSha(payload.pull_request?.head?.sha);
     return pr !== null
       ? `github-webhook:pr-refresh:${repo}#${pr}${headSha ? `@${headSha}` : ""}`
+      : null;
+  }
+  if (eventName === "pull_request" && COALESCABLE_PULL_REQUEST_LABEL_ACTIONS.has(action)) {
+    const pr =
+      normalizedNumber(payload.pull_request?.number) ??
+      normalizedNumber((payload as { number?: unknown }).number);
+    return pr !== null ? `github-webhook:pr-label:${repo}#${pr}` : null;
+  }
+  const reviewSurfaceActions = REVIEW_SURFACE_ACTIONS_BY_EVENT[eventName];
+  if (reviewSurfaceActions?.has(action)) {
+    const pr = normalizedNumber(payload.pull_request?.number);
+    const headSha = normalizedSha(payload.pull_request?.head?.sha);
+    return pr !== null
+      ? `github-webhook:pr-review:${repo}#${pr}${headSha ? `@${headSha}` : ""}`
       : null;
   }
   return null;

--- a/test/unit/github-webhook-coalesce.test.ts
+++ b/test/unit/github-webhook-coalesce.test.ts
@@ -40,15 +40,16 @@ describe("githubWebhookCoalesceKey", () => {
         pull_request: { number: 100, head: { sha: "BEEF123" } },
       } as GitHubWebhookPayload),
     ).toBe("github-webhook:pr-refresh:jsonbored/gittensory#100@beef123");
-    for (const action of ["labeled", "unlabeled", "closed"]) {
-      expect(
-        githubWebhookCoalesceKey("pull_request", {
-          action,
-          repository: { full_name: "JSONbored/Gittensory" },
-          pull_request: { number: 100, head: { sha: "BEEF123" } },
-        } as GitHubWebhookPayload),
-      ).toBeNull();
-    }
+    // "closed" is a terminal action -- merge/close has its own non-coalesced handling and must never collapse
+    // with anything else. "labeled"/"unlabeled" now coalesce too (see the dedicated pr-label tests below) --
+    // they are no longer in this "returns null" list.
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "closed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 100, head: { sha: "BEEF123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
   });
 
   it("coalesces a burst of reopened + synchronize + ready_for_review events for the same PR head into one key (regression for #audit-rate-headroom)", () => {
@@ -84,5 +85,151 @@ describe("githubWebhookCoalesceKey", () => {
       } as GitHubWebhookPayload),
     ).toBeNull();
     expect(githubWebhookCoalesceKey("pull_request", { action: "edited" } as GitHubWebhookPayload)).toBeNull();
+  });
+
+  it("coalesces PR label churn (labeled/unlabeled) into one job per PR (#selfhost-backlog-convergence)", () => {
+    for (const action of ["labeled", "unlabeled"]) {
+      expect(
+        githubWebhookCoalesceKey("pull_request", {
+          action,
+          repository: { full_name: "JSONbored/Gittensory" },
+          pull_request: { number: 42, head: { sha: "BEEF123" } },
+        } as GitHubWebhookPayload),
+      ).toBe("github-webhook:pr-label:jsonbored/gittensory#42");
+    }
+    // A burst of add/remove churn on the same PR collapses to the identical key regardless of which label
+    // action fired -- the handler re-syncs generically and doesn't act on the specific label.
+    const burstKeys = ["labeled", "unlabeled", "labeled"].map((action) =>
+      githubWebhookCoalesceKey("pull_request", {
+        action,
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 42 },
+      } as GitHubWebhookPayload),
+    );
+    expect(new Set(burstKeys).size).toBe(1);
+  });
+
+  it("falls back to the top-level number field for a label event missing pull_request.number", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "labeled",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: {},
+        number: 55,
+      } as unknown as GitHubWebhookPayload),
+    ).toBe("github-webhook:pr-label:jsonbored/gittensory#55");
+  });
+
+  it("returns null for a label event with no resolvable PR number", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request", {
+        action: "labeled",
+        repository: { full_name: "JSONbored/Gittensory" },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+  });
+
+  it("coalesces review-surface bursts (pull_request_review) into one job per PR+head (#selfhost-backlog-convergence)", () => {
+    for (const action of ["submitted", "edited", "dismissed"]) {
+      expect(
+        githubWebhookCoalesceKey("pull_request_review", {
+          action,
+          repository: { full_name: "JSONbored/Gittensory" },
+          pull_request: { number: 12, head: { sha: "CAFE123" } },
+        } as GitHubWebhookPayload),
+      ).toBe("github-webhook:pr-review:jsonbored/gittensory#12@cafe123");
+    }
+  });
+
+  it("coalesces review-surface bursts (pull_request_review_comment) into one job per PR+head", () => {
+    for (const action of ["created", "edited", "deleted"]) {
+      expect(
+        githubWebhookCoalesceKey("pull_request_review_comment", {
+          action,
+          repository: { full_name: "JSONbored/Gittensory" },
+          pull_request: { number: 12, head: { sha: "CAFE123" } },
+        } as GitHubWebhookPayload),
+      ).toBe("github-webhook:pr-review:jsonbored/gittensory#12@cafe123");
+    }
+  });
+
+  it("coalesces review-surface bursts (pull_request_review_thread) into one job per PR+head", () => {
+    for (const action of ["resolved", "unresolved"]) {
+      expect(
+        githubWebhookCoalesceKey("pull_request_review_thread", {
+          action,
+          repository: { full_name: "JSONbored/Gittensory" },
+          pull_request: { number: 12, head: { sha: "CAFE123" } },
+        } as GitHubWebhookPayload),
+      ).toBe("github-webhook:pr-review:jsonbored/gittensory#12@cafe123");
+    }
+  });
+
+  it("coalesces a mixed burst of review/comment/thread events for the same PR+head into ONE key", () => {
+    const burstKeys = [
+      ["pull_request_review", "submitted"],
+      ["pull_request_review_comment", "created"],
+      ["pull_request_review_thread", "resolved"],
+    ].map(([eventName, action]) =>
+      githubWebhookCoalesceKey(eventName as string, {
+        action,
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12, head: { sha: "CAFE123" } },
+      } as GitHubWebhookPayload),
+    );
+    expect(new Set(burstKeys).size).toBe(1);
+  });
+
+  it("omits the head sha suffix for a review-surface event with no resolvable head", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request_review", {
+        action: "submitted",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12 },
+      } as GitHubWebhookPayload),
+    ).toBe("github-webhook:pr-review:jsonbored/gittensory#12");
+  });
+
+  it("returns null for a review-surface event with no resolvable PR number", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request_review", {
+        action: "submitted",
+        repository: { full_name: "JSONbored/Gittensory" },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-actionable action on a review-surface event type", () => {
+    expect(
+      githubWebhookCoalesceKey("pull_request_review", {
+        action: "requested_changes_dismissed",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12, head: { sha: "CAFE123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+    expect(
+      githubWebhookCoalesceKey("pull_request_review_comment", {
+        action: "resolved",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12, head: { sha: "CAFE123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+    expect(
+      githubWebhookCoalesceKey("pull_request_review_thread", {
+        action: "created",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12, head: { sha: "CAFE123" } },
+      } as GitHubWebhookPayload),
+    ).toBeNull();
+  });
+
+  it("returns null for a review-surface event type with no matching entry (e.g. an unrelated event)", () => {
+    expect(
+      githubWebhookCoalesceKey("issue_comment", {
+        action: "created",
+        repository: { full_name: "JSONbored/Gittensory" },
+        pull_request: { number: 12, head: { sha: "CAFE123" } },
+      } as unknown as GitHubWebhookPayload),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- `githubWebhookCoalesceKey` (`src/github/webhook-coalesce.ts`) currently only coalesces `check_suite`/`check_run.completed` and PR `opened`/`reopened`/`synchronize`/`edited`/`ready_for_review` — every other event type (label churn, review submissions, review comments, review-thread resolutions) fans out one full job per delivery, even for repeated events that carry no distinct signal the handler actually acts on.
- **Label events (`labeled`/`unlabeled`)**: `shouldProcessPullRequestPublicSurface` (`processors.ts`) doesn't include them in `PR_PUBLIC_SURFACE_ACTIONS` at all — the handler just re-syncs the PR row (`upsertPullRequestFromGitHub`) identically regardless of which specific label changed. A burst of label add/remove churn on the same PR is pure duplicate overhead; now coalesces to one job per PR (`github-webhook:pr-label:{repo}#{pr}`).
- **Review-surface events** (`pull_request_review`, `pull_request_review_comment`, `pull_request_review_thread`): these three DO each trigger a full re-review pipeline run, per `shouldProcessPullRequestPublicSurface`'s own action allowlist (mirrored exactly here). A burst of review activity on one head — several reviewers submitting close together, or one reviewer leaving many inline comments — fanned out that many full re-reviews. The pipeline always re-fetches live review/comment state from GitHub rather than acting on the specific webhook payload, so collapsing a burst to one job per PR+head is safe — the identical safety property the existing PR-refresh coalescing already relies on. New key: `github-webhook:pr-review:{repo}#{pr}@{headSha}`.
- `"closed"` stays deliberately uncoalesced (merge/close has its own non-coalesced handling, unchanged). Issue-side `labeled`/`unlabeled` (a distinct event, with its own dedicated trailing-re-review coalescer in `processors.ts` specifically because an add-then-remove sequence there carries a genuinely different state) is untouched.

## Scope
- [x] `src/github/webhook-coalesce.ts`, its test file. Small, standalone — no dependency on the other self-host queue PRs in this stack.
- [x] In `wantedPaths`, narrow, single concern.
- [x] No secrets, wallet/hotkey/trust/reward terms anywhere.
- [x] No new migration needed.

## Validation
- `npm run typecheck`
- `npm run db:migrations:check`
- `npm run test:coverage` (full, unsharded) — 394 files / 7600 tests passing, 0 failures
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check` (clean)
- 100% statement/line coverage on every new branch in `webhook-coalesce.ts`; the two pre-existing sub-100% branch gaps reported for this file (a non-string `action` defensive fallback, a `pull_requests ?? []` defensive fallback) predate this diff and are unrelated to it.

## Safety
- [x] No auth/CORS/session paths touched.
- [x] Does not touch the two existing coalesce cases (CI-completion, PR-refresh) at all — additive only.
- [x] No secrets committed.