### PR TITLE
fix(signals): anchor best-fit label keyword exclusion to word boundaries

### DIFF
--- a/src/signals/reward-risk.ts
+++ b/src/signals/reward-risk.ts
@@ -768,7 +768,11 @@ function analysisRank(analysis: RepoRewardRisk): number {
 function bestFitLabels(repo: RepositoryRecord | null): string[] {
   const multipliers = repo?.registryConfig?.labelMultipliers ?? {};
   const labels = Object.entries(multipliers)
-    .filter(([label]) => !/status|source|contributor|verified|risk|codex/i.test(label))
+    // Exclude meta labels only at a keyword boundary (a real separator or end-of-string after the keyword),
+    // not mid-word — mirroring the anchored `suspiciousConfiguredLabels` matcher in engine.ts. The old
+    // unanchored regex over-matched substrings (e.g. "opensource" via "source", "risky-refactor" via "risk"),
+    // wrongly dropping a legitimate high-multiplier label from the best-fit suggestion.
+    .filter(([label]) => !/^(status|source|contributor|verified|risk|codex)([:/-]|$)/i.test(label))
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
     .map(([label]) => label);
   return labels.slice(0, 1);
@@ -915,5 +919,6 @@ function clamp(value: number, min: number, max: number): number {
 export const rewardRiskFreshnessInternals = {
   pickIssueTimestamp,
   issueAgeDays,
+  bestFitLabels,
 };
 /* v8 ignore stop */

--- a/test/unit/reward-risk-freshness.test.ts
+++ b/test/unit/reward-risk-freshness.test.ts
@@ -178,3 +178,22 @@ describe("reward-risk freshness parity with gittensory-engine", () => {
     expect(issueAgeDays("2026-07-03T00:00:00.000Z")).toBeGreaterThanOrEqual(0);
   });
 });
+
+describe("bestFitLabels keyword anchoring", () => {
+  const pick = (labelMultipliers: Record<string, number>) => {
+    const base = repo("owner/repo");
+    return rewardRiskFreshnessInternals.bestFitLabels({ ...base, registryConfig: { ...base.registryConfig!, labelMultipliers } });
+  };
+  it("excludes meta labels only at a keyword boundary, keeping mid-word matches", () => {
+    // Bare keyword and prefix forms are excluded...
+    expect(pick({ status: 5, bug: 2 })).toEqual(["bug"]);
+    expect(pick({ "risk:high": 5, bug: 2 })).toEqual(["bug"]);
+    // ...but a substring match must NOT drop a legitimate higher-multiplier label.
+    expect(pick({ opensource: 5, bug: 2 })).toEqual(["opensource"]);
+    expect(pick({ "risky-refactor": 5, docs: 1 })).toEqual(["risky-refactor"]);
+  });
+  it("returns no label when there are none, or the repo is null", () => {
+    expect(pick({})).toEqual([]);
+    expect(rewardRiskFreshnessInternals.bestFitLabels(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`bestFitLabels()` in `src/signals/reward-risk.ts` picks the single highest-multiplier "real" contribution label to feed the reward/upside score preview, excluding gittensor meta labels (`status`, `source`, `contributor`, `verified`, `risk`, `codex`). It matched those keywords with an **unanchored** regex (`/status|source|contributor|verified|risk|codex/i`), so any label merely *containing* one as a substring was wrongly dropped — e.g. `opensource` (via `source`), `risky-refactor` (via `risk`), `data-source`, `contributory`. When such a label carries the highest multiplier, the wrong (lower-multiplier) label is chosen and the simulated label multiplier / reward upside is understated.

The sibling matcher `suspiciousConfiguredLabels` in `engine.ts` was already **anchored** for exactly this reason (its comment calls out the `bottleneck`/`scoreboard`/`riskier` mid-word over-match). This brings `bestFitLabels` into parity: exclude a meta keyword only at a real boundary — a separator (`:` `/` `-`) or end-of-string after the keyword — not mid-word. Adds a direct regression test (exposing the helper through the existing `rewardRiskFreshnessInternals` test bag) covering both the excluded boundary forms and the mid-word matches that must be kept.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (anchor an existing keyword regex, mirroring the sibling matcher) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). The regression test exercises both filter branches (a matching boundary form is excluded; a mid-word/non-matching form is kept) plus the empty and null-repo paths, so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure backend/signal-logic change to an internal score-preview heuristic; the reward numbers it feeds are already exposed only as bands/multipliers, not raw private scoring. No auth/CORS/session surface, no API/OpenAPI shape change, no UI — the `Safety` boxes are checked on that basis.

## Notes

- Regex anchoring change plus a test-only addition of `bestFitLabels` to the existing `rewardRiskFreshnessInternals` export (the module's established internals-for-tests pattern). No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
