### PR TITLE
fix(review): finalize gate check before surface skip

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -7879,6 +7879,10 @@ async function maybePublishPrPublicSurface(
             { checkRunId: pendingGateCheckRunId, gate: gateEvaluation },
             mode,
           );
+          /* v8 ignore next -- refreshedGateCheckResult is only ever null when advisory.headSha is falsy or the
+           * write is dry-run-suppressed; pendingGateCheckRunId !== undefined already proves headSha was truthy
+           * and mode was "live" for the earlier pending-check post in this SAME pass (mode/advisory are both
+           * immutable locals shared by both calls), so the nullish `?.` short-circuit here is unreachable. */
           if (refreshedGateCheckResult?.kind === "published") {
             await recordPublishedGateCheckSummary(env, {
               repoFullName,

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -7868,16 +7868,55 @@ async function maybePublishPrPublicSurface(
           check.status === "completed",
       );
       if (currentGateCheck) {
-        incr("gittensory_public_surface_publish_skipped_current_total");
-        await recordAuditEvent(env, {
-          eventType: "github_app.public_surface_publish_skipped_current",
-          actor: author,
-          targetKey: `${repoFullName}#${pr.number}`,
-          outcome: "completed",
-          detail: "public surface already current for this head; skipped republish",
-          metadata: { deliveryId: webhook.deliveryId, repoFullName, /* v8 ignore next -- reached only inside aiReviewWillRun (which requires a truthy advisory.headSha) or the publish-skip guard's own `advisory.headSha &&` check; the `?? null` is a type-level fallback for an unreachable branch. */ headSha: advisory.headSha ?? null },
-        }).catch(() => undefined);
-        return gateEvaluation;
+        let canSkipCurrentSurface = true;
+        if (pendingGateCheckRunId !== undefined) {
+          const refreshedGateCheckResult = await createOrUpdateGateCheckRun(
+            env,
+            installationId,
+            repoFullName,
+            advisory,
+            gatePolicy,
+            { checkRunId: pendingGateCheckRunId, gate: gateEvaluation },
+            mode,
+          );
+          if (refreshedGateCheckResult?.kind === "published") {
+            await recordPublishedGateCheckSummary(env, {
+              repoFullName,
+              pullNumber: pr.number,
+              headSha: advisory.headSha,
+              checkRunId: refreshedGateCheckResult.id,
+              conclusion: gateEvaluation?.conclusion ?? null,
+              detailsUrl: refreshedGateCheckResult.html_url,
+              deliveryId: webhook.deliveryId,
+            }).catch((error) => {
+              console.error(
+                JSON.stringify({
+                  level: "warn",
+                  event: "gate_check_summary_upsert_failed",
+                  repoFullName,
+                  pullNumber: pr.number,
+                  error: errorMessage(error),
+                }),
+              );
+            });
+          } else {
+            canSkipCurrentSurface = false;
+          }
+        }
+        if (canSkipCurrentSurface) {
+          incr("gittensory_public_surface_publish_skipped_current_total");
+          await recordAuditEvent(env, {
+            eventType: "github_app.public_surface_publish_skipped_current",
+            actor: author,
+            targetKey: `${repoFullName}#${pr.number}`,
+            outcome: "completed",
+            detail: "public surface already current for this head; skipped republish",
+            metadata: { deliveryId: webhook.deliveryId, repoFullName, /* v8 ignore next -- reached only inside aiReviewWillRun (which requires a truthy advisory.headSha) or the publish-skip guard's own `advisory.headSha &&` check; the `?? null` is a type-level fallback for an unreachable branch. */ headSha: advisory.headSha ?? null },
+          }).catch(() => undefined);
+          return gateEvaluation;
+        }
+        // The no-op proof is only safe if the pending check this pass created is terminal too.
+        // Fall through to the normal publish path on any doubt so branch protection cannot be left pending.
       }
     }
     const finalFreshness = await freshnessForReviewOutput("final_publish");

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2767,6 +2767,172 @@ describe("queue processors", () => {
       ]);
     });
 
+    it("REGRESSION (#2947): still skips the republish when no pending check was posted this pass (gate permission missing)", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }) } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env);
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 72, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a72" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 72, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+      await putCachedAiReview(env, "JSONbored/gittensory", 72, "a72", "block", {
+        notes: "Looks fine.",
+        reviewerCount: 1,
+        cacheable: true,
+        metadata: {
+          inputFingerprint: await aiReviewCacheInputFingerprint({
+            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, baseSha: null,
+            reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
+            profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], changedPaths: ["src/a.ts"],
+            features: { grounding: false, rag: false, enrichment: false, reputation: false },
+          }),
+        },
+      });
+      await upsertCheckSummary(env, { id: "gate-72", repoFullName: "JSONbored/gittensory", pullNumber: 72, headSha: "a72", name: "Gittensory Orb Review Agent", status: "completed", conclusion: "success", payload: {} });
+      await repositoriesModule.markPullRequestSurfacePublished(env, "JSONbored/gittensory", 72, "a72");
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/72/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/72")) return Response.json({ number: 72, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a72" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a72/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        // The pending gate check-run POST fails with a permission error, so pendingGateCheckRunId stays
+        // undefined for the whole pass -- the "still-in-flight from THIS pass" refresh in the skip guard
+        // must never fire without a pending check id to refresh.
+        if (url.includes("/check-runs") && init?.method === "POST") {
+          return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+        }
+        if (url.includes("/check-runs")) return Response.json({ check_runs: [] });
+        return Response.json({});
+      });
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "surface-skip-no-pending", repoFullName: "JSONbored/gittensory", prNumber: 72, installationId: 123 });
+
+      const skipAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.public_surface_publish_skipped_current", "JSONbored/gittensory#72")
+        .first<{ n: number }>();
+      expect(skipAudit?.n).toBe(1);
+      const publishedAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#72")
+        .first<{ n: number }>();
+      expect(publishedAudit?.n).toBe(0); // still proven redundant up-front, even with no pending check id to refresh
+    });
+
+    it("REGRESSION (#2947): falls through to a full republish when this pass's own pending check does not finalize as published", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }) } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env);
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 73, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a73" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 73, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+      await putCachedAiReview(env, "JSONbored/gittensory", 73, "a73", "block", {
+        notes: "Looks fine.",
+        reviewerCount: 1,
+        cacheable: true,
+        metadata: {
+          inputFingerprint: await aiReviewCacheInputFingerprint({
+            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, baseSha: null,
+            reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
+            profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], changedPaths: ["src/a.ts"],
+            features: { grounding: false, rag: false, enrichment: false, reputation: false },
+          }),
+        },
+      });
+      await upsertCheckSummary(env, { id: "gate-73", repoFullName: "JSONbored/gittensory", pullNumber: 73, headSha: "a73", name: "Gittensory Orb Review Agent", status: "completed", conclusion: "success", payload: {} });
+      await repositoriesModule.markPullRequestSurfacePublished(env, "JSONbored/gittensory", 73, "a73");
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/73/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/73")) return Response.json({ number: 73, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a73" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a73/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        // The initial pending check-run POST succeeds (pendingGateCheckRunId gets set), but every
+        // subsequent PATCH to finalize it -- both this pass's refresh attempt AND any fallthrough publish
+        // attempt -- fails with a permission error, so the refresh never resolves as "published".
+        if (url.includes("/check-runs") && init?.method === "POST") return Response.json({ id: 7301 });
+        if (url.includes("/check-runs/7301") && init?.method === "PATCH") {
+          return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), { status: 403 });
+        }
+        if (url.includes("/check-runs")) return Response.json({ check_runs: [] });
+        return Response.json({});
+      });
+
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "surface-skip-refresh-not-published", repoFullName: "JSONbored/gittensory", prNumber: 73, installationId: 123 });
+
+      // The skip guard did NOT prove the surface redundant -- it must fall through to the normal publish
+      // path rather than silently returning early, even though the refresh attempt itself failed.
+      const skipAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.public_surface_publish_skipped_current", "JSONbored/gittensory#73")
+        .first<{ n: number }>();
+      expect(skipAudit?.n).toBe(0);
+    });
+
+    it("REGRESSION (#2947): swallows a failing check-summary write on the skip-guard's own refresh, still returning the gate evaluation", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => ({ response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }) } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env);
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 74, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a74" }, labels: [], body: "Closes #1" });
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 74, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+      await putCachedAiReview(env, "JSONbored/gittensory", 74, "a74", "block", {
+        notes: "Looks fine.",
+        reviewerCount: 1,
+        cacheable: true,
+        metadata: {
+          inputFingerprint: await aiReviewCacheInputFingerprint({
+            title: "Current PR", mode: "block", byok: false, provider: null, model: null, aiReviewAllAuthors: false,
+            aiReviewCloseConfidence: undefined, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, gatePack: "oss-anti-slop", reviewerPlan: env.AI_REVIEW_PLAN, selfHostProviderConfig: null, baseSha: null,
+            reviewFiles: [{ path: "src/a.ts", status: "modified", patch: "@@\n+export const ok = true;", additions: 1, deletions: 0 }],
+            profile: null, securityFocus: false, inlineComments: false, pathInstructions: [], pathGuidance: "", repoInstructions: null, excludePaths: [], changedPaths: ["src/a.ts"],
+            features: { grounding: false, rag: false, enrichment: false, reputation: false },
+          }),
+        },
+      });
+      await upsertCheckSummary(env, { id: "gate-74", repoFullName: "JSONbored/gittensory", pullNumber: 74, headSha: "a74", name: "Gittensory Orb Review Agent", status: "completed", conclusion: "success", payload: {} });
+      await repositoriesModule.markPullRequestSurfacePublished(env, "JSONbored/gittensory", 74, "a74");
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/74/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/74")) return Response.json({ number: 74, title: "Current PR", state: "open", user: { login: "contributor" }, head: { sha: "a74" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a74/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        if (url.includes("/check-runs") && init?.method === "POST") return Response.json({ id: 7401 });
+        if (url.includes("/check-runs/7401") && init?.method === "PATCH") return Response.json({ id: 7401 });
+        if (url.includes("/check-runs")) return Response.json({ check_runs: [] });
+        return Response.json({});
+      });
+      const upsertSpy = vi.spyOn(repositoriesModule, "upsertCheckSummary").mockRejectedValueOnce(new Error("check_summaries write failed"));
+
+      await expect(
+        processJob(env, { type: "agent-regate-pr", deliveryId: "surface-skip-summary-write-fails", repoFullName: "JSONbored/gittensory", prNumber: 74, installationId: 123 }),
+      ).resolves.toBeUndefined();
+
+      const skipAudit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.public_surface_publish_skipped_current", "JSONbored/gittensory#74")
+        .first<{ n: number }>();
+      expect(skipAudit?.n).toBe(1); // the check-summary write failure is swallowed; the redundant-surface skip still completes
+      upsertSpy.mockRestore();
+    });
+
     it("swallows a failing publish-skip audit write without throwing", async () => {
       const env = createTestEnv({
         GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2730,7 +2730,8 @@ describe("queue processors", () => {
         payload: {},
       });
       await repositoriesModule.markPullRequestSurfacePublished(env, "JSONbored/gittensory", 62, "a62");
-      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const checkRunWrites: Array<{ method: string; body: Record<string, unknown> }> = [];
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
         if (url.includes("/pulls/62/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
@@ -2738,6 +2739,15 @@ describe("queue processors", () => {
         if (url.includes("/commits/a62/status")) return Response.json({ state: "success", statuses: [] });
         if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
         if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        if (url.includes("/check-runs") && init?.method === "POST") {
+          checkRunWrites.push({ method: "POST", body: JSON.parse(String(init.body)) as Record<string, unknown> });
+          return Response.json({ id: 6201 });
+        }
+        if (url.includes("/check-runs/6201") && init?.method === "PATCH") {
+          checkRunWrites.push({ method: "PATCH", body: JSON.parse(String(init.body)) as Record<string, unknown> });
+          return Response.json({ id: 6201 });
+        }
+        if (url.includes("/check-runs")) return Response.json({ check_runs: [{ id: 6200, status: "completed" }] });
         return Response.json({});
       });
 
@@ -2751,6 +2761,10 @@ describe("queue processors", () => {
         .bind("github_app.pr_public_surface_published", "JSONbored/gittensory#62")
         .first<{ n: number }>();
       expect(publishedAudit?.n).toBe(0); // the full publish path never ran — it was proven redundant up-front
+      expect(checkRunWrites.map((write) => [write.method, write.body.status])).toEqual([
+        ["POST", "in_progress"],
+        ["PATCH", "completed"],
+      ]);
     });
 
     it("swallows a failing publish-skip audit write without throwing", async () => {


### PR DESCRIPTION
### Motivation
- Prevent a scheduled re-gate early-return from leaving a same-pass pending Gate check in `in_progress`, which can block merges on branch-protected repos when the no-op guard returns after posting a pending check. 

### Description
- In `src/queue/processors.ts` finalize any same-pass pending Gate check (created via `createOrUpdatePendingGateCheckRun`) by calling `createOrUpdateGateCheckRun` with the pending `checkRunId` and the computed `gate` and only treating the public-surface as a safe no-op when that finalization resolves as `published`. 
- If the pending check cannot be confirmed published, the code now falls through to the normal publish/finalization path instead of returning early. 
- Record a `check_summaries` upsert via `recordPublishedGateCheckSummary` on confirmed finalization and keep the existing audit event `github_app.public_surface_publish_skipped_current` when the skip is safe. 
- Extended the regression test in `test/unit/queue.test.ts` to capture GitHub `fetch` writes and assert the unchanged check-run-only re-gate posts an `in_progress` POST then a completing PATCH (ensuring the pending run is finalized). 

### Testing
- Ran type-check with `npm run typecheck` which passed. 
- Ran the targeted unit test with `npx vitest run test/unit/queue.test.ts -t "public surface is not republished"` which passed locally. 
- Ran `git diff --check` with no issues. 
- Attempted `npm run test:coverage` but the full suite experienced unrelated long-running queue sweep tests/timeouts in this environment, so full-coverage gating was not completed here. 
- Attempted `npm audit --audit-level=moderate` but the npm audit endpoint returned `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a489f35c6c8832c9dccfd2f71fa3f23)