### PR TITLE
fix(signals): classify PHP source files as code

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5515,11 +5515,11 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 }
 
 function isCodeFile(file: string): boolean {
-  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy added
-  // so C#/Swift/Groovy source counts as code, matching the test conventions
+  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php added
+  // so C#/Swift/Groovy/PHP source counts as code, matching the test conventions
   // isTestPath already recognizes).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php)$/i.test(file) &&
     !isTestFile(file)
   );
 }

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1267,12 +1267,12 @@ export function isTestFile(file: string): boolean {
 }
 
 export function isCodeFile(file: string): boolean {
-  // cs/swift/groovy round out the JVM/.NET/Swift set: isTestPath already
+  // cs/swift/groovy/php round out the JVM/.NET/Swift/PHP set: isTestPath already
   // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
-  // count as code too — otherwise a C#/Swift/Groovy source file is neither test
+  // count as code too — otherwise a C#/Swift/Groovy/PHP source file is neither test
   // nor code in the local scorer.
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php)$/i.test(file) &&
     !isTestFile(file)
   );
 }

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -122,6 +122,10 @@ describe("isCodeFile", () => {
       "Api/Controllers/UserController.cs",
       "Sources/App/Router.swift",
       "src/main/groovy/Pipeline.groovy",
+      // PHP source — isTestPath already recognizes PHPUnit/PHPSpec `SomethingTest`/`Spec`
+      // files, so PHP source must count as code too (else it is neither test nor code).
+      "app/Http/Controllers/UserController.php",
+      "src/Service/PaymentGateway.php",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }
@@ -141,6 +145,8 @@ describe("isCodeFile", () => {
       // C#/Swift test files carry a code extension but are tests, not code.
       "Services/AccountTests.cs",
       "AppTests/LoginTests.swift",
+      // PHP class-suffix test file (PHPUnit) — code extension, but a test, not code.
+      "app/Service/PaymentTest.php",
     ]) {
       expect(isCodeFile(path)).toBe(false);
     }


### PR DESCRIPTION
## Summary

`isTestPath` already recognizes PHP test files via the PHPUnit/PHPSpec `SomethingTest(s)`/`Spec`
class-suffix convention, but the sibling `isCodeFile` predicate was never given the matching `php`
source extension. A PHP source file was therefore classified as **neither test nor code** — the exact
failure `isCodeFile`'s own comment says it guards against, and the same inconsistency that #2743
resolved for the JVM/C#/Swift set.

This adds `php` to `isCodeFile` in both synced copies (`src/signals/local-branch.ts` and its
kept-in-sync mirror in `src/signals/engine.ts`), so PHP source now counts as genuine code in the local
scorer's `sourceLineCount`, the `missing_tests` signal, `classifyChangedFile`, and the slop code-file
counts. A `PaymentTest.php` file stays a test (the `!isTestFile` guard still excludes it).

No linked issue: this is a small, self-evident correctness fix — one extension added to two
already-synced deterministic predicates, plus regression tests — mirroring #2743's JVM/C#/Swift
class-suffix alignment. It touches no public behavior, auth, schema, or deploy surface, so it fits the
repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over the tests that exercise both changed predicates — 194 related unit tests pass and **both changed
  lines (and both `&&` branches) are covered**, so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only
  deterministic path-classifier change that touches no UI/API/OpenAPI/MCP/DB/workflow surface, so those
  jobs are no-ops for this diff; they run on CI (Linux). The `|php` addition only widens a regex
  alternation and adds no new branch.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — this is a pure, deterministic path-classifier
  fix, so the auth/UI/OpenAPI boxes are N/A.
- Regression tests added in `test/unit/local-branch-file-classifiers.test.ts`: PHP source
  (`UserController.php`, `PaymentGateway.php`) → code; PHP class-suffix test (`PaymentTest.php`) → not
  code.
