### PR TITLE
test(enrichment): add unit coverage for the ReDoS analyzer pure detectors

### DIFF
--- a/review-enrichment/test/redos.test.ts
+++ b/review-enrichment/test/redos.test.ts
@@ -1,0 +1,41 @@
+// Units for the ReDoS analyzer's pure detectors (#2095). Kept separate so analyzer PRs avoid collisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractRegexSources,
+  hasCatastrophicBacktracking,
+  scanPatchForRedos,
+} from "../dist/analyzers/redos.js";
+
+test("extractRegexSources pulls bodies from /.../ literals and RegExp(...) args", () => {
+  assert.deepEqual(extractRegexSources("const re = /(a+)+/.test(x);"), ["(a+)+"]);
+  assert.deepEqual(extractRegexSources('new RegExp("a|b")'), ["a|b"]);
+  assert.deepEqual(extractRegexSources("plain text, no slashes"), []);
+});
+
+test("hasCatastrophicBacktracking flags a nested unbounded quantifier and spares linear shapes", () => {
+  for (const bad of ["(a+)+", "(\\d+)*", "(.*)+", "([a-z]+)+"]) {
+    assert.equal(hasCatastrophicBacktracking(bad), true, bad);
+  }
+  for (const ok of ["(abc)+", "abc", "(a+)", "[a+]+", "(a|a)*"]) {
+    assert.equal(hasCatastrophicBacktracking(ok), false, ok);
+  }
+});
+
+test("scanPatchForRedos cites the added-line number of a catastrophic literal", () => {
+  const patch = ["@@ -1,2 +1,3 @@", " context", "+const re = /(a+)+/;", " more"].join("\n");
+  const findings = scanPatchForRedos("src/x.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.file, "src/x.ts");
+  assert.equal(findings[0]?.line, 2);
+  assert.equal(findings[0]?.kind, "nested-quantifier");
+});
+
+test("scanPatchForRedos ignores safe patterns and honours a zero finding budget", () => {
+  const safe = ["@@ -1 +1,1 @@", "+const re = /(abc)+/;"].join("\n");
+  assert.deepEqual(scanPatchForRedos("src/x.ts", safe), []);
+
+  const bad = ["@@ -1 +1,1 @@", "+const re = /(a+)+/;"].join("\n");
+  assert.deepEqual(scanPatchForRedos("src/x.ts", bad, { maxFindings: 0 }), []);
+});


### PR DESCRIPTION
## Summary

Adds dedicated unit coverage for the ReDoS analyzer's pure detectors (`review-enrichment/src/analyzers/redos.ts`): `extractRegexSources`, `hasCatastrophicBacktracking`, and `scanPatchForRedos`. Test-only, kept in its own file so analyzer PRs avoid collisions.

Closes #2095

## Coverage

- `extractRegexSources` pulls bodies from `/.../` literals and `RegExp(...)` string args, and returns nothing for lines with no pattern.
- `hasCatastrophicBacktracking` flags a group with an unbounded quantifier whose body also contains one (`(a+)+`, `(\d+)*`, `(.*)+`, `([a-z]+)+`) and spares linear shapes (`(abc)+`, `(a+)`, `[a+]+`, `(a|a)*`).
- `scanPatchForRedos` cites the added-line number of a catastrophic literal via the hunk header, ignores safe patterns, and honours a zero finding budget.

## Validation

- `node --test` under `review-enrichment` passes (4 tests) against the current analyzer build.
