### PR TITLE
fix(miner): keep in-progress portfolio rows off re-enqueue demotion

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -109,6 +109,7 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
     ON CONFLICT(repo_full_name, identifier) DO UPDATE SET
       priority = excluded.priority,
       status = 'queued'
+    WHERE miner_portfolio_queue.status <> 'in_progress'
   `);
   const getStatement = db.prepare(
     "SELECT * FROM miner_portfolio_queue WHERE repo_full_name = ? AND identifier = ?",

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -108,6 +108,17 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     expect(store.dequeueNext()?.identifier).toBe("1"); // re-queued → dequeuable again
   });
 
+  it("re-enqueue does not demote an in-progress item back to queued", () => {
+    const store = tempStore();
+    store.enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
+    expect(store.dequeueNext()).toMatchObject({ identifier: "work", status: "in_progress", priority: 1 });
+    expect(store.enqueue({ repoFullName: "o/a", identifier: "work", priority: 99 })).toMatchObject({
+      identifier: "work",
+      status: "in_progress",
+      priority: 1,
+    });
+  });
+
   it("re-enqueue keeps an item's FIFO position (no queue-jumping) even when timestamps collide", () => {
     // Freeze the clock so A and B share an enqueued_at — the case where a restamp-vs-rowid inconsistency would show.
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- Prevent portfolio queue re-enqueue from demoting an `in_progress` item back to `queued`.

## Problem

The upsert path always reset conflicting rows to `queued`, even when the item had already been claimed via `dequeueNext`. Re-enqueueing the same identifier could silently undo an in-progress claim.

## Validation

- [x] Added regression test covering re-enqueue on an in-progress row.
- [ ] Full CI gate on push.

## Safety

- [x] Local SQLite portfolio queue only — no network, no secrets.
