### PR TITLE
fix(config): route repository-settings reads through the resolver, not the raw DB accessor

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -282,6 +282,10 @@ type AppContext = Context<AppBindings>;
 async function loadPublicRepoBadge(env: Env, owner: string, repo: string): Promise<PublicRepoQuality | null> {
   const repository = await getRepository(env, `${owner}/${repo}`);
   if (!repository || repository.isPrivate || !repository.isInstalled) return null;
+  // Intentionally the raw DB row, not resolveRepositorySettings: this is an unauthenticated, high-frequency
+  // public route (a README-embedded badge image), so it deliberately trades honoring a yml-only `badgeEnabled`
+  // override for avoiding a manifest-cache lookup (and a possible cold-cache GitHub fetch) on every image load.
+  // `badgeEnabled` is normally set via the dashboard/API, which persists straight to this same DB row (#2912).
   const settings = await getRepositorySettings(env, repository.fullName);
   if (!settings.badgeEnabled) return null;
   const pullRequests = await listPullRequests(env, repository.fullName);
@@ -4332,6 +4336,11 @@ async function buildRepoOutcomePatternsResponse(env: Env, fullName: string) {
 
 async function buildRegistrationReadinessResponse(env: Env, fullName: string) {
   /* v8 ignore start -- Registration readiness route-level shaping over covered signal helpers. */
+  // Intentionally the raw DB `settings` alongside the raw (cache-only, never live-fetched) `focusManifest`,
+  // not resolveRepositorySettings's merged view: this endpoint's whole purpose is to advise on the
+  // relationship between the two config layers (e.g. "your yml sets X but the currently active settings say
+  // Y"), which requires seeing them unmerged (#2912). See buildRegistrationReadiness's use of `focusManifest`
+  // for the yml-compiled policy section, separate from `settings` for the currently-active-behavior section.
   const [intelligence, settings, upstreamReports, focusManifest] = await Promise.all([
     buildRepoIntelligenceResponse(env, fullName),
     getRepositorySettings(env, fullName),
@@ -4385,6 +4394,10 @@ async function buildSelfDogfoodRegistrationPackResponse(env: Env) {
 
 async function buildGittensorConfigRecommendationResponse(env: Env, fullName: string) {
   /* v8 ignore start -- Config recommendation route-level shaping over covered signal helpers. */
+  // Intentionally the raw DB settings, not resolveRepositorySettings's merged view: this tool recommends what
+  // to ADD to .gittensory.yml based on the repo's currently-active (dashboard/API-configured) behavior — using
+  // the yml-merged view here would be comparing the recommendation against itself once a yml override exists
+  // (#2912).
   const intelligence = await buildRepoIntelligenceResponse(env, fullName);
   const settings = await getRepositorySettings(env, fullName);
   const repo = intelligence.repo;

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -1,5 +1,4 @@
 import {
-  getRepositorySettings,
   getRepository,
   getPullRequest,
   countOpenIssues,
@@ -43,6 +42,7 @@ import {
   extractLinkedIssueNumbers,
 } from "../db/repositories";
 import { agentRequiresContentsWrite, agentRequiresPrWrite } from "../settings/agent-execution";
+import { resolveRepositorySettings } from "../settings/repository-settings";
 import type {
   ContributorRepoStatRecord,
   GitHubRateLimitObservationRecord,
@@ -373,7 +373,7 @@ export async function backfillRegisteredRepositories(
   const mode = options.mode ?? "light";
   const limits = { ...DEFAULT_LIMITS, ...MODE_LIMITS[mode], ...(options.limits ?? {}) };
   const repoResults = await mapWithConcurrency(repositories, limits.repoConcurrency, async (repo): Promise<RepoBackfillResult> => {
-    const settings = await getRepositorySettings(env, repo.fullName);
+    const settings = await resolveRepositorySettings(env, repo.fullName);
     if (!settings.backfillEnabled) {
       const completedAt = nowIso();
       await upsertSkippedSegments(env, repo, mode, completedAt, ["Backfill is disabled for this repository."]);
@@ -447,7 +447,7 @@ export async function enqueueRepositoryOpenDataBackfill(
   const repo = await getRepository(env, options.repoFullName);
   if (!repo?.isRegistered) return { ok: true, repoFullName: options.repoFullName, status: "skipped", warnings: ["Repository is not registered for Gittensory backfill."] };
   const mode = options.mode ?? "light";
-  const settings = await getRepositorySettings(env, repo.fullName);
+  const settings = await resolveRepositorySettings(env, repo.fullName);
   if (!settings.backfillEnabled) return { ok: true, repoFullName: repo.fullName, status: "skipped", warnings: ["Backfill is disabled for this repository."] };
   const token = await tokenForRepo(env, repo);
   const sourceKind: RepoSyncSegmentRecord["sourceKind"] = repo.installationId && token !== env.GITHUB_PUBLIC_TOKEN ? "installation" : "github";
@@ -950,7 +950,7 @@ export function enrichInstallationHealth(health: InstallationHealthRecord) {
 
 export async function buildInstallationRepairDiagnostics(env: Env, health: InstallationHealthRecord) {
   const installedRepos = (await listRepositories(env)).filter((repo) => repo.installationId === health.installationId && repo.isInstalled);
-  const installedSettings = await Promise.all(installedRepos.map((repo) => getRepositorySettings(env, repo.fullName)));
+  const installedSettings = await Promise.all(installedRepos.map((repo) => resolveRepositorySettings(env, repo.fullName)));
   const commentRepoCount = installedSettings.filter(usesCommentMode).length;
   const labelRepoCount = installedSettings.filter(usesLabelMode).length;
   const checkRunRepoCount = installedSettings.filter((settings) => settings.checkRunMode === "enabled").length;
@@ -1149,7 +1149,7 @@ async function refreshInstallationHealthRecords(env: Env, installations: Install
     const { installation: currentInstallation, errorSummary, authMode } = await refreshStoredInstallation(env, installation);
     const installedRepos = repositories.filter((repo) => repo.installationId === currentInstallation.id && repo.isInstalled);
     const registeredInstalled = installedRepos.filter((repo) => repo.isRegistered);
-    const installedSettings = await Promise.all(installedRepos.map((repo) => getRepositorySettings(env, repo.fullName)));
+    const installedSettings = await Promise.all(installedRepos.map((repo) => resolveRepositorySettings(env, repo.fullName)));
     const requiresChecks = installedSettings.some((settings) => settings.checkRunMode === "enabled");
     const requiresPrWrite = installedSettings.some((settings) => agentRequiresPrWrite(settings.autonomy));
     const requiresContentsWrite = installedSettings.some((settings) => agentRequiresContentsWrite(settings.autonomy));

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,7 +20,6 @@ import {
   getPendingAgentAction,
   getPullRequest,
   getRepository,
-  getRepositorySettings,
   isGlobalAgentFrozen,
   getRepoQueueTrendSnapshot,
   listAgentAuditEvents,
@@ -117,6 +116,7 @@ import {
 import { applyStepResult, buildPlanDag, nextReadySteps, planProgress, validatePlanDag, type PlanDag } from "../services/plan-dag";
 import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
 import { AGENT_ACTION_CLASSES, isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
+import { resolveRepositorySettings } from "../settings/repository-settings";
 import { MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildPredictedGateVerdict } from "../rules/predicted-gate";
@@ -2450,7 +2450,7 @@ export class GittensoryMcp {
     await this.requireRepoAccess(fullName);
     const [repo, settings, pendingActionCount] = await Promise.all([
       getRepository(this.env, fullName),
-      getRepositorySettings(this.env, fullName),
+      resolveRepositorySettings(this.env, fullName),
       countPendingAgentActions(this.env, { repoFullName: fullName, status: "pending" }),
     ]);
     const autonomy = settings.autonomy;

--- a/src/services/contributor-issue-draft.ts
+++ b/src/services/contributor-issue-draft.ts
@@ -500,6 +500,10 @@ function pathSlug(path: string): string {
 }
 
 async function loadContributorIssueDraftContext(env: Env, repoFullName: string): Promise<ContributorIssueDraftContext> {
+  // Intentionally the raw DB `settings` alongside the raw (cache-only, never live-fetched) `focusManifest`,
+  // not resolveRepositorySettings's merged view: downstream consumers (e.g. buildContributorIssueDraftTestingRequirements)
+  // read `focusManifest` on its own for the yml-authored policy (wantedPaths/testExpectations/etc.), separate
+  // from `settings` for the currently-active dashboard/API behavior (#2912).
   const [repo, settings, openIssues, declinedIssues, focusManifest, upstreamReports, issues, pullRequests, recentMergedPullRequests, labels, queueCounts] = await Promise.all([
     getRepository(env, repoFullName),
     getRepositorySettings(env, repoFullName),

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -939,6 +939,39 @@ describe("GitHub backfill", () => {
     );
   });
 
+  it("REGRESSION (#2912): repair diagnostics honor a .gittensory.yml-only checkRunMode: enabled override (DB row left at off)", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
+    // DB row explicitly says checkRunMode: off; only the yml manifest turns it on, so this only passes if the
+    // resolver (not the raw DB accessor) is consulted for the installed-repo settings scan.
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", checkRunMode: "off" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/.gittensory.yml")) return new Response("settings:\n  checkRunMode: enabled\n", { status: 200 });
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const repair = await buildInstallationRepairDiagnostics(env, {
+      installationId: 123,
+      accountLogin: "JSONbored",
+      repositorySelection: "selected",
+      installedReposCount: 1,
+      registeredInstalledCount: 0,
+      status: "healthy",
+      missingPermissions: [],
+      missingEvents: [],
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["issues", "issue_comment", "pull_request", "repository", "installation_repositories"],
+      checkedAt: "2026-05-28T00:00:00.000Z",
+      authMode: "local",
+    });
+
+    expect(repair.requiredPermissions).toHaveProperty("checks");
+    expect(repair.modeImpacts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ mode: "check_run", enabled: true, affectedRepoCount: 1 })]),
+    );
+  });
+
   it("repair diagnostics require contents:write for merge autonomy (#audit-install-health display)", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 123);
@@ -1115,6 +1148,22 @@ describe("GitHub backfill", () => {
       checkRunDetailLevel: "standard",
       backfillEnabled: false,
       privateTrustEnabled: true,
+    });
+
+    const result = await backfillRegisteredRepositories(env);
+
+    expect(result.repos[0]).toMatchObject({ status: "skipped", warnings: ["Backfill is disabled for this repository."] });
+  });
+
+  it("REGRESSION (#2912): honors a .gittensory.yml-only backfillEnabled: false override (DB row left at its true default)", async () => {
+    const env = createTestEnv();
+    await seedRegisteredRepo(env);
+    // No upsertRepositorySettings call: the DB row stays at its default (backfillEnabled: true). Only the
+    // yml manifest disables it, so this only passes if the resolver (not the raw DB accessor) is consulted.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/.gittensory.yml")) return new Response("settings:\n  backfillEnabled: false\n", { status: 200 });
+      return new Response("Not Found", { status: 404 });
     });
 
     const result = await backfillRegisteredRepositories(env);

--- a/test/unit/mcp-automation-state.test.ts
+++ b/test/unit/mcp-automation-state.test.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { getRepositoryCollaboratorPermission } from "../../src/github/app";
 import { mergePullRequest } from "../../src/github/pr-actions";
@@ -50,6 +50,10 @@ const mockedPermission = vi.mocked(getRepositoryCollaboratorPermission);
 beforeEach(() => {
   mockedPermission.mockReset();
   mockedPermission.mockResolvedValue("write");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 async function connect(env: Env, identity?: AuthIdentity) {
@@ -110,6 +114,27 @@ describe("MCP gittensory_get_automation_state (#784)", () => {
     expect(result.isError).toBeFalsy();
     const data = result.structuredContent as State;
     expect(data.pendingActionCount).toBe(201);
+  });
+
+  it("REGRESSION (#2912): honors a .gittensory.yml-only agentPaused: true override (DB row left at its false default)", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto" } });
+    // No agentPaused in the DB row above (stays at its false default): only the yml manifest pauses the repo,
+    // so this only passes if the resolver (not the raw DB accessor) is consulted.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/.gittensory.yml")) return new Response("settings:\n  agentPaused: true\n", { status: 200 });
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_automation_state", arguments: { owner: "owner", repo: "repo" } });
+
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as State;
+    expect(data.agentPaused).toBe(true);
+    expect(data.mode).toBe("paused");
   });
 
   it("reports unconfigured + not_required readiness for an unknown / un-onboarded repo (no repo record)", async () => {


### PR DESCRIPTION
## Summary

- `backfillRegisteredRepositories`, `enqueueRepositoryOpenDataBackfill`, `buildInstallationRepairDiagnostics`, `refreshInstallationHealthRecords`, and the MCP `getAutomationState` tool all read repository settings via the raw `getRepositorySettings` DB accessor instead of `resolveRepositorySettings`. A `.gittensory.yml` override for `backfillEnabled` / `checkRunMode` / `gateCheckMode` / `reviewCheckMode` / `autonomy` / `agentPaused` / `agentDryRun` was silently ignored at these five call sites, even though the actual gate/action-execution pipeline (`agent-approval-queue.ts` and friends) already resolves these correctly.
- Fixed by switching all five to `resolveRepositorySettings`.
- Three other call sites (`loadPublicRepoBadge`, `buildRegistrationReadinessResponse` + `buildGittensorConfigRecommendationResponse`, `loadContributorIssueDraftContext`) were investigated and found to be **intentional**, not bugs — each now has a comment explaining why:
  - `loadPublicRepoBadge` is an unauthenticated, high-frequency public route (a README-embedded badge image); it deliberately trades honoring a yml-only override for avoiding a manifest-cache lookup on every image load.
  - The two advisory/recommendation builders and the contributor-issue-draft context loader already load the raw DB settings **and** the raw (cache-only) `.gittensory.yml` manifest **separately**, because their entire purpose is to show the two config layers side-by-side for comparison/recommendation — merging them would defeat that purpose.

Resolves #2912. First of a series of follow-ups tracked under #1667 from a 2026-07-04 self-host review-engine audit.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: #2912.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] Targeted `vitest run` on all affected test files (`test/unit/backfill.test.ts`, `test/unit/mcp-automation-state.test.ts`, `test/unit/contributor-issue-draft.test.ts`, `test/unit/self-dogfood-registration-pack.test.ts`, `test/integration/api.test.ts`) — 306 tests passed
- [x] `npm run test:changed` (Vitest's real-import-graph diff selection against `main`) — 203 files / 5005 tests passed, 0 failed
- [ ] `npm run actionlint` / `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm audit` / `ui:*` — not run locally; no workflow, worker-pool, MCP-package, or UI files touched. CI runs the full gate.
- [x] New behavior (the resolver now being consulted) has regression tests for both sides: a `.gittensory.yml`-only override taking effect (3 new regression tests) alongside the pre-existing DB-only-override tests, which still pass unchanged.

If any required check was skipped, explain why:

- `test:coverage`/`test:ci` not run locally — this diff only swaps one function call per site (no new branches beyond the three regression tests, which are covered by the targeted run above) plus doc-only comments at the four intentional-exception sites. Per this repo's established practice, CI's full gate covers the rest.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes; this is a settings-read source swap.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (The MCP `getAutomationState` tool's output can now change based on yml, and is covered by a new regression test. No schema shape changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)

## Notes

- One test-isolation fix included: `test/unit/mcp-automation-state.test.ts` had no `afterEach(() => vi.unstubAllGlobals())`, so my new regression test's `vi.stubGlobal("fetch", ...)` leaked into two unrelated later tests in the same file. Added the missing cleanup hook (a no-op for every existing test, since none of them stub globals).