### PR TITLE
fix(signals): resolve contributor language fit when repo name case differs

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -1515,11 +1515,14 @@ export function buildContributorFit(
 ): ContributorFit {
   const opportunities = buildContributorOpportunities(profile, repositories, issues, pullRequests, bounties, issueQualityByRepo);
   const languageSet = new Set(profile.github.topLanguages.map((language) => language.toLowerCase()));
-  const syncByRepo = new Map(repoSyncStates.map((state) => [state.repoFullName, state]));
+  // Key by lowercased repo name: sync-state repoFullName (GitHub-canonical) and the registered repo.fullName
+  // can differ in case, and every other repo-keyed map in this module folds case for the same reason. Without
+  // it, a case mismatch misses the language lookup and emits a spurious no_language_fit.
+  const syncByRepo = new Map(repoSyncStates.map((state) => [state.repoFullName.toLowerCase(), state]));
   const languageFit = repositories
     .filter((repo) => repo.isRegistered)
     .map((repo) => {
-      const language = syncByRepo.get(repo.fullName)?.primaryLanguage ?? null;
+      const language = syncByRepo.get(repo.fullName.toLowerCase())?.primaryLanguage ?? null;
       return {
         repoFullName: repo.fullName,
         language,

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -562,6 +562,31 @@ describe("v2 signal builders", () => {
     expect(fit.repoStats[0]).toMatchObject({ mergedPullRequests: 1 });
   });
 
+  it("resolves language fit when the registered repo name and the synced repo name differ in case", () => {
+    const mixedCaseRepo: RepositoryRecord = {
+      fullName: "Acme/Widget",
+      owner: "Acme",
+      name: "Widget",
+      isInstalled: true,
+      isRegistered: true,
+      isPrivate: false,
+      defaultBranch: "main",
+      registryConfig: { repo: "Acme/Widget", emissionShare: 0.01, issueDiscoveryShare: 0, labelMultipliers: {}, trustedLabelPipeline: false, maintainerCut: 0, raw: {} },
+    };
+    const profile = buildContributorProfile("dev", { login: "dev", topLanguages: ["TypeScript"], source: "github" }, [], []);
+    const fit = buildContributorFit(
+      profile,
+      [mixedCaseRepo],
+      [],
+      [],
+      // GitHub-canonical lowercase repo name — differs in case from the registered repo.fullName above.
+      [{ repoFullName: "acme/widget", status: "success", sourceKind: "github", primaryLanguage: "TypeScript", openIssuesCount: 0, openPullRequestsCount: 0, recentMergedPullRequestsCount: 0, warnings: [] }],
+      [],
+    );
+    expect(fit.languageFit[0]).toMatchObject({ repoFullName: "Acme/Widget", language: "TypeScript", match: true });
+    expect(fit.findings.some((finding) => finding.code === "no_language_fit")).toBe(false);
+  });
+
   it("preflights local diffs without source content", () => {
     const result = buildLocalDiffPreflightResult(
       {


### PR DESCRIPTION
## Summary

`buildContributorFit()` in `src/signals/engine.ts` builds a `Map` of sync states keyed by the raw `state.repoFullName` and reads it with the raw `repo.fullName`:

```ts
const syncByRepo = new Map(repoSyncStates.map((state) => [state.repoFullName, state]));
// ...
const language = syncByRepo.get(repo.fullName)?.primaryLanguage ?? null;
```

Sync-state repo names come GitHub-canonical, while the registered `repo.fullName` can carry different casing (e.g. `Acme/Widget` vs `acme/widget`). When they differ in case the lookup misses, so `language` is `null`, the `languageFit` entry is marked `match: false`, and a spurious `no_language_fit` finding is emitted even though the contributor's languages do match the repo. Every other repo-keyed `Map` in this module already lowercases its key for exactly this reason — this is the one that didn't.

This keys and looks up the map lowercased, matching the module's own convention (and mirroring earlier case-insensitive repo-matching fixes). Adds a regression test where the registered repo name and the synced repo name differ in case and asserts the language fit still resolves (no `no_language_fit`).

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (case-fold one map's key + lookup to match the module convention) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:ci` ran green apart from a single unrelated timeout flake in `test/unit/ops-wire.test.ts` (46s under local CPU contention); it passes 17/17 in isolation (~0.8s per test) and does not touch this change. `npm audit --audit-level=moderate` is clean (0 vulnerabilities). The two changed lines are exercised by the existing `buildContributorFit` tests and the new case-divergence regression test, so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure backend/signal-logic change to an internal fit computation; no auth/CORS/session surface, no API/OpenAPI shape change, no UI. The `Safety` boxes are checked on that basis.

## Notes

- Two-line change (lowercase the map key and the lookup) plus an explanatory comment. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
