### PR TITLE
fix(agent-actions): audit denied/queued/dry_run accept outcomes as themselves, not error (#2423)

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -315,7 +315,12 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
     eventType: "agent.pending_action.accepted",
     actor: input.decidedBy,
     targetKey,
-    outcome: execOutcome === "completed" ? "completed" : "error",
+    // The audit outcome must reflect execOutcome the same way finalStatus's comment above describes it, not
+    // collapse every non-"completed" result into "error": "denied"/"queued" pass through as themselves, and
+    // "dry_run" folds into "completed" (mirroring agent-action-executor.ts's own audit() helper), since
+    // AuditEventRecord's outcome type has no "dry_run" member. Only a real executor failure — "error", or the
+    // defensive "no_outcome" fallback above — should ever surface as "error" here.
+    outcome: execOutcome === "dry_run" ? "completed" : execOutcome === "denied" || execOutcome === "queued" ? execOutcome : execOutcome === "completed" ? "completed" : "error",
     detail: `accepted ${pending.actionClass} → ${execOutcome}`,
     metadata: { ...baseMetadata, executionOutcome: execOutcome },
   });

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -880,7 +880,7 @@ describe("agent approval queue (#779)", () => {
     expect((await decidePendingAgentAction(env, { id: "nope", decision: "accept", decidedBy: "owner" })).status).toBe("not_found");
   });
 
-  it("accept records error when the staged action cannot execute (no write permission)", async () => {
+  it("REGRESSION: accept audits 'denied' (not 'error') when the staged action cleanly declines to run (no write permission)", async () => {
     const env = createTestEnv({});
     // No settings/installation seeded → autonomy is empty + no pull_requests:write → the merge is denied.
     const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash", expectedHeadSha: "h7" }, reason: "clean" });
@@ -888,7 +888,24 @@ describe("agent approval queue (#779)", () => {
     expect(result.status).toBe("accepted"); // the decision is recorded...
     expect(result.executionOutcome).toBe("denied"); // ...but the action could not run
     expect(mergePullRequest).not.toHaveBeenCalled();
-    expect((await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.pending_action.accepted").first<{ outcome: string }>())?.outcome).toBe("error");
+    // A "denied" execution outcome is an intentional policy decision, not a failure -- the audit row must say
+    // so, not collapse it into "error" alongside a genuine executor exception (see the #2423 regression below).
+    expect((await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.pending_action.accepted").first<{ outcome: string }>())?.outcome).toBe("denied");
+  });
+
+  it("REGRESSION: accept audits 'completed' (not 'error') when the executor runs in dry-run mode", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" }, agentDryRun: true });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 7, installationId: 5, actionClass: "merge", autonomyLevel: "auto_with_approval", params: { mergeMethod: "squash", expectedHeadSha: "h7" }, reason: "clean" });
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("dry_run");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    // AuditEventRecord's outcome type has no "dry_run" member -- it must fold into "completed" (mirroring
+    // agent-action-executor.ts's own audit() helper), not the unrelated "error" outcome.
+    expect((await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("agent.pending_action.accepted").first<{ outcome: string }>())?.outcome).toBe("completed");
   });
 
   it("REGRESSION (#2423): accept persists status=errored, not accepted, when the executor's mutation call throws", async () => {


### PR DESCRIPTION
## Summary

`decidePendingAgentAction`'s accept path (`src/services/agent-approval-queue.ts`) records an `agent.pending_action.accepted` audit event whose `outcome` field collapsed every executor result that wasn't literally `"completed"` into `"error"`:

```ts
outcome: execOutcome === "completed" ? "completed" : "error",
```

This directly contradicts the comment two lines above it, which explains that `"denied"` is "an intentional policy decision ... not a failure" and that `finalStatus` correctly stays `"accepted"` for every non-`"error"` outcome. The audit `outcome` field disagreed with that same reasoning: a maintainer's accept that the executor cleanly **denied** (autonomy no longer authorizes it, a live pre-condition failed cleanly), ran as a **dry-run**, or was **queued**, was audited as `"error"` — indistinguishable from a genuine GitHub-call exception. That's the maintainer-facing audit/action-history feed (`listAgentAuditEvents`, surfaced via `src/api/routes.ts` and `src/mcp/server.ts`), so a completely healthy dry-run or policy-denied accept reads as a real failure there.

The sibling audit helper in `agent-action-executor.ts` (`audit()`) already gets this right: `outcome === "dry_run" ? "completed" : outcome` passes `denied`/`queued`/`completed`/`error` straight through and only folds `dry_run` into `completed` (since `AuditEventRecord`'s `outcome` type has no `dry_run` member) — `agent-approval-queue.ts:318` was the one call site using the wrong, blanket mapping instead.

## Fix

`outcome` now passes `denied`/`queued`/`completed` straight through, folds `dry_run` into `completed` (mirroring the executor's own helper), and only maps to `error` for a genuine `error` (or the defensive, practically-unreachable `no_outcome` fallback).

An existing test (`accept records error when the staged action cannot execute (no write permission)`) was asserting the buggy behavior directly — it expected a `denied` execution outcome to audit as `"error"`. It's corrected to assert `"denied"`, and a new regression test covers the `dry_run` → `completed` fold.

## Why no linked issue

Small, self-evident, single-function fix in code already covered by an existing (now-corrected) test; this repo's `linkedIssuePolicy` is `preferred`, not required, for a change this scoped.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only change with no API/OpenAPI/UI surface touched, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable.
- `npm run test:coverage` was run scoped to `test/unit/agent-approval-queue.test.ts` (100% statement/branch coverage on `src/services/agent-approval-queue.ts`, verified with `--coverage.include`). The full unsharded suite could not be run clean in my local Windows dev environment: several unrelated test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention. I confirmed each of these reproduces identically with this diff stashed out against a clean `main`, so none of it originates from this change.
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, and `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff and expected to run on the Linux CI runner.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, `npm run build:mcp`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- New/updated tests: corrected the existing "no write permission" test to assert the audit outcome is `"denied"`, not `"error"`, and added a new dry-run regression test asserting the audit outcome folds to `"completed"`.
