### PR TITLE
fix(ci): isolate the release Docker build cache to its own GHA scope

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -211,12 +211,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
-          # Deliberately NO cache-from/cache-to here (#2502 tried type=gha, reverted): the GHA cache scope
-          # this would read from is the SAME one selfhost.yml's regular CI build writes to on every push/PR
-          # to this repo -- a publish/release path inheriting layers from that shared, more broadly-writable
-          # cache is a cache-poisoning vector into an officially published, public image. A cold build costs
-          # more time per release (infrequent, acceptable) in exchange for the release build never trusting
-          # any cache it didn't produce itself.
+          # #2502 originally shared selfhost.yml's default (unscoped) GHA cache bucket here for speed --
+          # reverted once a security scan correctly flagged it: that bucket is written to by regular CI on
+          # every push/PR to this repo, so a publish/release path reading from it is a cache-poisoning
+          # vector into an officially published, public image. `scope=release-orb` fixes this properly
+          # instead of just going cold forever: it's a completely separate GHA cache namespace that ONLY
+          # this workflow (tag pushes on `main` / `workflow_dispatch`, both already gated by "Verify release
+          # commit is on main" + the `release` environment) ever reads from or writes to -- selfhost.yml's
+          # CI never touches it. The first release still builds cold; every release after that (rc.2, a
+          # later stable, a patch) reuses the arm64/QEMU-emulated apt-get/npm-install layers from the PRIOR
+          # release build in this same isolated scope, with zero exposure to anything a regular CI run ever
+          # produced.
+          cache-from: type=gha,scope=release-orb
+          cache-to: type=gha,mode=max,scope=release-orb
 
       - name: Finalize Sentry release
         if: steps.sentry.outputs.enabled == 'true'

--- a/test/unit/release-selfhost-docker-cache.test.ts
+++ b/test/unit/release-selfhost-docker-cache.test.ts
@@ -3,20 +3,27 @@ import { describe, expect, it } from "vitest";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
-describe("release-selfhost.yml Docker layer caching (#2502, reverted for cache-poisoning)", () => {
-  it("does NOT share selfhost.yml's GHA cache scope in the release build-push-action step", () => {
+describe("release-selfhost.yml Docker layer caching (#2502, isolated after a cache-poisoning finding)", () => {
+  it("caches the multi-arch build-push-action step in a scope isolated from selfhost.yml's CI build", () => {
     const releaseWorkflow = read(".github/workflows/release-selfhost.yml");
+    const selfhostWorkflow = read(".github/workflows/selfhost.yml");
 
     const buildStep = releaseWorkflow.slice(
       releaseWorkflow.indexOf("- name: Build + push (linux/amd64 + linux/arm64)"),
       releaseWorkflow.indexOf("- name: Finalize Sentry release"),
     );
-    // #2502 originally had this step share selfhost.yml's CI build's GHA cache scope for speed. A
-    // release/publish path inheriting layers from that shared, more broadly-writable cache (written to
-    // by every push/PR to this repo) is a cache-poisoning vector into an officially published, public
-    // image -- removed once that risk surfaced reviewing the first cut release. The release build must
-    // stay cold: no cache-from/cache-to at all.
-    expect(buildStep).not.toContain("cache-from: type=gha");
-    expect(buildStep).not.toContain("cache-to: type=gha,mode=max");
+    // #2502 originally had this step share selfhost.yml's DEFAULT (unscoped) GHA cache bucket for speed.
+    // A release/publish path reading from a bucket that regular CI writes to on every push/PR to this
+    // repo is a cache-poisoning vector into an officially published, public image -- caught reviewing
+    // the first cut release. `scope=release-orb` fixes this properly instead of going cold forever: a
+    // completely separate GHA cache namespace that ONLY this workflow ever reads from or writes to.
+    expect(buildStep).toContain("cache-from: type=gha,scope=release-orb");
+    expect(buildStep).toContain("cache-to: type=gha,mode=max,scope=release-orb");
+
+    // selfhost.yml's own CI build must stay on the default (unscoped) bucket -- if it ever also wrote to
+    // `scope=release-orb`, the isolation this fix depends on would be gone.
+    expect(selfhostWorkflow).toContain("--cache-from type=gha");
+    expect(selfhostWorkflow).toContain("--cache-to type=gha,mode=max");
+    expect(selfhostWorkflow).not.toContain("release-orb");
   });
 });


### PR DESCRIPTION
## Summary

Closes the loop on #2502 after PR #2823 reverted its shared-cache approach for a real
cache-poisoning finding.

- #2502 asked for `cache-from`/`cache-to: type=gha` on the release build, shipped via #2578, to
  avoid rebuilding the slow `apt-get`/`npm install -g` layers (especially costly under QEMU
  emulation for arm64) on every release.
- Cutting the very first `orb-v0.1.0-beta.1` release, a security scan correctly flagged that
  config: the GHA cache bucket it read from is the SAME default bucket `selfhost.yml`'s regular CI
  build writes to on every push/PR to this repo — a publish/release path inheriting layers from
  that shared, more broadly-writable bucket is a cache-poisoning vector into an officially
  published, public image.
- PR #2823 removed the cache entirely to close that hole immediately, but that gave up #2502's
  actual goal (faster release builds) permanently, not just the unsafe part of it.

This PR restores the goal properly: `scope=release-orb` is a completely separate GHA cache
namespace that only `release-selfhost.yml` itself (tag pushes on `main` / `workflow_dispatch`,
both already gated by "Verify release commit is on main" + the `release` environment) ever reads
from or writes to. `selfhost.yml`'s own CI build stays on its default (unscoped) bucket, so there's
zero overlap. The very first release into this new scope still builds cold; every release after
that (an `-rc.2`, a later stable, a patch) reuses the arm64/QEMU-emulated layers from the prior
release build in the same isolated scope.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] Full `npx vitest run test/unit/` (7482 tests, all green) — not applicable for Codecov patch: no `src/**` change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, workflow-only change.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no changelog edit.

No linked issue: this closes the loop on #2502, which is already closed as complete — reopening
felt like the wrong signal for "the approach changed" rather than "the work wasn't done." Commented
on #2502 with this history instead.