### PR TITLE
fix(engine): cap miner goal list inspection

### DIFF
--- a/packages/gittensory-engine/src/miner-goal-spec-parse.ts
+++ b/packages/gittensory-engine/src/miner-goal-spec-parse.ts
@@ -32,7 +32,11 @@ function parseStringList(value: unknown, field: string, warnings: string[]): str
   }
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const entry of value) {
+  for (const [index, entry] of value.entries()) {
+    if (index >= MAX_LIST_ENTRIES) {
+      warnings.push(`MinerGoalSpec field "${field}" is capped at ${MAX_LIST_ENTRIES} entries; dropping the rest.`);
+      break;
+    }
     if (typeof entry !== "string") {
       warnings.push(`MinerGoalSpec field "${field}" entries must be strings; skipping non-string.`);
       continue;

--- a/packages/gittensory-engine/test/miner-goal-spec-parse.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-spec-parse.test.ts
@@ -63,3 +63,39 @@ test("parseMinerGoalSpec warns and falls back on malformed fields", () => {
   assert.equal(result.spec.issueDiscoveryPolicy, "neutral");
   assert.ok(result.warnings.length >= 4);
 });
+
+test("parseMinerGoalSpec caps list inspection for invalid entries", () => {
+  const result = parseMinerGoalSpec({
+    wantedPaths: Array.from({ length: 1_000 }, () => null),
+  });
+
+  assert.deepEqual(result.spec.wantedPaths, []);
+  assert.equal(result.warnings.length, 201);
+  assert.match(result.warnings.at(-1) ?? "", /capped at 200 entries/);
+});
+
+test("parseMinerGoalSpec caps list inspection for duplicate, empty, and overlong entries", () => {
+  const duplicates = parseMinerGoalSpec({
+    wantedPaths: Array.from({ length: 1_000 }, () => "src/**"),
+  });
+  assert.deepEqual(duplicates.spec.wantedPaths, ["src/**"]);
+  assert.deepEqual(duplicates.warnings, [
+    'MinerGoalSpec field "wantedPaths" is capped at 200 entries; dropping the rest.',
+  ]);
+
+  const empty = parseMinerGoalSpec({
+    wantedPaths: Array.from({ length: 1_000 }, () => " "),
+  });
+  assert.deepEqual(empty.spec.wantedPaths, []);
+  assert.deepEqual(empty.warnings, [
+    'MinerGoalSpec field "wantedPaths" is capped at 200 entries; dropping the rest.',
+  ]);
+
+  const overlong = parseMinerGoalSpec({
+    wantedPaths: Array.from({ length: 1_000 }, () => "x".repeat(301)),
+  });
+  assert.deepEqual(overlong.spec.wantedPaths, []);
+  assert.deepEqual(overlong.warnings, [
+    'MinerGoalSpec field "wantedPaths" is capped at 200 entries; dropping the rest.',
+  ]);
+});


### PR DESCRIPTION
### Motivation
- The `MinerGoalSpec` string-list parser only enforced `MAX_LIST_ENTRIES` after accepting valid unique strings, allowing malicious or malformed arrays to be scanned unbounded and generate unbounded warnings and CPU/memory work.
- The change bounds the amount of input inspected to prevent resource exhaustion while preserving existing normalization behavior.

### Description
- Stop iterating untrusted lists after `MAX_LIST_ENTRIES` inspected entries by switching to `for (const [index, entry] of value.entries())` and breaking with a capped warning when the limit is reached in `packages/gittensory-engine/src/miner-goal-spec-parse.ts`.
- Emit a clear cap warning when inspection stops early (`MinerGoalSpec field "<field>" is capped at 200 entries; dropping the rest.`).
- Add regression tests exercising hostile arrays of `null` entries, duplicates, empty strings, and overlong strings to assert parsing and warning growth are bounded in `packages/gittensory-engine/test/miner-goal-spec-parse.test.ts`.
- No behavioral changes to accepted normalized entries or exported API surface beyond hardening the input inspection bound.

### Testing
- `git diff --check` passed locally.
- `npm --workspace @jsonbored/gittensory-engine test` ran the package suite and all tests passed (51 passing, 0 failing), including the new regression tests.
- `npm run test:ci` could not be completed in this environment due to an external actionlint setup/download DNS failure and the local actionlint WASM fallback flagging a self-hosted runner label, so the full repo gate was not executed here.
- `npm audit --audit-level=moderate` could not be completed due to the registry audit endpoint returning a `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4814f253f8832c99cbf72b763547d5)