### PR TITLE
docs(config): correct gate knob semantics in .gittensory.yml.example

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -165,9 +165,9 @@ gate:
     # the gate. Bool. Default: false.
     aiAdvisory: false
 
-  # Oversized-PR gate. A PR at/above BOTH the file-count and line-count thresholds
+  # Oversized-PR gate. A PR at/above EITHER the file-count or line-count threshold
   # (engine defaults, not configurable here) gets a manual-review HOLD finding —
-  # never a hard blocker, so it's dry-run/advisory friendly regardless of mode.
+  # never a hard blocker; mode only turns this hold signal on or off.
   # off | advisory | block. Default: off. Config-as-code only — no DB column or
   # dashboard toggle; this can only be set here.
   size:
@@ -232,11 +232,12 @@ gate:
   # DB-backed (dashboard-settable too); this overrides the stored value.
   selfAuthoredLinkedIssue: advisory
 
-  # Gate-wide dry-run. When true, the gate evaluates and posts its verdict as
-  # normal but never actually blocks/merges/closes based on it — useful for
-  # trialing a stricter pack or mode change against real traffic before
-  # enforcing it. Bool. Default: false. Config-as-code only — no DB column or
-  # dashboard toggle; this can only be set here.
+  # Gate-check dry-run. When true, the posted check conclusion remains the real
+  # non-enforcing verdict while comments/check text may also show the would-be
+  # stricter verdict for AI-review blocker mode. It does not disable downstream
+  # merge/close planning for failures from already-enforced gates. Bool.
+  # Default: false. Config-as-code only — no DB column or dashboard toggle;
+  # this can only be set here.
   dryRun: false
 
   # First-time-contributor grace. RESERVED / currently INERT: this value is
@@ -291,8 +292,9 @@ gate:
     # String or null. Default: null (the key record's model, else a conservative
     # per-provider default).
     model: null
-    # Minimum calibrated AI-reviewer confidence (0-1) for a consensus defect to
-    # become a blocker; below this it stays advisory-only. Number 0–1, or null.
+    # Minimum calibrated AI-reviewer confidence (0-1) recorded for cache and
+    # calibration context. Under `mode: block`, consensus and split AI-review
+    # defects still block regardless of this floor. Number 0–1, or null.
     # Default: null (engine uses 0.93). Config-as-code only — no DB column or
     # dashboard toggle; this can only be set here.
     closeConfidence: null


### PR DESCRIPTION
### Motivation

- The example `.gittensory.yml` text introduced wording that does not match the runtime semantics of several enforcement-sensitive gate knobs, which could mislead maintainers into unsafe expectations. 
- Specifically, the size gate wording implied a BOTH threshold, `gate.dryRun` was presented as suppressing enforcement, and `gate.aiReview.closeConfidence` was described as preventing blocks below the floor. 
- The documentation should reflect the actual implemented behavior so repository owners can safely tune gate knobs.

### Description

- Updated `.gittensory.yml.example` to clarify the Oversized-PR gate: the manual-review HOLD triggers when EITHER the changed-file count or changed-line count exceeds its threshold, matching the implemented logic (`src/rules/advisory.ts`).
- Reworded `gate.dryRun` to clarify it is a check/comment preview (the posted check may show a would-be stricter verdict) and does not disable downstream merge/close planning for failures already enforced by the gate.
- Reworded `gate.aiReview.closeConfidence` to document that the value is recorded for cache/calibration context and does not downgrade block-mode AI defects into advisory-only, matching the evaluator logic.
- Change is documentation-only in `.gittensory.yml.example` and preserves existing behavior and tests.

### Testing

- Ran `git diff --check` which reported no whitespace/conflict issues and is clean. 
- Ran the focused unit test `npx vitest run test/unit/focus-manifest.test.ts --testNamePattern "parses \\.gittensory\\.yml\\.example"`, which passed and confirmed the example file parses with zero warnings and the parser round-trips the documented knobs. 
- Attempted full local gate with `npm run test:ci`, and `npm audit --audit-level=moderate`, but those runs were blocked in this environment due to external network/setup failures (actionlint setup/network and `npm audit` endpoint errors) and could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474cc72954832c9822dd1332a879fc)