### PR TITLE
fix(signals): recognize the fully-qualified owner/repo#N closing reference

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -2506,7 +2506,7 @@ export function buildPreflightResult(
   issueQuality?: IssueQualityReport | null | undefined,
 ): PreflightResult {
   const lane = buildLaneAdvice(repo, input.repoFullName);
-  const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssueNumbers(truncateText(input.body ?? "", PREFLIGHT_LIMITS.bodyChars))])].sort(
+  const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssueNumbers(truncateText(input.body ?? "", PREFLIGHT_LIMITS.bodyChars), input.repoFullName)])].sort(
     (left, right) => left - right,
   );
   // Flag an existing open-work cluster as a possible duplicate when it shares a
@@ -2621,7 +2621,7 @@ export function buildLocalDiffPreflightResult(
 ): LocalDiffPreflightResult {
   /* v8 ignore next -- Undefined metadata arrays are normalized at API/MCP boundaries; local analysis tests cover empty metadata behavior. */
   const changedFiles = [...new Set([...(input.changedFiles ?? []), ...(input.testFiles ?? [])])];
-  const linkedFromCommit = extractLinkedIssueNumbers([input.commitMessage, input.body, input.title].filter(Boolean).join("\n"));
+  const linkedFromCommit = extractLinkedIssueNumbers([input.commitMessage, input.body, input.title].filter(Boolean).join("\n"), input.repoFullName);
   const base = buildPreflightResult(
     {
       ...input,
@@ -5294,9 +5294,16 @@ function tokenize(value: string): string[] {
     .filter((term) => term.length > 2 && !STOPWORDS.has(term));
 }
 
-function extractLinkedIssueNumbers(text: string): number[] {
-  const matches = [...text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi)];
-  return [...new Set(matches.map((match) => Number(match[1])).filter((value) => Number.isInteger(value) && value > 0))];
+function extractLinkedIssueNumbers(text: string, repoFullName: string): number[] {
+  const numbers = [...text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi)].map((match) => Number(match[1]));
+  // GitHub also auto-closes via the fully-qualified `KEYWORD owner/repo#N` form (e.g. Renovate/Dependabot bodies).
+  // Count it only when owner/repo case-insensitively equals THIS repo — a reference to a different repo closes an
+  // issue elsewhere, not here, so it must not spoof a same-repo link. Same `\b`-anchored keywords as above (#1988).
+  const target = repoFullName.toLowerCase();
+  for (const match of text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([\w.-]+\/[\w.-]+)#(\d+)\b/gi)) {
+    if (match[1]!.toLowerCase() === target) numbers.push(Number(match[2]));
+  }
+  return [...new Set(numbers.filter((value) => Number.isInteger(value) && value > 0))];
 }
 
 function outcomeSuccessPatterns(history: ContributorOutcomeHistory): OutcomePattern[] {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -282,6 +282,29 @@ describe("signal coverage edge cases", () => {
     });
   });
 
+  it("recognizes GitHub's fully-qualified owner/repo#N closing reference, repo-scoped", () => {
+    const directRepo = repo("owner/direct");
+    const linkedIssuesFor = (body: string) =>
+      buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix cache invalidation", body }, directRepo, [issue(directRepo.fullName, 42, "Cache invalidation")], []);
+
+    // Same-repo fully-qualified closing ref (GitHub's documented `KEYWORD owner/repo#N` form) links issue 42.
+    const qualified = linkedIssuesFor("Fixes owner/direct#42");
+    expect(qualified.linkedIssues).toContain(42);
+    expect(qualified.findings.map((f) => f.code)).not.toContain("missing_linked_issue");
+
+    // …case-insensitively on owner/repo.
+    expect(linkedIssuesFor("Resolves Owner/Direct#42").linkedIssues).toContain(42);
+
+    // A cross-repo reference closes an issue elsewhere and must NOT spoof a same-repo link.
+    const crossRepo = linkedIssuesFor("Fixes other-org/other#42");
+    expect(crossRepo.linkedIssues).not.toContain(42);
+    expect(crossRepo.findings.map((f) => f.code)).toContain("missing_linked_issue");
+
+    // The bare `#N` form and word-boundary guard (#1988) are unchanged: `unfixes` is not a keyword.
+    expect(linkedIssuesFor("Closes #42").linkedIssues).toContain(42);
+    expect(linkedIssuesFor("unfixes owner/direct#42").linkedIssues).not.toContain(42);
+  });
+
   it("covers issue quality, burden, bounties, noise, and reviewability edge decisions", () => {
     const directRepo = repo("owner/direct");
     const issueRepo = repo("owner/issues", { issueDiscoveryShare: 1 });


### PR DESCRIPTION
`extractLinkedIssueNumbers` (the preflight linked-issue detector) matched only the **bare** `KEYWORD #N` closing form:

```
/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
```

The `\s+#` requires whitespace immediately before `#`, so GitHub's other **documented** auto-close syntax — the fully-qualified `KEYWORD owner/repo#N` (`Fixes octo-org/octo-repo#100`) — is silently dropped.

## Why it matters
`extractLinkedIssueNumbers` feeds `buildPreflightResult` / `buildLocalDiffPreflightResult`, whose linked-issue output drives real gating/scoring:
- **`missing_linked_issue`** preflight finding — a PR whose body says `Fixes myorg/myrepo#42` is flagged as having *no* linked issue, and `slop` receives `hasLinkedIssue: false`, tripping the `no_linked_issue_without_rationale` slop finding. A legitimately-linked PR is penalized as slop.
- **Duplicate-cluster detection** (`itemSharesPlannedLinkedIssue`) — two PRs linking the same issue via the qualified form aren't recognized as overlapping.
- **Bounty linkage** — the linked bounty issue is missed.

The qualified `owner/repo#N` form is standard — Renovate/Dependabot emit it routinely, and contributors paste fully-qualified references.

## Fix
Also match `KEYWORD owner/repo#N`, **repo-scoped**: include `N` only when `owner/repo` case-insensitively equals *this* repo. A cross-repo reference (`other-org/other#5`) closes an issue *elsewhere* and must not spoof a same-repo link — this is the correctness nuance that keeps it from over-linking. `repoFullName` is threaded from both call sites (already in scope). The bare `#N` form and the `#1988` word-boundary invariant (`unfixes …` is not a keyword) are unchanged.

| Body (repo = `owner/direct`) | Before | After |
|---|---|---|
| `Closes #10` | `[10]` | `[10]` |
| `Fixes owner/direct#42` | `[]` | `[42]` |
| `Resolves Owner/Direct#42` (case) | `[]` | `[42]` |
| `Fixes other-org/other#42` (cross-repo) | `[]` | `[]` |
| `unfixes owner/direct#42` (embedded kw) | `[]` | `[]` |

Scope note: a parallel, intentionally-independent copy lives in `src/db/repositories.ts` (`extractLinkedIssueNumbersWithOverflow`, per #1988); it is deliberately left out of scope because its consumers include a guarded code path — this PR targets the preflight/slop path only.

## Tests
Adds a regression case covering the same-repo qualified ref (links + suppresses `missing_linked_issue`), case-insensitive owner/repo match, cross-repo exclusion (still fires `missing_linked_issue`), the unchanged bare form, and the embedded-keyword guard. Verified the new cases FAIL on current `main` and PASS with the fix; `signals-coverage` + `slop` suites stay green.

No linked issue: issue creation is unavailable for this account.
