### PR TITLE
fix(miner): reject invalid since cursors in event ledger reads

### DIFF
--- a/packages/gittensory-miner/lib/event-ledger.js
+++ b/packages/gittensory-miner/lib/event-ledger.js
@@ -54,6 +54,15 @@ function normalizeOptionalRepoFullName(repoFullName) {
   return `${owner}/${repo}`;
 }
 
+/** Optional seq cursor for polling: omitted → undefined; otherwise a non-negative integer last-seen seq. */
+function normalizeOptionalSince(since) {
+  if (since === undefined) return undefined;
+  if (typeof since !== "number" || !Number.isInteger(since) || since < 0) {
+    throw new Error("invalid_since");
+  }
+  return since;
+}
+
 // Serialize an audit payload, enforcing that it round-trips through JSON VERBATIM. A plain JSON.stringify would
 // silently drop `undefined`/function/symbol values and coerce `NaN`/`Infinity` to `null` (and throw on BigInt or a
 // cycle), so a read-back would not equal the appended event. We reject any such lossy payload outright — an audit
@@ -155,7 +164,7 @@ export function initEventLedger(dbPath = resolveEventLedgerDbPath()) {
         : normalizeOptionalRepoFullName(filter.repoFullName);
       // `since` returns events with a seq STRICTLY greater than it — the "give me everything after the last seq I
       // saw" polling shape.
-      const since = typeof filter.since === "number" ? filter.since : undefined;
+      const since = normalizeOptionalSince(filter.since);
 
       let rows;
       if (repoFullName !== undefined && since !== undefined) {

--- a/test/unit/miner-event-ledger.test.ts
+++ b/test/unit/miner-event-ledger.test.ts
@@ -96,6 +96,15 @@ describe("gittensory-miner event ledger (#2290)", () => {
     expect(ledger.readEvents({ repoFullName: "o/a", since: 1 }).map((entry) => entry.seq)).toEqual([3]);
   });
 
+  it("rejects a non-integer or non-finite since cursor rather than querying with it", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "discovered_issue", payload: {} });
+    expect(() => ledger.readEvents({ since: Number.NaN })).toThrow("invalid_since");
+    expect(() => ledger.readEvents({ since: Number.POSITIVE_INFINITY })).toThrow("invalid_since");
+    expect(() => ledger.readEvents({ since: -1 })).toThrow("invalid_since");
+    expect(() => ledger.readEvents({ since: 1.5 })).toThrow("invalid_since");
+  });
+
   it("rejects a non-object payload and a malformed repo scope rather than persisting them", () => {
     const ledger = tempLedger();
     // @ts-expect-error — payload must be an object


### PR DESCRIPTION
## Summary

- Validate the `since` seq cursor in `readEvents` so polling rejects non-integer, negative, and non-finite values.
- Prevents corrupted cursors (e.g. `NaN` from bad arithmetic) from silently reaching SQLite.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on event-ledger `readEvents` filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover valid since filtering and rejection of NaN, Infinity, negative, and fractional cursors.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.
