### PR TITLE
fix(review): surface the real hold reason and honor expectedCiContexts at accept time

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1865,18 +1865,25 @@ export function precisionBreakerDowngradeDirections(planned: PlannedAgentAction[
 }
 
 /** PURE: the bounded `{actionClass, blockerClass}` label pair for the `gittensory_agent_disposition_total`
- *  counter (#terminal-outcome-audit), derived from the FINAL post-breaker plan and the gate's own blocker
+ *  counter (#terminal-outcome-audit), derived from the FINAL post-breaker plan and the gate's own blocker/hold
  *  codes -- never from free text. `actionClass` is "merge"/"close" when the final plan still contains that
  *  action, else "hold" (guardrail, owner-exemption, migration-collision, not-yet-mergeable, breaker-downgraded,
- *  or any other bucket that produces no merge/close action). `blockerClass` is the first gate-blocker code, or
- *  "none" when the gate reported none (a clean PR held for a non-blocker reason, e.g. CI still pending). */
-export function agentDispositionLabels(breakerOnPlan: PlannedAgentAction[], gateBlockerCodes: string[]): { actionClass: "merge" | "close" | "hold"; blockerClass: string } {
+ *  or any other bucket that produces no merge/close action). `blockerClass` is the first gate-blocker code
+ *  (a `failure` conclusion); when the gate reported none, it falls back to `holdReasonCode` -- the bounded
+ *  reason class for a `neutral` conclusion (guardrail_hold/oversized_pr/ai_review_inconclusive/etc., see
+ *  `neutralHoldReasonCode`) -- so a real, nameable hold is never flattened to the same "none" bucket as a
+ *  merge-ready PR waiting on nothing more than pending CI. */
+export function agentDispositionLabels(
+  breakerOnPlan: PlannedAgentAction[],
+  gateBlockerCodes: string[],
+  holdReasonCode: string | null,
+): { actionClass: "merge" | "close" | "hold"; blockerClass: string } {
   const actionClass = breakerOnPlan.some((action) => action.actionClass === "merge")
     ? "merge"
     : breakerOnPlan.some((action) => action.actionClass === "close")
       ? "close"
       : "hold";
-  return { actionClass, blockerClass: gateBlockerCodes[0] ?? "none" };
+  return { actionClass, blockerClass: gateBlockerCodes[0] ?? holdReasonCode ?? "none" };
 }
 
 /**
@@ -2400,8 +2407,11 @@ async function runAgentMaintenancePlanAndExecute(
   // BEFORE the early return so an empty breakerOnPlan (the most common hold shape: nothing was ever planned)
   // still increments. autonomy_level reports the class most directly relevant to the recorded action_class --
   // `close` for a hold, since "autonomy.close is auto but this PR still holds" is the exact symptom this
-  // metric exists to make visible without hand-querying review_audit.
-  const disposition = agentDispositionLabels(breakerOnPlan, gate.blockers.map((blocker) => blocker.code));
+  // metric exists to make visible without hand-querying review_audit. `gate.blockers` is always empty for a
+  // `neutral` conclusion (see evaluateGateCheckCore) -- neutralHoldReasonCode recovers the real, nameable hold
+  // reason from `gate.warnings` in that case, so a guardrail/size/manifest-blocked hold doesn't flatten to the
+  // same "none" bucket as a merge-ready PR waiting on nothing more than pending CI.
+  const disposition = agentDispositionLabels(breakerOnPlan, gate.blockers.map((blocker) => blocker.code), neutralHoldReasonCode(gate));
   incr("gittensory_agent_disposition_total", {
     repo: repoFullName,
     action_class: disposition.actionClass,
@@ -2467,6 +2477,10 @@ async function runAgentMaintenancePlanAndExecute(
         moderationWarningLabel: settings.moderationWarningLabel,
         moderationBannedLabel: settings.moderationBannedLabel,
       },
+      // #selfhost-ci-verification: the executor's own final pre-mutation live-CI re-check (immediately before a
+      // merge or a CI-driven close) must honor the same configured expectedCiContexts this plan was evaluated
+      // against, or the two can disagree on ciState.
+      expectedCiContexts: settings.expectedCiContexts,
     },
     breakerOnPlan,
   );

--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -16,7 +16,7 @@ import { isAuthorBlacklisted } from "../settings/contributor-blacklist";
 import { classifyMergeFailure, MERGE_RETRY_CAP } from "./merge-failure";
 import { notifyActionToDiscord, notifyActionToSlack, type NotifyOutcome } from "./notify-discord";
 import { cancelInFlightWorkflowRunsForHeadSha, createInstallationToken, githubErrorStatus, isGitHubRateLimitedError } from "../github/app";
-import { fetchLiveCiAggregate, refreshInstallationHealthForInstallation } from "../github/backfill";
+import { fetchLiveCiAggregate, mergeRequiredCiContexts, refreshInstallationHealthForInstallation } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 import { ensurePullRequestLabel, removePullRequestLabel } from "../github/labels";
 import { closeIssue, closePullRequest, createIssueComment, createPullRequestReview, dismissLatestBotApproval, mergePullRequest, updatePullRequestBranch } from "../github/pr-actions";
@@ -129,6 +129,14 @@ export type AgentActionExecutionContext = {
   // executor via getGlobalModerationConfig -- a single extra DB read only on the rare path where a
   // moderation-tracked close actually completed, not threaded through every caller.
   moderationSettings?: ModerationContextSettings | undefined;
+  // settings.expectedCiContexts (#selfhost-ci-verification), resolved by the CALLER (same "the executor has no
+  // settings access" shape as the fields above): the final pre-mutation live-CI re-verification (step 8 below)
+  // must honor the SAME configured-required-contexts view the planning pass already evaluated against, or a
+  // maintainer-configured expectedCiContexts repo could see the plan and its own execution-time re-check
+  // disagree on ciState (e.g. a still-in-progress NON-required check reading "pending" here when the plan's
+  // required-only view was already clean). Absent/undefined ⇒ fold-all mode, unchanged from before this field
+  // existed.
+  expectedCiContexts?: ReadonlyArray<string> | null | undefined;
 };
 
 export type ModerationContextSettings = {
@@ -298,7 +306,10 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     if (action.actionClass === "merge" || (action.actionClass === "close" && action.closeRequiresCiState === "failed") || isAmbiguousLegacyHeuristicClose) {
       const ciToken = await createInstallationToken(env, ctx.installationId).catch(() => undefined);
       const admissionKey = githubRateLimitAdmissionKeyForToken(env, ciToken, ctx.installationId);
-      const liveCi = await fetchLiveCiAggregate(env, ctx.repoFullName, expectedHeadSha, ciToken, undefined, admissionKey);
+      // mergeRequiredCiContexts(null, ...) -- no live branch-protection re-fetch here, just the maintainer's own
+      // configured expectedCiContexts (or null/fold-all when unset), matching the "no branch protection" arm of
+      // the planning pass's own merge (mergeRequiredCiContexts is pure and already exported for that call site).
+      const liveCi = await fetchLiveCiAggregate(env, ctx.repoFullName, expectedHeadSha, ciToken, mergeRequiredCiContexts(null, ctx.expectedCiContexts), admissionKey);
       // The planner itself only ever stages a merge when ciState === "passed" exactly (reviewGood in
       // agent-actions.ts; "pending" short-circuits to no actions at all upstream) -- the live re-check must
       // require the SAME exact state, not just "not failed". Otherwise a check that regressed to pending or

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -6,7 +6,7 @@ import { executeAgentMaintenanceActions, pendingActionToPlanned } from "./agent-
 import { downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, type PlannedAgentAction } from "../settings/agent-actions";
 import { findBlacklistEntry } from "../settings/contributor-blacklist";
 import { isCloseHoldOnly, isHoldOnly } from "../review/outcomes-wire";
-import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestReviewDecision } from "../github/backfill";
+import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestReviewDecision, mergeRequiredCiContexts } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 import type { AgentPendingActionParams, AgentPendingActionRecord } from "../types";
 
@@ -183,7 +183,10 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     // out of decidePendingAgentAction. A settled-rejected check is treated the same as "nothing concerning
     // found" -- exactly what each function's own internal fail-safe catch already resolves to on success.
     const [ciResult, mergeableResult, reviewResult] = await Promise.allSettled([
-      fetchLiveCiAggregate(env, pending.repoFullName, pr.headSha, token, undefined, admissionKey),
+      // mergeRequiredCiContexts(null, ...) -- no live branch-protection re-fetch here, just the maintainer's own
+      // configured expectedCiContexts (or null/fold-all when unset), so this accept-time re-check honors the
+      // same required-contexts view the original plan was evaluated against (#selfhost-ci-verification).
+      fetchLiveCiAggregate(env, pending.repoFullName, pr.headSha, token, mergeRequiredCiContexts(null, settings.expectedCiContexts), admissionKey),
       fetchLivePullRequestMergeState(env, pending.repoFullName, pending.pullNumber, token, admissionKey),
       fetchLivePullRequestReviewDecision(env, pending.repoFullName, pending.pullNumber, token, admissionKey),
     ]);
@@ -298,6 +301,10 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
       // approval (close autonomy = auto_with_approval), so the accept-replay path needs this resolved the
       // same way the live webhook path does (src/queue/processors.ts) for the cancel hook to fire here too.
       contributorCapCancelCi: settings.contributorCapCancelCi ?? env.CONTRIBUTOR_CAP_CANCEL_CI_DEFAULT === "true",
+      // #selfhost-ci-verification: the executor's OWN final pre-mutation live-CI re-check (step 8 of
+      // executeAgentMaintenanceActions) needs the same configured expectedCiContexts this accept-time
+      // re-check (above) and the original plan were both evaluated against.
+      expectedCiContexts: settings.expectedCiContexts,
     },
     plan,
   );

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -374,6 +374,23 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(mergePullRequest).not.toHaveBeenCalled();
   });
 
+  // REGRESSION (gate-flagged gap, #selfhost-ci-verification): the planning pass evaluates settings.expectedCiContexts,
+  // but this final pre-mutation re-check used to always pass `undefined` for requiredContexts (fold-all mode) --
+  // a maintainer-configured repo could see the plan and its own execution-time re-check disagree on ciState.
+  it("threads ctx.expectedCiContexts into the live CI re-check's requiredContexts argument", async () => {
+    const env = createTestEnv({});
+    const outcomes = await executeAgentMaintenanceActions(env, ctx({ expectedCiContexts: ["build", "test"] }), [merge]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "sha7", expect.any(String), new Set(["build", "test"]), expect.any(String));
+  });
+
+  it("passes null (fold-all) requiredContexts when ctx.expectedCiContexts is unset — unchanged pre-existing behavior", async () => {
+    const env = createTestEnv({});
+    const outcomes = await executeAgentMaintenanceActions(env, ctx(), [merge]);
+    expect(outcomes[0]?.outcome).toBe("completed");
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "sha7", expect.any(String), null, expect.any(String));
+  });
+
   it("the live CI re-check fails open on a token-mint error — it is defense-in-depth, not the primary gate (#2128)", async () => {
     const env = createTestEnv({});
     vi.mocked(createInstallationToken).mockRejectedValueOnce(new Error("mint failed"));

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -913,6 +913,20 @@ describe("closeConcreteEvidence — concrete-evidence exemption from the close-p
     expect(closeOf(plan)).toMatchObject({ closeKind: "heuristic", closeConcreteEvidence: true });
   });
 
+  // The "CONCRETE_EVIDENCE_BLOCKER_CODES parity" describe block below already proves surface_lane_reject and
+  // manifest_missing_tests are still hand-typed correctly against their producers; these two exercise them
+  // through the actual planAgentMaintenanceActions call, mirroring the direct per-code test secret_leak already
+  // has (gate-flagged gap: they were previously only covered generically via Set-membership, never individually).
+  it("a registry surface-lane rejection (surface_lane_reject) is concrete evidence via gateBlockerCodes", () => {
+    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, ciState: "passed", gateBlockerCodes: ["surface_lane_reject"], blockerTitles: ["Registry entry rejected by its surface lane"], pr: { labels: [] } }));
+    expect(closeOf(plan)).toMatchObject({ closeKind: "heuristic", closeConcreteEvidence: true });
+  });
+
+  it("missing required manifest tests (manifest_missing_tests) is concrete evidence via gateBlockerCodes", () => {
+    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, ciState: "passed", gateBlockerCodes: ["manifest_missing_tests"], blockerTitles: ["Manifest change is missing required tests"], pr: { labels: [] } }));
+    expect(closeOf(plan)).toMatchObject({ closeKind: "heuristic", closeConcreteEvidence: true });
+  });
+
   it("a dual-model AI CONSENSUS defect (ai_consensus_defect) is deliberately NOT concrete — two models agreeing is still a judgment call, not deterministic evidence (gate review finding, round 2)", () => {
     const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, ciState: "passed", gateBlockerCodes: ["ai_consensus_defect"], blockerTitles: ["AI review found a defect"], pr: { labels: [] } }));
     expect(closeOf(plan)).toMatchObject({ closeKind: "heuristic", closeConcreteEvidence: false });

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -50,6 +50,7 @@ import { ensurePullRequestLabel } from "../../src/github/labels";
 import { createInstallationToken } from "../../src/github/app";
 import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequestReviewDecision } from "../../src/github/backfill";
 import { resolveLinkedIssueHardRule } from "../../src/review/linked-issue-hard-rules";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { actionParams, executeAgentMaintenanceActions, pendingActionToPlanned, type AgentActionExecutionContext } from "../../src/services/agent-action-executor";
 import { decidePendingAgentAction } from "../../src/services/agent-approval-queue";
 import {
@@ -491,6 +492,25 @@ describe("agent approval queue (#779)", () => {
     const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("agent.pending_action.superseded").first<{ outcome: string; detail: string }>();
     expect(audit?.outcome).toBe("denied");
     expect(audit?.detail).toContain("live CI is no longer passing (now: failed)");
+  });
+
+  // REGRESSION (gate-flagged gap, #selfhost-ci-verification): this accept-time re-check used to always pass
+  // `undefined` for requiredContexts (fold-all mode), even for a repo with settings.expectedCiContexts
+  // configured -- so this re-check could disagree with the plan it is meant to validate.
+  it("threads the repo's settings.expectedCiContexts into the accept-time live CI re-check", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" } });
+    // expectedCiContexts (#selfhost-ci-verification) is config-as-code only, resolved from the repo's focus
+    // manifest (.gittensory.yml gate.expectedCiContexts) — not a repository_settings DB column.
+    await upsertRepoFocusManifest(env, "owner/repo", { gate: { expectedCiContexts: ["build", "test"] } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash", expectedHeadSha: "h7" }, reason: "clean" });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+
+    expect(result.status).toBe("accepted");
+    expect(fetchLiveCiAggregate).toHaveBeenCalledWith(env, "owner/repo", "h7", expect.any(String), new Set(["build", "test"]), expect.any(String));
   });
 
   it("accept supersedes a staged merge when live CI has since turned pending, not just failed (#2126)", async () => {

--- a/test/unit/precision-breakers-chain.test.ts
+++ b/test/unit/precision-breakers-chain.test.ts
@@ -93,30 +93,45 @@ describe("precisionBreakerDowngradeDirections — bounded-cardinality breaker-do
 
 describe("agentDispositionLabels — bounded {actionClass, blockerClass} for gittensory_agent_disposition_total (#terminal-outcome-audit)", () => {
   it("actionClass is 'merge' when the final plan still contains a merge action", () => {
-    expect(agentDispositionLabels([mergeAction], [])).toEqual({ actionClass: "merge", blockerClass: "none" });
+    expect(agentDispositionLabels([mergeAction], [], null)).toEqual({ actionClass: "merge", blockerClass: "none" });
   });
 
   it("actionClass is 'close' when the final plan still contains a close action (and no merge)", () => {
-    expect(agentDispositionLabels([heuristicClose], [])).toEqual({ actionClass: "close", blockerClass: "none" });
+    expect(agentDispositionLabels([heuristicClose], [], null)).toEqual({ actionClass: "close", blockerClass: "none" });
   });
 
   it("actionClass is 'hold' when the final plan has neither a merge nor a close action (the previously-silent bucket)", () => {
-    expect(agentDispositionLabels([changesLabel], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+    expect(agentDispositionLabels([changesLabel], [], null)).toEqual({ actionClass: "hold", blockerClass: "none" });
   });
 
   it("actionClass is 'hold' for a genuinely EMPTY plan (nothing was ever planned — the most common real hold shape)", () => {
-    expect(agentDispositionLabels([], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+    expect(agentDispositionLabels([], [], null)).toEqual({ actionClass: "hold", blockerClass: "none" });
   });
 
   it("blockerClass is the first gate-blocker code when the gate reported one", () => {
-    expect(agentDispositionLabels([], ["secret_leak", "duplicate_pr_risk"])).toEqual({ actionClass: "hold", blockerClass: "secret_leak" });
+    expect(agentDispositionLabels([], ["secret_leak", "duplicate_pr_risk"], null)).toEqual({ actionClass: "hold", blockerClass: "secret_leak" });
   });
 
   it("blockerClass is 'none' for a clean PR held for a non-blocker reason (e.g. CI still pending)", () => {
-    expect(agentDispositionLabels([], [])).toEqual({ actionClass: "hold", blockerClass: "none" });
+    expect(agentDispositionLabels([], [], null)).toEqual({ actionClass: "hold", blockerClass: "none" });
+  });
+
+  // REGRESSION (gate-flagged gap): gate.blockers is always [] for a `neutral` conclusion (guardrail/size/
+  // manifest-blocked/AI-inconclusive holds all report through `warnings`, never `blockers`), so a real, nameable
+  // hold used to flatten to blockerClass: "none" -- indistinguishable from a clean PR waiting on pending CI.
+  it("blockerClass falls back to holdReasonCode when the gate reported no blockers (a neutral-conclusion hold)", () => {
+    expect(agentDispositionLabels([], [], "guardrail_hold")).toEqual({ actionClass: "hold", blockerClass: "guardrail_hold" });
+  });
+
+  it("blockerClass prefers a real gate-blocker code over holdReasonCode when both are somehow present", () => {
+    expect(agentDispositionLabels([], ["secret_leak"], "guardrail_hold")).toEqual({ actionClass: "hold", blockerClass: "secret_leak" });
+  });
+
+  it("blockerClass is 'none' only when BOTH gateBlockerCodes and holdReasonCode are empty/null", () => {
+    expect(agentDispositionLabels([], [], null)).toEqual({ actionClass: "hold", blockerClass: "none" });
   });
 
   it("prefers 'merge' over 'close' when (hypothetically) both are present in the final plan", () => {
-    expect(agentDispositionLabels([mergeAction, heuristicClose], []).actionClass).toBe("merge");
+    expect(agentDispositionLabels([mergeAction, heuristicClose], [], null).actionClass).toBe("merge");
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -19617,6 +19617,46 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="close",autonomy_level="auto",blocker_class="missing_linked_issue"} 1');
   });
 
+  // REGRESSION (gate-flagged gap, #terminal-outcome-audit): a PR that touches a guardrail-protected path (e.g.
+  // .github/workflows/**) is otherwise clean, so the gate lands on conclusion:"neutral" via guardrailHit --
+  // gate.blockers is empty for that conclusion (see evaluateGateCheckCore), so before this fix the disposition
+  // metric's blocker_class silently read "none", indistinguishable from a clean PR held on nothing more than
+  // pending CI. neutralHoldReasonCode recovers the real reason from gate.warnings instead.
+  it("a guardrail-path hold (neutral gate conclusion) records blocker_class=guardrail_hold, not 'none'", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupAutoActionRepo(env, { autonomy: { merge: "auto", close: "auto" }, linkedIssueGateMode: "off" });
+    const seen = { closed: false, merged: false };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url === "https://api.github.com/graphql") return Response.json({ data: { repository: { pullRequest: { reviewDecision: "APPROVED" } } } });
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/61/files")) return Response.json([{ filename: ".github/workflows/ci.yml", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+  x: 1" }]);
+      if (url.includes("/pulls/61/reviews")) return Response.json([]);
+      if (url.includes("/pulls/61/commits")) return Response.json([]);
+      if (url.endsWith("/pulls/61/merge") && method === "PUT") { seen.merged = true; return Response.json({ merged: true }); }
+      if (url.endsWith("/pulls/61") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        if (body.state === "closed") seen.closed = true;
+        return Response.json({ number: 61, state: body.state ?? "open" });
+      }
+      if (url.endsWith("/pulls/61")) return Response.json({ number: 61, state: "open", user: { login: "contributor" }, head: { sha: "conv61" }, mergeable_state: "clean" });
+      if (url.includes("/commits/conv61/check-runs")) return Response.json({ total_count: 1, check_runs: [{ name: "CI", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+      if (url.includes("/commits/conv61/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/61/labels")) return Response.json([]);
+      if (url.includes("/issues/61/comments")) return Response.json([]);
+      return Response.json({});
+    });
+    resetMetrics();
+
+    await processJob(env, { type: "github-webhook", deliveryId: "conv-guardrail", eventName: "pull_request", payload: prPayload({ number: 61, head: { sha: "conv61" }, body: "no linked issue needed" }) });
+
+    expect(seen.merged).toBe(false);
+    expect(seen.closed).toBe(false);
+    expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="hold",autonomy_level="auto",blocker_class="guardrail_hold"} 1');
+  });
+
   it("reviewCheckMode: disabled still auto-closes a blocked contributor PR via the general heuristic-close path (#2852)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await setupAutoActionRepo(env, { autonomy: { close: "auto" }, reviewCheckMode: "disabled" });


### PR DESCRIPTION
## Summary

Two more terminal-outcome gaps found by re-auditing the original fix specs against the shipped code (follow-up to #2905):

- `gittensory_agent_disposition_total`'s `blocker_class` read `"none"` for *every* neutral-conclusion hold (guardrail/size/manifest-blocked/AI-inconclusive), because `gate.blockers` is always empty for that conclusion — the real reason only lives in `gate.warnings`. `agentDispositionLabels` now falls back to `neutralHoldReasonCode(gate)` so a guardrail hold no longer looks identical to a clean PR waiting on pending CI.
- The final pre-mutation live-CI re-check, run immediately before an agent-driven merge or CI-driven heuristic close (both in `executeAgentMaintenanceActions` and in `decidePendingAgentAction`'s own accept-time re-validation), always evaluated in fold-all mode — it never received the repo's configured `settings.expectedCiContexts` the way the planning pass does. A maintainer-configured repo could see the plan and its own execution-time re-check disagree on `ciState`. Threaded through via a new `AgentActionExecutionContext.expectedCiContexts` field, resolved by each caller the same way `contributorCapCancelCi`/`moderationSettings` already are.
- Also adds direct per-code close-disposition coverage for `surface_lane_reject`/`manifest_missing_tests` (previously exercised only generically via Set-membership).

Generic self-host engine behavior only; no repo-specific logic.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Found via an internal completeness audit of prior self-host review-engine fixes, same category as #2905.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (unsharded); precise diff-coverage cross-reference against `coverage/coverage-final.json` confirms 100% branch coverage on every changed line across all three changed `src/**` files
- [ ] `npm run test:workers` (not run — no Cloudflare-Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (not run — no `apps/gittensory-ui` or API/OpenAPI surface changes)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped checks above are for UI/MCP/Workers surfaces this PR does not touch (backend-only change to the review-engine disposition/CI-recheck path); CI's `validate` job runs them as a backstop.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- A related, low-priority coverage nit (a single test combining "installation cooling down" + "another job type still drains" in the queue rate-limit test suites) was found by the same audit but deliberately left out of this PR — different subsystem, kept the diff focused.