### PR TITLE
fix(selfhost): honor global moderation gate

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -99,7 +99,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "FOREGROUND_LIVENESS_ENABLED",
-    firstReference: "src/selfhost/foreground-liveness.ts:34",
+    firstReference: "src/selfhost/foreground-liveness.ts:41",
   },
   {
     name: "GITHUB_APP_ID",
@@ -337,7 +337,7 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/selfhost/discord-notify.ts:31` |",
   "| `DISCORD_WEBHOOK_URL` | `src/selfhost/discord-notify.ts:40` |",
-  "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:34` |",
+  "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:41` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
   "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:493` |",

--- a/migrations/0105_repository_moderation_settings.sql
+++ b/migrations/0105_repository_moderation_settings.sql
@@ -1,7 +1,7 @@
 -- Per-repo overrides for the moderation-rules engine (#selfhost-mod-engine), layered over
 -- global_moderation_config (0104). moderation_gate_mode defaults to 'inherit' (defers to the global master
--- switch) -- 'off'/'enabled' let one repo opt out of or into the whole layer regardless of the global default,
--- e.g. an operator piloting the feature on a single repo before flipping the global default on. The three
+-- switch) -- 'off' lets one repo opt out while the global layer is enabled; 'enabled' explicitly opts
+-- into the globally enabled layer but cannot override the install-wide master switch. The three
 -- override columns are nullable: NULL means "inherit the global value", never "unset to empty/off" -- an
 -- explicit repo-level empty rules list would be indistinguishable from "not configured" otherwise.
 ALTER TABLE repository_settings ADD COLUMN moderation_gate_mode TEXT NOT NULL DEFAULT 'inherit';

--- a/src/settings/moderation-rules.ts
+++ b/src/settings/moderation-rules.ts
@@ -102,14 +102,13 @@ export function resolveEffectiveModerationRules(globalRules: readonly Moderation
 
 export type ModerationGateMode = "inherit" | "off" | "enabled";
 
-/** Whether the WHOLE moderation layer runs for one repo: `off` force-disables regardless of the global
- *  default (an operator piloting the feature on some repos only), `enabled` force-enables regardless of the
- *  global default (a repo that wants it before the operator flips the global default on), `inherit` (the
- *  default) defers to the global master switch. */
+/** Whether the WHOLE moderation layer runs for one repo: the global master switch is authoritative;
+ *  `off` lets a repo opt out while the global layer is enabled, and `enabled`/`inherit` both require the
+ *  global switch to be on. */
 export function resolveModerationGateEnabled(globalEnabled: boolean, gateMode: ModerationGateMode): boolean {
+  if (!globalEnabled) return false;
   if (gateMode === "off") return false;
-  if (gateMode === "enabled") return true;
-  return globalEnabled;
+  return true;
 }
 
 export type ModerationTier = "none" | "warning" | "banned";

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -872,8 +872,16 @@ describe("moderation-rules engine escalation (#selfhost-mod-engine)", () => {
     expect(ensurePullRequestLabel).not.toHaveBeenCalledWith(env, 123, "owner/repo", 7, "mod:warning", expect.anything());
   });
 
-  it("per-repo moderationGateMode 'enabled' force-enables the layer even when the global config is disabled (the default)", async () => {
+  it("REGRESSION (security): per-repo moderationGateMode 'enabled' cannot override the disabled global master switch", async () => {
     const env = createTestEnv({});
+    await executeAgentMaintenanceActions(env, ctx({ authorLogin: "farmer99", moderationSettings: { moderationGateMode: "enabled" } }), [coupledClose, coupledLabel]);
+    expect(ensurePullRequestLabel).not.toHaveBeenCalledWith(env, 123, "owner/repo", 7, "mod:warning", expect.anything());
+    expect(await getGlobalContributorBlacklist(env)).toEqual([]);
+  });
+
+  it("per-repo moderationGateMode 'enabled' runs when the global master switch is enabled", async () => {
+    const env = createTestEnv({});
+    await upsertGlobalModerationConfig(env, { enabled: true });
     await executeAgentMaintenanceActions(env, ctx({ authorLogin: "farmer99", moderationSettings: { moderationGateMode: "enabled" } }), [coupledClose, coupledLabel]);
     expect(ensurePullRequestLabel).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "mod:warning", { createMissingLabel: true });
   });

--- a/test/unit/moderation-rules.test.ts
+++ b/test/unit/moderation-rules.test.ts
@@ -85,9 +85,9 @@ describe("resolveModerationGateEnabled (#selfhost-mod-engine)", () => {
     expect(resolveModerationGateEnabled(false, "off")).toBe(false);
   });
 
-  it("'enabled' force-enables regardless of the global default", () => {
+  it("'enabled' still requires the global master switch", () => {
     expect(resolveModerationGateEnabled(true, "enabled")).toBe(true);
-    expect(resolveModerationGateEnabled(false, "enabled")).toBe(true);
+    expect(resolveModerationGateEnabled(false, "enabled")).toBe(false);
   });
 
   it("'inherit' defers to the global default", () => {


### PR DESCRIPTION
### Motivation

- Prevent a per-repository `.gittensory.yml` from enabling the moderation layer when the install-wide global moderation master switch is disabled, which could otherwise allow a maintainer of one repo to trigger install-wide auto-blacklisting. 

### Description

- Require the global master switch to be enabled before any per-repo `moderationGateMode` can turn the layer on by changing `resolveModerationGateEnabled` in `src/settings/moderation-rules.ts` so `globalEnabled` is authoritative. 
- Clarify the repository-moderation migration comment in `migrations/0105_repository_moderation_settings.sql` to document that `moderationGateMode: enabled` cannot override the install-wide master switch. 
- Add regression coverage and update unit tests in `test/unit/agent-action-executor.test.ts` and `test/unit/moderation-rules.test.ts` to assert the disabled-global / per-repo-enabled case is denied and the allowed globally-enabled case still runs. 
- Regenerate the self-host environment reference artifact at `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` to keep gate artifacts in sync. 

### Testing

- Ran the targeted unit suites with `npx vitest run test/unit/moderation-rules.test.ts test/unit/agent-action-executor.test.ts --reporter=verbose`, and all targeted tests passed. 
- Ran `npm run typecheck` and `git diff --check`, both of which completed without type or diff errors. 
- Attempted the full local gate via `npm run test:ci`; earlier pre-checks passed but the run was terminated during the long coverage phase in this environment. 
- Ran `npm audit --audit-level=moderate`, which failed with a `403` from the npm audit endpoint (registry access issue) and is not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4852b4d754832cb57a0a1d8d6ad97d)