### PR TITLE
fix(miner): honor miner targeting opt-outs

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -263,7 +263,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
-    firstReference: "src/selfhost/queue-common.ts:120",
+    firstReference: "src/selfhost/queue-common.ts:130",
   },
   {
     name: "REDIS_URL",
@@ -382,7 +382,7 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
   "| `QDRANT_URL` | `src/server.ts:527` |",
-  "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:120` |",
+  "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:130` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
   "| `REVIEW_AUDIT_DIR` | `src/server.ts:572` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",

--- a/packages/gittensory-engine/src/opportunity-metadata.ts
+++ b/packages/gittensory-engine/src/opportunity-metadata.ts
@@ -1,4 +1,4 @@
-import { computeMinerGoalLaneFit } from "./miner-goal-lane-fit.js";
+import { computeMinerGoalLaneFit, isMinerRepoTargetable } from "./miner-goal-lane-fit.js";
 import { DEFAULT_MINER_GOAL_SPEC, type MinerGoalSpec } from "./miner-goal-spec.js";
 import { computeOpportunityCompetition } from "./opportunity-competition.js";
 import { computeOpportunityFreshness } from "./opportunity-freshness.js";
@@ -220,9 +220,12 @@ export function rankMetadataOpportunities<T extends MetadataCandidateIssue>(
   candidates: readonly T[],
   context: MetadataRankContext,
 ): Array<T & OpportunityRankInput & { rankScore: number }> {
-  const annotated = candidates.map((candidate) => ({
+  const targetableCandidates = candidates.filter((candidate) =>
+    isMinerRepoTargetable(resolveGoalSpec(candidate.repoFullName, context)),
+  );
+  const annotated = targetableCandidates.map((candidate) => ({
     ...candidate,
-    ...buildMetadataRankInput(candidate, candidates, context),
+    ...buildMetadataRankInput(candidate, targetableCandidates, context),
   }));
   /* v8 ignore next */
   return rankOpportunities(annotated) as Array<T & OpportunityRankInput & { rankScore: number }>;

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -84,6 +84,26 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(ranked[0]?.laneFit).toBeGreaterThanOrEqual(0.85);
   });
 
+  it("excludes repositories that explicitly opt out of miner targeting", () => {
+    const ranked = rankCandidateIssues([rawIssue({ labels: ["help wanted", "feature"] })], {
+      nowMs: NOW,
+      goalSpecContentByRepo: {
+        "acme/widgets": "minerEnabled: false\npreferredLabels: [feature]\n",
+      },
+    });
+    const summary = rankCandidateIssuesWithSummary([rawIssue()], {
+      nowMs: NOW,
+      goalSpecContentByRepo: {
+        "acme/widgets": "minerEnabled: false\n",
+      },
+    });
+
+    expect(ranked).toEqual([]);
+    expect(summary.issues).toEqual([]);
+    expect(summary.skippedInvalid).toBe(0);
+    expect(summary.usedDefaultGoalSpec).toBe(false);
+  });
+
   it("raises dupRisk when repo-level contention inputs are provided", () => {
     const calm = rankCandidateIssues([rawIssue()], { nowMs: NOW, highRiskDuplicateClusters: 0, openPullRequests: 4 });
     const busy = rankCandidateIssues([rawIssue()], { nowMs: NOW, highRiskDuplicateClusters: 4, openPullRequests: 4 });


### PR DESCRIPTION
### Motivation

- Prevent the metadata-only opportunity ranker from selecting repositories that explicitly opted out via `minerEnabled: false`, fixing an authorization/targeting bypass where opted-out repos could still be ranked.

### Description

- Filter metadata candidates through `isMinerRepoTargetable(resolveGoalSpec(...))` before building rank inputs so repos with `minerEnabled: false` are excluded from annotation and ranking in `rankMetadataOpportunities` (`packages/gittensory-engine/src/opportunity-metadata.ts`).
- Ensure `buildMetadataRankInput` is called with the filtered candidate set so dup-risk and peer-aware signals remain consistent for the annotated batch. 
- Add a regression test that exercises both `rankCandidateIssues` and `rankCandidateIssuesWithSummary` to assert repos with per-repo YAML `minerEnabled: false` are excluded (`test/unit/miner-opportunity-ranker.test.ts`).
- Regenerate the self-host environment reference artifact required by the local gate (`apps/gittensory-ui/src/lib/selfhost-env-reference.ts`).

### Testing

- Ran the unit tests relevant to this change with `npx vitest run test/unit/miner-opportunity-ranker.test.ts test/unit/opportunity-metadata-signals.test.ts`, and all tests passed.
- Built the affected packages with `npm --workspace @jsonbored/gittensory-engine run build` and `npm --workspace @jsonbored/gittensory-miner run build`, and both builds succeeded.
- Attempted the full local gate `npm run test:ci` and `npm audit --audit-level=moderate`, but the environment experienced transient network/DNS and registry audit errors so the full CI/ audit step could not be completed here (unit tests and package builds were successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4887ab95a0832cb6143626cbcfca2d)