### PR TITLE
fix(review): require linked issue authorization for label propagation

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6664,6 +6664,7 @@ async function maybePublishPrPublicSurface(
               repoFullName,
               linkedIssues: pr.linkedIssues,
               installationId,
+              prAuthorLogin: pr.authorLogin,
             })
           : [];
       const decisionResult = resolvePrTypeLabel({

--- a/src/review/linked-issue-label-propagation-fetch.ts
+++ b/src/review/linked-issue-label-propagation-fetch.ts
@@ -18,7 +18,9 @@ import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 const MAX_LINKED_ISSUES_TO_FETCH = 50;
 
 /** FETCH every linked issue's labels (fail-open) and flatten into one label list for
- *  `resolvePrTypeLabel` (`src/settings/pr-type-label.ts`) to match against. Mirrors
+ *  `resolvePrTypeLabel` (`src/settings/pr-type-label.ts`) to match against. Only OPEN issues
+ *  that are tied to the PR author (authored by them or assigned to them) can contribute labels;
+ *  closing-keyword text in a PR body is author-controlled and is not authority by itself. Mirrors
  *  `resolveLinkedIssueHardRule`'s own fetch idiom (`src/review/linked-issue-hard-rules.ts`): a per-issue
  *  fetch failure contributes no labels rather than throwing, so if EVERY linked issue fails, the result is
  *  `[]` — which can never match a mapping, meaning a sensitive label like `gittensor:priority` never applies
@@ -36,11 +38,19 @@ export async function fetchLinkedIssueLabelsForPropagation(args: {
   repoFullName: string;
   linkedIssues: number[];
   installationId: number;
+  prAuthorLogin?: string | null | undefined;
 }): Promise<string[]> {
   if (args.linkedIssues.length === 0) return [];
   const linkedIssues = args.linkedIssues.slice(0, MAX_LINKED_ISSUES_TO_FETCH);
   const token = (await createInstallationToken(args.env, args.installationId).catch(() => undefined)) ?? args.env.GITHUB_PUBLIC_TOKEN;
   const admissionKey = githubRateLimitAdmissionKeyForToken(args.env, token, args.installationId);
   const results = await Promise.all(linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(args.env, args.repoFullName, issueNumber, token, admissionKey)));
-  return results.flatMap((result) => (result.status === "found" ? result.facts.labels : []));
+  const prAuthorLogin = args.prAuthorLogin?.toLowerCase();
+  if (!prAuthorLogin) return [];
+  return results.flatMap((result) => {
+    if (result.status !== "found" || result.facts.state !== "open") return [];
+    const issueAuthorLogin = result.facts.authorLogin?.toLowerCase();
+    const assignees = new Set(result.facts.assignees.map((login) => login.toLowerCase()));
+    return issueAuthorLogin === prAuthorLogin || assignees.has(prAuthorLogin) ? result.facts.labels : [];
+  });
 }

--- a/test/unit/linked-issue-label-propagation-fetch.test.ts
+++ b/test/unit/linked-issue-label-propagation-fetch.test.ts
@@ -25,23 +25,23 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
   it("returns the flattened labels for a single found linked issue", async () => {
     stubFetch((url) => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", labels: ["gittensor:priority", "help wanted"] });
+      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority", "help wanted"] });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123, prAuthorLogin: "contrib" });
     expect(result).toEqual(["gittensor:priority", "help wanted"]);
   });
 
   it("surfaces only the successful issue's labels when one of several linked issues fails to fetch (partial fail-open)", async () => {
     stubFetch((url) => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] });
+      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", assignees: [{ login: "contrib" }], labels: ["gittensor:priority"] });
       if (url.endsWith("/issues/2")) return new Response("server error", { status: 500 });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123, prAuthorLogin: "contrib" });
     expect(result).toEqual(["gittensor:priority"]);
   });
 
@@ -57,9 +57,9 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
 
   it("falls back to the public token and still fails open (never throws) when the installation-token mint fails", async () => {
     const spy = vi.spyOn(appModule, "createInstallationToken").mockRejectedValue(new Error("mint failed"));
-    stubFetch((url) => (url.endsWith("/issues/1") ? Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] }) : new Response("not found", { status: 404 })));
+    stubFetch((url) => (url.endsWith("/issues/1") ? Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] }) : new Response("not found", { status: 404 })));
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123, prAuthorLogin: "contrib" });
     expect(result).toEqual(["gittensor:priority"]);
     spy.mockRestore();
   });
@@ -70,14 +70,48 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (/\/issues\/\d+$/.test(url)) {
         issueFetchCount += 1;
-        return Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] });
+        return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] });
       }
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
     const manyIssues = Array.from({ length: 75 }, (_, i) => i + 1);
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: manyIssues, installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: manyIssues, installationId: 123, prAuthorLogin: "contrib" });
     expect(issueFetchCount).toBe(50);
     expect(result).toEqual(Array(50).fill("gittensor:priority"));
   });
+
+  it("ignores a priority label on an unrelated linked issue, even when the PR body names it", async () => {
+    stubFetch((url) => {
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/777")) return Response.json({ number: 777, state: "open", user: { login: "maintainer" }, assignees: [], labels: ["gittensor:priority"] });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({});
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123, prAuthorLogin: "drive-by" });
+    expect(result).toEqual([]);
+  });
+
+  it("ignores a priority label on a closed linked issue, even when the PR author is tied to it", async () => {
+    stubFetch((url) => {
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/777")) return Response.json({ number: 777, state: "closed", user: { login: "contrib" }, labels: ["gittensor:priority"] });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({});
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123, prAuthorLogin: "contrib" });
+    expect(result).toEqual([]);
+  });
+
+  it("ignores linked-issue labels when the PR author is unavailable", async () => {
+    stubFetch((url) => {
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({});
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
+    expect(result).toEqual([]);
+  });
+
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -17436,7 +17436,7 @@ describe("queue processors", () => {
         },
       });
       const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
-      stubPropagationFetch(220, 1, seen, () => Response.json({ number: 1, state: "open", labels: ["gittensor:priority"] }));
+      stubPropagationFetch(220, 1, seen, () => Response.json({ number: 1, state: "open", user: { login: "contributor" }, labels: ["gittensor:priority"] }));
 
       await processJob(env, {
         type: "github-webhook",


### PR DESCRIPTION
### Motivation
- The linked-issue label propagation path previously trusted PR-body closing-keyword references and flattened labels from any referenced issue, allowing contributors to game maintainer-only priority labels (e.g. `gittensor:priority`).
- Propagation must only apply sensitive mappings when the referenced issue is verifiably authoritative for the PR, to preserve reward/priority integrity.

### Description
- Require per-PR authorization by passing the PR author's login into the propagation fetch: `fetchLinkedIssueLabelsForPropagation` now accepts `prAuthorLogin` and `maybePublishPrPublicSurface` forwards `pr.authorLogin` when calling it. 
- Filter fetched issue facts so only labels from issues that are both `open` and tied to the PR author (issue author or an assignee) contribute to the propagation label set. 
- Add unit tests covering authorized open issues, assigned issues, unrelated referenced issues, closed issues, and the missing PR-author case to prevent reintroduction of the original logic bug. 

### Testing
- Ran `npx vitest run test/unit/linked-issue-label-propagation-fetch.test.ts --reporter=verbose`, and all tests in that file passed (9/9). 
- Ran `npm run typecheck`, which completed successfully with no TypeScript errors. 
- Attempted full coverage with `npm run test:coverage`; a scoped run of the new unit file passed, but the full unsharded coverage run was started and did not meet the repo global thresholds in this environment (the process was stopped/inspected here). 
- `npm audit --audit-level=moderate` was attempted but the registry audit endpoint returned `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48925bd844832c8051171ba4eee8cc)