### PR TITLE
fix(review-enrichment): bound bundlephobia cache keys

### DIFF
--- a/review-enrichment/src/analyzers/heavy-dependency.ts
+++ b/review-enrichment/src/analyzers/heavy-dependency.ts
@@ -17,6 +17,8 @@ const TRIVIAL_USAGE_MAX = 2;
 const MIN_INSTALL_BYTES = 500_000;
 const MIN_BUNDLE_BYTES = 80_000;
 const MIN_GZIP_BYTES = 25_000;
+const MAX_NPM_PACKAGE_NAME_CHARS = 214;
+const MAX_NPM_PACKAGE_VERSION_CHARS = 256;
 
 // In-process TTL cache for bundlephobia size results. Keyed by "pkg@version".
 // Caching prevents redundant calls that would exhaust bundlephobia's rate limit
@@ -79,7 +81,12 @@ interface ScanOptions {
 }
 
 function isSafeNpmPackageVersion(name: string, version: string): boolean {
-  return NPM_PACKAGE_RE.test(name) && SEMVER_RE.test(version);
+  return (
+    name.length <= MAX_NPM_PACKAGE_NAME_CHARS &&
+    version.length <= MAX_NPM_PACKAGE_VERSION_CHARS &&
+    NPM_PACKAGE_RE.test(name) &&
+    SEMVER_RE.test(version)
+  );
 }
 
 function addedPatchLines(
@@ -181,6 +188,7 @@ export async function queryPackageWeight(
   options: Pick<ScanOptions, "analysis" | "diagnostics"> = {},
 ): Promise<PackageWeight | null> {
   if (signal?.aborted) return null;
+  if (!isSafeNpmPackageVersion(pkg, version)) return null;
 
   const cacheKey = `${pkg}@${version}`;
   const cached = weightCache.get(cacheKey);

--- a/review-enrichment/test/heavy-dependency.test.ts
+++ b/review-enrichment/test/heavy-dependency.test.ts
@@ -107,6 +107,37 @@ test("queryPackageWeight: does NOT cache a transient failure (network_error), so
   assert.equal(calls, 2, "a transient failure must not be cached — the next call should retry");
 });
 
+test("queryPackageWeight: rejects overlong package specs before fetch or cache (regression for unbounded cache keys)", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    return bundlephobiaResponse();
+  };
+
+  const overlongVersion = `1.0.0+${"a".repeat(256)}`;
+  const result = await queryPackageWeight("left-pad", overlongVersion, fetchImpl);
+
+  assert.equal(result, null);
+  assert.equal(calls, 0, "overlong versions must not be fetched or cached");
+  assert.equal(weightCacheSizeForTest(), 0);
+});
+
+test("queryPackageWeight: accepts package specs at the configured length bounds", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    return bundlephobiaResponse();
+  };
+  const scopedNameAtNpmLimit = `@${"a".repeat(106)}/${"b".repeat(106)}`;
+  const versionAtLimit = `1.0.0+${"a".repeat(250)}`;
+
+  const result = await queryPackageWeight(scopedNameAtNpmLimit, versionAtLimit, fetchImpl);
+
+  assert.equal(calls, 1);
+  assert.equal(result?.installSizeBytes, 1_000_000);
+  assert.equal(weightCacheSizeForTest(), 1);
+});
+
 test("queryPackageWeight: the cache is bounded, evicting the oldest entry once at capacity", async () => {
   const fetchImpl = async () => bundlephobiaResponse();
 


### PR DESCRIPTION
### Motivation

- Prevent a persistent memory-exhaustion vector where attacker-controlled npm package versions produce unbounded `pkg@version` cache keys retained for up to an hour in the process-wide Bundlephobia cache.
- The cache was already entry-count bounded but not size/length-bounded, allowing many large keys across requests to accumulate and degrade or crash the service.

### Description

- Added explicit length limits for npm package names and versions via `MAX_NPM_PACKAGE_NAME_CHARS` and `MAX_NPM_PACKAGE_VERSION_CHARS` and applied them in `isSafeNpmPackageVersion` to reject oversized specs.
- Short-circuited `queryPackageWeight` to return `null` for package specs that do not pass `isSafeNpmPackageVersion`, preventing building the unbounded `cacheKey`, issuing the external fetch, or inserting the entry into the `weightCache`.
- Added regression tests in `review-enrichment/test/heavy-dependency.test.ts` that assert overlong versions are rejected with no fetch/cache activity and that specs at the configured bounds are accepted and cached normally.

### Testing

- Ran per-service validation and targeted tests: `npm run build && npm run validate:sourcemaps && node scripts/generate-analyzer-metadata.mjs --check && node --test --experimental-strip-types test/heavy-dependency.test.ts`, and the targeted `queryPackageWeight` tests passed.
- Ran the REES Node test suite with `npm run test:node` and observed all REES tests passing locally (multiple hundred tests passed with zero failures).
- Attempted the full repo gate with `npm run test:ci` and `npm audit --audit-level=moderate`, but the run was interrupted by external network/setup issues (`actionlint` downloads failing with `getaddrinfo EAI_AGAIN github.com` and `npm audit` returning `403 Forbidden`), so the end-to-end CI was not completed in this environment; the focused analyzer tests covering the change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4813665a90832c85e1f7f75618ae17)