### PR TITLE
fix(orb): address transient-skip logging and test cleanup nits (#2868)

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -60,6 +60,10 @@ function logRelayTransientSkip(args: {
   installationId: number;
   phase: "initial" | "retry";
 }): void {
+  const message =
+    args.phase === "initial"
+      ? "Forwardable relay event skipped due to transient config — queued for retry cron"
+      : "Forwardable relay event skipped due to transient config — retained in retry cron with backoff";
   console.warn(
     JSON.stringify({
       level: "warn",
@@ -68,7 +72,7 @@ function logRelayTransientSkip(args: {
       deliveryId: args.deliveryId,
       eventName: args.eventName,
       installationId: args.installationId,
-      message: "Forwardable relay event skipped due to transient config — queued for retry cron",
+      message,
     }),
   );
 }
@@ -80,6 +84,12 @@ export async function persistRelayForwardOutcome(
   outcome: RelayForwardOutcome,
 ): Promise<void> {
   if (!shouldPersistRelayFailure(outcome, args.eventName, args.installationId)) return;
+  await storeRelayFailure(env, {
+    deliveryId: args.deliveryId,
+    eventName: args.eventName,
+    installationId: args.installationId!,
+    rawBody: args.rawBody,
+  });
   if (outcome === "skipped" && args.installationId != null) {
     logRelayTransientSkip({
       deliveryId: args.deliveryId,
@@ -88,12 +98,6 @@ export async function persistRelayForwardOutcome(
       phase: "initial",
     });
   }
-  await storeRelayFailure(env, {
-    deliveryId: args.deliveryId,
-    eventName: args.eventName,
-    installationId: args.installationId!,
-    rawBody: args.rawBody,
-  });
 }
 
 async function finalizeRelayFailureRetryRow(
@@ -105,6 +109,10 @@ async function finalizeRelayFailureRetryRow(
     await env.DB.prepare("DELETE FROM orb_relay_failures WHERE delivery_id = ?").bind(row.delivery_id).run();
     return;
   }
+  await env.DB
+    .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
+    .bind(row.delivery_id)
+    .run();
   if (outcome === "skipped") {
     logRelayTransientSkip({
       deliveryId: row.delivery_id,
@@ -113,10 +121,6 @@ async function finalizeRelayFailureRetryRow(
       phase: "retry",
     });
   }
-  await env.DB
-    .prepare("UPDATE orb_relay_failures SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE delivery_id = ?")
-    .bind(row.delivery_id)
-    .run();
 }
 
 /** HMAC-SHA256 hex over the raw event body — the relay signature BOTH sides compute (the Orb with the decrypted

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { issueOrbEnrollment } from "../../src/orb/broker";
 import { relayForward } from "../../src/orb/webhook";
@@ -12,6 +12,10 @@ const seedInstall = (e: Env, id: number, cols: Record<string, string | number | 
   return db(e).prepare(`INSERT INTO orb_github_installations (${keys.join(", ")}) VALUES (${keys.map(() => "?").join(", ")})`).bind(...keys.map((k) => all[k] as string | number | null)).run();
 };
 const brokeredEnv = () => createTestEnv({ ORB_BROKER_ENABLED: "true", TOKEN_ENCRYPTION_SECRET: "test-encryption-key-material-0001" });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 const enroll = async (e: Env, id: number): Promise<string> => {
   await seedInstall(e, id);
   return ((await issueOrbEnrollment(e, id)) as { secret: string }).secret;
@@ -247,7 +251,6 @@ describe("relayForward (deferred forward + failure persistence, #orb-ack-fast)",
     const row = await db(e).prepare("SELECT installation_id, event_name FROM orb_relay_failures WHERE delivery_id='rf-skip'").first<{ installation_id: number; event_name: string }>();
     expect(row).toMatchObject({ installation_id: 821, event_name: "pull_request" });
     expect(warnLog.mock.calls.some(([line]) => String(line).includes("orb_relay_transient_skip") && String(line).includes('"phase":"initial"'))).toBe(true);
-    warnLog.mockRestore();
   });
 
   it("does NOT persist permanently non-forwardable skips (check_run)", async () => {
@@ -401,7 +404,6 @@ describe("retryFailedRelays", () => {
     expect(row?.attempts).toBe(1); // transient skip must not delete the row — backoff and retry
     expect(row?.last_attempt_at).toBeTruthy(); // follows normal retry bookkeeping, not a silent delete
     expect(warnLog.mock.calls.some(([line]) => String(line).includes("orb_relay_transient_skip") && String(line).includes('"phase":"retry"'))).toBe(true);
-    warnLog.mockRestore();
   });
 
   it("KEEPS retrying when the encryption secret is temporarily missing", async () => {
@@ -455,7 +457,6 @@ describe("retryFailedRelays", () => {
     expect(row ?? null).toBeNull(); // pruned on the DELETE pass before the SELECT
     // The drop is no longer silent OR warn-only — an alertable level:error log reaches the Sentry forwarder.
     expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_events_dropped") && String(line).includes('"level":"error"'))).toBe(true);
-    errLog.mockRestore();
   });
 
   it("PRUNES expired rows (expires_at in the past) without attempting to forward", async () => {

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -774,7 +774,6 @@ describe("pullRelayPending", () => {
     expect(stale ?? null).toBeNull();
     // Pull-mode loss is now traced for the operator at error level (parity with the push-path drop).
     expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_pending_dropped") && String(line).includes('"level":"error"'))).toBe(true);
-    errLog.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2868 (merged). Addresses the non-blocking Gittensory review nits that landed on the branch after merge:

- Phase-aware `orb_relay_transient_skip` log messages (initial vs retry)
- Emit logs only **after** successful DB persistence (no false "queued" on store failure)
- `afterEach(vi.restoreAllMocks())` in orb-relay integration tests

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/orb-relay-policy.test.ts test/integration/orb-relay.test.ts` — 81 tests
