### PR TITLE
fix(miner): reject malformed repo slugs in opportunity ranker

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-ranker.js
+++ b/packages/gittensory-miner/lib/opportunity-ranker.js
@@ -19,16 +19,19 @@ function normalizeCandidate(candidate) {
     typeof candidate.repoFullName === "string" ? candidate.repoFullName.trim() : "";
   const issueNumber = candidate.issueNumber;
   const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
-  if (!repoFullName || !Number.isInteger(issueNumber) || issueNumber <= 0 || !title) return null;
+  const [owner, repo, extra] = repoFullName.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !title) return null;
+  const canonicalRepoFullName = `${owner}/${repo}`;
   const labels = Array.isArray(candidate.labels)
     ? candidate.labels
         .filter((label) => typeof label === "string" && label.trim())
         .map((label) => label.trim())
     : [];
   return {
-    owner: typeof candidate.owner === "string" ? candidate.owner : repoFullName.split("/")[0] ?? "",
-    repo: typeof candidate.repo === "string" ? candidate.repo : repoFullName.split("/")[1] ?? "",
-    repoFullName,
+    owner: typeof candidate.owner === "string" ? candidate.owner : owner,
+    repo: typeof candidate.repo === "string" ? candidate.repo : repo,
+    repoFullName: canonicalRepoFullName,
     issueNumber,
     title,
     labels,

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -56,12 +56,22 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
         rawIssue(),
         { ...rawIssue(), issueNumber: "nope" as unknown as number },
         { ...rawIssue(), repoFullName: "" },
+        { ...rawIssue(), repoFullName: "owner-only" },
         null as unknown as ReturnType<typeof rawIssue>,
       ],
       { nowMs: NOW },
     );
     expect(ranked).toHaveLength(1);
     expect(ranked[0]?.issueNumber).toBe(42);
+  });
+
+  it("counts malformed repo slugs as skipped invalid in the summary", () => {
+    const summary = rankCandidateIssuesWithSummary(
+      [rawIssue(), rawIssue({ repoFullName: "owner-only" })],
+      { nowMs: NOW },
+    );
+    expect(summary.issues).toHaveLength(1);
+    expect(summary.skippedInvalid).toBe(1);
   });
 
   it("parses per-repo goal-spec YAML content when ranking", () => {


### PR DESCRIPTION
## Summary

- Reject malformed `repoFullName` slugs in the miner opportunity ranker instead of ranking rows with an empty derived repo segment.

## Problem

`normalizeCandidate` accepted values like `owner-only` because it only checked for a non-empty string. Those rows were ranked with an empty `repo` field, diverging from the `owner/repo` validation used by the portfolio queue and claim ledger.

## Validation

- [x] Extended ranker tests to cover `owner-only` rejection and summary `skippedInvalid` counting.
- [ ] Full CI gate on push.

## Safety

- [x] Pure local normalization change only — no network, no persistence, no secrets.
