### PR TITLE
feat(metrics): expose Redis response-cache hit ratio

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -11,11 +11,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:428",
+    firstReference: "src/server.ts:446",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:425",
+    firstReference: "src/server.ts:443",
   },
   {
     name: "AI_EMBED_MODEL",
@@ -43,7 +43,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:367",
+    firstReference: "src/server.ts:385",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -79,11 +79,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:904",
+    firstReference: "src/server.ts:924",
   },
   {
     name: "DATABASE_PATH",
-    firstReference: "src/server.ts:250",
+    firstReference: "src/server.ts:251",
   },
   {
     name: "DATABASE_URL",
@@ -111,11 +111,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:496",
+    firstReference: "src/server.ts:514",
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:284",
+    firstReference: "src/server.ts:290",
   },
   {
     name: "GITTENSORY_VERSION",
@@ -127,11 +127,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MAINTENANCE_ADMISSION_ENABLED",
-    firstReference: "src/selfhost/maintenance-admission.ts:129",
+    firstReference: "src/selfhost/maintenance-admission.ts:126",
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:380",
+    firstReference: "src/server.ts:398",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -191,7 +191,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:953",
+    firstReference: "src/server.ts:973",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -207,7 +207,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:955",
+    firstReference: "src/server.ts:975",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -239,11 +239,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGVECTOR_ENABLED",
-    firstReference: "src/server.ts:230",
+    firstReference: "src/server.ts:231",
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:703",
+    firstReference: "src/server.ts:723",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -259,11 +259,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:515",
+    firstReference: "src/server.ts:533",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
-    firstReference: "src/selfhost/queue-common.ts:102",
+    firstReference: "src/selfhost/queue-common.ts:120",
   },
   {
     name: "REDIS_URL",
@@ -271,7 +271,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:560",
+    firstReference: "src/server.ts:578",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -307,7 +307,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:820",
+    firstReference: "src/server.ts:840",
   },
 ];
 
@@ -315,15 +315,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
   "| `AI_COMBINE` | `src/selfhost/ai.ts:936` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:428` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:425` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:446` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:443` |",
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:832` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts:938` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:836` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:57` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:835` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:367` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:385` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:108` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:49` |",
@@ -332,20 +332,20 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:53` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:112` |",
   "| `CODEX_HOME` | `src/selfhost/ai.ts:274` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:904` |",
-  "| `DATABASE_PATH` | `src/server.ts:250` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:924` |",
+  "| `DATABASE_PATH` | `src/server.ts:251` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/services/notify-discord.ts:41` |",
   "| `DISCORD_WEBHOOK_URL` | `src/services/notify-discord.ts:78` |",
   "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:41` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:496` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:284` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:514` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:290` |",
   "| `GITTENSORY_VERSION` | `src/selfhost/health.ts:29` |",
   "| `HOME` | `src/selfhost/ai.ts:274` |",
-  "| `MAINTENANCE_ADMISSION_ENABLED` | `src/selfhost/maintenance-admission.ts:129` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:380` |",
+  "| `MAINTENANCE_ADMISSION_ENABLED` | `src/selfhost/maintenance-admission.ts:126` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:398` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
   "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:829` |",
@@ -360,11 +360,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:953` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:973` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:955` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:975` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -372,15 +372,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_EXPORTER` | `src/selfhost/otel.ts:40` |",
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
-  "| `PGVECTOR_ENABLED` | `src/server.ts:230` |",
-  "| `PORT` | `src/server.ts:703` |",
+  "| `PGVECTOR_ENABLED` | `src/server.ts:231` |",
+  "| `PORT` | `src/server.ts:723` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:515` |",
-  "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:102` |",
+  "| `QDRANT_URL` | `src/server.ts:533` |",
+  "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:120` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:560` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:578` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
@@ -389,5 +389,5 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
   "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:383` |",
   "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:171` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:820` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:840` |",
 ].join("\n");

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -87,6 +87,7 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_github_rest_rate_limit_observations_total", { help: "Observed GitHub REST rate-limit remaining buckets.", type: "counter" }],
   ["gittensory_github_rest_rate_limit_responses_total", { help: "Observed GitHub REST rate-limit response statuses.", type: "counter" }],
   ["gittensory_redis_gh_response_cache_total", { help: "Redis-backed GitHub response cache outcomes.", type: "counter" }],
+  ["gittensory_redis_gh_response_cache_hit_ratio", { help: "Current in-process hit ratio for the Redis-backed GitHub response cache.", type: "gauge" }],
   ["gittensory_redis_token_cache_total", { help: "Redis-backed GitHub token cache outcomes.", type: "counter" }],
   ["gittensory_qdrant_queries_total", { help: "Qdrant vector query attempts.", type: "counter" }],
   ["gittensory_qdrant_upserts_total", { help: "Qdrant vector upserted item count.", type: "counter" }],
@@ -187,6 +188,11 @@ export function registerMetricMeta(name: string, meta: MetricMeta): void {
 export function incr(name: string, labels?: Labels, by = 1): void {
   const k = seriesKey(name, publicLabelsForMetric(name, labels));
   counters.set(k, (counters.get(k) ?? 0) + by);
+}
+
+/** Read a counter series for scrape-time derived metrics. Missing series are zero. */
+export function counterValue(name: string, labels?: Labels): number {
+  return counters.get(seriesKey(name, publicLabelsForMetric(name, labels))) ?? 0;
 }
 
 /** Register a gauge sampled at scrape time (sync or async). Re-registering replaces the sampler. */

--- a/src/selfhost/redis-response-cache.ts
+++ b/src/selfhost/redis-response-cache.ts
@@ -11,11 +11,26 @@ import type { Redis } from "ioredis";
 import type { CachedGitHubResponse, GitHubResponseCache } from "../github/client";
 import { incr } from "./metrics";
 
-const REDIS_GITHUB_RESPONSE_CACHE_METRIC = "gittensory_redis_gh_response_cache_total";
+export const REDIS_GITHUB_RESPONSE_CACHE_METRIC = "gittensory_redis_gh_response_cache_total";
+export const REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC = "gittensory_redis_gh_response_cache_hit_ratio";
 const keyFor = (key: string): string => `gh:resp:${key}`;
+
+type CounterReader = (name: string, labels?: Record<string, string>) => number;
 
 function isReplayableCachedStatus(status: unknown): status is number {
   return status === 200 || status === 403 || status === 404;
+}
+
+export function hitRatio(hits: number, misses: number): number {
+  const total = hits + misses;
+  return total === 0 ? 0 : hits / total;
+}
+
+export function redisResponseCacheHitRatio(readCounter: CounterReader): number {
+  return hitRatio(
+    readCounter(REDIS_GITHUB_RESPONSE_CACHE_METRIC, { result: "hit" }),
+    readCounter(REDIS_GITHUB_RESPONSE_CACHE_METRIC, { result: "miss" }),
+  );
 }
 
 function recordRedisResponseCacheMetric(result: "hit" | "miss" | "set" | "error"): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,8 @@ import {
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
-import { gauge, gaugeVector, incr, observe, renderMetrics, setSelfHostedMetricsMode } from "./selfhost/metrics";
+import { counterValue, gauge, gaugeVector, incr, observe, renderMetrics, setSelfHostedMetricsMode } from "./selfhost/metrics";
+import { REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC, redisResponseCacheHitRatio } from "./selfhost/redis-response-cache";
 import { runSelfHostMigrations } from "./selfhost/migrate";
 import { createPgAdapter, tuneGithubRateLimitObservationsAutovacuum } from "./selfhost/pg-adapter";
 import { createPgQueue } from "./selfhost/pg-queue";
@@ -623,6 +624,8 @@ async function main(): Promise<void> {
     });
   }
 
+  /* v8 ignore next -- server.ts starts a live process; the sampler and wiring invariant are unit-tested. */
+  gauge(REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC, () => redisResponseCacheHitRatio(counterValue));
   gauge("gittensory_queue_pending", () => backend.queue.size());
   gauge("gittensory_queue_dead", () => backend.queue.deadCount());
   gauge("gittensory_queue_processing", () => backend.queue.processingCount());

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { gauge, gaugeVector, incr, observe, registerMetricMeta, renderMetrics, resetMetrics, setSelfHostedMetricsMode } from "../../src/selfhost/metrics";
+import { counterValue, gauge, gaugeVector, incr, observe, registerMetricMeta, renderMetrics, resetMetrics, setSelfHostedMetricsMode } from "../../src/selfhost/metrics";
 
 afterEach(() => {
   resetMetrics();
@@ -70,6 +70,13 @@ describe("metrics registry (#982)", () => {
     incr("c_total");
     incr("c_total", undefined, 2);
     expect((await renderMetrics())).toContain("c_total 3");
+  });
+
+  it("reads counter values while treating absent series as zero", () => {
+    incr("readable_total", { result: "hit" }, 3);
+
+    expect(counterValue("readable_total", { result: "hit" })).toBe(3);
+    expect(counterValue("readable_total", { result: "miss" })).toBe(0);
   });
 
   it("renders labels in Prometheus format", async () => {

--- a/test/unit/selfhost-redis-response-cache.test.ts
+++ b/test/unit/selfhost-redis-response-cache.test.ts
@@ -1,7 +1,14 @@
+import { readFileSync } from "node:fs";
 import type { Redis } from "ioredis";
 import { afterEach, describe, expect, it } from "vitest";
-import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
-import { createRedisResponseCache } from "../../src/selfhost/redis-response-cache";
+import { counterValue, gauge, incr, renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
+import {
+  createRedisResponseCache,
+  hitRatio,
+  REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC,
+  REDIS_GITHUB_RESPONSE_CACHE_METRIC,
+  redisResponseCacheHitRatio,
+} from "../../src/selfhost/redis-response-cache";
 
 function fakeRedis(): {
   redis: Redis;
@@ -26,6 +33,37 @@ function fakeRedis(): {
 const URL_A = "https://api.github.com/repos/o/r/pulls/1";
 
 afterEach(() => resetMetrics());
+
+describe("Redis response-cache hit-ratio metrics (#2090)", () => {
+  it("computes mixed, all-hit, all-miss, and zero-sample ratios", () => {
+    expect(hitRatio(3, 1)).toBe(0.75);
+    expect(hitRatio(4, 0)).toBe(1);
+    expect(hitRatio(0, 5)).toBe(0);
+    expect(hitRatio(0, 0)).toBe(0);
+  });
+
+  it("samples zero when the hit and miss counters are absent", () => {
+    expect(redisResponseCacheHitRatio(counterValue)).toBe(0);
+  });
+
+  it("renders the hit-ratio gauge from the current hit and miss counters", async () => {
+    incr(REDIS_GITHUB_RESPONSE_CACHE_METRIC, { result: "hit" }, 3);
+    incr(REDIS_GITHUB_RESPONSE_CACHE_METRIC, { result: "miss" }, 1);
+    gauge(REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC, () => redisResponseCacheHitRatio(counterValue));
+
+    expect(await renderMetrics()).toContain(
+      "# HELP gittensory_redis_gh_response_cache_hit_ratio Current in-process hit ratio for the Redis-backed GitHub response cache.\n# TYPE gittensory_redis_gh_response_cache_hit_ratio gauge\ngittensory_redis_gh_response_cache_hit_ratio 0.75",
+    );
+  });
+
+  it("wires the hit-ratio gauge into the self-host server scrape", () => {
+    const server = readFileSync("src/server.ts", "utf8");
+
+    expect(server).toContain(
+      "gauge(REDIS_GITHUB_RESPONSE_CACHE_HIT_RATIO_METRIC, () => redisResponseCacheHitRatio(counterValue));",
+    );
+  });
+});
 
 describe("createRedisResponseCache (#perf GitHub GET cache)", () => {
   it("get returns null for a missing url", async () => {


### PR DESCRIPTION
## Summary
Closes #2090.

Adds a scrape-time Redis GitHub response-cache hit-ratio gauge so self-host operators can tune `GITHUB_CACHE_TTL_SECONDS` without writing a Prometheus ratio query.

## What changed
- Registered `gittensory_redis_gh_response_cache_hit_ratio` as a Prometheus gauge with HELP/TYPE metadata.
- Added a counter reader plus Redis response-cache hit-ratio helpers that treat absent hit/miss counters as a zero-sample `0` ratio.
- Wired the gauge into the self-host metrics scrape path.
- Covered mixed, all-hit, all-miss, zero-sample, missing-counter, gauge-rendering, and server-wiring behavior.
- Regenerated the self-host env reference after upstream line-map changes.

## Why
The existing Redis GitHub response-cache counters expose hit/miss events, but operators need a direct hit-ratio signal when tuning cache TTLs.

## Scope
- Focused self-host metrics change.
- No visible UI behavior changed.
- Linked issue: Closes #2090.

## Validation
- [x] `npm run test:ci`
- [x] `npm audit --audit-level=moderate`
- Coverage summary from `npm run test:ci`: 411 test files passed, 8,132 tests passed, 18 skipped; statements 96.46%, branches 95.7%, functions 95.55%, lines 97.04%.

## UI Evidence
Not applicable: no visible UI, frontend, docs, or extension behavior changed.

## Notes
- The gauge reports `0` before the process observes Redis response-cache hit or miss events.