### PR TITLE
fix(engine): restore missing export brace and drop unresolvable node:util import

### DIFF
--- a/packages/gittensory-engine/src/governor-ledger.ts
+++ b/packages/gittensory-engine/src/governor-ledger.ts
@@ -1,5 +1,3 @@
-import { isDeepStrictEqual } from "node:util";
-
 /** Immutable governor decision vocabulary — unknown values fail closed before insert. */
 export const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
   "allowed",
@@ -46,6 +44,27 @@ function normalizeOptionalRepoFullName(repoFullName: unknown): string | null {
   return `${owner}/${repo}`;
 }
 
+// Structural equality between a JSON.parse() result and the plain object it was stringified from. One side is
+// always JSON-safe (parsed from JSON text); this only needs to compare plain objects/arrays/primitives, not the
+// full generality of node:util's isDeepStrictEqual (no Dates/RegExp/Maps/getters/symbols to worry about) — this
+// package's tsconfig deliberately sets `types: []` (no Node ambient types leak into its public .d.ts surface),
+// so importing "node:util" here isn't viable; a small local check avoids that entirely.
+function jsonRoundTripEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  const aIsArray = Array.isArray(a);
+  if (aIsArray !== Array.isArray(b)) return false;
+  if (aIsArray) {
+    const bArr = b as unknown[];
+    const aArr = a as unknown[];
+    return aArr.length === bArr.length && aArr.every((value, index) => jsonRoundTripEqual(value, bArr[index]));
+  }
+  const aKeys = Object.keys(a as object);
+  const bRecord = b as Record<string, unknown>;
+  return aKeys.length === Object.keys(bRecord).length && aKeys.every((key) => Object.hasOwn(bRecord, key) && jsonRoundTripEqual((a as Record<string, unknown>)[key], bRecord[key]));
+}
+
 function serializePayload(payload: unknown): string {
   if (payload === undefined) return "{}";
   if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
@@ -57,7 +76,7 @@ function serializePayload(payload: unknown): string {
   } catch {
     throw new Error("invalid_payload");
   }
-  if (!isDeepStrictEqual(JSON.parse(json), payload)) {
+  if (!jsonRoundTripEqual(JSON.parse(json), payload)) {
     throw new Error("invalid_payload");
   }
   return json;

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -49,6 +49,7 @@ export {
   computeLaneFit,
   type GoalModelInput,
 } from "./goal-model.js";
+export {
   classifyContributorFit,
   type ContributorFit,
   type ContributorFitCheck,


### PR DESCRIPTION
## Summary
- \`packages/gittensory-engine/src/index.ts\`: PR #2787's inserted export block landed between PR #2795's export block and its own body, eating the opening \`export {\` for the \`contributor-fit.js\` re-export. This is a hard TS1005/TS1109 syntax error that currently breaks \`npm run typecheck\` (and therefore \`npm run test:ci\`) on \`main\` for everyone.
- \`packages/gittensory-engine/src/governor-ledger.ts\`: imports \`isDeepStrictEqual\` from \`node:util\`, but this package's \`tsconfig.json\` deliberately sets \`types: []\` (keeping Node ambient types out of its public \`.d.ts\` surface for downstream consumers), so the module's type declarations never resolve — \`npm run build:miner\` fails with TS2307. Replaced with a small local structural-equality check scoped to the JSON-safe values this one call site (\`serializePayload\`, already \`v8 ignore\`d) actually compares.

## Scope
- [x] Two-line + one-block fix, both within \`packages/gittensory-engine/src\`
- [x] No behavior change outside restoring the intended pre-splice export list and pre-#2795-regression compile state

## Validation
- \`npm run typecheck\` (repo root) — clean
- \`npm run build:miner\` (repo root) — clean
- \`npm test\` inside \`packages/gittensory-engine\` — 70/70 passing (was failing to even build before this fix)

## Safety
- No secrets/wallets/hotkeys/trust-scores/reward values touched
- No public API surface change (same exports, same names)