### PR TITLE
feat(review): skip more binary blobs in RAG indexing

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -120,7 +120,7 @@ const SKIP_DIR_RE =
 const SKIP_FILE_RE =
   /(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|lock|snap)$/i;
 const BINARY_EXT_RE =
-  /\.(png|jpe?g|gif|webp|avif|svg|ico|pdf|zip|gz|tgz|tar|wasm|woff2?|ttf|eot|mp4|mov|mp3|wav|bin|exe|dll|so|dylib|node|parquet|onnx)$/i;
+  /\.(png|jpe?g|gif|webp|avif|bmp|tiff?|heic|psd|svg|ico|pdf|zip|gz|tgz|tar|bz2|xz|zst|7z|rar|wasm|woff2?|otf|ttf|eot|mp4|mov|webm|mkv|mp3|wav|flac|ogg|opus|bin|exe|dll|so|dylib|node|class|jar|pyc|sqlite|db|parquet|onnx|gguf|safetensors|pt|pth|ckpt|npy|npz)$/i;
 const CODE_EXT_RE =
   /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|kts|rb|php|c|h|cc|cpp|hpp|cs|swift|scala|sh|bash|zsh|sql|graphql|proto|toml|yaml|yml|json|jsonc|css|scss|less|vue|svelte|astro|tf|hcl|dart|lua|ex|exs|clj|cljs|cljc|hs|jl|nim|zig|groovy)$/i;
 // Doc extensions mirror the canonical DOCS_EXTENSIONS set in signals/path-matchers.ts

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -75,6 +75,26 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
     expect(classifyRepoFile("pnpm-lock.yaml")).toBe("skip");
     expect(classifyRepoFile("public/logo.png")).toBe("skip");
     expect(classifyRepoFile("app.min.js")).toBe("skip");
+    // more binary blobs: media/archives/fonts/compiled artifacts and ML model weights
+    for (const p of [
+      "assets/photo.bmp",
+      "assets/scan.tiff",
+      "media/clip.webm",
+      "audio/track.flac",
+      "release/app.7z",
+      "release/pkg.zst",
+      "fonts/Inter.otf",
+      "build/App.class",
+      "lib/app.jar",
+      "cache/mod.pyc",
+      "db/local.sqlite",
+      "models/qwen3.gguf",
+      "models/weights.safetensors",
+      "checkpoints/model.ckpt",
+      "data/embeddings.npy",
+    ]) {
+      expect(classifyRepoFile(p)).toBe("skip");
+    }
   });
 
   it("skips oversized files and orders source before docs", () => {


### PR DESCRIPTION
`BINARY_EXT_RE` (src/review/rag.ts) skipped a good set of binary extensions but missed many common ones, so a changed `.bmp`/`.webm`/`.flac`/`.7z`/`.jar`/`.pyc`/`.sqlite`/`.gguf`/`.safetensors` file was treated as indexable source and wasted the free-tier vector budget on unreadable bytes.

Adds more image (bmp, tiff, heic, psd), archive (bz2, xz, zst, 7z, rar), font (otf), AV (webm, mkv, flac, ogg, opus), compiled-artifact (class, jar, pyc, sqlite, db), and ML-weight (gguf, safetensors, pt, pth, ckpt, npy, npz) extensions. Extends the `classifyRepoFile` skip test. Typecheck + unit tests green.