### PR TITLE
fix(engine): stop scoring issues with unknown timestamps as maximally fresh

### DIFF
--- a/packages/gittensory-engine/src/governor-ledger.ts
+++ b/packages/gittensory-engine/src/governor-ledger.ts
@@ -1,5 +1,3 @@
-import { isDeepStrictEqual } from "node:util";
-
 /** Immutable governor decision vocabulary — unknown values fail closed before insert. */
 export const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
   "allowed",
@@ -31,6 +29,24 @@ export type NormalizedGovernorLedgerEvent = {
 const governorEventTypeSet = new Set<string>(GOVERNOR_LEDGER_EVENT_TYPES);
 
 /* v8 ignore start -- Normalization helpers are covered through normalizeGovernorLedgerEvent export tests. */
+// Self-contained structural-equality check (no node:util) so this package stays runtime-portable across the
+// Worker backend and the Node-only miner CLI. Scoped to serializePayload's own round-trip-fidelity use: both
+// sides here are always plain objects/arrays/primitives (one is a fresh JSON.parse result), so this never needs
+// to handle Maps, Dates, RegExps, or prototypes the way a general-purpose deep-equal would.
+function deepStrictEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord);
+  const bKeys = Object.keys(bRecord);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (key) => Object.prototype.hasOwnProperty.call(bRecord, key) && deepStrictEqual(aRecord[key], bRecord[key]),
+  );
+}
+
 function normalizeRequiredString(value: unknown, code: string): string {
   if (typeof value !== "string") throw new Error(code);
   const trimmed = value.trim();
@@ -57,7 +73,7 @@ function serializePayload(payload: unknown): string {
   } catch {
     throw new Error("invalid_payload");
   }
-  if (!isDeepStrictEqual(JSON.parse(json), payload)) {
+  if (!deepStrictEqual(JSON.parse(json), payload)) {
     throw new Error("invalid_payload");
   }
   return json;

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -49,6 +49,7 @@ export {
   computeLaneFit,
   type GoalModelInput,
 } from "./goal-model.js";
+export {
   classifyContributorFit,
   type ContributorFit,
   type ContributorFitCheck,

--- a/packages/gittensory-engine/src/opportunity-freshness.ts
+++ b/packages/gittensory-engine/src/opportunity-freshness.ts
@@ -26,10 +26,16 @@ function pickTimestamp(issue: FreshnessIssue): string | null {
   return null;
 }
 
+// No usable timestamp survived pickTimestamp's updatedAt->createdAt fallback -- an unknown age must never
+// register as "just updated" (age 0, the freshest possible score). Floor it to a large sentinel so
+// computeOpportunityFreshness's exponential decay clamps straight to the 0.05 floor, matching how a genuinely
+// stale issue scores, not a fresh one.
+const UNKNOWN_AGE_DAYS = 9999;
+
 function issueAgeDays(value: string | null, nowMs: number): number {
-  if (!value) return 0;
+  if (!value) return UNKNOWN_AGE_DAYS;
   const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) return 0;
+  if (!Number.isFinite(parsed)) return UNKNOWN_AGE_DAYS;
   return Math.floor((nowMs - parsed) / 86_400_000);
 }
 


### PR DESCRIPTION
## Summary

- Root-caused the reported "date-drift flakiness" in `test/unit/opportunity-branch-internals.test.ts`, `opportunity-freshness.test.ts`, and `opportunity-metadata-signals.test.ts`: it is **not** a clock/date issue. `issueAgeDays` (`packages/gittensory-engine/src/opportunity-freshness.ts`) returns `0` — the freshest possible age — whenever an open issue's `updatedAt`/`createdAt` are both missing or unparseable, deterministically, regardless of what "now" is. An issue with no usable timestamp at all was being scored as "just updated" (freshness `1`) instead of falling to the `0.05` floor a genuinely stale issue gets.
- This is a real behavioral bug, not a stale test fixture: the same PR that introduced this file's current `issueAgeDays` (#2780) has a commit explicitly titled "fall back to createdAt when updatedAt is unparseable ... so malformed updatedAt cannot score a stale issue as fresh" — the intent was already to prevent exactly this outcome, but the remaining "no valid timestamp survived either fallback" case was left returning `0`. Fixed by flooring that case to a large sentinel (`9999`), which the existing exponential decay clamps to the same `0.05` floor a stale issue reaches — matching every failing assertion across all three test files.
- While verifying this fix's own gate (`npm run typecheck` / `npm run build:miner`), found and fixed two **separate, unrelated, currently-broken-on-main** build issues blocking any PR from passing `test:ci` right now:
  - `packages/gittensory-engine/src/index.ts`: a merge collision between two concurrent PRs (#2787 and an earlier contributor-fit export) dropped the `export {` opener before the `contributor-fit.js` re-export block, leaving four bare identifiers with no enclosing statement — a hard `tsc` parse error for the whole barrel file (`Expected a semicolon` / `Expression expected`).
  - `packages/gittensory-engine/src/governor-ledger.ts`: imports `node:util`'s `isDeepStrictEqual`, which doesn't type-check under this package's `"types": []` tsconfig (no ambient Node types) and pulls a Node-only builtin into a package explicitly shared with the Worker backend. Replaced with a small self-contained structural-equality check scoped to its one call site (a JSON round-trip fidelity check, so it only ever needs to compare plain objects/arrays/primitives) — keeps the package portable, matches the file's stated "shared by the Worker backend and the Node-only miner CLI" design.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused — one root cause plus two build-blocking prerequisites discovered while verifying this fix's own gate (not opportunistic unrelated cleanup).
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Small enough that the summary explains why an issue is not needed — a targeted bug fix with an obvious repro (4 pre-existing failing assertions).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (unaffected — no workflow files touched)
- [x] `npm run typecheck` — also confirms the `index.ts` barrel-file fix (this was failing on unmodified `origin/main` before this PR)
- [x] `npm run db:migrations:check` (no schema change)
- [x] `npm run build:miner` — confirms the `governor-ledger.ts` fix (also failing on unmodified `origin/main` before this PR)
- [x] `npm run test:coverage` locally (full, unsharded) — 403 files / 7876 tests, **0 failures** (previously 4 failures across 3 files before this fix)
- [ ] `npm run test:workers` (unaffected — no Worker-pool test files touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (unaffected — no MCP package changes)
- [ ] `npm run ui:openapi:check` (unaffected — no API/schema changes)
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (unaffected — no `apps/gittensory-ui` changes)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Existing tests already fully exercise both changes: the three previously-failing files pin the `issueAgeDays` fix exactly (`.toBe(9999)` / `.toBe(0.05)`), and `test/unit/governor-ledger.test.ts`'s `{ value: undefined }` round-trip case pins the `deepStrictEqual` replacement's core behavior. No new test files needed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] No auth/CORS/session paths touched — pure logic fix in a deterministic, side-effect-free package.
- [x] No UI changes.
- [x] No changelog edit.