### PR TITLE
fix(signals): scope broad-diff maintainer noise to open PRs

### DIFF
--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -430,7 +430,9 @@ export function buildMaintainerNoiseReport(
   const queueHealth = buildQueueHealth(repo, issues, pullRequests, collisions);
   const intake = buildContributorIntakeHealth(repo, issues, pullRequests, fullName, collisions);
   const unlinked = pullRequests.filter((pr) => pr.state === "open" && pr.linkedIssues.length === 0).length;
-  const broadDiffSignals = pullRequests.filter((pr) => pr.title.length > 120 || /refactor|cleanup|misc|various/i.test(pr.title)).length;
+  const broadDiffSignals = pullRequests.filter(
+    (pr) => pr.state === "open" && (pr.title.length > 120 || /refactor|cleanup|misc|various/i.test(pr.title)),
+  ).length;
   const noiseSources = [
     ...(unlinked > 0 ? [`${unlinked} open PR(s) lack linked issue context.`] : []),
     ...(collisions.summary.highRiskCount > 0 ? [`${collisions.summary.highRiskCount} high-risk duplicate/WIP cluster(s).`] : []),

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -451,6 +451,27 @@ describe("signal coverage edge cases", () => {
     expect(closedReviewability.noiseSources.join("\n")).toMatch(/failing|broad|closed PR rate|PR is closed/i);
   });
 
+  it("counts broad-diff maintainer-noise only for open PRs, not merged/closed history", () => {
+    const directRepo = repo("owner/direct");
+    const broadSource = (prRecord: PullRequestRecord) =>
+      buildMaintainerNoiseReport(directRepo, [], [prRecord], [], directRepo.fullName).noiseSources.join("\n");
+    // An OPEN PR whose title matches the broad regex is live queue burden -> surfaces as broad-diff noise.
+    const openBroadTitle = pr(directRepo.fullName, 41, "Refactor and cleanup of various modules", { linkedIssues: [1] });
+    expect(broadSource(openBroadTitle)).toMatch(/broad or hard to triage/i);
+    // An OPEN PR with an overlong (>120 char) title is also broad-diff noise.
+    const openLongTitle = pr(directRepo.fullName, 42, "Add pagination, filtering, and sorting to the labels endpoint across the API and MCP surfaces".padEnd(130, "."), {
+      linkedIssues: [1],
+    });
+    expect(broadSource(openLongTitle)).toMatch(/broad or hard to triage/i);
+    // An OPEN PR with a short, plain title is neither -> no broad-diff noise.
+    const openPlainTitle = pr(directRepo.fullName, 43, "Fix null check in cache loader", { linkedIssues: [1] });
+    expect(broadSource(openPlainTitle)).not.toMatch(/broad or hard to triage/i);
+    // The broad title on a MERGED PR is history, not queue burden -> must not surface, mirroring the
+    // open-only scoping the sibling unlinked-PR signal already uses.
+    const mergedBroad = pr(directRepo.fullName, 44, "Refactor and cleanup of various modules", { state: "merged", mergedAt: "2026-01-01T00:00:00.000Z", linkedIssues: [1] });
+    expect(broadSource(mergedBroad)).not.toMatch(/broad or hard to triage/i);
+  });
+
   it("covers private reward/risk edge scoring for unknown, issue-only, and maintainer contexts", () => {
     const directRepo = repo("owner/direct", { labelMultipliers: { "status:ready": 2, feature: 1.5 } });
     const issueRepo = repo("owner/issues", { issueDiscoveryShare: 1 });


### PR DESCRIPTION
## Summary

`buildMaintainerNoiseReport` in `src/signals/reward-risk.ts` measures **active-queue** noise, and every
other metric it computes is open-scoped: `unlinked` (the line directly above), `queueHealth`'s stale-PR
signal, and the intake counts all filter `pr.state === "open"`. But `broadDiffSignals` filtered PRs of
**every** state, so already **merged/closed** PRs with a broad-looking title (`refactor|cleanup|misc|various`,
or a title > 120 chars) were counted as live queue burden — inflating `noiseSources` with a phantom
"look broad or hard to triage" entry and lowering the maintainer-noise `score` (`- broadDiffSignals * 4`).

This reaches production via `buildMaintainerQueueDigest` (`src/github/commands.ts`), which passes the
full all-state PR list into the report (it derives its own `openPullRequests` separately, confirming the
input is not pre-filtered). So any repo whose closed/merged history contains broad-looking titles got
phantom queue noise.

Fix: add the same `pr.state === "open"` guard the sibling `unlinked` line already uses, so broad-diff
noise counts only open PRs. One-line predicate change, mirroring existing behavior.

No linked issue: small, self-evident correctness fix that aligns one queue metric with the open-only
scoping every sibling metric in the same function already applies; it changes no public behavior, auth,
schema, or deploy surface, so it fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over the tests that exercise `buildMaintainerNoiseReport` — 128 tests pass and the **changed predicate
  line is fully branch-covered** (open+merged for the new `state` guard, and the >120-char / regex /
  neither arms), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only
  deterministic signal-builder change touching no UI/API/OpenAPI/MCP/DB/workflow surface, so those jobs
  are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic signal-builder fix, so the
  auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/signals-coverage.test.ts` ("counts broad-diff maintainer-noise
  only for open PRs, not merged/closed history"): open broad-title and overlong-title PRs still surface
  the broad-diff noise; the same title on a merged PR, and an open short/plain-title PR, do not.
