### PR TITLE
fix(services): strip trailing hyphen after slug truncation

### DIFF
--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -146,8 +146,11 @@ export function slugify(value: unknown): string {
     .toLowerCase()
     .replace(/['"]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 120);
+    .slice(0, 120)
+    // Strip leading/trailing hyphens AFTER truncation — a 120-char cut can land on a separator and
+    // re-introduce a trailing "-", producing a malformed slug/path (`.../foo-.mdx`). Mirrors `oneLine`,
+    // which likewise normalizes after its truncation.
+    .replace(/^-+|-+$/g, "");
 }
 
 function yamlScalar(value: unknown): string {

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -926,6 +926,13 @@ describe("slugify — truncation + empty branches", () => {
     expect(slug.startsWith("a")).toBe(true);
   });
 
+  it("does not leave a trailing hyphen when the 120-char cut lands on a separator", () => {
+    // 119 "a"s + "-" + "tail": the .slice(0, 120) boundary falls on the separator hyphen.
+    const slug = slugify(`${"a".repeat(119)} tail`);
+    expect(slug).toBe("a".repeat(119));
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
   it("strips quotes and collapses non-alphanumerics", () => {
     expect(slugify(`It's a "Test" Value`)).toBe("its-a-test-value");
   });


### PR DESCRIPTION
## Summary

`slugify` in `src/services/draft.ts` stripped leading/trailing hyphens **before** its final
`.slice(0, 120)` truncation. When the 120-char cut lands on a separator hyphen, the slice re-introduces a
trailing `-` that the earlier strip already removed — violating the function's own normalization:

```ts
slugify(`${"a".repeat(119)} tail`)
// "a"×119 + "-" + "tail"  →  .slice(0,120)  →  "a"×119 + "-"   (ends with "-")
```

That slug feeds `targetPath = content/${category}/${slug}.mdx` and the `branchName` in `buildTarget`, so a
long title/name yields a malformed path like `content/agents/aaa…a-.mdx` and branch `…/submit-agents-aaa…a-`.
The slug is also consumed by `src/review/content-lane/scope.ts`.

Fix: move the `^-+|-+$` strip to run **after** the `.slice(0, 120)`, so truncation can't leave a dangling
separator. This mirrors the sibling `oneLine` helper, which likewise normalizes (`.trimEnd()`) after its
own truncation.

No linked issue: small, self-evident normalization correctness fix (a one-step reorder in a single pure
helper) with no public API, auth, schema, or deploy surface change — fits the repo's `preferred` (not
required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/draft.test.ts` — 96 tests pass and the changed `slugify` lines are fully covered (the
  only uncovered line in the file, 632, is pre-existing and outside this diff), so `codecov/patch` is
  100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only
  change to one deterministic string helper touching no UI/API/OpenAPI/MCP/DB/workflow surface, so those
  jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic string-normalization fix,
  so the auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/draft.test.ts` ("does not leave a trailing hyphen when the 120-char
  cut lands on a separator"): `slugify("a"×119 + " tail")` now yields `"a"×119` with no trailing `-`. The
  existing "truncates the final slug to 120 chars" assertion still holds.
