### PR TITLE
fix(miner): treat repeat markDone as a no-op

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -124,8 +124,8 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
     )
     RETURNING *
   `);
-  const setStatusStatement = db.prepare(
-    "UPDATE miner_portfolio_queue SET status = ? WHERE repo_full_name = ? AND identifier = ?",
+  const markDoneStatement = db.prepare(
+    "UPDATE miner_portfolio_queue SET status = 'done' WHERE repo_full_name = ? AND identifier = ? AND status <> 'done'",
   );
   const listAllStatement = db.prepare(`SELECT * FROM miner_portfolio_queue ${ORDER}`);
   const listRepoStatement = db.prepare(
@@ -155,7 +155,8 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
     markDone(repoFullName, identifier) {
       const normalizedRepo = normalizeRepoFullName(repoFullName);
       const normalizedIdentifier = normalizeIdentifier(identifier);
-      setStatusStatement.run("done", normalizedRepo, normalizedIdentifier);
+      const result = markDoneStatement.run(normalizedRepo, normalizedIdentifier);
+      if (result.changes === 0) return null;
       const row = getStatement.get(normalizedRepo, normalizedIdentifier);
       return row ? rowToEntry(row) : null;
     },

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -88,6 +88,21 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     expect(store.markDone("o/a", "missing")).toBeNull(); // no such row → null branch
   });
 
+  it("markDone is a no-op when the item is already done", () => {
+    const store = tempStore();
+    store.enqueue({ repoFullName: "o/a", identifier: "x", priority: 1 });
+    expect(store.markDone("o/a", "x")?.status).toBe("done");
+    expect(store.markDone("o/a", "x")).toBeNull();
+  });
+
+  it("markDone transitions in-progress items to done", () => {
+    const store = tempStore();
+    store.enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
+    expect(store.dequeueNext()?.status).toBe("in_progress");
+    expect(store.markDone("o/a", "work")?.status).toBe("done");
+    expect(store.markDone("o/a", "work")).toBeNull();
+  });
+
   it("isolates listQueue by repo and lists everything when unfiltered", () => {
     const store = tempStore();
     store.enqueue({ repoFullName: "o/a", identifier: "1", priority: 1 });


### PR DESCRIPTION
## Summary

- Make `markDone` only transition rows that are not already `done`, mirroring the active-only guard on `releaseClaim`.
- Return `null` when no row changed (missing item or already done) so callers can detect a true no-op.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on portfolio-queue `markDone` only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover first transition, double markDone no-op, and in-progress → done.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.
