### PR TITLE
fix(github): do not advance checksSyncedAt on a failed check-run fetch

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -628,7 +628,7 @@ export async function backfillOpenPullRequestDetails(
   await mapWithConcurrency(batch, 2, async (pr) => {
     await upsertPullRequestDetailSyncState(env, { repoFullName: repo.fullName, pullNumber: pr.number, status: "running" });
     const before = warnings.length;
-    const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
+    const { headSha, filesSyncedAt, reviewsSyncedAt, checksSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
     const syncedAt = nowIso();
     const newWarnings = warnings.slice(before);
     await upsertPullRequestDetailSyncState(env, {
@@ -638,7 +638,7 @@ export async function backfillOpenPullRequestDetails(
       headSha,
       filesSyncedAt,
       reviewsSyncedAt,
-      checksSyncedAt: syncedAt,
+      checksSyncedAt,
       lastSyncedAt: syncedAt,
       errorSummary: newWarnings.at(-1),
     });
@@ -704,7 +704,7 @@ export async function refreshPullRequestDetails(
   const admissionKey = repoAdmissionKeyForToken(env, repo, token);
   const warnings: string[] = [];
   await upsertPullRequestDetailSyncState(env, { repoFullName, pullNumber, status: "running" });
-  const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repoFullName, pr, token, warnings, admissionKey, "live_review", { forceFiles: options.force });
+  const { headSha, filesSyncedAt, reviewsSyncedAt, checksSyncedAt } = await fetchAndStorePullRequestDetails(env, repoFullName, pr, token, warnings, admissionKey, "live_review", { forceFiles: options.force });
   const syncedAt = nowIso();
   const status: PullRequestDetailSyncStateRecord["status"] = warnings.length > 0 ? "partial" : "complete";
   await upsertPullRequestDetailSyncState(env, {
@@ -714,7 +714,7 @@ export async function refreshPullRequestDetails(
     headSha,
     filesSyncedAt,
     reviewsSyncedAt,
-    checksSyncedAt: syncedAt,
+    checksSyncedAt,
     lastSyncedAt: syncedAt,
     errorSummary: warnings.at(-1),
   });
@@ -1991,7 +1991,7 @@ async function backfillRepository(env: Env, repo: RepositoryRecord, limits: Back
     const detailWarningStart = warnings.length;
     await mapWithConcurrency(detailTargets, limits.detailConcurrency, async (pr) => {
       const before = warnings.length;
-      const { headSha, filesSyncedAt, reviewsSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
+      const { headSha, filesSyncedAt, reviewsSyncedAt, checksSyncedAt } = await fetchAndStorePullRequestDetails(env, repo.fullName, pr, token, warnings, admissionKey, "backfill_open_pr_details");
       // Persist the repo+PR+headSha snapshot marker (#audit-rate-headroom) so a later call through ANY
       // cache-aware path (open-PR convergence, live review) can skip refetching this PR's files while its
       // head is unchanged — without this write, fetchAndStorePullRequestDetails's cache check always misses
@@ -2005,7 +2005,7 @@ async function backfillRepository(env: Env, repo: RepositoryRecord, limits: Back
         headSha,
         filesSyncedAt,
         reviewsSyncedAt,
-        checksSyncedAt: syncedAt,
+        checksSyncedAt,
         lastSyncedAt: syncedAt,
         errorSummary: newWarnings.at(-1),
       });
@@ -2191,7 +2191,7 @@ async function fetchAndStorePullRequestDetails(
   admissionKey: GitHubRateLimitAdmissionKey | undefined,
   caller: PullRequestFilesFetchCaller,
   options: { forceFiles?: boolean | undefined } = {},
-): Promise<{ headSha: string | null | undefined; filesSyncedAt: string | null | undefined; reviewsSyncedAt: string | null | undefined }> {
+): Promise<{ headSha: string | null | undefined; filesSyncedAt: string | null | undefined; reviewsSyncedAt: string | null | undefined; checksSyncedAt: string | null | undefined }> {
   // Durable repo+PR+headSha file snapshot (#audit-rate-headroom): a bare URL cache is insufficient because
   // `/pulls/{n}/files` has the SAME url across different heads. Reuse the stored `pull_request_files` rows
   // instead of refetching when the last successful files sync already covered the PR's CURRENT head SHA —
@@ -2223,6 +2223,7 @@ async function fetchAndStorePullRequestDetails(
   // fetch even starts, so it's safe: any invalidation racing in from this instant onward still leaves
   // `reviewsInvalidatedAt` newer than whatever we return below, forcing a correct refetch on the NEXT pass.
   const reviewFetchStartedAt = nowIso();
+  const checkFetchStartedAt = nowIso();
   const warningStart = warnings.length;
   const [files, reviews, checks] = await Promise.all([
     filesUpToDate ? Promise.resolve<GitHubFilePayload[]>([]) : fetchPullRequestFiles(env, repoFullName, pr.number, token, warnings, admissionKey, caller),
@@ -2251,6 +2252,17 @@ async function fetchAndStorePullRequestDetails(
   // snapshot) so a skipped/failed pass never regresses a marker a concurrent call has since advanced.
   const reviewSyncFailedThisCall = !reviewsUpToDate && warnings.slice(warningStart).some((warning) => warning.startsWith(`Review sync failed for #${pr.number}:`));
   const reviewsSyncedAtResult = !reviewsUpToDate && !reviewSyncFailedThisCall ? reviewFetchStartedAt : undefined;
+  // checksSyncedAt is a "last confirmed successful checks sync" marker, exactly like filesSyncedAt (#2765) and
+  // reviewsSyncedAt (#2537) -- and the completeness signal consumes all three symmetrically
+  // (`Boolean(filesSyncedAt && reviewsSyncedAt && checksSyncedAt)` in signals/engine.ts). Checks are never
+  // cached (they refresh every call at the current head, so there is no skip path), but on a fetch FAILURE
+  // fetchPullRequestChecks pushes "Check sync failed for #N:" and stores no runs -- so the marker must NOT
+  // advance, or a PR whose checks never synced would still count as fully detailed. Returning undefined leaves
+  // the caller's upsert column untouched (partial-update contract), never stamping a "checks synced" time over
+  // a sync that did not land. This was the lone un-guarded sibling: the two callers previously stamped it to a
+  // fresh `now` unconditionally.
+  const checkSyncFailed = warnings.slice(warningStart).some((warning) => warning.startsWith(`Check sync failed for #${pr.number}:`));
+  const checksSyncedAtResult = checkSyncFailed ? undefined : checkFetchStartedAt;
 
   if (!filesUpToDate && !fileSyncFailed) {
     await deletePullRequestFiles(env, repoFullName, pr.number);
@@ -2295,7 +2307,7 @@ async function fetchAndStorePullRequestDetails(
       payload: check as unknown as Record<string, JsonValue>,
     });
   }
-  return { headSha: headShaResult, filesSyncedAt: filesSyncedAtResult, reviewsSyncedAt: reviewsSyncedAtResult };
+  return { headSha: headShaResult, filesSyncedAt: filesSyncedAtResult, reviewsSyncedAt: reviewsSyncedAtResult, checksSyncedAt: checksSyncedAtResult };
 }
 
 // GitHub caps list endpoints at 100 items/page, so a single `per_page=100` fetch silently truncates a

--- a/test/unit/backfill-file-hydration-scoping.test.ts
+++ b/test/unit/backfill-file-hydration-scoping.test.ts
@@ -320,6 +320,59 @@ describe("GitHub PR file hydration scoping (#audit-rate-headroom)", () => {
     });
   });
 
+  it("does not advance checksSyncedAt when the check-run fetch fails, even though files and reviews sync (marker parity with filesSyncedAt/reviewsSyncedAt)", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    await seedRegisteredRepo(env);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 35,
+      title: "Open PR whose check-run fetch fails while files/reviews succeed",
+      state: "open",
+      user: { login: "oktofeesh1" },
+      head: { sha: "head-1" },
+      labels: [],
+      body: "",
+    });
+    // Prior successful sync at an older head; checksSyncedAt is a known past value we assert stays put.
+    await upsertPullRequestDetailSyncState(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 35,
+      status: "complete",
+      headSha: "head-0",
+      filesSyncedAt: "2026-05-20T00:00:00.000Z",
+      reviewsSyncedAt: "2026-05-20T00:00:00.000Z",
+      checksSyncedAt: "2026-05-20T00:00:00.000Z",
+    });
+    let failChecks = true;
+    const urls = stubFetchTracking((url) => {
+      // Files and reviews succeed; only the check-runs endpoint fails on the first pass.
+      if (url.includes("/pulls/35/files")) return Response.json([{ filename: "src/new.ts", status: "added", additions: 5, deletions: 0, changes: 5 }]);
+      if (url.includes("/pulls/35/reviews")) return Response.json([]);
+      if (url.includes("/commits/head-1/check-runs")) {
+        return failChecks ? new Response("transient REST failure", { status: 503 }) : Response.json({ check_runs: [] });
+      }
+      return Response.json([]);
+    });
+
+    const failed = await refreshPullRequestDetails(env, "JSONbored/gittensory", 35);
+
+    expect(failed).toMatchObject({ status: "partial", warnings: [expect.stringContaining("Check sync failed for #35")] });
+    const afterFailure = await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 35);
+    // The failed check fetch must leave checksSyncedAt exactly where it was -- never stamp a fresh "synced now"
+    // over a sync that did not land -- while the successful files/reviews fetches DO advance their own markers.
+    expect(afterFailure?.checksSyncedAt).toBe("2026-05-20T00:00:00.000Z");
+    expect(afterFailure?.filesSyncedAt).not.toBe("2026-05-20T00:00:00.000Z");
+    expect(afterFailure?.reviewsSyncedAt).not.toBe("2026-05-20T00:00:00.000Z");
+
+    failChecks = false;
+    urls.length = 0;
+    const retried = await refreshPullRequestDetails(env, "JSONbored/gittensory", 35);
+
+    expect(retried).toMatchObject({ status: "complete", warnings: [] });
+    expect(urls.some((url) => url.includes("/commits/head-1/check-runs"))).toBe(true);
+    // Once the check fetch succeeds, the marker advances past its seeded value.
+    expect((await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 35))?.checksSyncedAt).not.toBe("2026-05-20T00:00:00.000Z");
+  });
+
   it("defers historical merged-PR file hydration when the REST budget is below the historical-backfill floor, while cheap metadata still syncs", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     await seedRegisteredRepo(env);


### PR DESCRIPTION
## What

`fetchAndStorePullRequestDetails` treats each of the three PR-detail sync markers as a *"last confirmed successful sync"* timestamp. Two of them are already guarded against a failed fetch:

- **`filesSyncedAt`** — returned as `undefined` on a failed/skipped file sync (#2765)
- **`reviewsSyncedAt`** — returned as `undefined` on a failed/skipped review sync (#2537)

`undefined` leverages `upsertPullRequestDetailSyncState`'s partial-update contract (an omitted field leaves the column unchanged), so a failed pass never stamps a fresh "synced now" over a sync that did not land.

**`checksSyncedAt` was the lone un-guarded sibling.** All three callers stamped it to a fresh `now` *unconditionally* — even when `fetchPullRequestChecks` hit a page-1 failure, pushed `Check sync failed for #N:`, and returned no runs.

## Why it matters

The completeness signal consumes the three markers **symmetrically**:

```ts
// src/signals/engine.ts
return Boolean(state?.filesSyncedAt && state?.reviewsSyncedAt && state?.checksSyncedAt);
```

So a PR whose check-run fetch failed — while its files and reviews synced fine — would still have `checksSyncedAt` set and wrongly count as *fully detailed*, despite its check data never having been confirmed. (The check rows themselves aren't corrupted — they're upserted additively, never deleted — but the marker over-reports.)

## The fix

Thread a guarded `checksSyncedAt` through `fetchAndStorePullRequestDetails`'s return and all three callers, mirroring the files/reviews handling exactly: compute a `checkSyncFailed` flag from the same warning the fetch pushes, and advance the marker only when the check fetch actually succeeds. Checks are never cached (they refresh every call at the current head), so there is no skip path — the marker simply must not advance on failure.

## Test

`test/unit/backfill-file-hydration-scoping.test.ts` — a new case where files and reviews sync successfully but the check-run fetch fails: it asserts `checksSyncedAt` stays at its prior value (while `filesSyncedAt`/`reviewsSyncedAt` advance), then that a successful retry advances it. Fails on the pre-fix unconditional stamp (marker jumps to `now`), passes with the guard. Both branches of the new `checkSyncFailed` ternary are covered.