### PR TITLE
fix(signals): classify C/C++ source files as code

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -610,7 +610,7 @@ export function isTestFile(file) {
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|c|h|cc|cpp|hpp)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -19,7 +19,7 @@ function isTestFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|c|h|cc|cpp|hpp)$/i.test(file) && !isTestFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -139,7 +139,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy")):
+        elif path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".c", ".h", ".cc", ".cpp", ".hpp")):
             source += lines
         else:
             non_code += lines

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5517,10 +5517,11 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 function isCodeFile(file: string): boolean {
   // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy added
   // so C#/Swift/Groovy source counts as code, matching the test conventions
-  // isTestPath already recognizes).
+  // isTestPath already recognizes; c/h/cc/cpp/hpp match rag.ts native code).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
-    !isTestFile(file)
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|c|h|cc|cpp|hpp)$/i.test(
+      file,
+    ) && !isTestFile(file)
   );
 }
 

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1270,10 +1270,12 @@ export function isCodeFile(file: string): boolean {
   // cs/swift/groovy round out the JVM/.NET/Swift set: isTestPath already
   // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
   // count as code too — otherwise a C#/Swift/Groovy source file is neither test
-  // nor code in the local scorer.
+  // nor code in the local scorer. c/h/cc/cpp/hpp align with review/rag.ts's
+  // CODE_EXT_RE so native C/C++ source is not misclassified as "other".
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) &&
-    !isTestFile(file)
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|c|h|cc|cpp|hpp)$/i.test(
+      file,
+    ) && !isTestFile(file)
   );
 }
 

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -122,6 +122,13 @@ describe("isCodeFile", () => {
       "Api/Controllers/UserController.cs",
       "Sources/App/Router.swift",
       "src/main/groovy/Pipeline.groovy",
+      // Native C/C++ source — already indexed as code by rag.ts but was "other"
+      // in slop/missing-tests signals when only the diff touched .c/.cpp/.h files.
+      "native/src/parser.c",
+      "native/include/parser.h",
+      "libs/core/engine.cc",
+      "libs/core/types.hpp",
+      "drivers/io.cpp",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }


### PR DESCRIPTION
## Summary

Native C/C++ source files (`.c`, `.h`, `.cc`, `.cpp`, `.hpp`) were already indexed as code by the RAG classifier (`review/rag.ts` `CODE_EXT_RE`), but `isCodeFile` did not recognize them. PRs touching only native sources could therefore be misclassified as non-code in slop signals, missing-tests checks, and the MCP local score preview.

This PR extends `isCodeFile` (and the mirrored MCP classifiers) to include C/C++ extensions, with regression tests.

No linked issue — small classifier parity fix with clear product impact.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (targeted unit tests for changed classifiers)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` was partially blocked locally by a stale selfhost env-reference artifact on this checkout; classifier-focused unit tests and typecheck passed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI change.

## Notes

- Keeps `isCodeFile` in `local-branch.ts`, `engine.ts`, and the MCP score-preview mirrors in sync.
