### PR TITLE
fix(miner): treat an empty AI-USAGE.md as absent in the AI-policy verdict

### DIFF
--- a/packages/gittensory-engine/src/ai-policy-map.ts
+++ b/packages/gittensory-engine/src/ai-policy-map.ts
@@ -58,7 +58,10 @@ export function resolveAiPolicyVerdict(docs: {
   aiUsage: string | null | undefined;
   contributing: string | null | undefined;
 }): AiPolicyVerdict {
-  if (docs.aiUsage !== null && docs.aiUsage !== undefined) {
+  // An empty or whitespace-only AI-USAGE.md carries no policy and must fall through to CONTRIBUTING.md,
+  // exactly as an absent (null/undefined) file does — otherwise a stub AI-USAGE.md silently fails open and
+  // swallows a real ban declared in CONTRIBUTING.md (#2305).
+  if (docs.aiUsage !== null && docs.aiUsage !== undefined && docs.aiUsage.trim().length > 0) {
     return scanAiPolicyText(docs.aiUsage, "AI-USAGE.md");
   }
   if (docs.contributing !== null && docs.contributing !== undefined) {

--- a/test/unit/miner-ai-policy-map.test.ts
+++ b/test/unit/miner-ai-policy-map.test.ts
@@ -63,4 +63,13 @@ describe("miner AI policy map (#2305)", () => {
       source: "none",
     });
   });
+
+  it("treats an empty, whitespace-only, or undefined AI-USAGE.md as absent and falls back to CONTRIBUTING.md", () => {
+    const banned = { allowed: false, matchedPhrase: "ai-generated prs are rejected", source: "CONTRIBUTING.md" } as const;
+    const contributing = "AI-generated PRs are not accepted.";
+    // A stub AI-USAGE.md carries no policy and must not fail open over a real ban in CONTRIBUTING.md.
+    expect(resolveAiPolicyVerdict({ aiUsage: "", contributing })).toEqual(banned);
+    expect(resolveAiPolicyVerdict({ aiUsage: "   \n  ", contributing })).toEqual(banned);
+    expect(resolveAiPolicyVerdict({ aiUsage: undefined, contributing })).toEqual(banned);
+  });
 });


### PR DESCRIPTION
## Summary

`resolveAiPolicyVerdict` in `packages/gittensory-engine/src/ai-policy-map.ts` cascades from `AI-USAGE.md`
to `CONTRIBUTING.md` to an absent-doc default. Its `AI-USAGE.md` guard accepted **any** non-null string —
including an empty or whitespace-only one. `scanAiPolicyText("")` short-circuits to `allowed: true`, so a
stub `AI-USAGE.md` returned an allow verdict and the cascade to `CONTRIBUTING.md` never ran — **failing
open** and swallowing a real ban declared there.

The inconsistency is verdict-flipping: `aiUsage: null` correctly cascades, but `aiUsage: ""` does not.

```ts
resolveAiPolicyVerdict({ aiUsage: "", contributing: "No AI-generated pull requests." })
// before: { allowed: true,  matchedPhrase: null, source: "AI-USAGE.md" }   ← fails open
// after:  { allowed: false, matchedPhrase: "no ai-generated pull requests", source: "CONTRIBUTING.md" }
```

Fix: require the `AI-USAGE.md` text to be non-blank (`docs.aiUsage.trim().length > 0`) before treating it
as authoritative, so an empty/whitespace-only file falls through exactly like an absent one. This keeps
the module's stated conservative intent (#2305) — an empty file carries no policy and must not override a
ban in `CONTRIBUTING.md`.

No linked issue: small, self-evident fail-open correctness fix in one deterministic helper (one guard
clause) with no public API, auth, schema, or deploy surface change — fits the repo's `preferred` (not
required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:miner` (engine + miner build — the changed file is in `@jsonbored/gittensory-engine`)
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), the `@jsonbored/gittensory-engine`
  build (`tsc -p`, clean), and a focused `test:coverage` over `test/unit/miner-ai-policy-map.test.ts` —
  8 tests pass and `ai-policy-map.ts` is at **100% statements/branches/functions/lines** (both sides of
  the null/undefined/empty guard covered), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This change is confined to
  one deterministic engine helper and its unit test — it touches no UI/API/OpenAPI/MCP/DB/workflow
  surface, so those jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic engine helper fix, so the
  auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/miner-ai-policy-map.test.ts` ("treats an empty, whitespace-only, or
  undefined AI-USAGE.md as absent and falls back to CONTRIBUTING.md"): empty, whitespace-only, and
  undefined `aiUsage` now all cascade to the `CONTRIBUTING.md` ban instead of failing open.
