### PR TITLE
fix(queue): reclose padded ambiguous reopens

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9600,14 +9600,17 @@ async function recloseDisallowedReopenIfNeeded(
     pr.number,
   );
   const latestReopenerLogin = latestReopener.login?.toLowerCase() ?? null;
-  // A bounded scan that ran to completion but did NOT cover every page is still ambiguous when it finds no
-  // reopened event: an unread older page may contain either the original contributor reopen or a later maintainer
-  // reopen hidden by padding. Only a visible matching reopener proves this webhook is still the live disallowed
-  // reopen; every other shape fails closed, because wrongly re-closing a maintainer-authorized PR is worse than
-  // leaving a disallowed reopen open for one more tick. (#2369)
+  // A bounded scan that did NOT cover every page and found no reopened event is attacker-controllable: the
+  // original contributor can pad newer issue events until their reopen falls outside the inspected window. Treat
+  // only a visible different reopener (or a fully covered no-match) as superseding; an incomplete unknown result
+  // keeps enforcing the one-shot close. A read error remains distinct because it proves no timeline facts. (#2369)
+  const latestReopenerUnknownInPartialWindow =
+    latestReopenerLogin === null &&
+    !latestReopener.coveredAllPages &&
+    !latestReopener.errored;
   const reopenerSuperseded =
     latestReopener.errored ||
-    latestReopenerLogin !== reopener;
+    (!latestReopenerUnknownInPartialWindow && latestReopenerLogin !== reopener);
   if (reopenerSuperseded) {
     await recordAuditEvent(env, {
       eventType: "github_app.reopen_reclosed",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -17906,7 +17906,7 @@ describe("one-shot reopen prevention", () => {
     expect(audit?.outcome).toBe("completed");
   });
 
-  it("REGRESSION: denies when a maintainer reopener is hidden beyond the inspected event window", async () => {
+  it("REGRESSION: re-closes when padding hides the contributor reopen beyond the inspected event window", async () => {
     const calls: Array<{ url: string; method: string }> = [];
     const eventPages: number[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -17937,11 +17937,11 @@ describe("one-shot reopen prevention", () => {
 
     expect(eventPages).toContain(22);
     expect(eventPages).not.toContain(12);
-    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/issues/42/comments"))).toBe(false);
-    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/issues/42/comments"))).toBe(true);
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
     const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.reopen_reclosed").first<{ outcome: string; detail: string }>();
-    expect(audit?.outcome).toBe("denied");
-    expect(audit?.detail).toContain("the current reopener is now unknown, not contributor");
+    expect(audit?.outcome).toBe("completed");
+    expect(audit?.detail).toContain("re-closed a disallowed reopen by contributor");
   });
 
   it("REGRESSION: fails CLOSED (denies the re-close) when the reopener-timeline read errors (#2369)", async () => {


### PR DESCRIPTION
### Motivation

- A regression made an incomplete bounded timeline scan with no visible `reopened` actor treat the result as a superseding unknown and deny the one-shot re-close, allowing an attacker to pad events and keep a disallowed reopen open. This must be fixed to preserve the one-shot close enforcement while keeping read-errors and visible superseders unchanged. 

### Description

- Adjusts the reopener check in `src/queue/processors.ts` to treat `login === null && !coveredAllPages && !errored` as an attacker-controllable ambiguous partial-window result and continue enforcing the re-close. 
- Leaves existing denial semantics for explicit timeline read errors and for fully-covered/no-match scans intact. 
- Adds a small boolean `latestReopenerUnknownInPartialWindow` and changes `reopenerSuperseded` to ignore the ambiguous partial-window unknown when deciding to deny. 
- Updates the regression in `test/unit/queue.test.ts` so the padded issue-events test now asserts the handler posts the warning comment, attempts the close, and records a completed re-close audit when padding hides the contributor reopen.

### Testing

- Ran the focused unit test: `npx vitest run test/unit/queue.test.ts -t "one-shot reopen prevention"`, and the touched cases passed. 
- `git diff --check` and `npm run typecheck` passed locally. 
- Attempted `npm run test:coverage` (unsharded full suite) but the run exposed unrelated long-running/timeout failures in the broader queue test surface and was not completed here; the security regression fix was validated with the focused unit test above. 
- Committed change set includes `src/queue/processors.ts` and the updated `test/unit/queue.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a489061e800832cba30e4cba296484e)