### PR TITLE
fix(miner): harden deny-hook protected paths

### DIFF
--- a/packages/gittensory-miner/lib/deny-hooks.js
+++ b/packages/gittensory-miner/lib/deny-hooks.js
@@ -11,10 +11,10 @@
 // forbidden-path patterns enforced in `scripts/check-mcp-package.mjs` plus a conservative git force-push guard.
 
 /**
- * Compile a glob to an anchored RegExp. `**` matches across path segments (any char incl. `/`); a leading `**​/`
- * also matches zero directories; `*` matches within a single segment (no `/`); every other char is literal. Kept
- * intentionally small — it only needs the shapes the built-in rules use (`.github/workflows/**`, `**​/.env*`,
- * `**​/secret*​/**`, `**​/*private*key*`).
+ * Compile a glob to an anchored, case-insensitive RegExp. `**` matches across path segments (any char incl.
+ * `/`); a leading `**​/` also matches zero directories; `*` matches within a single segment (no `/`); every
+ * other char is literal. Inputs are normalized before matching so `./`, nested, and Windows-style variants
+ * cannot bypass the built-in path rules.
  */
 function globToRegExp(glob) {
   let source = "";
@@ -36,19 +36,28 @@ function globToRegExp(glob) {
       source += char.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
     }
   }
-  return new RegExp(`^${source}$`);
+  return new RegExp(`^${source}$`, "i");
 }
 
-/** Collect the string values in a tool-call input (top-level strings and string elements of top-level arrays) so a
- *  rule can test them without hard-coding field names. Non-object input yields no strings (rule can't match). */
-function collectInputStrings(input) {
+function normalizePathCandidate(value) {
+  return value
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/\.\//g, "/")
+    .replace(/\/+$/, "");
+}
+
+/** Collect string values anywhere in a tool-call input so rules can test nested tool arguments without
+ *  hard-coding field names. Non-object input yields no strings (rule can't match). */
+function collectInputStrings(input, seen = new WeakSet()) {
   const strings = [];
-  if (!input || typeof input !== "object" || Array.isArray(input)) return strings;
-  for (const value of Object.values(input)) {
+  if (!input || typeof input !== "object") return strings;
+  if (seen.has(input)) return strings;
+  seen.add(input);
+  const values = Array.isArray(input) ? input : Object.values(input);
+  for (const value of values) {
     if (typeof value === "string") strings.push(value);
-    else if (Array.isArray(value)) {
-      for (const element of value) if (typeof element === "string") strings.push(element);
-    }
+    else if (value && typeof value === "object") strings.push(...collectInputStrings(value, seen));
   }
   return strings;
 }
@@ -61,12 +70,15 @@ function collectInputStrings(input) {
  * the whole-value candidate.
  */
 function pathCandidates(value) {
-  const candidates = [value];
+  const candidates = new Set([value, normalizePathCandidate(value)]);
   for (const token of value.split(/\s+/)) {
     const trimmed = token.replace(/^["']+|["']+$/g, "");
-    if (trimmed && trimmed !== value) candidates.push(trimmed);
+    if (trimmed) {
+      candidates.add(trimmed);
+      candidates.add(normalizePathCandidate(trimmed));
+    }
   }
-  return candidates;
+  return [...candidates].filter(Boolean);
 }
 
 function matcherMatches(matcher, toolName) {
@@ -96,9 +108,13 @@ function ruleMatches(rule, toolName, inputStrings) {
  * key material) and adds a conservative git force-push guard (a command carrying both `push` and `--force`).
  */
 export const DEFAULT_DENY_RULES = [
-  { matcher: "*", pathPattern: ".github/workflows/**", reason: "Never modify CI workflows (.github/workflows/**)." },
+  { matcher: "*", pathPattern: "**/.github/workflows/**", reason: "Never modify CI workflows (.github/workflows/**)." },
   { matcher: "*", pathPattern: "**/.env*", reason: "Never read or write environment files (.env*)." },
-  { matcher: "*", pathPattern: "**/secret*/**", reason: "Never touch secret-bearing paths (**/secret*/**)." },
+  { matcher: "*", pathPattern: "**/.dev.vars", reason: "Never read or write local Worker secrets (.dev.vars)." },
+  { matcher: "*", pathPattern: "**/.npmrc", reason: "Never read or write npm credential files (.npmrc)." },
+  { matcher: "*", pathPattern: "**/*.pem", reason: "Never touch PEM key material (*.pem)." },
+  { matcher: "*", pathPattern: "**/*secret*/**", reason: "Never touch secret-bearing directories (**/*secret*/**)." },
+  { matcher: "*", pathPattern: "**/*secret*", reason: "Never touch secret-bearing paths (**/*secret*)." },
   { matcher: "*", pathPattern: "**/*private*key*", reason: "Never touch private key material (**/*private*key*)." },
   { matcher: "*", inputIncludesAll: ["push", "--force"], reason: "Never force-push (git push --force)." },
 ];

--- a/packages/gittensory-miner/lib/deny-hooks.js
+++ b/packages/gittensory-miner/lib/deny-hooks.js
@@ -112,10 +112,13 @@ export const DEFAULT_DENY_RULES = [
   { matcher: "*", pathPattern: "**/.env*", reason: "Never read or write environment files (.env*)." },
   { matcher: "*", pathPattern: "**/.dev.vars", reason: "Never read or write local Worker secrets (.dev.vars)." },
   { matcher: "*", pathPattern: "**/.npmrc", reason: "Never read or write npm credential files (.npmrc)." },
-  { matcher: "*", pathPattern: "**/*.pem", reason: "Never touch PEM key material (*.pem)." },
   { matcher: "*", pathPattern: "**/*secret*/**", reason: "Never touch secret-bearing directories (**/*secret*/**)." },
   { matcher: "*", pathPattern: "**/*secret*", reason: "Never touch secret-bearing paths (**/*secret*)." },
+  // Ordered before **/*.pem below: a file like id_private_key.pem matches both patterns, and
+  // evaluateDenyHooks returns the first matching rule's reason — this one is more specific
+  // (#2942, keeps the "private key material" reason for *private*key*.pem files).
   { matcher: "*", pathPattern: "**/*private*key*", reason: "Never touch private key material (**/*private*key*)." },
+  { matcher: "*", pathPattern: "**/*.pem", reason: "Never touch PEM key material (*.pem)." },
   { matcher: "*", inputIncludesAll: ["push", "--force"], reason: "Never force-push (git push --force)." },
 ];
 

--- a/test/unit/miner-deny-hooks.test.ts
+++ b/test/unit/miner-deny-hooks.test.ts
@@ -13,32 +13,42 @@ describe("evaluateDenyHooks — built-in DEFAULT_DENY_RULES", () => {
     expect(DEFAULT_DENY_RULES.length).toBeGreaterThan(0);
   });
 
-  it("blocks writing a CI workflow, allows an ordinary source path", () => {
+  it("blocks writing a CI workflow, including relative, nested, and Windows-style variants", () => {
     const blocked = evaluateDenyHooks({ name: "Write", input: { file_path: ".github/workflows/ci.yml" } });
     expect(blocked.allowed).toBe(false);
     expect(blocked.blockedBy?.reason).toContain("CI workflows");
+    expect(evaluateDenyHooks({ name: "Write", input: { file_path: "./.github/workflows/ci.yml" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Write", input: { file_path: "foo/.github/workflows/ci.yml" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Write", input: { file_path: ".github\\workflows\\ci.yml" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Write", input: { file_path: "src/review/rag.ts" } }).allowed).toBe(true);
   });
 
-  it("blocks touching an env file (at any depth), allows a normal config file", () => {
+  it("blocks env and credential files case-insensitively, allows a normal config file", () => {
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: ".env" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "app/.env.local" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: ".ENV" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: ".dev.vars" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: ".npmrc" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "app/config.ts" } }).allowed).toBe(true);
   });
 
-  it("blocks secret-bearing paths, allows an unrelated directory", () => {
+  it("blocks secret-bearing paths and filenames, allows an unrelated directory", () => {
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "config/secrets/prod.json" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: "config/secret.json" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "config/public/prod.json" } }).allowed).toBe(true);
   });
 
-  it("blocks private key material, allows a lookalike that is not a key", () => {
+  it("blocks private key and PEM material case-insensitively, allows a lookalike that is not a key", () => {
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "keys/id_private_key.pem" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: "keys/id_PRIVATE_KEY.pem" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { file_path: "certs/client.pem" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Read", input: { file_path: "docs/public-notes.md" } }).allowed).toBe(true);
   });
 
   it("blocks a protected path EMBEDDED in a command string (tokenizes; no pre-split path field required)", () => {
     // A command carrying a protected path as one argument must be caught, not just a bare path-valued field.
     expect(evaluateDenyHooks({ name: "Bash", input: { command: "git add .github/workflows/ci.yml && git commit" } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Bash", input: { command: "git add ./.github/workflows/ci.yml && git commit" } }).allowed).toBe(false);
     expect(evaluateDenyHooks({ name: "Bash", input: { command: "cat config/secrets/prod.json" } }).allowed).toBe(false);
     // A benign command carrying no protected token still passes.
     expect(evaluateDenyHooks({ name: "Bash", input: { command: "git status --short" } }).allowed).toBe(true);
@@ -87,10 +97,9 @@ describe("evaluateDenyHooks — rule composition and allow paths", () => {
     expect(evaluateDenyHooks({ name: "Write", input: { file_path: ".github/workflows/ci.yml" } }).allowed).toBe(false);
   });
 
-  it("degrades to allow on a malformed tool call (missing/empty input) rather than throwing", () => {
+  it("recursively inspects nested input strings without throwing on missing input", () => {
     expect(evaluateDenyHooks({ name: "Bash", input: {} }).allowed).toBe(true);
-    // A path constraint with no string input fields present cannot match.
-    const rules = [{ matcher: "*", pathPattern: "**/*", reason: "everything" }];
-    expect(evaluateDenyHooks({ name: "Bash", input: { count: 3, nested: { file: "x" } } }, rules).allowed).toBe(true);
+    expect(evaluateDenyHooks({ name: "Read", input: { request: { file_path: ".env" } } }).allowed).toBe(false);
+    expect(evaluateDenyHooks({ name: "Read", input: { count: 3, nested: { file: "src/x.ts" } } }).allowed).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation

- The deny-hook primitive exposed a policy bypass where glob matching was case-sensitive and path candidates were not normalized, allowing variants like `./.github/workflows/ci.yml`, Windows separators, case variants, nested inputs, and certain credential files to slip through.
- The built-in `DEFAULT_DENY_RULES` did not fully mirror the repository's forbidden-path policy (omitted `.dev.vars`, `.npmrc`, `*.pem`, secret filenames, and nested workflow variants), so the safety primitive would be weaker than intended when used by downstream drivers.

### Description

- Normalize and strengthen glob matching by returning case-insensitive `RegExp`s from `globToRegExp` so matches are not bypassed by case variants. (`packages/gittensory-miner/lib/deny-hooks.js`)
- Normalize path candidates (convert backslashes to `/`, strip leading `./`, collapse `/.//`, trim trailing slashes) and include normalized candidates alongside raw tokens when testing patterns. (`packages/gittensory-miner/lib/deny-hooks.js`)
- Collect string values recursively from tool-call inputs (handle nested objects and arrays, protect against cycles with a `WeakSet`) so hidden/nested file paths are inspected. (`packages/gittensory-miner/lib/deny-hooks.js`)
- Extend `pathCandidates` to split command-like strings into tokens and normalize each token so embedded paths (including relative and Windows-style) are detected. (`packages/gittensory-miner/lib/deny-hooks.js`)
- Expand `DEFAULT_DENY_RULES` to cover `**/.github/workflows/**`, `**/.env*`, `**/.dev.vars`, `**/.npmrc`, `**/*.pem`, secret-bearing filenames/directories, and private-key name patterns, while keeping the git force-push guard. (`packages/gittensory-miner/lib/deny-hooks.js`)
- Add regression unit tests that assert blocking of relative, nested, Windows-style workflow paths, case-variant env/credential/PEM/private-key names, secret filenames, command-embedded paths, and nested input objects. (`test/unit/miner-deny-hooks.test.ts`)
- Regenerate the self-host env reference artifact required by the local gate. (`apps/gittensory-ui/src/lib/selfhost-env-reference.ts`)

### Testing

- Ran the dedicated unit suite for the change with `npm exec vitest run test/unit/miner-deny-hooks.test.ts -- --reporter=dot`, and the updated tests all passed (14/14). (success)
- Ran `npm run typecheck` and `npm run build:miner` to validate types and build-time checks, and both completed without error. (success)
- Regenerated self-host metadata with `npm run selfhost:env-reference` to satisfy the local gate; generation completed successfully. (success)
- Attempted the full local gate `npm run test:ci`; the gate progressed but the run encountered unrelated timing/network issues in the environment (long `queue`-suite sweeps timed out/retried) and therefore did not fully complete green in this execution. (partial / environment-related failures)
- `npm audit --audit-level=moderate` failed here due to the npm registry audit endpoint returning `403 Forbidden` from this environment, not due to code changes. (environment-related failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48904a0ec4832caef7c8770021bf00)