### PR TITLE
fix(miner): canonicalize ranker owner/repo from repoFullName

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-ranker.js
+++ b/packages/gittensory-miner/lib/opportunity-ranker.js
@@ -29,8 +29,8 @@ function normalizeCandidate(candidate) {
         .map((label) => label.trim())
     : [];
   return {
-    owner: typeof candidate.owner === "string" ? candidate.owner : owner,
-    repo: typeof candidate.repo === "string" ? candidate.repo : repo,
+    owner,
+    repo,
     repoFullName: canonicalRepoFullName,
     issueNumber,
     title,

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -230,6 +230,22 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(ranked[0]?.aiPolicySource).toBe("AI-USAGE.md");
   });
 
+  it("ignores conflicting owner/repo fields when repoFullName is valid", () => {
+    const ranked = rankCandidateIssues(
+      [
+        rawIssue({
+          owner: "wrong",
+          repo: "name",
+          repoFullName: "acme/widgets",
+        }),
+      ],
+      { nowMs: NOW },
+    );
+    expect(ranked[0]?.owner).toBe("acme");
+    expect(ranked[0]?.repo).toBe("widgets");
+    expect(ranked[0]?.repoFullName).toBe("acme/widgets");
+  });
+
   it("uses Date.now when nowMs is not finite", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-03T12:00:00.000Z"));


### PR DESCRIPTION
## Summary

- Always derive `owner` and `repo` from the validated `repoFullName` slug in the opportunity ranker.
- Prevents malformed fan-out metadata with conflicting owner/repo fields from leaking into ranked output.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on opportunity-ranker normalization only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers conflicting owner/repo fields overridden by canonical slug parsing.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, local-only: no network calls.

## UI Evidence

Not applicable — miner library only.
