### PR TITLE
feat(signals): recognize Conan/sbt/setuptools dependency manifests

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -143,6 +143,19 @@ const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([
   // manifests they resolve belong in the same dependency-manifest category.
   "package.swift",
   "podfile",
+  // Conan (C/C++) manifests — conan.lock is already recognized above, so the
+  // manifests it resolves belong here for the same reason as the Swift/CocoaPods
+  // pair. Conan accepts either the classic .txt or the Python-based recipe.
+  "conanfile.txt",
+  "conanfile.py",
+  // sbt (Scala/JVM) build definition — the JVM ecosystem is already represented
+  // by build.gradle(.kts) and pom.xml; build.sbt is sbt's dependency manifest.
+  "build.sbt",
+  // setuptools (Python) manifests — the Python ecosystem is already represented
+  // by requirements.txt/pyproject.toml/pipfile; setup.py/setup.cfg are the
+  // classic setuptools packaging manifests.
+  "setup.py",
+  "setup.cfg",
 ]);
 
 const DOCS_EXTENSIONS: ReadonlySet<string> = new Set(["md", "mdx", "markdown", "rst", "adoc", "asciidoc"]);

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -146,6 +146,11 @@ describe("isDependencyManifestFile", () => {
       "pubspec.yaml",
       "backend/mix.exs",
       "go.work",
+      "conanfile.txt",
+      "libs/native/conanfile.py",
+      "build.sbt",
+      "setup.py",
+      "packages/py/setup.cfg",
     ]) {
       expect(isDependencyManifestFile(path)).toBe(true);
     }


### PR DESCRIPTION
Extends `DEPENDENCY_MANIFEST_NAMES` (src/signals/path-matchers.ts) with well-known manifests for ecosystems already partially represented in the set, so slop classification counts them as real dependency manifests:

- **conanfile.txt / conanfile.py** (Conan, C/C++) — `conan.lock` is already a recognized lockfile, so the manifests it resolves belong here too, exactly mirroring the existing Swift/CocoaPods justification.
- **build.sbt** (Scala/sbt) — the JVM ecosystem is already covered by build.gradle(.kts) and pom.xml.
- **setup.py / setup.cfg** (Python setuptools) — complements the existing requirements.txt / pyproject.toml / pipfile.

Extends the `isDependencyManifestFile` positive test cases to cover each. Typecheck + unit tests green.