### PR TITLE
chore(selfhost): wire up the unwired config-lint.ts manifest validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "selfhost:env-reference": "node scripts/gen-selfhost-env-reference.mjs",
     "selfhost:env-reference:check": "node scripts/gen-selfhost-env-reference.mjs --check",
     "selfhost:validate-observability": "node scripts/validate-observability-configs.mjs",
+    "selfhost:config-lint": "tsx scripts/gittensory-config-lint.ts",
     "cf-typegen": "wrangler types && perl -pi -e 's/[[:blank:]]+$//' worker-configuration.d.ts",
     "cf-typegen:check": "wrangler types --check",
     "db:migrate:local": "wrangler d1 migrations apply gittensory --local",

--- a/scripts/gittensory-config-lint.ts
+++ b/scripts/gittensory-config-lint.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env tsx
+// Wires up the previously-unwired src/selfhost/config-lint.ts validator (#2906): a self-hoster (or the
+// maintainer, dogfooding on JSONbored/gittensory) can now actually run it against a real .gittensory.yml or
+// private-config file and get actionable feedback, instead of the validator existing only in its own test suite.
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { lintManifestText, type SelfHostConfigLintResult } from "../src/selfhost/config-lint";
+
+function usage(): string {
+  return `Usage: npm run selfhost:config-lint -- [path]
+
+Validates a Gittensory focus manifest (.gittensory.yml, a per-repo/global self-host
+private-config file, or any equivalent YAML/JSON file with the same shape) and reports
+unrecognized top-level fields and parser warnings, without echoing any of the file's values.
+
+Options:
+  path   Manifest file to lint. Defaults to ".gittensory.yml" in the current directory.`;
+}
+
+export function formatLintReport(path: string, result: SelfHostConfigLintResult): string {
+  const lines = [`${path}: ${result.summary}`];
+  if (result.recognizedFields.length > 0) lines.push(`  recognized fields: ${result.recognizedFields.join(", ")}`);
+  for (const warning of result.warnings) lines.push(`  - ${warning}`);
+  return lines.join("\n");
+}
+
+/* v8 ignore start -- CLI entrypoint (file I/O + process.exit); formatLintReport above carries the tested logic. */
+function main(): void {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(usage());
+    return;
+  }
+  const path = args[0] ?? ".gittensory.yml";
+  if (!existsSync(path)) {
+    console.error(`gittensory-config-lint: no such file: ${path}\n\n${usage()}`);
+    process.exit(1);
+  }
+  const text = readFileSync(path, "utf8");
+  const result = lintManifestText(text);
+  console.log(formatLintReport(path, result));
+  if (!result.ok) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();
+/* v8 ignore stop */

--- a/test/unit/gittensory-config-lint-script.test.ts
+++ b/test/unit/gittensory-config-lint-script.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatLintReport } from "../../scripts/gittensory-config-lint";
+import { lintManifestText } from "../../src/selfhost/config-lint";
+
+describe("formatLintReport (#2906)", () => {
+  it("reports a valid manifest's summary and recognized fields, no warnings", () => {
+    const result = lintManifestText("wantedPaths:\n  - src/\n");
+    expect(formatLintReport(".gittensory.yml", result)).toBe(
+      ".gittensory.yml: Manifest parsed 1 recognized field.\n  recognized fields: wantedPaths",
+    );
+  });
+
+  it("reports warnings without a recognized-fields line when none are recognized", () => {
+    const result = lintManifestText("unknownSecretKey: super-secret-value\n");
+    expect(formatLintReport(".gittensory.yml", result)).toBe(
+      [
+        ".gittensory.yml: Manifest has 2 warnings.",
+        "  - Manifest contained no recognized focus fields; falling back to deterministic signals.",
+        "  - Manifest contains unknown top-level field: unknownSecretKey.",
+      ].join("\n"),
+    );
+    // Never echoes the raw supplied value into the report (#2906 dogfoods config-lint's own secret-redaction).
+    expect(formatLintReport(".gittensory.yml", result)).not.toContain("super-secret-value");
+  });
+
+  it("reports both recognized fields and warnings together for a partially-valid manifest", () => {
+    const result = lintManifestText("wantedPaths: [src/]\nunknownSecretKey: super-secret-value\n");
+    expect(formatLintReport("private-config.yml", result)).toBe(
+      [
+        "private-config.yml: Manifest has 1 warning.",
+        "  recognized fields: wantedPaths",
+        "  - Manifest contains unknown top-level field: unknownSecretKey.",
+      ].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `src/selfhost/config-lint.ts`'s `lintManifestText` was a complete, well-tested manifest validator (parses a `.gittensory.yml`-shaped file, flags unknown top-level fields and parser warnings, redacts supplied values) with **zero production callers** — no CLI, API route, or boot-time check invoked it.
- Adds `scripts/gittensory-config-lint.ts`, run via `npm run selfhost:config-lint -- [path]` (defaults to `.gittensory.yml` in the current directory). Thin CLI wrapper only: reads the file, calls the existing `lintManifestText`, prints a report, exits non-zero on any warning. Follows the same shape as the repo's other `tsx scripts/*.ts` self-host CLI (`selfhost:postgres:migrate`) and its `main()` v8-ignore convention (see `scripts/validate-observability-configs.mjs`).
- Manually verified end-to-end against this repo's real `.gittensory.yml` (see Validation) and against a missing-file path and `--help`.

Resolves #2906. Part of the #1667 self-host review-stack roadmap (follow-up to #2912).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: #2906.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `vitest run test/unit/gittensory-config-lint-script.test.ts test/unit/selfhost-config-lint.test.ts` — 16 tests passed
- [x] `npm run test:changed` — 1 file / 3 tests in scope, passed
- [x] Manual end-to-end smoke test: `npx tsx scripts/gittensory-config-lint.ts .gittensory.yml` (parsed 9 recognized fields, exit 0), a missing path (clear error + usage, exit 1), and `--help`
- [ ] `npm run actionlint` / `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm audit` / `ui:*` — not run locally; no workflow, worker-pool, MCP-package, or UI files touched. CI runs the full gate.

If any required check was skipped, explain why:

- `test:coverage`/`test:ci` not run locally — `scripts/**` is Codecov-ignored per this repo's gate, and the one `src/**`-adjacent test file added has 100% of its own logic covered by the 3 new test cases (the CLI's `main()` is v8-ignored, matching the existing `validate-observability-configs.mjs` convention). CI runs the full gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (The validator itself already redacts supplied config values from its output; the CLI wrapper adds no new value-echoing.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/schema/MCP surface touched, this is a standalone dev-time CLI script.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (Deferred: none of this repo's sibling `selfhost:*` scripts are currently documented in README either; a README/self-host-docs mention is folded into the upcoming self-host config-docs issue (#2907) instead of duplicated here.)

## Notes

- Deliberately did not also add an API route in this PR — the issue allowed either a CLIor a route (or both), and a CLI is the better fit for a self-hoster validating a local file before deploying, without ballooning this PR's scope.