### PR TITLE
fix(health): limit public liveness metadata

### DIFF
--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -8,40 +8,12 @@ export interface Readiness {
   durationsMs: Record<string, number>;
 }
 
-export type HealthBackend = "sqlite" | "postgres";
-
 export interface HealthBody {
   status: "ok";
-  version: string;
-  uptimeSeconds: number;
-  backend: HealthBackend;
 }
 
-function nonBlank(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-export function resolveHealthVersion(
-  env: { GITTENSORY_VERSION?: string | undefined },
-  packageVersion?: string,
-): string {
-  const envVersion = nonBlank(env.GITTENSORY_VERSION);
-  if (envVersion) return envVersion;
-  return nonBlank(packageVersion) ?? "unknown";
-}
-
-export function buildHealthBody(opts: {
-  version?: string;
-  startedAt: number;
-  dbBackend: HealthBackend;
-}): HealthBody {
-  return {
-    status: "ok",
-    version: nonBlank(opts.version) ?? "unknown",
-    uptimeSeconds: Math.max(0, Math.floor((Date.now() - opts.startedAt) / 1000)),
-    backend: opts.dbBackend,
-  };
+export function buildHealthBody(): HealthBody {
+  return { status: "ok" };
 }
 
 /** An extra readiness check for a CONFIGURED optional backend (Redis, Qdrant …). `check` resolves true when the

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,6 @@ import {
   codexAuthReadinessProbe,
   githubAppReadinessProbe,
   readiness,
-  resolveHealthVersion,
   sqliteBackupAdvisory,
   type ReadinessProbe,
 } from "./selfhost/health";
@@ -350,10 +349,6 @@ async function main(): Promise<void> {
     ? await buildPostgresBackend(databaseUrl as string, consume)
     : buildSqliteBackend(consume);
   const dbBackend = usePostgres ? "postgres" : "sqlite";
-  const healthVersion = resolveHealthVersion(
-    { GITTENSORY_VERSION: process.env.GITTENSORY_VERSION },
-    packageJson.version,
-  );
   console.log(
     JSON.stringify({
       event: "selfhost_backend",
@@ -707,7 +702,7 @@ async function main(): Promise<void> {
         const path = new URL(request.url).pathname;
         if (path === "/health")
           return new Response(
-            JSON.stringify(buildHealthBody({ version: healthVersion, startedAt, dbBackend })),
+            JSON.stringify(buildHealthBody()),
             { headers: { "content-type": "application/json" } },
           );
         if (path === "/ready") {

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -2,74 +2,19 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import {
   buildHealthBody,
   codexAuthReadinessProbe,
   githubAppReadinessProbe,
   readiness,
-  resolveHealthVersion,
   sqliteBackupAdvisory,
 } from "../../src/selfhost/health";
 
 describe("buildHealthBody (#2077)", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("reports the configured version, rounded uptime, and Postgres backend", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-02T12:00:10.900Z"));
-
-    expect(
-      buildHealthBody({
-        version: "2026.7.2",
-        startedAt: Date.parse("2026-07-02T12:00:00.100Z"),
-        dbBackend: "postgres",
-      }),
-    ).toEqual({
-      status: "ok",
-      version: "2026.7.2",
-      uptimeSeconds: 10,
-      backend: "postgres",
-    });
-  });
-
-  it("falls back to unknown and never reports negative uptime", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-02T12:00:00.000Z"));
-
-    expect(
-      buildHealthBody({
-        version: "   ",
-        startedAt: Date.parse("2026-07-02T12:00:02.000Z"),
-        dbBackend: "sqlite",
-      }),
-    ).toEqual({
-      status: "ok",
-      version: "unknown",
-      uptimeSeconds: 0,
-      backend: "sqlite",
-    });
-  });
-});
-
-describe("resolveHealthVersion (#2077)", () => {
-  it("prefers the image version over the package fallback", () => {
-    expect(resolveHealthVersion({ GITTENSORY_VERSION: "  image-2026.07.02  " }, "0.1.0")).toBe(
-      "image-2026.07.02",
-    );
-  });
-
-  it("uses the package fallback when the image version is absent or blank", () => {
-    expect(resolveHealthVersion({}, "0.1.0")).toBe("0.1.0");
-    expect(resolveHealthVersion({ GITTENSORY_VERSION: "   " }, "0.1.0")).toBe("0.1.0");
-  });
-
-  it("reports unknown when no nonblank version is available", () => {
-    expect(resolveHealthVersion({}, undefined)).toBe("unknown");
-    expect(resolveHealthVersion({ GITTENSORY_VERSION: "" }, "   ")).toBe("unknown");
+  it("keeps unauthenticated liveness responses minimal", () => {
+    expect(buildHealthBody()).toEqual({ status: "ok" });
   });
 });
 


### PR DESCRIPTION
### Motivation

- The public self-host `/health` liveness endpoint was returning deployment metadata (version, uptime, backend) that can be used for remote fingerprinting; this change restores a minimal unauthenticated liveness response to reduce information disclosure.
- The intent is a narrow security remediation that preserves readiness checks for internal probes while keeping the public liveness route minimal and non-revealing.

### Description

- Simplified the `HealthBody` and `buildHealthBody()` in `src/selfhost/health.ts` so the public liveness body only returns `{ status: "ok" }` and removed the code paths that populated version, uptime, and backend.
- Updated the unauthenticated `/health` handler in `src/server.ts` to call the new `buildHealthBody()` and stop serializing deployment metadata.
- Adjusted the unit test `test/unit/selfhost-health.test.ts` to assert the minimal unauthenticated liveness response.

### Testing

- Ran the focused unit suite with `npx vitest run test/unit/selfhost-health.test.ts --reporter=verbose` and the health-related tests passed (all relevant tests succeeded). 
- Ran type checking with `npm run typecheck` which completed successfully. 
- Attempted `npm run test:coverage` and a focused `npm run test:coverage -- test/unit/selfhost-health.test.ts` but the repo-wide coverage job did not complete within the session and global coverage thresholds reported failures when the full coverage run was attempted. 
- `npm audit --audit-level=moderate` could not complete due to the registry returning `403 Forbidden` for the audit endpoint during the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4890523980832c9940f47ab8bd72af)