### PR TITLE
fix(miner): reject duplicate step ids in plan store saves

### DIFF
--- a/packages/gittensory-miner/lib/plan-store.js
+++ b/packages/gittensory-miner/lib/plan-store.js
@@ -79,6 +79,11 @@ function validatePlanDag(plan) {
   if (keys.length !== 1 || keys[0] !== "steps") throw new Error("invalid_plan");
   if (!Array.isArray(plan.steps) || plan.steps.length > 100) throw new Error("invalid_plan");
   if (!plan.steps.every(isValidStep)) throw new Error("invalid_plan");
+  const seenStepIds = new Set();
+  for (const step of plan.steps) {
+    if (seenStepIds.has(step.id)) throw new Error("invalid_plan");
+    seenStepIds.add(step.id);
+  }
   return plan;
 }
 

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -88,6 +88,14 @@ describe("gittensory-miner plan store (#2318)", () => {
     expect(() => store.savePlan("x", { steps: "nope" as never })).toThrow("invalid_plan");
     expect(() => store.savePlan("x", { steps: [], extra: 1 } as never)).toThrow("invalid_plan"); // strict: no unknown keys
     expect(() => store.savePlan("", PLAN)).toThrow("invalid_plan_id");
+    expect(() =>
+      store.savePlan("dup", {
+        steps: [
+          { id: "a", title: "A", dependsOn: [], status: "pending", attempts: 0, maxAttempts: 1 },
+          { id: "a", title: "B", dependsOn: [], status: "pending", attempts: 0, maxAttempts: 1 },
+        ],
+      }),
+    ).toThrow("invalid_plan");
   });
 
   it("rejects a corrupted plan blob on load instead of returning a malformed plan", () => {


### PR DESCRIPTION
## Summary

- Reject plan DAGs with duplicate step ids in `validatePlanDag` so ambiguous plans cannot be persisted locally.
- Aligns the plan store with the stateless MCP plan contract, where `stepId` must uniquely identify one step.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on plan-store validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers duplicate step ids rejected on save.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

No linked issue — small validation gap fix in foundation plan persistence (#2318).
