### PR TITLE
docs(miner-discovery): document the .gittensory-miner.yml MinerGoalSpec schema

### DIFF
--- a/packages/gittensory-miner/docs/miner-goal-spec.md
+++ b/packages/gittensory-miner/docs/miner-goal-spec.md
@@ -1,0 +1,62 @@
+# `.gittensory-miner.yml` — MinerGoalSpec reference
+
+`.gittensory-miner.yml` is a per-repo config file that tells autonomous gittensory **miners** what work to
+look for in a repo and how to behave when targeting it. It is the miner-facing sibling of `.gittensory.yml`.
+
+- The machine-readable schema is [`schema/miner-goal-spec.schema.json`](../schema/miner-goal-spec.schema.json)
+  (JSON Schema draft 2020-12).
+- A ready-to-copy commented example lives at [`.gittensory-miner.yml.example`](../../../.gittensory-miner.yml.example) at the repo root.
+- The parsed shape is the `MinerGoalSpec` type in
+  [`packages/gittensory-engine/src/miner-goal-spec.ts`](../../gittensory-engine/src/miner-goal-spec.ts); this
+  document tracks that type (the source of truth), not any earlier field sketch.
+
+**Discovery order (first match wins):** `.gittensory-miner.yml` → `.github/gittensory-miner.yml` →
+`.gittensory-miner.json` → `.github/gittensory-miner.json`. YAML or JSON are both accepted.
+
+**Safe by default:** every field is optional and has a safe default. A public repo with no file is still minable
+under quiet defaults. The file is parsed tolerantly — an unknown key is ignored and a single malformed field falls
+back to its default with a warning, so a broken file never hard-fails a miner. The JSON Schema mirrors this: it sets
+`additionalProperties: true`, so an unknown key validates cleanly rather than failing, matching the parser.
+
+## Fields
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `minerEnabled` | boolean | `true` | Whether this repo permits autonomous miners at all. Explicit **opt-out**: set `false` to halt all miner targeting of this repo. |
+| `wantedPaths` | glob list | `[]` | Work areas a miner should prefer; a candidate touching these is favored. |
+| `blockedPaths` | glob list | `[]` | Paths off-limits to a miner; a candidate touching one of these should be skipped. |
+| `preferredLabels` | string list | `[]` | Issue/PR labels a miner should prefer to target; a candidate carrying one is favored. |
+| `blockedLabels` | string list | `[]` | Issue/PR labels a miner must not target; a candidate carrying one should be skipped. |
+| `maxConcurrentClaims` | integer ≥ 1 | `1` | Maximum issues a single miner may hold claimed on this repo at once, so no one miner monopolizes the queue. A non-integer is floored toward zero and a value below 1 is rejected. |
+| `issueDiscoveryPolicy` | `encouraged` \| `neutral` \| `discouraged` | `neutral` | How strongly this repo encourages a miner to open discovery issues. |
+
+## Example
+
+```yaml
+minerEnabled: true
+wantedPaths:
+  - "src/**"
+blockedPaths:
+  - "vendor/**"
+  - ".github/workflows/**"
+preferredLabels:
+  - bug
+  - enhancement
+blockedLabels:
+  - wontfix
+maxConcurrentClaims: 1
+issueDiscoveryPolicy: neutral
+```
+
+## Relationship to `.gittensory.yml`
+
+`.gittensory.yml` and `.gittensory-miner.yml` are read by **different actors** and never conflict:
+
+- **`.gittensory.yml`** governs how a maintainer's repo **reviews** incoming PRs (the review focus-manifest parsed
+  by `src/signals/focus-manifest.ts`) — how the *reviewer* behaves.
+- **`.gittensory-miner.yml`** governs how a miner **searches for and prioritizes** work in a target repo — how the
+  *miner* behaves.
+
+They are independent, but a well-behaved miner should still treat a target repo's public `.gittensory.yml`
+`wantedPaths` / `blockedPaths` as a hard floor: never work a path the repo's own review manifest blocks, regardless
+of this file's preferences.

--- a/packages/gittensory-miner/schema/miner-goal-spec.schema.json
+++ b/packages/gittensory-miner/schema/miner-goal-spec.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gittensory.dev/schema/miner-goal-spec.schema.json",
+  "title": "MinerGoalSpec",
+  "description": "Per-repo miner configuration parsed from .gittensory-miner.yml. Describes what an autonomous miner should look for in a target repo and how it should behave. Mirrors the implemented MinerGoalSpec type in packages/gittensory-engine/src/miner-goal-spec.ts. Safe by default: a repo with no file is still minable. The parser is tolerant, so unknown keys are ignored rather than rejected; this schema permits them (additionalProperties: true) to stay consistent with that runtime contract.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "minerEnabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether this repo permits autonomous miners at all. Explicit opt-out: set false to halt all miner targeting of this repo."
+    },
+    "wantedPaths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Glob list of work areas a miner should prefer; a candidate touching these is favored."
+    },
+    "blockedPaths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Glob list of paths off-limits to a miner; a candidate touching one of these should be skipped."
+    },
+    "preferredLabels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Issue/PR labels a miner should prefer to target; a candidate carrying one is favored."
+    },
+    "blockedLabels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Issue/PR labels a miner must not target; a candidate carrying one should be skipped."
+    },
+    "maxConcurrentClaims": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Maximum number of issues a single miner may hold claimed on this repo at once, so one miner cannot monopolize the queue."
+    },
+    "issueDiscoveryPolicy": {
+      "type": "string",
+      "enum": ["encouraged", "neutral", "discouraged"],
+      "default": "neutral",
+      "description": "How strongly this repo encourages a miner to open discovery issues."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Documents the `.gittensory-miner.yml` (MinerGoalSpec) config: a field-by-field reference doc and a machine-readable JSON Schema (draft 2020-12). Documentation only, no parser. Both track the implemented `MinerGoalSpec` type in `packages/gittensory-engine/src/miner-goal-spec.ts` (the source of truth) and match the committed `.gittensory-miner.yml.example`.

Closes #2300

## Deliverables

- `packages/gittensory-miner/docs/miner-goal-spec.md` - field-by-field reference (types, defaults, meaning) plus a "relationship to `.gittensory.yml`" section.
- `packages/gittensory-miner/schema/miner-goal-spec.schema.json` - JSON Schema (draft 2020-12) for `minerEnabled`, `wantedPaths`, `blockedPaths`, `preferredLabels`, `blockedLabels`, `maxConcurrentClaims`, `issueDiscoveryPolicy`.

## Note (fix vs the earlier close)

The schema now sets `additionalProperties: true` to match the tolerant parser contract (the parser ignores unknown keys rather than rejecting them, per the doc and the committed example). Both the schema and the doc now state this explicitly, so a runtime-accepted config also validates cleanly against the published schema.
