### PR TITLE
fix(miner): correct usedDefaultGoalSpec for non-matching goal specs

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-ranker.js
+++ b/packages/gittensory-miner/lib/opportunity-ranker.js
@@ -84,6 +84,16 @@ function collectCandidates(candidates) {
   return { normalized, skippedInvalid };
 }
 
+function rankedUsesDefaultGoalSpec(ranked, options = {}) {
+  const goalSpecsByRepo = buildGoalSpecsByRepo(options);
+  const specRepos = Object.keys(goalSpecsByRepo);
+  if (ranked.length === 0) return specRepos.length === 0;
+  return ranked.some((issue) => {
+    const target = issue.repoFullName.trim().toLowerCase();
+    return !specRepos.some((repo) => repo.trim().toLowerCase() === target);
+  });
+}
+
 /**
  * Rank metadata-only fan-out candidates locally. Never clones source, never uploads metadata, and never writes to
  * GitHub — it only composes deterministic engine signals and returns the sorted list.
@@ -99,7 +109,7 @@ export function rankCandidateIssuesWithSummary(candidates, options = {}) {
   return {
     issues: ranked,
     skippedInvalid,
-    usedDefaultGoalSpec: Object.keys(buildGoalSpecsByRepo(options)).length === 0,
+    usedDefaultGoalSpec: rankedUsesDefaultGoalSpec(ranked, options),
     defaultGoalSpec: DEFAULT_MINER_GOAL_SPEC,
   };
 }

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -100,6 +100,42 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(summary.skippedInvalid).toBe(0);
   });
 
+  it("summary reports default goal-spec usage when supplied specs do not match ranked repos", () => {
+    const summary = rankCandidateIssuesWithSummary([rawIssue()], {
+      nowMs: NOW,
+      goalSpecsByRepo: {
+        "other/repo": {
+          minerEnabled: true,
+          wantedPaths: [],
+          blockedPaths: [],
+          preferredLabels: ["feature"],
+          blockedLabels: [],
+          maxConcurrentClaims: 2,
+          issueDiscoveryPolicy: "neutral",
+        },
+      },
+    });
+    expect(summary.usedDefaultGoalSpec).toBe(true);
+  });
+
+  it("summary reports custom goal-spec usage when a ranked repo has a matching spec", () => {
+    const summary = rankCandidateIssuesWithSummary([rawIssue()], {
+      nowMs: NOW,
+      goalSpecsByRepo: {
+        "acme/widgets": {
+          minerEnabled: true,
+          wantedPaths: [],
+          blockedPaths: [],
+          preferredLabels: ["help wanted"],
+          blockedLabels: [],
+          maxConcurrentClaims: 2,
+          issueDiscoveryPolicy: "neutral",
+        },
+      },
+    });
+    expect(summary.usedDefaultGoalSpec).toBe(false);
+  });
+
   it("prefers fresher, better-labeled opportunities over stale question threads", () => {
     const ranked = rankCandidateIssues(
       [


### PR DESCRIPTION
## Summary

- Fix `rankCandidateIssuesWithSummary` so `usedDefaultGoalSpec` reflects whether ranked repos actually matched a supplied goal spec, not merely whether any goal spec map was present.

## Problem

When callers passed `goalSpecsByRepo` entries for repos that did not appear in the ranked candidate list, the summary incorrectly reported `usedDefaultGoalSpec: false` even though every ranked issue fell back to `DEFAULT_MINER_GOAL_SPEC`.

## Validation

- [x] Added regression tests for non-matching and matching goal-spec repos.
- [ ] Full CI gate on push.

## Safety

- [x] Pure local ranker change only — no network, no persistence, no secrets.
