### PR TITLE
fix(signals): floor unknown issue ages in reward-risk freshness scoring

### DIFF
--- a/src/queue-intelligence.ts
+++ b/src/queue-intelligence.ts
@@ -74,8 +74,8 @@ function computeDaysSince(isoDateString: string, now: Date): number {
   // A malformed/empty timestamp -> NaN, which flows into computePrivateBurdenReductionScore and then the
   // analyzePRQueue sort comparator (`b.score - a.score`). NaN makes Array.sort non-deterministic, and even
   // Infinity would reintroduce that (`Infinity - Infinity = NaN` when two PRs share a bad timestamp), so the
-  // fallback must be finite. 0 degrades a bad timestamp to "just-created" (lowest burden priority); mirrors the
-  // issueAgeDays guard in signals/reward-risk.ts.
+  // fallback must be finite. 0 degrades a bad timestamp to "just-created" (lowest burden priority) for queue
+  // sorting — independent of reward-risk freshness, which floors unknown issue ages to minimum freshness.
   const parsed = Date.parse(isoDateString);
   return Number.isFinite(parsed) ? (now.getTime() - parsed) / MILLISECONDS_PER_DAY : 0;
 }

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -910,3 +910,10 @@ function round(value: number): number {
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
+
+/* v8 ignore start -- Test-only export surface for branch coverage. */
+export const rewardRiskFreshnessInternals = {
+  pickIssueTimestamp,
+  issueAgeDays,
+};
+/* v8 ignore stop */

--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -834,16 +834,34 @@ function opportunityCompetitionFactor(highRiskDuplicateClusters: number, openPul
 function opportunityFreshnessFactor(issues: IssueRecord[]): number {
   const openIssues = issues.filter((issue) => issue.state === "open");
   if (openIssues.length === 0) return 0;
-  const mostRecentAgeDays = Math.min(...openIssues.map((issue) => issueAgeDays(issue.updatedAt ?? issue.createdAt)));
+  let mostRecentAgeDays = Number.POSITIVE_INFINITY;
+  for (const issue of openIssues) {
+    const ageDays = issueAgeDays(pickIssueTimestamp(issue));
+    if (ageDays < mostRecentAgeDays) mostRecentAgeDays = ageDays;
+  }
   // Freshness decays exponentially: ~1.0 at 0 days, ~0.6 at 7 days, ~0.2 at 30 days, ~0.05 at 90 days.
   return round(clamp(Math.exp(-mostRecentAgeDays / 20), 0.05, 1));
 }
 
-function issueAgeDays(value: string | null | undefined): number {
-  if (!value) return 0;
+function isParseableIssueTimestamp(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
+}
+
+function pickIssueTimestamp(issue: IssueRecord): string | null {
+  const updated = typeof issue.updatedAt === "string" ? issue.updatedAt.trim() : "";
+  if (updated && isParseableIssueTimestamp(updated)) return updated;
+
+  const created = typeof issue.createdAt === "string" ? issue.createdAt.trim() : "";
+  if (created && isParseableIssueTimestamp(created)) return created;
+
+  return null;
+}
+
+/** Unknown/unparseable timestamps floor freshness (parity with gittensory-engine opportunity-freshness.ts). */
+function issueAgeDays(value: string | null): number {
+  if (!value) return Number.POSITIVE_INFINITY;
   const parsed = Date.parse(value);
-  /* v8 ignore next -- Invalid provider timestamps normalize to fresh; stale timestamp handling is covered by signal tests. */
-  if (!Number.isFinite(parsed)) return 0;
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
   return Math.floor((Date.now() - parsed) / 86_400_000);
 }
 

--- a/test/unit/reward-risk-freshness.test.ts
+++ b/test/unit/reward-risk-freshness.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeOpportunityFreshness,
+  type FreshnessIssue,
+} from "../../packages/gittensory-engine/src/opportunity-freshness";
+import {
+  buildContributorOutcomeHistory,
+  buildContributorProfile,
+} from "../../src/signals/engine";
+import { buildRepoRewardRisk } from "../../src/signals/reward-risk";
+import type { IssueRecord, RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
+
+function scoringSnapshot(): ScoringModelSnapshotRecord {
+  return {
+    id: "freshness-scoring",
+    sourceKind: "test",
+    sourceUrl: "fixture://freshness",
+    fetchedAt: "2026-05-25T00:00:00.000Z",
+    activeModel: "current_density_model",
+    constants: {},
+    programmingLanguages: {},
+    warnings: [],
+    payload: {},
+  };
+}
+
+function repo(fullName: string): RepositoryRecord {
+  const [owner, name] = fullName.split("/") as [string, string];
+  return {
+    fullName,
+    owner,
+    name,
+    isInstalled: true,
+    isRegistered: true,
+    isPrivate: false,
+    defaultBranch: "main",
+    registryConfig: {
+      repo: fullName,
+      emissionShare: 0.02,
+      issueDiscoveryShare: 0,
+      labelMultipliers: {},
+      trustedLabelPipeline: false,
+      maintainerCut: 0,
+      raw: {},
+    },
+  };
+}
+
+function issue(fullName: string, number: number, title: string, overrides: Partial<IssueRecord> = {}): IssueRecord {
+  return {
+    repoFullName: fullName,
+    number,
+    title,
+    state: "open",
+    authorLogin: "dev",
+    authorAssociation: "NONE",
+    labels: [],
+    linkedPrs: [],
+    body: "Issue body",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function toFreshnessIssues(issues: IssueRecord[]): FreshnessIssue[] {
+  return issues.map((item) => ({
+    state: item.state,
+    updatedAt: item.updatedAt ?? null,
+    createdAt: item.createdAt ?? null,
+  }));
+}
+
+describe("reward-risk freshness parity with gittensory-engine", () => {
+  const collab = repo("owner/collab-repo");
+  const profile = buildContributorProfile("dev", { login: "dev", topLanguages: [], source: "github" }, [], []);
+  const history = buildContributorOutcomeHistory({
+    login: "dev",
+    profile,
+    repositories: [collab],
+    pullRequests: [],
+    issues: [],
+    repoStats: [],
+  });
+  const base = {
+    login: "dev" as const,
+    repo: collab,
+    repoFullName: collab.fullName,
+    profile,
+    outcomeHistory: history,
+    scoringSnapshot: scoringSnapshot(),
+  };
+
+  it("matches computeOpportunityFreshness for fresh, stale, and undated open issues", () => {
+    const nowMs = Date.now();
+    const freshIssues = [
+      issue(collab.fullName, 1, "Fresh", { updatedAt: new Date(nowMs - 2 * 86_400_000).toISOString() }),
+    ];
+    const staleIssues = [issue(collab.fullName, 2, "Stale", { updatedAt: "2020-01-01T00:00:00.000Z" })];
+    const undatedIssues = [issue(collab.fullName, 3, "Undated", { updatedAt: null, createdAt: null })];
+
+    const fresh = buildRepoRewardRisk({ ...base, issues: freshIssues, pullRequests: [] });
+    const stale = buildRepoRewardRisk({ ...base, issues: staleIssues, pullRequests: [] });
+    const undated = buildRepoRewardRisk({ ...base, issues: undatedIssues, pullRequests: [] });
+
+    expect(fresh.rewardUpside.opportunityFactors.freshnessFactor).toBe(
+      computeOpportunityFreshness(toFreshnessIssues(freshIssues), nowMs),
+    );
+    expect(stale.rewardUpside.opportunityFactors.freshnessFactor).toBe(
+      computeOpportunityFreshness(toFreshnessIssues(staleIssues), nowMs),
+    );
+    expect(undated.rewardUpside.opportunityFactors.freshnessFactor).toBe(
+      computeOpportunityFreshness(toFreshnessIssues(undatedIssues), nowMs),
+    );
+    expect(undated.rewardUpside.opportunityFactors.freshnessFactor).toBeLessThanOrEqual(0.05);
+  });
+
+  it("uses createdAt when updatedAt is malformed", () => {
+    const issuesForRisk = [
+      issue(collab.fullName, 1, "Fallback", {
+        updatedAt: "not-a-date",
+        createdAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+      }),
+    ];
+    const result = buildRepoRewardRisk({ ...base, issues: issuesForRisk, pullRequests: [] });
+    expect(result.rewardUpside.opportunityFactors.freshnessFactor).toBeGreaterThan(0.7);
+  });
+
+  it("scores from the freshest open issue when multiple are present", () => {
+    const issuesForRisk = [
+      issue(collab.fullName, 1, "Stale", { updatedAt: "2020-01-01T00:00:00.000Z" }),
+      issue(collab.fullName, 2, "Fresh", { updatedAt: new Date(Date.now() - 2 * 86_400_000).toISOString() }),
+    ];
+    const result = buildRepoRewardRisk({ ...base, issues: issuesForRisk, pullRequests: [] });
+    expect(result.rewardUpside.opportunityFactors.freshnessFactor).toBeGreaterThan(0.7);
+  });
+});

--- a/test/unit/reward-risk-freshness.test.ts
+++ b/test/unit/reward-risk-freshness.test.ts
@@ -7,7 +7,7 @@ import {
   buildContributorOutcomeHistory,
   buildContributorProfile,
 } from "../../src/signals/engine";
-import { buildRepoRewardRisk } from "../../src/signals/reward-risk";
+import { buildRepoRewardRisk, rewardRiskFreshnessInternals } from "../../src/signals/reward-risk";
 import type { IssueRecord, RepositoryRecord, ScoringModelSnapshotRecord } from "../../src/types";
 
 function scoringSnapshot(): ScoringModelSnapshotRecord {
@@ -133,5 +133,48 @@ describe("reward-risk freshness parity with gittensory-engine", () => {
     ];
     const result = buildRepoRewardRisk({ ...base, issues: issuesForRisk, pullRequests: [] });
     expect(result.rewardUpside.opportunityFactors.freshnessFactor).toBeGreaterThan(0.7);
+  });
+
+  it("pickIssueTimestamp and issueAgeDays cover defensive timestamp branches", () => {
+    const { pickIssueTimestamp, issueAgeDays } = rewardRiskFreshnessInternals;
+    expect(
+      pickIssueTimestamp({
+        repoFullName: collab.fullName,
+        number: 1,
+        title: "t",
+        state: "open",
+        labels: [],
+        linkedPrs: [],
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        createdAt: "2020-01-01T00:00:00.000Z",
+      }),
+    ).toBe("2026-07-03T00:00:00.000Z");
+    expect(
+      pickIssueTimestamp({
+        repoFullName: collab.fullName,
+        number: 2,
+        title: "t",
+        state: "open",
+        labels: [],
+        linkedPrs: [],
+        updatedAt: "   ",
+        createdAt: "2026-07-03T00:00:00.000Z",
+      }),
+    ).toBe("2026-07-03T00:00:00.000Z");
+    expect(
+      pickIssueTimestamp({
+        repoFullName: collab.fullName,
+        number: 3,
+        title: "t",
+        state: "open",
+        labels: [],
+        linkedPrs: [],
+        updatedAt: null,
+        createdAt: null,
+      }),
+    ).toBeNull();
+    expect(issueAgeDays(null)).toBe(Number.POSITIVE_INFINITY);
+    expect(issueAgeDays("not-a-date")).toBe(Number.POSITIVE_INFINITY);
+    expect(issueAgeDays("2026-07-03T00:00:00.000Z")).toBeGreaterThanOrEqual(0);
   });
 });

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1981,10 +1981,18 @@ describe("signal coverage edge cases", () => {
     const withClosed = buildRepoRewardRisk({ ...base, issues: [closedIssue], pullRequests: [] });
     expect(withClosed.rewardUpside.opportunityFactors.freshnessFactor).toBe(0);
 
-    // Issue with null dates → treated as fresh (conservative fallback)
+    // Issue with null dates → unknown age floors to minimum freshness (parity with gittensory-engine)
     const noDateIssue = issue(collab.fullName, 23, "Undated request", { updatedAt: null, createdAt: null });
     const withNoDate = buildRepoRewardRisk({ ...base, issues: [noDateIssue], pullRequests: [] });
-    expect(withNoDate.rewardUpside.opportunityFactors.freshnessFactor).toBeGreaterThan(0);
+    expect(withNoDate.rewardUpside.opportunityFactors.freshnessFactor).toBeLessThanOrEqual(0.05);
+
+    // Malformed updatedAt falls back to createdAt before scoring age
+    const fallbackIssue = issue(collab.fullName, 24, "Fallback timestamp", {
+      updatedAt: "not-a-date",
+      createdAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    });
+    const withFallback = buildRepoRewardRisk({ ...base, issues: [fallbackIssue], pullRequests: [] });
+    expect(withFallback.rewardUpside.opportunityFactors.freshnessFactor).toBeGreaterThan(0.7);
   });
 
   it("eligibilityGap: surfaces repos within 1–5 PR cleanups of threshold, excludes zero-cleanup and out-of-range repos", () => {


### PR DESCRIPTION
## Summary

The HTTP/decision-pack reward-risk path treated missing or unparseable issue timestamps as **age 0** (maximally fresh), while `gittensory-engine`'s `computeOpportunityFreshness` already floors unknown ages to the **0.05 minimum**. That divergence inflated `freshnessFactor` for backfill gaps and malformed metadata in decision packs and scoring previews.

This PR mirrors the engine semantics in `src/signals/reward-risk.ts`:

- `pickIssueTimestamp` prefers `updatedAt`, falls back to `createdAt`
- Unknown/unparseable timestamps use `POSITIVE_INFINITY` (floors to ~0.05)
- Iterative min scan (no `Math.min(...spread)`) for large issue lists

Adds `test/unit/reward-risk-freshness.test.ts` with parity tests against `computeOpportunityFreshness`, plus `rewardRiskFreshnessInternals` branch coverage (codecov patch).

Supersedes #2874 (auto-closed on codecov/patch 91.66%).

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/reward-risk-freshness.test.ts` (4/4)
- [x] Updated `signals-coverage` opportunityFactors assertions
- [ ] CI (Linux) green including codecov/patch ≥ 99%
