### PR TITLE
fix(review): hold artifact companions for manual review

### DIFF
--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -191,15 +191,15 @@ export async function runSurfaceReview(spec: RegistryLaneSpec, input: SurfaceRev
   // mixed-files, since there's nothing else in that diff worth preserving.
   const directFile = scope.directFile as string;
   const companionProviderFile = scope.providerCompanionFile;
-  // Anything besides the direct file must be a companion the classifier already approved: the recognized debut-
-  // provider companion (validated below) or a spec.artifactPattern match (a generated build artifact — allowed
-  // as-is, never validated). Anything else here is an unrecognized/ambiguous shape (classifyRegistryPrScope only
-  // reaches this scope when every file matched SOME allowed pattern, so this is the residual "which companion is
-  // it" case, e.g. more than one provider companion) — fall back to routing it to manual review.
+  // Anything besides the direct file must be the recognized debut-provider companion validated below. Generated
+  // artifact companions match an allowed path pattern, but the surface lane does not prove they match the source
+  // entry, so route them to manual review rather than treating arbitrary artifact content as merge-safe. Anything
+  // else here is an unrecognized/ambiguous shape (classifyRegistryPrScope only reaches this scope when every file
+  // matched SOME allowed pattern, so this is the residual "which companion is it" case, e.g. more than one provider
+  // companion) — fall back to routing it to manual review.
   for (const file of input.changedFiles) {
     const normalized = file.trim();
     if (normalized === "" || normalized === directFile || normalized === companionProviderFile) continue;
-    if (spec.artifactPattern?.test(normalized)) continue;
     return { verdict: "manual", summary: "Registry submission includes companion file changes — routing to review." };
   }
   if (scope.isProvider) {

--- a/test/unit/content-lane-orchestrator.test.ts
+++ b/test/unit/content-lane-orchestrator.test.ts
@@ -175,19 +175,21 @@ describe("runSurfaceReview (deterministic + decisive: merge/close, rarely manual
     expect(r?.verdict).toBe("merge");
   });
 
-  it("[test 3] merges an entry submission accompanied ONLY by an artifactPattern companion, without validating it as a provider", async () => {
+  it("[test 3] routes an entry submission with an artifactPattern companion to manual review", async () => {
     const calls: string[] = [];
     const r = await runSurfaceReview(METAGRAPHED_LANE_SPEC, {
       changedFiles: [SUBNET, ARTIFACT],
       loadFile: (path, ref) => {
         calls.push(`${ref}:${path}`);
-        if (path === ARTIFACT) return Promise.resolve("<<not even valid json>>"); // garbage content, never read
+        if (path === ARTIFACT) return Promise.resolve("<<not even valid json>>");
         return Promise.resolve(ref === "head" ? doc([existing, newEntry]) : doc([existing]));
       },
     });
-    expect(r?.verdict).toBe("merge");
-    // The artifact companion is allowed as-is (generated build output) — never loaded/validated.
-    expect(calls.some((c) => c.includes(ARTIFACT))).toBe(false);
+    expect(r).toEqual({
+      verdict: "manual",
+      summary: "Registry submission includes companion file changes — routing to review.",
+    });
+    expect(calls).toEqual([]);
   });
 
   it("[test 4] a companion file matching NEITHER providerFilePattern NOR artifactPattern is still mixed-files (close), unchanged", async () => {


### PR DESCRIPTION
### Motivation
- Close a security gap where files matching `spec.artifactPattern` (generated artifacts) were silently accepted as companions and could allow malformed or malicious generated artifacts to be auto-merged with a valid entry.
- Ensure the surface review lane validates or human-reviews any companion that is not a recognized debut provider before returning a merge verdict.

### Description
- Changed `src/review/content-lane/orchestrator.ts` to stop auto-skipping `spec.artifactPattern` companions and route any non-direct, non-provider companion to manual review instead. 
- Kept provider-companion behavior intact so genuine debut providers are still validated via `assessProviderEntry` and combined with the entry assessment before merging. 
- Updated `test/unit/content-lane-orchestrator.test.ts` to assert that an entry bundled with an `artifactPattern` companion is routed to manual review and that artifact content is not fetched/treated as merge-safe. 
- Preserved the concurrent fetch strategy for entry/provider files and the other existing adjudication flows.

### Testing
- Ran the unit file: `npx vitest run test/unit/content-lane-orchestrator.test.ts` and all tests in that file passed (42/42).
- Ran type checking with `npm run typecheck` and it passed (`tsc --noEmit`).
- Ran scoped coverage: `npm run test:coverage -- test/unit/content-lane-orchestrator.test.ts` produced passing tests but failed the repository-wide coverage gate due to global thresholds, as expected for a focused run.
- Attempted the full `npm run test:coverage` (full suite) and `npm audit --audit-level=moderate`; the full coverage run exceeded the available run window and was not completed, and the audit endpoint returned `403 Forbidden` when invoked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47abf2c39c832ca5a38ad58f213a93)