### PR TITLE
feat(review): skip more build/cache/dep directories in RAG indexing

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -116,7 +116,7 @@ export function ragDimensionsFromEnv(value: string | undefined): number {
 
 // ── Filtering: index CODE, not content/data corpora (the primary free-tier cost guard) ───────────
 const SKIP_DIR_RE =
-  /(^|\/)(node_modules|dist|build|out|coverage|vendor|\.git|\.next|\.turbo|\.cache|content|data|fixtures|__snapshots__|__fixtures__|testdata|generated|public)\//i;
+  /(^|\/)(node_modules|dist|build|out|coverage|vendor|\.git|\.next|\.nuxt|\.svelte-kit|\.turbo|\.cache|target|\.gradle|_build|\.venv|venv|__pycache__|\.mypy_cache|\.pytest_cache|\.ruff_cache|\.tox|\.terraform|content|data|fixtures|__snapshots__|__fixtures__|testdata|generated|public)\//i;
 const SKIP_FILE_RE =
   /(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|lock|snap)$/i;
 const BINARY_EXT_RE =

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -77,6 +77,25 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
     expect(classifyRepoFile("app.min.js")).toBe("skip");
   });
 
+  it("skips more build/cache/dependency output directories", () => {
+    for (const p of [
+      "target/release/app.rs",
+      ".venv/lib/site.py",
+      "venv/bin/thing.py",
+      "src/__pycache__/mod.cpython-312.pyc",
+      ".mypy_cache/3.12/foo.data.json",
+      ".pytest_cache/v/cache/lastfailed",
+      ".tox/py312/log.txt",
+      "web/.svelte-kit/generated/root.svelte",
+      "app/.nuxt/app.config.mjs",
+      ".gradle/caches/x.bin",
+      "backend/_build/dev/lib/app.beam",
+      "infra/.terraform/providers/plugin.go",
+    ]) {
+      expect(classifyRepoFile(p)).toBe("skip");
+    }
+  });
+
   it("skips oversized files and orders source before docs", () => {
     expect(isIndexablePath("src/a.ts")).toBe(true);
     expect(isIndexablePath("src/a.ts", 2_000_000)).toBe(false); // > 1MB


### PR DESCRIPTION
`SKIP_DIR_RE` (src/review/rag.ts) skipped node_modules/dist/build/etc. but missed many common build/cache/dependency output directories, so files under `target/`, `.venv/`, `__pycache__/`, `.pytest_cache/`, `.svelte-kit/`, `.nuxt/`, `.gradle/`, `_build/`, `.terraform/` were indexed as source.

Adds .nuxt, .svelte-kit, target, .gradle, _build, .venv, venv, __pycache__, .mypy_cache, .pytest_cache, .ruff_cache, .tox, and .terraform. Adds a dedicated `classifyRepoFile` test (a separate `it()` block so it does not collide with sibling RAG-filter PRs). Typecheck + unit tests green.