### PR TITLE
fix(review): record neutral gate holds and bound audit-event reason text

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -437,7 +437,7 @@ import {
   recordReversalSignals,
   runSelfTuneBreaker,
 } from "../review/outcomes-wire";
-import { recordNativeGateDecision } from "../review/parity-wire";
+import { neutralHoldReasonCode, recordNativeGateDecision } from "../review/parity-wire";
 import type { SubmissionOutcome } from "../review/submitter-reputation";
 import type {
   AdvisoryFinding,
@@ -1876,6 +1876,21 @@ export function precisionBreakerDowngradeDirections(planned: PlannedAgentAction[
   return directions;
 }
 
+/** PURE: the bounded `{actionClass, blockerClass}` label pair for the `gittensory_agent_disposition_total`
+ *  counter (#terminal-outcome-audit), derived from the FINAL post-breaker plan and the gate's own blocker
+ *  codes -- never from free text. `actionClass` is "merge"/"close" when the final plan still contains that
+ *  action, else "hold" (guardrail, owner-exemption, migration-collision, not-yet-mergeable, breaker-downgraded,
+ *  or any other bucket that produces no merge/close action). `blockerClass` is the first gate-blocker code, or
+ *  "none" when the gate reported none (a clean PR held for a non-blocker reason, e.g. CI still pending). */
+export function agentDispositionLabels(breakerOnPlan: PlannedAgentAction[], gateBlockerCodes: string[]): { actionClass: "merge" | "close" | "hold"; blockerClass: string } {
+  const actionClass = breakerOnPlan.some((action) => action.actionClass === "merge")
+    ? "merge"
+    : breakerOnPlan.some((action) => action.actionClass === "close")
+      ? "close"
+      : "hold";
+  return { actionClass, blockerClass: gateBlockerCodes[0] ?? "none" };
+}
+
 /**
  * Historical compatibility helper for callers/tests that still need to know whether branch-protection contexts
  * were readable. The disposition planner no longer uses this to soften red CI: any visible completed red
@@ -2391,6 +2406,20 @@ async function runAgentMaintenancePlanAndExecute(
   for (const direction of precisionBreakerDowngradeDirections(planned, breakerOnPlan)) {
     incr("gittensory_precision_breaker_downgrades_total", { direction });
   }
+  // Observability (#terminal-outcome-audit): the final per-pass disposition, ALWAYS recorded -- including the
+  // "hold" bucket below (guardrail, owner-exemption, migration-collision, breaker-downgraded, or any other
+  // reason that produces no merge/close action), which previously left NO aggregate signal at all. Placed
+  // BEFORE the early return so an empty breakerOnPlan (the most common hold shape: nothing was ever planned)
+  // still increments. autonomy_level reports the class most directly relevant to the recorded action_class --
+  // `close` for a hold, since "autonomy.close is auto but this PR still holds" is the exact symptom this
+  // metric exists to make visible without hand-querying review_audit.
+  const disposition = agentDispositionLabels(breakerOnPlan, gate.blockers.map((blocker) => blocker.code));
+  incr("gittensory_agent_disposition_total", {
+    repo: repoFullName,
+    action_class: disposition.actionClass,
+    blocker_class: disposition.blockerClass,
+    autonomy_level: resolveAutonomy(settings.autonomy, disposition.actionClass === "merge" ? "merge" : "close"),
+  });
   if (breakerOnPlan.length === 0) return;
 
   // #2552 (gate review finding, round 2): force a fresh rebase + CI recheck when the base has advanced within
@@ -7667,10 +7696,14 @@ async function maybePublishPrPublicSurface(
     // authoritative 'reviewbot' rows it is later compared against are written by reviewbot's deploy-time dual-
     // run, not here (see src/review/parity-wire.ts). Only a finalized gate evaluation (not skipped) is recorded.
     if (gateEvaluation) {
+      // #terminal-outcome-audit: a neutral conclusion is now ALSO recorded as a hold (nativeGateActionFromConclusion),
+      // so give it the same bounded-reason-class treatment "failure" already gets, instead of falling back to
+      // the bare "neutral" string -- an operator asking "why is this held" should see guardrail_hold /
+      // oversized_pr / ai_review_inconclusive / etc, not an undifferentiated bucket.
       const reasonCode =
         gateEvaluation.conclusion === "failure"
           ? (gateEvaluation.blockers[0]?.code ?? gateEvaluation.conclusion)
-          : gateEvaluation.conclusion;
+          : (neutralHoldReasonCode(gateEvaluation) ?? gateEvaluation.conclusion);
       await recordNativeGateDecision(env, {
         project: repoFullName,
         pullNumber: pr.number,

--- a/src/review/parity-wire.ts
+++ b/src/review/parity-wire.ts
@@ -28,9 +28,36 @@
 // cutover step, out of scope for this PR.
 
 import { computeGateParity, isParityCutoverReady, type GateAction, type GateParityRow } from "./parity";
-import type { GateCheckConclusion } from "../rules/advisory";
+import type { GateCheckConclusion, GateCheckEvaluation } from "../rules/advisory";
 import { isSelfHostedReviewRuntime } from "../selfhost/review-runtime";
 import { errorMessage, nowIso } from "../utils/json";
+
+// Bounded reason-class codes evaluateGateCheckCore (rules/advisory.ts) attaches to a NEUTRAL evaluation's
+// `warnings`, in the same priority order as its own return branches. Kept here (not re-exported from
+// advisory.ts) because "which of these codes counts as the neutral hold's reason" is a recording/observability
+// concern, not a gate-evaluation one. #terminal-outcome-audit: a neutral conclusion is a real "hold this PR for
+// a human" decision -- these are the finding codes that explain WHY, bounded so a raw finding title/detail
+// (which can embed contributor-controlled or per-repo text) never leaks into a metric or audit reason.
+const NEUTRAL_HOLD_REASON_CODES = [
+  "ai_review_inconclusive",
+  "oversized_pr",
+  "guardrail_hold",
+  "manifest_blocked_path",
+  "repo_not_registered",
+  "repo_not_seen",
+  "pr_not_cached",
+  "pre_merge_check_unresolved",
+  "cla_check_unresolved",
+];
+
+/** PURE: the bounded reason-class code for a NEUTRAL gate evaluation, derived from its `warnings` (never from
+ *  a finding's free-text `title`/`detail`). Returns `null` for a non-neutral evaluation, or a neutral one whose
+ *  warnings don't (yet) carry a recognized code -- callers fall back to the bare conclusion string in that case,
+ *  exactly as they already do for `success`/`skipped`. */
+export function neutralHoldReasonCode(gateEvaluation: Pick<GateCheckEvaluation, "conclusion" | "warnings">): string | null {
+  if (gateEvaluation.conclusion !== "neutral") return null;
+  return NEUTRAL_HOLD_REASON_CODES.find((code) => gateEvaluation.warnings.some((finding) => finding.code === code)) ?? null;
+}
 
 /** True when the shadow-parity audit is enabled. Flag-OFF (default) → recordNativeGateDecision is a no-op and
  *  the parity endpoint 404s. Truthy follows the codebase convention (`/^(1|true|yes|on)$/i`, same as
@@ -60,8 +87,16 @@ const PARITY_WINDOW_DAYS = 90;
  *                                                  keeps the parity SAFETY metric honest: a shadow 'hold' is
  *                                                  never the dangerous "shadow merges where authoritative
  *                                                  wouldn't" direction.
- *   • 'neutral' | 'skipped'            → null    — no decision was made (not gated / pre-empted); not recorded,
- *                                                  so it is never paired.
+ *   • 'neutral'                        → 'hold'  — a REAL, deliberate decision (a guardrail/size/manifest-blocked
+ *                                                  hold, or an AI-inconclusive fail-closed hold): the gate chose
+ *                                                  to hold this PR for a human rather than pass it automatically.
+ *                                                  This is exactly as terminal, from an observability standpoint,
+ *                                                  as a 'failure' hold (#terminal-outcome-audit) -- recording it
+ *                                                  is what lets an operator see "N PRs held for reason X" without
+ *                                                  hand-querying, instead of the hold vanishing silently.
+ *   • 'skipped'                        → null    — genuinely NOT gated yet (not gated / pre-empted, e.g. the repo
+ *                                                  hasn't finished syncing); no decision was made at all, so
+ *                                                  there is nothing meaningful to record or pair.
  *
  * (computeGateParity only pairs 'merge' | 'close' | 'hold'; a null here means the row is simply not written.)
  */
@@ -71,9 +106,10 @@ export function nativeGateActionFromConclusion(conclusion: GateCheckConclusion):
       return "merge";
     case "failure":
     case "action_required":
+    case "neutral":
       return "hold";
     default:
-      return null; // neutral / skipped → no comparable decision
+      return null; // skipped → genuinely not gated yet, no comparable decision
   }
 }
 

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -113,6 +113,7 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_public_surface_publish_skipped_current_total", { help: "Public surface publishes skipped because state is current.", type: "counter" }],
   ["gittensory_gate_decisions_total", { help: "Gate decisions by conclusion.", type: "counter" }],
   ["gittensory_precision_breaker_downgrades_total", { help: "Would-merge/would-close actions downgraded to a human hold by an accuracy circuit-breaker, by breaker direction.", type: "counter" }],
+  ["gittensory_agent_disposition_total", { help: "Final agent disposition per PR pass (merge/close/hold), by repo, action class, blocker-code class, and autonomy level.", type: "counter" }],
   ["gittensory_reviews_published_total", { help: "Published review comments.", type: "counter" }],
   ["gittensory_github_branch_protection_permission_denied_total", { help: "GitHub branch-protection reads denied by permissions.", type: "counter" }],
   ["gittensory_github_pr_files_fetch_total", { help: "GitHub pull-request file fetch attempts.", type: "counter" }],
@@ -120,14 +121,27 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
 ];
 const metricMeta = new Map<string, MetricMeta>(DEFAULT_METRIC_META);
 
-// These public counters are scraped without auth; redact repo labels at the counter call-site.
+// These public counters are scraped without auth on the shared CLOUD worker, so redact repo labels at the
+// counter call-site there. A self-hosted instance's /metrics endpoint is the operator's own Prometheus/Grafana
+// scrape target, not a publicly reachable one -- there is no other-tenant repo name to protect from itself, and
+// redacting `repo` there just breaks the operator's own per-repo dashboards (#terminal-outcome-audit gap: the
+// one label gittensory_gate_decisions_total carried was being dropped even for self-host, with no bypass).
+let selfHostedMetricsMode = false;
+
+/** Call ONCE at boot (self-host entrypoint only) to stop redacting `repo` from PRIVATE_REPO_LABEL_METRICS.
+ *  Never called on the shared cloud worker, so its default (false, i.e. redact) stays byte-identical there. */
+export function setSelfHostedMetricsMode(isSelfHosted: boolean): void {
+  selfHostedMetricsMode = isSelfHosted;
+}
+
 const PRIVATE_REPO_LABEL_METRICS = new Set([
   "gittensory_gate_decisions_total",
   "gittensory_reviews_published_total",
+  "gittensory_agent_disposition_total",
 ]);
 
 function publicLabelsForMetric(name: string, labels?: Labels): Labels | undefined {
-  if (!labels || !PRIVATE_REPO_LABEL_METRICS.has(name) || !("repo" in labels)) return labels;
+  if (!labels || selfHostedMetricsMode || !PRIVATE_REPO_LABEL_METRICS.has(name) || !("repo" in labels)) return labels;
   const publicLabels = { ...labels };
   delete publicLabels.repo;
   return Object.keys(publicLabels).length > 0 ? publicLabels : undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ import {
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
-import { gauge, gaugeVector, incr, observe, renderMetrics } from "./selfhost/metrics";
+import { gauge, gaugeVector, incr, observe, renderMetrics, setSelfHostedMetricsMode } from "./selfhost/metrics";
 import { runSelfHostMigrations } from "./selfhost/migrate";
 import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "./selfhost/pg-adapter";
 import { createPgQueue } from "./selfhost/pg-queue";
@@ -276,6 +276,11 @@ async function main(): Promise<void> {
   loadFileSecrets();
   /* v8 ignore next -- importing this entrypoint starts the Node server; pure validation is covered in selfhost-preflight tests. */
   assertSelfHostPreflight(process.env);
+  // This entrypoint IS the self-host runtime by definition (the cloud worker never imports server.ts), so the
+  // /metrics endpoint it serves is the operator's own private scrape target, not a publicly reachable one --
+  // stop redacting the `repo` label PRIVATE_REPO_LABEL_METRICS otherwise drops for every deployment
+  // (#terminal-outcome-audit).
+  setSelfHostedMetricsMode(true);
   // Container-private per-repo config (self-host): register the GITTENSORY_REPO_CONFIG_DIR reader so the focus-
   // manifest loader prefers a mounted `{owner}__{repo}.yml`, deep-merged over an optional root `.gittensory.yml`
   // global default, over the public `.gittensory.yml` (review policy stays private; see
@@ -288,6 +293,18 @@ async function main(): Promise<void> {
   // repo's conventions. Unset dir ⇒ null reader ⇒ no change.
   setLocalReviewContextReader(
     makeLocalReviewContextReader(process.env.GITTENSORY_REPO_CONFIG_DIR),
+  );
+  // Boot-time visibility (config-drift guardrail): state which config dir is actually in effect, unconditionally
+  // -- neither reader above logs anything, so an operator previously had no way to confirm from the logs alone
+  // which directory (if any) was live, which is exactly the ambiguity that let a stale, no-longer-mounted config
+  // path get mistaken for the real one during a past incident. Never touches or validates any file; this is
+  // purely a log line, same "state what's in effect" shape as the sentry/otel boot logs below.
+  console.log(
+    JSON.stringify({
+      event: "selfhost_config_dir",
+      configured: Boolean(process.env.GITTENSORY_REPO_CONFIG_DIR?.trim()),
+      dir: process.env.GITTENSORY_REPO_CONFIG_DIR?.trim() || null,
+    }),
   );
   // Error tracking (#1468): opt-in via SENTRY_DSN — a complete no-op when unset. When on, capture uncaught crashes
   // + unhandled rejections (flush before exit for the fatal case); per-subsystem captures (queue dead-letter,

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -40,6 +40,12 @@ import { incr } from "../selfhost/metrics";
 // autonomy (the config IS the authorization; there is no human commenter to authorize, unlike #824).
 const AGENT_ACTOR = "gittensory";
 
+// Bound on audit_events.detail / the reason embedded in buildAgentActionAudit (#terminal-outcome-audit). A
+// heuristic close/hold reason is built by joining every blocker's title (agent-actions.ts), so an unbounded PR
+// with many blockers could otherwise write an arbitrarily large string; matches the existing 280-char bound
+// already used for mergeBlockedReason (db/repositories.ts) and the merge_blocked audit metadata below.
+const AUDIT_REASON_MAX_LENGTH = 280;
+
 // The PR-visible action classes that require an elevated GitHub App write permission. Most use
 // `pull_requests: write`; merge uses `contents: write`; `label` mutates through the Issues API, so it is exempt
 // from this readiness gate.
@@ -186,10 +192,15 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     const autonomyLevel = resolveAutonomy(ctx.autonomy, action.autonomyClass ?? action.actionClass);
     const audit = (outcome: AgentActionOutcome["outcome"], detail: string) => {
       const auditOutcome = outcome === "dry_run" ? "completed" : outcome;
-      outcomes.push({ actionClass: action.actionClass, outcome, detail });
+      // Bounded like every other audit-facing reason field in this codebase (agent-action-executor.ts's own
+      // merge_blocked path below, db/repositories.ts's mergeBlockedReason) -- a heuristic close's reason is
+      // built by joining every blocker title, so a PR with many blockers could otherwise write an arbitrarily
+      // large, un-truncated string into audit_events.detail (#terminal-outcome-audit).
+      const boundedDetail = detail.length > AUDIT_REASON_MAX_LENGTH ? `${detail.slice(0, AUDIT_REASON_MAX_LENGTH)}…` : detail;
+      outcomes.push({ actionClass: action.actionClass, outcome, detail: boundedDetail });
       return recordAuditEvent(
         env,
-        buildAgentActionAudit({ actionClass: action.actionClass, autonomyLevel, mode, outcome: auditOutcome, repoFullName: ctx.repoFullName, targetKey, actor: AGENT_ACTOR, reason: detail }),
+        buildAgentActionAudit({ actionClass: action.actionClass, autonomyLevel, mode, outcome: auditOutcome, repoFullName: ctx.repoFullName, targetKey, actor: AGENT_ACTOR, reason: boundedDetail }),
       );
     };
 
@@ -516,10 +527,15 @@ export async function executeIssueMaintenanceActions(env: Env, ctx: IssueActionE
     const autonomyLevel = resolveAutonomy(ctx.autonomy, action.autonomyClass ?? action.actionClass);
     const audit = (outcome: AgentActionOutcome["outcome"], detail: string) => {
       const auditOutcome = outcome === "dry_run" ? "completed" : outcome;
-      outcomes.push({ actionClass: action.actionClass, outcome, detail });
+      // Bounded like every other audit-facing reason field in this codebase (agent-action-executor.ts's own
+      // merge_blocked path below, db/repositories.ts's mergeBlockedReason) -- a heuristic close's reason is
+      // built by joining every blocker title, so a PR with many blockers could otherwise write an arbitrarily
+      // large, un-truncated string into audit_events.detail (#terminal-outcome-audit).
+      const boundedDetail = detail.length > AUDIT_REASON_MAX_LENGTH ? `${detail.slice(0, AUDIT_REASON_MAX_LENGTH)}…` : detail;
+      outcomes.push({ actionClass: action.actionClass, outcome, detail: boundedDetail });
       return recordAuditEvent(
         env,
-        buildAgentActionAudit({ actionClass: action.actionClass, autonomyLevel, mode, outcome: auditOutcome, repoFullName: ctx.repoFullName, targetKey, actor: AGENT_ACTOR, reason: detail }),
+        buildAgentActionAudit({ actionClass: action.actionClass, autonomyLevel, mode, outcome: auditOutcome, repoFullName: ctx.repoFullName, targetKey, actor: AGENT_ACTOR, reason: boundedDetail }),
       );
     };
 

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -122,6 +122,31 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect((await auditFor(env, "merge"))?.outcome).toBe("completed");
   });
 
+  // #terminal-outcome-audit: a heuristic close's reason is built by joining every blocker title
+  // (planAgentMaintenanceActions), so a PR with many/verbose blockers could otherwise write an unbounded string
+  // into audit_events.detail. Bounded the same way the pre-existing merge_blocked/mergeBlockedReason paths
+  // already are (280 chars).
+  it("truncates an oversized action reason to AUDIT_REASON_MAX_LENGTH (280 chars) before writing to audit_events.detail", async () => {
+    const env = createTestEnv({});
+    const longReason = "blocker: ".repeat(50); // 450 chars, well over the 280-char bound
+    expect(longReason.length).toBeGreaterThan(280);
+    const closeWithLongReason: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: longReason, closeComment: "closing" };
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [closeWithLongReason]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(outcomes[0]?.detail.length).toBe(281); // 280 chars + the "…" truncation marker
+    expect(outcomes[0]?.detail.endsWith("…")).toBe(true);
+    const audit = await (env.DB.prepare("select detail from audit_events where event_type = 'agent.action.close' order by created_at desc limit 1").first<{ detail: string }>());
+    expect(audit?.detail).toBe(outcomes[0]?.detail);
+    expect(audit?.detail.length).toBeLessThan(longReason.length);
+  });
+
+  it("does NOT truncate a reason at or under the bound (no stray truncation marker on ordinary-length reasons)", async () => {
+    const env = createTestEnv({});
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [close]);
+    expect(outcomes[0]?.detail).toBe("noise");
+    expect(outcomes[0]?.detail.endsWith("…")).toBe(false);
+  });
+
   it("#label-scoping: a label action's autonomyClass (not the literal actionClass) governs the durable re-check", async () => {
     const env = createTestEnv({});
     // autonomy.label is OFF; autonomy.close is ON — a label authorized via autonomyClass: "close" must still
@@ -1128,6 +1153,29 @@ describe("executeIssueMaintenanceActions (#2270 issue-side actuation)", () => {
     const outcomes = await executeIssueMaintenanceActions(env, issueCtx(), [issueClose]);
     expect(outcomes[0]?.outcome).toBe("error");
     expect((await auditFor(env, "close"))?.outcome).toBe("error");
+  });
+
+  // #terminal-outcome-audit: the issue-actions executor has its own `audit` closure (a separate function scope
+  // from executeAgentMaintenanceActions above), so the same bounded-reason fix needed its own coverage here.
+  it("truncates an oversized action reason to AUDIT_REASON_MAX_LENGTH (280 chars) before writing to audit_events.detail", async () => {
+    const env = createTestEnv({});
+    const longReason = "over the per-contributor open-item cap: ".repeat(10); // well over the 280-char bound
+    expect(longReason.length).toBeGreaterThan(280);
+    const closeWithLongReason: PlannedAgentAction = { ...issueClose, reason: longReason };
+    const outcomes = await executeIssueMaintenanceActions(env, issueCtx(), [closeWithLongReason]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(outcomes[0]?.detail.length).toBe(281); // 280 chars + the "…" truncation marker
+    expect(outcomes[0]?.detail.endsWith("…")).toBe(true);
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = 'agent.action.close' order by created_at desc limit 1").first<{ detail: string }>();
+    expect(audit?.detail).toBe(outcomes[0]?.detail);
+    expect(audit?.detail.length).toBeLessThan(longReason.length);
+  });
+
+  it("does NOT truncate a reason at or under the bound (no stray truncation marker on ordinary-length reasons)", async () => {
+    const env = createTestEnv({});
+    const outcomes = await executeIssueMaintenanceActions(env, issueCtx(), [issueClose]);
+    expect(outcomes[0]?.detail).toBe(issueClose.reason);
+    expect(outcomes[0]?.detail.endsWith("…")).toBe(false);
   });
 });
 

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -16,8 +16,10 @@ import {
   computeParityReadiness,
   isParityAuditEnabled,
   nativeGateActionFromConclusion,
+  neutralHoldReasonCode,
   recordNativeGateDecision,
 } from "../../src/review/parity-wire";
+import type { AdvisoryFinding } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
 // ── Direct D1 helpers over the real migrated schema (0049 review_audit) ──────────────────────────────────────
@@ -54,12 +56,44 @@ describe("isParityAuditEnabled — default OFF, truthy convention", () => {
 // ── nativeGateActionFromConclusion — gittensory conclusion → comparable GateAction (pure) ────────────────────
 
 describe("nativeGateActionFromConclusion — gittensory gate conclusion → parity GateAction", () => {
-  it("maps success → merge, failure/action_required → hold (gittensory never closes), neutral/skipped → null", () => {
+  it("maps success → merge, failure/action_required/neutral → hold (gittensory never closes), skipped → null", () => {
     expect(nativeGateActionFromConclusion("success")).toBe("merge");
     expect(nativeGateActionFromConclusion("failure")).toBe("hold");
     expect(nativeGateActionFromConclusion("action_required")).toBe("hold");
-    expect(nativeGateActionFromConclusion("neutral")).toBeNull();
+    // #terminal-outcome-audit: neutral is a REAL "hold this PR for a human" decision (guardrail/size/manifest-
+    // blocked/ai-inconclusive), not "no decision was made" -- recording it is what lets an operator see holds
+    // without hand-querying review_audit for a hold class the parity recorder used to silently discard.
+    expect(nativeGateActionFromConclusion("neutral")).toBe("hold");
+    // skipped is genuinely different: the gate was never evaluated at all (e.g. the repo hasn't finished
+    // syncing), so there is no decision, comparable or otherwise, to record.
     expect(nativeGateActionFromConclusion("skipped")).toBeNull();
+  });
+});
+
+// ── neutralHoldReasonCode — bounded reason-class for a neutral hold (pure) ───────────────────────────────────
+
+describe("neutralHoldReasonCode — bounded hold-reason class for a neutral gate evaluation", () => {
+  const finding = (code: string): AdvisoryFinding => ({ code, severity: "warning", title: "t", detail: "d" });
+
+  it("returns null for a non-neutral conclusion, regardless of warnings", () => {
+    expect(neutralHoldReasonCode({ conclusion: "success", warnings: [finding("guardrail_hold")] })).toBeNull();
+    expect(neutralHoldReasonCode({ conclusion: "failure", warnings: [finding("guardrail_hold")] })).toBeNull();
+    expect(neutralHoldReasonCode({ conclusion: "skipped", warnings: [] })).toBeNull();
+  });
+
+  it("returns the recognized code for each known neutral-hold class (guardrail, size, manifest-blocked, ai-inconclusive, sync-state)", () => {
+    for (const code of ["guardrail_hold", "oversized_pr", "manifest_blocked_path", "ai_review_inconclusive", "repo_not_registered", "repo_not_seen", "pr_not_cached", "pre_merge_check_unresolved", "cla_check_unresolved"]) {
+      expect(neutralHoldReasonCode({ conclusion: "neutral", warnings: [finding(code)] })).toBe(code);
+    }
+  });
+
+  it("returns null (fail-safe fallback) when neutral but no recognized code is present in warnings", () => {
+    expect(neutralHoldReasonCode({ conclusion: "neutral", warnings: [finding("readiness_score_below_threshold")] })).toBeNull();
+    expect(neutralHoldReasonCode({ conclusion: "neutral", warnings: [] })).toBeNull();
+  });
+
+  it("picks the first recognized code by priority order when multiple hold findings are present (oversized_pr before guardrail_hold)", () => {
+    expect(neutralHoldReasonCode({ conclusion: "neutral", warnings: [finding("guardrail_hold"), finding("oversized_pr")] })).toBe("oversized_pr");
   });
 });
 
@@ -101,12 +135,22 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(2);
   });
 
-  it("does NOT record a non-comparable conclusion (neutral/skipped) or a decision with no head_sha", async () => {
+  it("does NOT record a genuinely non-comparable conclusion (skipped) or a decision with no head_sha", async () => {
     const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
-    await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 1, headSha: "sha", conclusion: "neutral" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 2, headSha: "sha", conclusion: "skipped" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 3, headSha: null, conclusion: "success" });
     expect((await rawAll(env, "SELECT * FROM review_audit")).length).toBe(0);
+  });
+
+  // #terminal-outcome-audit: neutral (a guardrail/size/manifest-blocked/ai-inconclusive hold) now records as a
+  // comparable 'hold' row, same as failure -- this is the fix for the class of hold that used to vanish
+  // silently (nativeGateActionFromConclusion previously mapped neutral to null, same as skipped).
+  it("records a neutral conclusion as a 'hold' row (the fix for a previously-silent hold class)", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 1, headSha: "sha", conclusion: "neutral", reasonCode: "guardrail_hold" });
+    const rows = await rawAll(env, "SELECT * FROM review_audit");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ decision: "hold", summary: "guardrail_hold" });
   });
 
   it("flag-OFF records NOTHING on the CLOUD WORKER — no D1 write (byte-identical review path)", async () => {

--- a/test/unit/precision-breakers-chain.test.ts
+++ b/test/unit/precision-breakers-chain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyPrecisionBreakers, precisionBreakerDowngradeDirections } from "../../src/queue/processors";
+import { agentDispositionLabels, applyPrecisionBreakers, precisionBreakerDowngradeDirections } from "../../src/queue/processors";
 import { AGENT_LABEL_CHANGES, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, type PlannedAgentAction } from "../../src/settings/agent-actions";
 
 // The processors chaining at maybeRunAgentMaintenance:
@@ -88,5 +88,35 @@ describe("precisionBreakerDowngradeDirections — bounded-cardinality breaker-do
     expect(breakerOnPlan.some((a) => a.actionClass === "close" && a.closeKind === "linked-issue-hard-rule")).toBe(true);
     expect(breakerOnPlan.some((a) => a.actionClass === "close" && a.closeKind === "heuristic")).toBe(false);
     expect(precisionBreakerDowngradeDirections(planned, breakerOnPlan)).toEqual(["close"]);
+  });
+});
+
+describe("agentDispositionLabels — bounded {actionClass, blockerClass} for gittensory_agent_disposition_total (#terminal-outcome-audit)", () => {
+  it("actionClass is 'merge' when the final plan still contains a merge action", () => {
+    expect(agentDispositionLabels([mergeAction], [])).toEqual({ actionClass: "merge", blockerClass: "none" });
+  });
+
+  it("actionClass is 'close' when the final plan still contains a close action (and no merge)", () => {
+    expect(agentDispositionLabels([heuristicClose], [])).toEqual({ actionClass: "close", blockerClass: "none" });
+  });
+
+  it("actionClass is 'hold' when the final plan has neither a merge nor a close action (the previously-silent bucket)", () => {
+    expect(agentDispositionLabels([changesLabel], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+  });
+
+  it("actionClass is 'hold' for a genuinely EMPTY plan (nothing was ever planned — the most common real hold shape)", () => {
+    expect(agentDispositionLabels([], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+  });
+
+  it("blockerClass is the first gate-blocker code when the gate reported one", () => {
+    expect(agentDispositionLabels([], ["secret_leak", "duplicate_pr_risk"])).toEqual({ actionClass: "hold", blockerClass: "secret_leak" });
+  });
+
+  it("blockerClass is 'none' for a clean PR held for a non-blocker reason (e.g. CI still pending)", () => {
+    expect(agentDispositionLabels([], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+  });
+
+  it("prefers 'merge' over 'close' when (hypothetically) both are present in the final plan", () => {
+    expect(agentDispositionLabels([mergeAction, heuristicClose], []).actionClass).toBe("merge");
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -19607,12 +19607,17 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     await setupAutoActionRepo(env, { autonomy: { close: "auto" } });
     const seen = { closed: false, merged: false };
     stubPrFetch(60, "conv60", seen);
+    resetMetrics();
 
     await processJob(env, { type: "github-webhook", deliveryId: "conv-close", eventName: "pull_request", payload: prPayload() });
 
     expect(seen.closed).toBe(true);
     const closeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.close'").first<{ n: number }>();
     expect(closeAudit?.n).toBeGreaterThanOrEqual(1);
+    // #terminal-outcome-audit: the disposition counter's "close" action_class, with the actual gate-blocker
+    // code (missing_linked_issue, from the default linkedIssueGateMode:block + no-linked-issue body) as the
+    // bounded blocker_class -- proof this reaches the real gate.blockers, not just a hardcoded label.
+    expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="close",autonomy_level="auto",blocker_class="missing_linked_issue"} 1');
   });
 
   it("reviewCheckMode: disabled still auto-closes a blocked contributor PR via the general heuristic-close path (#2852)", async () => {
@@ -19716,6 +19721,7 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     // Step 2: CI finishes; a check_suite.completed webhook for the SAME head re-triggers the pipeline, which now
     // sees a passing CI aggregate and merges.
     ciState = "passed";
+    resetMetrics();
     await processJob(env, {
       type: "github-webhook",
       deliveryId: "conv-chain-2",
@@ -19731,6 +19737,8 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     expect(seen.merged).toBe(true);
     const mergeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.merge'").first<{ n: number }>();
     expect(mergeAudit?.n).toBeGreaterThanOrEqual(1);
+    // #terminal-outcome-audit: the disposition counter's "merge" action_class, on the actual live call site.
+    expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="merge",autonomy_level="auto",blocker_class="none"} 1');
   });
 
   // #terminal-outcome-audit: end-to-end proof that the LIVE runAgentMaintenancePlanAndExecute call site (not just
@@ -19800,6 +19808,11 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     const mergeAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'agent.action.merge'").first<{ n: number }>();
     expect(mergeAudit?.n).toBe(0);
     expect(await renderMetrics()).toContain('gittensory_precision_breaker_downgrades_total{direction="merge"} 1');
+    // #terminal-outcome-audit: the ALWAYS-recorded disposition counter, placed before the "nothing was planned"
+    // early return -- this is the exact "hold, but no audit_events row at all" shape (the breaker downgrade
+    // leaves no merge/close action) that previously had zero aggregate signal. close autonomy is unset in this
+    // repo's settings (only merge/approve are configured), so it resolves to the default "observe".
+    expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="hold",autonomy_level="observe",blocker_class="none"} 1');
   });
 
   it("reviewCheckMode: disabled still auto-merges a green PR via the general heuristic path, with ZERO check-run API calls (#2852)", async () => {

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { gauge, gaugeVector, incr, observe, registerMetricMeta, renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
+import { gauge, gaugeVector, incr, observe, registerMetricMeta, renderMetrics, resetMetrics, setSelfHostedMetricsMode } from "../../src/selfhost/metrics";
 
-afterEach(() => resetMetrics());
+afterEach(() => {
+  resetMetrics();
+  // setSelfHostedMetricsMode is a separate module-level flag from the counters/gauges resetMetrics() clears --
+  // reset it explicitly so a test that turns it on can never leak into an unrelated later test.
+  setSelfHostedMetricsMode(false);
+});
 
 describe("metrics registry (#982)", () => {
   it("renders unregistered counters exactly as bare samples", async () => {
@@ -107,6 +112,30 @@ describe("metrics registry (#982)", () => {
   it("preserves repository labels for unrelated metrics", async () => {
     incr("debug_total", { repo: "public-owner/public-repo" });
     expect(await renderMetrics()).toContain('debug_total{repo="public-owner/public-repo"} 1');
+  });
+
+  // #terminal-outcome-audit: a self-hosted instance's /metrics is the operator's own private scrape target, not
+  // a publicly reachable one -- setSelfHostedMetricsMode(true) (called once at self-host boot) must stop
+  // redacting `repo` from these counters so an operator can actually slice their OWN dashboards by repo.
+  it("setSelfHostedMetricsMode(true) stops redacting the repo label on the cloud-private counters", async () => {
+    setSelfHostedMetricsMode(true);
+    incr("gittensory_gate_decisions_total", { repo: "owner/repo", conclusion: "success" });
+    incr("gittensory_reviews_published_total", { repo: "owner/repo" });
+    incr("gittensory_agent_disposition_total", { repo: "owner/repo", action_class: "hold", blocker_class: "none", autonomy_level: "auto" });
+
+    const out = await renderMetrics();
+    expect(out).toContain('gittensory_gate_decisions_total{conclusion="success",repo="owner/repo"} 1');
+    expect(out).toContain('gittensory_reviews_published_total{repo="owner/repo"} 1');
+    expect(out).toContain('repo="owner/repo"');
+  });
+
+  it("setSelfHostedMetricsMode(false) (the default) still redacts — byte-identical to the cloud worker", async () => {
+    setSelfHostedMetricsMode(false);
+    incr("gittensory_agent_disposition_total", { repo: "owner/repo", action_class: "hold", blocker_class: "none", autonomy_level: "auto" });
+
+    const out = await renderMetrics();
+    expect(out).not.toContain("owner/repo");
+    expect(out).toContain('gittensory_agent_disposition_total{action_class="hold",autonomy_level="auto",blocker_class="none"} 1');
   });
 
   it("gauges sample at scrape time", async () => {


### PR DESCRIPTION
## Summary

- `nativeGateActionFromConclusion` discarded a `neutral` gate conclusion entirely (guardrail/size/manifest-blocked holds, and AI-inconclusive fail-closed holds), so `recordNativeGateDecision` never wrote a row for them — indistinguishable from "not evaluated yet" in the native gate-decision ledger. These are now recorded as a comparable `hold`, tagged with a bounded reason-code class (`neutralHoldReasonCode`) derived from the gate's own finding codes, never from free-text title/detail.
- A heuristic close/merge's audit reason is built by joining every blocker title, so a PR with many/verbose blockers could write an unbounded string into `audit_events.detail`. Bounded to 280 chars, matching the existing `merge_blocked` convention.
- Added `gittensory_agent_disposition_total`, a bounded-cardinality metric (`repo`/`action_class`/`blocker_class`/`autonomy_level`) emitted on every disposition pass — including a fully empty plan — so an operator can see the final merge/close/hold outcome without deriving it from raw audit rows.
- Fixed self-host's `/metrics` repo-label redaction being unconditional: it stripped repo names even on self-host's own private, non-publicly-scraped endpoint, so operators couldn't slice their own dashboards by repo either. Gated behind a boot-time self-host-detection flag.
- Logs the resolved per-repo config directory once at self-host boot for the same operator-visibility reason.

All four changes close observability/audit gaps in the terminal-outcome path of the self-host review engine's disposition pipeline (generic, config-driven — no repo-specific logic).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No pre-existing issue; these are self-host review-engine observability gaps found via internal audit, same category as recent merged fixes in this area.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (unsharded); precise diff-coverage cross-reference against `coverage/coverage-final.json` confirms 100% branch coverage on every changed line across all four changed `src/**` files
- [ ] `npm run test:workers` (not run — no Cloudflare-Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (not run — no `apps/gittensory-ui` or API/OpenAPI surface changes)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped checks above are for UI/MCP/Workers surfaces this PR does not touch (backend-only change to the review-engine disposition/audit/metrics path); CI's `validate` job runs them as a backstop.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Generic self-host engine behavior only; no repo-specific hardcoding.