### PR TITLE
fix(miner): only release active claim-ledger rows

### DIFF
--- a/packages/gittensory-miner/lib/claim-ledger.js
+++ b/packages/gittensory-miner/lib/claim-ledger.js
@@ -106,7 +106,7 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
     "SELECT * FROM miner_claims WHERE repo_full_name = ? AND issue_number = ?",
   );
   const releaseStatement = db.prepare(
-    "UPDATE miner_claims SET status = 'released' WHERE repo_full_name = ? AND issue_number = ?",
+    "UPDATE miner_claims SET status = 'released' WHERE repo_full_name = ? AND issue_number = ? AND status = 'active'",
   );
   const listAllStatement = db.prepare("SELECT * FROM miner_claims ORDER BY id ASC");
   const listRepoStatement = db.prepare(
@@ -138,7 +138,8 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
     releaseClaim(repoFullName, issueNumber) {
       const normalizedRepo = normalizeRepoFullName(repoFullName);
       const normalizedIssue = normalizeIssueNumber(issueNumber);
-      releaseStatement.run(normalizedRepo, normalizedIssue);
+      const result = releaseStatement.run(normalizedRepo, normalizedIssue);
+      if (result.changes === 0) return null;
       const row = getStatement.get(normalizedRepo, normalizedIssue);
       return row ? rowToClaim(row) : null;
     },

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -84,6 +84,7 @@ describe("gittensory-miner claim ledger (#2314)", () => {
     ledger.recordClaim({ repoFullName: "o/a", issueNumber: 9, note: "v1" });
     const released = ledger.releaseClaim("o/a", 9);
     expect(released?.status).toBe("released");
+    expect(ledger.releaseClaim("o/a", 9)).toBeNull();
     // Re-claim after release: same single row, back to active, note refreshed.
     const reclaimed = ledger.recordClaim({ repoFullName: "o/a", issueNumber: 9, note: "v2" });
     expect(reclaimed).toMatchObject({ status: "active", note: "v2", id: released?.id });


### PR DESCRIPTION
## Summary

- Make `releaseClaim` transition only active soft-claims to `released`, returning `null` when no active row exists.

## Problem

`releaseClaim` updated any existing row regardless of status, so a second release call on an already-released claim still returned a row instead of signaling a no-op. That made it impossible for callers to distinguish a fresh release from a duplicate call.

## Validation

- [x] Extended claim-ledger tests for double-release no-op behavior.
- [ ] Full CI gate on push.

## Safety

- [x] Local SQLite claim ledger only — no network, no secrets.
