### PR TITLE
fix(selfhost): redact codex stdout diagnostics

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -449,7 +449,7 @@ export function codexErrorFromStdout(stdout: string): string | null {
         (typeof o.msg === "string" && o.msg) ||
         (errorObj && typeof errorObj.message === "string" ? errorObj.message : null) ||
         null;
-      if (detail) return detail.slice(0, 500);
+      if (detail) return redactSecrets(detail).slice(0, 500);
     } catch {
       /* not JSON — skip */
     }

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -854,6 +854,11 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(codexErrorFromStdout("")).toBeNull();
   });
 
+  it("codexErrorFromStdout redacts token-shaped stdout details before they reach provider errors", () => {
+    const leaky = JSON.stringify({ message: "model echoed private token ghp_ABCDEFGHIJ0123456789KLMNOPQRSTUV" });
+    expect(codexErrorFromStdout(leaky)).toBe("model echoed private token [redacted]");
+  });
+
   it("Codex fails closed when a mounted OAuth home would be exposed to the review sandbox", async () => {
     const shouldNotSpawn: StubSpawn = async () => {
       throw new Error("spawned");


### PR DESCRIPTION
### Motivation
- Prevent unredacted Codex JSONL stdout details from being embedded in thrown provider errors and logged to diagnostics, which could leak token-shaped or other sensitive output from model stdout.

### Description
- Apply `redactSecrets(detail)` before returning a stdout-derived diagnostic in `codexErrorFromStdout` in `src/selfhost/ai.ts` so JSONL-derived messages are redacted like stderr-derived messages.
- Add a unit regression test in `test/unit/selfhost-ai.test.ts` verifying token-shaped data emitted via Codex stdout is redacted before it can flow into provider errors/logs.
- Changes touch `src/selfhost/ai.ts` and `test/unit/selfhost-ai.test.ts` only and preserve existing behavior while applying the same secret-redaction boundary to stdout-derived diagnostics.

### Testing
- Ran the targeted unit tests with `npx vitest run test/unit/selfhost-ai.test.ts -t "codexErrorFromStdout|Codex on timeout|redacts key-shaped tokens from codex"`, and they passed.
- Ran TypeScript typecheck with `npm run typecheck`, and it passed with no errors.
- Attempted repository coverage with `npm run test:coverage`; the repo-wide coverage gate cannot be completed in this constrained environment (coverage enforcement caused a failure/interrupt), so full CI coverage/`npm run test:ci` should be run in CI or a full local environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48142c0284832cb47494b5b2b389e5)