### PR TITLE
fix(review): classify .markdown/.asciidoc files as doc in RAG indexing

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -123,7 +123,11 @@ const BINARY_EXT_RE =
   /\.(png|jpe?g|gif|webp|avif|svg|ico|pdf|zip|gz|tgz|tar|wasm|woff2?|ttf|eot|mp4|mov|mp3|wav|bin|exe|dll|so|dylib|node|parquet|onnx)$/i;
 const CODE_EXT_RE =
   /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|kts|rb|php|c|h|cc|cpp|hpp|cs|swift|scala|sh|bash|zsh|sql|graphql|proto|toml|yaml|yml|json|jsonc|css|scss|less|vue|svelte|astro|tf|hcl)$/i;
-const DOC_EXT_RE = /\.(md|mdx|rst|txt|adoc)$/i;
+// Doc extensions mirror the canonical DOCS_EXTENSIONS set in signals/path-matchers.ts
+// (md, mdx, markdown, rst, adoc, asciidoc); the long-form `markdown`/`asciidoc`
+// spellings were missing here, so e.g. NOTES.markdown / guide.asciidoc were
+// misclassified as skip instead of doc.
+const DOC_EXT_RE = /\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i;
 const ALLOW_EXTLESS_RE = /(^|\/)(Dockerfile|Makefile|Justfile|Procfile)$/i;
 
 /** code | doc | skip. Skips dependency/build/content/data/binary paths — RAG indexes code for code

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -47,6 +47,9 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
     expect(classifyRepoFile("scripts/build.mjs")).toBe("code");
     expect(classifyRepoFile("README.md")).toBe("doc");
     expect(classifyRepoFile("docs/architecture.mdx")).toBe("doc");
+    // long-form doc spellings (parity with signals/path-matchers DOCS_EXTENSIONS)
+    expect(classifyRepoFile("NOTES.markdown")).toBe("doc");
+    expect(classifyRepoFile("docs/guide.asciidoc")).toBe("doc");
     // skipped: the huge content corpus, data, deps, build output, binaries, lockfiles
     expect(classifyRepoFile("content/mcp/some-entry.mdx")).toBe("skip");
     expect(classifyRepoFile("data/fixtures.json")).toBe("skip");


### PR DESCRIPTION
`DOC_EXT_RE` (src/review/rag.ts) recognized `md`/`mdx`/`rst`/`adoc` but not the long-form `markdown`/`asciidoc` spellings, so files like `NOTES.markdown` / `guide.asciidoc` were classified as `skip` instead of `doc` and dropped from RAG code-review indexing.

Aligns it with the canonical `DOCS_EXTENSIONS` set in src/signals/path-matchers.ts, which already lists both `markdown` and `asciidoc`. Extends `classifyRepoFile` test coverage for both new spellings. Typecheck + unit tests green.