### PR TITLE
fix(orb): use nearest-rank index for fleet cycle percentiles

### DIFF
--- a/src/orb/analytics.ts
+++ b/src/orb/analytics.ts
@@ -53,7 +53,11 @@ function median(xs: number[]): number | null {
 
 function percentile(sorted: number[], p: number): number | null {
   if (sorted.length === 0) return null;
-  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  // Nearest-rank: the p-th percentile is the value at 1-based rank ceil(p/100 * N), i.e. index
+  // ceil(p/100 * N) - 1. `Math.floor(p/100 * N)` overshot by one rank whenever p/100 * N was an
+  // integer (e.g. P50 of an even-sized set returned the upper-half boundary — at the extreme, the
+  // maximum). Clamp both ends so p=0 and p=100 stay in range.
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
   return sorted[idx]!;
 }
 

--- a/test/unit/orb-analytics.test.ts
+++ b/test/unit/orb-analytics.test.ts
@@ -146,4 +146,16 @@ describe("computeFleetAnalytics()", () => {
     expect(a.fleet.cycleP50Ms).toBe(1000);
     expect(a.fleet.cycleP95Ms).toBe(1000);
   });
+
+  it("reports cycle P50 as a nearest-rank percentile, not the upper-half boundary", async () => {
+    const env = createTestEnv();
+    // Sorted cycle = [1000×5, 3000×5]. The P50 must be a lower-half value, never the maximum.
+    await signals(env, "fast", 5, { verdict: "merge", outcome: "merged", ms: 1000 });
+    await signals(env, "slow", 5, { verdict: "merge", outcome: "merged", ms: 3000 });
+    await register(env, "fast", "slow");
+    const a = await computeFleetAnalytics(env);
+    expect(a.instanceCount).toBe(2);
+    expect(a.fleet.cycleP50Ms).toBe(1000); // floor-based index returned 3000 (the max) here
+    expect(a.fleet.cycleP95Ms).toBe(3000);
+  });
 });


### PR DESCRIPTION
## Summary

`percentile()` in `src/orb/analytics.ts` (used for the fleet `cycleP50Ms` / `cycleP95Ms` calibration
metrics) computed its index with `Math.floor((p / 100) * N)`. That overshoots the correct nearest-rank
position by one whenever `(p / 100) * N` is an integer — so the p-th percentile returns the element one
rank too high. At the extreme this returns the **maximum**:

- `percentile([1000, 3000], 50)` → `floor(0.5 * 2) = 1` → `3000` (the max), when the P50 should be a
  lower-half value (`1000`).

This is reachable through `computeFleetAnalytics`: a fleet whose sorted cycle times are
`[1000×5, 3000×5]` reports `cycleP50Ms = 3000` instead of `1000`.

Fix: use the standard nearest-rank index `ceil(p / 100 * N) - 1`, clamped to `[0, N-1]` so `p = 0` and
`p = 100` stay in range. The sibling `median()` helper is unaffected (it interpolates and was already
correct). No new branches are introduced (the change is `Math.min`/`Math.max`/`Math.ceil` calls), so the
`sorted.length === 0` guard remains the only branch.

No linked issue: small, self-evident off-by-one correctness fix in one private helper; it changes no
public API, auth, schema, or deploy surface, so it fits the repo's `preferred` (not required)
linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/orb-analytics.test.ts` — 12 tests pass and `src/orb/analytics.ts` is at **100%
  statements/branches/functions/lines**, so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only
  change to one deterministic analytics helper touching no UI/API/OpenAPI/MCP/DB/workflow surface, so
  those jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic analytics helper fix, so
  the auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/orb-analytics.test.ts` ("reports cycle P50 as a nearest-rank
  percentile, not the upper-half boundary"): a fleet with sorted cycle `[1000×5, 3000×5]` now reports
  `cycleP50Ms = 1000` (was `3000`, the max) and `cycleP95Ms = 3000`.
