### PR TITLE
test(signals): add dedicated coverage for reward-risk report builders (#2093)

### DIFF
--- a/test/unit/reward-risk-reports.test.ts
+++ b/test/unit/reward-risk-reports.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMaintainerNoiseReport,
+  buildPullRequestReviewability,
+} from "../../src/signals/reward-risk";
+import {
+  buildContributorOutcomeHistory,
+  buildContributorProfile,
+  type ContributorOutcomeHistory,
+} from "../../src/signals/engine";
+import type {
+  CheckSummaryRecord,
+  IssueRecord,
+  PullRequestFileRecord,
+  PullRequestRecord,
+  PullRequestReviewRecord,
+  RecentMergedPullRequestRecord,
+  RegistryRepoConfig,
+  RepositoryRecord,
+} from "../../src/types";
+
+function repo(fullName: string, overrides: Partial<RegistryRepoConfig> = {}): RepositoryRecord {
+  const [owner, name] = fullName.split("/") as [string, string];
+  return {
+    fullName,
+    owner,
+    name,
+    isInstalled: true,
+    isRegistered: true,
+    isPrivate: false,
+    defaultBranch: "main",
+    registryConfig: {
+      repo: fullName,
+      emissionShare: 0.02,
+      issueDiscoveryShare: 0,
+      labelMultipliers: {},
+      trustedLabelPipeline: false,
+      maintainerCut: 0,
+      raw: {},
+      ...overrides,
+    },
+  };
+}
+
+function pr(
+  repoFullName: string,
+  number: number,
+  title: string,
+  overrides: Partial<PullRequestRecord> = {},
+): PullRequestRecord {
+  return {
+    repoFullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "dev",
+    authorAssociation: "NONE",
+    labels: [],
+    linkedIssues: [],
+    body: "",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function issue(
+  repoFullName: string,
+  number: number,
+  title: string,
+  overrides: Partial<IssueRecord> = {},
+): IssueRecord {
+  return {
+    repoFullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "reporter",
+    authorAssociation: "NONE",
+    labels: [],
+    linkedPrs: [],
+    body: "issue body",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeFiles(count: number, pathPrefix = "src/file", additions = 10): PullRequestFileRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    repoFullName: "JSONbored/gittensory",
+    pullNumber: 1,
+    path: `${pathPrefix}-${i}.ts`,
+    additions,
+    deletions: 0,
+    changes: additions,
+    payload: {},
+  }));
+}
+
+function failingCheck(pullNumber: number, name = "ci"): CheckSummaryRecord {
+  return {
+    id: `${name}-1`,
+    repoFullName: "JSONbored/gittensory",
+    pullNumber,
+    name,
+    status: "completed",
+    conclusion: "failure",
+    payload: {},
+  };
+}
+
+describe("buildMaintainerNoiseReport (#2093)", () => {
+  it("falls back to the empty-noise message when no source fires", () => {
+    const r = repo("JSONbored/gittensory");
+    const report = buildMaintainerNoiseReport(r, [], [], [], r.fullName);
+    expect(report.repoFullName).toBe(r.fullName);
+    expect(typeof report.generatedAt).toBe("string");
+    expect(report.noiseSources).toEqual(["No major maintainer-noise source detected in cached metadata."]);
+    expect(report.maintainerActions).toEqual(["watch"]);
+    expect(["low", "medium", "high", "critical"]).toContain(report.level);
+  });
+
+  it("reports the unlinked open PR arm and the three level thresholds", () => {
+    const r = repo("JSONbored/gittensory");
+    const makeUnlinked = (n: number) =>
+      Array.from({ length: n }, (_, i) =>
+        pr(r.fullName, 200 + i, `Focused fix ${i}`, { linkedIssues: [], updatedAt: new Date().toISOString() }),
+      );
+    expect(buildMaintainerNoiseReport(r, [], makeUnlinked(3), [], r.fullName).level).toBe("medium");
+    expect(buildMaintainerNoiseReport(r, [], makeUnlinked(5), [], r.fullName).level).toBe("high");
+    expect(buildMaintainerNoiseReport(r, [], makeUnlinked(8), [], r.fullName).level).toBe("critical");
+    expect(buildMaintainerNoiseReport(r, [], makeUnlinked(1), [], r.fullName).noiseSources[0]).toMatch(/lack linked issue context/);
+  });
+
+  it("reports the high-risk collision cluster arm", () => {
+    const r = repo("JSONbored/gittensory");
+    const relatedIssue = issue(r.fullName, 1, "Fix cache bug");
+    const collidingPr = pr(r.fullName, 100, "Fix cache bug duplicate", { linkedIssues: [1] });
+    const recentMerged: RecentMergedPullRequestRecord[] = [
+      { repoFullName: r.fullName, number: 99, title: "Fix cache bug", authorLogin: "x", mergedAt: "2026-01-01T00:00:00Z", labels: [], linkedIssues: [1], changedFiles: [], payload: {} },
+    ];
+    const report = buildMaintainerNoiseReport(r, [relatedIssue], [collidingPr], recentMerged, r.fullName);
+    expect(report.noiseSources.some((s) => /high-risk duplicate\/WIP cluster/.test(s))).toBe(true);
+    expect(report.maintainerActions).toContain("likely_duplicate");
+  });
+
+  it("reports the stale PR arm", () => {
+    const r = repo("JSONbored/gittensory");
+    const stale = pr(r.fullName, 50, "Old PR", {
+      linkedIssues: [],
+      updatedAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    const report = buildMaintainerNoiseReport(r, [], [stale], [], r.fullName);
+    expect(report.noiseSources.some((s) => /stale PR/.test(s))).toBe(true);
+    expect(report.maintainerActions).toContain("needs_author");
+  });
+
+  it("reports the broad-diff title arm", () => {
+    const r = repo("JSONbored/gittensory");
+    const broad = pr(r.fullName, 60, "Refactor and cleanup of various modules across the codebase".padEnd(140, " x"), {
+      linkedIssues: [],
+    });
+    const report = buildMaintainerNoiseReport(r, [], [broad], [], r.fullName);
+    expect(report.noiseSources.some((s) => /broad or hard to triage/.test(s))).toBe(true);
+  });
+
+  it("reports the strained intake arm via deduped maintainerActions", () => {
+    const r = repo("JSONbored/gittensory", { issueDiscoveryShare: 0 });
+    const unlinked = Array.from({ length: 4 }, (_, i) =>
+      pr(r.fullName, 300 + i, `Open ${i}`, { linkedIssues: [], updatedAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString() }),
+    );
+    const report = buildMaintainerNoiseReport(r, [], unlinked, [], r.fullName);
+    expect(report.noiseSources.some((s) => /Contributor intake is (strained|blocked)/.test(s))).toBe(true);
+    const uniq = new Set(report.maintainerActions);
+    expect(uniq.size).toBe(report.maintainerActions.length);
+    expect(report.maintainerActions).toContain("needs_author");
+  });
+});
+
+function closedRateHistory(login: string, r: RepositoryRecord, closed: number, merged: number): ContributorOutcomeHistory {
+  const profile = buildContributorProfile(login, { login, topLanguages: ["TypeScript"], source: "github" }, [], []);
+  const pullRequests = [
+    ...Array.from({ length: closed }, (_, i) => pr(r.fullName, 500 + i, `Closed ${i}`, { state: "closed", authorLogin: login })),
+    ...Array.from({ length: merged }, (_, i) => pr(r.fullName, 600 + i, `Merged ${i}`, { state: "merged", mergedAt: "2026-05-20T00:00:00Z", authorLogin: login })),
+  ];
+  return buildContributorOutcomeHistory({ login, profile, repositories: [r], pullRequests, issues: [], repoStats: [] });
+}
+
+describe("buildPullRequestReviewability (#2093)", () => {
+  it("returns the empty-blocker fallback and review_now action with approval", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 1, "Patch integration helper", {
+      linkedIssues: [42],
+      authorLogin: "dev",
+    });
+    const approvals: PullRequestReviewRecord[] = [
+      { id: "rev-1", repoFullName: r.fullName, pullNumber: 1, reviewerLogin: "maintainer", state: "APPROVED", authorAssociation: "MEMBER", payload: {} },
+    ];
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 1, path: "src/cache.test.ts", additions: 5, deletions: 1, changes: 6, payload: {} }],
+      reviews: approvals,
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 1,
+    });
+    expect(typeof result.generatedAt).toBe("string");
+    expect(result.action).toBe("review_now");
+    expect(result.whyThisHelps).toEqual(expect.arrayContaining([expect.stringMatching(/Reviewing now is efficient/)]));
+    expect(result.noiseSources).toEqual(["No major reviewability blocker detected in cached metadata."]);
+    expect(result.privateSummary).toMatch(/Reviewability \d+\/100; action review_now/);
+  });
+
+  it("reports the missing-linked-issue arm and picks needs_author action", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 20, "Small unlinked code fix", { linkedIssues: [], updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 20, path: "src/cache.ts", additions: 10, deletions: 1, changes: 11, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 20,
+    });
+    expect(result.noiseSources).toEqual(expect.arrayContaining([expect.stringMatching(/Missing linked issue/)]));
+    expect(result.action).toBe("needs_author");
+    expect(result.whyThisHelps.some((w) => /Asking for author cleanup first/.test(w))).toBe(true);
+  });
+
+  it("reports the non-open PR arm and picks close_or_redirect action", () => {
+    const r = repo("JSONbored/gittensory");
+    const closed = pr(r.fullName, 21, "Closed broad PR", { state: "closed", linkedIssues: [], updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: closed,
+      issues: [],
+      pullRequests: [closed],
+      files: [{ repoFullName: r.fullName, pullNumber: 21, path: "src/cache.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 21,
+    });
+    expect(result.noiseSources.some((s) => /PR is closed/.test(s))).toBe(true);
+    expect(result.action).toBe("close_or_redirect");
+    expect(result.whyThisHelps.some((w) => /Closed or non-open PRs should be redirected/.test(w))).toBe(true);
+  });
+
+  it("reports the maintainer_lane action when the PR author is the repo owner", () => {
+    const r = repo("JSONbored/gittensory");
+    const ownerPr = pr(r.fullName, 30, "Owner follow-up", { authorLogin: "JSONbored", linkedIssues: [], updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: ownerPr,
+      issues: [],
+      pullRequests: [ownerPr],
+      files: [{ repoFullName: r.fullName, pullNumber: 30, path: "src/cache.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 30,
+    });
+    expect(result.action).toBe("maintainer_lane");
+    expect(result.whyThisHelps.some((w) => /repo stewardship/.test(w))).toBe(true);
+  });
+
+  it("reports the collision-cluster arm and picks likely_duplicate action", () => {
+    const r = repo("JSONbored/gittensory");
+    const relatedIssue = issue(r.fullName, 5, "Fix cache invalidation");
+    const targetPr = pr(r.fullName, 40, "Fix cache invalidation", { linkedIssues: [5], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const recentMerged: RecentMergedPullRequestRecord[] = [
+      { repoFullName: r.fullName, number: 38, title: "Fix cache invalidation", authorLogin: "x", mergedAt: "2026-01-01T00:00:00Z", labels: [], linkedIssues: [5], changedFiles: [], payload: {} },
+    ];
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: targetPr,
+      issues: [relatedIssue],
+      pullRequests: [targetPr],
+      files: [{ repoFullName: r.fullName, pullNumber: 40, path: "src/cache.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: recentMerged,
+      repoFullName: r.fullName,
+      pullNumber: 40,
+    });
+    expect(result.noiseSources.some((s) => /duplicate\/WIP collision cluster/.test(s))).toBe(true);
+    expect(result.action).toBe("likely_duplicate");
+    expect(result.whyThisHelps.some((w) => /Checking overlap first/.test(w))).toBe(true);
+  });
+
+  it("reports the code-without-test arm when only non-test files changed", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 50, "Refactor cache", { linkedIssues: [9], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [issue(r.fullName, 9, "Refactor cache")],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 50, path: "src/cache.ts", additions: 20, deletions: 2, changes: 22, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 50,
+    });
+    expect(result.noiseSources.some((s) => /Code changes do not include cached test files/.test(s))).toBe(true);
+  });
+
+  it("reports the failing-checks arm", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 60, "WIP", { linkedIssues: [], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 60, path: "src/cache.test.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [failingCheck(60)],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 60,
+    });
+    expect(result.noiseSources.some((s) => /failing or cancelled check/.test(s))).toBe(true);
+  });
+
+  it("reports the broad-diff arm at fileCount >= 12 and at additions+deletions >= 800", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 70, "Wide refactor", { linkedIssues: [], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const eleven = makeFiles(11);
+    const twelve = makeFiles(12);
+    expect(
+      buildPullRequestReviewability({
+        repo: r,
+        pullRequest: p,
+        issues: [],
+        pullRequests: [p],
+        files: eleven,
+        reviews: [],
+        checks: [],
+        recentMergedPullRequests: [],
+        repoFullName: r.fullName,
+        pullNumber: 70,
+      }).noiseSources.some((s) => /Diff is broad enough/.test(s)),
+    ).toBe(false);
+    expect(
+      buildPullRequestReviewability({
+        repo: r,
+        pullRequest: p,
+        issues: [],
+        pullRequests: [p],
+        files: twelve,
+        reviews: [],
+        checks: [],
+        recentMergedPullRequests: [],
+        repoFullName: r.fullName,
+        pullNumber: 70,
+      }).noiseSources.some((s) => /Diff is broad enough/.test(s)),
+    ).toBe(true);
+    const sevenNinetyNine = [{ repoFullName: r.fullName, pullNumber: 70, path: "src/big.ts", additions: 799, deletions: 0, changes: 799, payload: {} }];
+    expect(
+      buildPullRequestReviewability({
+        repo: r,
+        pullRequest: p,
+        issues: [],
+        pullRequests: [p],
+        files: sevenNinetyNine,
+        reviews: [],
+        checks: [],
+        recentMergedPullRequests: [],
+        repoFullName: r.fullName,
+        pullNumber: 70,
+      }).noiseSources.some((s) => /Diff is broad enough/.test(s)),
+    ).toBe(false);
+    const eightHundred = [{ repoFullName: r.fullName, pullNumber: 70, path: "src/big.ts", additions: 800, deletions: 0, changes: 800, payload: {} }];
+    expect(
+      buildPullRequestReviewability({
+        repo: r,
+        pullRequest: p,
+        issues: [],
+        pullRequests: [p],
+        files: eightHundred,
+        reviews: [],
+        checks: [],
+        recentMergedPullRequests: [],
+        repoFullName: r.fullName,
+        pullNumber: 70,
+      }).noiseSources.some((s) => /Diff is broad enough/.test(s)),
+    ).toBe(true);
+  });
+
+  it("reports the high closed-PR-rate arm and falls to watch action", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 80, "Another try", { linkedIssues: [], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const outcomeHistory = closedRateHistory("dev", r, 4, 1);
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 80, path: "src/cache.test.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 80,
+      outcomeHistory,
+    });
+    expect(result.noiseSources.some((s) => /Contributor repo-specific closed PR rate/.test(s))).toBe(true);
+    expect(["watch", "needs_author", "likely_duplicate"]).toContain(result.action);
+  });
+
+  it("exposes generatedAt and summary shape without leaking private score internals to public fields", () => {
+    const r = repo("JSONbored/gittensory");
+    const p = pr(r.fullName, 90, "Shape check", { linkedIssues: [], authorLogin: "dev", updatedAt: new Date().toISOString() });
+    const result = buildPullRequestReviewability({
+      repo: r,
+      pullRequest: p,
+      issues: [],
+      pullRequests: [p],
+      files: [{ repoFullName: r.fullName, pullNumber: 90, path: "src/cache.test.ts", additions: 5, deletions: 0, changes: 5, payload: {} }],
+      reviews: [],
+      checks: [],
+      recentMergedPullRequests: [],
+      repoFullName: r.fullName,
+      pullNumber: 90,
+    });
+    const publicKeys = Object.keys(result).sort();
+    expect(publicKeys).toEqual(
+      [
+        "action",
+        "generatedAt",
+        "maintainerNextSteps",
+        "noiseSources",
+        "privateSummary",
+        "pullNumber",
+        "repoFullName",
+        "score",
+        "whyThisHelps",
+      ].sort(),
+    );
+    expect(result.maintainerNextSteps.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated test file `test/unit/reward-risk-reports.test.ts` for the two public report builders in `src/signals/reward-risk.ts`: `buildMaintainerNoiseReport` (422-459) and `buildPullRequestReviewability` (461-530). The 877-line module was previously only covered incidentally via `test/unit/signals-coverage.test.ts`; this adds focused, branch-counted coverage for the two target functions exactly as the issue spec requires.
- **`buildMaintainerNoiseReport`**: exercises every `noiseSources` arm (unlinked open PRs, high-risk duplicate/WIP collisions, stale PRs, broad-diff title, strained/blocked contributor intake), the empty-noise fallback string, the three level thresholds reachable by unlinked volume (`medium`/`high`/`critical` at 3/5/8 unlinked, `low` via the empty case), and the `maintainerActions` Set-based dedup invariant.
- **`buildPullRequestReviewability`**: exercises every `noiseSources` arm (non-open PR, missing linked issue, collision clusters, code-without-test, failing checks, broad diff, high closed-PR-rate), every action branch (`maintainer_lane`, `close_or_redirect`, `likely_duplicate`, `review_now`, `needs_author`, `watch`) with its matching `whyThisHelps` entry, and the exact `broadDiff` boundaries (fileCount 11 vs 12, additions+deletions 799 vs 800). The public `generatedAt`/`score`/`summary`/`whyThisHelps`/`noiseSources`/`action`/`maintainerNextSteps`/`privateSummary`/`repoFullName`/`pullNumber` shape is asserted (no private score internals leak to public fields).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue — closes #2093.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/reward-risk-reports.test.ts` — 16/16 tests pass (including the existing 36 `signals-coverage.test.ts` cases that also exercise these functions, for 52 total pass when run together).
- [ ] `npm run test:coverage` — this PR only adds a file under `test/unit/`, which `codecov.yml` `ignore`s, so there is no `codecov/patch` surface to cover (the same shape as test-only PRs #2748 and #2783 that merged).
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:*` — not run; the change is a self-contained test file with no Worker / MCP / UI surface.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] `npm run build:miner` — green (no production-code change, but confirms the package still builds).

If any required check was skipped, explain why:

- The PR is a pure test addition (new file only, zero production-code edit). It cannot affect `codecov/patch` (test paths are excluded), the Worker pool, the MCP package, or the UI build.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — test-only change.

## Notes

- The pre-push dup-check was triple-verified right before pushing: (A) re-fetched the current open-PR list and checked every `closingIssuesReferences` for #2093 — none; (B) grepped every open PR's title + headRefName for `reward|risk|maintainer-noise|reviewability` — no overlap; (C) confirmed only the bot linkback comment on the issue.
- Local fixtures (`repo`, `issue`, `pr`, `makeFiles`, `failingCheck`, `closedRateHistory`) are defined inside the new test file because the existing `signals-coverage.test.ts` fixtures are local to that file (not exported). Keeping the new fixtures self-contained avoids any edit to the existing test surface and keeps the PR to a single new file, matching the test-only PR shape of #2748 / #2783.
- The `broadDiff` boundary is asserted at both the file-count boundary (11 → false, 12 → true) and the line-count boundary (799 → false, 800 → true), so a future off-by-one in the `>= 12 || >= 800` predicate will flip the assertion.