### PR TITLE
fix(orb): harden relay delivery policy for transient skip outcomes

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -26,6 +26,99 @@ const RELAY_FORWARD_EVENTS = new Set([
   "issues",
 ]);
 
+export type RelayForwardOutcome = "forwarded" | "queued" | "skipped" | "failed";
+
+/** Events brokered self-host containers need for review/actuation (excludes CI firehose + install lifecycle). */
+export function isRelayForwardableEvent(eventName: string): boolean {
+  return RELAY_FORWARD_EVENTS.has(eventName);
+}
+
+/** A persisted `orb_relay_failures` row is terminal (delete) when delivery succeeded or the event can never be relayed. */
+export function isRelayFailureRetryTerminal(outcome: RelayForwardOutcome, eventName: string): boolean {
+  if (outcome === "forwarded" || outcome === "queued") return true;
+  // Permanently non-forwardable (e.g. check_run removed from the allowlist) — the row is obsolete.
+  if (outcome === "skipped" && !isRelayForwardableEvent(eventName)) return true;
+  return false;
+}
+
+/** Whether a deferred forward attempt should INSERT into `orb_relay_failures` for the retry cron. */
+export function shouldPersistRelayFailure(
+  outcome: RelayForwardOutcome,
+  eventName: string,
+  installationId: number | null | undefined,
+): boolean {
+  if (installationId == null) return false;
+  if (!isRelayForwardableEvent(eventName)) return false;
+  // Push HTTP failure, or a forwardable event that is temporarily undeliverable (no relay_url yet,
+  // TOKEN_ENCRYPTION_SECRET absent during deploy, enrollment mid re-register, not-yet-enrolled install).
+  return outcome === "failed" || outcome === "skipped";
+}
+
+function logRelayTransientSkip(args: {
+  deliveryId: string;
+  eventName: string;
+  installationId: number;
+  phase: "initial" | "retry";
+}): void {
+  console.warn(
+    JSON.stringify({
+      level: "warn",
+      event: "orb_relay_transient_skip",
+      phase: args.phase,
+      deliveryId: args.deliveryId,
+      eventName: args.eventName,
+      installationId: args.installationId,
+      message: "Forwardable relay event skipped due to transient config — queued for retry cron",
+    }),
+  );
+}
+
+/** Record a deferred forward outcome that needs the retry cron (initial delivery path). Idempotent on delivery_id. */
+export async function persistRelayForwardOutcome(
+  env: Env,
+  args: { deliveryId: string; eventName: string; installationId: number | null | undefined; rawBody: string },
+  outcome: RelayForwardOutcome,
+): Promise<void> {
+  if (!shouldPersistRelayFailure(outcome, args.eventName, args.installationId)) return;
+  if (outcome === "skipped" && args.installationId != null) {
+    logRelayTransientSkip({
+      deliveryId: args.deliveryId,
+      eventName: args.eventName,
+      installationId: args.installationId,
+      phase: "initial",
+    });
+  }
+  await storeRelayFailure(env, {
+    deliveryId: args.deliveryId,
+    eventName: args.eventName,
+    installationId: args.installationId!,
+    rawBody: args.rawBody,
+  });
+}
+
+async function finalizeRelayFailureRetryRow(
+  env: Env,
+  row: { delivery_id: string; event_name: string; installation_id: number },
+  outcome: RelayForwardOutcome,
+): Promise<void> {
+  if (isRelayFailureRetryTerminal(outcome, row.event_name)) {
+    await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
+    return;
+  }
+  if (outcome === "skipped") {
+    logRelayTransientSkip({
+      deliveryId: row.delivery_id,
+      eventName: row.event_name,
+      installationId: row.installation_id,
+      phase: "retry",
+    });
+  }
+  await env.DB
+    .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
+    .bind(row.delivery_id)
+    .run();
+}
+
 /** HMAC-SHA256 hex over the raw event body — the relay signature BOTH sides compute (the Orb with the decrypted
  *  enrollment secret, the container with its own ORB_ENROLLMENT_SECRET). Web Crypto (worker + node). */
 export async function relaySignature(secret: string, body: string): Promise<string> {
@@ -300,23 +393,12 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
   if (!results.length) return;
 
   const retryRow = async (row: { delivery_id: string; event_name: string; installation_id: number; raw_body: string }) => {
-    const result = await forwardOrbEvent(
+    const outcome = await forwardOrbEvent(
       env,
       { eventName: row.event_name, installationId: row.installation_id, deliveryId: row.delivery_id, rawBody: row.raw_body },
       opts?.fetchImpl,
     );
-    // "skipped" is NOT always terminal: forwardOrbEvent also skips forwardable events when push relay is
-    // temporarily undeliverable (no relay_url yet, TOKEN_ENCRYPTION_SECRET absent during deploy, enrollment row
-    // mid re-register). Deleting those rows silently dropped webhook events that had already failed once.
-    // Only permanently non-forwardable events (outside RELAY_FORWARD_EVENTS, e.g. check_run) are obsolete.
-    if (result === "forwarded" || result === "queued" || (result === "skipped" && !RELAY_FORWARD_EVENTS.has(row.event_name))) {
-      await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
-    } else {
-      await env.DB
-        .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
-        .bind(row.delivery_id)
-        .run();
-    }
+    await finalizeRelayFailureRetryRow(env, row, outcome);
   };
 
   for (let i = 0; i < results.length; i += RELAY_RETRY_CONCURRENCY) {

--- a/src/orb/webhook.ts
+++ b/src/orb/webhook.ts
@@ -13,7 +13,7 @@ import { sha256Hex, verifyGitHubSignature } from "../utils/crypto";
 import { parsePositiveInt } from "../utils/json";
 import { upsertOrbInstallation } from "./installations";
 import { recordOrbPrOutcome } from "./outcomes";
-import { forwardOrbEvent, storeRelayFailure } from "./relay";
+import { forwardOrbEvent, persistRelayForwardOutcome } from "./relay";
 
 const DEFAULT_MAX_ORB_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
@@ -88,8 +88,8 @@ export async function handleOrbWebhook(c: Context<{ Bindings: Env }>): Promise<R
   return c.json({ ok: true, deliveryId, eventName, status: "received" }, 202);
 }
 
-/** Forward an Orb webhook to the brokered self-host registered for the installation, persisting a FAILED push for
- *  the retry-orb-relay cron (a temporarily-down container recovers without losing events; max 5 attempts / 1h TTL).
+/** Forward an Orb webhook to the brokered self-host registered for the installation, persisting retryable
+ *  outcomes (HTTP push failure OR transient skip for a forwardable event) for the retry-orb-relay cron.
  *  Self-contained + fail-safe (never throws) so it can run AFTER the response via {@link scheduleAfterResponse}. */
 export async function relayForward(
   env: Env,
@@ -97,12 +97,8 @@ export async function relayForward(
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
   try {
-    const relayResult = await forwardOrbEvent(env, args, fetchImpl);
-    // forwardOrbEvent returns "failed" only for an ENROLLED install (a null/absent id "skips"), so installationId is
-    // non-null here — persist the failed push so the retry-orb-relay cron re-attempts it.
-    if (relayResult === "failed") {
-      await storeRelayFailure(env, { deliveryId: args.deliveryId, eventName: args.eventName, installationId: args.installationId!, rawBody: args.rawBody });
-    }
+    const outcome = await forwardOrbEvent(env, args, fetchImpl);
+    await persistRelayForwardOutcome(env, args, outcome);
   } catch {
     /* v8 ignore next -- fail-safe: a forward/persist error must never surface from the deferred task */
   }

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -397,8 +397,9 @@ describe("retryFailedRelays", () => {
     await enroll(e, 9602); // enrolled push mode, relay not registered yet
     await storeRelayFailure(e, { deliveryId: "transient-skip", eventName: "pull_request", installationId: 9602, rawBody: "{}" });
     await retryFailedRelays(e);
-    const row = await db(e).prepare("SELECT attempts FROM orb_relay_failures WHERE delivery_id='transient-skip'").first<{ attempts: number }>();
+    const row = await db(e).prepare("SELECT attempts, last_attempt_at FROM orb_relay_failures WHERE delivery_id='transient-skip'").first<{ attempts: number; last_attempt_at: string | null }>();
     expect(row?.attempts).toBe(1); // transient skip must not delete the row — backoff and retry
+    expect(row?.last_attempt_at).toBeTruthy(); // follows normal retry bookkeeping, not a silent delete
     expect(warnLog.mock.calls.some(([line]) => String(line).includes("orb_relay_transient_skip") && String(line).includes('"phase":"retry"'))).toBe(true);
     warnLog.mockRestore();
   });

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -239,11 +239,22 @@ describe("relayForward (deferred forward + failure persistence, #orb-ack-fast)",
     expect(row).toMatchObject({ installation_id: 820, event_name: "pull_request" });
   });
 
-  it("does NOT persist when the forward is skipped (enrolled but no relay) and never throws", async () => {
+  it("persists a TRANSIENT skip (enrolled push mode, relay not registered yet) for the retry cron", async () => {
     const e = brokeredEnv();
+    const warnLog = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     await enroll(e, 821); // enrolled, but no relay registered → forwardOrbEvent skips before any fetch
     await expect(relayForward(e, { eventName: "pull_request", installationId: 821, deliveryId: "rf-skip", rawBody: "{}" })).resolves.toBeUndefined();
-    expect(await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='rf-skip'").first()).toBeFalsy();
+    const row = await db(e).prepare("SELECT installation_id, event_name FROM orb_relay_failures WHERE delivery_id='rf-skip'").first<{ installation_id: number; event_name: string }>();
+    expect(row).toMatchObject({ installation_id: 821, event_name: "pull_request" });
+    expect(warnLog.mock.calls.some(([line]) => String(line).includes("orb_relay_transient_skip") && String(line).includes('"phase":"initial"'))).toBe(true);
+    warnLog.mockRestore();
+  });
+
+  it("does NOT persist permanently non-forwardable skips (check_run)", async () => {
+    const e = brokeredEnv();
+    await enroll(e, 8211);
+    await relayForward(e, { eventName: "check_run", installationId: 8211, deliveryId: "rf-check-run", rawBody: "{}" });
+    expect(await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='rf-check-run'").first()).toBeFalsy();
   });
 });
 
@@ -382,11 +393,14 @@ describe("retryFailedRelays", () => {
 
   it("KEEPS retrying a forwardable event when forwardOrbEvent skips due to transient config (no relay URL)", async () => {
     const e = brokeredEnv();
+    const warnLog = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     await enroll(e, 9602); // enrolled push mode, relay not registered yet
     await storeRelayFailure(e, { deliveryId: "transient-skip", eventName: "pull_request", installationId: 9602, rawBody: "{}" });
     await retryFailedRelays(e);
     const row = await db(e).prepare("SELECT attempts FROM orb_relay_failures WHERE delivery_id='transient-skip'").first<{ attempts: number }>();
     expect(row?.attempts).toBe(1); // transient skip must not delete the row — backoff and retry
+    expect(warnLog.mock.calls.some(([line]) => String(line).includes("orb_relay_transient_skip") && String(line).includes('"phase":"retry"'))).toBe(true);
+    warnLog.mockRestore();
   });
 
   it("KEEPS retrying when the encryption secret is temporarily missing", async () => {

--- a/test/unit/orb-relay-policy.test.ts
+++ b/test/unit/orb-relay-policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRelayFailureRetryTerminal,
+  isRelayForwardableEvent,
+  shouldPersistRelayFailure,
+} from "../../src/orb/relay";
+
+describe("orb relay delivery policy", () => {
+  describe("isRelayForwardableEvent", () => {
+    it("includes review/actuation events and excludes CI firehose + install lifecycle", () => {
+      expect(isRelayForwardableEvent("pull_request")).toBe(true);
+      expect(isRelayForwardableEvent("check_suite")).toBe(true);
+      expect(isRelayForwardableEvent("check_run")).toBe(false);
+      expect(isRelayForwardableEvent("installation")).toBe(false);
+    });
+  });
+
+  describe("shouldPersistRelayFailure", () => {
+    it("persists HTTP failures and transient skips for forwardable events with an installation id", () => {
+      expect(shouldPersistRelayFailure("failed", "pull_request", 42)).toBe(true);
+      expect(shouldPersistRelayFailure("skipped", "pull_request", 42)).toBe(true);
+    });
+
+    it("does not persist success outcomes or permanently non-forwardable events", () => {
+      expect(shouldPersistRelayFailure("forwarded", "pull_request", 42)).toBe(false);
+      expect(shouldPersistRelayFailure("queued", "pull_request", 42)).toBe(false);
+      expect(shouldPersistRelayFailure("skipped", "check_run", 42)).toBe(false);
+      expect(shouldPersistRelayFailure("failed", "check_run", 42)).toBe(false);
+    });
+
+    it("does not persist when the installation id is absent", () => {
+      expect(shouldPersistRelayFailure("failed", "pull_request", null)).toBe(false);
+      expect(shouldPersistRelayFailure("skipped", "pull_request", undefined)).toBe(false);
+    });
+  });
+
+  describe("isRelayFailureRetryTerminal", () => {
+    it("deletes rows after successful delivery", () => {
+      expect(isRelayFailureRetryTerminal("forwarded", "pull_request")).toBe(true);
+      expect(isRelayFailureRetryTerminal("queued", "pull_request")).toBe(true);
+    });
+
+    it("deletes skipped rows only when the event is permanently non-forwardable", () => {
+      expect(isRelayFailureRetryTerminal("skipped", "check_run")).toBe(true);
+      expect(isRelayFailureRetryTerminal("skipped", "pull_request")).toBe(false);
+    });
+
+    it("keeps failed and transient-skipped forwardable rows for backoff retry", () => {
+      expect(isRelayFailureRetryTerminal("failed", "pull_request")).toBe(false);
+      expect(isRelayFailureRetryTerminal("skipped", "issues")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #2864, which merged the **retry-cron** half of the transient-skip fix. This PR completes the work with an explicit **relay delivery policy** applied on **both** paths:

| Path | #2864 (merged) | This PR |
|------|----------------|---------|
| `retryFailedRelays` | Transient `"skipped"` no longer deleted | Refactored via `finalizeRelayFailureRetryRow` + policy helpers |
| `relayForward` (initial delivery) | Still dropped transient skips | Now persists via `persistRelayForwardOutcome` |

Also adds structured `orb_relay_transient_skip` warn logs and a unit policy matrix.

## Design

| Function | Role |
|----------|------|
| `isRelayForwardableEvent` | Allowlist gate |
| `shouldPersistRelayFailure` | Initial path: persist `"failed"` + transient `"skipped"` |
| `isRelayFailureRetryTerminal` | Retry path: delete on success or permanent skip |
| `persistRelayForwardOutcome` | Initial deferred forward → `orb_relay_failures` |
| `finalizeRelayFailureRetryRow` | Retry cron row lifecycle |

## Test plan

- [x] `npx vitest run test/unit/orb-relay-policy.test.ts test/integration/orb-relay.test.ts` — 81 tests
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Transient skip retry asserts `attempts` **and** `last_attempt_at` (review nit from #2864)
- [ ] CI validate-code (Linux) — expected green; local Windows run hits unrelated bash/script failures only

## Related

- Builds on #2864 (`72c10bfb`)
- Not a duplicate of `#1950` / `#2769` (backoff for `"failed"` only)
