### PR TITLE
fix(signals): count only open PRs as broad-diff maintainer noise

### DIFF
--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -430,7 +430,10 @@ export function buildMaintainerNoiseReport(
   const queueHealth = buildQueueHealth(repo, issues, pullRequests, collisions);
   const intake = buildContributorIntakeHealth(repo, issues, pullRequests, fullName, collisions);
   const unlinked = pullRequests.filter((pr) => pr.state === "open" && pr.linkedIssues.length === 0).length;
-  const broadDiffSignals = pullRequests.filter((pr) => pr.title.length > 120 || /refactor|cleanup|misc|various/i.test(pr.title)).length;
+  // Only OPEN PRs are live maintainer-queue noise. Without the state guard (which the sibling `unlinked`
+  // count above already applies), already-merged/closed PRs with common churn titles ("refactor", "cleanup",
+  // "various", …) are miscounted as active noise, inflating noiseSources and depressing the score.
+  const broadDiffSignals = pullRequests.filter((pr) => pr.state === "open" && (pr.title.length > 120 || /refactor|cleanup|misc|various/i.test(pr.title))).length;
   const noiseSources = [
     ...(unlinked > 0 ? [`${unlinked} open PR(s) lack linked issue context.`] : []),
     ...(collisions.summary.highRiskCount > 0 ? [`${collisions.summary.highRiskCount} high-risk duplicate/WIP cluster(s).`] : []),

--- a/test/unit/reward-risk-reports.test.ts
+++ b/test/unit/reward-risk-reports.test.ts
@@ -163,6 +163,18 @@ describe("buildMaintainerNoiseReport (#2093)", () => {
     expect(report.noiseSources.some((s) => /broad or hard to triage/.test(s))).toBe(true);
   });
 
+  it("excludes already-merged/closed broad-title PRs from the broad-diff noise arm (only open PRs are live noise)", () => {
+    const r = repo("JSONbored/gittensory");
+    // A merged and a closed PR whose titles hit the churn regex must NOT be counted as live queue noise.
+    const merged = pr(r.fullName, 61, "Refactor cleanup of various modules", { state: "merged" });
+    const closed = pr(r.fullName, 62, "Misc cleanup", { state: "closed" });
+    expect(buildMaintainerNoiseReport(r, [], [merged, closed], [], r.fullName).noiseSources.some((s) => /broad or hard to triage/.test(s))).toBe(false);
+    // With one open broad PR alongside the two non-open ones, only the open PR is counted (1, not 3).
+    const open = pr(r.fullName, 63, "Refactor cleanup various", { state: "open" });
+    const mixed = buildMaintainerNoiseReport(r, [], [open, merged, closed], [], r.fullName);
+    expect(mixed.noiseSources.some((s) => /^1 PR\(s\) look broad or hard to triage/.test(s))).toBe(true);
+  });
+
   it("reports the strained intake arm via deduped maintainerActions", () => {
     const r = repo("JSONbored/gittensory", { issueDiscoveryShare: 0 });
     const unlinked = Array.from({ length: 4 }, (_, i) =>


### PR DESCRIPTION
## Summary

`buildMaintainerNoiseReport()` in `src/signals/reward-risk.ts` scores live maintainer-queue noise, but its `broadDiffSignals` filter counted **every** PR with a broad/churn-style title (`refactor`, `cleanup`, `misc`, `various`, or >120 chars) regardless of state — while the sibling `unlinked` count one line above correctly guards on `pr.state === "open"`. The command path that feeds this report (`maintainerDigestSections` → the `@gittensory noise-report` command) passes the **full** PR array (open, closed, and merged), so already-resolved PRs with those very common titles were miscounted as active queue noise: each added a false `noiseSources` entry and shaved 4 points off the score, and enough of them could push the reported `level` from `low` toward `medium`.

This scopes the broad-diff arm to open PRs, matching the sibling count and every other noise input in the report. Adds a regression test that a merged and a closed broad-title PR are excluded, while an open one alongside them is still counted (asserting the count is 1, not 3).

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (a one-clause state guard, brought into parity with the adjacent sibling filter) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). Both branches of the new `pr.state === "open"` guard are exercised (an open broad PR is counted; merged/closed broad PRs are excluded), so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure backend/signal-logic change to a maintainer-facing report builder (it emits a `score`/`level`/`noiseSources` band, not raw private scoring; that boundary is untouched). No auth/CORS/session surface, no API/OpenAPI shape change, no UI — the `Safety` boxes are checked on that basis.

## Notes

- One-clause behavioral change (add `pr.state === "open" &&`) with an explanatory comment, matching the adjacent `unlinked` sibling. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
