### PR TITLE
feat(signals): classify more tool ignore-files as config

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -208,6 +208,14 @@ const CONFIG_FILE_NAMES: ReadonlySet<string> = new Set([
   ".gitignore",
   ".gitattributes",
   ".dockerignore",
+  // Further tool ignore-files, siblings to .gitignore/.dockerignore above. (The
+  // .eslintignore/.prettierignore variants are already covered by the .eslint/
+  // .prettier prefixes.)
+  ".npmignore",
+  ".stylelintignore",
+  ".vercelignore",
+  ".helmignore",
+  ".gcloudignore",
   // Dependency automation and local toolchain version pins.
   "renovate.json",
   "dependabot.yml",

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -241,6 +241,11 @@ describe("isConfigFile", () => {
       "packages/app/.gitignore",
       ".gitattributes",
       "services/api/.dockerignore",
+      ".npmignore",
+      "libs/ui/.stylelintignore",
+      ".vercelignore",
+      "charts/app/.helmignore",
+      ".gcloudignore",
     ]) {
       expect(isConfigFile(path)).toBe(true);
     }


### PR DESCRIPTION
`CONFIG_FILE_NAMES` (src/signals/path-matchers.ts) recognized .gitignore/.gitattributes/.dockerignore but not several other well-known tool ignore-files, so a changed `.npmignore` / `.stylelintignore` / `.vercelignore` / `.helmignore` / `.gcloudignore` counted as hand-authored source.

Adds them as siblings of the existing ignore entries. The `.eslintignore`/`.prettierignore` variants are intentionally omitted because they are already covered by the `.eslint`/`.prettier` config prefixes (verified — no redundant matches). Extends the `isConfigFile` positive test cases. Typecheck + unit tests green.