### PR TITLE
fix(signals): classify C/C++/CUDA source (and .kts) as code, in both isCodeFile mirrors

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5522,11 +5522,11 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 }
 
 function isCodeFile(file: string): boolean {
-  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php added
-  // so C#/Swift/Groovy/PHP source counts as code, matching the test conventions
-  // isTestPath already recognizes).
+  // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php, and the C/C++/CUDA
+  // family + kts, added so their source counts as code, matching the test conventions isTestPath
+  // already recognizes).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php)$/i.test(file) &&
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|kts|scala|java|go|sql|cs|swift|groovy|php|c|cc|cpp|cxx|h|hpp|hh|hxx|cu|cuh)$/i.test(file) &&
     !isTestFile(file)
   );
 }

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1271,8 +1271,12 @@ export function isCodeFile(file: string): boolean {
   // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
   // count as code too — otherwise a C#/Swift/Groovy/PHP source file is neither test
   // nor code in the local scorer.
+  // The C/C++/CUDA family (c/cc/cpp/cxx headers+impl, cu/cuh) covers native components common in
+  // registered subnet repos (C-extension modules, CUDA kernels); their `*_test.cc` tests are recognized
+  // by isTestPath, so the source must count as code. `kts` (Kotlin script) restores parity with isTestPath,
+  // whose `SomethingTests.kts` rule already treats `.kts` as a test extension.
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php)$/i.test(file) &&
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|kts|scala|java|go|sql|cs|swift|groovy|php|c|cc|cpp|cxx|h|hpp|hh|hxx|cu|cuh)$/i.test(file) &&
     !isTestFile(file)
   );
 }

--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -2,7 +2,7 @@ export function isTestPath(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|c|cc|cpp|cxx)$/i.test(file) || // Go/Python/Ruby + C/C++ (GoogleTest-style `*_test.cc`)
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -126,6 +126,16 @@ describe("isCodeFile", () => {
       // files, so PHP source must count as code too (else it is neither test nor code).
       "app/Http/Controllers/UserController.php",
       "src/Service/PaymentGateway.php",
+      // C/C++/CUDA native sources (C-extension modules, kernels) common in subnet repos — source, not churn.
+      "csrc/ops/attention.cpp",
+      "native/reduce.cc",
+      "src/module.c",
+      "include/kernel.h",
+      "include/api.hpp",
+      "kernels/gemm.cu",
+      "kernels/util.cuh",
+      // Kotlin script source — parity with isTestPath, whose `SomethingTests.kts` rule already treats .kts as a test ext.
+      "gradle/plugin.kts",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }
@@ -147,6 +157,12 @@ describe("isCodeFile", () => {
       "AppTests/LoginTests.swift",
       // PHP class-suffix test file (PHPUnit) — code extension, but a test, not code.
       "app/Service/PaymentTest.php",
+      // C/C++ GoogleTest-style `*_test.cc` files carry a code extension but are tests, not source.
+      "native/attention_test.cc",
+      "src/reduce_test.cpp",
+      "lib/parser_test.c",
+      // A C/C++ test living under a tests/ directory is caught by the directory rule.
+      "tests/kernel_bench.cc",
     ]) {
       expect(isCodeFile(path)).toBe(false);
     }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -54,6 +54,10 @@ describe("isGeneratedFile", () => {
     for (const path of ["src/service.h", "include/foo.h", "src/service.cc"]) {
       expect(isGeneratedFile(path)).toBe(false);
     }
+    // Precedence: the generated check runs before the (now C/C++-aware) source check, so a generated `.pb.cc`
+    // stays "generated" while a hand-written `.cc` is "source".
+    expect(classifyChangedFile("proto/service.pb.cc")).toBe("generated");
+    expect(classifyChangedFile("src/service.cc")).toBe("source");
   });
 
   it("matches Python gRPC protobuf stubs alongside the message stubs", () => {

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -305,6 +305,26 @@ describe("signal coverage edge cases", () => {
     expect(linkedIssuesFor("unfixes owner/direct#42").linkedIssues).not.toContain(42);
   });
 
+  it("counts C/C++/CUDA source via the engine-side isCodeFile mirror (kept in sync with local-branch)", () => {
+    const directRepo = repo("owner/direct");
+    const local = buildLocalDiffPreflightResult(
+      {
+        repoFullName: directRepo.fullName,
+        title: "Add fused attention CUDA kernel",
+        body: "Fixes #1",
+        changedFiles: ["csrc/attention.cpp", "kernels/gemm.cu"],
+        testFiles: ["native/attention_test.cc"],
+        changedLineCount: 80,
+      },
+      directRepo,
+      [issue(directRepo.fullName, 1, "kernel")],
+      [],
+    );
+    // engine.ts's private isCodeFile mirror must recognize C/C++/CUDA source (both changed files are code), and
+    // the GoogleTest-style `_test.cc` must count as a test, not source — otherwise a native PR is mis-scored.
+    expect(local.localDiff).toMatchObject({ codeFileCount: 2, testFileCount: 1 });
+  });
+
   it("covers issue quality, burden, bounties, noise, and reviewability edge decisions", () => {
     const directRepo = repo("owner/direct");
     const issueRepo = repo("owner/issues", { issueDiscoveryShare: 1 });

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -4,6 +4,11 @@ import { classifyTestCoverage, hasLocalTestEvidence, isTestPath } from "../../sr
 describe("test evidence helpers", () => {
   it("detects common test path conventions", () => {
     expect(isTestPath("pkg/foo_test.go")).toBe(true);
+    // C/C++ GoogleTest-style `*_test.{cc,cpp,c,cxx}` suffix next to source (not only under a tests/ dir).
+    expect(isTestPath("native/attention_test.cc")).toBe(true);
+    expect(isTestPath("src/reduce_test.cpp")).toBe(true);
+    expect(isTestPath("lib/parser_test.c")).toBe(true);
+    expect(isTestPath("include/kernel.h")).toBe(false); // a bare header is source, not a test
     expect(isTestPath("spec/models/widget_spec.rb")).toBe(true);
     expect(isTestPath("src/test/helpers.ts")).toBe(true);
     expect(isTestPath("tests/integration/api.test.ts")).toBe(true);


### PR DESCRIPTION
`isCodeFile` recognizes the JVM/.NET/JS/Python/Ruby/Rust/Go source family but **silently drops the entire C/C++/CUDA family** — `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hh`, `.hxx`, `.cu`, `.cuh` — and `.kts`.

> Supersedes #2862, which updated only the `local-branch.ts` copy of the extension list and left the `engine.ts` mirror stale. **This PR updates BOTH mirrors** so engine-side gating stays consistent (the exact defect that closed #2862).

## Why it matters
`isCodeFile` is load-bearing across scoring/gating, via **two copies kept in sync by contract**: the exported `isCodeFile` in `local-branch.ts` and the private mirror in `engine.ts` (used by the preflight code-file counts). Both feed:
1. **Token score** — source lines counted only from `isCodeFile`; a C/C++ PR's source becomes non-code churn, **deflating the score**.
2. **Trivial-churn slop** — a genuine C++ diff can score as ~0 substantive lines → **false trivial-churn slop finding**.
3. **`missing_tests`** — a C/C++ PR with no tests is **wrongly exempted**.

Native components are common in registered subnet repos (C-extension modules, CUDA kernels, `pybind11` ops).

## Why this is a defect, not a convention
The module's own comment establishes the rule: cs/swift/groovy/php were added because "isTestPath already recognizes their test files, so their source must count as code too." This extends it:
- **`.kts`** is a direct sibling contradiction — `isTestPath` already treats `SomethingTests.kts` as a test extension, but `isCodeFile` had `kt` without `kts`.
- `path-matchers` already assumes `.pb.cc` / `.pb.h` exist (C/C++ codegen output).

## Fix (both mirrors + test side)
- `isCodeFile` in **`local-branch.ts` AND `engine.ts`** (the documented "kept in sync" mirror): add the C/C++/CUDA extensions + `.kts`.
- `isTestPath`: recognize the GoogleTest-style `*_test.{c,cc,cpp,cxx}` suffix — **required**, so a `foo_test.cc` next to source isn't miscounted as source (keeping the `&& !isTestFile` guard correct).

Precedence unchanged: `classifyChangedFile` runs the generated check before the source check, so a generated `.pb.cc` stays `generated` while a hand-written `.cc` is `source` (asserted).

## Tests
- `isCodeFile`: C/C++/CUDA/`.kts` source cases + C/C++ `*_test.{cc,cpp,c}` exclusions.
- `isTestPath`: the `*_test.cc` suffix.
- `path-matchers`: `classifyChangedFile` precedence guard (`.pb.cc`→generated, `.cc`→source).
- **`signals-coverage`: an engine-side assertion** (`localDiff.codeFileCount` on `.cpp`+`.cu` changed files) that exercises the `engine.ts` mirror specifically — it fails if that mirror drifts from `local-branch.ts`.

Verified the new cases FAIL on `main` and PASS with the fix; `local-branch-file-classifiers`, `test-evidence`, `path-matchers`, `slop`, `contributor-open-pr-monitor`, and `signals-coverage` suites stay green.

No linked issue: issue creation is unavailable for this account.
