### PR TITLE
feat(ui): add dead-letter-queue table view for self-host operators (#2214)

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -16095,6 +16095,36 @@
           }
         ]
       }
+    },
+    "/v1/app/selfhost/queue/dead": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
@@ -1,0 +1,77 @@
+export type DeadLetterQueueItem = {
+  id: number;
+  jobType: string;
+  attempts: number;
+  lastError: string | null;
+  createdAtMs: number;
+  deadAtMs: number | null;
+};
+
+export type DeadLetterQueuePage = {
+  generatedAt: string;
+  limit: number;
+  offset: number;
+  total: number;
+  items: DeadLetterQueueItem[];
+};
+
+export const DEAD_LETTER_QUEUE_PAGE_SIZE = 25;
+export const DEAD_LETTER_ERROR_TRUNCATE_LENGTH = 80;
+
+export function buildDeadLetterQueuePath(
+  offset: number,
+  limit = DEAD_LETTER_QUEUE_PAGE_SIZE,
+): string {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  params.set("offset", String(offset));
+  return `/v1/app/selfhost/queue/dead?${params.toString()}`;
+}
+
+function isDeadLetterQueueItem(value: unknown): value is DeadLetterQueueItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<DeadLetterQueueItem>;
+  return (
+    typeof item.id === "number" &&
+    typeof item.jobType === "string" &&
+    typeof item.attempts === "number" &&
+    (item.lastError === null || typeof item.lastError === "string") &&
+    typeof item.createdAtMs === "number" &&
+    (item.deadAtMs === null || typeof item.deadAtMs === "number")
+  );
+}
+
+export function normalizeDeadLetterQueuePage(data: unknown): DeadLetterQueuePage | null {
+  if (!data || typeof data !== "object") return null;
+  const raw = data as Partial<DeadLetterQueuePage>;
+  if (
+    typeof raw.generatedAt !== "string" ||
+    typeof raw.limit !== "number" ||
+    typeof raw.offset !== "number" ||
+    typeof raw.total !== "number" ||
+    !Array.isArray(raw.items)
+  ) {
+    return null;
+  }
+  return {
+    generatedAt: raw.generatedAt,
+    limit: raw.limit,
+    offset: raw.offset,
+    total: raw.total,
+    items: raw.items.filter(isDeadLetterQueueItem),
+  };
+}
+
+export function formatDeadLetterTimestamp(ms: number | null): string {
+  if (ms === null) return "—";
+  return new Date(ms).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+/** Truncates a last-error message for the collapsed table row; the panel expands the full text on click. */
+export function truncateErrorMessage(
+  message: string,
+  maxLength = DEAD_LETTER_ERROR_TRUNCATE_LENGTH,
+): string {
+  if (message.length <= maxLength) return message;
+  return `${message.slice(0, maxLength).trimEnd()}…`;
+}

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import {
+  buildDeadLetterQueuePath,
+  DEAD_LETTER_ERROR_TRUNCATE_LENGTH,
+  formatDeadLetterTimestamp,
+  normalizeDeadLetterQueuePage,
+  truncateErrorMessage,
+} from "@/components/site/dead-letter-queue-panel-model";
+import { DeadLetterQueuePanel } from "@/components/site/dead-letter-queue-panel";
+
+const SAMPLE_PAGE = {
+  generatedAt: "2026-07-03T00:00:05.000Z",
+  limit: 25,
+  offset: 0,
+  total: 2,
+  items: [
+    {
+      id: 2,
+      jobType: "github-webhook",
+      attempts: 1,
+      lastError: "kaboom",
+      createdAtMs: 2_000,
+      deadAtMs: 9_000,
+    },
+    {
+      id: 1,
+      jobType: "agent-regate-pr",
+      attempts: 3,
+      lastError: null,
+      createdAtMs: 1_000,
+      deadAtMs: 5_000,
+    },
+  ],
+};
+
+describe("dead-letter queue panel model", () => {
+  it("builds the query path with a default and a custom limit", () => {
+    expect(buildDeadLetterQueuePath(0)).toBe("/v1/app/selfhost/queue/dead?limit=25&offset=0");
+    expect(buildDeadLetterQueuePath(50, 10)).toBe("/v1/app/selfhost/queue/dead?limit=10&offset=50");
+  });
+
+  it("normalizes a valid page and rejects malformed payloads/items", () => {
+    expect(normalizeDeadLetterQueuePage(SAMPLE_PAGE)).toEqual(SAMPLE_PAGE);
+    expect(normalizeDeadLetterQueuePage(null)).toBeNull();
+    expect(normalizeDeadLetterQueuePage({ generatedAt: "x" })).toBeNull();
+    expect(
+      normalizeDeadLetterQueuePage({
+        ...SAMPLE_PAGE,
+        items: [SAMPLE_PAGE.items[0], null, "bad", { id: "not-a-number" }],
+      }),
+    ).toMatchObject({ items: [SAMPLE_PAGE.items[0]] });
+  });
+
+  it("formats a null death/creation timestamp as an em dash, and a real one as a non-empty string", () => {
+    expect(formatDeadLetterTimestamp(null)).toBe("—");
+    const formatted = formatDeadLetterTimestamp(1_751_500_000_000);
+    expect(formatted).not.toBe("—");
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+
+  it("truncates a long error message and leaves a short one untouched", () => {
+    const short = "boom";
+    expect(truncateErrorMessage(short)).toBe(short);
+    const long = "x".repeat(DEAD_LETTER_ERROR_TRUNCATE_LENGTH + 20);
+    const truncated = truncateErrorMessage(long);
+    expect(truncated.endsWith("…")).toBe(true);
+    expect(truncated.length).toBeLessThan(long.length);
+    // Exact boundary: a message of exactly maxLength characters must NOT be truncated.
+    const exact = "y".repeat(DEAD_LETTER_ERROR_TRUNCATE_LENGTH);
+    expect(truncateErrorMessage(exact)).toBe(exact);
+  });
+});
+
+describe("DeadLetterQueuePanel", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue({ ok: true, data: SAMPLE_PAGE });
+  });
+
+  it("renders populated dead-letter rows with job id, type, attempts, and formatted timestamps", async () => {
+    render(<DeadLetterQueuePanel />);
+    expect(await screen.findByText("github-webhook")).toBeTruthy();
+    expect(screen.getByText("agent-regate-pr")).toBeTruthy();
+    expect(screen.getByText("kaboom")).toBeTruthy();
+    expect(screen.getByText("2 dead")).toBeTruthy();
+    // A null lastError renders as an em dash, not "null" or an empty cell.
+    const dashCells = screen.getAllByText("—");
+    expect(dashCells.length).toBeGreaterThan(0);
+  });
+
+  it("shows an empty state when the queue has no dead-letter jobs", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { ...SAMPLE_PAGE, total: 0, items: [] } });
+    render(<DeadLetterQueuePanel />);
+    expect(await screen.findByText("No dead-letter jobs")).toBeTruthy();
+  });
+
+  it("shows an error state when the request fails", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "insufficient_role" });
+    render(<DeadLetterQueuePanel />);
+    expect(await screen.findByText("Couldn't load the dead-letter queue")).toBeTruthy();
+    expect(screen.getByText("insufficient_role")).toBeTruthy();
+  });
+
+  it("shows an error state when the response is malformed", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { generatedAt: "x" } });
+    render(<DeadLetterQueuePanel />);
+    expect(await screen.findByText("Couldn't load the dead-letter queue")).toBeTruthy();
+    expect(
+      screen.getByText("The dead-letter queue endpoint returned an unexpected response."),
+    ).toBeTruthy();
+  });
+
+  it("expands and collapses a truncated error message", async () => {
+    const longError = "x".repeat(120);
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { ...SAMPLE_PAGE, items: [{ ...SAMPLE_PAGE.items[0], lastError: longError }] },
+    });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    expect(screen.queryByText(longError)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /show more/i }));
+    expect(screen.getByText(longError)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /show less/i }));
+    expect(screen.queryByText(longError)).toBeNull();
+  });
+
+  it("does not render a Show more toggle for an error message under the truncation length", async () => {
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("kaboom");
+    expect(screen.queryByRole("button", { name: /show more/i })).toBeNull();
+  });
+
+  it("disables Previous on the first page and fetches the next page on Next", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { ...SAMPLE_PAGE, total: 60 } });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    expect(screen.getByRole("link", { name: /previous/i }).getAttribute("aria-disabled")).toBe(
+      "true",
+    );
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { ...SAMPLE_PAGE, offset: 25, total: 60, items: [{ ...SAMPLE_PAGE.items[0], id: 99 }] },
+    });
+    fireEvent.click(screen.getByRole("link", { name: /next/i }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=25",
+        expect.any(Object),
+      ),
+    );
+    await screen.findByText("99");
+  });
+
+  it("disables Next once the last page is reached", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: SAMPLE_PAGE }); // total(2) <= limit(25) -- no next page
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+    expect(screen.getByRole("link", { name: /next/i }).getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from "react";
+
+import {
+  buildDeadLetterQueuePath,
+  formatDeadLetterTimestamp,
+  normalizeDeadLetterQueuePage,
+  truncateErrorMessage,
+  type DeadLetterQueueItem,
+} from "@/components/site/dead-letter-queue-panel-model";
+import { StatusPill } from "@/components/site/control-primitives";
+import { StateBoundary } from "@/components/site/state-views";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { useApiResource } from "@/lib/api/use-api-resource";
+
+export function DeadLetterQueuePanel() {
+  const [offset, setOffset] = useState(0);
+  const path = useMemo(() => buildDeadLetterQueuePath(offset), [offset]);
+  const resource = useApiResource<unknown>(path, "Dead-letter queue");
+  const page = resource.status === "ready" ? normalizeDeadLetterQueuePage(resource.data) : null;
+  const isMalformed = resource.status === "ready" && page === null;
+
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Dead-letter queue</h2>
+          <p className="mt-1 max-w-2xl text-token-xs text-muted-foreground">
+            Jobs that exhausted their retry budget. Newest failures first.
+          </p>
+        </div>
+        {page ? (
+          <StatusPill status={page.total === 0 ? "ready" : "warn"}>{page.total} dead</StatusPill>
+        ) : null}
+      </div>
+
+      <div className="mt-4">
+        <StateBoundary
+          isLoading={resource.status === "loading"}
+          isError={resource.status === "error" || isMalformed}
+          isEmpty={page !== null && page.items.length === 0}
+          onRetry={resource.reload}
+          onRefresh={resource.reload}
+          loadingTitle="Loading dead-letter queue…"
+          loadingDescription="Fetching failed jobs from the self-host queue backend."
+          emptyTitle="No dead-letter jobs"
+          emptyDescription="Jobs that exhaust their retry budget will appear here."
+          errorTitle="Couldn't load the dead-letter queue"
+          errorDescription={
+            resource.status === "error"
+              ? resource.error
+              : "The dead-letter queue endpoint returned an unexpected response."
+          }
+        >
+          {page && page.items.length > 0 ? (
+            <DeadLetterQueueTable page={page} onPageChange={setOffset} />
+          ) : null}
+        </StateBoundary>
+      </div>
+    </section>
+  );
+}
+
+function DeadLetterQueueTable({
+  page,
+  onPageChange,
+}: {
+  page: { limit: number; offset: number; total: number; items: DeadLetterQueueItem[] };
+  onPageChange: (offset: number) => void;
+}) {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  const toggleExpanded = (id: number) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const rangeStart = page.total === 0 ? 0 : page.offset + 1;
+  const rangeEnd = Math.min(page.offset + page.items.length, page.total);
+  const hasPrevious = page.offset > 0;
+  const hasNext = page.offset + page.limit < page.total;
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto rounded-token border border-border bg-transparent">
+        <table className="w-full min-w-[760px] text-left text-token-sm">
+          <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3 font-medium">Job ID</th>
+              <th className="px-4 py-3 font-medium">Type</th>
+              <th className="px-4 py-3 font-medium">Attempts</th>
+              <th className="px-4 py-3 font-medium">Last error</th>
+              <th className="px-4 py-3 font-medium">Created</th>
+              <th className="px-4 py-3 font-medium">Died</th>
+            </tr>
+          </thead>
+          <tbody>
+            {page.items.map((item) => {
+              const error = item.lastError ?? "";
+              const isTruncated = error.length > truncateErrorMessage(error).length;
+              const isExpanded = expanded.has(item.id);
+              return (
+                <tr key={item.id} className="border-b border-border/60 last:border-0 align-top">
+                  <td className="px-4 py-3 font-mono text-token-xs">{item.id}</td>
+                  <td className="px-4 py-3 font-mono text-token-xs">{item.jobType}</td>
+                  <td className="px-4 py-3 font-mono text-token-xs">{item.attempts}</td>
+                  <td className="px-4 py-3 text-token-xs text-muted-foreground">
+                    {item.lastError === null ? (
+                      "—"
+                    ) : (
+                      <>
+                        {isExpanded ? item.lastError : truncateErrorMessage(item.lastError)}
+                        {isTruncated ? (
+                          <button
+                            type="button"
+                            onClick={() => toggleExpanded(item.id)}
+                            className="ml-1.5 text-mint hover:underline focus-ring rounded-token"
+                          >
+                            {isExpanded ? "Show less" : "Show more"}
+                          </button>
+                        ) : null}
+                      </>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-token-xs text-muted-foreground whitespace-nowrap">
+                    {formatDeadLetterTimestamp(item.createdAtMs)}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-token-xs text-muted-foreground whitespace-nowrap">
+                    {formatDeadLetterTimestamp(item.deadAtMs)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-token-2xs text-muted-foreground">
+          Showing {rangeStart}–{rangeEnd} of {page.total}
+        </p>
+        <Pagination className="mx-0 w-auto justify-end">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                aria-disabled={!hasPrevious}
+                onClick={(event) => {
+                  event.preventDefault();
+                  if (hasPrevious) onPageChange(Math.max(0, page.offset - page.limit));
+                }}
+                className={hasPrevious ? undefined : "pointer-events-none opacity-40"}
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                aria-disabled={!hasNext}
+                onClick={(event) => {
+                  event.preventDefault();
+                  if (hasNext) onPageChange(page.offset + page.limit);
+                }}
+                className={hasNext ? undefined : "pointer-events-none opacity-40"}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.operator.tsx
+++ b/apps/gittensory-ui/src/routes/app.operator.tsx
@@ -9,6 +9,7 @@ import {
   Stat,
   StatusPill,
 } from "@/components/site/control-primitives";
+import { DeadLetterQueuePanel } from "@/components/site/dead-letter-queue-panel";
 import { NotificationReadinessCard } from "@/components/site/notification-readiness-card";
 import { StateBoundary } from "@/components/site/state-views";
 import { getApiOrigin } from "@/lib/api/origin";
@@ -445,6 +446,7 @@ function OperatorDashboard() {
               ) : null}
             </div>
           </section>
+          <DeadLetterQueuePanel />
           <NotificationReadinessCard />
         </div>
       ) : null}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -271,6 +271,7 @@ import type {
   RepositorySettings,
 } from "../types";
 import { errorMessage, nowIso } from "../utils/json";
+import { queueDeadLetterPageFromBinding } from "../selfhost/queue-common";
 
 type AppBindings = { Bindings: Env };
 type AppContext = Context<AppBindings>;
@@ -434,6 +435,13 @@ const issueSlopSchema = z.object({
   title: z.string().max(500).optional(),
   body: z.string().max(40000).optional(),
 });
+
+const selfhostDeadLetterQueueQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().optional(),
+    offset: z.coerce.number().int().optional(),
+  })
+  .strict();
 
 const skippedPrAuditQuerySchema = z
   .object({
@@ -1365,6 +1373,26 @@ export function createApp() {
     const forbidden = await requireAppRole(c, ["operator"]);
     if (forbidden) return forbidden;
     return c.json(await buildOperatorDashboardPayload(c.env));
+  });
+
+  // Dead-letter-queue table view (#2214), read-only: the self-host queue backend's admin surface is mirrored
+  // onto `env.JOBS` (see queueDeadLetterPageFromBinding) rather than a new Env field -- absent entirely on
+  // Cloudflare, where the plain Queue binding has neither method.
+  app.get("/v1/app/selfhost/queue/dead", async (c) => {
+    const forbidden = await requireAppRole(c, ["operator"]);
+    if (forbidden) return forbidden;
+    const parsed = selfhostDeadLetterQueueQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: "invalid_query", issues: parsed.error.issues }, 400);
+    const limit = clampInteger(parsed.data.limit ?? 25, 1, 100);
+    const offset = Math.max(0, parsed.data.offset ?? 0);
+    const page = await queueDeadLetterPageFromBinding(c.env.JOBS, limit, offset);
+    if (!page) {
+      return c.json(
+        { error: "dead_letter_admin_unavailable", message: "This deployment's queue backend does not expose dead-letter admin." },
+        501,
+      );
+    }
+    return c.json({ generatedAt: nowIso(), limit, offset, total: page.total, items: page.items });
   });
 
   // Global agent kill-switch (#2359): the write side (setGlobalAgentFrozen) previously had zero callers — the

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -720,6 +720,7 @@ export function buildOpenApiSpec() {
     "/v1/app/miner-dashboard",
     "/v1/app/maintainer-dashboard",
     "/v1/app/operator-dashboard",
+    "/v1/app/selfhost/queue/dead",
     "/v1/app/commands",
     "/v1/app/commands/usefulness",
     "/v1/app/digest",

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -36,6 +36,7 @@ import {
   queueStartupJitterMs,
   rateLimitRetryDelayWithJitter,
   matchesGitHubRateLimitAdmissionTarget,
+  type DeadLetterJob,
   type GitHubRateLimitAdmissionTarget,
   type SelfHostQueueSnapshot,
 } from "./queue-common";
@@ -177,10 +178,12 @@ ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS job_key TEXT;
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS claim_sort_key BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS is_maintenance INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS foreground_lane TEXT;
+ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS dead_at BIGINT;
 DROP INDEX IF EXISTS ${TABLE}_claim;
 CREATE INDEX IF NOT EXISTS ${TABLE}_claim ON ${TABLE}(status, priority, claim_sort_key, run_after);
 CREATE INDEX IF NOT EXISTS ${TABLE}_pending_job_key ON ${TABLE}(job_key, status);
 CREATE INDEX IF NOT EXISTS ${TABLE}_lane_claim ON ${TABLE}(status, foreground_lane, run_after);
+CREATE INDEX IF NOT EXISTS ${TABLE}_dead ON ${TABLE}(status, dead_at, id);
 CREATE TABLE IF NOT EXISTS ${STATS_TABLE} (
   name TEXT PRIMARY KEY,
   value BIGINT NOT NULL DEFAULT 0
@@ -219,6 +222,9 @@ export interface PgDurableQueue {
   /** Top-N repos by backlog-convergence pending depth, for the observability dashboard's per-repo backlog panel
    *  (#selfhost-lane-observability). */
   topBacklogRepos(limit: number): Promise<BacklogRepoCount[]>;
+  /** Paginated dead-letter rows, newest-death-first, for the DLQ dashboard table (#2214). Also mirrored onto
+   *  `binding` (see queue-common.ts's SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
+  listDeadLetterJobs(limit: number, offset: number): Promise<DeadLetterJob[]>;
 }
 
 interface JobRow {
@@ -498,6 +504,38 @@ export function createPgQueue(
     }));
   }
 
+  async function deadCount(): Promise<number> {
+    return Number((await pool.query(`SELECT COUNT(*) AS c FROM ${TABLE} WHERE status='dead'`)).rows[0].c);
+  }
+
+  async function listDeadLetterJobs(limit: number, offset: number): Promise<DeadLetterJob[]> {
+    const res = await pool.query(
+      `SELECT id, payload, attempts, last_error, created_at, dead_at
+         FROM ${TABLE}
+        WHERE status='dead'
+        ORDER BY COALESCE(dead_at, created_at) DESC, id DESC
+        LIMIT $1 OFFSET $2`,
+      [Math.max(0, limit), Math.max(0, offset)],
+    );
+    return (
+      res.rows as Array<{
+        id: string | number;
+        payload: string;
+        attempts: number | string;
+        last_error: string | null;
+        created_at: number | string;
+        dead_at: number | string | null;
+      }>
+    ).map((row) => ({
+      id: Number(row.id),
+      jobType: extractPayloadType(row.payload) ?? "unknown",
+      attempts: Number(row.attempts),
+      lastError: row.last_error,
+      createdAtMs: Number(row.created_at),
+      deadAtMs: row.dead_at === null ? null : Number(row.dead_at),
+    }));
+  }
+
   async function recoverProcessingJobs(): Promise<number> {
     const res = await pool.query(
       `SELECT id, payload, job_key FROM ${TABLE} WHERE status='processing'`,
@@ -540,7 +578,7 @@ export function createPgQueue(
       // one fires) could flip a row that's already been claimed into 'processing' back to 'pending', letting it
       // run a second time concurrently. rowCount is 0 (not counted as revived) when another reviver won the race.
       const update = await pool.query(
-        `UPDATE ${TABLE} SET status='pending', run_after=$1, last_error=NULL WHERE id=$2 AND status='dead'`,
+        `UPDATE ${TABLE} SET status='pending', run_after=$1, last_error=NULL, dead_at=NULL WHERE id=$2 AND status='dead'`,
         [runAfter, row.id],
       );
       revived += update.rowCount ?? 0;
@@ -955,8 +993,8 @@ export function createPgQueue(
         message = JSON.parse(job.payload) as JobMessage;
       } catch {
         await pool.query(
-          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload' WHERE id=$1`,
-          [job.id],
+          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload', dead_at=$1 WHERE id=$2`,
+          [Date.now(), job.id],
         );
         await recordQueueMetric("gittensory_jobs_dead_total");
         logAudit({
@@ -1197,8 +1235,8 @@ export function createPgQueue(
         await recordQueueMetric("gittensory_jobs_failed_total");
         if (attempts >= maxRetries) {
           await pool.query(
-            `UPDATE ${TABLE} SET status='dead', attempts=$1, last_error=$2 WHERE id=$3`,
-            [attempts, errMsg, job.id],
+            `UPDATE ${TABLE} SET status='dead', attempts=$1, last_error=$2, dead_at=$3 WHERE id=$4`,
+            [attempts, errMsg, Date.now(), job.id],
           );
           await recordQueueMetric("gittensory_jobs_dead_total");
           console.error(
@@ -1306,7 +1344,13 @@ export function createPgQueue(
         res.rows as Array<{ payload: string; status: string; run_after: string | number }>,
       );
     },
-  } as unknown as Queue & { snapshot(): Promise<SelfHostQueueSnapshot> };
+    deadCount,
+    listDeadLetterJobs,
+  } as unknown as Queue & {
+    snapshot(): Promise<SelfHostQueueSnapshot>;
+    deadCount(): Promise<number>;
+    listDeadLetterJobs(limit: number, offset: number): Promise<DeadLetterJob[]>;
+  };
 
   return {
     binding,
@@ -1352,15 +1396,7 @@ export function createPgQueue(
         ).rows[0].c,
       );
     },
-    async deadCount() {
-      return Number(
-        (
-          await pool.query(
-            `SELECT COUNT(*) AS c FROM ${TABLE} WHERE status='dead'`,
-          )
-        ).rows[0].c,
-      );
-    },
+    deadCount,
     async processingCount() {
       return Number(
         (
@@ -1380,6 +1416,7 @@ export function createPgQueue(
       return maintenancePressureSignals(Date.now());
     },
     topBacklogRepos,
+    listDeadLetterJobs,
   };
 
   async function reclaimExpiredProcessingJobs(): Promise<number> {

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -48,6 +48,27 @@ export interface SelfHostQueueIntrospection {
   snapshot(): SelfHostQueueSnapshot | Promise<SelfHostQueueSnapshot>;
 }
 
+// Dead-letter-queue admin surface (#2214/#2215): a self-host-only slice of DurableQueue's rich introspection,
+// mirrored onto the `.binding` object (same trick as `snapshot` above) so the Hono routes -- which only ever see
+// `env.JOBS`, a plain Cloudflare `Queue` -- can reach it via an optional-cast feature check instead of a new
+// `Env` field. Cloudflare's real Queue binding never has these methods, so the feature check below is also the
+// production-safe "self-host only" gate.
+export type DeadLetterJob = {
+  id: number;
+  /** The job's `payload.type` discriminant (e.g. "agent-regate-pr"), or "unknown" if unparseable. */
+  jobType: string;
+  attempts: number;
+  lastError: string | null;
+  createdAtMs: number;
+  /** Epoch ms the job was marked dead. Null for rows that died before this column existed (#2214). */
+  deadAtMs: number | null;
+};
+
+export interface SelfHostQueueDeadLetterAdmin {
+  deadCount(): number | Promise<number>;
+  listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[] | Promise<DeadLetterJob[]>;
+}
+
 // Webhook-driven work (a fresh PR -> its review) jumps ahead of heavy background jobs. Per-PR review refreshes
 // sit just below real webhooks, and sweep fan-out sits below those so stale surfaces are repaired during bursts.
 // Bot-generated comment edits are background noise; keeping them with real webhooks lets panel edits starve repair.
@@ -176,6 +197,24 @@ export async function queueSnapshotFromBinding(binding: Queue): Promise<SelfHost
   const snapshot = (binding as Queue & Partial<SelfHostQueueIntrospection>).snapshot;
   if (typeof snapshot !== "function") return null;
   return snapshot.call(binding);
+}
+
+export type DeadLetterQueuePage = { items: DeadLetterJob[]; total: number };
+
+/** Null on Cloudflare (the real Queue binding has neither method) or any binding that hasn't wired the
+ *  dead-letter admin surface -- callers 501 in that case rather than pretending the DLQ is simply empty. */
+export async function queueDeadLetterPageFromBinding(
+  binding: Queue,
+  limit: number,
+  offset: number,
+): Promise<DeadLetterQueuePage | null> {
+  const admin = binding as Queue & Partial<SelfHostQueueDeadLetterAdmin>;
+  if (typeof admin.listDeadLetterJobs !== "function" || typeof admin.deadCount !== "function") return null;
+  const [items, total] = await Promise.all([
+    Promise.resolve(admin.listDeadLetterJobs(limit, offset)),
+    Promise.resolve(admin.deadCount()),
+  ]);
+  return { items, total };
 }
 
 function queueStatus(value: unknown): SelfHostQueueJobStatus | null {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -37,6 +37,7 @@ import {
   queueStartupJitterMs,
   rateLimitRetryDelayWithJitter,
   matchesGitHubRateLimitAdmissionTarget,
+  type DeadLetterJob,
   type GitHubRateLimitAdmissionTarget,
   type SelfHostQueueSnapshot,
 } from "./queue-common";
@@ -88,6 +89,8 @@ CREATE TABLE IF NOT EXISTS ${TABLE} (
   job_key TEXT,
   claim_sort_key INTEGER NOT NULL DEFAULT 0
 );`;
+const DEAD_LETTER_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS ${TABLE}_dead ON ${TABLE}(status, dead_at, id);`;
 const STATS_DDL = `
 CREATE TABLE IF NOT EXISTS ${STATS_TABLE} (
   name TEXT PRIMARY KEY,
@@ -134,6 +137,9 @@ export interface DurableQueue {
   /** Top-N repos by backlog-convergence pending depth, for the observability dashboard's per-repo backlog panel
    *  (#selfhost-lane-observability). */
   topBacklogRepos(limit: number): BacklogRepoCount[];
+  /** Paginated dead-letter rows, newest-death-first, for the DLQ dashboard table (#2214). Also mirrored onto
+   *  `binding` (see queue-common.ts's SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
+  listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[];
 }
 
 interface JobRow {
@@ -208,9 +214,15 @@ export function createSqliteQueue(
   } catch {
     /* column already present */
   }
+  try {
+    driver.exec(`ALTER TABLE ${TABLE} ADD COLUMN dead_at INTEGER`);
+  } catch {
+    /* column already present */
+  }
   driver.exec(CLAIM_INDEX_DDL);
   driver.exec(JOB_KEY_INDEX_DDL);
   driver.exec(LANE_INDEX_DDL);
+  driver.exec(DEAD_LETTER_INDEX_DDL);
   driver.exec(FAIRNESS_DDL);
   driver.exec(`INSERT OR IGNORE INTO ${FAIRNESS_TABLE} (id, claim_sequence) VALUES ('singleton', 0)`);
   const priorityBackfilled = backfillJobPriorities(driver);
@@ -623,6 +635,40 @@ export function createSqliteQueue(
     return (rows as Array<{ repo: string; cnt: number }>).map((row) => ({ repo: row.repo, count: Number(row.cnt) }));
   }
 
+  function deadCount(): number {
+    return Number(
+      (driver.query(`SELECT COUNT(*) AS c FROM ${TABLE} WHERE status='dead'`, []).rows[0] as { c: number }).c,
+    );
+  }
+
+  function listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[] {
+    const { rows } = driver.query(
+      `SELECT id, payload, attempts, last_error, created_at, dead_at
+         FROM ${TABLE}
+        WHERE status='dead'
+        ORDER BY COALESCE(dead_at, created_at) DESC, id DESC
+        LIMIT ? OFFSET ?`,
+      [Math.max(0, limit), Math.max(0, offset)],
+    );
+    return (
+      rows as Array<{
+        id: number;
+        payload: string;
+        attempts: number;
+        last_error: string | null;
+        created_at: number;
+        dead_at: number | null;
+      }>
+    ).map((row) => ({
+      id: row.id,
+      jobType: extractPayloadType(row.payload) ?? "unknown",
+      attempts: Number(row.attempts),
+      lastError: row.last_error,
+      createdAtMs: Number(row.created_at),
+      deadAtMs: row.dead_at === null ? null : Number(row.dead_at),
+    }));
+  }
+
   function claimNextWhere(
     now: number,
     priorityPredicate: string,
@@ -686,8 +732,8 @@ export function createSqliteQueue(
         message = JSON.parse(job.payload) as JobMessage;
       } catch {
         driver.query(
-          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload' WHERE id=?`,
-          [job.id],
+          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload', dead_at=? WHERE id=?`,
+          [Date.now(), job.id],
         );
         recordQueueMetric(driver, "gittensory_jobs_dead_total");
         logAudit({
@@ -881,8 +927,8 @@ export function createSqliteQueue(
         recordQueueMetric(driver, "gittensory_jobs_failed_total");
         if (attempts >= maxRetries) {
           driver.query(
-            `UPDATE ${TABLE} SET status='dead', attempts=?, last_error=? WHERE id=?`,
-            [attempts, errMsg, job.id],
+            `UPDATE ${TABLE} SET status='dead', attempts=?, last_error=?, dead_at=? WHERE id=?`,
+            [attempts, errMsg, Date.now(), job.id],
           );
           recordQueueMetric(driver, "gittensory_jobs_dead_total");
           console.error(
@@ -993,7 +1039,13 @@ export function createSqliteQueue(
         ).rows as Array<{ payload: string; status: string; run_after: number }>,
       );
     },
-  } as unknown as Queue & { snapshot(): SelfHostQueueSnapshot };
+    deadCount,
+    listDeadLetterJobs,
+  } as unknown as Queue & {
+    snapshot(): SelfHostQueueSnapshot;
+    deadCount(): number;
+    listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[];
+  };
 
   return {
     binding,
@@ -1037,16 +1089,7 @@ export function createSqliteQueue(
         ).c,
       );
     },
-    deadCount() {
-      return Number(
-        (
-          driver.query(
-            `SELECT COUNT(*) AS c FROM ${TABLE} WHERE status='dead'`,
-            [],
-          ).rows[0] as { c: number }
-        ).c,
-      );
-    },
+    deadCount,
     processingCount() {
       return Number(
         (
@@ -1067,6 +1110,7 @@ export function createSqliteQueue(
       return maintenancePressureSignals(driver, Date.now());
     },
     topBacklogRepos,
+    listDeadLetterJobs,
   };
 }
 
@@ -1234,7 +1278,7 @@ function reviveEligibleDeadJobs(driver: SqliteDriver, maxRetries: number): numbe
     // that's already been claimed into 'processing' back to 'pending', letting it run a second time concurrently.
     // `changes` is 0 (not counted as revived) when the row already moved out of 'dead'.
     const { changes } = driver.query(
-      `UPDATE ${TABLE} SET status='pending', run_after=?, last_error=NULL WHERE id=? AND status='dead'`,
+      `UPDATE ${TABLE} SET status='pending', run_after=?, last_error=NULL, dead_at=NULL WHERE id=? AND status='dead'`,
       [runAfter, row.id],
     );
     revived += changes;

--- a/test/unit/routes-selfhost-dead-letter-queue.test.ts
+++ b/test/unit/routes-selfhost-dead-letter-queue.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { createApp } from "../../src/api/routes";
+import { createSessionForGitHubUser } from "../../src/auth/security";
+import { createTestEnv } from "../helpers/d1";
+
+// #2214: the read-only dead-letter-queue table view. The self-host queue backend's admin surface is mirrored
+// onto env.JOBS (see queueDeadLetterPageFromBinding) rather than a new Env field, so a plain Cloudflare-shaped
+// JOBS stub (createTestEnv()'s default) exercises the "admin unavailable" 501 path, and an override JOBS with
+// listDeadLetterJobs/deadCount exercises the populated self-host path.
+
+function selfhostJobsStub(overrides: {
+  listDeadLetterJobs?: (limit: number, offset: number) => unknown[];
+  deadCount?: () => number;
+} = {}): Queue {
+  return {
+    async send() {},
+    async sendBatch() {},
+    listDeadLetterJobs: overrides.listDeadLetterJobs ?? (() => []),
+    deadCount: overrides.deadCount ?? (() => 0),
+  } as unknown as Queue;
+}
+
+describe("dead-letter-queue table route (#2214)", () => {
+  it("is unauthorized with no identity at all", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/selfhost/queue/dead", {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("is forbidden for an authenticated session without the operator role", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "not-an-operator", id: 501 });
+    const res = await app.request("/v1/app/selfhost/queue/dead", { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 501 (not a false empty page) when the queue backend has no dead-letter admin surface", async () => {
+    const app = createApp();
+    const env = createTestEnv(); // default JOBS stub is Cloudflare-shaped: no listDeadLetterJobs/deadCount
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request("/v1/app/selfhost/queue/dead", { headers: { cookie: `gittensory_session=${token}` } }, env);
+    expect(res.status).toBe(501);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_admin_unavailable" });
+  });
+
+  it("returns a populated page for an operator session against a self-host-shaped JOBS binding", async () => {
+    const app = createApp();
+    const items = [
+      { id: 2, jobType: "github-webhook", attempts: 1, lastError: "kaboom", createdAtMs: 2000, deadAtMs: 9000 },
+      { id: 1, jobType: "agent-regate-pr", attempts: 3, lastError: "boom", createdAtMs: 1000, deadAtMs: 5000 },
+    ];
+    const env = createTestEnv({ JOBS: selfhostJobsStub({ listDeadLetterJobs: () => items, deadCount: () => 2 }) });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request("/v1/app/selfhost/queue/dead", { headers: { cookie: `gittensory_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ limit: 25, offset: 0, total: 2, items });
+  });
+
+  it("returns an empty items array (not 501) when the admin surface reports a genuinely empty DLQ", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub() });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request("/v1/app/selfhost/queue/dead", { headers: { cookie: `gittensory_session=${token}` } }, env);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ total: 0, items: [] });
+  });
+
+  it("clamps limit/offset query params before they reach the queue backend", async () => {
+    const app = createApp();
+    let seenLimit = -1;
+    let seenOffset = -1;
+    const env = createTestEnv({
+      JOBS: selfhostJobsStub({
+        listDeadLetterJobs: (limit, offset) => {
+          seenLimit = limit;
+          seenOffset = offset;
+          return [];
+        },
+      }),
+    });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead?limit=500&offset=-5",
+      { headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(seenLimit).toBe(100); // clampInteger ceiling
+    expect(seenOffset).toBe(0); // Math.max(0, ...) floor
+  });
+
+  it("rejects an invalid query instead of silently coercing it", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub() });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead?limit=not-a-number",
+      { headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_query" });
+  });
+});

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1338,6 +1338,87 @@ describe("createPgQueue (durable #977)", () => {
     });
   });
 
+  describe("listDeadLetterJobs (#2214)", () => {
+    // Same rationale as topBacklogRepos above: the ORDER BY/LIMIT/OFFSET run in SQL, which this mock can't
+    // execute, so these tests stub a pre-ordered row set and verify (a) param binding (limit/offset, clamped)
+    // and (b) row -> DeadLetterJob mapping (bigint-as-string coercion, jobType extraction, deadAtMs null
+    // passthrough). The query shape itself is verified directly against the real SQLite engine (identical SQL
+    // shape, ported 1:1) in selfhost-sqlite-queue.test.ts.
+    function stubDeadLetterRows(
+      rows: Array<{
+        id: string | number;
+        payload: string;
+        attempts: number | string;
+        last_error: string | null;
+        created_at: number | string;
+        dead_at: number | string | null;
+      }>,
+    ): {
+      pool: { query: Pool["query"] };
+      calls: Array<{ sql: string; params: unknown[] }>;
+    } {
+      const calls: Array<{ sql: string; params: unknown[] }> = [];
+      return {
+        pool: {
+          query: (async (sql: unknown, params?: unknown[]) => {
+            const q = String(sql);
+            if (q.includes("status='dead'") && q.includes("COALESCE(dead_at, created_at)")) {
+              calls.push({ sql: q, params: params ?? [] });
+              return { rows, rowCount: rows.length };
+            }
+            return { rows: [], rowCount: 0 };
+          }) as Pool["query"],
+        },
+        calls,
+      };
+    }
+
+    it("returns an empty array when there are no dead-letter rows", async () => {
+      const m = stubDeadLetterRows([]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+      expect(await q.listDeadLetterJobs(25, 0)).toEqual([]);
+    });
+
+    it("maps bigint-as-string rows to DeadLetterJob, binding limit/offset as params", async () => {
+      const m = stubDeadLetterRows([
+        {
+          id: "2",
+          payload: JSON.stringify(msg("github-webhook")),
+          attempts: "1",
+          last_error: "kaboom",
+          created_at: "2000",
+          dead_at: "9000",
+        },
+      ]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.listDeadLetterJobs(25, 10)).toEqual([
+        { id: 2, jobType: "github-webhook", attempts: 1, lastError: "kaboom", createdAtMs: 2000, deadAtMs: 9000 },
+      ]);
+      expect(m.calls).toHaveLength(1);
+      expect(m.calls[0]?.params).toEqual([25, 10]);
+    });
+
+    it("reports deadAtMs null for a legacy row with no dead_at, and jobType 'unknown' for an unparseable payload", async () => {
+      const m = stubDeadLetterRows([
+        { id: 1, payload: "not-json", attempts: 0, last_error: "unparseable payload", created_at: 1000, dead_at: null },
+      ]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.listDeadLetterJobs(25, 0)).toEqual([
+        { id: 1, jobType: "unknown", attempts: 0, lastError: "unparseable payload", createdAtMs: 1000, deadAtMs: null },
+      ]);
+    });
+
+    it("clamps a negative limit/offset to 0 rather than passing it through to SQL", async () => {
+      const m = stubDeadLetterRows([]);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      await q.listDeadLetterJobs(-5, -2);
+      expect(m.calls[0]?.params).toEqual([0, 0]);
+    });
+  });
+
   it("REGRESSION: releases the reserved background slot when a background claim query rejects (#selfhost-bg-slot-leak)", async () => {
     // A raw pool failure during the BACKGROUND claim (a dropped connection / lock timeout — the exact failures
     // pump() is documented to catch) rejects out of claimNext(), which runs OUTSIDE processOne's try/finally, so
@@ -1816,11 +1897,15 @@ describe("createPgQueue (durable #977)", () => {
       // count of 2, which would have double-counted the row another reviver already claimed.
       expect(revived).toBe(1);
       expect(m.fn).toHaveBeenCalledWith(
-        expect.stringContaining("SET status='pending', run_after=$1, last_error=NULL WHERE id=$2 AND status='dead'"),
+        expect.stringContaining(
+          "SET status='pending', run_after=$1, last_error=NULL, dead_at=NULL WHERE id=$2 AND status='dead'",
+        ),
         expect.arrayContaining(["1"]),
       );
       expect(m.fn).toHaveBeenCalledWith(
-        expect.stringContaining("SET status='pending', run_after=$1, last_error=NULL WHERE id=$2 AND status='dead'"),
+        expect.stringContaining(
+          "SET status='pending', run_after=$1, last_error=NULL, dead_at=NULL WHERE id=$2 AND status='dead'",
+        ),
         expect.arrayContaining(["2"]),
       );
       expect(await renderMetrics()).toContain("gittensory_jobs_dead_letter_revived_total 1");
@@ -2170,7 +2255,7 @@ describe("createPgQueue (durable #977)", () => {
     );
     expect(m.pool.query).toHaveBeenCalledWith(
       expect.stringContaining("SET status='dead', attempts=$1"),
-      [2, "openai api rate limit exceeded", "1"],
+      [2, "openai api rate limit exceeded", expect.any(Number), "1"],
     );
     expect(m.pool.query).not.toHaveBeenCalledWith(
       expect.stringContaining("gittensory_jobs_rate_limited_total"),

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -29,6 +29,7 @@ import {
   parsePositiveIntEnv,
   queueBackgroundConcurrency,
   queueDeadLetterAutoRetryMaxExtraAttempts,
+  queueDeadLetterPageFromBinding,
   queueDeadLetterReviveIntervalMs,
   queueProcessingTimeoutMs,
   queueRecoveryJitterMs,
@@ -122,6 +123,58 @@ describe("self-host queue common helpers", () => {
 
     await expect(queueSnapshotFromBinding(binding)).resolves.toBe(snapshot);
     await expect(queueSnapshotFromBinding({ async send() {}, async sendBatch() {} } as unknown as Queue)).resolves.toBeNull();
+  });
+
+  it("reads a dead-letter-queue page only from self-host bindings that expose BOTH admin methods (#2214)", async () => {
+    const items = [
+      { id: 1, jobType: "agent-regate-pr", attempts: 3, lastError: "boom", createdAtMs: 1000, deadAtMs: 5000 },
+    ];
+    const binding = {
+      async send() {},
+      async sendBatch() {},
+      listDeadLetterJobs: (limit: number, offset: number) => {
+        expect(limit).toBe(25);
+        expect(offset).toBe(10);
+        return items;
+      },
+      deadCount: () => 7,
+    } as unknown as Queue;
+
+    await expect(queueDeadLetterPageFromBinding(binding, 25, 10)).resolves.toEqual({ items, total: 7 });
+
+    // Cloudflare's real Queue binding (and any binding missing either half of the surface) returns null rather
+    // than a false "zero dead-letter jobs" -- callers 501 instead of rendering a misleadingly-empty table.
+    await expect(
+      queueDeadLetterPageFromBinding({ async send() {}, async sendBatch() {} } as unknown as Queue, 25, 0),
+    ).resolves.toBeNull();
+    await expect(
+      queueDeadLetterPageFromBinding(
+        { async send() {}, async sendBatch() {}, deadCount: () => 0 } as unknown as Queue,
+        25,
+        0,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      queueDeadLetterPageFromBinding(
+        { async send() {}, async sendBatch() {}, listDeadLetterJobs: () => [] } as unknown as Queue,
+        25,
+        0,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("awaits async (Postgres-backed) admin methods for a dead-letter-queue page", async () => {
+    const items = [
+      { id: 2, jobType: "github-webhook", attempts: 1, lastError: "kaboom", createdAtMs: 2000, deadAtMs: 9000 },
+    ];
+    const binding = {
+      async send() {},
+      async sendBatch() {},
+      listDeadLetterJobs: async () => items,
+      deadCount: async () => 1,
+    } as unknown as Queue;
+
+    await expect(queueDeadLetterPageFromBinding(binding, 25, 0)).resolves.toEqual({ items, total: 1 });
   });
 
   it("identifies GitHub-budget background jobs without pre-yielding fresh webhooks or manual re-gates", () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1710,6 +1710,78 @@ describe("createSqliteQueue (durable #980)", () => {
     });
   });
 
+  describe("listDeadLetterJobs (#2214)", () => {
+    it("returns an empty array when there are no dead-letter rows", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      expect(q.listDeadLetterJobs(10, 0)).toEqual([]);
+    });
+
+    it("maps dead rows newest-death-first, extracting job type/attempts/error, and excludes non-dead rows", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error, dead_at) VALUES (?, 'dead', 3, 0, 1000, 'boom', 5000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error, dead_at) VALUES (?, 'dead', 1, 0, 2000, 'kaboom', 9000)",
+        [JSON.stringify(msg("github-webhook"))],
+      );
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 0, 500)",
+        [JSON.stringify(msg("agent-regate-sweep"))],
+      );
+      expect(q.listDeadLetterJobs(10, 0)).toEqual([
+        { id: 2, jobType: "github-webhook", attempts: 1, lastError: "kaboom", createdAtMs: 2000, deadAtMs: 9000 },
+        { id: 1, jobType: "agent-regate-pr", attempts: 3, lastError: "boom", createdAtMs: 1000, deadAtMs: 5000 },
+      ]);
+    });
+
+    it("falls back to created_at ordering and reports deadAtMs null for a legacy row with no dead_at", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      // Legacy row: no dead_at, but its created_at (7000) is newer than the other row's real dead_at (3000) --
+      // COALESCE(dead_at, created_at) must use 7000 here, so this row sorts FIRST despite having a null deadAtMs.
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error) VALUES (?, 'dead', 2, 0, 7000, 'legacy failure')",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error, dead_at) VALUES (?, 'dead', 1, 0, 1000, 'recent failure', 3000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.listDeadLetterJobs(10, 0)).toEqual([
+        { id: 1, jobType: "agent-regate-pr", attempts: 2, lastError: "legacy failure", createdAtMs: 7000, deadAtMs: null },
+        { id: 2, jobType: "agent-regate-pr", attempts: 1, lastError: "recent failure", createdAtMs: 1000, deadAtMs: 3000 },
+      ]);
+    });
+
+    it("reports jobType 'unknown' for an unparseable payload", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error, dead_at) VALUES ('not-json', 'dead', 0, 0, 1000, 'unparseable payload', 1000)",
+        [],
+      );
+      expect(q.listDeadLetterJobs(10, 0)).toEqual([
+        { id: 1, jobType: "unknown", attempts: 0, lastError: "unparseable payload", createdAtMs: 1000, deadAtMs: 1000 },
+      ]);
+    });
+
+    it("paginates via limit/offset", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      for (let i = 0; i < 3; i++) {
+        driver.query(
+          "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, dead_at) VALUES (?, 'dead', 0, 0, ?, ?)",
+          [JSON.stringify(msg("agent-regate-pr")), 1000 + i, 1000 + i],
+        );
+      }
+      expect(q.listDeadLetterJobs(1, 1).map((job) => job.createdAtMs)).toEqual([1001]);
+    });
+  });
+
   it("retries then dead-letters after maxRetries", async () => {
     const driver = makeDriver();
     let calls = 0;
@@ -1726,6 +1798,10 @@ describe("createSqliteQueue (durable #980)", () => {
     expect(calls).toBe(3);
     expect(q.deadCount()).toBe(1);
     expect(q.size()).toBe(0);
+    // #2214: a max-retries death also stamps dead_at, so the DLQ table can sort/report a real death time.
+    const [row] = q.listDeadLetterJobs(10, 0);
+    expect(row).toMatchObject({ jobType: "x", attempts: 3, lastError: "boom" });
+    expect(row!.deadAtMs).not.toBeNull();
   });
 
   describe("reviveDeadLetterJobs (#audit-rate-headroom)", () => {
@@ -1769,6 +1845,10 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(row.status).not.toBe("dead");
       expect(row.attempts).toBe(1); // untouched -- one more failure re-dead-letters it, not a fresh budget
       expect(row.last_error).toBeNull();
+      // #2214: dead_at is cleared on revival too, so a re-dead-lettered job gets a fresh death timestamp
+      // instead of reporting when it FIRST died.
+      const { rows: deadAtRows } = driver.query("SELECT dead_at FROM _selfhost_jobs", []);
+      expect((deadAtRows[0] as { dead_at: number | null }).dead_at).toBeNull();
 
       await q.drain(); // the one extra attempt the revival granted
       expect(calls).toBe(1);
@@ -2813,6 +2893,10 @@ describe("createSqliteQueue (durable #980)", () => {
     driver.query("INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES ('not-json','pending',0,0,0)", []);
     await q.drain();
     expect(q.deadCount()).toBe(1);
+    // #2214: an unparseable payload has no `type` field to extract -- the DLQ table falls back to "unknown".
+    const [row] = q.listDeadLetterJobs(10, 0);
+    expect(row).toMatchObject({ jobType: "unknown", lastError: "unparseable payload" });
+    expect(row!.deadAtMs).not.toBeNull();
   });
 
   it("sendBatch enqueues all; default backoff reschedules a failure into the future", async () => {


### PR DESCRIPTION
## Summary

- Self-host operators had no way to inspect jobs that exhausted their retry budget short of querying the queue database directly (see #2214, part of #1208). Adds a read-only, paginated dead-letter-queue table to the operator dashboard.
- Backend: adds a `dead_at` timestamp column (both SQLite and Postgres queue backends) and a `listDeadLetterJobs(limit, offset)` method, mirrored onto the `Queue` binding the same way the existing `snapshot()` introspection is (see `queueSnapshotFromBinding`) — this lets the new Hono route reach the self-host queue backend through `env.JOBS` without adding a new `Env` field. The method is a no-op/absent on Cloudflare's real `Queue` binding, so `queueDeadLetterPageFromBinding` returns `null` there and the route replies `501` instead of a misleading empty table.
- Route: `GET /v1/app/selfhost/queue/dead?limit=&offset=`, gated by `requireAppRole(c, ["operator"])` — the same operator-only pattern used by `/v1/app/operator-dashboard` and `/v1/app/kill-switch`, since this is an install-wide (not per-repo) admin surface.
- UI: new `DeadLetterQueuePanel` component (paginated table via `components/ui/pagination.tsx`, `useApiResource`, `StateBoundary` for loading/empty/error) added as a new section on `/app/operator`.

**Note on scope vs. the issue's suggested shape:** #2214/#1208's own text suggests `GET /api/selfhost/queue/dead` gated by a `SELFHOST_API_SECRET`. Neither that route prefix nor that env var exists anywhere in the codebase — I used the real, existing `/v1/app/*` + `requireAppRole` pattern instead, which is how every other operator-only dashboard endpoint in this repo is actually gated.

This PR is the read-only table only (per #2214: "This is the display half only — replay/purge actions are a separate bounty"); replay/purge (#2215) is a natural follow-up once this lands.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (backend queue capability + one route + one UI panel, all for the same feature) and does not mix in unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not touch `site/`, `CNAME`, or `**/lovable/**`.
- [x] Linked issue: #2214 (part of #1208).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no `.github/workflows/**` changes in this diff)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — full unsharded run, 8072 passed / 7 skipped, 0 failed. All new/changed lines in `src/api/routes.ts`, `src/selfhost/queue-common.ts`, and `src/selfhost/sqlite-queue.ts` are covered (verified against `coverage/lcov.info` directly). `src/selfhost/pg-queue.ts` is Codecov-ignored per this repo's existing convention (integration/smoke-tested instead) but the pg-side additions are still covered by dedicated unit tests.
- [ ] `npm run test:workers` (not run — no Cloudflare Workers pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no `packages/gittensory-mcp` changes)
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior has unit tests for new branches, fallback paths, and pagination edges (both backends, the binding-introspection helper, the route's auth/clamping/501 paths, and the UI component's loading/empty/error/expand/pagination states)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, or private maintainer evidence are exposed. The dead-letter table shows only job id/type/attempts/error/timestamps.
- [x] Public GitHub text is unaffected — this is a private, operator-only dashboard surface, not public PR/issue output.
- [x] Auth: the new route has explicit tests for unauthenticated (401) and non-operator (403) requests.
- [x] API/OpenAPI is updated (`/v1/app/selfhost/queue/dead` added to `src/openapi/spec.ts`, regenerated `openapi.json`).
- [x] UI uses live API data via `useApiResource` with real loading/empty/error states — no mock/demo fallback.
- [ ] UI Evidence screenshots — see note below.
- [x] No changelog edit.

## UI Evidence

I verified this live in a local dev server (Chrome preview) signed in via the sanctioned `?preview=1` local-preview session, with the dashboard and DLQ endpoints stubbed via a `window.fetch` override, and confirmed: the panel is absent before this change, present after; the table renders id/type/attempts/error/created/died columns; "Show more"/"Show less" correctly expands/collapses a long error message; Previous/Next correctly disable at the first/last page. I do not have a mechanism in this environment to upload the captured screenshots to a GitHub-hosted image URL for embedding in this table (no arbitrary-image-upload CLI path found), so I'm not fabricating a broken image link here — happy to attach screenshots as a follow-up comment if there's a preferred upload path, or a maintainer can pull the branch and check `/app/operator?preview=1` directly.

## Notes

- The new `dead_at` column is set at both existing dead-letter transition points (unparseable payload, max-retries-exceeded) in both queue backends, and cleared on revival (`reviveDeadLetterJobs`) so a job that dies again after being auto-revived gets a fresh death timestamp rather than reporting when it first died.
- While adding the binding-mirrored `deadCount`, I noticed the existing `snapshot()`/`topBacklogRepos` pattern (one shared closure reused via property shorthand on both the `.binding` object and the returned queue object) wasn't being followed for `deadCount` — I refactored the pre-existing duplicate inline `deadCount()` implementations (one on `.binding`, one on the returned object) in both `sqlite-queue.ts` and `pg-queue.ts` down to one shared closure each, matching the established pattern. Behavior-preserving, no functional change.