### PR TITLE
fix(mcp): bound lint-pr-text body file reads

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { closeSync, constants as fsConstants, existsSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, constants as fsConstants, existsSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, readSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -1503,7 +1503,19 @@ function readCliTextFile(path, label) {
     const stats = fstatSync(fd);
     if (!stats.isFile()) throw new Error(`${label} file must be a regular file: ${path}`);
     if (stats.size > cliTextFileMaxBytes) throw new Error(`${label} file is too large: ${path} (max ${cliTextFileMaxBytes} bytes)`);
-    return readFileSync(fd, "utf8");
+    // Bound the READ itself rather than trusting stats.size alone: a regular file can grow between fstatSync
+    // and the read below (the fd is the same, but nothing stops another process from appending to the file
+    // in between), so read at most cliTextFileMaxBytes + 1 bytes directly from the descriptor and fail if that
+    // cap is exceeded, instead of handing the now-possibly-stale size to an unbounded readFileSync.
+    const buffer = Buffer.alloc(cliTextFileMaxBytes + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const n = readSync(fd, buffer, bytesRead, buffer.length - bytesRead, null);
+      if (n === 0) break;
+      bytesRead += n;
+    }
+    if (bytesRead > cliTextFileMaxBytes) throw new Error(`${label} file is too large: ${path} (max ${cliTextFileMaxBytes} bytes)`);
+    return buffer.subarray(0, bytesRead).toString("utf8");
   } finally {
     closeSync(fd);
   }

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -20,6 +20,7 @@ const currentApiVersion = "0.1.0";
 const decisionPackCacheSchemaVersion = 1;
 const decisionPackCacheMaxEntries = 25;
 const decisionPackCacheMaxBytes = 512 * 1024;
+const cliTextFileMaxBytes = 1024 * 1024;
 const changelogPath = new URL("../CHANGELOG.md", import.meta.url);
 const cliArgs = process.argv.slice(2);
 const defaultProfileName = "default";
@@ -1484,6 +1485,14 @@ async function runCli(args) {
   writeBranchAnalysisCli(result, command);
 }
 
+function readCliTextFile(path, label) {
+  if (!existsSync(path)) throw new Error(`${label} file not found: ${path}`);
+  const stats = lstatSync(path);
+  if (!stats.isFile()) throw new Error(`${label} file must be a regular file: ${path}`);
+  if (stats.size > cliTextFileMaxBytes) throw new Error(`${label} file is too large: ${path} (max ${cliTextFileMaxBytes} bytes)`);
+  return readFileSync(path, "utf8");
+}
+
 function printLintPrTextHelp() {
   process.stdout.write(
     [
@@ -1503,8 +1512,7 @@ async function lintPrTextCli(args) {
   const commitMessages = Array.isArray(options.commit) ? options.commit : options.commit ? [options.commit] : undefined;
   let prBody = options.body;
   if (options.bodyFile) {
-    if (!existsSync(options.bodyFile)) throw new Error(`Body file not found: ${options.bodyFile}`);
-    prBody = readFileSync(options.bodyFile, "utf8");
+    prBody = readCliTextFile(options.bodyFile, "Body");
   }
   const linkedIssue = parsePositiveIntegerOption(options.linkedIssue, "--linked-issue");
   const payload = await apiPost("/v1/lint/pr-text", {
@@ -1562,8 +1570,7 @@ async function slopRiskCli(args) {
   let description = options.description ?? options.body;
   const descriptionFile = options.descriptionFile ?? options.bodyFile;
   if (descriptionFile) {
-    if (!existsSync(descriptionFile)) throw new Error(`Description file not found: ${descriptionFile}`);
-    description = readFileSync(descriptionFile, "utf8");
+    description = readCliTextFile(descriptionFile, "Description");
   }
   const changedFiles = stringArrayOption(options.changedFile).map(parseChangedFileSpec);
   const tests = stringArrayOption(options.test);
@@ -1600,8 +1607,7 @@ async function issueSlopCli(args) {
   const options = parseOptions(args);
   let body = normalizeOptionalStringOption(options.body);
   if (options.bodyFile) {
-    if (!existsSync(options.bodyFile)) throw new Error(`Body file not found: ${options.bodyFile}`);
-    body = readFileSync(options.bodyFile, "utf8");
+    body = readCliTextFile(options.bodyFile, "Body");
   }
   const title = normalizeOptionalStringOption(options.title);
   const payload = await apiPost("/v1/lint/issue-slop", {

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, constants as fsConstants, existsSync, fstatSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -1485,12 +1485,28 @@ async function runCli(args) {
   writeBranchAnalysisCli(result, command);
 }
 
+// Opens, type-checks, and reads the file through ONE file descriptor rather than a separate
+// stat-then-read pair: a check-then-read on a path string leaves a race window where a symlink or
+// special file (FIFO, device) can be swapped in between the two calls, letting the earlier
+// isFile()/size validation apply to a different, unvalidated file than the one actually read.
+// O_NOFOLLOW makes a symlinked path fail to open outright instead of silently following it.
 function readCliTextFile(path, label) {
-  if (!existsSync(path)) throw new Error(`${label} file not found: ${path}`);
-  const stats = lstatSync(path);
-  if (!stats.isFile()) throw new Error(`${label} file must be a regular file: ${path}`);
-  if (stats.size > cliTextFileMaxBytes) throw new Error(`${label} file is too large: ${path} (max ${cliTextFileMaxBytes} bytes)`);
-  return readFileSync(path, "utf8");
+  let fd;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (error) {
+    if (error && error.code === "ENOENT") throw new Error(`${label} file not found: ${path}`);
+    if (error && (error.code === "ELOOP" || error.code === "EMLINK")) throw new Error(`${label} file must be a regular file: ${path}`);
+    throw error;
+  }
+  try {
+    const stats = fstatSync(fd);
+    if (!stats.isFile()) throw new Error(`${label} file must be a regular file: ${path}`);
+    if (stats.size > cliTextFileMaxBytes) throw new Error(`${label} file is too large: ${path} (max ${cliTextFileMaxBytes} bytes)`);
+    return readFileSync(fd, "utf8");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function printLintPrTextHelp() {

--- a/test/unit/mcp-cli-issue-slop.test.ts
+++ b/test/unit/mcp-cli-issue-slop.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -58,6 +58,23 @@ describe("gittensory-mcp CLI — issue-slop", () => {
       band: string;
     };
     expect(json.band).toBe("clean");
+  });
+
+  it("rejects non-regular and oversized --body-file inputs before posting", async () => {
+    const e = await env();
+    const directoryPath = join(tempDir!, "body-dir");
+    mkdirSync(directoryPath);
+    await expect(runAsync(["issue-slop", "--title", "Add retries", "--body-file", directoryPath], e)).rejects.toThrow(/Body file must be a regular file/);
+
+    const targetPath = join(tempDir!, "target.md");
+    const symlinkPath = join(tempDir!, "symlink.md");
+    writeFileSync(targetPath, "Retry widget reconnects.", "utf8");
+    symlinkSync(targetPath, symlinkPath);
+    await expect(runAsync(["issue-slop", "--title", "Add retries", "--body-file", symlinkPath], e)).rejects.toThrow(/Body file must be a regular file/);
+
+    const oversizedPath = join(tempDir!, "oversized.md");
+    writeFileSync(oversizedPath, "x".repeat(1024 * 1024 + 1), "utf8");
+    await expect(runAsync(["issue-slop", "--title", "Add retries", "--body-file", oversizedPath], e)).rejects.toThrow(/Body file is too large/);
   });
 
   it("surfaces elevated issue slop findings in plain output", async () => {

--- a/test/unit/mcp-cli-lint-pr-text.test.ts
+++ b/test/unit/mcp-cli-lint-pr-text.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -67,6 +67,23 @@ describe("gittensory-mcp CLI — lint-pr-text", () => {
     ) as { verdict: string; components: Array<{ key: string }> };
     expect(json.verdict).toBe("strong");
     expect(json.components[0]).toMatchObject({ key: "traceability" });
+  });
+
+  it("rejects non-regular and oversized --body-file inputs before posting", async () => {
+    const e = await env();
+    const directoryPath = join(tempDir!, "body-dir");
+    mkdirSync(directoryPath);
+    await expect(runAsync(["lint-pr-text", "--body-file", directoryPath], e)).rejects.toThrow(/Body file must be a regular file/);
+
+    const targetPath = join(tempDir!, "target.md");
+    const symlinkPath = join(tempDir!, "symlink.md");
+    writeFileSync(targetPath, "Fixes #7", "utf8");
+    symlinkSync(targetPath, symlinkPath);
+    await expect(runAsync(["lint-pr-text", "--body-file", symlinkPath], e)).rejects.toThrow(/Body file must be a regular file/);
+
+    const oversizedPath = join(tempDir!, "oversized.md");
+    writeFileSync(oversizedPath, "x".repeat(1024 * 1024 + 1), "utf8");
+    await expect(runAsync(["lint-pr-text", "--body-file", oversizedPath], e)).rejects.toThrow(/Body file is too large/);
   });
 
   it("surfaces weak verdicts and actionable fixes in plain output", async () => {

--- a/test/unit/mcp-cli-slop-risk.test.ts
+++ b/test/unit/mcp-cli-slop-risk.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -74,6 +74,29 @@ describe("gittensory-mcp CLI — slop-risk", () => {
       ),
     ) as { band: string };
     expect(json.band).toBe("clean");
+  });
+
+  it("rejects non-regular and oversized --description-file inputs before posting", async () => {
+    const e = await env();
+    const directoryPath = join(tempDir!, "description-dir");
+    mkdirSync(directoryPath);
+    await expect(runAsync(["slop-risk", "--changed-file", "src/widget.ts:80:2", "--description-file", directoryPath], e)).rejects.toThrow(
+      /Description file must be a regular file/,
+    );
+
+    const targetPath = join(tempDir!, "target.md");
+    const symlinkPath = join(tempDir!, "symlink.md");
+    writeFileSync(targetPath, "Fixes #7", "utf8");
+    symlinkSync(targetPath, symlinkPath);
+    await expect(runAsync(["slop-risk", "--changed-file", "src/widget.ts:80:2", "--description-file", symlinkPath], e)).rejects.toThrow(
+      /Description file must be a regular file/,
+    );
+
+    const oversizedPath = join(tempDir!, "oversized.md");
+    writeFileSync(oversizedPath, "x".repeat(1024 * 1024 + 1), "utf8");
+    await expect(runAsync(["slop-risk", "--changed-file", "src/widget.ts:80:2", "--description-file", oversizedPath], e)).rejects.toThrow(
+      /Description file is too large/,
+    );
   });
 
   it("surfaces elevated slop findings in plain output", async () => {


### PR DESCRIPTION
### Motivation
- The `lint-pr-text` CLI accepted `--body-file` paths and used `readFileSync` after only `existsSync`, which allowed special files (FIFOs, symlinks, devices) or very large files to hang or exhaust memory. 
- This change hardens local CLI behavior to prevent local hangs and DoS-like memory exhaustion when a repository or automation provides attacker-controlled paths.

### Description
- Add a `cliTextFileMaxBytes` (1 MiB) limit and import `lstatSync` in `packages/gittensory-mcp/bin/gittensory-mcp.js` to enable robust file checks. 
- Introduce `readCliTextFile(path, label)` which validates existence, requires a regular file (`stats.isFile()`), enforces the size cap, and then reads the file. 
- Route `lint-pr-text`, `slop-risk`, and `issue-slop` CLI codepaths to use `readCliTextFile` instead of raw `readFileSync`, preserving normal functionality for regular files under the cap. 
- Add a unit test in `test/unit/mcp-cli-lint-pr-text.test.ts` that asserts `--body-file` rejects directories, symlinks, and oversized files.

### Testing
- Ran `git diff --check` to validate whitespace/metadata, which passed. 
- Built the MCP bundle with `npm run build:mcp`, which succeeded. 
- Ran unit tests with `npx vitest run test/unit/mcp-cli-lint-pr-text.test.ts test/unit/mcp-cli-slop-risk.test.ts`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4890581e30832c9aa670146b915cb3)