### PR TITLE
refactor(selfhost): consolidate triplicated self-repo-default resolver

### DIFF
--- a/src/services/self-dogfood-registration-pack.ts
+++ b/src/services/self-dogfood-registration-pack.ts
@@ -1,3 +1,4 @@
+import { GITTENSOR_SELF_REPO_DEFAULT, resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 import {
   buildGittensorConfigRecommendation,
   buildRegistrationReadiness,
@@ -8,7 +9,10 @@ import {
 } from "../signals/registration-readiness";
 import { nowIso } from "../utils/json";
 
-export const DEFAULT_SELF_DOGFOOD_REPO = "JSONbored/gittensory";
+// Re-exported for backward compatibility with existing callers/tests (#2911); the actual default value and
+// resolver logic live in config/gittensory-repo-focus-manifest.ts, the single source of truth shared with
+// upstream/ruleset.ts.
+export const DEFAULT_SELF_DOGFOOD_REPO = GITTENSOR_SELF_REPO_DEFAULT;
 
 export type SelfDogfoodActionArea = {
   area: string;
@@ -32,11 +36,7 @@ export type SelfDogfoodRegistrationPack = {
   rerunHint: string;
 };
 
-export function resolveSelfDogfoodRepoFullName(env: { GITTENSORY_DRIFT_ISSUE_REPO?: string }): string {
-  const configured = env.GITTENSORY_DRIFT_ISSUE_REPO?.trim();
-  if (!configured || !configured.includes("/")) return DEFAULT_SELF_DOGFOOD_REPO;
-  return configured;
-}
+export const resolveSelfDogfoodRepoFullName = resolveGittensorySelfRepoFullName;
 
 export function buildSelfDogfoodRegistrationPack(args: {
   repoFullName: string;

--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -10,6 +10,7 @@ import {
   updateUpstreamDriftReportIssue,
   upsertUpstreamDriftReport,
 } from "../db/repositories";
+import { resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 import { timeoutFetch } from "../github/client";
 import { resolveUpstreamCommitSha } from "./commit";
 import { isGlobalAgentPause } from "../settings/agent-execution";
@@ -34,7 +35,6 @@ import { errorMessage, jsonString, nowIso } from "../utils/json";
 
 // The Gittensor upstream repo/ref defaults are single-sourced from src/scoring/model.ts (where the same
 // env.GITTENSOR_UPSTREAM_* override is honoured) — see DEFAULT_GITTENSOR_UPSTREAM_REPO/REF.
-const DEFAULT_DRIFT_ISSUE_REPO = "JSONbored/gittensory";
 const UPSTREAM_STALE_MS = 2 * 60 * 60 * 1000;
 const REGISTRY_HYPERPARAMETER_DRIFT_LIMIT = 100;
 
@@ -285,7 +285,7 @@ export async function fileUpstreamDriftIssues(env: Env): Promise<Record<string, 
   }
   const token = env.GITTENSORY_DRIFT_ISSUE_TOKEN ?? env.GITHUB_PUBLIC_TOKEN;
   if (!token) return { status: "skipped", reason: "missing_issue_token", created: 0, updated: 0, skipped: 0 };
-  const repo = env.GITTENSORY_DRIFT_ISSUE_REPO || DEFAULT_DRIFT_ISSUE_REPO;
+  const repo = resolveGittensorySelfRepoFullName(env);
   const assignees = resolveDriftAssignees(env);
   const reports = (await listUpstreamDriftReports(env, 20)).filter((report) => report.status === "open");
   let created = 0;


### PR DESCRIPTION
## Summary

The literal default `"JSONbored/gittensory"` (as a self-repo fallback, overridable via `GITTENSORY_DRIFT_ISSUE_REPO`) was independently reimplemented three times:

- `src/config/gittensory-repo-focus-manifest.ts` — `GITTENSOR_SELF_REPO_DEFAULT` / `resolveGittensorySelfRepoFullName` (the canonical, most complete implementation: validates the configured value is non-empty AND contains a `/`).
- `src/services/self-dogfood-registration-pack.ts` — `DEFAULT_SELF_DOGFOOD_REPO` / `resolveSelfDogfoodRepoFullName` (functionally **identical** logic, just written with the branches in the opposite order — confirmed by truth-table comparison, not just visual similarity).
- `src/upstream/ruleset.ts` — a bare `env.GITTENSORY_DRIFT_ISSUE_REPO || DEFAULT_DRIFT_ISSUE_REPO` fallback with **no validation at all**.

Routes the latter two through the shared `resolveGittensorySelfRepoFullName`. `self-dogfood-registration-pack.ts` keeps its two prior export names (`DEFAULT_SELF_DOGFOOD_REPO`, `resolveSelfDogfoodRepoFullName`) as thin re-exports, so `src/api/routes.ts`'s four call sites and the existing test file needed zero changes.

**Found and deliberately fixed the genuine validation gap** the issue asked me to check for before consolidating: `upstream/ruleset.ts`'s bare `||` fallback would use a malformed `GITTENSORY_DRIFT_ISSUE_REPO` value (e.g. one missing a `/`) as-is, where the other two implementations would reject it and fall back to the safe default. Verified this fix doesn't break anything by running the existing test that specifically exercises this case (`GITTENSORY_DRIFT_ISSUE_REPO: "bad-repo-name"`) — it still passes unchanged, since the code already degrades gracefully regardless of which invalid-vs-default repo string it ends up trying.

Resolves #2911. Part of the #1667 self-host review-stack roadmap.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: #2911.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `vitest run test/unit/self-dogfood-registration-pack.test.ts test/unit/upstream-ruleset.test.ts` — 50 tests passed, including the specific "bad-repo-name" and "defaults to the gittensory maintainer when unset, empty, or whitespace-only" cases that exercise the validation-gap fix
- [x] `npm run test:changed` — 75 files / 1757 tests passed, 0 failed
- [ ] `npm run actionlint` / `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm audit` / `ui:*` — not run locally; no workflow, worker-pool, MCP-package, or UI files touched. CI runs the full gate.

If any required check was skipped, explain why:

- `test:coverage`/`test:ci` not run locally — this diff is a pure consolidation (net -8/+8 lines across 2 files) with one deliberate, disclosed behavior narrowing (rejecting a previously-accepted malformed env value); the existing test suite already covers both the default-value and override paths for all three sites, confirmed passing above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/schema/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)