### PR TITLE
fix(engine): floor freshness for missing or invalid issue timestamps

### DIFF
--- a/packages/gittensory-engine/src/opportunity-freshness.ts
+++ b/packages/gittensory-engine/src/opportunity-freshness.ts
@@ -26,10 +26,18 @@ function pickTimestamp(issue: FreshnessIssue): string | null {
   return null;
 }
 
+// An open issue whose timestamp is missing or unparseable is treated as maximally STALE, not fresh: a
+// malformed row must not rank ahead of genuinely fresh opportunities in the metadata ranker. This restores
+// the flooring introduced with this scorer (#2806, "invalid or missing issue timestamps floor freshness
+// instead of ranking malformed metadata first"). exp(-STALE_AGE_DAYS / 20) underflows to ~0, which the
+// clamp raises to the 0.05 freshness floor.
+const STALE_AGE_DAYS = 9999;
+
 function issueAgeDays(value: string | null, nowMs: number): number {
-  if (!value) return 0;
+  if (!value) return STALE_AGE_DAYS;
   const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return 0;
+  /* v8 ignore next -- pickTimestamp only ever yields a parseable string or null; kept as a defensive floor. */
+  if (!Number.isFinite(parsed)) return STALE_AGE_DAYS;
   return Math.floor((nowMs - parsed) / 86_400_000);
 }
 


### PR DESCRIPTION
## What

`computeOpportunityFreshness` (the miner engine's local opportunity scorer) treated an open issue with a **missing or unparseable timestamp** as maximally *fresh* (`issueAgeDays` returned `0` → `exp(0)` → freshness `1`), rather than *stale*. A malformed metadata row could therefore rank ahead of genuinely fresh opportunities in the local ranker.

This restores the stale flooring the scorer originally shipped with: `issueAgeDays` returns `STALE_AGE_DAYS` for a `null`/unparseable timestamp, which underflows through `exp(-STALE_AGE_DAYS / 20)` to the `0.05` freshness floor after the clamp.

## Why this is the right direction

When this scorer landed (#2806), its stale-flooring was a deliberate, documented choice — the commit message states: *"Invalid or missing issue timestamps now floor freshness instead of ranking malformed metadata first."* A subsequent change reverted `issueAgeDays`'s missing/invalid returns to `0` (fresh) without updating the scorer's tests, turning the mainline red.

The intended contract is asserted by the scorer's **own existing tests**, which currently fail on `main`:
- `opportunity-freshness.test.ts` → *"treats missing timestamps as stale"* and *"falls back cleanly when timestamps are absent or non-string"* (expect `0.05`)
- `opportunity-metadata-signals.test.ts` → *"freshness … helpers stay pure with … safe inputs"* (expect `0.05`)
- `opportunity-branch-internals.test.ts`

This change makes all of them green again.

Note: the scorer's docstring references `opportunityFreshnessFactor` in `src/signals/reward-risk.ts`. That canonical intentionally normalizes invalid timestamps to *fresh* for the on-server reward signal; the engine copy deliberately diverges to *stale* for the local metadata ranker (so malformed rows don't rank first), exactly as #2806 introduced. This restores that intended divergence — the shared shape (exponential decay, `[0.05, 1]` clamp, injected clock) is unchanged.

## Test

No new test needed — the fix is proven by the scorer's existing tests, which fail on `main` (missing/invalid timestamp → `1`) and pass with this change (→ `0.05`). The now-defensive non-finite branch (unreachable because `pickTimestamp` only yields a parseable string or `null`) is `v8 ignore`-annotated, matching the file's existing convention.