### PR TITLE
feat(signals): recognize Crystal/Erlang/Elm/Clojure/conda dependency manifests

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -171,6 +171,16 @@ const DEPENDENCY_MANIFEST_NAMES: ReadonlySet<string> = new Set([
   // classic setuptools packaging manifests.
   "setup.py",
   "setup.cfg",
+  // Crystal (shards) + Erlang (rebar3) manifests — their lockfiles (shard.lock,
+  // rebar.lock) are already recognized above, so the manifests they resolve
+  // belong here for the same reason as the Conan/Swift/CocoaPods pairs.
+  "shard.yml",
+  "rebar.config",
+  // Further well-known dependency manifests for ecosystems not yet represented.
+  "elm.json", // Elm
+  "deps.edn", // Clojure (tools.deps)
+  "project.clj", // Clojure (Leiningen)
+  "environment.yml", // conda
 ]);
 
 const DOCS_EXTENSIONS: ReadonlySet<string> = new Set(["md", "mdx", "markdown", "rst", "adoc", "asciidoc"]);

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -182,6 +182,12 @@ describe("isDependencyManifestFile", () => {
       "build.sbt",
       "setup.py",
       "packages/py/setup.cfg",
+      "shard.yml",
+      "erlang/rebar.config",
+      "elm.json",
+      "deps.edn",
+      "project.clj",
+      "conda/environment.yml",
     ]) {
       expect(isDependencyManifestFile(path)).toBe(true);
     }


### PR DESCRIPTION
Extends `DEPENDENCY_MANIFEST_NAMES` (src/signals/path-matchers.ts) with well-known dependency manifests for ecosystems not yet represented, so slop classification counts them as real manifests:

- **shard.yml** (Crystal) and **rebar.config** (Erlang) — their lockfiles (`shard.lock`, `rebar.lock`) are already recognized, so the manifests they resolve belong here for the same reason as the existing Conan/Swift pairs.
- **elm.json** (Elm), **deps.edn** / **project.clj** (Clojure), **environment.yml** (conda).

`classifyChangedFile` already orders `dependency_manifest` ahead of `config`/`source`, so each new name classifies as a manifest (verified — no dual-classification). Extends the `isDependencyManifestFile` positive test cases to cover every new name. Typecheck + unit tests green.