### PR TITLE
fix(review): clamp implicit synthesis onMerge floor

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -96,7 +96,7 @@ export type { CombineStrategy, OnMerge } from "../types";
  *   - operator floor `either` + repo override `both`  → CLAMPED to `either` (an attempted loosening).
  *   - operator floor `either` + repo override `either` → `either` (a no-op tightening).
  *   - operator floor `both` (or unset)                → the repo override (or the operator's own value) wins
- *     unclamped — there is no stricter floor to violate.
+ *     unclamped — there is no stricter floor visible to this field-level helper.
  * Returns the resolved value alongside whether a clamp fired, so the caller can log/surface it (a maintainer
  * who configured a loosening override should see it was not honored, not have it silently ignored).
  */
@@ -138,8 +138,12 @@ export function resolveEffectiveAiReviewPlan(
   repoOverride: AiReviewPlanShape,
   operatorPlan: AiReviewPlanShape | null | undefined,
 ): { combine: CombineStrategy | null | undefined; onMerge: OnMerge | null | undefined; reviewers: AiReviewPlanShape["reviewers"]; clamped: boolean } {
-  const onMergeResolution = resolveEffectiveAiReviewOnMerge(repoOverride.onMerge, operatorPlan?.onMerge);
-  const hasOperatorFloor = operatorPlan?.onMerge === "either";
+  // In synthesis mode, an omitted operator onMerge is not "no floor": combineReviews' historical effective
+  // default is `either`. Clamp against that implicit default too, otherwise a repo could set `both` and loosen a
+  // self-host dual-review plan whose operator simply relied on the default.
+  const operatorOnMergeFloor = operatorPlan?.onMerge ?? (operatorPlan?.combine === "synthesis" ? "either" : undefined);
+  const onMergeResolution = resolveEffectiveAiReviewOnMerge(repoOverride.onMerge, operatorOnMergeFloor);
+  const hasOperatorFloor = operatorOnMergeFloor === "either";
   if (hasOperatorFloor) {
     // The operator's OWN effective reviewer count under their plan -- absent reviewers falls back to the
     // built-in default pair (2), the historical dual-reviewer behavior (see GittensoryAiReviewInput.reviewers).

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1087,7 +1087,7 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
       expect(await renderMetrics()).not.toContain("gittensory_ai_review_onmerge_clamped_total");
     });
 
-    it("when the operator set no onMerge floor at all, any per-repo value is honored unclamped", async () => {
+    it("a synthesis operator plan with no onMerge still clamps repo both against the implicit either floor", async () => {
       const env = planEnv(
         { reviewers: [{ model: "claude-code" }, { model: "codex" }], combine: "synthesis" }, // no onMerge set
         async (model) =>
@@ -1099,11 +1099,11 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
         ...baseInput,
         mode: "block",
         combine: "synthesis",
-        onMerge: "both", // no floor to violate
+        onMerge: "both", // attempted loosening of synthesis' implicit "either" default
       });
       if (result.status !== "ok") throw new Error("expected ok");
-      expect(result.consensusDefect).toBeNull(); // "both" honored: lone blocker does not decide
-      expect(await renderMetrics()).not.toContain("gittensory_ai_review_onmerge_clamped_total");
+      expect(result.consensusDefect?.title).toContain("Lone blocker");
+      expect(await renderMetrics()).toContain('gittensory_ai_review_onmerge_clamped_total{mode="block"} 1');
     });
   });
 });
@@ -1144,6 +1144,14 @@ describe("resolveEffectiveAiReviewPlan (#2567 gate-review follow-up: combine/rev
 
     const noOperatorPlan = resolveEffectiveAiReviewPlan({ combine: "single", reviewers: [{ model: "claude-code" }] }, null);
     expect(noOperatorPlan).toEqual({ combine: "single", onMerge: undefined, reviewers: [{ model: "claude-code" }], clamped: false });
+  });
+
+  it("gate finding: synthesis with omitted operator onMerge protects its implicit either floor", () => {
+    const implicitFloor = resolveEffectiveAiReviewPlan(
+      { onMerge: "both" },
+      { combine: "synthesis", reviewers: TWO_REVIEWERS },
+    );
+    expect(implicitFloor).toEqual({ combine: "synthesis", onMerge: "either", reviewers: TWO_REVIEWERS, clamped: true });
   });
 
   it("gate finding: an either-floor operator plan cannot be neutered by a repo override reducing reviewer count", () => {


### PR DESCRIPTION
### Motivation
- Prevent a repo `gate.aiReview.onMerge: both` override from loosening a self-host operator's implicit `either` behavior when the operator relied on the historical `synthesis` default but did not explicitly set `onMerge`.
- The field-level clamp helper only handled an explicit operator floor, so an omitted `onMerge` in a `synthesis` plan allowed unsafe overrides.

### Description
- Treat an operator `synthesis` plan with no explicit `onMerge` as having an implicit `either` floor by computing `operatorOnMergeFloor = operatorPlan?.onMerge ?? (operatorPlan?.combine === "synthesis" ? "either" : undefined)` and passing it to `resolveEffectiveAiReviewOnMerge` in `resolveEffectiveAiReviewPlan`.
- Updated the doc comment for the field-level helper to clarify visibility of an unset floor at that helper layer.
- Added regression unit tests exercising the self-host dual-review path and a pure-plan test so that a repo `both` override is clamped back to `either` when the operator relies on the implicit synthesis default.

### Testing
- Ran targeted and full unit tests with `npx vitest run test/unit/ai-review.test.ts` and the focused pattern `npx vitest run test/unit/ai-review.test.ts -t "implicit either|per-repo onMerge|resolveEffectiveAiReviewPlan|resolveEffectiveAiReviewOnMerge"`, all passing (104 tests total for the suite run).
- Ran `npm run typecheck` which completed with no TypeScript errors.
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate`, but they could not complete in this environment due to network/bootstrap constraints (actionlint bootstrap could not reach GitHub and the npm audit endpoint returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48142944b4832ca5f0b5e9f8d6bc0a)