### PR TITLE
fix(scoring): clamp time-decay override params to their documented bounds (#703)

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -1327,11 +1327,32 @@ export function resolveTimeDecay(
   overrides?: RepoTimeDecayOverrides | null,
 ): { gracePeriodHours: number; sigmoidMidpointDays: number; sigmoidSteepness: number; minMultiplier: number } {
   return {
-    gracePeriodHours: Math.trunc(pickOverride(overrides?.gracePeriodHours, constant(constants, "TIME_DECAY_GRACE_PERIOD_HOURS"))),
+    gracePeriodHours: clampGracePeriodHours(Math.trunc(pickOverride(overrides?.gracePeriodHours, constant(constants, "TIME_DECAY_GRACE_PERIOD_HOURS")))),
     sigmoidMidpointDays: pickOverride(overrides?.sigmoidMidpointDays, constant(constants, "TIME_DECAY_SIGMOID_MIDPOINT")),
     sigmoidSteepness: pickOverride(overrides?.sigmoidSteepness, constant(constants, "TIME_DECAY_SIGMOID_STEEPNESS_SCALAR")),
-    minMultiplier: pickOverride(overrides?.minMultiplier, constant(constants, "TIME_DECAY_MIN_MULTIPLIER")),
+    minMultiplier: clampMinMultiplier(pickOverride(overrides?.minMultiplier, constant(constants, "TIME_DECAY_MIN_MULTIPLIER"))),
   };
+}
+
+// Documented bound (see the parity note above): upstream validates 0 <= grace_period_hours <= 168. The
+// override reaches this resolver via a bare Number.isFinite check (registry/normalize.ts's parseTimeDecayOverrides),
+// so an out-of-band value (negative, or beyond a week) would otherwise apply verbatim.
+const GRACE_PERIOD_HOURS_MIN = 0;
+const GRACE_PERIOD_HOURS_MAX = 168;
+
+function clampGracePeriodHours(value: number): number {
+  return clamp(value, GRACE_PERIOD_HOURS_MIN, GRACE_PERIOD_HOURS_MAX);
+}
+
+// minMultiplier is the sigmoid's floor (calculateTimeDecay: Math.max(sigmoid, minMultiplier)), and the
+// sigmoid itself is always in (0, 1). A per-repo override above 1 would floor every aged PR ABOVE a fresh
+// PR's multiplier -- inverting time decay into an age bonus -- and a negative override applied verbatim
+// today has no floor semantics at all. Bound to the sigmoid's own range so the floor invariant always holds.
+const MIN_MULTIPLIER_MIN = 0;
+const MIN_MULTIPLIER_MAX = 1;
+
+function clampMinMultiplier(value: number): number {
+  return clamp(value, MIN_MULTIPLIER_MIN, MIN_MULTIPLIER_MAX);
 }
 
 function pickOverride(value: number | null | undefined, fallback: number): number {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1812,6 +1812,24 @@ NOVELTY_BONUS_SCALAR = 3
       expect(calculateTimeDecay(13.5, c, { gracePeriodHours: 13.9 })).toBeLessThan(1);
     });
 
+    it("clamps an out-of-band grace_period_hours override to the documented [0, 168] range", () => {
+      const c = DEFAULT_SCORING_CONSTANTS;
+      // Negative override clamps to 0 rather than applying verbatim.
+      expect(resolveTimeDecay(c, { gracePeriodHours: -10 }).gracePeriodHours).toBe(0);
+      // An override beyond the documented week-long ceiling clamps to 168.
+      expect(resolveTimeDecay(c, { gracePeriodHours: 500 }).gracePeriodHours).toBe(168);
+    });
+
+    it("clamps an out-of-band minMultiplier override to the sigmoid's own [0, 1] floor range", () => {
+      const c = DEFAULT_SCORING_CONSTANTS;
+      expect(resolveTimeDecay(c, { minMultiplier: -0.5 }).minMultiplier).toBe(0);
+      expect(resolveTimeDecay(c, { minMultiplier: 1.5 }).minMultiplier).toBe(1);
+      // Before the fix, an override above 1 floored every aged PR ABOVE a fresh PR's 1.0 multiplier,
+      // inverting decay into an age bonus. After the fix the floor caps at 1, so a very old PR decays
+      // down to at most the fresh multiplier -- never above it.
+      expect(calculateTimeDecay(2400, c, { minMultiplier: 1.5 })).toBe(1);
+    });
+
     it("applies each live repo's resolved curve in the preview (per-repo, not global)", () => {
       const input: ScorePreviewInput = { repoFullName: repo.fullName, sourceTokenScore: 58, totalTokenScore: 600, sourceLines: 60, openPrCount: 0, credibility: 1, applyTimeDecay: true, prAgeHours: 18 };
       // Repo with a 24h grace override (like JSONbored/gittensory) → an 18h-old PR is still fresh.


### PR DESCRIPTION
## Summary

`resolveTimeDecay` (`src/scoring/preview.ts`) resolves each repo's time-decay curve by overlaying registry overrides on top of the global scoring defaults, but the overrides only ever pass through a bare `Number.isFinite` check (`registry/normalize.ts`'s `parseTimeDecayOverrides`). Two of the four resolved fields have documented bounds that were never enforced:

- `gracePeriodHours`: the function's own parity-note comment states "upstream validates `0 <= grace_period_hours <= 168`," but the value was only `Math.trunc`'d, never clamped — a misconfigured negative or >168 override applied verbatim.
- `minMultiplier`: this is the sigmoid's floor in `calculateTimeDecay` (`Math.max(sigmoid, minMultiplier)`), and the sigmoid itself is always in `(0, 1)`. An override above 1 (e.g. `1.5`) would floor every aged PR's decay multiplier **above** a fresh PR's multiplier (`1.0`) — inverting time decay into an age-based score bonus instead of a penalty. A negative override had no floor semantics at all.

This is the same class of gap already fixed for `fixed_base_score` and `SRC_TOK_SATURATION_SCALE` in the same file (both clamped to their documented `[min, max]` bounds via `clampFixedBaseScore`/`clampSaturationScale`) — `resolveTimeDecay`'s two other numeric overrides never got the same treatment.

## Fix

Adds `clampGracePeriodHours` (`[0, 168]`) and `clampMinMultiplier` (`[0, 1]`), mirroring the existing `clampFixedBaseScore`/`clampSaturationScale` helpers in the same file, and applies them inside `resolveTimeDecay`.

## Why no linked issue

Small, self-evident, single-file logic fix discovered while reading `resolveTimeDecay`; this repo's `linkedIssuePolicy` is `preferred`, not required, for a change this scoped.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only change with no API/OpenAPI/UI surface touched, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable.
- `npm run test:coverage` was run scoped to `test/unit/scoring.test.ts` (100% statement/branch coverage on every changed line in `src/scoring/preview.ts`, verified with `--coverage.include`). The full unsharded suite could not be run clean in my local Windows dev environment: several unrelated test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention. I confirmed each of these reproduces identically with this diff stashed out against a clean `main`, so none of it originates from this change.
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, and `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff and expected to run on the Linux CI runner.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, `npm run build:mcp`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- New tests: `resolveTimeDecay overlays...` suite gains two cases — clamping an out-of-band `gracePeriodHours` override to `[0, 168]`, and clamping an out-of-band `minMultiplier` override to `[0, 1]` (including the inversion scenario the bug allowed: `calculateTimeDecay(2400, c, { minMultiplier: 1.5 })` now returns `1`, never above the fresh-PR multiplier).
