### PR TITLE
feat(signals): recognize more ecosystems' dependency lockfiles

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -126,6 +126,14 @@ const LOCKFILE_NAMES: ReadonlySet<string> = new Set([
   "pdm.lock",
   "conan.lock",
   "pixi.lock",
+  // More ecosystems' resolved-dependency lockfiles, siblings to the above: a
+  // committed lockfile is generated, not hand-authored contributor effort.
+  "cartfile.resolved", // Carthage (Swift/Obj-C)
+  "gopkg.lock", // dep (legacy Go)
+  "shard.lock", // Shards (Crystal)
+  "rebar.lock", // rebar3 (Erlang)
+  "renv.lock", // renv (R)
+  "chart.lock", // Helm charts
 ]);
 
 const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -106,6 +106,13 @@ describe("isLockfile", () => {
       "pdm.lock",
       "conan.lock",
       "pixi.lock",
+      "Cartfile.resolved",
+      "ios/Cartfile.resolved",
+      "Gopkg.lock",
+      "shard.lock",
+      "rebar.lock",
+      "renv.lock",
+      "charts/app/Chart.lock",
     ]) {
       expect(isLockfile(path)).toBe(true);
     }


### PR DESCRIPTION
Extends `LOCKFILE_NAMES` (src/signals/path-matchers.ts) with well-known resolved-dependency lockfiles for ecosystems not yet covered, so slop classification counts them as generated (non-hand-authored) files like the rest of the lockfile set:

- **Cartfile.resolved** (Carthage, Swift/Obj-C)
- **Gopkg.lock** (dep, legacy Go)
- **shard.lock** (Shards, Crystal)
- **rebar.lock** (rebar3, Erlang)
- **renv.lock** (renv, R)
- **Chart.lock** (Helm charts)

Extends the `isLockfile` positive test cases to cover each (including nested-path and case-insensitive forms). Typecheck + unit tests green.