### PR TITLE
fix(agent-actions): scope CI cancellation to closed PR

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -484,9 +484,20 @@ function hasNextWorkflowRunPage(link: string | null): boolean {
 // per-branch coverage tracking attributes hits correctly across repeated loop iterations with early returns
 // -- an inline loop body with early `return`s inside a `for` inside an `async function` can under-report the
 // "condition false" side of a branch even when it demonstrably executes (confirmed via a live debug trace).
+type WorkflowRunListItem = {
+  id: number;
+  event?: string | null;
+  pull_requests?: Array<{ number?: number | null } | null> | null;
+};
+
+function workflowRunBelongsToPull(run: WorkflowRunListItem, pullNumber: number): boolean {
+  return (run.event === "pull_request" || run.event === "pull_request_target") && (run.pull_requests ?? []).some((pull) => pull?.number === pullNumber);
+}
+
 async function listWorkflowRunIdsForStatus(
   repoPath: string,
   headSha: string,
+  pullNumber: number,
   status: "in_progress" | "queued",
   fetchOptions: ActionsRunFetchOptions,
 ): Promise<{ kind: "ids"; ids: number[] } | { kind: "permission_missing"; warning: string } | { kind: "error"; warning: string }> {
@@ -503,8 +514,8 @@ async function listWorkflowRunIdsForStatus(
       }
       return { kind: "error", warning: `Failed to list workflow runs (${response.status}): ${message || "unknown error"}` };
     }
-    const payload = (await response.json()) as { workflow_runs?: Array<{ id: number }> };
-    ids.push(...(payload.workflow_runs ?? []).map((run) => run.id));
+    const payload = (await response.json()) as { workflow_runs?: WorkflowRunListItem[] };
+    ids.push(...(payload.workflow_runs ?? []).filter((run) => workflowRunBelongsToPull(run, pullNumber)).map((run) => run.id));
     if (!hasNextWorkflowRunPage(response.headers.get("link"))) break;
   }
   return { kind: "ids", ids };
@@ -542,6 +553,7 @@ export async function cancelInFlightWorkflowRunsForHeadSha(
   installationId: number,
   repoFullName: string,
   headSha: string,
+  pullNumber: number,
 ): Promise<CancelWorkflowRunsOutcome> {
   const [owner, repo] = repoFullName.split("/");
   if (!owner || !repo) return { kind: "error", warning: `Invalid repository full name: ${repoFullName}` };
@@ -555,7 +567,7 @@ export async function cancelInFlightWorkflowRunsForHeadSha(
     };
     const runIds = new Set<number>();
     for (const status of ["in_progress", "queued"] as const) {
-      const listed = await listWorkflowRunIdsForStatus(repoPath, headSha, status, fetchOptions);
+      const listed = await listWorkflowRunIdsForStatus(repoPath, headSha, pullNumber, status, fetchOptions);
       if (listed.kind !== "ids") return listed;
       for (const id of listed.ids) runIds.add(id);
     }

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -289,7 +289,7 @@ async function auditContributorCapCiCancelFailed(env: Env, targetKey: string, re
 
 async function recordContributorCapCiCancelOutcome(env: Env, ctx: AgentActionExecutionContext, headSha: string): Promise<void> {
   const targetKey = `${ctx.repoFullName}#${ctx.pullNumber}`;
-  const outcome = await cancelInFlightWorkflowRunsForHeadSha(env, ctx.installationId, ctx.repoFullName, headSha);
+  const outcome = await cancelInFlightWorkflowRunsForHeadSha(env, ctx.installationId, ctx.repoFullName, headSha, ctx.pullNumber);
   if (outcome.kind === "cancelled") {
     await auditContributorCapCiCancelled(env, targetKey, ctx.repoFullName, headSha, outcome);
     return;

--- a/test/unit/github-app.test.ts
+++ b/test/unit/github-app.test.ts
@@ -669,8 +669,8 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=abc123&status=in_progress")) return Response.json({ workflow_runs: [{ id: 1 }, { id: 2 }] });
-      if (url.includes("/actions/runs?head_sha=abc123&status=queued")) return Response.json({ workflow_runs: [{ id: 3 }] });
+      if (url.includes("/actions/runs?head_sha=abc123&status=in_progress")) return Response.json({ workflow_runs: [{ id: 1, event: "pull_request", pull_requests: [{ number: 55 }] }, { id: 2, event: "pull_request", pull_requests: [{ number: 55 }] }] });
+      if (url.includes("/actions/runs?head_sha=abc123&status=queued")) return Response.json({ workflow_runs: [{ id: 3, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
         cancelledIds.push(Number(url.match(/\/actions\/runs\/(\d+)\/cancel/)?.[1]));
         return new Response(null, { status: 202 });
@@ -678,9 +678,41 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "abc123");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "abc123", 55);
     expect(outcome).toEqual({ kind: "cancelled", cancelledCount: 3, totalFound: 3 });
     expect(cancelledIds.sort()).toEqual([1, 2, 3]);
+  });
+
+  it("cancelInFlightWorkflowRunsForHeadSha only cancels workflow runs attached to the closed PR", async () => {
+    const privateKey = await generatePrivateKeyPem();
+    const cancelledIds: number[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+      if (url.includes("/actions/runs?head_sha=shared-sha&status=in_progress")) {
+        return Response.json({
+          workflow_runs: [
+            { id: 101, event: "pull_request", pull_requests: [{ number: 55 }] },
+            { id: 202, event: "pull_request", pull_requests: [{ number: 56 }] },
+            { id: 303, event: "push", pull_requests: [{ number: 55 }] },
+            { id: 404, event: "workflow_dispatch", pull_requests: [] },
+            { id: 505, event: "pull_request", pull_requests: null },
+            { id: 606, event: "pull_request_target", pull_requests: [{ number: 55 }] },
+          ],
+        });
+      }
+      if (url.includes("/actions/runs?head_sha=shared-sha&status=queued")) return Response.json({ workflow_runs: [] });
+      if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
+        cancelledIds.push(Number(url.match(/\/actions\/runs\/(\d+)\/cancel/)?.[1]));
+        return new Response(null, { status: 202 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "shared-sha", 55);
+    expect(outcome).toEqual({ kind: "cancelled", cancelledCount: 2, totalFound: 2 });
+    expect(cancelledIds.sort()).toEqual([101, 606]);
   });
 
   it("cancelInFlightWorkflowRunsForHeadSha (gate finding) follows Link: rel=\"next\" pagination — a head SHA with MORE than one page of in_progress runs still gets every page cancelled", async () => {
@@ -691,10 +723,10 @@ describe("GitHub check runs", () => {
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
       if (url.includes("/actions/runs?head_sha=multipage&status=in_progress&per_page=100&page=1")) {
-        return new Response(JSON.stringify({ workflow_runs: [{ id: 1 }, { id: 2 }] }), { headers: { link: '<https://api.github.com/repos/owner/repo/actions/runs?head_sha=multipage&status=in_progress&per_page=100&page=2>; rel="next"' } });
+        return new Response(JSON.stringify({ workflow_runs: [{ id: 1, event: "pull_request", pull_requests: [{ number: 55 }] }, { id: 2, event: "pull_request", pull_requests: [{ number: 55 }] }] }), { headers: { link: '<https://api.github.com/repos/owner/repo/actions/runs?head_sha=multipage&status=in_progress&per_page=100&page=2>; rel="next"' } });
       }
       if (url.includes("/actions/runs?head_sha=multipage&status=in_progress&per_page=100&page=2")) {
-        return Response.json({ workflow_runs: [{ id: 3 }] }); // no Link header — last page
+        return Response.json({ workflow_runs: [{ id: 3, event: "pull_request", pull_requests: [{ number: 55 }] }] }); // no Link header — last page
       }
       if (url.includes("/actions/runs?head_sha=multipage&status=queued")) return Response.json({ workflow_runs: [] });
       if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
@@ -704,7 +736,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "multipage");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "multipage", 55);
     expect(outcome).toEqual({ kind: "cancelled", cancelledCount: 3, totalFound: 3 });
     expect(cancelledIds.sort()).toEqual([1, 2, 3]);
   });
@@ -719,7 +751,7 @@ describe("GitHub check runs", () => {
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "no-runs-sha"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "no-runs-sha", 55),
     ).resolves.toEqual({ kind: "cancelled", cancelledCount: 0, totalFound: 0 });
   });
 
@@ -729,14 +761,14 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 9 }] });
+      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 9, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs?head_sha=") && url.includes("status=queued")) return Response.json({ workflow_runs: [] });
       if (url.endsWith("/actions/runs/9/cancel") && method === "POST") return Response.json({ message: "already completed" }, { status: 409 });
       return new Response("not found", { status: 404 });
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha409"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha409", 55),
     ).resolves.toEqual({ kind: "cancelled", cancelledCount: 1, totalFound: 1 });
   });
 
@@ -749,7 +781,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha403");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha403", 55);
     expect(outcome.kind).toBe("permission_missing");
     expect((outcome as { warning: string }).warning).toMatch(/actions: write permission is missing/i);
   });
@@ -760,13 +792,13 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 5 }] });
+      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 5, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs?head_sha=") && url.includes("status=queued")) return Response.json({ workflow_runs: [] });
       if (url.endsWith("/actions/runs/5/cancel") && method === "POST") return Response.json({ message: "Resource not accessible by integration" }, { status: 403 });
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha403cancel");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha403cancel", 55);
     expect(outcome.kind).toBe("permission_missing");
   });
 
@@ -779,7 +811,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-ratelimited");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-ratelimited", 55);
     expect(outcome.kind).toBe("error");
   });
 
@@ -792,13 +824,13 @@ describe("GitHub check runs", () => {
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-network-error"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-network-error", 55),
     ).resolves.toEqual({ kind: "error", warning: "network down" });
   });
 
   it("cancelInFlightWorkflowRunsForHeadSha returns an error result for a malformed repoFullName (#2462)", async () => {
     const privateKey = await generatePrivateKeyPem();
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "not-a-valid-repo-name", "sha");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "not-a-valid-repo-name", "sha", 55);
     expect(outcome.kind).toBe("error");
   });
 
@@ -813,7 +845,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-no-message");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-no-message", 55);
     expect(outcome.kind).toBe("permission_missing");
     expect((outcome as { warning: string }).warning).toContain("resource not accessible by integration");
   });
@@ -829,7 +861,7 @@ describe("GitHub check runs", () => {
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-no-workflow-runs-field"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-no-workflow-runs-field", 55),
     ).resolves.toEqual({ kind: "cancelled", cancelledCount: 0, totalFound: 0 });
   });
 
@@ -842,7 +874,7 @@ describe("GitHub check runs", () => {
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-non-error-throw"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-non-error-throw", 55),
     ).resolves.toEqual({ kind: "error", warning: "unknown error" });
   });
 
@@ -857,7 +889,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-list-500");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-list-500", 55);
     expect(outcome).toEqual({ kind: "error", warning: "Failed to list workflow runs (500): unknown error" });
   });
 
@@ -867,7 +899,7 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 42 }] });
+      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 42, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs?head_sha=") && url.includes("status=queued")) return Response.json({ workflow_runs: [] });
       // Neither ok/409 (cancelled) nor a genuine permission-missing 403 -- a transient 500 must surface as a
       // typed `error` result, not be silently dropped and reported as `kind: "cancelled"` with an undercounted
@@ -877,7 +909,7 @@ describe("GitHub check runs", () => {
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-500"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-500", 55),
     ).resolves.toEqual({ kind: "error", warning: expect.stringContaining("Failed to cancel workflow run 42 (500)") });
   });
 
@@ -887,14 +919,14 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 43 }] });
+      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 43, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs?head_sha=") && url.includes("status=queued")) return Response.json({ workflow_runs: [] });
       if (url.endsWith("/actions/runs/43/cancel") && method === "POST") return Response.json({ message: "secondary rate limit exceeded" }, { status: 403 });
       return new Response("not found", { status: 404 });
     });
 
     await expect(
-      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-ratelimited"),
+      cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-ratelimited", 55),
     ).resolves.toEqual({ kind: "error", warning: expect.stringContaining("secondary rate limit exceeded") });
   });
 
@@ -905,7 +937,7 @@ describe("GitHub check runs", () => {
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
-      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 44 }, { id: 45 }] });
+      if (url.includes("/actions/runs?head_sha=") && url.includes("status=in_progress")) return Response.json({ workflow_runs: [{ id: 44, event: "pull_request", pull_requests: [{ number: 55 }] }, { id: 45, event: "pull_request", pull_requests: [{ number: 55 }] }] });
       if (url.includes("/actions/runs?head_sha=") && url.includes("status=queued")) return Response.json({ workflow_runs: [] });
       if (url.endsWith("/actions/runs/44/cancel") && method === "POST") return new Response(null, { status: 500 });
       if (url.endsWith("/actions/runs/45/cancel") && method === "POST") {
@@ -915,7 +947,7 @@ describe("GitHub check runs", () => {
       return new Response("not found", { status: 404 });
     });
 
-    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-partial");
+    const outcome = await cancelInFlightWorkflowRunsForHeadSha(createTestEnv({ GITHUB_APP_PRIVATE_KEY: privateKey }), 123, "owner/repo", "sha-cancel-partial", 55);
 
     expect(outcome.kind).toBe("error");
     expect(secondCancelCalled).toBe(false); // stopped at the first failure rather than continuing past it

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -7747,8 +7747,8 @@ describe("queue processors", () => {
       if (url.includes("/commits/f55/status")) return Response.json({ state: "success", statuses: [] });
       if (url.includes("/issues/55/labels")) return Response.json([]);
       if (url.includes("/issues/55/comments")) return Response.json([]);
-      if (url.includes("/actions/runs?head_sha=f55&status=in_progress")) { seen.listedStatuses.push("in_progress"); return Response.json({ workflow_runs: (runListResponses.in_progress ?? []).map((id) => ({ id })) }); }
-      if (url.includes("/actions/runs?head_sha=f55&status=queued")) { seen.listedStatuses.push("queued"); return Response.json({ workflow_runs: (runListResponses.queued ?? []).map((id) => ({ id })) }); }
+      if (url.includes("/actions/runs?head_sha=f55&status=in_progress")) { seen.listedStatuses.push("in_progress"); return Response.json({ workflow_runs: (runListResponses.in_progress ?? []).map((id) => ({ id, event: "pull_request", pull_requests: [{ number: 55 }] })) }); }
+      if (url.includes("/actions/runs?head_sha=f55&status=queued")) { seen.listedStatuses.push("queued"); return Response.json({ workflow_runs: (runListResponses.queued ?? []).map((id) => ({ id, event: "pull_request", pull_requests: [{ number: 55 }] })) }); }
       if (url.includes("/actions/runs/") && url.endsWith("/cancel") && method === "POST") {
         seen.cancelledIds.push(Number(url.match(/\/actions\/runs\/(\d+)\/cancel/)?.[1]));
         return cancelResponse();


### PR DESCRIPTION
### Motivation
- Prevent a low-privilege contributor from abusing the `actions: write` permission to cancel unrelated workflow runs that share the same commit SHA by narrowing cancellation to the closed PR's runs only.
- Ensure CI cancellation only affects `pull_request` / `pull_request_target` workflow runs whose `pull_requests` metadata includes the closed PR number, avoiding push/workflow_dispatch and same-SHA runs from other PRs.

### Description
- Change `cancelInFlightWorkflowRunsForHeadSha` to accept the closed PR number and only cancel runs that belong to that PR by inspecting run `event` and `pull_requests` metadata; added `WorkflowRunListItem` and `workflowRunBelongsToPull` helpers in `src/github/app.ts` and changed `listWorkflowRunIdsForStatus` to filter accordingly.
- Wire the PR number through the call chain by passing `ctx.pullNumber` from `src/services/agent-action-executor.ts` into the cancellation helper so the executor scopes cancellations to the closed PR.
- Update unit test fixtures and add a regression test in `test/unit/github-app.test.ts` that verifies same-SHA runs from another PR, `push`, and `workflow_dispatch` are ignored while `pull_request` and `pull_request_target` runs for the closed PR are cancelled.
- Adjust `test/unit/queue.test.ts` fixtures to include `event`/`pull_requests` metadata for the contributor-cap cancellation coverage.

### Testing
- Ran `npx vitest run test/unit/github-app.test.ts -t "cancelInFlightWorkflowRunsForHeadSha"` and the targeted tests passed.
- Ran `npx vitest run test/unit/queue.test.ts -t "contributor open-PR cap"` and the targeted tests passed.
- Ran `npm run typecheck` which completed successfully and `git diff --check` produced no issues.
- Attempted `npm audit --audit-level=moderate` but the npm audit endpoint returned `403 Forbidden` in this environment so the audit could not be completed.
- Attempted `npm run test:coverage` (full coverage) but the run did not complete within the available session time and was interrupted; focused regression suites and typecheck succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a481365f3b0832ca9d0497b2752b142)