### PR TITLE
feat(signals): detect Swift/Dart/C# codegen as generated files

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -50,13 +50,18 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
   return (
     /(^|\/)(__generated__|generated)\//.test(norm) ||
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
-    // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, and the reference C++ plugin
-    // emits `.pb.cc` / `.pb.h` (the `.pb` infix keeps a hand-written `.h`/`.cc` from matching).
-    /\.pb\.(go|ts|js|cc|h)$/.test(norm) ||
+    // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
+    // `.pb.cc` / `.pb.h`, and the Swift plugin emits `.pb.swift` (the `.pb` infix keeps a
+    // hand-written `.h`/`.cc`/`.swift` from matching).
+    /\.pb\.(go|ts|js|cc|h|swift)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||
-    /\.g\.dart$/.test(norm) ||
+    // Dart codegen: build_runner (`.g.dart`), freezed (`.freezed.dart`), and
+    // retrofit/injectable (`.gr.dart`) all emit generated part files.
+    /\.(g|freezed|gr)\.dart$/.test(norm) ||
+    // C# codegen: WinForms/WPF designer partials (`.designer.cs`) and XAML/T4 output (`.g.cs`).
+    /\.(designer|g)\.cs$/.test(norm) ||
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -61,6 +61,22 @@ describe("isGeneratedFile", () => {
       expect(isGeneratedFile(path)).toBe(true);
     }
   });
+
+  it("matches Swift protobuf, Dart freezed/retrofit, and C# designer/XAML codegen", () => {
+    for (const path of [
+      "proto/messages.pb.swift",
+      "lib/user.freezed.dart",
+      "lib/api_client.gr.dart",
+      "ui/MainForm.Designer.cs",
+      "views/App.g.cs",
+    ]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+    // hand-written siblings must NOT match (the codegen infix is required).
+    for (const path of ["src/MainForm.cs", "lib/user.dart", "net/message.swift"]) {
+      expect(isGeneratedFile(path)).toBe(false);
+    }
+  });
 });
 
 describe("isVendoredFile", () => {


### PR DESCRIPTION
`isGeneratedFile` (src/signals/path-matchers.ts) recognized protobuf (Go/TS/JS/C++/Python), source maps, and Dart build_runner (`.g.dart`) output, but missed several common codegen suffixes, so a generated `.pb.swift` / `.freezed.dart` / `.gr.dart` / `.designer.cs` / `.g.cs` file counted as hand-authored source.

Extends the protobuf rule with `.pb.swift`, the Dart rule with freezed/retrofit (`.freezed.dart`/`.gr.dart`), and adds a C# rule for designer partials and XAML/T4 output (`.designer.cs`/`.g.cs`). The required codegen infix keeps hand-written siblings (MainForm.cs, user.dart, message.swift) from matching — verified with negative test cases. Typecheck + unit tests green.