### PR TITLE
fix(queue): bound concurrency of contributor issue-cap live-checks

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4373,12 +4373,14 @@ async function maybeCloseIssueOverContributorCap(
   const liveToken = token ?? env.GITHUB_PUBLIC_TOKEN;
   const admissionKey = githubAdmissionKeyForToken(env, installationId, liveToken);
   const confirmedOpen = new Set<number>();
-  await Promise.all(
-    otherAuthorIssueNumbers.map(async (number) => {
-      const liveState = await fetchLiveIssueState(env, repoFullName, number, liveToken, admissionKey).catch(() => undefined);
-      if (liveState === "open") confirmedOpen.add(number);
-    }),
-  );
+  // Bounded fan-out, mirroring the per-repo PR cap (#2766): an unbounded Promise.all scales with the author's
+  // own open-issue count, so a single delivery could fire dozens of concurrent live-state calls. Every sibling
+  // must still be verified (the over-cap numbers below depend on the complete confirmed-open set), so this
+  // bounds concurrency via the shared CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY rather than stopping early.
+  await mapWithConcurrency(otherAuthorIssueNumbers, CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY, async (number) => {
+    const liveState = await fetchLiveIssueState(env, repoFullName, number, liveToken, admissionKey).catch(() => undefined);
+    if (liveState === "open") confirmedOpen.add(number);
+  });
   const authorOpenIssueNumbers = otherAuthorIssueNumbers
     .filter((number) => confirmedOpen.has(number))
     .concat(issue.number)

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -9603,6 +9603,63 @@ describe("queue processors", () => {
     expect(closeAudit?.n).toBeGreaterThanOrEqual(1);
   });
 
+  it("contributor open-ISSUE cap (#2270): bounds the sibling live-check fan-out instead of firing one request per open issue at once (#2766 parity)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, {
+      installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" }, target_type: "User", repository_selection: "all", permissions: { metadata: "read", issues: "write" }, events: ["issues"] },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    // SIBLING_COUNT other open issues from the same author, well beyond the concurrency bound, so an unbounded
+    // Promise.all would fire every live-state GET at once. The cap is set BELOW the total so the newest issue is
+    // over the cap and the sibling live-verification path actually runs (it walks the complete sibling set).
+    const SIBLING_COUNT = 30;
+    const EXPECTED_LIVE_CHECK_CONCURRENCY = 10; // mirrors CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY in processors.ts
+    const newIssue = SIBLING_COUNT + 1;
+    for (let number = 1; number <= SIBLING_COUNT; number += 1) {
+      await upsertIssueFromGitHub(env, "JSONbored/gittensory", { number, title: `Prolific issue ${number}`, state: "open", user: { login: "prolific" }, labels: [], body: "x" });
+    }
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      autonomy: { close: "auto", label: "auto" },
+      contributorOpenIssueCap: SIBLING_COUNT,
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let closed = false;
+    const siblingCheckPattern = new RegExp(`/issues/(?:${Array.from({ length: SIBLING_COUNT }, (_, i) => i + 1).join("|")})$`);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+      if (siblingCheckPattern.test(url) && method === "GET") {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5)); // force genuine overlap between concurrent checks
+        inFlight -= 1;
+        return Response.json({ state: "open" });
+      }
+      if (url.endsWith(`/issues/${newIssue}`) && method === "PATCH") { closed = JSON.parse(String(init?.body ?? "{}")).state === "closed"; return Response.json({ state: "closed" }); }
+      if (url.includes(`/issues/${newIssue}/comments`) && method === "POST") return Response.json({ id: 1 }, { status: 201 });
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "contributor-issue-cap-bounded-concurrency",
+      eventName: "issues",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: newIssue, title: "Prolific author's newest issue", state: "open", user: { login: "prolific" }, labels: [], body: "x" },
+      },
+    });
+
+    expect(closed).toBe(true); // the over-cap issue is closed, confirming the sibling live-check path actually ran
+    expect(maxInFlight).toBeGreaterThan(1); // genuinely concurrent, not accidentally serial
+    expect(maxInFlight).toBeLessThanOrEqual(EXPECTED_LIVE_CHECK_CONCURRENCY);
+  });
+
   it("contributor open-ISSUE cap (#2270): a maintainer-named autoCloseExemptLogins entry is exempt from the PER-REPO issue cap too (not just the install-wide cap)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, {


### PR DESCRIPTION
## What

The per-repo contributor **issue** cap (`maybeCloseIssueOverContributorCap`) live-verifies every counted sibling issue is still open before trusting it toward an irreversible auto-close. It did so with an unbounded `Promise.all` over the author's complete open-issue set — firing one concurrent `fetchLiveIssueState` call per open issue from a single webhook delivery.

An author with dozens of open issues on one repo would fire that many simultaneous GitHub API calls at once, straining the installation's rate-limit budget.

## Why this is the right fix

The **PR** side of the same per-repo cap already bounds this exact fan-out — #2766 introduced `CONTRIBUTOR_CAP_LIVE_CHECK_CONCURRENCY` (10) and routed the PR-cap live-check through `mapWithConcurrency` for precisely this reason (flagged as a security-review finding). The constant is named generically for the contributor-cap live-verification, and the issue cap shares the identical live-verify shape — it was simply left on the old unbounded `Promise.all`.

This wires the issue cap through the same constant and helper. Every sibling is still verified (the exact over-cap issue numbers depend on the complete confirmed-open set, not just whether the count is over cap), so it bounds concurrency rather than stopping early.

Note: unlike the PR path, the issue path has no delivery-order-guard sibling wake, so it does not compound into the same near-quadratic growth — but the per-delivery unbounded fan-out is identical, and shares the same fix.

## Test

Adds a regression test mirroring #2766's PR-cap concurrency test for the issue path: 30 sibling issues from one author, instrumenting the sibling live-state GETs to track max in-flight requests. Asserts the check is genuinely concurrent (`> 1`) but bounded (`<= 10`). Fails on the pre-fix unbounded `Promise.all` (all 30 fire at once); passes with the bounded helper. Both arms of the live-state callback stay covered by the existing stale-open regression test.