### PR TITLE
docs(observability): disambiguate audit.ts from recordAuditEvent, document gate-check-publish audit decision

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5238,6 +5238,14 @@ type PublicSurfaceOutputFailure = {
   error: string;
 };
 
+// Intentionally writes to check_summaries only, not audit_events (#2908): this fires on every successful gate-
+// check publish, which is a very high-frequency event (every review pass, potentially several times per PR as
+// it iterates) -- check_summaries is the purpose-built, already-queryable canonical record for "when was this
+// check published and what did it conclude" (repo/PR/headSha/checkRunId/conclusion/detailsUrl), so a parallel
+// audit_events row would roughly double that table's volume for no new queryable information. The DOWNSTREAM
+// actions this verdict triggers (merge/close/hold) are already fully audited via recordNativeGateDecision and
+// agent-action-executor's audit() closure. Only the FAILURE/degraded sub-paths of the caller below are audited
+// (auditGateCheckPermissionMissing, auditPrVisibilitySkip) -- that asymmetry is deliberate, not a gap.
 async function recordPublishedGateCheckSummary(
   env: Env,
   args: {

--- a/src/selfhost/audit.ts
+++ b/src/selfhost/audit.ts
@@ -2,6 +2,11 @@
 // operators can grep / pipe to their log aggregator (Loki, CloudWatch, Datadog, etc.) without any extra
 // setup. Written to process.stdout so it is captured by Docker's default json-file log driver and is
 // accessible via `docker compose logs gittensory`.
+//
+// NOT the durable audit_events DB table (#2908): this module is a stdout-only logger for exactly the 4 queue-
+// lifecycle events below, called only from sqlite-queue.ts/pg-queue.ts. For the actual queryable audit trail of
+// contributor-affecting decisions (review published, PR merged/closed, notification sent/failed, guardrail
+// hold, ...), see recordAuditEvent in ../db/repositories.ts.
 
 import { otelTraceLogFields } from "./otel";
 


### PR DESCRIPTION
## Summary

Re-investigated all four sub-items originally filed under #2908 against current `main` (it moved substantially since the audit that filed this issue). Two were already resolved by other merged work; two dead-export candidates turned out not to be dead on closer inspection. What's left is two doc-only clarifications:

- `src/selfhost/audit.ts`'s `logAudit` is a stdout-only logger for exactly 4 queue-lifecycle events (`job_complete`/`job_dead`/`job_error`/`job_rate_limited`), **not** the durable `audit_events` DB writer — a naming trap that's easy to fall into (this repo's own prior audit did). Added a doc-comment cross-reference to `recordAuditEvent` in `db/repositories.ts`.
- The successful gate-check-run publish path (`src/queue/processors.ts`'s `recordPublishedGateCheckSummary`) writes to `check_summaries` but not `audit_events`. Documented this as an **intentional** decision rather than a gap: `check_summaries` is the purpose-built canonical record for this specific, very-high-frequency event (repo/PR/headSha/checkRunId/conclusion/detailsUrl), and the downstream actions the verdict triggers (merge/close/hold) are already fully audited elsewhere. A parallel `audit_events` row would roughly double that table's volume with no new queryable information.

**Already resolved by other work** (verified, not touched here):
- Notification send/suppress/fail audit coverage — #2881 already added `notify-discord.ts`'s `auditExternalNotification`, called for every Discord/Slack `completed`/`denied`/`error` outcome.

**Not actually dead** (correcting the original audit's classification after re-checking against current `main`):
- `registerMetricMeta`/`resetMetrics` (`src/selfhost/metrics.ts`) — extensively used by test setup/teardown across dozens of test files; `resetMetrics` in particular is essential test-isolation infrastructure, not dead code.
- `DEFAULT_BUCKETS` (`src/selfhost/metrics.ts`) — used internally as `observe()`'s own default parameter value; exported so a caller COULD override with a variant, not unused.
- `flushOpenTelemetry` (`src/selfhost/otel.ts`) — confirmed `shutdownOpenTelemetry` does NOT need to call it: `NodeTracerProvider.shutdown()` already flushes pending spans as part of its own OTel SDK contract, so this is a legitimate standalone "flush now without shutting down" utility, not a missing step.
- (I did confirm `registerMetricMeta` genuinely has zero production callers, meaning `/metrics` currently emits no Prometheus HELP/TYPE lines for any metric — real, but authoring HELP text for every metric in the system is a much larger, separate undertaking than this issue's scope; not attempted here.)

Resolves #2908. Part of the #1667 self-host review-stack roadmap.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: #2908.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `vitest run` on tests touching both changed files (`test/unit/queue.test.ts` gate-check tests, `test/unit/selfhost-sqlite-queue.test.ts`, `test/unit/selfhost-pg-queue.test.ts`) — all passed
- [x] `npm run test:changed` — 61 files / 1907 tests passed, 0 failed
- [ ] `npm run actionlint` / `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm audit` / `ui:*` — not run locally; no workflow, worker-pool, MCP-package, or UI files touched. CI runs the full gate.

If any required check was skipped, explain why:

- `test:coverage`/`test:ci` not run locally — this diff is 13 added comment lines across 2 files, zero behavior change, so there is no new code path for Codecov's patch-coverage gate to evaluate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — comments only.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)