### PR TITLE
feat(miner): add laptop-mode init and doctor commands

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -99,7 +99,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "FOREGROUND_LIVENESS_ENABLED",
-    firstReference: "src/selfhost/foreground-liveness.ts:34",
+    firstReference: "src/selfhost/foreground-liveness.ts:41",
   },
   {
     name: "GITHUB_APP_ID",
@@ -337,7 +337,7 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/selfhost/discord-notify.ts:31` |",
   "| `DISCORD_WEBHOOK_URL` | `src/selfhost/discord-notify.ts:40` |",
-  "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:34` |",
+  "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:41` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
   "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:493` |",

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -48,7 +48,8 @@ gittensory-miner doctor
 
 `init` bootstraps the local config directory and the SQLite-backed `run-state.sqlite3` file. Path
 resolution mirrors the package's other local stores: `GITTENSORY_MINER_CONFIG_DIR`, then
-`XDG_CONFIG_HOME`, then `~/.config/gittensory-miner/`.
+`XDG_CONFIG_HOME`, then `~/.config/gittensory-miner/`. If you need the SQLite file elsewhere, set
+`GITTENSORY_MINER_RUN_STATE_DB`; that overrides the DB path only, not the config-dir chain.
 
 ## Commands
 
@@ -61,8 +62,8 @@ gittensory-miner init
 gittensory-miner doctor
 ```
 
-`doctor` always reports Docker as informational only. Laptop mode never requires Docker, Redis, or
-Postgres to initialize.
+`doctor` always reports Docker as informational only and times out quickly if `docker --version`
+hangs. Laptop mode never requires Docker, Redis, or Postgres to initialize.
 
 ## Version check
 

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -49,7 +49,8 @@ gittensory-miner doctor
 `init` bootstraps the local config directory and the SQLite-backed `run-state.sqlite3` file. Path
 resolution mirrors the package's other local stores: `GITTENSORY_MINER_CONFIG_DIR`, then
 `XDG_CONFIG_HOME`, then `~/.config/gittensory-miner/`. If you need the SQLite file elsewhere, set
-`GITTENSORY_MINER_RUN_STATE_DB`; that overrides the DB path only, not the config-dir chain.
+`GITTENSORY_MINER_RUN_STATE_DB`; that overrides the DB path only, not the config-dir chain, and
+`init` still creates the configured laptop-mode config directory.
 
 ## Commands
 

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -2,7 +2,7 @@
 
 Foundation CLI for the local Gittensory miner runtime.
 
-This package is the future home of the autonomous discover → analyze → plan → prepare → create → manage miner workflow. In this foundation phase it provides the package scaffold, a minimal CLI surface for `--help` and `--version`, and a non-blocking npm registry version nudge on startup.
+This package is the future home of the autonomous discover → analyze → plan → prepare → create → manage miner workflow. In this foundation phase it provides the package scaffold, a local laptop-mode bootstrap (`init` + `doctor`), and a non-blocking npm registry version nudge on startup.
 
 ## Status
 
@@ -10,6 +10,7 @@ Current scope is intentionally small:
 
 - workspace package wiring
 - CLI entry point
+- laptop-mode bootstrap for a zero-infra local config dir + SQLite state file
 - `--help` and `version` commands
 - startup npm version nudge (override with `--no-update-check` or `GITTENSORY_MINER_NO_UPDATE_CHECK=1`)
 
@@ -37,6 +38,18 @@ npm install
 npm --workspace @jsonbored/gittensory-miner run build
 ```
 
+Laptop mode from npm:
+
+```sh
+npm install -g @jsonbored/gittensory-miner
+gittensory-miner init
+gittensory-miner doctor
+```
+
+`init` bootstraps the local config directory and the SQLite-backed `run-state.sqlite3` file. Path
+resolution mirrors the package's other local stores: `GITTENSORY_MINER_CONFIG_DIR`, then
+`XDG_CONFIG_HOME`, then `~/.config/gittensory-miner/`.
+
 ## Commands
 
 ```sh
@@ -44,7 +57,12 @@ gittensory-miner --help
 gittensory-miner help
 gittensory-miner --version
 gittensory-miner version
+gittensory-miner init
+gittensory-miner doctor
 ```
+
+`doctor` always reports Docker as informational only. Laptop mode never requires Docker, Redis, or
+Postgres to initialize.
 
 ## Version check
 

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -1,3 +1,5 @@
+import { formatLaptopDoctor, initLaptopMode, inspectLaptopMode } from "./laptop-mode.js";
+
 export function printVersion(input) {
   console.log(`${input.packageName}/${input.packageVersion} (node ${process.version})`);
 }
@@ -14,6 +16,8 @@ export function printHelp(input) {
       "  gittensory-miner --version",
       "  gittensory-miner help",
       "  gittensory-miner version",
+      "  gittensory-miner init",
+      "  gittensory-miner doctor",
       "  gittensory-miner hooks check --tool <name> --input <json> [--json]",
       "  gittensory-miner state get <owner/repo> [--json]",
       "  gittensory-miner state set <owner/repo> <idle|discovering|planning|preparing> [--json]",
@@ -26,6 +30,30 @@ export function printHelp(input) {
 
 export function runCli(cliArgs, input) {
   const command = cliArgs[0] ?? "";
+  const commandArgs = cliArgs.slice(1).filter((arg) => arg !== "--no-update-check");
+  if (command === "init") return runInit(commandArgs);
+  if (command === "doctor") return runDoctor(commandArgs);
   console.error(`Unknown command: ${command}. Run ${input.packageName} --help.`);
   return 1;
+}
+
+function runInit(commandArgs) {
+  if (commandArgs.length > 0) {
+    console.error("Usage: gittensory-miner init");
+    return 1;
+  }
+  const result = initLaptopMode();
+  console.log("Gittensory miner laptop mode is ready.");
+  console.log(`Config dir: ${result.configDir}`);
+  console.log(`State DB: ${result.stateDbPath}`);
+  return 0;
+}
+
+function runDoctor(commandArgs) {
+  if (commandArgs.length > 0) {
+    console.error("Usage: gittensory-miner doctor");
+    return 1;
+  }
+  console.log(formatLaptopDoctor(inspectLaptopMode()));
+  return 0;
 }

--- a/packages/gittensory-miner/lib/laptop-mode.d.ts
+++ b/packages/gittensory-miner/lib/laptop-mode.d.ts
@@ -1,0 +1,45 @@
+export type LaptopModeInitResult = {
+  configDir: string;
+  configDirExisted: boolean;
+  stateDbPath: string;
+  stateDbExisted: boolean;
+};
+
+export type LaptopModePathCheck = {
+  path: string;
+  exists: boolean;
+  writable: boolean;
+  error: string | null;
+};
+
+export type LaptopModeStateDbCheck = LaptopModePathCheck & {
+  sqliteReady: boolean;
+  schemaReady: boolean;
+  schemaError: string | null;
+};
+
+export type LaptopModeDoctorReport = {
+  nodeVersion: string;
+  configDir: LaptopModePathCheck;
+  stateDb: LaptopModeStateDbCheck;
+  docker: {
+    available: boolean;
+    detail: string;
+  };
+};
+
+export function resolveLaptopModeStateDbPath(env?: Record<string, string | undefined>): string;
+
+export function resolveLaptopModeConfigDir(env?: Record<string, string | undefined>): string;
+
+export function initLaptopMode(input?: {
+  env?: Record<string, string | undefined>;
+  initStore?: (dbPath?: string) => { close(): void };
+}): LaptopModeInitResult;
+
+export function inspectLaptopMode(input?: {
+  env?: Record<string, string | undefined>;
+  spawnSyncFn?: typeof import("node:child_process").spawnSync;
+}): LaptopModeDoctorReport;
+
+export function formatLaptopDoctor(report: LaptopModeDoctorReport): string;

--- a/packages/gittensory-miner/lib/laptop-mode.js
+++ b/packages/gittensory-miner/lib/laptop-mode.js
@@ -1,8 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { accessSync, constants, existsSync } from "node:fs";
-import { dirname } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
+
+const dockerProbeTimeoutMs = 1500;
 
 function errorDetail(error) {
   return error instanceof Error && error.message ? error.message : "unknown_error";
@@ -13,7 +16,15 @@ export function resolveLaptopModeStateDbPath(env = process.env) {
 }
 
 export function resolveLaptopModeConfigDir(env = process.env) {
-  return dirname(resolveLaptopModeStateDbPath(env));
+  const explicitConfigDir = typeof env.GITTENSORY_MINER_CONFIG_DIR === "string"
+    ? env.GITTENSORY_MINER_CONFIG_DIR.trim()
+    : "";
+  if (explicitConfigDir) return explicitConfigDir;
+
+  const configHome = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME.trim()
+    : join(homedir(), ".config");
+  return join(configHome, "gittensory-miner");
 }
 
 /**
@@ -41,10 +52,29 @@ export function initLaptopMode(input = {}) {
   }
 }
 
+function nearestExistingAncestor(path) {
+  let candidate = dirname(path);
+  while (!existsSync(candidate)) {
+    const parent = dirname(candidate);
+    if (parent === candidate) return null;
+    candidate = parent;
+  }
+  return candidate;
+}
+
 function inspectWritablePath(path) {
   const exists = existsSync(path);
   if (!exists) {
-    return { path, exists: false, writable: false, error: null };
+    const ancestor = nearestExistingAncestor(path);
+    if (!ancestor) {
+      return { path, exists: false, writable: false, error: "missing_parent_directory" };
+    }
+    try {
+      accessSync(ancestor, constants.W_OK | constants.X_OK);
+      return { path, exists: false, writable: true, error: null };
+    } catch (error) {
+      return { path, exists: false, writable: false, error: errorDetail(error) };
+    }
   }
   try {
     accessSync(path, constants.W_OK);
@@ -96,12 +126,19 @@ function probeDocker(spawn = spawnSync) {
     result = spawn("docker", ["--version"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: dockerProbeTimeoutMs,
     });
   } catch (error) {
     return { available: false, detail: errorDetail(error) };
   }
 
   if (result.error) {
+    if (result.error.code === "ETIMEDOUT") {
+      return {
+        available: false,
+        detail: `docker --version timed out after ${dockerProbeTimeoutMs}ms`,
+      };
+    }
     return {
       available: false,
       detail: result.error.code === "ENOENT" ? "docker not found on PATH" : errorDetail(result.error),

--- a/packages/gittensory-miner/lib/laptop-mode.js
+++ b/packages/gittensory-miner/lib/laptop-mode.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { accessSync, constants, existsSync } from "node:fs";
+import { accessSync, constants, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -39,6 +39,7 @@ export function initLaptopMode(input = {}) {
   const configDir = resolveLaptopModeConfigDir(env);
   const configDirExisted = existsSync(configDir);
   const stateDbExisted = existsSync(stateDbPath);
+  mkdirSync(configDir, { recursive: true, mode: 0o700 });
   const store = (input.initStore ?? initRunStateStore)(stateDbPath);
   try {
     return {
@@ -62,7 +63,8 @@ function nearestExistingAncestor(path) {
   return candidate;
 }
 
-function inspectWritablePath(path) {
+function inspectWritablePath(path, input = {}) {
+  const existingMode = input.existingMode ?? constants.W_OK;
   const exists = existsSync(path);
   if (!exists) {
     const ancestor = nearestExistingAncestor(path);
@@ -77,7 +79,7 @@ function inspectWritablePath(path) {
     }
   }
   try {
-    accessSync(path, constants.W_OK);
+    accessSync(path, existingMode);
     return { path, exists: true, writable: true, error: null };
   } catch (error) {
     return { path, exists: true, writable: false, error: errorDetail(error) };
@@ -159,7 +161,9 @@ export function inspectLaptopMode(input = {}) {
   const env = input.env ?? process.env;
   return {
     nodeVersion: process.version,
-    configDir: inspectWritablePath(resolveLaptopModeConfigDir(env)),
+    configDir: inspectWritablePath(resolveLaptopModeConfigDir(env), {
+      existingMode: constants.W_OK | constants.X_OK,
+    }),
     stateDb: inspectRunStateDb(resolveLaptopModeStateDbPath(env)),
     docker: probeDocker(input.spawnSyncFn),
   };

--- a/packages/gittensory-miner/lib/laptop-mode.js
+++ b/packages/gittensory-miner/lib/laptop-mode.js
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+import { accessSync, constants, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
+
+function errorDetail(error) {
+  return error instanceof Error && error.message ? error.message : "unknown_error";
+}
+
+export function resolveLaptopModeStateDbPath(env = process.env) {
+  return resolveRunStateDbPath(env);
+}
+
+export function resolveLaptopModeConfigDir(env = process.env) {
+  return dirname(resolveLaptopModeStateDbPath(env));
+}
+
+/**
+ * Bootstrap the miner's zero-infra laptop mode by ensuring the local config dir and the real
+ * SQLite-backed run-state store exist. We intentionally open the store on EVERY run, not only when
+ * the DB file is missing, so an existing empty file is repaired by the same idempotent schema init
+ * path instead of being reported as "ready" while still unusable. (#2329)
+ */
+export function initLaptopMode(input = {}) {
+  const env = input.env ?? process.env;
+  const stateDbPath = resolveLaptopModeStateDbPath(env);
+  const configDir = resolveLaptopModeConfigDir(env);
+  const configDirExisted = existsSync(configDir);
+  const stateDbExisted = existsSync(stateDbPath);
+  const store = (input.initStore ?? initRunStateStore)(stateDbPath);
+  try {
+    return {
+      configDir,
+      configDirExisted,
+      stateDbPath,
+      stateDbExisted,
+    };
+  } finally {
+    store.close();
+  }
+}
+
+function inspectWritablePath(path) {
+  const exists = existsSync(path);
+  if (!exists) {
+    return { path, exists: false, writable: false, error: null };
+  }
+  try {
+    accessSync(path, constants.W_OK);
+    return { path, exists: true, writable: true, error: null };
+  } catch (error) {
+    return { path, exists: true, writable: false, error: errorDetail(error) };
+  }
+}
+
+function inspectRunStateDb(stateDbPath) {
+  const base = inspectWritablePath(stateDbPath);
+  if (!base.exists) {
+    return {
+      ...base,
+      sqliteReady: false,
+      schemaReady: false,
+      schemaError: null,
+    };
+  }
+
+  try {
+    const db = new DatabaseSync(stateDbPath, { readOnly: true });
+    try {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'miner_run_state'")
+        .get();
+      return {
+        ...base,
+        sqliteReady: true,
+        schemaReady: row?.name === "miner_run_state",
+        schemaError: row?.name === "miner_run_state" ? null : "missing miner_run_state table",
+      };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    return {
+      ...base,
+      sqliteReady: false,
+      schemaReady: false,
+      schemaError: errorDetail(error),
+    };
+  }
+}
+
+function probeDocker(spawn = spawnSync) {
+  let result;
+  try {
+    result = spawn("docker", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    return { available: false, detail: errorDetail(error) };
+  }
+
+  if (result.error) {
+    return {
+      available: false,
+      detail: result.error.code === "ENOENT" ? "docker not found on PATH" : errorDetail(result.error),
+    };
+  }
+  if (result.status === 0) {
+    const detail = (result.stdout || result.stderr || "docker available").trim();
+    return { available: true, detail };
+  }
+
+  const detail = [result.stderr, result.stdout]
+    .map((value) => value?.trim())
+    .find(Boolean) ?? `docker exited ${result.status ?? "unknown"}`;
+  return { available: false, detail };
+}
+
+export function inspectLaptopMode(input = {}) {
+  const env = input.env ?? process.env;
+  return {
+    nodeVersion: process.version,
+    configDir: inspectWritablePath(resolveLaptopModeConfigDir(env)),
+    stateDb: inspectRunStateDb(resolveLaptopModeStateDbPath(env)),
+    docker: probeDocker(input.spawnSyncFn),
+  };
+}
+
+function formatPathStatus(check) {
+  const parts = [];
+  parts.push(check.exists ? "present" : "missing");
+  if (check.exists) parts.push(check.writable ? "writable" : "not writable");
+  return parts.join(", ");
+}
+
+export function formatLaptopDoctor(report) {
+  const stateStatus = [
+    formatPathStatus(report.stateDb),
+    report.stateDb.sqliteReady ? "sqlite ok" : "sqlite unavailable",
+    report.stateDb.schemaReady ? "miner_run_state ready" : "miner_run_state missing",
+  ].join(", ");
+
+  const lines = [
+    "Gittensory miner doctor",
+    `- Node: ${report.nodeVersion}`,
+    `- Config dir: ${report.configDir.path} (${formatPathStatus(report.configDir)})${report.configDir.error ? ` - ${report.configDir.error}` : ""}`,
+    `- State DB: ${report.stateDb.path} (${stateStatus})${report.stateDb.error ? ` - ${report.stateDb.error}` : report.stateDb.schemaError ? ` - ${report.stateDb.schemaError}` : ""}`,
+    `- Docker: ${report.docker.available ? report.docker.detail : `unavailable (${report.docker.detail}; informational only)`}`,
+  ];
+  return lines.join("\n");
+}

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -31,7 +31,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/run-state-cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/claim-ledger.js && node --check lib/portfolio-queue.js && node --check lib/opportunity-ranker.js && node --check lib/plan-store.js && node --check lib/rejection-templates.js && node --check lib/governor-ledger.js"
+    "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/run-state-cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/claim-ledger.js && node --check lib/portfolio-queue.js && node --check lib/opportunity-ranker.js && node --check lib/laptop-mode.js && node --check lib/plan-store.js && node --check lib/rejection-templates.js && node --check lib/governor-ledger.js"
   },
   "dependencies": {
     "@jsonbored/gittensory-engine": "0.1.0"

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -1,10 +1,12 @@
 import { spawnSync } from "node:child_process";
+import { delimiter, dirname } from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   bin,
   closeFixtureServer,
   runCapture,
   startRegistryFixture,
+  tempEnvPrefix,
 } from "./support/miner-cli-harness";
 
 type MinerCli = typeof import("../../packages/gittensory-miner/lib/cli.js");
@@ -64,6 +66,8 @@ describe("gittensory-miner CLI helpers", () => {
     const text = log.mock.calls[0]?.[0];
     expect(text).toContain("gittensory-miner --help");
     expect(text).toContain("gittensory-miner version");
+    expect(text).toContain("gittensory-miner init");
+    expect(text).toContain("gittensory-miner doctor");
     expect(text).toContain("--no-update-check");
   });
 
@@ -294,6 +298,32 @@ describe("gittensory-miner startup update check (#2331)", () => {
   it("serves --version without blocking when update checks are disabled", () => {
     const output = runCapture(["--version", "--no-update-check"]);
     expect(output).toContain("@jsonbored/gittensory-miner/0.1.0");
+  });
+
+  it("bootstraps laptop mode from the bin entry and reports the resolved paths", () => {
+    const configDir = tempEnvPrefix();
+    const output = runCapture(["init", "--no-update-check"], {
+      GITTENSORY_MINER_CONFIG_DIR: configDir,
+    });
+    expect(output).toContain("Gittensory miner laptop mode is ready.");
+    expect(output).toContain(`Config dir: ${configDir}`);
+    expect(output).toContain(`State DB: ${configDir}/run-state.sqlite3`);
+  });
+
+  it("reports absent Docker from the doctor command without treating it as an error", () => {
+    const configDir = tempEnvPrefix();
+    const pathDir = tempEnvPrefix();
+    const nodePathDir = dirname(process.execPath);
+    runCapture(["init", "--no-update-check"], {
+      GITTENSORY_MINER_CONFIG_DIR: configDir,
+    });
+    const output = runCapture(["doctor", "--no-update-check"], {
+      GITTENSORY_MINER_CONFIG_DIR: configDir,
+      PATH: [pathDir, nodePathDir].join(delimiter),
+    });
+    expect(output).toContain("Gittensory miner doctor");
+    expect(output).toContain("Docker: unavailable (docker not found on PATH; informational only)");
+    expect(output).toContain("miner_run_state ready");
   });
 
   it("serves --help immediately without waiting for a slow registry check", async () => {

--- a/test/unit/miner-laptop-mode.test.ts
+++ b/test/unit/miner-laptop-mode.test.ts
@@ -38,6 +38,21 @@ describe("gittensory-miner laptop mode bootstrap (#2329)", () => {
     expect(resolveLaptopModeStateDbPath({})).toMatch(/\/\.config\/gittensory-miner\/run-state\.sqlite3$/);
   });
 
+  it("keeps the laptop-mode config dir on the config chain even when the run-state DB path is overridden", () => {
+    const env = {
+      GITTENSORY_MINER_RUN_STATE_DB: "/custom/state.sqlite3",
+      GITTENSORY_MINER_CONFIG_DIR: "/custom/config",
+      XDG_CONFIG_HOME: "/xdg",
+    };
+
+    expect(resolveLaptopModeConfigDir(env)).toBe("/custom/config");
+    expect(resolveLaptopModeStateDbPath(env)).toBe("/custom/state.sqlite3");
+    expect(resolveLaptopModeConfigDir({
+      GITTENSORY_MINER_RUN_STATE_DB: "/custom/state.sqlite3",
+      XDG_CONFIG_HOME: "/xdg",
+    })).toBe("/xdg/gittensory-miner");
+  });
+
   it("initializes the config dir and SQLite run-state store on a fresh laptop-mode boot", () => {
     const configDir = join(tempRoot(), "config");
     const result = initLaptopMode({ env: { GITTENSORY_MINER_CONFIG_DIR: configDir } });
@@ -111,9 +126,8 @@ describe("gittensory-miner laptop mode bootstrap (#2329)", () => {
     expect(formatLaptopDoctor(report)).toContain("miner_run_state ready");
   });
 
-  it("doctor handles missing Docker and a missing state DB gracefully", () => {
+  it("doctor treats a fresh, creatable config dir as writable and handles missing Docker gracefully", () => {
     const configDir = join(tempRoot(), "config");
-    mkdirSync(configDir, { recursive: true });
 
     const report = inspectLaptopMode({
       env: { GITTENSORY_MINER_CONFIG_DIR: configDir },
@@ -125,16 +139,41 @@ describe("gittensory-miner laptop mode bootstrap (#2329)", () => {
       })) as never,
     });
 
+    expect(report.configDir).toMatchObject({
+      path: configDir,
+      exists: false,
+      writable: true,
+      error: null,
+    });
     expect(report.stateDb).toMatchObject({
       path: join(configDir, "run-state.sqlite3"),
       exists: false,
-      writable: false,
+      writable: true,
       sqliteReady: false,
       schemaReady: false,
       schemaError: null,
     });
     expect(report.docker).toEqual({ available: false, detail: "docker not found on PATH" });
     expect(formatLaptopDoctor(report)).toContain("Docker: unavailable (docker not found on PATH; informational only)");
+  });
+
+  it("doctor treats a timed-out Docker probe as informational only", () => {
+    const configDir = join(tempRoot(), "config");
+    initLaptopMode({ env: { GITTENSORY_MINER_CONFIG_DIR: configDir } });
+
+    const report = inspectLaptopMode({
+      env: { GITTENSORY_MINER_CONFIG_DIR: configDir },
+      spawnSyncFn: vi.fn(() => ({
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: Object.assign(new Error("spawn docker ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      })) as never,
+    });
+
+    expect(report.docker.available).toBe(false);
+    expect(report.docker.detail).toContain("timed out");
+    expect(formatLaptopDoctor(report)).toContain("informational only");
   });
 
   it("doctor surfaces an invalid existing SQLite file with the schema error detail in the human output", () => {

--- a/test/unit/miner-laptop-mode.test.ts
+++ b/test/unit/miner-laptop-mode.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -65,6 +65,37 @@ describe("gittensory-miner laptop mode bootstrap (#2329)", () => {
     });
 
     const db = new DatabaseSync(result.stateDbPath, { readOnly: true });
+    try {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'miner_run_state'")
+        .get();
+      expect(row).toEqual({ name: "miner_run_state" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("creates the config dir even when the run-state DB is overridden outside it", () => {
+    const root = tempRoot();
+    const configDir = join(root, "config");
+    const stateDbPath = join(root, "state", "run-state.sqlite3");
+
+    const result = initLaptopMode({
+      env: {
+        GITTENSORY_MINER_CONFIG_DIR: configDir,
+        GITTENSORY_MINER_RUN_STATE_DB: stateDbPath,
+      },
+    });
+
+    expect(result).toMatchObject({
+      configDir,
+      configDirExisted: false,
+      stateDbPath,
+      stateDbExisted: false,
+    });
+    expect(existsSync(configDir)).toBe(true);
+
+    const db = new DatabaseSync(stateDbPath, { readOnly: true });
     try {
       const row = db
         .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'miner_run_state'")

--- a/test/unit/miner-laptop-mode.test.ts
+++ b/test/unit/miner-laptop-mode.test.ts
@@ -1,0 +1,171 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  formatLaptopDoctor,
+  initLaptopMode,
+  inspectLaptopMode,
+  resolveLaptopModeConfigDir,
+  resolveLaptopModeStateDbPath,
+} from "../../packages/gittensory-miner/lib/laptop-mode.js";
+
+const roots: string[] = [];
+
+function tempRoot(prefix = "gittensory-miner-laptop-") {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("gittensory-miner laptop mode bootstrap (#2329)", () => {
+  it("resolves the config dir and state DB path from miner config env, then XDG, then the home default", () => {
+    expect(resolveLaptopModeConfigDir({ GITTENSORY_MINER_CONFIG_DIR: "/custom/config" })).toBe("/custom/config");
+    expect(resolveLaptopModeStateDbPath({ GITTENSORY_MINER_CONFIG_DIR: "/custom/config" })).toBe(
+      "/custom/config/run-state.sqlite3",
+    );
+    expect(resolveLaptopModeConfigDir({ XDG_CONFIG_HOME: "/xdg" })).toBe("/xdg/gittensory-miner");
+    expect(resolveLaptopModeStateDbPath({ XDG_CONFIG_HOME: "/xdg" })).toBe("/xdg/gittensory-miner/run-state.sqlite3");
+    expect(resolveLaptopModeConfigDir({})).toMatch(/\/\.config\/gittensory-miner$/);
+    expect(resolveLaptopModeStateDbPath({})).toMatch(/\/\.config\/gittensory-miner\/run-state\.sqlite3$/);
+  });
+
+  it("initializes the config dir and SQLite run-state store on a fresh laptop-mode boot", () => {
+    const configDir = join(tempRoot(), "config");
+    const result = initLaptopMode({ env: { GITTENSORY_MINER_CONFIG_DIR: configDir } });
+
+    expect(result).toMatchObject({
+      configDir,
+      configDirExisted: false,
+      stateDbPath: join(configDir, "run-state.sqlite3"),
+      stateDbExisted: false,
+    });
+
+    const db = new DatabaseSync(result.stateDbPath, { readOnly: true });
+    try {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'miner_run_state'")
+        .get();
+      expect(row).toEqual({ name: "miner_run_state" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("re-runs idempotently and repairs an existing empty file by creating the real schema", () => {
+    const configDir = join(tempRoot(), "config");
+    mkdirSync(configDir, { recursive: true });
+    const stateDbPath = join(configDir, "run-state.sqlite3");
+    writeFileSync(stateDbPath, "");
+
+    const result = initLaptopMode({ env: { GITTENSORY_MINER_CONFIG_DIR: configDir } });
+
+    expect(result).toMatchObject({
+      configDir,
+      configDirExisted: true,
+      stateDbPath,
+      stateDbExisted: true,
+    });
+
+    const header = readFileSync(stateDbPath).subarray(0, 16).toString("utf8");
+    expect(header).toBe("SQLite format 3\u0000");
+
+    const db = new DatabaseSync(stateDbPath, { readOnly: true });
+    try {
+      const row = db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'miner_run_state'")
+        .get();
+      expect(row).toEqual({ name: "miner_run_state" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("doctor reports a ready local state store and formats a human-readable summary", () => {
+    const configDir = join(tempRoot(), "config");
+    initLaptopMode({ env: { GITTENSORY_MINER_CONFIG_DIR: configDir } });
+
+    const report = inspectLaptopMode({
+      env: { GITTENSORY_MINER_CONFIG_DIR: configDir },
+      spawnSyncFn: vi.fn(() => ({ status: 0, stdout: "Docker version 27.0.0", stderr: "" })) as never,
+    });
+
+    expect(report.configDir).toMatchObject({ path: configDir, exists: true, writable: true, error: null });
+    expect(report.stateDb).toMatchObject({
+      path: join(configDir, "run-state.sqlite3"),
+      exists: true,
+      writable: true,
+      sqliteReady: true,
+      schemaReady: true,
+      schemaError: null,
+    });
+    expect(report.docker).toEqual({ available: true, detail: "Docker version 27.0.0" });
+    expect(formatLaptopDoctor(report)).toContain("miner_run_state ready");
+  });
+
+  it("doctor handles missing Docker and a missing state DB gracefully", () => {
+    const configDir = join(tempRoot(), "config");
+    mkdirSync(configDir, { recursive: true });
+
+    const report = inspectLaptopMode({
+      env: { GITTENSORY_MINER_CONFIG_DIR: configDir },
+      spawnSyncFn: vi.fn(() => ({
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }),
+      })) as never,
+    });
+
+    expect(report.stateDb).toMatchObject({
+      path: join(configDir, "run-state.sqlite3"),
+      exists: false,
+      writable: false,
+      sqliteReady: false,
+      schemaReady: false,
+      schemaError: null,
+    });
+    expect(report.docker).toEqual({ available: false, detail: "docker not found on PATH" });
+    expect(formatLaptopDoctor(report)).toContain("Docker: unavailable (docker not found on PATH; informational only)");
+  });
+
+  it("doctor surfaces an invalid existing SQLite file with the schema error detail in the human output", () => {
+    const configDir = join(tempRoot(), "config");
+    mkdirSync(configDir, { recursive: true });
+    const stateDbPath = join(configDir, "run-state.sqlite3");
+    writeFileSync(stateDbPath, "not a sqlite database");
+
+    const report = inspectLaptopMode({
+      env: { GITTENSORY_MINER_CONFIG_DIR: configDir },
+      spawnSyncFn: vi.fn(() => ({ status: 0, stdout: "Docker version 27.0.0", stderr: "" })) as never,
+    });
+
+    expect(report.stateDb).toMatchObject({
+      path: stateDbPath,
+      exists: true,
+      writable: true,
+      sqliteReady: false,
+      schemaReady: false,
+    });
+    expect(report.stateDb.schemaError).toBeTruthy();
+    expect(formatLaptopDoctor(report)).toContain(report.stateDb.schemaError!);
+  });
+
+  it("documents the laptop-mode quickstart in the package README", () => {
+    const readme = readFileSync("packages/gittensory-miner/README.md", "utf8");
+
+    expect(readme).toMatch(/npm install -g @jsonbored\/gittensory-miner/);
+    expect(readme).toContain("gittensory-miner init");
+    expect(readme).toContain("gittensory-miner doctor");
+    expect(readme).toContain("run-state.sqlite3");
+    expect(readme).toMatch(/Laptop mode never requires Docker, Redis, or\s+Postgres/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #2329 by adding zero-infra `gittensory-miner init` and `gittensory-miner doctor` commands to the packaged CLI.
- `init` now resolves the local config directory through `GITTENSORY_MINER_CONFIG_DIR`, `XDG_CONFIG_HOME`, then the homedir fallback, and always bootstraps the real SQLite-backed run-state store so an existing empty file is repaired instead of being treated as ready.
- `doctor` reports Node, config-dir, SQLite file/schema health, and Docker availability as informational only, and the README plus CLI/laptop-mode tests now cover the npm quickstart, idempotent bootstrap, and absent-Docker path.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:coverage` was exercised as `npm run test:coverage -- --maxWorkers=4`, which passed on the rebased branch and matches the CI-stable worker cap used during local validation.
- `npm run test:ci` was rerun from the rebased branch to smoke the full wrapper, but its uncapped `npm run test:coverage` leg is host-load-sensitive here; the required sub-checks above were still run and verified individually.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title                         | JPG/PNG evidence |
| ------------------------------------- | ---------------- |
| No visible UI changes                 | N/A              |

## Notes

- No visible UI changes in this PR.
- The generated `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` line references were refreshed so the self-host env-reference check stays green.
