### PR TITLE
fix(review): keep public review accuracy within range when reversals exceed decided

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -87,7 +87,11 @@ function accuracyPct(
 ): number | null {
   const decided = merged + closed;
   if (decided <= 0) return null;
-  return Math.round((1 - reversed / decided) * 1000) / 10;
+  // `reversed` counts engine auto-actions regardless of a PR's CURRENT disposition, so a reopened
+  // auto-close (now open, dropped from merged+closed) can push reversed above decided. Clamp the reversal
+  // rate to 1 so the public accuracy percentage can never go negative / out of the [0,100] range.
+  const reversalRate = Math.min(1, reversed / decided);
+  return Math.round((1 - reversalRate) * 1000) / 10;
 }
 
 /** The own-ledger side of public stats is intentionally constrained to an explicit allowlist (privacy: publish

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -157,6 +157,19 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(excludeBindArg).toBe("");
   });
 
+  it("clamps review accuracy to 0 when reopened auto-closes push reversals above the decided count", async () => {
+    // JSONbored/gittensory: 1 auto-merge that held, plus 2 auto-closes that were reopened (now open, so out
+    // of merged+closed but still counted as reversals). decided=1, reversed=2 → an unclamped 1 - 2/1 = -100%.
+    const handler = (sql: string): Row[] => {
+      if (isDispositions(sql)) return [{ project: "JSONbored/gittensory", reviewed: 3, merged: 1, closed: 0, inReview: 2 }];
+      if (isReversal(sql)) return [{ project: "JSONbored/gittensory", reversed: 2 }];
+      return [];
+    };
+    const out = await getPublicStats(stubEnv(handler), NOW);
+    expect(out.byProject[0]!.accuracyPct).toBe(0);
+    expect(out.totals.accuracyPct).toBe(0);
+  });
+
   it("publishes only projects from the reviewed-repo allowlist", async () => {
     const out = await getPublicStats(
       stubEnv((sql, args) => {


### PR DESCRIPTION
## Summary

`accuracyPct()` in `src/review/public-stats.ts` powers the public "review accuracy" homepage stat as `1 - reversed / (merged + closed)`. But the two inputs come from different populations: `merged`/`closed` are the PR's **current** disposition, while `reversed` counts engine auto-actions **regardless** of current disposition. They are not nested — an engine auto-**closed** PR that a human **reopened** is now `state = "open"`, so it drops out of `merged + closed` (the `decided` denominator) yet is still counted as a reversal. When reopened auto-closes outnumber the currently-decided PRs, `reversed / decided` exceeds 1 and the function returns a **negative** percentage (e.g. `accuracyPct(1, 0, 2)` → `-100.0`), which is then published on the public counter and per-project breakdown. Reopening an auto-closed PR is exactly the "the engine was wrong" signal this metric targets, so it is a normal, recurring event.

The only existing guard is `decided <= 0 → null`; there is no upper clamp. This clamps the reversal rate to 1 so the public accuracy percentage always stays in `[0, 100]` (an all-overturned project reads as `0%`, which is the intended meaning). Adds a regression test where reopened auto-closes push `reversed` above `decided` and asserts both the per-project and totals accuracy are `0`, not negative.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (a one-line range clamp on a public-facing percentage) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). The new clamp line is exercised by the regression test (reversed > decided) and the existing accuracy cases (reversed < decided), so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This corrects a public-facing aggregate to stay within its valid range; it exposes counts only (no PR content, authors, scores, or reward internals — that boundary is untouched). No auth/CORS/session surface, no API/OpenAPI shape change, no UI — the `Safety` boxes are checked on that basis.

## Notes

- One-line range clamp (`Math.min(1, reversed / decided)`) plus an explanatory comment. The public payload shape (`accuracyPct: number | null`) is unchanged. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
