### PR TITLE
test(miner): add deny-hook fixture corpus for house-rule primitives

### DIFF
--- a/test/fixtures/deny-hooks/README.md
+++ b/test/fixtures/deny-hooks/README.md
@@ -1,0 +1,45 @@
+# Deny-hook fixture corpus (#2296)
+
+A table-driven corpus that stress-tests the deny-hook primitive
+(`packages/gittensory-miner/lib/deny-hooks.js`'s `evaluateDenyHooks`) against realistic tool-call
+shapes a future coding-agent driver will produce — file writes, shell/git commands, multi-path edits
+— beyond the hand-rolled examples in that module's own unit tests. It is driven by
+`test/unit/deny-hooks-fixtures.test.ts`.
+
+## Fixture format
+
+Each entry in `cases.ts` (`DenyHookFixture`) is:
+
+```ts
+{
+  name: string,                       // human-readable case label (shown per-test)
+  toolCall: { name, input },          // the proposed tool call to evaluate
+  rules?: DenyRule[],                 // optional; omitted → the built-in DEFAULT_DENY_RULES
+  expected: {
+    allowed: boolean,                 // the verdict evaluateDenyHooks must return
+    blockedByIncludes?: string,       // when blocked, a substring the matched rule's `reason` must contain
+  },
+}
+```
+
+The test asserts `evaluateDenyHooks(toolCall, rules).allowed === expected.allowed` for every case, and
+— for blocked cases — that the matched rule's `reason` contains `blockedByIncludes`.
+
+## Coverage
+
+Every built-in default rule is exercised on both sides (a matching call that IS blocked and a
+clearly-benign call that is NOT), plus:
+
+- **glob edge cases** — a path that superficially resembles a blocked pattern but isn't
+  (`src/environment.ts` vs `.env`) and a path blocked via a less-obvious match (`secretstore/` via the
+  `secret*` prefix);
+- **command-embedded paths** — a protected path passed as a shell argument (tokenized, not a bare path
+  field);
+- **order-independent content matching** — the git force-push guard triggering regardless of flag order;
+- **custom rules** — an empty rule set (allows everything) and a scoped exact-tool matcher.
+
+## Extending
+
+When a later phase adds a new default rule to `DEFAULT_DENY_RULES`, add fixtures here covering both a
+matching (blocked) call and a clearly-benign (allowed) call for it, so the corpus keeps the matcher
+honest before any real driver is plugged in.

--- a/test/fixtures/deny-hooks/cases.ts
+++ b/test/fixtures/deny-hooks/cases.ts
@@ -1,0 +1,117 @@
+import type { DenyRule, ProposedToolCall } from "../../../packages/gittensory-miner/lib/deny-hooks.js";
+
+// Table-driven fixture corpus for the deny-hook primitive (#2296). Each case is a realistic tool-call shape a
+// future coding-agent driver will actually produce (file writes, shell/git commands, multi-path edits). `rules`
+// omitted → the built-in DEFAULT_DENY_RULES. `expected.allowed` is the verdict; `expected.blockedByIncludes` (when
+// blocked) is a substring the matched rule's reason must contain. See README.md for the format + how to extend it.
+
+export type DenyHookFixture = {
+  name: string;
+  toolCall: ProposedToolCall;
+  rules?: DenyRule[];
+  expected: { allowed: boolean; blockedByIncludes?: string };
+};
+
+export const denyHookFixtures: DenyHookFixture[] = [
+  // ── workflow-file writes (never touch CI config) ──────────────────────────────────────────────
+  {
+    name: "blocks a write to a top-level CI workflow file",
+    toolCall: { name: "Write", input: { file_path: ".github/workflows/ci.yml" } },
+    expected: { allowed: false, blockedByIncludes: "CI workflows" },
+  },
+  {
+    name: "blocks a write to a DEEPLY-nested workflow file (** spans segments)",
+    toolCall: { name: "Write", input: { file_path: ".github/workflows/release/deploy.yml" } },
+    expected: { allowed: false, blockedByIncludes: "CI workflows" },
+  },
+  {
+    name: "blocks a workflow path EMBEDDED in a shell command (tokenized, not a bare path field)",
+    toolCall: { name: "Bash", input: { command: "cat .github/workflows/ci.yml" } },
+    expected: { allowed: false, blockedByIncludes: "CI workflows" },
+  },
+  {
+    name: "allows an ordinary source write",
+    toolCall: { name: "Write", input: { file_path: "src/signals/foo.ts" } },
+    expected: { allowed: true },
+  },
+
+  // ── env files (never read/write) ──────────────────────────────────────────────────────────────
+  { name: "blocks reading .env", toolCall: { name: "Read", input: { file_path: ".env" } }, expected: { allowed: false, blockedByIncludes: "environment files" } },
+  {
+    name: "blocks a nested .env.local",
+    toolCall: { name: "Read", input: { file_path: "apps/web/.env.local" } },
+    expected: { allowed: false, blockedByIncludes: "environment files" },
+  },
+  {
+    name: "GLOB EDGE: `src/environment.ts` is NOT an env file (segment does not start with .env)",
+    toolCall: { name: "Write", input: { file_path: "src/environment.ts" } },
+    expected: { allowed: true },
+  },
+
+  // ── secret-bearing paths ──────────────────────────────────────────────────────────────────────
+  {
+    name: "blocks a write under a secrets directory",
+    toolCall: { name: "Write", input: { file_path: "config/secrets/prod.json" } },
+    expected: { allowed: false, blockedByIncludes: "secret-bearing" },
+  },
+  {
+    name: "GLOB EDGE: blocks a less-obvious `secretstore` segment (secret* prefix match, not literal `secrets`)",
+    toolCall: { name: "Read", input: { file_path: "app/secretstore/data.bin" } },
+    expected: { allowed: false, blockedByIncludes: "secret-bearing" },
+  },
+  {
+    name: "allows an unrelated public directory",
+    toolCall: { name: "Read", input: { file_path: "config/public/prod.json" } },
+    expected: { allowed: true },
+  },
+
+  // ── private key material ──────────────────────────────────────────────────────────────────────
+  {
+    name: "blocks touching a private key file",
+    toolCall: { name: "Read", input: { file_path: "keys/id_private_key.pem" } },
+    expected: { allowed: false, blockedByIncludes: "private key" },
+  },
+  {
+    name: "allows a public-notes markdown lookalike",
+    toolCall: { name: "Read", input: { file_path: "docs/public-notes.md" } },
+    expected: { allowed: true },
+  },
+
+  // ── git force-push guard (command content, order-independent) ──────────────────────────────────
+  {
+    name: "blocks git push --force",
+    toolCall: { name: "Bash", input: { command: "git push --force origin main" } },
+    expected: { allowed: false, blockedByIncludes: "force-push" },
+  },
+  {
+    name: "blocks --force-with-lease push (contains push + --force, either order)",
+    toolCall: { name: "Bash", input: { command: "git --force-with-lease push" } },
+    expected: { allowed: false, blockedByIncludes: "force-push" },
+  },
+  { name: "allows a normal push", toolCall: { name: "Bash", input: { command: "git push origin main" } }, expected: { allowed: true } },
+  { name: "allows running the test suite", toolCall: { name: "Bash", input: { command: "npm test" } }, expected: { allowed: true } },
+
+  // ── multi-path edits + custom-rule cases ──────────────────────────────────────────────────────
+  {
+    name: "blocks a MultiEdit whose paths array includes a workflow file",
+    toolCall: { name: "MultiEdit", input: { paths: ["README.md", ".github/workflows/x.yml"] } },
+    expected: { allowed: false, blockedByIncludes: "CI workflows" },
+  },
+  {
+    name: "allows a MultiEdit over only ordinary files",
+    toolCall: { name: "MultiEdit", input: { paths: ["src/a.ts", "src/b.ts"] } },
+    expected: { allowed: true },
+  },
+  {
+    name: "an empty rule set allows everything (even a normally-blocked path)",
+    toolCall: { name: "Write", input: { file_path: ".github/workflows/ci.yml" } },
+    rules: [],
+    expected: { allowed: true },
+  },
+  {
+    name: "a custom exact-tool matcher fires only for that tool",
+    toolCall: { name: "Write", input: { file_path: "pnpm-lock.yaml" } },
+    rules: [{ matcher: "Write", pathPattern: "**/*lock*", reason: "no lockfile edits" }],
+    expected: { allowed: false, blockedByIncludes: "lockfile" },
+  },
+];

--- a/test/unit/deny-hooks-fixtures.test.ts
+++ b/test/unit/deny-hooks-fixtures.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { evaluateDenyHooks } from "../../packages/gittensory-miner/lib/deny-hooks.js";
+import { denyHookFixtures } from "../fixtures/deny-hooks/cases.js";
+
+// Data-driven deny-hook corpus (#2296): every fixture in test/fixtures/deny-hooks/cases.ts is evaluated against
+// evaluateDenyHooks and must match its expected verdict exactly, so the rule matcher is proven to generalize across
+// realistic tool-call shapes before any real coding-agent driver is plugged in.
+
+describe("deny-hook fixture corpus (#2296)", () => {
+  it("has a non-trivial number of fixtures spanning every default rule", () => {
+    expect(denyHookFixtures.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it.each(denyHookFixtures)("$name", (fixture) => {
+    const verdict = fixture.rules
+      ? evaluateDenyHooks(fixture.toolCall, fixture.rules)
+      : evaluateDenyHooks(fixture.toolCall);
+    expect(verdict.allowed).toBe(fixture.expected.allowed);
+    if (fixture.expected.allowed) {
+      expect(verdict.blockedBy).toBeUndefined();
+    } else if (fixture.expected.blockedByIncludes !== undefined) {
+      expect(verdict.blockedBy?.reason).toContain(fixture.expected.blockedByIncludes);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the table-driven **deny-hook fixture corpus** (`test/fixtures/deny-hooks/`) that exercises the merged `evaluateDenyHooks` primitive (`packages/gittensory-miner/lib/deny-hooks.js`) against realistic tool-call shapes a future coding-agent driver will actually produce — file writes, shell/git commands, multi-path edits — rather than only the hand-rolled examples in the primitive's own unit tests.

- `test/fixtures/deny-hooks/cases.ts` — 20 `{ toolCall, rules?, expected }` fixtures spanning every default rule on both sides (blocked + clearly-benign), plus **glob edge cases** (`src/environment.ts` vs `.env`; a less-obvious `secret*` prefix match), a command-embedded protected path, order-independent force-push matching, and custom-rule cases (empty rule set, scoped exact-tool matcher).
- `test/unit/deny-hooks-fixtures.test.ts` — data-driven test iterating the corpus and asserting each verdict (and the matched rule's reason) exactly.
- `test/fixtures/deny-hooks/README.md` — documents the fixture format + how to extend it when new default rules land.

Test-only and self-contained (no `src/**`, no runtime change, no new dependency); the corpus + test pass locally (`npm run typecheck` clean, 21 assertions green).

Closes #2296.

## Scope
- [x] Conventional Commit title; focused; follows CONTRIBUTING; linked issue #2296.

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new `test/unit/deny-hooks-fixtures.test.ts` passes. Test-only change under `test/**`, which Codecov does not measure.
- [ ] `npm audit` — no dependencies added.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward terms. Fixtures reference secret-bearing **path patterns** as deny targets only; no secret values.
- [x] n/a: no auth/API/UI/DB/network surface — this is a test corpus for an existing pure function.

## Notes
Additive: 2 new test files + 1 fixture README. No existing code is modified.