### PR TITLE
fix(ui): reject the whole DLQ page on a malformed row instead of filtering

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -16100,7 +16100,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Live app API response",
+            "description": "Paginated dead-letter jobs for the self-host queue backend",
             "content": {
               "application/json": {
                 "schema": {
@@ -16112,8 +16112,17 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid query"
+          },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin (e.g. Cloudflare)"
           }
         },
         "security": [
@@ -16122,6 +16131,28 @@
           },
           {
             "GittensorySessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "25"
+            },
+            "required": false,
+            "description": "Maximum rows to return, clamped from 1 to 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "0"
+            },
+            "required": false,
+            "description": "Pagination offset, floored to 0.",
+            "name": "offset",
+            "in": "query"
           }
         ]
       }

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
@@ -49,7 +49,10 @@ export function normalizeDeadLetterQueuePage(data: unknown): DeadLetterQueuePage
     typeof raw.limit !== "number" ||
     typeof raw.offset !== "number" ||
     typeof raw.total !== "number" ||
-    !Array.isArray(raw.items)
+    !Array.isArray(raw.items) ||
+    // A malformed item means the response itself is untrustworthy -- filtering it out silently would render
+    // a corrupted backend response as a plausible partial/empty queue instead of surfacing the corruption.
+    !raw.items.every(isDeadLetterQueueItem)
   ) {
     return null;
   }
@@ -58,7 +61,7 @@ export function normalizeDeadLetterQueuePage(data: unknown): DeadLetterQueuePage
     limit: raw.limit,
     offset: raw.offset,
     total: raw.total,
-    items: raw.items.filter(isDeadLetterQueueItem),
+    items: raw.items,
   };
 }
 

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -49,12 +49,17 @@ describe("dead-letter queue panel model", () => {
     expect(normalizeDeadLetterQueuePage(SAMPLE_PAGE)).toEqual(SAMPLE_PAGE);
     expect(normalizeDeadLetterQueuePage(null)).toBeNull();
     expect(normalizeDeadLetterQueuePage({ generatedAt: "x" })).toBeNull();
+    // A single malformed item makes the WHOLE response untrustworthy -- it must reject to null (an error
+    // state), not silently filter the bad item and render a plausible-looking partial/empty queue.
     expect(
       normalizeDeadLetterQueuePage({
         ...SAMPLE_PAGE,
         items: [SAMPLE_PAGE.items[0], null, "bad", { id: "not-a-number" }],
       }),
-    ).toMatchObject({ items: [SAMPLE_PAGE.items[0]] });
+    ).toBeNull();
+    expect(
+      normalizeDeadLetterQueuePage({ ...SAMPLE_PAGE, items: [{ id: "not-a-number" }] }),
+    ).toBeNull();
   });
 
   it("formats a null death/creation timestamp as an em dash, and a real one as a non-empty string", () => {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -720,7 +720,6 @@ export function buildOpenApiSpec() {
     "/v1/app/miner-dashboard",
     "/v1/app/maintainer-dashboard",
     "/v1/app/operator-dashboard",
-    "/v1/app/selfhost/queue/dead",
     "/v1/app/commands",
     "/v1/app/commands/usefulness",
     "/v1/app/digest",
@@ -736,6 +735,29 @@ export function buildOpenApiSpec() {
       },
     });
   }
+  registry.registerPath({
+    method: "get",
+    path: "/v1/app/selfhost/queue/dead",
+    request: {
+      query: z.object({
+        limit: z.string().optional().openapi({
+          param: { description: "Maximum rows to return, clamped from 1 to 100." },
+          example: "25",
+        }),
+        offset: z.string().optional().openapi({
+          param: { description: "Pagination offset, floored to 0." },
+          example: "0",
+        }),
+      }),
+    },
+    responses: {
+      200: { description: "Paginated dead-letter jobs for the self-host queue backend", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      400: { description: "Invalid query" },
+      401: { description: "Unauthorized" },
+      403: { description: "Insufficient app role (operator only)" },
+      501: { description: "This deployment's queue backend does not expose dead-letter admin (e.g. Cloudflare)" },
+    },
+  });
   registry.registerPath({
     method: "get",
     path: "/v1/app/analytics/weekly-value-report",

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -201,8 +201,22 @@ export async function queueSnapshotFromBinding(binding: Queue): Promise<SelfHost
 
 export type DeadLetterQueuePage = { items: DeadLetterJob[]; total: number };
 
-/** Null on Cloudflare (the real Queue binding has neither method) or any binding that hasn't wired the
- *  dead-letter admin surface -- callers 501 in that case rather than pretending the DLQ is simply empty. */
+function isDeadLetterJob(value: unknown): value is DeadLetterJob {
+  if (!value || typeof value !== "object") return false;
+  const job = value as Partial<DeadLetterJob>;
+  return (
+    typeof job.id === "number" &&
+    typeof job.jobType === "string" &&
+    typeof job.attempts === "number" &&
+    (job.lastError === null || typeof job.lastError === "string") &&
+    typeof job.createdAtMs === "number" &&
+    (job.deadAtMs === null || typeof job.deadAtMs === "number")
+  );
+}
+
+/** Null on Cloudflare (the real Queue binding has neither method), any binding that hasn't wired the
+ *  dead-letter admin surface, or a binding that returned a malformed row -- callers 501 in every case rather
+ *  than pretending the DLQ is simply empty or serving an unvalidated shape as if it were trustworthy. */
 export async function queueDeadLetterPageFromBinding(
   binding: Queue,
   limit: number,
@@ -214,6 +228,7 @@ export async function queueDeadLetterPageFromBinding(
     Promise.resolve(admin.listDeadLetterJobs(limit, offset)),
     Promise.resolve(admin.deadCount()),
   ]);
+  if (!items.every(isDeadLetterJob) || typeof total !== "number") return null;
   return { items, total };
 }
 

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -163,6 +163,26 @@ describe("self-host queue common helpers", () => {
     ).resolves.toBeNull();
   });
 
+  it("rejects the whole page (not a partial/filtered one) when a binding returns a malformed row or total (#2214)", async () => {
+    const validItem = { id: 1, jobType: "agent-regate-pr", attempts: 3, lastError: "boom", createdAtMs: 1000, deadAtMs: 5000 };
+
+    const malformedItemBinding = {
+      async send() {},
+      async sendBatch() {},
+      listDeadLetterJobs: () => [validItem, { id: "not-a-number" }],
+      deadCount: () => 2,
+    } as unknown as Queue;
+    await expect(queueDeadLetterPageFromBinding(malformedItemBinding, 25, 0)).resolves.toBeNull();
+
+    const malformedTotalBinding = {
+      async send() {},
+      async sendBatch() {},
+      listDeadLetterJobs: () => [validItem],
+      deadCount: () => "seven",
+    } as unknown as Queue;
+    await expect(queueDeadLetterPageFromBinding(malformedTotalBinding, 25, 0)).resolves.toBeNull();
+  });
+
   it("awaits async (Postgres-backed) admin methods for a dead-letter-queue page", async () => {
     const items = [
       { id: 2, jobType: "github-webhook", attempts: 1, lastError: "kaboom", createdAtMs: 2000, deadAtMs: 9000 },

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -174,6 +174,16 @@ describe("self-host queue common helpers", () => {
     } as unknown as Queue;
     await expect(queueDeadLetterPageFromBinding(malformedItemBinding, 25, 0)).resolves.toBeNull();
 
+    // A falsy row (not just a truthy-but-wrong-shaped object) must also be rejected -- exercises isDeadLetterJob's
+    // own `!value` branch, distinct from `typeof value !== "object"` on a wrong-shaped object.
+    const nullItemBinding = {
+      async send() {},
+      async sendBatch() {},
+      listDeadLetterJobs: () => [validItem, null],
+      deadCount: () => 2,
+    } as unknown as Queue;
+    await expect(queueDeadLetterPageFromBinding(nullItemBinding, 25, 0)).resolves.toBeNull();
+
     const malformedTotalBinding = {
       async send() {},
       async sendBatch() {},


### PR DESCRIPTION
## Summary

- Follow-up to #2921 (dead-letter-queue table view, #2214) — this addresses the Gittensory review nits that landed on that PR's branch a few minutes after it was already merged, so they never made it to main. Same diff, opened fresh against current `main`.
- `normalizeDeadLetterQueuePage` previously filtered out malformed items with `.filter()`, so a fully-corrupted backend response would silently render as a plausible partial/empty dead-letter queue instead of surfacing as an error. It now rejects the whole page (`null`, triggering the panel's malformed-response error state) if any item fails validation.
- The same boundary check is now applied server-side in `queueDeadLetterPageFromBinding`: any binding whose `listDeadLetterJobs`/`deadCount` return a malformed row or a non-numeric total causes the route to `501` rather than serving unvalidated data.
- `src/openapi/spec.ts` now documents `/v1/app/selfhost/queue/dead`'s actual `400`/`403`/`501` outcomes (it was folded into a shared loop that only declared `200`/`401`), with its query params (`limit`/`offset`) documented too.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused — a single boundary-validation fix plus the OpenAPI documentation it implies, no unrelated changes.
- [x] Follows `CONTRIBUTING.md`, no `site/`/`CNAME`/`lovable` changes.
- [x] Linked context: follow-up to #2921 / #2214. No separate issue needed — this is corrective on already-reviewed code.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no `.github/workflows/**` changes)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, on this exact diff, before the original PR was merged — full unsharded run, 8131 passed / 7 skipped, 0 failed, with the new/changed lines in `src/openapi/spec.ts` and `src/selfhost/queue-common.ts` fully covered (verified against `coverage/lcov.info` directly). Re-ran the specific affected test files again after rebasing this fix onto current `main`: `selfhost-queue-common.test.ts` (79/79) and the UI `dead-letter-queue-panel.test.tsx` (12/12), both green.
- [ ] `npm run test:workers` (not run — no Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no `packages/gittensory-mcp` changes)
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities (checked on the parent diff before this fix was split out)
- [x] New behavior has unit tests: a whole-page-rejected-on-malformed-item test (UI model) and a malformed-row/malformed-total rejection test (`queueDeadLetterPageFromBinding`, both sync and async binding shapes)

## Safety

- [x] No secrets, wallet/hotkey/trust-score/reward data exposed — same private operator-only surface as #2921.
- [x] Public GitHub text unaffected.
- [x] N/A — no auth/cookie/CORS/session changes in this diff.
- [x] API/OpenAPI updated (`src/openapi/spec.ts` now declares the route's real status codes; regenerated `openapi.json`).
- [x] UI still uses live API data via `useApiResource`; this change only tightens the error-state boundary, no mock/demo fallback introduced.
- [ ] No UI Evidence table — this change alters an error-boundary code path only, not visible layout/styling; the panel's existing malformed-response error state (unchanged visually) is exercised by the new test.
- [x] No changelog edit.

## Notes

- Timeline for context: #2921 was merged by the maintainer (`JSONbored`) at `2026-07-04T05:27:42Z`, ~11 minutes before this follow-up commit was pushed to that PR's branch — so it landed on an already-merged PR and never reached `main`. This PR carries the exact same commit (cherry-picked), rebased onto current `main`.