### PR TITLE
feat(selfhost): add backlog/fresh-intake lane gauges and a live GitHub rate-limit gauge

### DIFF
--- a/grafana/dashboards/gittensory.json
+++ b/grafana/dashboards/gittensory.json
@@ -2786,6 +2786,163 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 182 },
+      "id": 152,
+      "title": "Backlog-vs-Fresh-Intake Lane Fairness (#selfhost-lane-observability)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 30 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 183 },
+      "id": 153,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Backlog-Convergence Pending",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_backlog_convergence_pending",
+          "legendFormat": "backlog pending"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 30 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 183 },
+      "id": 154,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "title": "Fresh-Intake Pending",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_fresh_intake_pending",
+          "legendFormat": "fresh pending"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }
+      },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 183 },
+      "id": 155,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "GitHub REST Rate Limit Remaining (by scope)",
+      "description": "The NEWEST observed x-ratelimit-remaining per key_scope -- unlike gittensory_github_rest_rate_limit_observations_total (a bucketed rate() counter), this is the actual current remaining count.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_github_rest_rate_limit_remaining",
+          "legendFormat": "{{key_scope}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 189 },
+      "id": 156,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Foreground Claims by Lane (rate)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (lane) (rate(gittensory_jobs_claimed_by_lane_total[5m])) or vector(0)",
+          "legendFormat": "{{lane}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 189 },
+      "id": 157,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": { "show": false, "reducer": ["sum"], "fields": "" }
+      },
+      "title": "Top Repos by Backlog Depth",
+      "description": "Top-10 repos by backlog-convergence pending depth, recomputed fresh every scrape -- bounded so a large multi-repo self-host install never explodes this panel's series count.",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "gittensory_queue_backlog_by_repo",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true },
+            "indexByName": { "repo": 0, "Value": 1 }
+          }
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -235,6 +235,27 @@ export function latestGitHubRestRateLimitObservation(admissionKey: GitHubRateLim
   return latestRestRateLimitObservations.get(admissionKey) ?? null;
 }
 
+/** gaugeVector sampler (see selfhost/metrics.ts + server.ts) for a genuine "remaining right now" GitHub REST
+ *  rate-limit gauge -- the existing gittensory_github_rest_rate_limit_observations_total counter only supports a
+ *  bucketed `rate()` over a window, never the actual current value. Grouped by key_scope (installation / public /
+ *  global / unknown / other -- a small, fixed set, NOT per-installation, so cardinality stays bounded regardless
+ *  of how many installations a self-host deploy has), picking the NEWEST observation (by observedAtMs) among
+ *  every admission key sharing that scope -- multiple installations all fall under "installation", and a stale
+ *  observation from an installation that hasn't made a request recently must never mask a fresher one from a
+ *  DIFFERENT installation in the same scope. Pure given the current contents of latestRestRateLimitObservations. */
+export function githubRestRateLimitRemainingSamples(): Array<{ labels: { key_scope: string }; value: number }> {
+  const newestByScope = new Map<string, LocalGitHubRestRateLimitObservation>();
+  for (const [admissionKey, observation] of latestRestRateLimitObservations) {
+    const scope = githubAdmissionKeyScope(admissionKey);
+    const existing = newestByScope.get(scope);
+    if (!existing || observation.observedAtMs > existing.observedAtMs) newestByScope.set(scope, observation);
+  }
+  return [...newestByScope.entries()].map(([key_scope, observation]) => ({
+    labels: { key_scope },
+    value: observation.remaining,
+  }));
+}
+
 async function sha256Short(value: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("").slice(0, 16);

--- a/src/selfhost/maintenance-admission.ts
+++ b/src/selfhost/maintenance-admission.ts
@@ -92,6 +92,12 @@ export interface MaintenancePressureSignals {
    *  work too). A high count here means a real, currently-unresolved PR-review backlog exists; generic
    *  maintenance should yield to draining it, same as it already yields to live webhook pressure. */
   backlogConvergencePendingCount: number;
+  /** #selfhost-lane-observability: pending+processing count of `github-webhook` PR open/reopen/synchronize/
+   *  ready-for-review jobs tagged `foreground_lane='fresh'` (queue-fairness.ts) -- the COMPLEMENT of
+   *  backlogConvergencePendingCount within the fairness mechanism's classified lanes, exposed purely for the
+   *  dashboard breakdown (unlike backlogConvergencePendingCount, evaluateMaintenanceAdmission never consults
+   *  this field -- fresh-intake pressure has no maintenance-admission gate of its own). */
+  freshIntakePendingCount: number;
 }
 
 export interface MaintenanceAdmissionConfig {

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -4,7 +4,11 @@
 // Rendered at GET /metrics. No deps, no cardinality explosion: callers use a small fixed label set.
 type Labels = Record<string, string>;
 type GaugeSample = () => number | Promise<number>;
+type GaugeVectorSample = () => VectorSample[] | Promise<VectorSample[]>;
 type MetricType = "counter" | "gauge" | "histogram";
+
+/** One labeled series in a {@link gaugeVector}'s result. */
+export type VectorSample = { labels: Labels; value: number };
 
 export type MetricMeta = {
   help: string;
@@ -22,6 +26,12 @@ interface HistogramState {
 
 const counters = new Map<string, number>();
 const gauges = new Map<string, GaugeSample>();
+// A gauge whose LABEL SET varies scrape-to-scrape (e.g. the current top-N repos by backlog depth), rather than
+// a fixed set registered once at startup -- see gaugeVector(). Kept as a SEPARATE registry from `gauges`
+// (single-value samplers) rather than widening GaugeSample's return type: every existing gauge() call site
+// returns a plain number, and threading an alternate array-of-labeled-values shape through that same map would
+// force every reader (including renderMetrics' gauges loop) to branch on which shape a given entry holds.
+const gaugeVectors = new Map<string, GaugeVectorSample>();
 const histograms = new Map<string, HistogramState>();
 const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_queue_pending", { help: "Current in-process queue depth.", type: "gauge" }],
@@ -34,6 +44,11 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_queue_oldest_live_pending_age_seconds", { help: "Age in seconds of the oldest live pending job.", type: "gauge" }],
   ["gittensory_queue_oldest_live_runnable_age_seconds", { help: "Age in seconds of the oldest live pending job that is currently due.", type: "gauge" }],
   ["gittensory_queue_oldest_maintenance_pending_age_seconds", { help: "Age in seconds of the oldest maintenance pending job.", type: "gauge" }],
+  ["gittensory_queue_backlog_convergence_pending", { help: "Pending+processing agent-regate-pr jobs tagged foreground_lane=backlog.", type: "gauge" }],
+  ["gittensory_queue_fresh_intake_pending", { help: "Pending+processing github-webhook jobs tagged foreground_lane=fresh.", type: "gauge" }],
+  ["gittensory_queue_backlog_by_repo", { help: "Top-N repos by backlog-convergence pending depth, this scrape.", type: "gauge" }],
+  ["gittensory_jobs_claimed_by_lane_total", { help: "Foreground jobs claimed via the backlog-vs-fresh-intake fairness lane.", type: "counter" }],
+  ["gittensory_github_rest_rate_limit_remaining", { help: "Newest observed GitHub REST rate-limit remaining count, by key scope.", type: "gauge" }],
   ["gittensory_host_load_avg1_per_core", { help: "One-minute host load average normalized by CPU core count.", type: "gauge" }],
   ["gittensory_uptime_seconds", { help: "Self-host process uptime in seconds.", type: "gauge" }],
   ["gittensory_http_requests_total", { help: "HTTP app requests by response status class.", type: "counter" }],
@@ -164,6 +179,17 @@ export function gauge(name: string, sample: GaugeSample): void {
   gauges.set(name, sample);
 }
 
+/** Register a gauge whose complete set of labeled series is recomputed fresh at EVERY scrape (sync or async
+ *  sampler returning an array of `{ labels, value }`) -- for a dynamic, bounded-N breakdown (e.g. the top-10
+ *  repos by backlog depth) where the label VALUES themselves change over time, not just the numbers. Because
+ *  each scrape asks the sampler for the complete current set rather than reading back stale per-label state,
+ *  a repo that drops out of the top-10 simply stops appearing on the next scrape -- no manual
+ *  registration/deregistration bookkeeping, and no risk of a stale label lingering forever. Re-registering
+ *  replaces the sampler, same as gauge(). */
+export function gaugeVector(name: string, sample: GaugeVectorSample): void {
+  gaugeVectors.set(name, sample);
+}
+
 /** Observe a value into a histogram (created on first use). `buckets` must be ascending upper bounds. */
 export function observe(name: string, value: number, labels?: Labels, buckets: number[] = DEFAULT_BUCKETS): void {
   const k = seriesKey(name, labels);
@@ -197,6 +223,20 @@ export async function renderMetrics(): Promise<string> {
       /* a failing sampler must not break the scrape */
     }
   }
+  for (const [name, sample] of gaugeVectors) {
+    try {
+      const values = await sample();
+      // An empty result is a valid scrape (e.g. no backlog-convergence work queued anywhere right now) -- emit
+      // HELP/TYPE with zero series rather than skipping the metric name entirely, so a dashboard panel querying
+      // it sees "no data" (not present) rather than a stale metric name lingering with no TYPE line at all.
+      pushMetricMeta(lines, emittedMeta, name);
+      for (const { labels, value } of values) {
+        lines.push(`${seriesKey(name, labels)} ${value}`);
+      }
+    } catch {
+      /* a failing sampler must not break the scrape */
+    }
+  }
   for (const h of histograms.values()) {
     pushMetricMeta(lines, emittedMeta, h.name);
     for (let i = 0; i < h.buckets.length; i++) {
@@ -214,6 +254,7 @@ export async function renderMetrics(): Promise<string> {
 export function resetMetrics(): void {
   counters.clear();
   gauges.clear();
+  gaugeVectors.clear();
   histograms.clear();
   metricMeta.clear();
   for (const [name, meta] of DEFAULT_METRIC_META) metricMeta.set(name, meta);

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -138,6 +138,8 @@ import {
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
+  topBacklogRepoCounts,
+  type BacklogRepoCount,
   type ForegroundLane,
 } from "./queue-fairness";
 import {
@@ -210,6 +212,9 @@ export interface PgDurableQueue {
    *  boot and on a timer while running (see init()/start()), and exposed directly so tests and an
    *  operator-triggered repair path don't have to wait for the real interval. Returns the number released. */
   releaseStaleForegroundDeferrals(): Promise<number>;
+  /** Top-N repos by backlog-convergence pending depth, for the observability dashboard's per-repo backlog panel
+   *  (#selfhost-lane-observability). */
+  topBacklogRepos(limit: number): Promise<BacklogRepoCount[]>;
 }
 
 interface JobRow {
@@ -406,6 +411,9 @@ export function createPgQueue(
     const backlogConvergenceRes = await pool.query(
       `SELECT COUNT(*) AS cnt FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
     );
+    const freshIntakeRes = await pool.query(
+      `SELECT COUNT(*) AS cnt FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='fresh'`,
+    );
     const live = liveRes.rows[0] as {
       cnt: string | number;
       oldest: string | number | null;
@@ -414,6 +422,7 @@ export function createPgQueue(
     };
     const maintenance = maintenanceRes.rows[0] as { cnt: string | number; oldest: string | number | null };
     const backlogConvergence = backlogConvergenceRes.rows[0] as { cnt: string | number };
+    const freshIntake = freshIntakeRes.rows[0] as { cnt: string | number };
     return {
       livePendingCount: Number(live.cnt),
       oldestLivePendingAgeMs: live.oldest != null ? now - Number(live.oldest) : null,
@@ -422,8 +431,24 @@ export function createPgQueue(
       maintenancePendingCount: Number(maintenance.cnt),
       oldestMaintenancePendingAgeMs: maintenance.oldest != null ? now - Number(maintenance.oldest) : null,
       backlogConvergencePendingCount: Number(backlogConvergence.cnt),
+      freshIntakePendingCount: Number(freshIntake.cnt),
       hostLoadAvg1PerCore: hostLoadAvg1PerCore(),
     };
+  }
+
+  /** Top-N repos by backlog-convergence pending DEPTH, for the observability dashboard's per-repo backlog panel
+   *  (#selfhost-lane-observability) -- a snapshot read, distinct from claimNextForegroundLane's own backlog
+   *  query (which is scoped to run_after<=now and only reads job_key+created_at for the round-robin picker).
+   *  This one counts EVERY pending+processing backlog-lane row regardless of run_after, matching the "how deep
+   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set. */
+  async function topBacklogRepos(limit: number): Promise<BacklogRepoCount[]> {
+    const res = await pool.query(
+      `SELECT job_key FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
+    );
+    return topBacklogRepoCounts(
+      (res.rows as Array<{ job_key: string | null }>).map((row) => ({ jobKey: row.job_key })),
+      limit,
+    );
   }
 
   async function recoverProcessingJobs(): Promise<number> {
@@ -787,7 +812,9 @@ export function createPgQueue(
     const sequence = fairness ? Number(fairness.claim_sequence) : 0;
     const lane: ForegroundLane = nextForegroundLane(sequence);
     if (lane === "fresh") {
-      return claimNextWhere(now, "priority >= $2", { sql: "foreground_lane='fresh'", params: [] });
+      const freshRow = await claimNextWhere(now, "priority >= $2", { sql: "foreground_lane='fresh'", params: [] });
+      if (freshRow) incr("gittensory_jobs_claimed_by_lane_total", { lane: "fresh" });
+      return freshRow;
     }
     const backlogRes = await pool.query(
       `SELECT job_key, created_at FROM ${TABLE} WHERE status='pending' AND run_after<=$1 AND foreground_lane='backlog'`,
@@ -808,6 +835,7 @@ export function createPgQueue(
     });
     if (row) {
       await pool.query(`UPDATE ${FAIRNESS_TABLE} SET last_backlog_repo=$1 WHERE id='singleton'`, [repo]);
+      incr("gittensory_jobs_claimed_by_lane_total", { lane: "backlog" });
     }
     return row;
   }
@@ -1288,6 +1316,7 @@ export function createPgQueue(
     pressureSignals() {
       return maintenancePressureSignals(Date.now());
     },
+    topBacklogRepos,
   };
 
   async function reclaimExpiredProcessingJobs(): Promise<number> {

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -134,11 +134,11 @@ import {
   type MaintenancePressureSignals,
 } from "./maintenance-admission";
 import {
+  AGENT_REGATE_PR_JOB_KEY_PREFIX,
   backlogRepoCandidatesFromJobKeys,
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
-  topBacklogRepoCounts,
   type BacklogRepoCount,
   type ForegroundLane,
 } from "./queue-fairness";
@@ -440,15 +440,33 @@ export function createPgQueue(
    *  (#selfhost-lane-observability) -- a snapshot read, distinct from claimNextForegroundLane's own backlog
    *  query (which is scoped to run_after<=now and only reads job_key+created_at for the round-robin picker).
    *  This one counts EVERY pending+processing backlog-lane row regardless of run_after, matching the "how deep
-   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set. */
+   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set.
+   *  The COUNT/GROUP BY/ORDER BY/LIMIT run IN SQL (gate review, #selfhost-lane-observability) -- a self-host
+   *  install with a large real backlog must never pull every matching job_key into JS on every /metrics scrape
+   *  just to throw away all but the top 10; only the final, already-bounded rows ever leave the DB. */
   async function topBacklogRepos(limit: number): Promise<BacklogRepoCount[]> {
     const res = await pool.query(
-      `SELECT job_key FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
+      `WITH backlog_rest AS (
+         SELECT substring(job_key, length($1) + 1) AS rest
+           FROM ${TABLE}
+          WHERE status IN ('pending','processing') AND foreground_lane='backlog' AND job_key LIKE $2
+       ),
+       backlog_repos AS (
+         SELECT CASE WHEN position('#' in rest) > 0 THEN substring(rest, 1, position('#' in rest) - 1) ELSE rest END AS repo
+           FROM backlog_rest
+       )
+       SELECT repo, COUNT(*) AS cnt
+         FROM backlog_repos
+        WHERE repo != ''
+        GROUP BY repo
+        ORDER BY cnt DESC, repo ASC
+        LIMIT $3`,
+      [AGENT_REGATE_PR_JOB_KEY_PREFIX, `${AGENT_REGATE_PR_JOB_KEY_PREFIX}%`, Math.max(0, limit)],
     );
-    return topBacklogRepoCounts(
-      (res.rows as Array<{ job_key: string | null }>).map((row) => ({ jobKey: row.job_key })),
-      limit,
-    );
+    return (res.rows as Array<{ repo: string; cnt: string | number }>).map((row) => ({
+      repo: row.repo,
+      count: Number(row.cnt),
+    }));
   }
 
   async function recoverProcessingJobs(): Promise<number> {

--- a/src/selfhost/queue-fairness.ts
+++ b/src/selfhost/queue-fairness.ts
@@ -115,3 +115,34 @@ export function backlogRepoCandidatesFromJobKeys(
   }
   return [...oldestAgeByRepo.entries()].map(([repo, oldestPendingAgeMs]) => ({ repo, oldestPendingAgeMs }));
 }
+
+export type BacklogRepoCount = { repo: string; count: number };
+
+/**
+ * Top-N repos by backlog-convergence pending DEPTH (count), for the observability dashboard's per-repo backlog
+ * panel (#selfhost-lane-observability) -- deliberately a SEPARATE aggregate from
+ * {@link backlogRepoCandidatesFromJobKeys} (which tracks oldest-age for the claim-time round-robin) rather than
+ * widening that already-shipped, tested shape: the two callers want different rollups of the same raw rows and
+ * have no reason to share a return type. Reuses the identical `agent-regate-pr:{repo}#{pr}` job_key parsing
+ * idiom so a row with no/malformed job_key is skipped the same way in both places. Sorted by count DESCENDING,
+ * ties broken by repo name ascending (deterministic rendering — two repos with an identical backlog depth must
+ * not reorder between scrapes). `limit` bounds the returned array so a large multi-repo self-host install can
+ * never explode the dashboard's per-repo label cardinality (#selfhost-lane-observability). Pure. */
+export function topBacklogRepoCounts(
+  rows: readonly { jobKey: string | null | undefined }[],
+  limit: number,
+): BacklogRepoCount[] {
+  const countByRepo = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.jobKey || !row.jobKey.startsWith(AGENT_REGATE_PR_JOB_KEY_PREFIX)) continue;
+    const rest = row.jobKey.slice(AGENT_REGATE_PR_JOB_KEY_PREFIX.length);
+    const hashIndex = rest.indexOf("#");
+    const repo = hashIndex === -1 ? rest : rest.slice(0, hashIndex);
+    if (!repo) continue;
+    countByRepo.set(repo, (countByRepo.get(repo) ?? 0) + 1);
+  }
+  return [...countByRepo.entries()]
+    .map(([repo, count]) => ({ repo, count }))
+    .sort((a, b) => b.count - a.count || a.repo.localeCompare(b.repo))
+    .slice(0, Math.max(0, limit));
+}

--- a/src/selfhost/queue-fairness.ts
+++ b/src/selfhost/queue-fairness.ts
@@ -88,7 +88,11 @@ export function pickBacklogRepo(candidates: readonly BacklogRepoCandidate[], las
   return (sorted[(lastIndex + 1) % sorted.length] as BacklogRepoCandidate).repo;
 }
 
-const AGENT_REGATE_PR_JOB_KEY_PREFIX = "agent-regate-pr:";
+// Exported so the queue backends' own topBacklogRepos SQL (COUNT/GROUP BY/ORDER BY/LIMIT pushed into the
+// database, #selfhost-lane-observability gate review) can bind the identical prefix rather than duplicating
+// the literal — this module stays the single source of truth for the `agent-regate-pr:{repo}#{pr}` job_key
+// shape (queue-common.ts's jobCoalesceKey).
+export const AGENT_REGATE_PR_JOB_KEY_PREFIX = "agent-regate-pr:";
 
 /**
  * Derive per-repo backlog candidates from raw pending backlog-lane job rows (job_key + created_at), rather than
@@ -117,32 +121,3 @@ export function backlogRepoCandidatesFromJobKeys(
 }
 
 export type BacklogRepoCount = { repo: string; count: number };
-
-/**
- * Top-N repos by backlog-convergence pending DEPTH (count), for the observability dashboard's per-repo backlog
- * panel (#selfhost-lane-observability) -- deliberately a SEPARATE aggregate from
- * {@link backlogRepoCandidatesFromJobKeys} (which tracks oldest-age for the claim-time round-robin) rather than
- * widening that already-shipped, tested shape: the two callers want different rollups of the same raw rows and
- * have no reason to share a return type. Reuses the identical `agent-regate-pr:{repo}#{pr}` job_key parsing
- * idiom so a row with no/malformed job_key is skipped the same way in both places. Sorted by count DESCENDING,
- * ties broken by repo name ascending (deterministic rendering — two repos with an identical backlog depth must
- * not reorder between scrapes). `limit` bounds the returned array so a large multi-repo self-host install can
- * never explode the dashboard's per-repo label cardinality (#selfhost-lane-observability). Pure. */
-export function topBacklogRepoCounts(
-  rows: readonly { jobKey: string | null | undefined }[],
-  limit: number,
-): BacklogRepoCount[] {
-  const countByRepo = new Map<string, number>();
-  for (const row of rows) {
-    if (!row.jobKey || !row.jobKey.startsWith(AGENT_REGATE_PR_JOB_KEY_PREFIX)) continue;
-    const rest = row.jobKey.slice(AGENT_REGATE_PR_JOB_KEY_PREFIX.length);
-    const hashIndex = rest.indexOf("#");
-    const repo = hashIndex === -1 ? rest : rest.slice(0, hashIndex);
-    if (!repo) continue;
-    countByRepo.set(repo, (countByRepo.get(repo) ?? 0) + 1);
-  }
-  return [...countByRepo.entries()]
-    .map(([repo, count]) => ({ repo, count }))
-    .sort((a, b) => b.count - a.count || a.repo.localeCompare(b.repo))
-    .slice(0, Math.max(0, limit));
-}

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -54,6 +54,8 @@ import {
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
+  topBacklogRepoCounts,
+  type BacklogRepoCount,
   type ForegroundLane,
 } from "./queue-fairness";
 import {
@@ -127,6 +129,9 @@ export interface DurableQueue {
    *  boot and on a timer while running (see the module-init block/start()), and exposed directly so tests and
    *  an operator-triggered repair path don't have to wait for the real interval. Returns the number released. */
   releaseStaleForegroundDeferrals(): number;
+  /** Top-N repos by backlog-convergence pending depth, for the observability dashboard's per-repo backlog panel
+   *  (#selfhost-lane-observability). */
+  topBacklogRepos(limit: number): BacklogRepoCount[];
 }
 
 interface JobRow {
@@ -538,7 +543,9 @@ export function createSqliteQueue(
     const lane: ForegroundLane = nextForegroundLane(sequence);
     driver.query(`UPDATE ${FAIRNESS_TABLE} SET claim_sequence=claim_sequence+1 WHERE id='singleton'`, []);
     if (lane === "fresh") {
-      return claimNextWhere(now, "priority>=?", { sql: "foreground_lane='fresh'", params: [] });
+      const freshRow = claimNextWhere(now, "priority>=?", { sql: "foreground_lane='fresh'", params: [] });
+      if (freshRow) incr("gittensory_jobs_claimed_by_lane_total", { lane: "fresh" });
+      return freshRow;
     }
     const { rows: backlogRows } = driver.query(
       `SELECT job_key, created_at FROM ${TABLE} WHERE status='pending' AND run_after<=? AND foreground_lane='backlog'`,
@@ -559,8 +566,25 @@ export function createSqliteQueue(
     });
     if (row) {
       driver.query(`UPDATE ${FAIRNESS_TABLE} SET last_backlog_repo=? WHERE id='singleton'`, [repo]);
+      incr("gittensory_jobs_claimed_by_lane_total", { lane: "backlog" });
     }
     return row;
+  }
+
+  /** Top-N repos by backlog-convergence pending DEPTH, for the observability dashboard's per-repo backlog panel
+   *  (#selfhost-lane-observability) -- a snapshot read, distinct from claimNextForegroundLane's own backlog
+   *  query (which is scoped to run_after<=now and only reads job_key+created_at for the round-robin picker).
+   *  This one counts EVERY pending+processing backlog-lane row regardless of run_after, matching the "how deep
+   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set. */
+  function topBacklogRepos(limit: number): BacklogRepoCount[] {
+    const { rows } = driver.query(
+      `SELECT job_key FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
+      [],
+    );
+    return topBacklogRepoCounts(
+      (rows as Array<{ job_key: string | null }>).map((row) => ({ jobKey: row.job_key })),
+      limit,
+    );
   }
 
   function claimNextWhere(
@@ -1000,6 +1024,7 @@ export function createSqliteQueue(
     pressureSignals() {
       return maintenancePressureSignals(driver, Date.now());
     },
+    topBacklogRepos,
   };
 }
 
@@ -1090,6 +1115,10 @@ function maintenancePressureSignals(driver: SqliteDriver, now: number): Maintena
     `SELECT COUNT(*) as cnt FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
     [],
   ).rows[0] as { cnt: number };
+  const freshIntake = driver.query(
+    `SELECT COUNT(*) as cnt FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='fresh'`,
+    [],
+  ).rows[0] as { cnt: number };
   return {
     livePendingCount: Number(live.cnt),
     oldestLivePendingAgeMs: live.oldest != null ? now - Number(live.oldest) : null,
@@ -1098,6 +1127,7 @@ function maintenancePressureSignals(driver: SqliteDriver, now: number): Maintena
     maintenancePendingCount: Number(maintenance.cnt),
     oldestMaintenancePendingAgeMs: maintenance.oldest != null ? now - Number(maintenance.oldest) : null,
     backlogConvergencePendingCount: Number(backlogConvergence.cnt),
+    freshIntakePendingCount: Number(freshIntake.cnt),
     hostLoadAvg1PerCore: hostLoadAvg1PerCore(),
   };
 }

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -50,11 +50,11 @@ import {
   type MaintenancePressureSignals,
 } from "./maintenance-admission";
 import {
+  AGENT_REGATE_PR_JOB_KEY_PREFIX,
   backlogRepoCandidatesFromJobKeys,
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
-  topBacklogRepoCounts,
   type BacklogRepoCount,
   type ForegroundLane,
 } from "./queue-fairness";
@@ -575,16 +575,30 @@ export function createSqliteQueue(
    *  (#selfhost-lane-observability) -- a snapshot read, distinct from claimNextForegroundLane's own backlog
    *  query (which is scoped to run_after<=now and only reads job_key+created_at for the round-robin picker).
    *  This one counts EVERY pending+processing backlog-lane row regardless of run_after, matching the "how deep
-   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set. */
+   *  is each repo's backlog right now" framing of a dashboard panel rather than a claim-time eligibility set.
+   *  The COUNT/GROUP BY/ORDER BY/LIMIT run IN SQL (gate review, #selfhost-lane-observability) -- a self-host
+   *  install with a large real backlog must never pull every matching job_key into JS on every /metrics scrape
+   *  just to throw away all but the top 10; only the final, already-bounded rows ever leave the DB. */
   function topBacklogRepos(limit: number): BacklogRepoCount[] {
     const { rows } = driver.query(
-      `SELECT job_key FROM ${TABLE} WHERE status IN ('pending','processing') AND foreground_lane='backlog'`,
-      [],
+      `WITH backlog_rest AS (
+         SELECT substr(job_key, length(?) + 1) AS rest
+           FROM ${TABLE}
+          WHERE status IN ('pending','processing') AND foreground_lane='backlog' AND job_key LIKE ?
+       ),
+       backlog_repos AS (
+         SELECT CASE WHEN instr(rest, '#') > 0 THEN substr(rest, 1, instr(rest, '#') - 1) ELSE rest END AS repo
+           FROM backlog_rest
+       )
+       SELECT repo, COUNT(*) AS cnt
+         FROM backlog_repos
+        WHERE repo != ''
+        GROUP BY repo
+        ORDER BY cnt DESC, repo ASC
+        LIMIT ?`,
+      [AGENT_REGATE_PR_JOB_KEY_PREFIX, `${AGENT_REGATE_PR_JOB_KEY_PREFIX}%`, Math.max(0, limit)],
     );
-    return topBacklogRepoCounts(
-      (rows as Array<{ job_key: string | null }>).map((row) => ({ jobKey: row.job_key })),
-      limit,
-    );
+    return (rows as Array<{ repo: string; cnt: number }>).map((row) => ({ repo: row.repo, count: Number(row.cnt) }));
   }
 
   function claimNextWhere(

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { DatabaseSync } from "node:sqlite";
 import { serve } from "@hono/node-server";
 import packageJson from "../package.json";
 import worker from "./index";
+import { githubRestRateLimitRemainingSamples } from "./github/client";
 import { processJob } from "./queue/processors";
 import {
   createOpenAiCompatibleAi,
@@ -50,12 +51,13 @@ import {
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
-import { gauge, incr, observe, renderMetrics } from "./selfhost/metrics";
+import { gauge, gaugeVector, incr, observe, renderMetrics } from "./selfhost/metrics";
 import { runSelfHostMigrations } from "./selfhost/migrate";
 import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "./selfhost/pg-adapter";
 import { createPgQueue } from "./selfhost/pg-queue";
 import { createPgVectorize, initPgVectorize } from "./selfhost/pg-vectorize";
 import { resolvePostgresPoolMax, type SelfHostQueueSnapshot } from "./selfhost/queue-common";
+import type { BacklogRepoCount } from "./selfhost/queue-fairness";
 import type { MaintenancePressureSignals } from "./selfhost/maintenance-admission";
 import { createSqliteQueue } from "./selfhost/sqlite-queue";
 import { createSqliteVectorize } from "./selfhost/vectorize";
@@ -134,6 +136,7 @@ interface Backend {
     stats(): Record<string, number> | Promise<Record<string, number>>;
     pressureSignals(): MaintenancePressureSignals | Promise<MaintenancePressureSignals>;
     snapshot(): SelfHostQueueSnapshot | Promise<SelfHostQueueSnapshot>;
+    topBacklogRepos(limit: number): BacklogRepoCount[] | Promise<BacklogRepoCount[]>;
   };
   vectorize?: Vectorize;
   shutdown(): Promise<void>;
@@ -651,6 +654,22 @@ async function main(): Promise<void> {
   // -1 (not 0) when unavailable -- a genuine idle host reads 0, so a dashboard can tell "known idle" apart
   // from "no signal on this platform" (see host-pressure.ts).
   gauge("gittensory_host_load_avg1_per_core", async () => (await maintenancePressure()).hostLoadAvg1PerCore ?? -1);
+  // Backlog-vs-fresh-intake fairness lanes (#selfhost-lane-observability, see queue-fairness.ts): the SAME
+  // `foreground_lane` classification the claim-time fairness mechanism itself consults, so an operator can see
+  // whether a stuck-looking queue is actually a real, unresolved PR-review backlog (high backlog-convergence
+  // pending) or a burst of brand-new webhook traffic (high fresh-intake pending) -- two very different causes
+  // that both otherwise just show up as "live pending is high."
+  gauge("gittensory_queue_backlog_convergence_pending", async () => (await maintenancePressure()).backlogConvergencePendingCount);
+  gauge("gittensory_queue_fresh_intake_pending", async () => (await maintenancePressure()).freshIntakePendingCount);
+  // Top-10 repos by backlog-convergence depth, recomputed fresh every scrape (gaugeVector -- see metrics.ts) so
+  // a repo that drains out of the top-10 stops appearing on its own, with no stale per-repo series lingering.
+  // Bounded to 10 regardless of how many repos a self-host install has registered.
+  gaugeVector("gittensory_queue_backlog_by_repo", async () =>
+    (await backend.queue.topBacklogRepos(10)).map((r) => ({ labels: { repo: r.repo }, value: r.count })),
+  );
+  // A genuine "remaining right now" gauge, by key_scope -- gittensory_github_rest_rate_limit_observations_total
+  // only supports a bucketed rate() over a window, never the actual current value (#selfhost-lane-observability).
+  gaugeVector("gittensory_github_rest_rate_limit_remaining", () => githubRestRateLimitRemainingSamples());
   gauge("gittensory_uptime_seconds", () =>
     Math.floor((Date.now() - startedAt) / 1000),
   );

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -6,6 +6,7 @@ import {
   githubRateLimitAdmissionKeyForInstallation,
   githubRateLimitAdmissionKeyForPublicToken,
   githubRateLimitAdmissionKeyForToken,
+  githubRestRateLimitRemainingSamples,
   GITHUB_RESPONSE_CACHE_REPLAY_HEADER,
   githubResponseCacheTtlSeconds,
   isCacheableGithubUrl,
@@ -1213,6 +1214,101 @@ describe("timeoutFetch", () => {
     expect(metrics).toContain('gittensory_github_response_cache_total{class="non_get",result="bypassed"} 1');
     expect(metrics).toContain('gittensory_github_response_cache_total{class="non_github",result="bypassed"} 1');
     expect(metrics).toContain('gittensory_github_response_cache_total{class="sensitive",result="bypassed"} 1');
+  });
+});
+
+describe("githubRestRateLimitRemainingSamples (#selfhost-lane-observability)", () => {
+  function stubCoreRateLimit(remaining: string, resetIso = "2026-06-24T12:10:00.000Z"): void {
+    vi.stubGlobal("fetch", async () =>
+      new Response("ok", {
+        headers: {
+          "x-ratelimit-resource": "core",
+          "x-ratelimit-remaining": remaining,
+          "x-ratelimit-reset": String(Math.floor(Date.parse(resetIso) / 1000)),
+        },
+      }),
+    );
+  }
+
+  it("returns an empty array when no observation has ever been recorded", () => {
+    expect(githubRestRateLimitRemainingSamples()).toEqual([]);
+  });
+
+  it("returns one sample for a single observed admission key", async () => {
+    stubCoreRateLimit("42");
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(1),
+    });
+
+    expect(githubRestRateLimitRemainingSamples()).toEqual([{ labels: { key_scope: "installation" }, value: 42 }]);
+  });
+
+  it("picks the NEWEST observation among multiple admission keys sharing the same scope", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse("2026-06-24T12:00:00.000Z"));
+    stubCoreRateLimit("100");
+    // Installation 1 observed FIRST (older).
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(1),
+    });
+
+    vi.setSystemTime(Date.parse("2026-06-24T12:05:00.000Z"));
+    stubCoreRateLimit("30");
+    // Installation 2 observed LATER (newer) -- both share the "installation" scope.
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(2),
+    });
+
+    // The newer (installation 2, remaining=30) observation wins -- NOT installation 1's remaining=100, and NOT
+    // two separate series (key_scope, not admission key, is the label).
+    expect(githubRestRateLimitRemainingSamples()).toEqual([{ labels: { key_scope: "installation" }, value: 30 }]);
+  });
+
+  it("keeps the already-recorded newer observation when an OLDER one for the same scope is processed after it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse("2026-06-24T12:05:00.000Z"));
+    stubCoreRateLimit("30");
+    // Installation 2 observed FIRST in Map iteration order, and it is the NEWER of the two.
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(2),
+    });
+
+    vi.setSystemTime(Date.parse("2026-06-24T12:00:00.000Z"));
+    stubCoreRateLimit("100");
+    // Installation 1 is a NEW map key inserted SECOND, but its observation is OLDER -- exercises the "existing
+    // entry is already newer" false-comparison arm, not just the "no existing entry yet" arm.
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(1),
+    });
+
+    expect(githubRestRateLimitRemainingSamples()).toEqual([{ labels: { key_scope: "installation" }, value: 30 }]);
+  });
+
+  it("returns one sample per DISTINCT scope when scopes differ", async () => {
+    stubCoreRateLimit("10");
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(1),
+    });
+    stubCoreRateLimit("20");
+    await timeoutFetch("https://api.github.com/repos/o/r/issues", {
+      githubRateLimitAdmission: true,
+      githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForPublicToken(),
+    });
+
+    const samples = githubRestRateLimitRemainingSamples();
+    expect(samples).toHaveLength(2);
+    expect(samples).toEqual(
+      expect.arrayContaining([
+        { labels: { key_scope: "installation" }, value: 10 },
+        { labels: { key_scope: "public" }, value: 20 },
+      ]),
+    );
   });
 });
 

--- a/test/unit/selfhost-grafana-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-dashboard.test.ts
@@ -9,6 +9,8 @@ type DashboardTarget = {
   legendFormat?: string;
   queryText?: string;
   rawQueryText?: string;
+  format?: string;
+  instant?: boolean;
 };
 
 type DashboardPanel = {
@@ -175,6 +177,29 @@ describe("Gittensory Self-Host Grafana dashboard", () => {
     expect(targets.some((target) => target.expr === "sum by (actionClass) (rate(gittensory_agent_action_permission_denied_total[5m]))")).toBe(true);
     expect(targets.some((target) => target.expr === "sum by (actionClass) (rate(gittensory_agent_action_permission_denied_suppressed_total[5m]))")).toBe(true);
     expect(targets.some((target) => target.expr === "sum by (mode, result) (rate(gittensory_orb_relay_register_total[5m]))")).toBe(true);
+  });
+
+  it("surfaces the backlog-vs-fresh-intake lane fairness panels (#selfhost-lane-observability)", () => {
+    const dashboard = readDashboard(selfhostDashboardPath);
+    const targets = dashboard.panels.flatMap((panel) => panel.targets ?? []);
+    const titles = dashboard.panels.map((panel) => panel.title);
+
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        "Backlog-vs-Fresh-Intake Lane Fairness (#selfhost-lane-observability)",
+        "Backlog-Convergence Pending",
+        "Fresh-Intake Pending",
+        "GitHub REST Rate Limit Remaining (by scope)",
+        "Foreground Claims by Lane (rate)",
+        "Top Repos by Backlog Depth",
+      ]),
+    );
+    expect(targets.some((target) => target.expr === "gittensory_queue_backlog_convergence_pending")).toBe(true);
+    expect(targets.some((target) => target.expr === "gittensory_queue_fresh_intake_pending")).toBe(true);
+    expect(targets.some((target) => target.expr === "gittensory_github_rest_rate_limit_remaining")).toBe(true);
+    expect(targets.some((target) => target.legendFormat === "{{key_scope}}" && target.expr === "gittensory_github_rest_rate_limit_remaining")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum by (lane) (rate(gittensory_jobs_claimed_by_lane_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "gittensory_queue_backlog_by_repo" && target.format === "table" && target.instant === true)).toBe(true);
   });
 });
 

--- a/test/unit/selfhost-maintenance-admission.test.ts
+++ b/test/unit/selfhost-maintenance-admission.test.ts
@@ -19,6 +19,7 @@ const CLEAR_SIGNALS: MaintenancePressureSignals = {
   maintenancePendingCount: 0,
   oldestMaintenancePendingAgeMs: null,
   backlogConvergencePendingCount: 0,
+  freshIntakePendingCount: 0,
   hostLoadAvg1PerCore: null,
 };
 

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { gauge, incr, observe, registerMetricMeta, renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
+import { gauge, gaugeVector, incr, observe, registerMetricMeta, renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
 afterEach(() => resetMetrics());
 
@@ -123,6 +123,60 @@ describe("metrics registry (#982)", () => {
     });
     incr("ok_total");
     expect((await renderMetrics())).toContain("ok_total 1");
+  });
+});
+
+describe("gaugeVector (#selfhost-lane-observability)", () => {
+  it("renders one series per labeled sample, sharing one HELP/TYPE block", async () => {
+    registerMetricMeta("v", { help: "Vector gauge.", type: "gauge" });
+    gaugeVector("v", () => [
+      { labels: { repo: "owner/a" }, value: 3 },
+      { labels: { repo: "owner/b" }, value: 5 },
+    ]);
+
+    const out = await renderMetrics();
+    expect(out.match(/^# HELP v /gm)).toHaveLength(1);
+    expect(out.match(/^# TYPE v gauge$/gm)).toHaveLength(1);
+    expect(out).toContain('v{repo="owner/a"} 3');
+    expect(out).toContain('v{repo="owner/b"} 5');
+  });
+
+  it("supports an async sampler", async () => {
+    gaugeVector("async_v", async () => [{ labels: { key_scope: "public" }, value: 42 }]);
+    expect(await renderMetrics()).toContain('async_v{key_scope="public"} 42');
+  });
+
+  it("emits HELP/TYPE with zero series for an empty sample array (no data, not absent)", async () => {
+    registerMetricMeta("empty_v", { help: "Empty vector gauge.", type: "gauge" });
+    gaugeVector("empty_v", () => []);
+
+    const out = await renderMetrics();
+    expect(out).toContain("# HELP empty_v Empty vector gauge.\n# TYPE empty_v gauge\n");
+    expect(out).not.toMatch(/^empty_v\{/m);
+  });
+
+  it("a throwing sampler does not break the scrape", async () => {
+    gaugeVector("bad_v", () => {
+      throw new Error("x");
+    });
+    incr("ok_total");
+    expect(await renderMetrics()).toContain("ok_total 1");
+  });
+
+  it("re-registering the same name replaces the sampler", async () => {
+    gaugeVector("replaced_v", () => [{ labels: { x: "1" }, value: 1 }]);
+    gaugeVector("replaced_v", () => [{ labels: { x: "2" }, value: 2 }]);
+
+    const out = await renderMetrics();
+    expect(out).not.toContain('replaced_v{x="1"}');
+    expect(out).toContain('replaced_v{x="2"} 2');
+  });
+
+  it("resetMetrics clears gauge vectors", async () => {
+    gaugeVector("cleared_v", () => [{ labels: { x: "1" }, value: 1 }]);
+    resetMetrics();
+
+    expect(await renderMetrics()).toBe("\n");
   });
 });
 

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -69,15 +69,16 @@ interface MockPool {
    *  on a specific row (rowCount 0) while another succeeds (rowCount 1). */
   setReviveUpdateRowCounts(rowCounts: number[]): void;
   setRateLimitRows(rows: Array<{ admission_key?: string | null; repo_full_name?: string | null; remaining: number | string | null; reset_at: string | null; observed_at?: string | null }>): void;
-  /** Configures the three maintenance-admission pressure aggregate queries (live + maintenance + backlog-
-   *  convergence lane). Defaults to zero pending / null oldest in all lanes (pressure clear) until set.
-   *  `runnableCnt`/`oldestRunnable` back the #selfhost-queue-liveness runnable-now split (see
+  /** Configures the four maintenance-admission pressure aggregate queries (live + maintenance + backlog-
+   *  convergence + fresh-intake lane). Defaults to zero pending / null oldest in all lanes (pressure clear)
+   *  until set. `runnableCnt`/`oldestRunnable` back the #selfhost-queue-liveness runnable-now split (see
    *  maintenancePressureSignals's FILTER columns); they default to 0/null (nothing runnable) so existing tests
    *  that never set them keep working. */
   setPressureSignals(signals: {
     live?: { cnt: number; oldest: number | null; runnableCnt?: number; oldestRunnable?: number | null };
     maintenance?: { cnt: number; oldest: number | null };
     backlogConvergence?: { cnt: number };
+    freshIntake?: { cnt: number };
   }): void;
   /** Programs the exact rows returned by releaseStaleForegroundDeferrals' candidate SELECT
    *  (`WHERE status='pending' AND priority>=$1 AND run_after>$2`), and the per-row rowCount its conditional
@@ -105,6 +106,7 @@ function makePool(): MockPool {
   };
   let pressureMaintenance: { cnt: number; oldest: number | null } = { cnt: 0, oldest: null };
   let pressureBacklogConvergence: { cnt: number } = { cnt: 0 };
+  let pressureFreshIntake: { cnt: number } = { cnt: 0 };
   let foregroundLivenessCandidates: Array<{ id: string; created_at: number; payload?: string }> = [];
   const foregroundLivenessUpdateRowCounts: number[] = [];
   const DEFAULT_FOREGROUND_LIVENESS_PAYLOAD = JSON.stringify({
@@ -151,6 +153,9 @@ function makePool(): MockPool {
     }
     if (q.includes("AS cnt") && q.includes("foreground_lane='backlog'")) {
       return { rows: [{ cnt: String(pressureBacklogConvergence.cnt) }], rowCount: 1 };
+    }
+    if (q.includes("AS cnt") && q.includes("foreground_lane='fresh'")) {
+      return { rows: [{ cnt: String(pressureFreshIntake.cnt) }], rowCount: 1 };
     }
     if (q.includes("FROM github_rate_limit_observations")) {
       const admissionKey = typeof params?.[0] === "string" ? params[0] : null;
@@ -213,6 +218,7 @@ function makePool(): MockPool {
       if (signals.live) pressureLive = signals.live;
       if (signals.maintenance) pressureMaintenance = signals.maintenance;
       if (signals.backlogConvergence) pressureBacklogConvergence = signals.backlogConvergence;
+      if (signals.freshIntake) pressureFreshIntake = signals.freshIntake;
     },
     setRateLimitRows(rows) {
       rateLimitRows = rows;
@@ -1015,6 +1021,7 @@ describe("createPgQueue (durable #977)", () => {
       expect(claimSql[0]).toContain("foreground_lane='backlog'");
       expect(sequenceAllocations).toBeGreaterThan(0);
       expect(repoRecorded).toBe("owner/repo");
+      expect(await renderMetrics()).toContain('gittensory_jobs_claimed_by_lane_total{lane="backlog"} 1');
     });
 
     it("falls through to the plain unscoped foreground claim when the backlog lane has no pending candidates", async () => {
@@ -1052,6 +1059,36 @@ describe("createPgQueue (durable #977)", () => {
       // query, which still finds the untagged foreground row rather than stalling.
       expect(seen).toEqual(["recapture-preview"]);
       expect(claimSql[0]).not.toContain("foreground_lane");
+      // The unscoped fallback claim is not lane-scoped, so it must never record a lane-claim increment
+      // (#selfhost-lane-observability).
+      expect(await renderMetrics()).not.toContain("gittensory_jobs_claimed_by_lane_total");
+    });
+
+    it("records the fresh-intake lane-claim counter on a successful fresh-lane claim (#selfhost-lane-observability)", async () => {
+      let claimed = false; // one-shot: the row is only claimable until the first successful claim
+      const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+        const q = String(sql);
+        // Sequence 3 (the default 3-backlog:1-fresh ratio's 4th slot) prefers "fresh".
+        if (q.includes("UPDATE _selfhost_queue_fairness SET claim_sequence=claim_sequence+1") && q.includes("RETURNING claim_sequence, last_backlog_repo")) {
+          return { rows: [{ claim_sequence: 3, last_backlog_repo: null }], rowCount: 1 };
+        }
+        if (!claimed && q.includes("UPDATE _selfhost_jobs SET status='processing'") && q.includes("foreground_lane='fresh'")) {
+          claimed = true;
+          return {
+            rows: [{ id: "fresh-1", payload: JSON.stringify(msg("github-webhook")), attempts: 0, job_key: "github-webhook:owner/repo#1@sha", priority: 10, created_at: 1000 }],
+            rowCount: 1,
+          };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      const seen: string[] = [];
+      const q = createPgQueue({ query: fn } as unknown as Pool, async (m) => void seen.push(typeOf(m)));
+
+      await q.init();
+      await q.drain();
+
+      expect(seen).toEqual(["github-webhook"]);
+      expect(await renderMetrics()).toContain('gittensory_jobs_claimed_by_lane_total{lane="fresh"} 1');
     });
 
     it("allocates the claim sequence atomically via UPDATE ... RETURNING, not a separate SELECT-then-UPDATE (#selfhost-backlog-convergence review)", async () => {
@@ -1122,6 +1159,42 @@ describe("createPgQueue (durable #977)", () => {
         expect.stringContaining("UPDATE _selfhost_jobs SET foreground_lane=$1"),
         ["backlog", "legacy"],
       );
+    });
+  });
+
+  describe("topBacklogRepos (#selfhost-lane-observability)", () => {
+    function stubBacklogJobKeys(jobKeys: Array<string | null>): { query: Pool["query"] } {
+      return {
+        query: (async (sql: unknown) => {
+          const q = String(sql);
+          if (q.includes("SELECT job_key FROM") && q.includes("foreground_lane='backlog'")) {
+            return { rows: jobKeys.map((job_key) => ({ job_key })), rowCount: jobKeys.length };
+          }
+          return { rows: [], rowCount: 0 };
+        }) as Pool["query"],
+      };
+    }
+
+    it("returns an empty array when no backlog-lane row is pending", async () => {
+      const q = createPgQueue(stubBacklogJobKeys([]) as unknown as Pool, async () => undefined);
+      expect(await q.topBacklogRepos(10)).toEqual([]);
+    });
+
+    it("counts rows grouped by repo, sorted by depth, honoring the limit", async () => {
+      const q = createPgQueue(
+        stubBacklogJobKeys([
+          "agent-regate-pr:owner/a#1",
+          "agent-regate-pr:owner/b#1",
+          "agent-regate-pr:owner/b#2",
+          "agent-regate-pr:owner/b#3",
+          "agent-regate-pr:owner/c#1",
+        ]) as unknown as Pool,
+        async () => undefined,
+      );
+      expect(await q.topBacklogRepos(2)).toEqual([
+        { repo: "owner/b", count: 3 },
+        { repo: "owner/a", count: 1 },
+      ]);
     });
   });
 
@@ -2641,12 +2714,13 @@ describe("createPgQueue (durable #977)", () => {
       expect(await renderMetrics()).not.toContain("gittensory_jobs_maintenance_admission_granted_under_pressure_total");
     });
 
-    it("pressureSignals() surfaces the live, maintenance, and backlog-convergence aggregate reads", async () => {
+    it("pressureSignals() surfaces the live, maintenance, backlog-convergence, and fresh-intake aggregate reads", async () => {
       const m = makePool();
       m.setPressureSignals({
         live: { cnt: 2, oldest: now - 1_000 },
         maintenance: { cnt: 4, oldest: now - 2_000 },
         backlogConvergence: { cnt: 3 },
+        freshIntake: { cnt: 5 },
       });
       const q = createPgQueue(m.pool, async () => undefined);
       const signals = await q.pressureSignals();
@@ -2658,6 +2732,7 @@ describe("createPgQueue (durable #977)", () => {
         maintenancePendingCount: 4,
         oldestMaintenancePendingAgeMs: expect.any(Number),
         backlogConvergencePendingCount: 3,
+        freshIntakePendingCount: 5,
         hostLoadAvg1PerCore: null,
       });
     });

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1163,38 +1163,61 @@ describe("createPgQueue (durable #977)", () => {
   });
 
   describe("topBacklogRepos (#selfhost-lane-observability)", () => {
-    function stubBacklogJobKeys(jobKeys: Array<string | null>): { query: Pool["query"] } {
+    // The COUNT/GROUP BY/ORDER BY/LIMIT run IN SQL now (gate review) -- this mock can't execute real SQL, so it
+    // returns a pre-aggregated {repo, cnt} result set (as the real query would) and these tests verify (a) the
+    // query is scoped to the backlog lane + the agent-regate-pr job_key prefix with the limit bound as a
+    // parameter, and (b) the {repo, cnt} rows map to {repo, count} correctly. The aggregation SQL itself
+    // (substring/position extraction, GROUP BY, ORDER BY, exclusion of dead/fresh-lane/no-hash-edge rows) is
+    // verified directly against a real Postgres instance and, identically, against the real SQLite engine in
+    // selfhost-sqlite-queue.test.ts (both backends share the same query shape).
+    function stubAggregatedBacklogRepos(rows: Array<{ repo: string; cnt: string | number }>): {
+      pool: { query: Pool["query"] };
+      calls: Array<{ sql: string; params: unknown[] }>;
+    } {
+      const calls: Array<{ sql: string; params: unknown[] }> = [];
       return {
-        query: (async (sql: unknown) => {
-          const q = String(sql);
-          if (q.includes("SELECT job_key FROM") && q.includes("foreground_lane='backlog'")) {
-            return { rows: jobKeys.map((job_key) => ({ job_key })), rowCount: jobKeys.length };
-          }
-          return { rows: [], rowCount: 0 };
-        }) as Pool["query"],
+        pool: {
+          query: (async (sql: unknown, params?: unknown[]) => {
+            const q = String(sql);
+            if (q.includes("foreground_lane='backlog'") && q.includes("GROUP BY repo")) {
+              calls.push({ sql: q, params: params ?? [] });
+              return { rows, rowCount: rows.length };
+            }
+            return { rows: [], rowCount: 0 };
+          }) as Pool["query"],
+        },
+        calls,
       };
     }
 
     it("returns an empty array when no backlog-lane row is pending", async () => {
-      const q = createPgQueue(stubBacklogJobKeys([]) as unknown as Pool, async () => undefined);
+      const m = stubAggregatedBacklogRepos([]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
       expect(await q.topBacklogRepos(10)).toEqual([]);
     });
 
-    it("counts rows grouped by repo, sorted by depth, honoring the limit", async () => {
-      const q = createPgQueue(
-        stubBacklogJobKeys([
-          "agent-regate-pr:owner/a#1",
-          "agent-regate-pr:owner/b#1",
-          "agent-regate-pr:owner/b#2",
-          "agent-regate-pr:owner/b#3",
-          "agent-regate-pr:owner/c#1",
-        ]) as unknown as Pool,
-        async () => undefined,
-      );
+    it("maps aggregated {repo, cnt} rows to {repo, count}, binding the prefix, LIKE pattern, and limit as params", async () => {
+      const m = stubAggregatedBacklogRepos([
+        { repo: "owner/b", cnt: "3" },
+        { repo: "owner/a", cnt: 1 },
+      ]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
       expect(await q.topBacklogRepos(2)).toEqual([
         { repo: "owner/b", count: 3 },
         { repo: "owner/a", count: 1 },
       ]);
+      expect(m.calls).toHaveLength(1);
+      expect(m.calls[0]?.params).toEqual(["agent-regate-pr:", "agent-regate-pr:%", 2]);
+      expect(m.calls[0]?.sql).toContain("status IN ('pending','processing')");
+    });
+
+    it("clamps a negative limit to 0 rather than passing it through to SQL (LIMIT -1 means unlimited in some dialects)", async () => {
+      const m = stubAggregatedBacklogRepos([]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      await q.topBacklogRepos(-5);
+      expect(m.calls[0]?.params).toEqual(["agent-regate-pr:", "agent-regate-pr:%", 0]);
     });
   });
 

--- a/test/unit/selfhost-queue-fairness.test.ts
+++ b/test/unit/selfhost-queue-fairness.test.ts
@@ -5,6 +5,7 @@ import {
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
+  topBacklogRepoCounts,
 } from "../../src/selfhost/queue-fairness";
 
 function webhookPayload(eventName: string, action?: string): string {
@@ -188,5 +189,92 @@ describe("backlogRepoCandidatesFromJobKeys (#selfhost-backlog-convergence)", () 
   it("clamps a negative age (createdAt in the future) to zero", () => {
     const candidates = backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-pr:owner/repo#1", createdAtMs: 9000 }], 1000);
     expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 0 }]);
+  });
+});
+
+describe("topBacklogRepoCounts (#selfhost-lane-observability)", () => {
+  it("returns an empty array for no rows", () => {
+    expect(topBacklogRepoCounts([], 10)).toEqual([]);
+  });
+
+  it("skips a row with a null/undefined job_key", () => {
+    expect(topBacklogRepoCounts([{ jobKey: null }, { jobKey: undefined }], 10)).toEqual([]);
+  });
+
+  it("skips a row whose job_key does not carry the agent-regate-pr prefix", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-sweep:owner/repo" }], 10)).toEqual([]);
+  });
+
+  it("skips a row whose job_key has no repo segment after the prefix", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:#7" }], 10)).toEqual([]);
+  });
+
+  it("counts one row for a single repo", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], 10)).toEqual([{ repo: "owner/repo", count: 1 }]);
+  });
+
+  it("takes the whole remainder as the repo when the job_key has no # suffix", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo" }], 10)).toEqual([{ repo: "owner/repo", count: 1 }]);
+  });
+
+  it("aggregates multiple rows for the same repo into one count", () => {
+    const rows = [
+      { jobKey: "agent-regate-pr:owner/repo#1" },
+      { jobKey: "agent-regate-pr:owner/repo#2" },
+      { jobKey: "agent-regate-pr:owner/repo#3" },
+    ];
+    expect(topBacklogRepoCounts(rows, 10)).toEqual([{ repo: "owner/repo", count: 3 }]);
+  });
+
+  it("sorts multiple repos by count DESCENDING", () => {
+    const rows = [
+      { jobKey: "agent-regate-pr:owner/a#1" },
+      { jobKey: "agent-regate-pr:owner/b#1" },
+      { jobKey: "agent-regate-pr:owner/b#2" },
+      { jobKey: "agent-regate-pr:owner/b#3" },
+      { jobKey: "agent-regate-pr:owner/c#1" },
+      { jobKey: "agent-regate-pr:owner/c#2" },
+    ];
+    expect(topBacklogRepoCounts(rows, 10)).toEqual([
+      { repo: "owner/b", count: 3 },
+      { repo: "owner/c", count: 2 },
+      { repo: "owner/a", count: 1 },
+    ]);
+  });
+
+  it("breaks a tied count by repo name ascending, deterministically", () => {
+    const rows = [
+      { jobKey: "agent-regate-pr:owner/z#1" },
+      { jobKey: "agent-regate-pr:owner/a#1" },
+      { jobKey: "agent-regate-pr:owner/m#1" },
+    ];
+    expect(topBacklogRepoCounts(rows, 10)).toEqual([
+      { repo: "owner/a", count: 1 },
+      { repo: "owner/m", count: 1 },
+      { repo: "owner/z", count: 1 },
+    ]);
+  });
+
+  it("truncates to the requested limit, keeping the highest counts", () => {
+    const rows = [
+      { jobKey: "agent-regate-pr:owner/a#1" },
+      { jobKey: "agent-regate-pr:owner/b#1" },
+      { jobKey: "agent-regate-pr:owner/b#2" },
+      { jobKey: "agent-regate-pr:owner/c#1" },
+      { jobKey: "agent-regate-pr:owner/c#2" },
+      { jobKey: "agent-regate-pr:owner/c#3" },
+    ];
+    expect(topBacklogRepoCounts(rows, 2)).toEqual([
+      { repo: "owner/c", count: 3 },
+      { repo: "owner/b", count: 2 },
+    ]);
+  });
+
+  it("returns an empty array for a limit of 0", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], 0)).toEqual([]);
+  });
+
+  it("returns an empty array for a negative limit (clamped to 0)", () => {
+    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], -5)).toEqual([]);
   });
 });

--- a/test/unit/selfhost-queue-fairness.test.ts
+++ b/test/unit/selfhost-queue-fairness.test.ts
@@ -5,7 +5,6 @@ import {
   foregroundLaneForJob,
   nextForegroundLane,
   pickBacklogRepo,
-  topBacklogRepoCounts,
 } from "../../src/selfhost/queue-fairness";
 
 function webhookPayload(eventName: string, action?: string): string {
@@ -189,92 +188,5 @@ describe("backlogRepoCandidatesFromJobKeys (#selfhost-backlog-convergence)", () 
   it("clamps a negative age (createdAt in the future) to zero", () => {
     const candidates = backlogRepoCandidatesFromJobKeys([{ jobKey: "agent-regate-pr:owner/repo#1", createdAtMs: 9000 }], 1000);
     expect(candidates).toEqual([{ repo: "owner/repo", oldestPendingAgeMs: 0 }]);
-  });
-});
-
-describe("topBacklogRepoCounts (#selfhost-lane-observability)", () => {
-  it("returns an empty array for no rows", () => {
-    expect(topBacklogRepoCounts([], 10)).toEqual([]);
-  });
-
-  it("skips a row with a null/undefined job_key", () => {
-    expect(topBacklogRepoCounts([{ jobKey: null }, { jobKey: undefined }], 10)).toEqual([]);
-  });
-
-  it("skips a row whose job_key does not carry the agent-regate-pr prefix", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-sweep:owner/repo" }], 10)).toEqual([]);
-  });
-
-  it("skips a row whose job_key has no repo segment after the prefix", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:#7" }], 10)).toEqual([]);
-  });
-
-  it("counts one row for a single repo", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], 10)).toEqual([{ repo: "owner/repo", count: 1 }]);
-  });
-
-  it("takes the whole remainder as the repo when the job_key has no # suffix", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo" }], 10)).toEqual([{ repo: "owner/repo", count: 1 }]);
-  });
-
-  it("aggregates multiple rows for the same repo into one count", () => {
-    const rows = [
-      { jobKey: "agent-regate-pr:owner/repo#1" },
-      { jobKey: "agent-regate-pr:owner/repo#2" },
-      { jobKey: "agent-regate-pr:owner/repo#3" },
-    ];
-    expect(topBacklogRepoCounts(rows, 10)).toEqual([{ repo: "owner/repo", count: 3 }]);
-  });
-
-  it("sorts multiple repos by count DESCENDING", () => {
-    const rows = [
-      { jobKey: "agent-regate-pr:owner/a#1" },
-      { jobKey: "agent-regate-pr:owner/b#1" },
-      { jobKey: "agent-regate-pr:owner/b#2" },
-      { jobKey: "agent-regate-pr:owner/b#3" },
-      { jobKey: "agent-regate-pr:owner/c#1" },
-      { jobKey: "agent-regate-pr:owner/c#2" },
-    ];
-    expect(topBacklogRepoCounts(rows, 10)).toEqual([
-      { repo: "owner/b", count: 3 },
-      { repo: "owner/c", count: 2 },
-      { repo: "owner/a", count: 1 },
-    ]);
-  });
-
-  it("breaks a tied count by repo name ascending, deterministically", () => {
-    const rows = [
-      { jobKey: "agent-regate-pr:owner/z#1" },
-      { jobKey: "agent-regate-pr:owner/a#1" },
-      { jobKey: "agent-regate-pr:owner/m#1" },
-    ];
-    expect(topBacklogRepoCounts(rows, 10)).toEqual([
-      { repo: "owner/a", count: 1 },
-      { repo: "owner/m", count: 1 },
-      { repo: "owner/z", count: 1 },
-    ]);
-  });
-
-  it("truncates to the requested limit, keeping the highest counts", () => {
-    const rows = [
-      { jobKey: "agent-regate-pr:owner/a#1" },
-      { jobKey: "agent-regate-pr:owner/b#1" },
-      { jobKey: "agent-regate-pr:owner/b#2" },
-      { jobKey: "agent-regate-pr:owner/c#1" },
-      { jobKey: "agent-regate-pr:owner/c#2" },
-      { jobKey: "agent-regate-pr:owner/c#3" },
-    ];
-    expect(topBacklogRepoCounts(rows, 2)).toEqual([
-      { repo: "owner/c", count: 3 },
-      { repo: "owner/b", count: 2 },
-    ]);
-  });
-
-  it("returns an empty array for a limit of 0", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], 0)).toEqual([]);
-  });
-
-  it("returns an empty array for a negative limit (clamped to 0)", () => {
-    expect(topBacklogRepoCounts([{ jobKey: "agent-regate-pr:owner/repo#1" }], -5)).toEqual([]);
   });
 });

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1503,6 +1503,116 @@ describe("createSqliteQueue (durable #980)", () => {
       const row = driver.query("SELECT foreground_lane FROM _selfhost_jobs", []).rows[0] as { foreground_lane: string | null };
       expect(row.foreground_lane).toBe("fresh");
     });
+
+    it("increments the lane-claim counter on a successful backlog-lane claim (#selfhost-lane-observability)", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined, { concurrency: 1 });
+      await q.binding.send(backlogJob("owner/repo", 1));
+      await q.drain();
+      expect(await renderMetrics()).toContain('gittensory_jobs_claimed_by_lane_total{lane="backlog"} 1');
+      expect(await renderMetrics()).not.toContain('lane="fresh"');
+    });
+
+    it("increments the lane-claim counter on a successful fresh-intake claim (#selfhost-lane-observability)", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined, { concurrency: 1 });
+      // Sequence 0/1/2 prefer "backlog" (default 3:1 ratio) -- pre-populate 3 backlog rows so those claims
+      // actually hit the backlog-scoped branch, THEN sequence 3 prefers "fresh" and the fresh row is pending,
+      // so the scoped fresh claim itself (not the unscoped fallback) is what claims it.
+      await q.binding.send(backlogJob("owner/repo", 1));
+      await q.binding.send(backlogJob("owner/repo", 2));
+      await q.binding.send(backlogJob("owner/repo", 3));
+      await q.binding.send(prWebhook("fresh-1"));
+      await q.drain();
+      expect(await renderMetrics()).toContain('gittensory_jobs_claimed_by_lane_total{lane="fresh"} 1');
+      expect(await renderMetrics()).toContain('gittensory_jobs_claimed_by_lane_total{lane="backlog"} 3');
+    });
+
+    it("does NOT increment the lane-claim counter when the preferred lane has nothing pending (falls through unscoped)", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined, { concurrency: 1 });
+      // Sequence 0 prefers "backlog", but only a "fresh" row is pending -- the backlog-scoped claim misses (no
+      // increment) and the row is claimed via the PLAIN UNSCOPED fallback (claimNext()'s own `??`), not via
+      // claimNextForegroundLane's "fresh" branch -- so NEITHER lane value is recorded for this claim.
+      await q.binding.send(prWebhook("fresh-only"));
+      await q.drain();
+      expect(await renderMetrics()).not.toContain("gittensory_jobs_claimed_by_lane_total");
+    });
+
+    it("does NOT increment the lane-claim counter when the picked repo's candidate row can't actually be claimed (defensive)", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined, { concurrency: 1 });
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, 'pending', 0, 0, 1000, 0, ?, 'backlog')",
+        [JSON.stringify(backlogJob("owner/repo", 1)), "agent-regate-pr:owner/repo#1"],
+      );
+      await q.drain();
+      expect(await renderMetrics()).not.toContain("gittensory_jobs_claimed_by_lane_total");
+    });
+  });
+
+  describe("topBacklogRepos (#selfhost-lane-observability)", () => {
+    const backlogJob = (repo: string, prNumber: number): JobMessage =>
+      ({
+        type: "agent-regate-pr",
+        deliveryId: `backlog-convergence:${repo}#${prNumber}`,
+        repoFullName: repo,
+        prNumber,
+        installationId: 1,
+      }) as unknown as JobMessage;
+
+    it("returns an empty array when no backlog-lane row is pending", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      expect(q.topBacklogRepos(10)).toEqual([]);
+    });
+
+    it("counts pending AND processing backlog-lane rows, grouped by repo, sorted by depth", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      const rows: Array<{ repo: string; prNumber: number; status: string }> = [
+        { repo: "owner/a", prNumber: 1, status: "pending" },
+        { repo: "owner/b", prNumber: 1, status: "pending" },
+        { repo: "owner/b", prNumber: 2, status: "processing" },
+        { repo: "owner/b", prNumber: 3, status: "pending" },
+      ];
+      for (const { repo, prNumber, status } of rows) {
+        driver.query(
+          `INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, ?, 0, 0, 1000, 9, ?, 'backlog')`,
+          [JSON.stringify(backlogJob(repo, prNumber)), status, `agent-regate-pr:${repo}#${prNumber}`],
+        );
+      }
+      expect(q.topBacklogRepos(10)).toEqual([
+        { repo: "owner/b", count: 3 },
+        { repo: "owner/a", count: 1 },
+      ]);
+    });
+
+    it("excludes fresh-lane and unclassified rows, and honors the limit", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, foreground_lane) VALUES (?, 'pending', 0, 0, 1000, 10, 'fresh')",
+        [JSON.stringify(prWebhook("fresh-1"))],
+      );
+      for (const repo of ["owner/a", "owner/b", "owner/c"]) {
+        driver.query(
+          "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, 'pending', 0, 0, 1000, 9, ?, 'backlog')",
+          [JSON.stringify(backlogJob(repo, 1)), `agent-regate-pr:${repo}#1`],
+        );
+      }
+      expect(q.topBacklogRepos(2)).toHaveLength(2);
+    });
+
+    it("excludes a terminal (dead/cancelled) backlog-lane row", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, foreground_lane) VALUES (?, 'dead', 0, 0, 1000, 9, ?, 'backlog')",
+        [JSON.stringify(backlogJob("owner/repo", 1)), "agent-regate-pr:owner/repo#1"],
+      );
+      expect(q.topBacklogRepos(10)).toEqual([]);
+    });
   });
 
   it("retries then dead-letters after maxRetries", async () => {
@@ -2961,6 +3071,7 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(signals.maintenancePendingCount).toBe(0);
       expect(signals.oldestMaintenancePendingAgeMs).toBeNull();
       expect(signals.backlogConvergencePendingCount).toBe(0);
+      expect(signals.freshIntakePendingCount).toBe(0);
       // Zero foreground rows at all -- SQLite's SUM(CASE...)/MIN(CASE...) return NULL (not 0) over a zero-row
       // aggregate group, exercising the `?? 0` nullish arm on runnable_cnt (see maintenancePressureSignals).
       expect(signals.liveRunnableNowCount).toBe(0);
@@ -2981,6 +3092,22 @@ describe("createSqliteQueue (durable #980)", () => {
       await q.binding.send(prWebhook("fresh-unrelated"));
       const signals = q.pressureSignals();
       expect(signals.backlogConvergencePendingCount).toBe(1);
+    });
+
+    it("pressureSignals() reports the fresh-intake lane pending count (#selfhost-lane-observability)", async () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      await q.binding.send(prWebhook("fresh-1"));
+      // A backlog-convergence row (foreground_lane='backlog') must NOT count toward the fresh-intake signal.
+      await q.binding.send({
+        type: "agent-regate-pr",
+        deliveryId: "backlog-convergence:owner/repo#1",
+        repoFullName: "owner/repo",
+        prNumber: 1,
+        installationId: 1,
+      } as unknown as JobMessage);
+      const signals = q.pressureSignals();
+      expect(signals.freshIntakePendingCount).toBe(1);
     });
 
     // #selfhost-queue-liveness: liveRunnableNowCount/oldestLiveRunnableAgeMs must reflect only the SUBSET of


### PR DESCRIPTION
## Summary

- Closes out the observability item from the self-host queue/convergence PR stack (`#2830`, `#2829`, `#2837`, `#2836` all merged): the dashboard could show `live` vs `maintenance` queue depth but had no visibility into the backlog-vs-fresh-intake fairness lanes (`#2829`) themselves, and GitHub REST rate-limit remaining was only a bucketed `rate()` counter — never the actual current value.
- New pending gauges: `gittensory_queue_backlog_convergence_pending` / `gittensory_queue_fresh_intake_pending`, reusing the existing `maintenancePressureSignals()` read pattern (adds a `freshIntakePendingCount` field alongside the already-shipped `backlogConvergencePendingCount`, same query shape, both queue backends).
- New `gittensory_jobs_claimed_by_lane_total{lane="backlog"|"fresh"}` counter recorded at the exact point `claimNextForegroundLane` actually claims a row in each lane (not on a miss/fallback).
- New bounded top-10-by-depth per-repo backlog panel (`gittensory_queue_backlog_by_repo`), backed by a new pure `topBacklogRepoCounts` helper (`queue-fairness.ts`) — deliberately a separate aggregate from the existing `backlogRepoCandidatesFromJobKeys` (oldest-age, used by the claim-time round-robin), not a widened version of it.
- New `gittensory_github_rest_rate_limit_remaining{key_scope}` gauge: the newest observed `x-ratelimit-remaining`, grouped by the existing small fixed `key_scope` set (`installation`/`public`/`global`/`unknown`/`other`) so cardinality never scales with installation count.
- New `gaugeVector()` primitive in `selfhost/metrics.ts` — a gauge whose complete labeled series set is recomputed fresh every scrape (for the two above: dynamic top-N repos, and the fixed-but-unknown-ahead-of-time scope set), alongside the existing single-value `gauge()`. A repo that drains out of the top-10 just stops appearing on the next scrape; no manual registration/deregistration bookkeeping.
- Six new Grafana panels (2 stat, 2 timeseries, 1 table) under a new "Backlog-vs-Fresh-Intake Lane Fairness" row.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Small enough that the summary explains why an issue is not needed — this is the last item in the already-approved self-host queue/convergence PR stack.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (unaffected — no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run db:migrations:check` (no schema change — the queue backends own their embedded DDL, not Drizzle migrations)
- [x] `npm run test:coverage` locally (full, unsharded) — 399 files / 7903 tests passing. 3 files / 4 tests fail (`opportunity-freshness`/`opportunity-branch-internals`/`opportunity-metadata-signals`) but are **pre-existing and unrelated**: they hardcode `NOW = Date.parse("2026-07-03T12:00:00.000Z")` as an injected clock fixture, and real wall-clock time has now caught up to that exact date — none of those files are touched by this diff. Flagged separately for a standalone fix.
- [ ] `npm run test:workers` (unaffected — no Worker-pool test files touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (unaffected — no MCP package changes)
- [ ] `npm run ui:openapi:check` (unaffected — no API/schema changes)
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (unaffected — no `apps/gittensory-ui` changes)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] 100% branch coverage on every new/changed line: `queue-fairness.ts`, `metrics.ts`, `maintenance-admission.ts` all at 100% branch in isolation; `github/client.ts`'s new function fully covered (file-level gaps are pre-existing, outside this diff's lines). `pg-queue.ts`/`server.ts` are Codecov-ignored per repo convention — still covered with correctness tests, not chasing the number.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] No auth/CORS/session/GitHub App paths touched — purely additive observability (new gauges/counters/dashboard panels), zero behavior change to any decision path.
- [x] No UI changes (Grafana dashboard JSON only, not `apps/gittensory-ui`).
- [x] No changelog edit.

## Notes

- Final PR in the self-host queue/convergence stack: `#2830`, `#2829`, `#2837`, `#2836` (all merged).
- Filed a separate follow-up for the pre-existing `opportunity-freshness` date-drift test failures found while running the full suite for this PR — unrelated to this change.