### PR TITLE
feat(secrets): detect Stripe, SendGrid, and Hugging Face keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -43,6 +43,24 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Stripe live secret / restricted key: `sk_live_` / `rk_live_` + >=24 base62.
+    kind: "stripe_secret_key",
+    re: /\b(?:sk|rk)_live_[0-9A-Za-z]{24,}\b/,
+    confidence: "high",
+  },
+  {
+    // SendGrid API key: `SG.` + 22-char id + `.` + 43-char secret (base64url).
+    kind: "sendgrid_key",
+    re: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Hugging Face user access token: `hf_` + 34 base62 chars.
+    kind: "huggingface_token",
+    re: /\bhf_[A-Za-z0-9]{34}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -14,9 +14,14 @@ const hunk = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l
 const awsKeyFragmentA = "AKIA" + "IOSFODNN7"; // 13 chars — too short alone to match \bAKIA[0-9A-Z]{16}\b
 const awsKeyFragmentB = "EXAMPLE"; // matches no RULES pattern alone
 const fakeAwsKey = awsKeyFragmentA + awsKeyFragmentB;
-const fakeStripeKey = ["sk_live_", "abcdefghijklmnop1234567890"].join("");
+const fakeStripeKey = ["sk_live_", "abcdefghijklmnop1234567890"].join(""); // sk_live_ + 26 base62
+const fakeSendgridKey = ["SG.", "a".repeat(22), ".", "b".repeat(43)].join("");
+const fakeHuggingfaceToken = "hf_" + "a".repeat(34);
 const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
 const fakeNpmToken = "npm_" + "a".repeat(36);
+// A high-entropy value that matches NO format-specific rule, so it only trips the
+// generic keyword-assignment rule (built from fragments, never a contiguous literal).
+const fakeGenericValue = "aK9xQ2mZw7Ln" + "4Rv8Pt3Bh6Tc";
 
 test("scanPatch flags a single-line AWS access key with high confidence", () => {
   const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeAwsKey}";`]));
@@ -47,8 +52,39 @@ test("scanPatch flags an npm token with high confidence", () => {
   assert.equal(findings[0].confidence, "high");
 });
 
-test("scanPatch flags a generic secret assignment", () => {
+test("scanPatch flags a Stripe live secret key with high confidence", () => {
   const findings = scanPatch("src/config.ts", hunk([`const apiKey = "${fakeStripeKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "stripe_secret_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags a SendGrid API key with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const sg = "${fakeSendgridKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "sendgrid_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags a SendGrid key whose final secret character is a hyphen", () => {
+  // Regression: a `\b` terminator would miss a key ending in `-`; the rule uses a
+  // negative lookahead so the trailing hyphen still terminates the match.
+  const hyphenTail = ["SG.", "a".repeat(22), ".", "b".repeat(42), "-"].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const sg = "${hyphenTail}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "sendgrid_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags a Hugging Face access token with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const hfToken = "${fakeHuggingfaceToken}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "huggingface_token");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags a generic secret assignment", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const apiKey = "${fakeGenericValue}";`]));
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "generic_secret_assignment");
   assert.equal(findings[0].confidence, "medium");

--- a/src/review/content-lane/security-scan.ts
+++ b/src/review/content-lane/security-scan.ts
@@ -22,6 +22,12 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "google_api_key", re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
   { name: "gitlab_token", re: /\bglpat-[0-9A-Za-z_-]{20}\b/ },
   { name: "npm_token", re: /\bnpm_[A-Za-z0-9]{36}\b/ },
+  // Stripe live secret / restricted keys: `sk_live_` / `rk_live_` + >=24 base62.
+  { name: "stripe_secret_key", re: /\b(?:sk|rk)_live_[0-9A-Za-z]{24,}\b/ },
+  // SendGrid API key: `SG.` + 22-char id + `.` + 43-char secret (base64url).
+  { name: "sendgrid_key", re: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/ },
+  // Hugging Face user access token: `hf_` + 34 base62 chars.
+  { name: "huggingface_token", re: /\bhf_[A-Za-z0-9]{34}\b/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },
@@ -119,6 +125,9 @@ const HARD_SECRET_KINDS = new Set([
   "google_api_key",
   "gitlab_token",
   "npm_token",
+  "stripe_secret_key",
+  "sendgrid_key",
+  "huggingface_token",
   "jwt",
   "generic_secret_assignment",
 ]);

--- a/src/review/safety.ts
+++ b/src/review/safety.ts
@@ -31,6 +31,9 @@ const HARD_SECRET_KINDS = new Set([
   "google_api_key",
   "gitlab_token",
   "npm_token",
+  "stripe_secret_key",
+  "sendgrid_key",
+  "huggingface_token",
   "jwt",
   "generic_secret_assignment",
 ]);

--- a/src/review/secrets-scan.ts
+++ b/src/review/secrets-scan.ts
@@ -22,6 +22,12 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "google_api_key", re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
   { name: "gitlab_token", re: /\bglpat-[0-9A-Za-z_-]{20}\b/ },
   { name: "npm_token", re: /\bnpm_[A-Za-z0-9]{36}\b/ },
+  // Stripe live secret / restricted keys: `sk_live_` / `rk_live_` + >=24 base62.
+  { name: "stripe_secret_key", re: /\b(?:sk|rk)_live_[0-9A-Za-z]{24,}\b/ },
+  // SendGrid API key: `SG.` + 22-char id + `.` + 43-char secret (base64url).
+  { name: "sendgrid_key", re: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/ },
+  // Hugging Face user access token: `hf_` + 34 base62 chars.
+  { name: "huggingface_token", re: /\bhf_[A-Za-z0-9]{34}\b/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },

--- a/test/unit/content-lane-security-scan.test.ts
+++ b/test/unit/content-lane-security-scan.test.ts
@@ -39,6 +39,18 @@ describe("scanForSecrets", () => {
     expect(scanForSecrets("npm_" + "a".repeat(36)).kinds).toContain("npm_token");
   });
 
+  it("flags Stripe, SendGrid, and Hugging Face keys (parity with the PR-diff gate)", () => {
+    expect(scanForSecrets("sk_live_" + "a".repeat(24)).kinds).toContain("stripe_secret_key");
+    expect(scanForSecrets("SG." + "a".repeat(22) + "." + "b".repeat(43)).kinds).toContain("sendgrid_key");
+    expect(scanForSecrets("hf_" + "a".repeat(34)).kinds).toContain("huggingface_token");
+  });
+
+  it("flags a SendGrid key whose final secret character is a hyphen", () => {
+    // Regression: the terminator must not be `\b`, which would fail to match when the
+    // final char of the `[A-Za-z0-9_-]` run is `-` (no word boundary before a quote/space).
+    expect(scanForSecrets(`sg = "SG.${"a".repeat(22)}.${"b".repeat(42)}-"`).kinds).toContain("sendgrid_key");
+  });
+
   it("flags a generic secret/password/token assignment with a high-entropy value", () => {
     expect(scanForSecrets(`secret = "${GENERIC_VALUE}"`).kinds).toContain("generic_secret_assignment");
     expect(scanForSecrets(`api_key: '${GENERIC_VALUE}'`).kinds).toContain("generic_secret_assignment");
@@ -191,6 +203,9 @@ describe("secret-scan parity with the PR-diff gate (secrets-scan.ts)", () => {
     ["aws_access_key", "AKIA" + "ABCDEFGHIJKLMNOP"],
     ["private_key_block", "-----BEGIN OPENSSH " + "PRIVATE KEY-----"],
     ["google_api_key", "AIza" + "SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"],
+    ["stripe_secret_key", "sk_live_" + "a".repeat(24)],
+    ["sendgrid_key", "SG." + "a".repeat(22) + "." + "b".repeat(43)],
+    ["huggingface_token", "hf_" + "a".repeat(34)],
     ["jwt", jwt],
     ["generic_secret_assignment", `secret = "${GENERIC_VALUE}"`],
     ["benign prose", "just normal documentation prose"],

--- a/test/unit/secrets-scan.test.ts
+++ b/test/unit/secrets-scan.test.ts
@@ -65,6 +65,28 @@ describe("scanForSecrets — deterministic secret-pattern scanner", () => {
     expect(scanForSecrets(fakeToken).kinds).toContain("npm_token");
   });
 
+  it("flags a Stripe live secret key", () => {
+    const fakeToken = "sk_live_" + "a".repeat(24);
+    expect(scanForSecrets(fakeToken).kinds).toContain("stripe_secret_key");
+  });
+
+  it("flags a SendGrid API key", () => {
+    const fakeToken = "SG." + "a".repeat(22) + "." + "b".repeat(43);
+    expect(scanForSecrets(fakeToken).kinds).toContain("sendgrid_key");
+  });
+
+  it("flags a SendGrid API key whose final secret character is a hyphen", () => {
+    // Regression: a `\b` terminator would miss a key ending in `-` (a `-` before a
+    // quote/space is not a word boundary), so the rule uses a negative lookahead.
+    const fakeToken = "SG." + "a".repeat(22) + "." + "b".repeat(42) + "-";
+    expect(scanForSecrets(`sg = "${fakeToken}"`).kinds).toContain("sendgrid_key");
+  });
+
+  it("flags a Hugging Face access token", () => {
+    const fakeToken = "hf_" + "a".repeat(34);
+    expect(scanForSecrets(fakeToken).kinds).toContain("huggingface_token");
+  });
+
   it("flags a JWT", () => {
     const fakeJwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");


### PR DESCRIPTION
Adds three well-known, format-precise credential patterns across all four secret scanners in lockstep — the PR-diff gate (`secrets-scan.ts`), the content-lane scanner, the shared `safety.ts` `HARD_SECRET_KINDS`, and the `review-enrichment` analyzer — matching the precision of the existing gitlab/npm rules so they are safe as unconditional hard blockers:

- **stripe_secret_key** — `sk_live_` / `rk_live_` + ≥24 base62
- **sendgrid_key** — `SG.` + 22-char id + `.` + 43-char secret
- **huggingface_token** — `hf_` + 34 base62

The SendGrid rule terminates with a negative lookahead `(?![A-Za-z0-9_-])` rather than `\b`: because its final class includes `-`, a trailing `\b` would fail to match a key whose last character is `-` (a `-` before a quote/space is not a word boundary). Regression tests cover a hyphen-terminated key in every scanner.

All fixtures are assembled from fragments at runtime so the source never embeds a contiguous secret literal. Verified: `tsc` clean, 96 vitest tests, 529 review-enrichment `node:test`.

(Supersedes #2878, which was closed for the SendGrid `\b`-terminator defect now fixed here.)